### PR TITLE
Install runtime events for runtime5

### DIFF
--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -117,7 +117,7 @@ $(ocamldir)/otherlibs/dune:
 	if [ "$(RUNTIME_DIR)" = "runtime4" ]; then \
           echo "(dirs (:standard \ systhreads))" > $@; \
 	else \
-          echo "(dirs (:standard \ systhreads4))" > $@; \
+          echo "(dirs (:standard \ systhreads4 runtime_events))" > $@; \
 	fi
 
 $(ocamldir)/dune.runtime_selection:
@@ -249,11 +249,14 @@ install_for_test: _install
 	 done; \
 	 ln -s . lex; ln -s . yacc; \
 	 ln -s _install/lib/ocaml/compiler-libs compilerlibs; \
-	 mkdir -p otherlibs/{unix,dynlink/native,str,bigarray}; \
+	 mkdir -p otherlibs/{unix,dynlink/native,str,bigarray,runtime_events}; \
 	 ln -s ../stdlib/threads otherlibs/systhreads$(RUNTIME_SUFFIX); \
          $(cpl) stdlib/unix/{lib,}unix* otherlibs/unix; \
          $(cpl) stdlib/dynlink/dynlink* otherlibs/dynlink; \
          $(cpl) stdlib/str/{lib,}str* otherlibs/str; \
+	if [[ x"$(RUNTIME_DIR)" = x ]]; then \
+		$(cpl) stdlib/runtime_events/{lib,}runtime_events* otherlibs/runtime_events; \
+	fi; \
 	 ln -s ../_build/main/$(ocamldir)/toplevel/byte/.ocamltoplevel.objs/byte toplevel; \
 	)
 

--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -115,9 +115,9 @@ dune_config_targets = \
 
 $(ocamldir)/otherlibs/dune:
 	if [ "$(RUNTIME_DIR)" = "runtime4" ]; then \
-          echo "(dirs (:standard \ systhreads))" > $@; \
+          echo "(dirs (:standard \ systhreads runtime_events))" > $@; \
 	else \
-          echo "(dirs (:standard \ systhreads4 runtime_events))" > $@; \
+          echo "(dirs (:standard \ systhreads4))" > $@; \
 	fi
 
 $(ocamldir)/dune.runtime_selection:
@@ -254,7 +254,7 @@ install_for_test: _install
          $(cpl) stdlib/unix/{lib,}unix* otherlibs/unix; \
          $(cpl) stdlib/dynlink/dynlink* otherlibs/dynlink; \
          $(cpl) stdlib/str/{lib,}str* otherlibs/str; \
-	if [[ x"$(RUNTIME_DIR)" = x ]]; then \
+	if [[ x"$(RUNTIME_DIR)" = x"runtime" ]]; then \
 		$(cpl) stdlib/runtime_events/{lib,}runtime_events* otherlibs/runtime_events; \
 	fi; \
 	 ln -s ../_build/main/$(ocamldir)/toplevel/byte/.ocamltoplevel.objs/byte toplevel; \

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -13643,6 +13643,13 @@ esac
 
 otherlibraries="dynlink"
 lib_dynlink=true
+
+if test x"$enable_runtime5" = x"yes"
+then :
+  otherlibraries = "$otherlibraries runtime_events"
+   lib_runtime_events = true
+fi
+
 if test x"$enable_unix_lib" != "xno"
 then :
   enable_unix_lib=yes
@@ -19288,9 +19295,10 @@ esac
 
 ## Activate the systhread library
 
-if [ x"$enable_runtime5" = x"yes" ]; then
+if test x"$enable_runtime5" = x"yes"
+then :
   runtime_suffix=
-else
+else $as_nop
   runtime_suffix=4
 fi
 

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -667,12 +667,15 @@ AS_CASE([$host],
     [exeext=".exe"],
   [exeext=''])
 
-dnl CR ocaml 5 runtime:
-dnl otherlibraries="dynlink runtime_events"
 otherlibraries="dynlink"
 lib_dynlink=true
-dnl CR ocaml 5 runtime:
-dnl lib_runtime_events = true
+
+AS_IF(
+  [test x"$enable_runtime5" = x"yes"],
+  [otherlibraries = "$otherlibraries runtime_events"
+   lib_runtime_events = true],
+  [])
+
 AS_IF([test x"$enable_unix_lib" != "xno"],
   [enable_unix_lib=yes
   AC_CONFIG_FILES([otherlibs/unix/META])
@@ -2118,11 +2121,10 @@ AS_CASE([$host],
 
 ## Activate the systhread library
 
-if [[ x"$enable_runtime5" = x"yes" ]]; then
-  runtime_suffix=
-else
-  runtime_suffix=4
-fi
+AS_IF(
+  [test x"$enable_runtime5" = x"yes"],
+  [runtime_suffix=],
+  [runtime_suffix=4])
 
 AS_CASE([$enable_systhreads,$enable_unix_lib],
   [yes,no],

--- a/ocaml/otherlibs/runtime_events/dune
+++ b/ocaml/otherlibs/runtime_events/dune
@@ -1,0 +1,47 @@
+;**************************************************************************
+;*                                                                        *
+;*                                 OCaml                                  *
+;*                                                                        *
+;*                     Thomas Refis, Jane Street Europe                   *
+;*                                                                        *
+;*   Copyright 2018 Jane Street Group LLC                                 *
+;*                                                                        *
+;*   All rights reserved.  This file is distributed under the terms of    *
+;*   the GNU Lesser General Public License version 2.1, with the          *
+;*   special exception on linking described in the file LICENSE.          *
+;*                                                                        *
+;**************************************************************************
+
+(library
+ (name runtime_events)
+ (wrapped false)
+ (modes byte native)
+ (flags (
+   -strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66
+   -warn-error A -bin-annot -safe-string -strict-formats
+ ))
+ (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+ (library_flags (:standard -linkall))
+ (foreign_stubs (language c) (names runtime_events_consumer)
+  (flags ((:include %{project_root}/oc_cflags.sexp)
+          (:include %{project_root}/sharedlib_cflags.sexp)
+          (:include %{project_root}/oc_cppflags.sexp)))))
+
+(install
+  (files
+    (.runtime_events.objs/native/runtime_events.cmx as runtime_events/runtime_events.cmx)
+    (libruntime_events_stubs.a as runtime_events/libruntime_events_stubs.a)
+    (libruntime_events_stubs.a as libruntime_events_stubs_native.a) ; for special_dune compat
+    (dllruntime_events_stubs.so as stublibs/dllruntime_events_stubs.so)
+    (runtime_events.cmxa as runtime_events/runtime_events.cmxa)
+    (runtime_events.a as runtime_events/runtime_events.a)
+    (runtime_events.cmxs as runtime_events/runtime_events.cmxs)
+    (runtime_events.cma as runtime_events/runtime_events.cma)
+    (runtime_events.mli as runtime_events/runtime_events.mli)
+    (.runtime_events.objs/byte/runtime_events.cmi as runtime_events/runtime_events.cmi)
+    (.runtime_events.objs/byte/runtime_events.cmt as runtime_events/runtime_events.cmt)
+    (.runtime_events.objs/byte/runtime_events.cmti as runtime_events/runtime_events.cmti)
+    (runtime_events_consumer.h as runtime_events_consumer.h)
+  )
+  (section lib)
+  (package ocaml))

--- a/ocaml/testsuite/tests/lib-runtime-events/test.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test.ml
@@ -1,8 +1,6 @@
 (* TEST
 modules = "stubs.c"
 include runtime_events
-* skip
-reason = "OCaml 5 only"
 *)
 
 external start_runtime_events : unit -> unit = "start_runtime_events"

--- a/ocaml/testsuite/tests/lib-runtime-events/test_caml.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_caml.ml
@@ -1,7 +1,5 @@
 (* TEST
 include runtime_events
-* skip
-reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/ocaml/testsuite/tests/lib-runtime-events/test_caml_counters.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_caml_counters.ml
@@ -1,7 +1,5 @@
 (* TEST
 include runtime_events
-* skip
-reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/ocaml/testsuite/tests/lib-runtime-events/test_caml_exception.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_caml_exception.ml
@@ -1,7 +1,5 @@
 (* TEST
 include runtime_events
-* skip
-reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/ocaml/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
@@ -1,7 +1,7 @@
 (* TEST
 include runtime_events
 * skip
-reason = "OCaml 5 only"
+reason = "CR OCaml 5 domain"
 *)
 open Runtime_events
 

--- a/ocaml/testsuite/tests/lib-runtime-events/test_caml_reentry.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_caml_reentry.ml
@@ -1,7 +1,5 @@
 (* TEST
 include runtime_events
-* skip
-reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/ocaml/testsuite/tests/lib-runtime-events/test_caml_runparams.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_caml_runparams.ml
@@ -1,8 +1,6 @@
 (* TEST
 include runtime_events
 ocamlrunparam += ",e=4"
-* skip
-reason = "OCaml 5 only"
 *)
 
 (* We set the ring buffer size smaller and witness that we do indeed

--- a/ocaml/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
@@ -1,7 +1,7 @@
 (* TEST
 include runtime_events
 * skip
-reason = "OCaml 5 only"
+reason = "CR OCaml 5 Domain.spawn"
 *)
 open Runtime_events
 

--- a/ocaml/testsuite/tests/lib-runtime-events/test_caml_stubs_gc.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_caml_stubs_gc.ml
@@ -1,7 +1,5 @@
 (* TEST
 include runtime_events
-* skip
-reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/ocaml/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -3,7 +3,7 @@
    include unix
    set OCAMLRUNPARAM = "e=6"
    * skip
-   reason = "OCaml 5 only"
+   reason = "CR OCaml 5 domain"
    ** libunix
    *** native
    *** bytecode

--- a/ocaml/testsuite/tests/lib-runtime-events/test_env_start.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_env_start.ml
@@ -1,8 +1,6 @@
 (* TEST
 include runtime_events
 set OCAML_RUNTIME_EVENTS_START = "1"
-* skip
-reason = "OCaml 5 only"
 *)
 
 (* In this test the runtime_events should already be started by the environment

--- a/ocaml/testsuite/tests/lib-runtime-events/test_external.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_external.ml
@@ -2,10 +2,9 @@
    reason = "OCaml 5 only"
    include runtime_events
    include unix
-   * skip
-   ** libunix
-   *** bytecode
-   *** native *)
+   * libunix
+   ** bytecode
+   ** native *)
 
 let got_major = ref false
 let got_minor = ref false

--- a/ocaml/testsuite/tests/lib-runtime-events/test_external_preserve.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_external_preserve.ml
@@ -2,11 +2,9 @@
   include runtime_events
   include unix
   set OCAML_RUNTIME_EVENTS_PRESERVE = "1"
-  * skip
-  reason = "OCaml 5 only"
-  ** libunix
-  *** bytecode
-  *** native *)
+  * libunix
+  ** bytecode
+  ** native *)
 
   (* this tests the preservation of ring buffers after termination *)
 

--- a/ocaml/testsuite/tests/lib-runtime-events/test_fork.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_fork.ml
@@ -1,11 +1,9 @@
 (* TEST
    include runtime_events
    include unix
-   * skip
-   reason = "OCaml 5 only"
-   ** libunix
-   *** bytecode
-   *** native *)
+   * libunix
+   ** bytecode
+   ** native *)
 
 let got_start = ref false
 let got_fork_child = ref false

--- a/ocaml/testsuite/tests/lib-runtime-events/test_instrumented.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_instrumented.ml
@@ -1,11 +1,8 @@
 (* TEST
    include runtime_events
    flags = "-runtime-variant=i"
-
-   * skip
-   reason = "OCaml 5 only"
-   ** instrumented-runtime
-   *** native
+   * instrumented-runtime
+   ** native
 *)
 
 open Runtime_events

--- a/ocaml/testsuite/tests/lib-runtime-events/test_instrumented.reference
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_instrumented.reference
@@ -1,1 +1,1 @@
-lost_event_words: 0, total_sizes: 2000004, total_minors: 31
+lost_event_words: 0, total_sizes: 2000004, total_minors: 15

--- a/ocaml/testsuite/tests/lib-runtime-events/test_user_event.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_user_event.ml
@@ -1,7 +1,5 @@
 (* TEST
 include runtime_events
-* skip
-reason = "OCaml 5 only"
 *)
 open Runtime_events
 

--- a/ocaml/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_user_event_unknown.ml
@@ -2,11 +2,9 @@
    include runtime_events
    include unix
    set OCAML_RUNTIME_EVENTS_PRESERVE = "1"
-   * skip
-   reason = "OCaml 5 only"
-   ** libunix
-   *** bytecode
-   *** native
+   * libunix
+   ** bytecode
+   ** native
 *)
 open Runtime_events
 


### PR DESCRIPTION
This install the `runtime_events` library for runtime5.

Note that one of the tests that counts minor collection is promoted. We will see how flaky it is before further actions.