### PR TITLE
More CR ocaml 5 comments

### DIFF
--- a/ocaml/bytecomp/emitcode.ml
+++ b/ocaml/bytecomp/emitcode.ml
@@ -421,7 +421,8 @@ let to_file outchan unit_name objfile ~required_globals code =
         (Filename.dirname (Location.absolute_path objfile))
         !debug_dirs;
       let p = pos_out outchan in
-      (* CR mshinwell: Compression not supported in the OCaml 4 runtime
+      (* CR ocaml 5 compressed-marshal mshinwell:
+         Compression not supported in the OCaml 4 runtime
       Marshal.(to_channel outchan !events [Compression]);
       Marshal.(to_channel outchan (String.Set.elements !debug_dirs)
                           [Compression]);

--- a/ocaml/file_formats/cmi_format.ml
+++ b/ocaml/file_formats/cmi_format.ml
@@ -167,7 +167,8 @@ let output_cmi filename oc cmi =
   output_int64 oc len;
   Out_channel.seek oc val_pos;
   (* BACKPORT BEGIN *)
-  (* mshinwell: upstream uses [Compression] here *)
+  (* CR ocaml 5 compressed-marshal mshinwell:
+     upstream uses [Compression] here *)
   output_value oc ((cmi.cmi_name, sign) : header);
   (* BACKPORT END *)
   flush oc;

--- a/ocaml/file_formats/cmt_format.ml
+++ b/ocaml/file_formats/cmt_format.ml
@@ -110,7 +110,8 @@ let input_cmt ic = (input_value ic : cmt_infos)
 let output_cmt oc cmt =
   output_string oc Config.cmt_magic_number;
   (* BACKPORT BEGIN *)
-  (* mshinwell: upstream uses [Compression] here *)
+  (* CR ocaml 5 compressed-marshal mshinwell:
+     upstream uses [Compression] here *)
   Marshal.(to_channel oc (cmt : cmt_infos) [])
   (* BACKPORT END *)
 

--- a/ocaml/testsuite/tests/backtrace/backtrace_effects_nested.ml
+++ b/ocaml/testsuite/tests/backtrace/backtrace_effects_nested.ml
@@ -3,7 +3,7 @@
 
 flags = "-g"
 * skip
-  reason = "OCaml 5 only"
+  reason = "CR ocaml 5 effects: re-enable this test"
 ** bytecode
 ** no-flambda
 *** native

--- a/ocaml/testsuite/tests/callback/callback_effects_gc.ml
+++ b/ocaml/testsuite/tests/callback/callback_effects_gc.ml
@@ -1,7 +1,7 @@
 (* TEST
    ocamlrunparam += ",s=512"
    * skip
-   reason = "OCaml 5 only"
+   reason = "CR ocaml 5 effects: re-enable this test"
    ** native
 *)
 

--- a/ocaml/testsuite/tests/callback/nested_fiber.ml
+++ b/ocaml/testsuite/tests/callback/nested_fiber.ml
@@ -2,7 +2,7 @@
    include unix
    modules = "nested_fiber_.c"
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 effects: re-enable this test"
    ** libunix
    *** bytecode
    *** native

--- a/ocaml/testsuite/tests/callback/stack_overflow.ml
+++ b/ocaml/testsuite/tests/callback/stack_overflow.ml
@@ -2,7 +2,7 @@
    include unix
    modules = "stack_overflow_.c"
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 effects: re-enable this test"
    ** libunix
    *** bytecode
    *** native

--- a/ocaml/testsuite/tests/callback/test7.ml
+++ b/ocaml/testsuite/tests/callback/test7.ml
@@ -3,7 +3,7 @@
    include unix
    modules = "test7_.c"
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 effects: re-enable this test"
    ** libunix
    *** bytecode
    *** native

--- a/ocaml/testsuite/tests/effects/marshal.ml
+++ b/ocaml/testsuite/tests/effects/marshal.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 effects: re-enable this test"
  *)
 
 open Effect

--- a/ocaml/testsuite/tests/effects/unhandled_unlinked.ml
+++ b/ocaml/testsuite/tests/effects/unhandled_unlinked.ml
@@ -3,7 +3,7 @@
 
      exit_status= "2"
      * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 effects: re-enable this test"
 *)
 
 open Effect

--- a/ocaml/testsuite/tests/frame-pointers/effects.ml
+++ b/ocaml/testsuite/tests/frame-pointers/effects.ml
@@ -3,7 +3,7 @@
 
 
 * skip
-reason - "OCaml 5 only"
+reason = "CR ocaml 5 effects: re-enable this test"
 ** frame_pointers
 *** native
 readonly_files = "fp_backtrace.c"

--- a/ocaml/testsuite/tests/frame-pointers/reperform.ml
+++ b/ocaml/testsuite/tests/frame-pointers/reperform.ml
@@ -3,7 +3,7 @@
 
 
 * skip
-reason - "OCaml 5 only"
+reason = "CR ocaml 5 effects: re-enable this test"
 ** frame_pointers
 *** native
 

--- a/ocaml/testsuite/tests/frame-pointers/stack_realloc.ml
+++ b/ocaml/testsuite/tests/frame-pointers/stack_realloc.ml
@@ -3,7 +3,7 @@
 
 
 * skip
-reason - "OCaml 5 only"
+reason = "CR ocaml 5 effects: re-enable this test"
 ** frame_pointers
 *** native
 

--- a/ocaml/testsuite/tests/frame-pointers/stack_realloc2.ml
+++ b/ocaml/testsuite/tests/frame-pointers/stack_realloc2.ml
@@ -3,7 +3,7 @@
 
 
 * skip
-reason - "OCaml 5 only"
+reason = "CR ocaml 5 effects: re-enable this test"
 ** frame_pointers
 *** native
 

--- a/ocaml/testsuite/tests/gc-roots/globroots_parallel.ml
+++ b/ocaml/testsuite/tests/gc-roots/globroots_parallel.ml
@@ -3,7 +3,7 @@
    modules = "globrootsprim.c globroots.ml"
 
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 open Globroots

--- a/ocaml/testsuite/tests/gc-roots/globroots_parallel_spawn_burn.ml
+++ b/ocaml/testsuite/tests/gc-roots/globroots_parallel_spawn_burn.ml
@@ -3,7 +3,7 @@
    modules = "globrootsprim.c globroots.ml"
 
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 open Globroots

--- a/ocaml/testsuite/tests/lazy/lazy2.ml
+++ b/ocaml/testsuite/tests/lazy/lazy2.ml
@@ -1,7 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 open Domain

--- a/ocaml/testsuite/tests/lazy/lazy3.ml
+++ b/ocaml/testsuite/tests/lazy/lazy3.ml
@@ -1,7 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 let f count =

--- a/ocaml/testsuite/tests/lazy/lazy5.ml
+++ b/ocaml/testsuite/tests/lazy/lazy5.ml
@@ -1,7 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 domains: re-enable this test"
 *)
 let rec safe_force l =
   try Lazy.force l with

--- a/ocaml/testsuite/tests/lazy/lazy6.ml
+++ b/ocaml/testsuite/tests/lazy/lazy6.ml
@@ -1,7 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 let flag1 = Atomic.make false

--- a/ocaml/testsuite/tests/lazy/lazy7.ml
+++ b/ocaml/testsuite/tests/lazy/lazy7.ml
@@ -1,7 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 let num_domains = 4

--- a/ocaml/testsuite/tests/lazy/lazy8.ml
+++ b/ocaml/testsuite/tests/lazy/lazy8.ml
@@ -1,7 +1,7 @@
 (* TEST
    ocamlopt_flags += " -O3 "
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 exception E

--- a/ocaml/testsuite/tests/lf_skiplist/test_parallel.ml
+++ b/ocaml/testsuite/tests/lf_skiplist/test_parallel.ml
@@ -2,7 +2,7 @@
    modules = "stubs.c"
 
    * skip
-     reason = "OCaml 5 only"
+     reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 external init_skiplist : unit -> unit = "init_skiplist"

--- a/ocaml/testsuite/tests/lib-channels/refcounting.ml
+++ b/ocaml/testsuite/tests/lib-channels/refcounting.ml
@@ -1,6 +1,6 @@
 (* TEST
    * skip
-   reason = "OCaml 5 only"
+   reason = "CR ocaml 5 domains: re-enable this test"
    ** expect
 *)
 

--- a/ocaml/testsuite/tests/lib-dynlink-domains/main.ml
+++ b/ocaml/testsuite/tests/lib-dynlink-domains/main.ml
@@ -1,6 +1,6 @@
 (* TEST
  * skip
-   reason = "OCaml 5 only"
+   reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 (* BACKPORT

--- a/ocaml/testsuite/tests/lib-format/domains.ml
+++ b/ocaml/testsuite/tests/lib-format/domains.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 (** Test that domains stdout and stderr are flushed at domain exit *)

--- a/ocaml/testsuite/tests/lib-format/mc_pr586_par.ml
+++ b/ocaml/testsuite/tests/lib-format/mc_pr586_par.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 let () =

--- a/ocaml/testsuite/tests/lib-format/mc_pr586_par2.ml
+++ b/ocaml/testsuite/tests/lib-format/mc_pr586_par2.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 let () =

--- a/ocaml/testsuite/tests/lib-marshal/intext_par.ml
+++ b/ocaml/testsuite/tests/lib-marshal/intext_par.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
    modules = "intextaux_par.c"
 *)
 

--- a/ocaml/testsuite/tests/lib-random/parallel.ml
+++ b/ocaml/testsuite/tests/lib-random/parallel.ml
@@ -1,7 +1,7 @@
 (* TEST
    include unix
    * skip
-   reason = "OCaml 5 only"
+   reason = "CR ocaml 5 domains: re-enable this test"
    ** libunix
    *** bytecode
    *** native

--- a/ocaml/testsuite/tests/lib-str/parallel.ml
+++ b/ocaml/testsuite/tests/lib-str/parallel.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hasstr
 include str
 *** bytecode

--- a/ocaml/testsuite/tests/lib-sync/prodcons.ml
+++ b/ocaml/testsuite/tests/lib-sync/prodcons.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 (* Classic producer-consumer *)

--- a/ocaml/testsuite/tests/lib-systhreads/multicore_lifecycle.ml
+++ b/ocaml/testsuite/tests/lib-systhreads/multicore_lifecycle.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hassysthreads
 include systhreads
 *** bytecode

--- a/ocaml/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
+++ b/ocaml/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
@@ -1,7 +1,7 @@
 (* TEST
 include unix
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hasunix
 *** not-windows
 **** bytecode

--- a/ocaml/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
+++ b/ocaml/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
@@ -1,7 +1,7 @@
 (* TEST
 include unix
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hasunix
 *** not-windows
 **** bytecode

--- a/ocaml/testsuite/tests/memory-model/publish.ml
+++ b/ocaml/testsuite/tests/memory-model/publish.ml
@@ -1,7 +1,7 @@
 (* TEST
   modules="opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml"
   * skip
-  reason = "OCaml 5 only"
+  reason = "CR ocaml 5 domains: re-enable this test"
   ** not-bsd
   *** not-windows
   **** bytecode

--- a/ocaml/testsuite/tests/parallel/atomics.ml
+++ b/ocaml/testsuite/tests/parallel/atomics.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 type u = U of unit

--- a/ocaml/testsuite/tests/parallel/backup_thread.ml
+++ b/ocaml/testsuite/tests/parallel/backup_thread.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hasunix
 include unix
 *** bytecode

--- a/ocaml/testsuite/tests/parallel/backup_thread_pipe.ml
+++ b/ocaml/testsuite/tests/parallel/backup_thread_pipe.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hasunix
 include unix
 *** bytecode

--- a/ocaml/testsuite/tests/parallel/constpromote.ml
+++ b/ocaml/testsuite/tests/parallel/constpromote.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 (* when run with the bytecode debug runtime, this test

--- a/ocaml/testsuite/tests/parallel/deadcont.ml
+++ b/ocaml/testsuite/tests/parallel/deadcont.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 effects: re-enable this test"
 *)
 
 (*

--- a/ocaml/testsuite/tests/parallel/domain_dls.ml
+++ b/ocaml/testsuite/tests/parallel/domain_dls.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 let check_dls () =

--- a/ocaml/testsuite/tests/parallel/domain_dls2.ml
+++ b/ocaml/testsuite/tests/parallel/domain_dls2.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 let _ =

--- a/ocaml/testsuite/tests/parallel/domain_id.ml
+++ b/ocaml/testsuite/tests/parallel/domain_id.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 open Domain

--- a/ocaml/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
+++ b/ocaml/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 open Domain

--- a/ocaml/testsuite/tests/parallel/domain_parallel_spawn_burn_gc_set.ml
+++ b/ocaml/testsuite/tests/parallel/domain_parallel_spawn_burn_gc_set.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 open Domain

--- a/ocaml/testsuite/tests/parallel/domain_serial_spawn_burn.ml
+++ b/ocaml/testsuite/tests/parallel/domain_serial_spawn_burn.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hasunix
 include unix
 *** bytecode

--- a/ocaml/testsuite/tests/parallel/fib_threads.ml
+++ b/ocaml/testsuite/tests/parallel/fib_threads.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hassysthreads
 include systhreads
 *** bytecode

--- a/ocaml/testsuite/tests/parallel/join.ml
+++ b/ocaml/testsuite/tests/parallel/join.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 let test_size =

--- a/ocaml/testsuite/tests/parallel/major_gc_wait_backup.ml
+++ b/ocaml/testsuite/tests/parallel/major_gc_wait_backup.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hasunix
 include unix
 *** native

--- a/ocaml/testsuite/tests/parallel/mctest.ml
+++ b/ocaml/testsuite/tests/parallel/mctest.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 effects: re-enable this test"
 ** hasunix
 include unix
 *** bytecode

--- a/ocaml/testsuite/tests/parallel/multicore_systhreads.ml
+++ b/ocaml/testsuite/tests/parallel/multicore_systhreads.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hassysthreads
 include systhreads
 *** bytecode

--- a/ocaml/testsuite/tests/parallel/pingpong.ml
+++ b/ocaml/testsuite/tests/parallel/pingpong.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 let r = ref (Some 0)

--- a/ocaml/testsuite/tests/parallel/poll.ml
+++ b/ocaml/testsuite/tests/parallel/poll.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hasunix
 include unix
 *** bytecode

--- a/ocaml/testsuite/tests/parallel/prodcons_domains.ml
+++ b/ocaml/testsuite/tests/parallel/prodcons_domains.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 (* Classic producer-consumer *)

--- a/ocaml/testsuite/tests/parallel/recommended_domain_count.ml
+++ b/ocaml/testsuite/tests/parallel/recommended_domain_count.ml
@@ -1,7 +1,7 @@
 (* TEST
 modules = "recommended_domain_count_cstubs.c"
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 external get_max_domains : unit -> int = "caml_get_max_domains"

--- a/ocaml/testsuite/tests/parallel/recommended_domain_count_unix.ml
+++ b/ocaml/testsuite/tests/parallel/recommended_domain_count_unix.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 ** hasunix
 include unix
 *** bytecode

--- a/ocaml/testsuite/tests/parallel/tak.ml
+++ b/ocaml/testsuite/tests/parallel/tak.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 (* filling minor heaps in parallel to trigger

--- a/ocaml/testsuite/tests/parallel/test_c_thread_register.ml
+++ b/ocaml/testsuite/tests/parallel/test_c_thread_register.ml
@@ -1,7 +1,7 @@
 (* TEST
    modules = "test_c_thread_register_cstubs.c"
    * skip
-   reason = "OCaml 5 only"
+   reason = "CR ocaml 5 domains: re-enable this test"
    ** hassysthreads
    include systhreads
    *** bytecode

--- a/ocaml/testsuite/tests/parallel/test_issue_11094.ml
+++ b/ocaml/testsuite/tests/parallel/test_issue_11094.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 effects: re-enable this test"
 ** bytecode
 ** native
 *)

--- a/ocaml/testsuite/tests/tsan/array_elt.ml
+++ b/ocaml/testsuite/tests/tsan/array_elt.ml
@@ -3,7 +3,7 @@
  include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
- reason = "OCaml 5 only";
+ reason = "CR ocaml 5 domains: re-enable this test";
  skip;
  tsan;
  native;

--- a/ocaml/testsuite/tests/tsan/exn_from_c.ml
+++ b/ocaml/testsuite/tests/tsan/exn_from_c.ml
@@ -6,7 +6,7 @@
  include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
- reason = "OCaml 5 only";
+ reason = "CR ocaml 5 domains: re-enable this test";
  skip;
  tsan;
  native;

--- a/ocaml/testsuite/tests/tsan/exn_in_callback.ml
+++ b/ocaml/testsuite/tests/tsan/exn_in_callback.ml
@@ -6,7 +6,7 @@
  include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
- reason = "OCaml 5 only";
+ reason = "CR ocaml 5 domains: re-enable this test";
  skip;
  tsan;
  native;

--- a/ocaml/testsuite/tests/tsan/exn_reraise.ml
+++ b/ocaml/testsuite/tests/tsan/exn_reraise.ml
@@ -4,7 +4,7 @@
  include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
- reason = "OCaml 5 only";
+ reason = "CR ocaml 5 domains: re-enable this test";
  skip;
  tsan;
  native;

--- a/ocaml/testsuite/tests/tsan/handlers_at_tail.ml
+++ b/ocaml/testsuite/tests/tsan/handlers_at_tail.ml
@@ -3,7 +3,7 @@
  ocamlopt_flags = "-g";
  set TSAN_OPTIONS="detect_deadlocks=0";
 
- reason = "OCaml 5 only";
+ reason = "CR ocaml 5 domains: re-enable this test";
  skip;
  tsan;
  native;

--- a/ocaml/testsuite/tests/tsan/norace_atomics.ml
+++ b/ocaml/testsuite/tests/tsan/norace_atomics.ml
@@ -3,7 +3,7 @@
  include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
- reason = "OCaml 5 only";
+ reason = "CR ocaml 5 domains: re-enable this test";
  skip;
  tsan;
  native;

--- a/ocaml/testsuite/tests/tsan/perform.ml
+++ b/ocaml/testsuite/tests/tsan/perform.ml
@@ -4,7 +4,7 @@
  include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
- reason = "OCaml 5 only";
+ reason = "CR ocaml 5 domains: re-enable this test";
  skip;
  tsan;
  native;

--- a/ocaml/testsuite/tests/tsan/raise_through_handler.ml
+++ b/ocaml/testsuite/tests/tsan/raise_through_handler.ml
@@ -4,7 +4,7 @@
  include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
- reason = "OCaml 5 only";
+ reason = "CR ocaml 5 domains: re-enable this test";
  skip;
  tsan;
  native;

--- a/ocaml/testsuite/tests/tsan/record_field.ml
+++ b/ocaml/testsuite/tests/tsan/record_field.ml
@@ -3,7 +3,7 @@
  include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
- reason = "OCaml 5 only";
+ reason = "CR ocaml 5 domains: re-enable this test";
  skip;
  tsan;
  native;

--- a/ocaml/testsuite/tests/tsan/reperform.ml
+++ b/ocaml/testsuite/tests/tsan/reperform.ml
@@ -4,7 +4,7 @@
  include unix;
  set TSAN_OPTIONS="detect_deadlocks=0";
 
- reason = "OCaml 5 only";
+ reason = "CR ocaml 5 domains: re-enable this test";
  skip;
  tsan;
  native;

--- a/ocaml/testsuite/tests/weak-ephe-final/ephetest_par.ml
+++ b/ocaml/testsuite/tests/weak-ephe-final/ephetest_par.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 (* Due to GCs running at non-deterministic places, the output from these tests

--- a/ocaml/testsuite/tests/weak-ephe-final/finaliser2.ml
+++ b/ocaml/testsuite/tests/weak-ephe-final/finaliser2.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 let () = Out_channel.set_buffered stdout false

--- a/ocaml/testsuite/tests/weak-ephe-final/finaliser_handover.ml
+++ b/ocaml/testsuite/tests/weak-ephe-final/finaliser_handover.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 (* ocaml-multicore issues 528 and 468 *)

--- a/ocaml/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
+++ b/ocaml/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
@@ -1,6 +1,6 @@
 (* TEST
 * skip
-reason = "OCaml 5 only"
+reason = "CR ocaml 5 domains: re-enable this test"
 *)
 
 (* Testing unsynchronized, parallel Weak usage *)

--- a/ocaml/tools/dumpobj.ml
+++ b/ocaml/tools/dumpobj.ml
@@ -358,7 +358,8 @@ let op_shapes = [
   opUGEINT, Nothing;
   opBULTINT, Uint_Disp;
   opBUGEINT, Uint_Disp;
-  (* BACKPORT
+  (* CR ocaml 5 effects:
+  BACKPORT
   opPERFORM, Nothing;
   opRESUME, Nothing;
   opRESUMETERM, Uint;


### PR DESCRIPTION
Changes to comments only.

This adds `domains` and `effects` classifications to tests marked as `OCaml 5 only`.  The remaining occurrences of `OCaml 5 only` should only be for tests that it seems we can re-enable now (to be done in a subsequent PR).

This also adds `CR ocaml 5 compressed-marshal` comments to places where compressed marshalling was disabled.  `CR ocaml 5 effects` was added to `dumpobj.ml` to clarify a `BACKPORT` marker.