### PR TITLE
Revert unixsupport_unix.c to the upstream version

### DIFF
--- a/ocaml/runtime/caml/config.h
+++ b/ocaml/runtime/caml/config.h
@@ -16,6 +16,7 @@
 #ifndef CAML_CONFIG_H
 #define CAML_CONFIG_H
 
+/* CR ocaml 5 all-runtime5: remove this and all uses of it */
 #define CAML_RUNTIME_5
 
 /* CAML_NAME_SPACE was introduced in OCaml 3.08 to declare compatibility with


### PR DESCRIPTION
Removing `BACKPORT` markers and the temporary code.