### PR TITLE
Use upstream implementation of caml_unix_error_message for runtime5

### DIFF
--- a/ocaml/otherlibs/unix/errmsg_unix.c
+++ b/ocaml/otherlibs/unix/errmsg_unix.c
@@ -21,6 +21,17 @@
 #include <caml/sys.h>
 #include "unixsupport.h"
 
+#ifdef CAML_RUNTIME_5
+
+CAMLprim value caml_unix_error_message(value err)
+{
+  char buf[1024];
+  int errnum = caml_unix_code_of_unix_error(err);
+  return caml_copy_string(caml_strerror(errnum, buf, sizeof(buf)));
+}
+
+#else
+
 CAMLprim value caml_unix_error_message(value err)
 {
   char buf[1024];
@@ -32,3 +43,5 @@ CAMLprim value caml_unix_error_message(value err)
     */
     buf);
 }
+
+#endif

--- a/ocaml/runtime4/caml/sys.h
+++ b/ocaml/runtime4/caml/sys.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+CAMLextern char * caml_strerror(int errnum, char * buf, size_t buflen);
+
 #define NO_ARG Val_int(0)
 
 CAMLnoreturn_start

--- a/ocaml/runtime4/sys.c
+++ b/ocaml/runtime4/sys.c
@@ -61,6 +61,23 @@
 #include "caml/callback.h"
 #include "caml/startup_aux.h"
 
+CAMLexport char * caml_strerror(int errnum, char * buf, size_t buflen)
+{
+#ifdef _WIN32
+  /* Windows has a thread-safe strerror */
+  return strerror(errnum);
+#else
+  int res = strerror_r(errnum, buf, buflen);
+  /* glibc<2.13 returns -1/sets errno, >2.13 returns +ve errno.
+     We assume that buffer size is large enough not to get ERANGE,
+     so we assume we got EINVAL. */
+  if (res != 0) {
+    snprintf(buf, buflen, "Unknown error %d", errnum);
+  }
+  return buf;
+#endif
+}
+
 static char * error_message(void)
 {
   return strerror(errno);


### PR DESCRIPTION
As subject.