### PR TITLE
zero_alloc: fix treatment of caml_flambda2_invalid

### DIFF
--- a/backend/checkmach.mli
+++ b/backend/checkmach.mli
@@ -94,3 +94,5 @@ end
 type iter_witnesses = (string -> Witnesses.components -> unit) -> unit
 
 val iter_witnesses : iter_witnesses
+
+val is_check_enabled : Cmm.codegen_option list -> string -> Debuginfo.t -> bool

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -645,3 +645,5 @@ let equal_integer_comparison left right =
     false
 
 let all_properties = [Zero_alloc]
+
+let caml_flambda2_invalid = "caml_flambda2_invalid"

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -643,3 +643,5 @@ let equal_integer_comparison left right =
   | Cle, (Ceq | Cne | Clt | Cgt | Cge)
   | Cge, (Ceq | Cne | Clt | Cgt | Cle) ->
     false
+
+let all_properties = [Zero_alloc]

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -396,3 +396,4 @@ val equal_exttype : exttype -> exttype -> bool
 val equal_float_comparison : float_comparison -> float_comparison -> bool
 val equal_memory_chunk : memory_chunk -> memory_chunk -> bool
 val equal_integer_comparison : integer_comparison -> integer_comparison -> bool
+val all_properties : property list

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -397,3 +397,5 @@ val equal_float_comparison : float_comparison -> float_comparison -> bool
 val equal_memory_chunk : memory_chunk -> memory_chunk -> bool
 val equal_integer_comparison : integer_comparison -> integer_comparison -> bool
 val all_properties : property list
+
+val caml_flambda2_invalid : string

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -1077,7 +1077,7 @@ method emit_expr_aux (env:environment) exp ~bound_name :
               let keep_for_checking =
                 not returns &&
                 !current_function_is_check_enabled &&
-                String.equal func "caml_flambda2_invalid"
+                String.equal func Cmm.caml_flambda2_invalid
               in
               let returns, ty =
                 if keep_for_checking then true, typ_int

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -411,6 +411,7 @@ let join_array env rs ~bound_name =
 
 (* Name of function being compiled *)
 let current_function_name = ref ""
+let current_function_is_check_enabled = ref false
 
 module Effect = struct
   type t =
@@ -1070,13 +1071,22 @@ method emit_expr_aux (env:environment) exp ~bound_name :
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
               Some (rd, unclosed_regions)
-          | Iextcall ({ ty_args; returns; _} as r) ->
+          | Iextcall ({ func; ty_args; returns; _} as r) ->
               let (loc_arg, stack_ofs) =
                 self#emit_extcall_args env ty_args new_args in
+              let keep_for_checking =
+                not returns &&
+                !current_function_is_check_enabled &&
+                String.equal func "caml_flambda2_invalid"
+              in
+              let returns, ty =
+                if keep_for_checking then true, typ_int
+                else returns, ty
+              in
               let rd = self#regs_for ty in
               let loc_res =
                 self#insert_op_debug env
-                  (Iextcall {r with stack_ofs = stack_ofs}) dbg
+                  (Iextcall {r with stack_ofs = stack_ofs; returns }) dbg
                   loc_arg (Proc.loc_external_results (Reg.typv rd)) in
               add_naming_op_for_bound_name loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
@@ -1877,6 +1887,8 @@ method private emit_tail_sequence ?at_start env exp =
 
 method emit_fundecl ~future_funcnames f =
   current_function_name := f.Cmm.fun_name.sym_name;
+  current_function_is_check_enabled :=
+    Checkmach.is_check_enabled f.Cmm.fun_codegen_options f.Cmm.fun_name.sym_name f.Cmm.fun_dbg;
   let num_regs_per_arg = Array.make (List.length f.Cmm.fun_args) 0 in
   let rargs =
     List.mapi

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -1942,6 +1942,3 @@ method emit_fundecl ~future_funcnames f =
   }
 
 end
-
-let reset () =
-  current_function_name := ""

--- a/backend/selectgen.mli
+++ b/backend/selectgen.mli
@@ -188,5 +188,3 @@ class virtual selector_generic : object
      because the traversal uses functional object copies. *)
   val contains_calls : bool ref
 end
-
-val reset : unit -> unit

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -243,7 +243,7 @@ let invalid res ~message =
   in
   let call_expr =
     extcall ~dbg ~alloc:false ~is_c_builtin:false ~returns:false ~ty_args:[XInt]
-      "caml_flambda2_invalid" Cmm.typ_void
+      Cmm.caml_flambda2_invalid Cmm.typ_void
       [symbol ~dbg (To_cmm_result.symbol res message_sym)]
   in
   call_expr, res

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -5,3 +5,33 @@
 (rule
  (alias  runtest)
  (action (diff dune.inc dune.inc.gen)))
+
+
+;; Tests that work on in flambda2 only.
+;; This condition is not expressible in "enable_if" clause
+;; because dune does not  support %{config:flamba2} yet.
+
+ (rule
+  (enabled_if (= %{context_name} "main"))
+  (targets fail24.output.corrected)
+  (deps (:ml fail24.ml) filter.sh (:expected fail24.output))
+  (action
+    (with-outputs-to fail24.output.corrected
+     (pipe-outputs
+     (with-accepted-exit-codes 2
+      (bash
+         "if %{bin:ocamlopt.opt} -config | grep -q \"flambda2: true\" ;
+         then
+          %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+           -zero-alloc-check default -checkmach-details-cutoff 20 -O3 ;
+         else
+         # fake it for flambda1 and closure
+          (cat %{expected}; exit 2);
+         fi"))
+     (run "./filter.sh")))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main")))
+ (deps fail24.output fail24.output.corrected)
+ (action (diff fail24.output fail24.output.corrected)))

--- a/tests/backend/checkmach/fail24.ml
+++ b/tests/backend/checkmach/fail24.ml
@@ -1,0 +1,10 @@
+let f x len pos =
+  let[@zero_alloc][@inline] unsafe_set_int64
+                                             ba
+                                             pos
+    =
+    Bigarray.Array1.unsafe_set ba pos (Int64.of_int x)
+  in
+    let ba = Bigarray.Array1.create Int64 C_layout (Array.length len) in
+    unsafe_set_int64 ba pos;
+    ba

--- a/tests/backend/checkmach/fail24.output
+++ b/tests/backend/checkmach/fail24.output
@@ -1,0 +1,8 @@
+File "fail24.ml", line 2, characters 7-17:
+Error: Annotation check for zero_alloc failed on function Fail24.f.unsafe_set_int64 (camlFail24.unsafe_set_int64_HIDE_STAMP)
+
+File "fail24.ml", line 6, characters 4-54:
+Error: Unexpected external call to caml_ba_set_1
+
+File "fail24.ml", line 6, characters 38-54:
+Error: Unexpected allocation of 24 bytes


### PR DESCRIPTION
Fixes a soundness problem in zero_alloc checking.

It turns out that `zero_alloc` annotations are ignored in some cases on functions that became dead because all calls to them were inlined (the functions themselves are not deleted, thanks to #1378). The culprit is `returns=false` field of the `extcall` to `caml_flambda2_invalid`, which is sometimes inserted by flambda2 in dead code. It allows `selectgen` to eliminate the rest of the code of the function, including any allocations, so `zero_alloc` check that runs later on does not report an error. However, the inlined copy of these allocatons may not have been eliminated. This is not sound: the user expects that if the original function is `zero_alloc` then its inlined copies have no allocations. 

The fix is to pretend that a call to `caml_flambda2_invalid` returns when it appears inside a function annotated with `[@zero_alloc]`. This is done in `selectgen` but can probably be done earlier.


Here is an example (can probably be simplied):
```ocaml
let f x len pos =
  let[@zero_alloc][@inline] unsafe_set_int64 ba pos =
    Bigarray.Array1.unsafe_set ba pos (Int64.of_int x)  
  in
  let ba = Bigarray.Array1.create Int64 C_layout (Iarray.length len) in
  unsafe_set_int64 ba pos;
  ba
```
The inner function `unsafe_set_int64` allocates (it contains an `alloc` and an `extcall` to `caml_ba_set_1` that is not marked as `@noalloc`): 
```
(function{dead.ml:7,45-157} assert_zero_alloc
 camlDead__unsafe_set_int64_1_3_code
     (ba/525: val pos/526: int my_closure/527: val)
 (extcall "caml_ba_set_1"{dead.ml:10,4-54} ba/525 pos/526
   (alloc{dead.ml:10,38-54} 2303 G:"caml_int64_ops"
     (>>s (extcall "caml_flambda2_invalid" L:"camlDead__invalid116" int->.)
       1))
   int,int,int->val))
```
but `zero_alloc` check used to succeed because the above cmm code was compiled to:
```
camlDead__unsafe_set_int64_1_3_code(R/0[%rax] R/1[%rbx] R/2[%rdi]) {dead.ml:7,45-157} assert_zero_alloc
  { + R/0[%rax]}
  ba/45 := R/0[%rax]
  { + R/1[%rbx]}
  pos/46 := R/1[%rbx]
  { + R/2[%rdi]}
  my_closure/47 := R/2[%rdi]
  {}
  I/48 := "camlDead__invalid116"
  { + I/48}
  R/2[%rdi] := I/48
  { + R/2[%rdi]}
  extcall "caml_flambda2_invalid" R/2[%rdi] (noalloc)
```