### PR TITLE
Print jkind on locally abstract type

### DIFF
--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -176,7 +176,7 @@ val instance_list: type_expr list -> type_expr list
         (* Take an instance of a list of type schemes *)
 val new_local_type:
         ?loc:Location.t -> ?manifest_and_scope:(type_expr * int) ->
-        Jkind.t -> type_declaration
+        Jkind.t -> jkind_annot:Jkind.annotation option -> type_declaration
 val existential_name: constructor_description -> type_expr -> string
 
 type existential_treatment =

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -1402,6 +1402,7 @@ let solve_constructor_annotation tps env name_list sty ty_args ty_ex =
             annotations on explicitly quantified vars in gadt constructors.
             See: https://github.com/ocaml/ocaml/pull/9584/ *)
         let decl = new_local_type ~loc:name.loc
+                     ~jkind_annot:None
                      (Jkind.value ~why:Existential_type_variable) in
         let (id, new_env) =
           Env.enter_type ~scope:expansion_scope name.txt decl !env in
@@ -7656,7 +7657,7 @@ and type_newtype ~loc ~env ~expected_mode ~rue ~attributes
   (* Use [with_local_level] just for scoping *)
   let body, ety = with_local_level begin fun () ->
     (* Create a fake abstract type declaration for name. *)
-    let decl = new_local_type ~loc jkind in
+    let decl = new_local_type ~loc jkind ~jkind_annot in
     let scope = create_scope () in
     let (id, new_env) = Env.enter_type ~scope name decl env in
 


### PR DESCRIPTION
This PR is for merlin's benefit.

When printing a locally abstract type's "declaration", print the jkind annotation written by the user. Before we dropped this.

"Declaration" is in scare quotes because this declaration of course does not exist in the source code and is forged by the type-checker. But it's already the case that merlin prints such a "declaration" when queried by the user:

```
let f (type a) (x : a) = x
                    ^
                          
Merlin output: "type a"
```

The specific change enacted by this PR:
```
let f (type a : immediate) (x : a) = x
                                ^
                          
Old merlin output: "type a"
New merlin output: "type a : immediate"
```

Testing: done in https://github.com/janestreet/merlin-jst/pull/29