### PR TITLE
Backport caml_sys_is_regular_file to the 4 runtime

### DIFF
--- a/ocaml/runtime4/sys.c
+++ b/ocaml/runtime4/sys.c
@@ -282,6 +282,18 @@ CAMLprim value caml_sys_is_directory(value name)
 #endif
 }
 
+CAMLprim value caml_sys_is_regular_file(value name)
+{
+  CAMLparam1(name);
+  int mode = caml_sys_file_mode(name);
+  if (mode == -1) caml_sys_error(name);
+#ifdef S_ISREG
+  CAMLreturn(Val_bool(S_ISREG(mode)));
+#else
+  CAMLreturn(Val_bool(mode & S_IFREG));
+#endif
+}
+
 CAMLprim value caml_sys_remove(value name)
 {
   CAMLparam1(name);

--- a/ocaml/runtime4/sys.c
+++ b/ocaml/runtime4/sys.c
@@ -236,6 +236,25 @@ CAMLprim value caml_sys_close(value fd_v)
   return Val_unit;
 }
 
+static int caml_sys_file_mode(value name)
+{
+#ifdef _WIN32
+  struct _stati64 st;
+#else
+  struct stat st;
+#endif
+  char_os * p;
+  int ret;
+
+  if (! caml_string_is_c_safe(name)) { errno = ENOENT; return -1; }
+  p = caml_stat_strdup_to_os(String_val(name));
+  caml_enter_blocking_section();
+  ret = stat_os(p, &st);
+  caml_leave_blocking_section();
+  caml_stat_free(p);
+  if (ret == -1) return -1; else return st.st_mode;
+}
+
 CAMLprim value caml_sys_file_exists(value name)
 {
 #ifdef _WIN32

--- a/ocaml/stdlib/sys.ml.in
+++ b/ocaml/stdlib/sys.ml.in
@@ -52,10 +52,7 @@ external runtime_parameters : unit -> string = "caml_runtime_parameters"
 
 external file_exists: string -> bool = "caml_sys_file_exists"
 external is_directory : string -> bool = "caml_sys_is_directory"
-(* BACKPORT
-   not in 4.x runtime (caml_sys_is_regular_file)
 external is_regular_file : string -> bool = "caml_sys_is_regular_file"
-*)
 external remove: string -> unit = "caml_sys_remove"
 external rename : string -> string -> unit = "caml_sys_rename"
 external getenv: string -> string = "caml_sys_getenv"

--- a/ocaml/stdlib/sys.mli
+++ b/ocaml/stdlib/sys.mli
@@ -45,14 +45,11 @@ external is_directory : string -> bool = "caml_sys_is_directory"
     @since 3.10
 *)
 
-(* BACKPORT
-   not in 4.x runtime (caml_sys_is_regular_file)
 external is_regular_file : string -> bool = "caml_sys_is_regular_file"
 (** Returns [true] if the given name refers to a regular file,
     [false] if it refers to another kind of file.
     @raise Sys_error if no file exists with the given name.
     @since 5.1
-*)
 *)
 
 external remove : string -> unit = "caml_sys_remove"


### PR DESCRIPTION
This enables uncommenting of the `is_regular_file` function in `Sys`.