### PR TITLE
`Cfg_dominators`: tentative fix for dead code handling

### DIFF
--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -72,35 +72,106 @@ let invariant_doms : Cfg.t -> doms -> unit =
           doms))
     doms
 
-(* CR-soon xclerc for xclerc: factor out with the function in
-   `Regalloc_ls_utils`; the only difference is the point where `f` is called. *)
-let iter_blocks_dfs : Cfg.t -> f:(Cfg.basic_block -> unit) -> unit =
- fun cfg ~f ->
-  let marked = ref Label.Set.empty in
-  let rec iter (label : Label.t) : unit =
-    if not (Label.Set.mem label !marked)
-    then (
-      marked := Label.Set.add label !marked;
-      let block = Cfg.get_block_exn cfg label in
-      Label.Set.iter
-        (fun succ_label -> iter succ_label)
-        (Cfg.successor_labels ~normal:true ~exn:true block);
-      f block)
-  in
-  iter cfg.entry_label;
-  (* note: some block may not have been seen since we currently cannot remove
-     all non-reachable blocks. *)
-  if Label.Set.cardinal !marked <> Label.Tbl.length cfg.blocks
-  then
-    Cfg.iter_blocks cfg ~f:(fun label block ->
-        if not (Label.Set.mem label !marked) then f block)
+module DFSUtils : sig
+  type component
+  (* Identifier of a "component", which is the set of blocks reachable from a
+     given (pseudo-)entry (i.e. a block with no predecessors). *)
 
-(* CR-soon xclerc for xclerc: we could compute the stack once, and use
-   `Stack.copy` when we need to iterate. *)
-let reverse_post_order : Cfg.t -> f:(Cfg.basic_block -> unit) -> unit =
- fun cfg ~f ->
+  val equal_component : component -> component -> bool
+
+  type components
+  (* Map from block labels to component identifier. *)
+
+  val find_component : components -> Label.t -> component
+  (* [find_component components label] return the component identifier for
+     [label] in [components] - cannot raise. *)
+
+  val iter_blocks : Cfg.t -> f:(Cfg.basic_block -> unit) -> components
+  (* [iter_blocks cfg ~f] iterates over the blocks of [cfg] in depth-first
+     order, calling [f] on each node. In order to visit all blocks, even the
+     ones actually dead, it first iterates from the entry point of [cfg], and
+     then does the same from each pseudo-entry. The entry, and then each
+     pseudo-entry, defines a component (set of blocks reachable from that
+     origin), and the returned value is a (total) map from block labels to
+     components. *)
+end = struct
+  type component = int
+
+  let equal_component = Int.equal
+
+  type components = component Label.Tbl.t
+
+  let find_component components label =
+    match Label.Tbl.find_opt components label with
+    | None -> Misc.fatal_errorf "no component identifier for label %d" label
+    | Some component -> component
+
+  let iter_blocks_from :
+      Cfg.t ->
+      from:Label.t ->
+      f:(Cfg.basic_block -> unit) ->
+      component:component ->
+      components:components ->
+      unit =
+   fun cfg ~from ~f ~component ~components ->
+    let rec iter (label : Label.t) : unit =
+      if not (Label.Tbl.mem components label)
+      then (
+        Label.Tbl.replace components label component;
+        let block = Cfg.get_block_exn cfg label in
+        Label.Set.iter
+          (fun succ_label -> iter succ_label)
+          (Cfg.successor_labels ~normal:true ~exn:true block);
+        f block)
+    in
+    iter from
+
+  exception Found of Label.t
+
+  let find_pseudo_entry : Cfg.t -> components:components -> Label.t =
+   fun cfg ~components ->
+    try
+      Cfg.iter_blocks cfg ~f:(fun label block ->
+          if (not (Label.Tbl.mem components label))
+             && Label.Set.is_empty block.predecessors
+          then raise (Found label));
+      Misc.fatal_error "did not find a block with no predecessors"
+    with Found label -> label
+
+  let rec iter_blocks_pseudo_entries :
+      Cfg.t ->
+      f:(Cfg.basic_block -> unit) ->
+      component:component ->
+      components:components ->
+      unit =
+   fun cfg ~f ~component ~components ->
+    if Label.Tbl.length components < Label.Tbl.length cfg.blocks
+    then (
+      let from = find_pseudo_entry cfg ~components in
+      iter_blocks_from cfg ~from ~f ~component ~components;
+      iter_blocks_pseudo_entries cfg ~f ~component:(succ component) ~components)
+
+  let iter_blocks : Cfg.t -> f:(Cfg.basic_block -> unit) -> components =
+   fun cfg ~f ->
+    let components = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
+    iter_blocks_from cfg ~from:cfg.entry_label ~f ~component:0 ~components;
+    iter_blocks_pseudo_entries cfg ~f ~component:1 ~components;
+    components
+end
+
+type post_order_stack = Cfg.basic_block Stack.t
+
+let build_reverse_post_order : Cfg.t -> post_order_stack * DFSUtils.components =
+ fun cfg ->
   let stack : Cfg.basic_block Stack.t = Stack.create () in
-  iter_blocks_dfs cfg ~f:(fun block -> Stack.push block stack);
+  let components =
+    DFSUtils.iter_blocks cfg ~f:(fun block -> Stack.push block stack)
+  in
+  stack, components
+
+let iter_stack : post_order_stack -> f:(Cfg.basic_block -> unit) -> unit =
+ fun post_order_stack ~f ->
+  let stack = Stack.copy post_order_stack in
   while not (Stack.is_empty stack) do
     let block : Cfg.basic_block = Stack.pop stack in
     f block
@@ -108,13 +179,14 @@ let reverse_post_order : Cfg.t -> f:(Cfg.basic_block -> unit) -> unit =
 
 type order = int Label.Tbl.t
 
-let build_order : Cfg.t -> order =
+let build_order : Cfg.t -> post_order_stack * order * DFSUtils.components =
  fun cfg ->
   let order = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
-  reverse_post_order cfg ~f:(fun (block : Cfg.basic_block) ->
+  let stack, components = build_reverse_post_order cfg in
+  iter_stack stack ~f:(fun (block : Cfg.basic_block) ->
       let label = block.start in
       Label.Tbl.replace order label (Label.Tbl.length order));
-  order
+  stack, order, components
 
 (* See Figure 3 in the cited article. The only difference is the comparison,
    which is reversed because of the way we distribute the idenfier when we build
@@ -130,44 +202,71 @@ let intersect : doms -> order -> Label.t -> Label.t -> Label.t =
     while before_in_post_order !finger1 !finger2 do
       match Label.Tbl.find_opt doms !finger1 with
       | None -> assert false
-      | Some f -> finger1 := f
+      | Some f ->
+        assert (not (Label.equal f !finger1));
+        finger1 := f
     done;
     while before_in_post_order !finger2 !finger1 do
       match Label.Tbl.find_opt doms !finger2 with
       | None -> assert false
-      | Some f -> finger2 := f
+      | Some f ->
+        assert (not (Label.equal f !finger2));
+        finger2 := f
     done
   done;
   !finger1
 
-(* See Figure 3 in the cited article. The only difference is "Undefined", which
-   is encoded here as a missing key. *)
+(* See Figure 3 in the cited article. There are two differences:
+
+   - a minor one: "Undefined", which is encoded here as a missing key;
+
+   - a major one: we perform the computation "per-component", in order to handle
+   dead code. *)
 let compute_doms : Cfg.t -> doms =
  fun cfg ->
   let doms = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
-  Label.Tbl.replace doms cfg.entry_label cfg.entry_label;
-  let order = build_order cfg in
+  Cfg.iter_blocks cfg ~f:(fun label block ->
+      if Label.Set.is_empty block.predecessors
+      then Label.Tbl.replace doms label label);
+  (match Label.Tbl.find_opt doms cfg.entry_label with
+  | None -> assert false
+  | Some label -> assert (Label.equal label cfg.entry_label));
+  let stack, order, components = build_order cfg in
   let changed = ref true in
   while !changed do
     changed := false;
-    reverse_post_order cfg ~f:(fun (block : Cfg.basic_block) ->
+    iter_stack stack ~f:(fun (block : Cfg.basic_block) ->
         let label = block.start in
-        if not (Label.equal label cfg.entry_label)
+        let same =
+          match Label.Tbl.find_opt doms label with
+          | None -> false
+          | Some label' -> Label.equal label label'
+        in
+        if not same
         then (
+          let label_component = DFSUtils.find_component components label in
           let new_idom = ref None in
           let predecessor_labels = Cfg.predecessor_labels block in
           List.iter predecessor_labels ~f:(fun predecessor_label ->
-              match Label.Tbl.find_opt doms predecessor_label with
-              | None -> ()
-              | Some _ -> (
-                match !new_idom with
-                | None -> new_idom := Some predecessor_label
-                | Some new_idom_pred ->
-                  new_idom
-                    := Some
-                         (intersect doms order predecessor_label new_idom_pred)));
+              let predecessor_component =
+                DFSUtils.find_component components predecessor_label
+              in
+              if DFSUtils.equal_component label_component predecessor_component
+              then
+                match Label.Tbl.find_opt doms predecessor_label with
+                | None -> ()
+                | Some _ -> (
+                  match !new_idom with
+                  | None -> new_idom := Some predecessor_label
+                  | Some new_idom_pred ->
+                    new_idom
+                      := Some
+                           (intersect doms order predecessor_label new_idom_pred)
+                  ));
           let new_idom =
-            match !new_idom with None -> label | Some new_idom -> new_idom
+            match !new_idom with
+            | None -> Misc.fatal_errorf "no new idom for label %d" label
+            | Some new_idom -> new_idom
           in
           match Label.Tbl.find_opt doms label with
           | None ->

--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -190,7 +190,7 @@ let build_order : Cfg.t -> post_order_stack * order * DFSUtils.components =
 
 (* See Figure 3 in the cited article. The only difference is the comparison,
    which is reversed because of the way we distribute the idenfier when we build
-   `post_order`. *)
+   `post_order`. Both labels are in the same component. *)
 let intersect : doms -> order -> Label.t -> Label.t -> Label.t =
  fun doms post_order b1 b2 ->
   let finger1 = ref b1 in


### PR DESCRIPTION
Pull request #1868, which was meant to support
functions whose dominators structure was a forest
rather than a tree, is incorrect and in (very)
rare cases leads to an infinite loop.

The reason why we wanted to support forests is
because we can end up with a CFG containing
dead code (*i.e.* blocks which cannot be reached
from the entry point). If all reachable blocks
on one hand, and all unreachable blocks on the
other hand live in unconnected sub-graphs, the
changes in #1868 are fine.

However, if a block has a predecessor which
is reachable and another one which is not, this
can result in a infinite loop in the `intersect`
function. This function essentially starts from
two blocks and moves "upwards" until it finds a
common ancestor. Such an ancestor is
unfortunately not guaranteed to exist in
presence of dead code.

This pull request fixes the issue by first computing
the "components" of the CFG and, by then
essentially running the main part of the algorithm
"within" components. A component is the set of
blocks which can be reached from a given block
with no predecessors. The first component is the
one whose starting block is the entry point of the
CFG.

Inside a component we know a common ancestor
exists. Working "inside" components means that
when a block would be reached from two (or more)
origins, we arbitrarily pick one. Since we start from
the entry point, we know that all reachable blocks
are in the same component. We may arbitrarily cut
unreachable portions of the graphs into components,
but that does not matter since it is about dead code.


note: the above relies on the fact that unreachable
components have a "pseudo-entry", *i.e.* a node
with no predecessors. It is currently true because
all unreachable blocks will eventually an exception
handler as their origin, but we may want to not rely
on this property. (If the property does no hold, a
fatal error will be raised.)
