### PR TITLE
Add caml_hot__code{begin,end} symbols in runtime5

### DIFF
--- a/ocaml/runtime/amd64.S
+++ b/ocaml/runtime/amd64.S
@@ -404,11 +404,15 @@
 #if defined(FUNCTION_SECTIONS)
         TEXT_SECTION(caml_hot.code_begin)
         .globl  G(caml_hot.code_begin)
+        .globl  G(caml_hot__code_begin)
 G(caml_hot.code_begin):
+G(caml_hot__code_begin):
 
         TEXT_SECTION(caml_hot.code_end)
         .globl  G(caml_hot.code_end)
+        .globl  G(caml_hot__code_end)
 G(caml_hot.code_end):
+G(caml_hot__code_end):
 #endif
 
 /******************************************************************************/

--- a/ocaml/runtime/arm64.S
+++ b/ocaml/runtime/arm64.S
@@ -137,11 +137,15 @@
 #if defined(FUNCTION_SECTIONS)
         TEXT_SECTION(caml_hot.code_begin)
         .globl  G(caml_hot.code_begin)
+        .globl  G(caml_hot__code_begin)
 G(caml_hot.code_begin):
+G(caml_hot__code_begin):
 
         TEXT_SECTION(caml_hot.code_end)
         .globl  G(caml_hot.code_end)
+        .globl  G(caml_hot__code_end)
 G(caml_hot.code_end):
+G(caml_hot__code_end):
 #endif
 
 #if defined(SYS_macosx)


### PR DESCRIPTION
This allows C `extern` declarations to be used to get hold of these symbols under runtime5.  The runtime5 symbols involving "`.`" characters cannot be accessed in this manner, as the full stop is illegal in C identifiers.