### PR TITLE
Fix caml_gc_compaction in the 5 runtime to run finalizers

### DIFF
--- a/ocaml/runtime/gc_ctrl.c
+++ b/ocaml/runtime/gc_ctrl.c
@@ -268,7 +268,7 @@ static value gc_full_major_exn(int force_compaction)
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
     caml_empty_minor_heaps_once();
-    caml_finish_major_cycle(force_compaction);
+    caml_finish_major_cycle(force_compaction && i == 2);
     exn = caml_process_pending_actions_exn();
     if (Is_exception_result(exn)) break;
   }

--- a/ocaml/runtime/gc_ctrl.c
+++ b/ocaml/runtime/gc_ctrl.c
@@ -299,8 +299,7 @@ CAMLprim value caml_gc_compaction(value v)
   Caml_check_caml_state();
   CAML_EV_BEGIN(EV_EXPLICIT_GC_COMPACT);
   CAMLassert (v == Val_unit);
-  value exn = gc_major_exn(1);
-  ++ Caml_state->stat_forced_major_collections;
+  value exn = gc_full_major_exn();
   CAML_EV_END(EV_EXPLICIT_GC_COMPACT);
   return caml_raise_async_if_exception(exn, "");
 }


### PR DESCRIPTION
At present, `caml_gc_compaction` in the 5 runtime doesn't do a full major collection, meaning that finalizers aren't run.  At least in the JS tree there are multiple places that assume compaction does run finalizers, and it seems a reasonable and useful assumption to me.  This small patch fixes this.