### PR TITLE
fix `custom_condvar` initialization

### DIFF
--- a/ocaml/runtime/caml/platform.h
+++ b/ocaml/runtime/caml/platform.h
@@ -108,7 +108,7 @@ void caml_plat_assert_all_locks_unlocked(void);
 Caml_inline void caml_plat_unlock(caml_plat_mutex*);
 void caml_plat_mutex_free(caml_plat_mutex*);
 typedef struct { custom_condvar cond; caml_plat_mutex* mutex; } caml_plat_cond;
-#define CAML_PLAT_COND_INITIALIZER(m) { PTHREAD_COND_INITIALIZER, m }
+#define CAML_PLAT_COND_INITIALIZER(m) { CUSTOM_COND_INITIALIZER, m }
 void caml_plat_cond_init(caml_plat_cond*, caml_plat_mutex*);
 void caml_plat_wait(caml_plat_cond*);
 /* like caml_plat_wait, but if nanoseconds surpasses the second parameter

--- a/ocaml/runtime/caml/sync.h
+++ b/ocaml/runtime/caml/sync.h
@@ -31,15 +31,17 @@ CAMLextern int caml_mutex_unlock(sync_mutex mut);
 
 /* If we're using glibc, use a custom condition variable implementation to
    avoid this bug: https://sourceware.org/bugzilla/show_bug.cgi?id=25847
-   
+
    For now we only have this on linux because it directly uses the linux futex
    syscalls. */
 #if defined(__linux__) && defined(__GNU_LIBRARY__) && defined(__GLIBC__) && defined(__GLIBC_MINOR__)
 typedef struct {
   volatile unsigned counter;
 } custom_condvar;
+#define CUSTOM_COND_INITIALIZER {0}
 #else
 typedef pthread_cond_t custom_condvar;
+#define CUSTOM_COND_INITIALIZER PTHREAD_COND_INITIALIZER
 #endif
 
 #endif /* CAML_INTERNALS */


### PR DESCRIPTION
This fixes the warning caused by #2076 . I checked that there is no other occurrence of `PTHREAD_COND_INITIALIZER` in the whole source tree.