### PR TITLE
Make local GC scanning respect header reserved bits

### DIFF
--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -93,6 +93,8 @@ typedef opcode_t * code_t;
 /* Structure of the header:
 
 For 16-bit and 32-bit architectures:
+
+len     22        2      8
      +--------+-------+-----+
      | wosize | color | tag |
      +--------+-------+-----+
@@ -100,13 +102,16 @@ bits  31    10 9     8 7   0
 
 For 64-bit architectures:
 
-     +----------+--------+-------+-----+
-     | reserved | wosize | color | tag |
-     +----------+--------+-------+-----+
-bits  63    64-R 63-R  10 9     8 7   0
+len        R         1     53-R       2      8
+     +----------+--------+--------+-------+-----+
+     | reserved | lcolor | wosize | color | tag |
+     +----------+--------+--------+-------+-----+
+bits  63    64-R 63-R 63-R 62-R 10 9     8 7   0
 
 where 0 <= R <= 31 is HEADER_RESERVED_BITS, set with the
---enable-reserved-header-bits=R argument to configure.
+--enable-reserved-header-bits=R argument to configure,
+
+and lcolor is a bit used to mark local allocations during GC scanning.
 
 */
 

--- a/ocaml/runtime/fiber.c
+++ b/ocaml/runtime/fiber.c
@@ -225,7 +225,7 @@ void caml_get_stack_sp_pc (struct stack_info* stack,
 
 
 static const header_t Hd_high_bit =
-  ((uintnat)-1) << (sizeof(uintnat) * 8 - 1);
+  ((uintnat)-1) << (sizeof(uintnat) * 8 - 1 - HEADER_RESERVED_BITS);
 
 
 /* Returns the arena number of a block,


### PR DESCRIPTION
Prior to this PR, the bit used by the GC when it scanned the local stack would clobber the top reserved header bits (if any bits were reserved). This PR shifts that bit down by the number of reserved header bits to avoid this clobbering.

This is anticipation of using reserved header bits for mixed blocks.