### PR TITLE
Take the local scanning bit into account for Max_wosize

### DIFF
--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -117,6 +117,12 @@ and lcolor is a bit used to mark local allocations during GC scanning.
 
 #define HEADER_BITS (sizeof(header_t) * CHAR_BIT)
 
+/* lcolor above. We don't use this in the definition of HEADER_WOSIZE_BITS
+   because this bit is only used in GC scanning of locals and then set back
+   to 0 later. However, it does affect Max_wosize.
+*/
+#define HEADER_LOCAL_GC_SCANNING_BITS 1
+
 #define HEADER_TAG_BITS 8
 #define HEADER_TAG_MASK ((1ull << HEADER_TAG_BITS) - 1ull)
 
@@ -174,7 +180,8 @@ and lcolor is a bit used to mark local allocations during GC scanning.
 #define Bp_hp(hp) ((char *) Val_hp (hp))
 
 #define Num_tags (1ull << HEADER_TAG_BITS)
-#define Max_wosize ((1ull << HEADER_WOSIZE_BITS) - 1ull)
+#define Max_wosize \
+  ((1ull << (HEADER_WOSIZE_BITS - HEADER_LOCAL_GC_SCANNING_BITS)) - 1ull)
 
 #define Wosize_val(val) (Wosize_hd (Hd_val (val)))
 #define Wosize_op(op) (Wosize_val (op))

--- a/ocaml/testsuite/tests/runtime-errors/max_wosize.ml
+++ b/ocaml/testsuite/tests/runtime-errors/max_wosize.ml
@@ -1,0 +1,28 @@
+(* TEST
+   modules = "max_wosize_stub.c"
+   * runtime5
+     * native
+*)
+
+(* This test demonstrates that you can't make a block that's
+   larger than what's supported by the header format. This test is
+   very much tied to the current format of the header, so if we
+   change that format substantially, we should delete the test or
+   revamp it.
+*)
+
+external header_reserved_bits : unit -> int = "caml_header_reserved_bits"
+let header_reserved_bits = header_reserved_bits ()
+
+let () =
+  let num_non_wosize_bits =
+    8 (* tag bits *)
+    + 2 (* GC color bits *)
+    + 1 (* local scanning bit *)
+    + header_reserved_bits
+  in
+  let max_allowed_size = (1 lsl (Sys.word_size - num_non_wosize_bits)) - 1 in
+  try
+    ignore (Array.make (max_allowed_size + 1) 0 : int array);
+    failwith "should have raised"
+  with _ -> ()

--- a/ocaml/testsuite/tests/runtime-errors/max_wosize.ml
+++ b/ocaml/testsuite/tests/runtime-errors/max_wosize.ml
@@ -1,7 +1,7 @@
 (* TEST
    modules = "max_wosize_stub.c"
    * runtime5
-     * native
+   ** native
 *)
 
 (* This test demonstrates that you can't make a block that's

--- a/ocaml/testsuite/tests/runtime-errors/max_wosize.output
+++ b/ocaml/testsuite/tests/runtime-errors/max_wosize.output
@@ -1,0 +1,1 @@
+Exception: Invalid_argument "Array.make".

--- a/ocaml/testsuite/tests/runtime-errors/max_wosize_stub.c
+++ b/ocaml/testsuite/tests/runtime-errors/max_wosize_stub.c
@@ -1,0 +1,7 @@
+#include <caml/mlvalues.h>
+
+/* returns a value that represents a number of words */
+CAMLprim value caml_header_reserved_bits(value unit)
+{
+  return Val_long(HEADER_RESERVED_BITS) ;
+}


### PR DESCRIPTION
Halve `Max_wosize` to account for the fact that we use a bit for tracking locals/externals during GC. This ensures that (e.g.) array creation operations will raise if you try to create an array whose size would need to use this bit.