### PR TITLE
Enable warn-error by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
             build_ocamlparam: _,ocamlcfg=0
 
           - name: flambda2_macos
-            config: --enable-middle-end=flambda2
+            config: --enable-middle-end=flambda2 --disable-warn-error
             os: macos-latest
 
           - name: irc

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -1632,7 +1632,7 @@ Optional Features:
                           headers
   --disable-stdlib-manpages
                           do not build or install the library man pages
-  --enable-warn-error     treat C compiler warnings as errors
+  --disable-warn-error    do not treat C compiler warnings as errors
   --disable-flat-float-array
                           do not use flat float arrays
   --disable-function-sections
@@ -13646,8 +13646,8 @@ lib_dynlink=true
 
 if test x"$enable_runtime5" = x"yes"
 then :
-  otherlibraries = "$otherlibraries runtime_events"
-   lib_runtime_events = true
+  otherlibraries="$otherlibraries runtime_events"
+   lib_runtime_events=true
 fi
 
 if test x"$enable_unix_lib" != "xno"
@@ -13767,8 +13767,10 @@ case $ocaml_cv_cc_vendor in #(
 -Wold-style-definition" ;;
 esac
 
-case $enable_warn_error,false in #(
-  yes,*|,true) :
+case $enable_warn_error in #(
+  no) :
+     ;; #(
+  *) :
     cc_warnings="$cc_warnings $warn_error_flag" ;; #(
   *) :
      ;;

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -474,8 +474,8 @@ AC_ARG_ENABLE([stdlib-manpages],
     [do not build or install the library man pages])])
 
 AC_ARG_ENABLE([warn-error],
-  [AS_HELP_STRING([--enable-warn-error],
-    [treat C compiler warnings as errors])])
+  [AS_HELP_STRING([--disable-warn-error],
+    [do not treat C compiler warnings as errors])])
 
 AC_ARG_VAR([WINDOWS_UNICODE_MODE],
   [how to handle Unicode under Windows: ansi, compatible])
@@ -750,8 +750,9 @@ AS_CASE([$ocaml_cv_cc_vendor],
   cc_warnings="-Wall -Wno-pragmas -Wint-conversion -Wstrict-prototypes \
 -Wold-style-definition"])
 
-AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
-  [yes,*|,true],
+AS_CASE([$enable_warn_error],
+  [no], [],
+  [*],
     [cc_warnings="$cc_warnings $warn_error_flag"])
 
 # We select high optimization levels, provided we can turn off:


### PR DESCRIPTION
Change the default for the `warn-error` configure flag:
  * Previously, it was disabled by default and had to be turned on with `--enable-warn-error`
  * Now, it is enabled by default and has to be turned off with `--disable-warn-error`

I think it's a good idea to need to fix warnings in the development process. This would have caught e.g. https://github.com/ocaml-flambda/flambda-backend/pull/2136.