### PR TITLE
Delete duplicate copy of `print_out_jkind`

### DIFF
--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -420,10 +420,6 @@ let mode_agree expected real =
   uniqueness_agree expected.oam_uniqueness real.oam_uniqueness &&
   linearity_agree expected.oam_linearity real.oam_linearity
 
-let print_out_jkind ppf = function
-  | Olay_const jkind -> fprintf ppf "%s" (Jkind.string_of_const jkind)
-  | Olay_var v     -> fprintf ppf "%s" v
-
 let is_local mode =
   match mode.oam_locality with
   | Olm_local -> true


### PR DESCRIPTION
Viz. https://github.com/ocaml-flambda/flambda-backend/blob/36600aab2afb165cdf1bb4315ef00bb29eb538e7/ocaml/typing/oprint.ml#L318-L320

As pointed out by @alanechang in https://github.com/janestreet/merlin-jst/pull/32.