### PR TITLE
Fix ast iteration/mapping for layout type declarations

### DIFF
--- a/ocaml/parsing/ast_iterator.ml
+++ b/ocaml/parsing/ast_iterator.ml
@@ -178,12 +178,19 @@ module T = struct
     | Ptyp_extension x -> sub.extension sub x
 
   let iter_type_declaration sub
-      {ptype_name; ptype_params; ptype_cstrs;
+     ({ptype_name; ptype_params; ptype_cstrs;
        ptype_kind;
        ptype_private = _;
        ptype_manifest;
        ptype_attributes;
-       ptype_loc} =
+       ptype_loc} as ty_decl) =
+    let ptype_attributes =
+      match Jane_syntax.Layouts.of_type_declaration ty_decl with
+      | Some (jkind, attrs) ->
+          iter_loc_txt sub sub.jkind_annotation jkind;
+          attrs
+      | None -> ptype_attributes
+    in
     iter_loc sub ptype_name;
     List.iter (iter_fst (sub.typ sub)) ptype_params;
     List.iter

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -1742,10 +1742,18 @@ and type_def_list ctxt f (rf, exported, l) =
       else if exported then " ="
       else " :="
     in
-    pp f "@[<2>%s %a%a%s%s%a@]%a" kwd
+    let layout_annot, x =
+      match Jane_syntax.Layouts.of_type_declaration x with
+      | None -> "", x
+      | Some (jkind, remaining_attributes) ->
+          Printf.sprintf " : %s"
+            (Jane_asttypes.jkind_to_string jkind.txt),
+          { x with ptype_attributes = remaining_attributes }
+    in
+    pp f "@[<2>%s %a%a%s%s%s%a@]%a" kwd
       nonrec_flag rf
       (type_params ctxt) x.ptype_params
-      x.ptype_name.txt eq
+      x.ptype_name.txt layout_annot eq
       (type_declaration ctxt) x
       (item_attributes ctxt) x.ptype_attributes
   in

--- a/ocaml/testsuite/tests/parsetree/ppx_no_op.ml
+++ b/ocaml/testsuite/tests/parsetree/ppx_no_op.ml
@@ -1,0 +1,8 @@
+open Ast_mapper
+
+(* This PPX rewriter does nothing. *)
+
+let () =
+  Language_extension.enable_maximal ();
+  Ast_mapper.register "no-op" (fun _ -> Ast_mapper.default_mapper);
+;;

--- a/ocaml/testsuite/tests/parsetree/source_jane_street.ml
+++ b/ocaml/testsuite/tests/parsetree/source_jane_street.ml
@@ -25,6 +25,8 @@ let f (type a : immediate) (type b : immediate)
 
 module type S_for_layouts = sig
   type t : float64
+
+  type variant = A : ('a : immediate). 'a -> variant
 end;;
 
 type ('a : immediate) for_layouts = 'a;;

--- a/ocaml/testsuite/tests/parsetree/source_jane_street.ml
+++ b/ocaml/testsuite/tests/parsetree/source_jane_street.ml
@@ -23,6 +23,12 @@ let f (type a : immediate) (type b : immediate)
       (type (c : immediate) (d : immediate))
   = ();;
 
+module type S_for_layouts = sig
+  type t : float64
+end;;
+
+type ('a : immediate) for_layouts = 'a;;
+
 (******************)
 (* Comprehensions *)
 
@@ -61,7 +67,7 @@ let f (type a : immediate) (type b : immediate)
 (* Local *)
 
 (* parameters *)
-let f (local_ x) ~(local_ y) ~z:(local_ z) ?foo:(local_ w = 1) = x + y + z + w;;
+let f (local_ x) ~(local_ y) ~z:(local_ z) ?foo:(local_ w = 1) () = x + y + z + w;;
 
 (* bindings *)
 let g () =
@@ -94,17 +100,22 @@ type 'a parameterized_record = {
 type fn = local_ int -> local_ int;;
 type nested_fn = (local_ int -> local_ int) -> local_ int;;
 type ('a, 'b) labeled_fn =
-  a:local_ 'a -> ?b:local_ b -> local_ 'a -> (int -> local_ 'b);;
+  a:local_ 'a -> ?b:local_ 'b -> local_ 'a -> (int -> local_ 'b);;
 
 (*******************)
 (* Include functor *)
 
+module F_struct (_ : sig end) = struct
+end
+
+module type F_sig = functor (_ : sig end) -> sig end
+
 module T = struct
-  include functor F
+  include functor F_struct
 end;;
 
 module type S = sig
-  include functor F
+  include functor F_sig
 end;;
 
 (********************)
@@ -115,10 +126,15 @@ let f x =
   | [::] -> [::]
   | ([:x:] [@test.attr1]) -> (([:x:])[@test.attr1])
   | ([:x;y:] [@test.attr2][@test.attr3]) ->
-      ([:x;y:] [@test.attr2][@test.attr3]);;
+      ([:x;y:] [@test.attr2][@test.attr3])
+  | _ -> assert false;;
 
 (******************)
 (* Labeled tuples *)
+let z, punned = 4, 5
+let x_must_be_even _ = assert false
+exception Odd
+
 let x = (~x:1, ~y:2)
 let x = ((~x:1, ~y:2) [@test.attr])
 let _ = ( ~x: 5, 2, ~z, ~(punned:int))

--- a/ocaml/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/ocaml/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -1,0 +1,9 @@
+File "source_jane_street.ml", line 27, characters 2-18:
+27 |   type t : float64
+       ^^^^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "jane.erasable.layouts.annot" attribute cannot appear in this context
+
+File "source_jane_street.ml", line 27, characters 2-18:
+27 |   type t : float64
+       ^^^^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "jane.erasable.layouts" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/ocaml/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -1,9 +1,0 @@
-File "source_jane_street.ml", line 27, characters 2-18:
-27 |   type t : float64
-       ^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "jane.erasable.layouts.annot" attribute cannot appear in this context
-
-File "source_jane_street.ml", line 27, characters 2-18:
-27 |   type t : float64
-       ^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "jane.erasable.layouts" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/parsetree/test_ppx.ml
+++ b/ocaml/testsuite/tests/parsetree/test_ppx.ml
@@ -1,0 +1,19 @@
+(* TEST
+readonly_files = "source_jane_street.ml ppx_no_op.ml"
+include ocamlcommon
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+program = "${test_build_directory}/ppx_no_op.exe"
+all_modules = "ppx_no_op.ml"
+*** ocamlc.byte
+module = "source_jane_street.ml"
+flags = "-I ${test_build_directory} \
+         -w -26 \
+         -extension layouts \
+         -extension comprehensions \
+         -ppx ${program}"
+**** check-ocamlc.byte-output
+*)
+
+(* This test ensures that Jane Street syntax continues to be
+   handled properly by the compiler even after applying a PPX rewriter. *)


### PR DESCRIPTION
Demonstrate and fix a bug where type declarations with layouts were causing the compiler to flag warning 53. That's because AST mapping/iteration had a bug: Jane Syntax attributes were being directly exposed to the `attribute` mapper/iterator rather than being hidden.

This PR should be reviewed commit-by-commit. Both commits pass all tests.
  * The first commit fixes a small pretty-printing bug, adds a regression test that runs a no-op ppx driver, and commits the result of the failing test.
  * The second test fixes the mapping/iteration issue, thus fixing the regression test from the previous commit.

How can we prevent this in the future? We should remember to add new syntactical features to this test that exercises them.