### PR TITLE
Fix merge_infos bug

### DIFF
--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -111,7 +111,9 @@ let rec is_tailcall = function
 let preserve_tailcall_for_prim = function
     Popaque _ | Psequor | Psequand
   | Pobj_magic _
-  | Prunstack | Pperform | Presume | Preperform ->
+  | Prunstack | Pperform | Presume | Preperform
+  | Pbox_float _ | Punbox_float
+  | Pbox_int _ | Punbox_int _ ->
       true
   | Pbytes_to_string | Pbytes_of_string
   | Parray_to_iarray | Parray_of_iarray
@@ -127,7 +129,6 @@ let preserve_tailcall_for_prim = function
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
   | Pasrint | Pintcomp _ | Poffsetint _ | Poffsetref _ | Pintoffloat
   | Pfloatofint _ | Pnegfloat _ | Pabsfloat _ | Paddfloat _ | Psubfloat _ | Pmulfloat _
-  | Punbox_float | Pbox_float _ | Punbox_int _ | Pbox_int _
   | Pdivfloat _ | Pfloatcomp _| Punboxed_float_comp _
   | Pstringlength | Pstringrefu  | Pstringrefs
   | Pcompare_ints | Pcompare_floats | Pcompare_bints _

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -1010,7 +1010,6 @@ let lambda_primitive_needs_event_after = function
      collect the call stack. *)
   | Pduprecord _ | Pccall _ | Pfloatofint _ | Pnegfloat _ | Pabsfloat _
   | Paddfloat _ | Psubfloat _ | Pmulfloat _ | Pdivfloat _ | Pstringrefs | Pbytesrefs
-  | Pbox_float _ | Pbox_int _
   | Pbytessets | Pmakearray (Pgenarray, _, _) | Pduparray _
   | Parrayrefu (Pgenarray_ref _ | Pfloatarray_ref _)
   | Parrayrefs _ | Parraysets _ | Pbintofint _ | Pcvtbint _ | Pnegbint _
@@ -1047,7 +1046,10 @@ let lambda_primitive_needs_event_after = function
   | Patomic_exchange | Patomic_cas | Patomic_fetch_add | Patomic_load _
   | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer _ | Popaque _
   | Pdls_get
-  | Pobj_magic _ | Punbox_float | Punbox_int _  -> false
+  | Pobj_magic _ | Punbox_float | Punbox_int _
+  (* These don't allocate in bytecode; they're just identity functions: *)
+  | Pbox_float _ | Pbox_int _
+    -> false
 
 (* Determine if a primitive should be surrounded by an "after" debug event *)
 let primitive_needs_event_after = function

--- a/ocaml/testsuite/tests/typing-layouts-float64/debug_events.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/debug_events.ml
@@ -1,0 +1,7 @@
+(* TEST
+   * bytecode
+   flags = "-g -extension layouts"
+ *)
+
+let f1 f i = Stdlib__Float_u.to_float (f i)
+let f2 f i = Stdlib__Float_u.to_float (f i) +. 0.


### PR DESCRIPTION
When compiling in bytecode with `-g`, we create debug events around every non-trivial primitive. But in bytecode, boxing and unboxing types are actually trivial: they're just identity functions. Accordingly, we want to treat these as trivial, avoiding creating extra events that cause trouble when merged with other events.