### PR TITLE
Add `ocamlyacc` as dependency of `.mly` -> `.ml` pattern rule

### DIFF
--- a/ocaml/Makefile.common
+++ b/ocaml/Makefile.common
@@ -214,7 +214,7 @@ OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
 
 OCAMLYACCFLAGS ?= --strict -v
 
-%.ml %.mli: %.mly
+%.ml %.mli: %.mly $(OCAMLYACC)
 	$(V_OCAMLYACC)$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
 
 SAK = $(ROOTDIR)/$(RUNTIME_DIR)/sak$(EXE)


### PR DESCRIPTION
This missing dependency breaks `make depend`, which depends on `lex/parser.ml` but not the `ocamlyacc` that is needed to actually build it.