### PR TITLE
zero_alloc: relaxed interpretation of [@zero_alloc assume]

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -316,8 +316,7 @@ end = struct
 
   let top w = { nor = V.Top w; exn = V.Top w; div = V.Top w }
 
-  let relaxed w =
-    { nor = V.Safe; exn = V.Top w; div = V.Top w }
+  let relaxed w = { nor = V.Safe; exn = V.Top w; div = V.Top w }
 
   let print ~witnesses ppf { nor; exn; div } =
     let pp = V.print ~witnesses in
@@ -1086,8 +1085,7 @@ end = struct
           (* Assume that the operation does not diverge. *)
           let div = V.Bot in
           { Value.nor; exn; div }
-        else
-          S.transform_specific w s
+        else S.transform_specific w s
       in
       transform t ~next ~exn ~effect "Arch.specific_operation" dbg
     | Idls_get -> Misc.fatal_error "Idls_get not supported"

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -578,3 +578,22 @@
  (enabled_if (= %{context_name} "main"))
  (deps test_zero_alloc_opt2.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check opt -dcse -dcheckmach -dump-into-file -O3)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_assume_fail.output.corrected)
+ (deps (:ml test_assume_fail.ml) filter.sh)
+ (action
+   (with-outputs-to test_assume_fail.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_fail.output test_assume_fail.output.corrected)
+ (action (diff test_assume_fail.output test_assume_fail.output.corrected)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -124,4 +124,5 @@ let () =
   print_test_expected_output ~extra_flags:"-zero-alloc-check opt" ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "fail23";
   print_test ~extra_flags:"-zero-alloc-check opt" ~flambda_only:false "test_zero_alloc_opt1.ml";
   print_test ~extra_flags:"-zero-alloc-check opt" ~flambda_only:false "test_zero_alloc_opt2.ml";
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_assume_fail";
   ()

--- a/tests/backend/checkmach/test_assume_fail.ml
+++ b/tests/backend/checkmach/test_assume_fail.ml
@@ -1,0 +1,12 @@
+let[@zero_alloc assume][@inline never][@specialise never][@local never] bar x =
+  if x > 0 then failwith (Printf.sprintf "BOO %d!" x);
+  (x+1,x)
+
+let[@zero_alloc strict] foo x = bar x
+
+
+let[@zero_alloc assume][@inline always] bar' x =
+  if x > 0 then failwith (Printf.sprintf "BOO %d!" x);
+  (x+1,x)
+
+let[@zero_alloc strict] foo' x = bar' x

--- a/tests/backend/checkmach/test_assume_fail.output
+++ b/tests/backend/checkmach/test_assume_fail.output
@@ -1,0 +1,14 @@
+File "test_assume_fail.ml", line 5, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.foo (camlTest_assume_fail.foo_HIDE_STAMP)
+
+File "test_assume_fail.ml", line 5, characters 32-37:
+Error: Unexpected direct tailcall camlTest_assume_fail.bar_HIDE_STAMP on a path to exceptional return
+
+File "test_assume_fail.ml", line 12, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.foo' (camlTest_assume_fail.foo'_HIDE_STAMP)
+
+File "test_assume_fail.ml", line 12, characters 33-39:
+Error: Unexpected direct call camlCamlinternalFormat.make_printf_120_401_code (test_assume_fail.ml:12,33--39;test_assume_fail.ml:9,25--53;printf.ml:47,18--43;printf.ml:45,2--31) on a path to exceptional return
+
+File "test_assume_fail.ml", line 12, characters 33-39:
+Error: Unexpected indirect call (test_assume_fail.ml:12,33--39;test_assume_fail.ml:9,25--53) on a path to exceptional return


### PR DESCRIPTION
Interpretation of `assume` should be `relaxed` to match the "assert" annotations without explicit `strict`.  

Currently, `assume` is always interpreted as `strict` when it is propagated on expressions in `lambda` (for inlining). This can cause zero alloc check to fail when a callee annotated with `zero_alloc assume` stops being inlined. For example, 
```ocaml
let[@zero_alloc assume] bar x =
  if x > 0 then failwith (Printf.sprintf "BOO %d!" x);
  (x+1,x)
  
let[@zero_alloc strict] foo x = bar x
```
the check of `foo` passes when `bar`  is inlined but fails when `bar` is not inlined, even though inlining doesn't cause allocations to be comletely optimized away. This happens because `assume` is propagate incorrectly. This PR fixes the bug.

A follow-up PR will also propagate `strict` and `never_returns_normally`, in preparation for assume on calls.