### PR TITLE
Issue misplaced attribute warning earlier

### DIFF
--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -39,6 +39,7 @@ let compile i typed ~transl_style ~unix ~pipeline =
   |> Compiler_hooks.execute_and_pipe Compiler_hooks.Raw_lambda
   |> Profile.(record generate)
    (fun program ->
+      Builtin_attributes.warn_unused ();
       let code = Simplif.simplify_lambda program.Lambda.code in
       { program with Lambda.code }
       |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.program

--- a/ocaml/driver/compile.ml
+++ b/ocaml/driver/compile.ml
@@ -36,6 +36,7 @@ let to_bytecode i Typedtree.{structure; coercion; _} =
     (Translmod.transl_implementation i.module_name ~style:Set_global_to_block)
   |> Profile.(record ~accumulate:true generate)
     (fun { Lambda.code = lambda; required_globals } ->
+       Builtin_attributes.warn_unused ();
        lambda
        |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.lambda
        |> Simplif.simplify_lambda

--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -139,6 +139,6 @@ let implementation ~hook_parse_tree ~hook_typed_tree info ~backend =
         backend info typed
       end;
     end;
-    Builtin_attributes.warn_unused ();
+    Builtin_attributes.warn_unchecked_property ();
     Warnings.check_fatal ();
   )

--- a/ocaml/driver/optcompile.ml
+++ b/ocaml/driver/optcompile.ml
@@ -40,6 +40,7 @@ let compile i ~backend ~middle_end ~transl_style
   |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.program
   |> Profile.(record generate)
     (fun program ->
+       Builtin_attributes.warn_unused ();
        let code = Simplif.simplify_lambda program.Lambda.code in
        { program with Lambda.code }
        |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.program

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -38,6 +38,10 @@ let mark_property_checked txt loc =
 let register_property attr =
     Attribute_table.replace unchecked_properties attr ()
 let warn_unchecked_property () =
+    (* When using -i, attributes will not have been translated, so we can't
+     warn about missing ones. *)
+  if !Clflags.print_types then ()
+  else
   let keys = List.of_seq (Attribute_table.to_seq_keys unchecked_properties) in
   let keys = List.sort attr_order keys in
   List.iter (fun sloc ->
@@ -50,7 +54,6 @@ let warn_unused () =
   if !Clflags.print_types then ()
   else
   begin
-    warn_unchecked_property ();
     let keys = List.of_seq (Attribute_table.to_seq_keys unused_attrs) in
     let keys = List.sort attr_order keys in
     List.iter (fun sloc ->

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -92,6 +92,7 @@ val mark_payload_attrs_used : Parsetree.payload -> unit
 (** Issue misplaced attribute warnings for all attributes created with
     [mk_internal] but not yet marked used. *)
 val warn_unused : unit -> unit
+val warn_unchecked_property : unit -> unit
 
 val check_alerts: Location.t -> Parsetree.attributes -> string -> unit
 val check_alerts_inclusion:

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -581,10 +581,10 @@
 
 (rule
  (enabled_if (= %{context_name} "main"))
- (targets test_assume_fail.output.corrected)
- (deps (:ml test_assume_fail.ml) filter.sh)
+ (targets test_assume_on_call.output.corrected)
+ (deps (:ml test_assume_on_call.ml) filter.sh)
  (action
-   (with-outputs-to test_assume_fail.output.corrected
+   (with-outputs-to test_assume_on_call.output.corrected
     (pipe-outputs
     (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
@@ -597,3 +597,4 @@
  (enabled_if (= %{context_name} "main"))
  (deps test_assume_fail.output test_assume_fail.output.corrected)
  (action (diff test_assume_fail.output test_assume_fail.output.corrected)))
+

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -581,6 +581,25 @@
 
 (rule
  (enabled_if (= %{context_name} "main"))
+ (targets test_assume_fail.output.corrected)
+ (deps (:ml test_assume_fail.ml) filter.sh)
+ (action
+   (with-outputs-to test_assume_fail.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_fail.output test_assume_fail.output.corrected)
+ (action (diff test_assume_fail.output test_assume_fail.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
  (targets test_assume_on_call.output.corrected)
  (deps (:ml test_assume_on_call.ml) filter.sh)
  (action
@@ -595,6 +614,24 @@
 (rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
- (deps test_assume_fail.output test_assume_fail.output.corrected)
- (action (diff test_assume_fail.output test_assume_fail.output.corrected)))
+ (deps test_assume_on_call.output test_assume_on_call.output.corrected)
+ (action (diff test_assume_on_call.output test_assume_on_call.output.corrected)))
 
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_misplaced_assume.output.corrected)
+ (deps (:ml test_misplaced_assume.ml) filter.sh)
+ (action
+   (with-outputs-to test_misplaced_assume.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_misplaced_assume.output test_misplaced_assume.output.corrected)
+ (action (diff test_misplaced_assume.output test_misplaced_assume.output.corrected)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -125,4 +125,6 @@ let () =
   print_test ~extra_flags:"-zero-alloc-check opt" ~flambda_only:false "test_zero_alloc_opt1.ml";
   print_test ~extra_flags:"-zero-alloc-check opt" ~flambda_only:false "test_zero_alloc_opt2.ml";
   print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_assume_fail";
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_assume_on_call";
+  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_misplaced_assume";
   ()

--- a/tests/backend/checkmach/test_assume_on_call.ml
+++ b/tests/backend/checkmach/test_assume_on_call.ml
@@ -1,0 +1,10 @@
+let[@inline always] bar x = (x,x)
+
+let[@zero_alloc] test1 x =
+  (bar[@zero_alloc]) x
+
+let[@zero_alloc] test2 x =
+  (bar[@zero_alloc assume strict]) x
+
+let[@zero_alloc] test3 x =
+  (bar[@zero_alloc assume never_returns_normally]) x

--- a/tests/backend/checkmach/test_assume_on_call.ml
+++ b/tests/backend/checkmach/test_assume_on_call.ml
@@ -1,5 +1,9 @@
 let[@inline always] bar x = (x,x)
 
+(* The following functions currently report misplaced attribute warnings.
+   They are expected to compile successfully and pass the check
+   when zero_alloc annotations on function calls are supported. *)
+
 let[@zero_alloc] test1 x =
   (bar[@zero_alloc]) x
 

--- a/tests/backend/checkmach/test_assume_on_call.output
+++ b/tests/backend/checkmach/test_assume_on_call.output
@@ -1,26 +1,26 @@
-File "test_assume_on_call.ml", line 4, characters 8-18:
+File "test_assume_on_call.ml", line 8, characters 8-18:
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "test_assume_on_call.ml", line 7, characters 8-18:
+File "test_assume_on_call.ml", line 11, characters 8-18:
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "test_assume_on_call.ml", line 10, characters 8-18:
+File "test_assume_on_call.ml", line 14, characters 8-18:
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "test_assume_on_call.ml", line 3, characters 5-15:
+File "test_assume_on_call.ml", line 7, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test1 (camlTest_assume_on_call.test1_HIDE_STAMP)
 
-File "test_assume_on_call.ml", line 4, characters 2-22:
-Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:4,2--22;test_assume_on_call.ml:1,28--33)
+File "test_assume_on_call.ml", line 8, characters 2-22:
+Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:8,2--22;test_assume_on_call.ml:1,28--33)
 
-File "test_assume_on_call.ml", line 6, characters 5-15:
+File "test_assume_on_call.ml", line 10, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test2 (camlTest_assume_on_call.test2_HIDE_STAMP)
 
-File "test_assume_on_call.ml", line 7, characters 2-36:
-Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:7,2--36;test_assume_on_call.ml:1,28--33)
+File "test_assume_on_call.ml", line 11, characters 2-36:
+Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:11,2--36;test_assume_on_call.ml:1,28--33)
 
-File "test_assume_on_call.ml", line 9, characters 5-15:
+File "test_assume_on_call.ml", line 13, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test3 (camlTest_assume_on_call.test3_HIDE_STAMP)
 
-File "test_assume_on_call.ml", line 10, characters 2-52:
-Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:10,2--52;test_assume_on_call.ml:1,28--33)
+File "test_assume_on_call.ml", line 14, characters 2-52:
+Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:14,2--52;test_assume_on_call.ml:1,28--33)

--- a/tests/backend/checkmach/test_assume_on_call.output
+++ b/tests/backend/checkmach/test_assume_on_call.output
@@ -1,0 +1,26 @@
+File "test_assume_on_call.ml", line 4, characters 8-18:
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "test_assume_on_call.ml", line 7, characters 8-18:
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "test_assume_on_call.ml", line 10, characters 8-18:
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "test_assume_on_call.ml", line 3, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test1 (camlTest_assume_on_call.test1_HIDE_STAMP)
+
+File "test_assume_on_call.ml", line 4, characters 2-22:
+Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:4,2--22;test_assume_on_call.ml:1,28--33)
+
+File "test_assume_on_call.ml", line 6, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test2 (camlTest_assume_on_call.test2_HIDE_STAMP)
+
+File "test_assume_on_call.ml", line 7, characters 2-36:
+Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:7,2--36;test_assume_on_call.ml:1,28--33)
+
+File "test_assume_on_call.ml", line 9, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test3 (camlTest_assume_on_call.test3_HIDE_STAMP)
+
+File "test_assume_on_call.ml", line 10, characters 2-52:
+Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:10,2--52;test_assume_on_call.ml:1,28--33)

--- a/tests/backend/checkmach/test_misplaced_assume.ml
+++ b/tests/backend/checkmach/test_misplaced_assume.ml
@@ -1,0 +1,6 @@
+[@@@warnings "+53"]
+
+let[@inline never] bar x = (x,x)
+
+let[@zero_alloc] foo x =
+  ((bar x)[@zero_alloc assume])

--- a/tests/backend/checkmach/test_misplaced_assume.output
+++ b/tests/backend/checkmach/test_misplaced_assume.output
@@ -1,0 +1,8 @@
+File "test_misplaced_assume.ml", line 6, characters 12-22:
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "test_misplaced_assume.ml", line 5, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_misplaced_assume.foo (camlTest_misplaced_assume.foo_HIDE_STAMP)
+
+File "test_misplaced_assume.ml", line 6, characters 2-31:
+Error: Unexpected direct tailcall camlTest_misplaced_assume.bar_HIDE_STAMP


### PR DESCRIPTION
Call `Builtin_attributes.warn_unused` earlier, before `Simplify_lambda`, instead of calling it after code generation.  This is sound and accurate because all attributes should have been registered during Parsing and consumed before or during the Translation to Lambda (i.e., there are no calls to [Builtin_attributes.mark_*] and [Builtin_attributes.filter*] etc after Translmod).

Split out [Builtin_attributes.warn_unchecked_property] to be called after backend.

The motivation for this change is to report misplaced attribute warnings earlier, even if there are user-facing compilation errors in the backend during zero_alloc check (i.e., the check fails, so compilation fails).

Previously, there was no need to report warnings for misplaced attributes if there were any compilation errors, because there were no user facing checks that depended on attributes.

With zero_alloc check, it is possible to get errors during code generation that would prevent the misplaced attribute warnings from being printed. At the same time, zero_alloc check is controlled using "zero_alloc" attributes. This makes it hard for users to understand zero alloc error messages caused by misplaced attributes, as for example in the following case:

```ocaml
let[@inline never] bar x = (x,x)
let[@zero_alloc] foo x =  ((bar x)[@zero_alloc assume])
```
Here, `@zero_alloc assume` is not consumed, it's only allowed only on function definition at the moment.
