### PR TITLE
Remove dummy var from `-as-parameter` command line help

### DIFF
--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -633,7 +633,7 @@ let mk_match_context_rows f =
 
 let mk_as_parameter f =
   "-as-parameter", Arg.Unit f,
-  "<module name> Compiles the interface as a parameter for an open module."
+  " Compiles the interface as a parameter for an open module."
 ;;
 
 let mk_use_prims f =


### PR DESCRIPTION
During the merlin merge, I was confused why `-as-parameter`'s command line help mentioned a `<module name>` metavariable when the corresponding `Clflags.as_parameter` binding was just a bool. I'm fairly sure this is just a mistake in the command line help. This PR removes the metavariable.