### PR TITLE
Reinitialize IO mutexes in systhreads5

### DIFF
--- a/ocaml/runtime/caml/io.h
+++ b/ocaml/runtime/caml/io.h
@@ -105,6 +105,7 @@ CAMLextern void (*caml_channel_mutex_unlock) (struct channel *);
 CAMLextern void (*caml_channel_mutex_unlock_exn) (void);
 
 CAMLextern struct channel * caml_all_opened_channels;
+CAMLextern caml_plat_mutex caml_all_opened_channels_mutex;
 
 #define Lock(channel) \
   if (caml_channel_mutex_lock != NULL) (*caml_channel_mutex_lock)(channel)


### PR DESCRIPTION
See 5: https://github.com/ocaml/ocaml/blob/trunk/otherlibs/systhreads/st_stubs.c#L410 
See 4: https://github.com/ocaml-flambda/flambda-backend/blob/main/ocaml/otherlibs/systhreads4/st_stubs.c#L524

Systhreads4 destroys all channel mutexes upon a fork, since other threads may have locked them at the time of the fork. 
We also need to do this in 5, though support for forking with threads is only best-effort and applications really shouldn't do it.

Also, I noticed that `caml_seek_in` and `caml_ml_close_channel` in `io.c` both call `caml_enter_blocking_section_no_pending` without first calling `check_pending`. Is this wrong? Once we enter the blocking section, another thread can start running and process pending signals while this channel is locked. But the point of `check_pending` is to ensure that the channel is not locked while signal handlers/finalizers run. 