### PR TITLE
Disable new caml_apply_split_max_arity test on macOS

### DIFF
--- a/tests/backend/caml_apply_split_max_arity/dune
+++ b/tests/backend/caml_apply_split_max_arity/dune
@@ -6,7 +6,9 @@
 
 (rule
  (enabled_if
-  (= %{context_name} "main"))
+  (and
+   (<> %{system} "macosx")
+   (= %{context_name} "main")))
  (target t.output)
  (deps t.exe)
  (action
@@ -21,7 +23,9 @@
  (alias runtest)
  (enabled_if
   (and
-   (= %{context_name} "main")
-   (<> %{ocaml-config:flambda} true)))
+   (<> %{system} "macosx")
+   (and
+    (= %{context_name} "main")
+    (<> %{ocaml-config:flambda} true))))
  (action
   (diff t.expected t.output)))


### PR DESCRIPTION
`readelf` is different on these systems.  Note that the pull request CI won't test this, but I have tested it on a Mac.