### PR TITLE
Improve codegen for int intrinsics

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -37,6 +37,9 @@ let sse42_support = ref true
 (* Carry-less multiplication (Westmere+) *)
 let clmul_support = ref true
 
+(* Bit manipulation (Haswell+) *)
+let bmi_support = ref true
+
 (* Bit manipulation 2 (Haswell+) *)
 let bmi2_support = ref true
 
@@ -87,6 +90,10 @@ let command_line_options =
       " Enable CLMUL intrinsics (default)";
     "-fno-clmul", Arg.Clear clmul_support,
       " Disable CLMUL intrinsics";
+    "-fbmi", Arg.Set bmi_support,
+      " Enable BMI intrinsics (default)";
+    "-fno-bmi", Arg.Clear bmi_support,
+      " Disable BMI intrinsics";
     "-fbmi2", Arg.Set bmi2_support,
       " Enable BMI2 intrinsics (default)";
     "-fno-bmi2", Arg.Clear bmi2_support,

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -21,6 +21,7 @@ val prefetchw_support : bool ref
 val prefetchwt1_support : bool ref
 val trap_notes : bool ref
 val clmul_support : bool ref
+val bmi_support : bool ref
 val bmi2_support : bool ref
 val sse3_support : bool ref
 val ssse3_support : bool ref

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1481,9 +1481,9 @@ let emit_instr fallthrough i =
       instr_for_intop op (arg i 1) (res i 0)
   | Lop(Iintop_imm(Iadd, n)) when i.arg.(0).loc <> i.res.(0).loc ->
       I.lea (mem64 NONE n (arg64 i 0)) (res i 0)
-  | Lop(Iintop_imm(Iadd, 1) | Iintop_imm(Isub, -1)) when not !fastcode_flag ->
+  | Lop(Iintop_imm(Iadd, 1) | Iintop_imm(Isub, -1)) ->
       I.inc (res i 0)
-  | Lop(Iintop_imm(Iadd, -1) | Iintop_imm(Isub, 1)) when not !fastcode_flag ->
+  | Lop(Iintop_imm(Iadd, -1) | Iintop_imm(Isub, 1)) ->
       I.dec (res i 0)
   | Lop(Iintop_imm(op, n)) ->
       (* We have i.arg.(0) = i.res.(0) *)
@@ -1571,7 +1571,9 @@ let emit_instr fallthrough i =
          previous experience with similar things, but maybe the change
          should be left for later.
          mshinwell: The current situation is fine for now. *)
-      if arg_is_non_zero then begin
+      if !Arch.bmi_support then begin
+        I.lzcnt (arg i 0) (res i 0)
+      end else  if arg_is_non_zero then begin
         (* No need to handle that bsr is undefined on 0 input. *)
         I.bsr (arg i 0) (res i 0);
         (* We need (63 - result_of_bsr), which can be done with xor. *)
@@ -1589,7 +1591,9 @@ let emit_instr fallthrough i =
       end
   | Lop(Iintop(Ictz { arg_is_non_zero; })) ->
     (* CR-someday gyorsh: can we do it at selection? *)
-    if arg_is_non_zero then begin
+    if !Arch.bmi_support then begin
+      I.tzcnt (arg i 0) (res i 0)
+    end else if arg_is_non_zero then begin
       (* No need to handle that bsf is undefined on 0 input. *)
       I.bsf (arg i 0) (res i 0)
     end else begin

--- a/backend/x86_ast.mli
+++ b/backend/x86_ast.mli
@@ -356,6 +356,8 @@ type instruction =
   | PMULLD of arg * arg
   | PEXT of arg * arg * arg
   | PDEP of arg * arg * arg
+  | TZCNT of arg * arg
+  | LZCNT of arg * arg
 
 (* ELF specific *)
 type reloc_type =

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1646,6 +1646,32 @@ let emit_popcnt b ~dst ~src =
     emit_mod_rm_reg b rexw [ 0x0F; 0xB8 ] rm (rd_of_reg64 reg);
   | _ -> assert false
 
+let emit_tzcnt b ~dst ~src =
+  match (dst, src) with
+  | (Reg16 reg, ((Reg16 _ | Mem _ | Mem64_RIP _) as rm))
+  | (Reg32 reg, ((Reg32 _ | Mem _ | Mem64_RIP _) as rm)) ->
+    (* TZCNT r16, r/m16 and TZCNT r32, r/m32 *)
+    buf_int8 b 0xF3;
+    emit_mod_rm_reg b no_rex [ 0x0F; 0xBC ] rm (rd_of_reg64 reg);
+  | (Reg64 reg, ((Reg64 _ | Mem _ | Mem64_RIP _) as rm)) ->
+    (* TZCNT r64, r/m64 *)
+    buf_int8 b 0xF3;
+    emit_mod_rm_reg b rexw [ 0x0F; 0xBC ] rm (rd_of_reg64 reg);
+  | _ -> assert false
+
+let emit_lzcnt b ~dst ~src =
+  match (dst, src) with
+  | (Reg16 reg, ((Reg16 _ | Mem _ | Mem64_RIP _) as rm))
+  | (Reg32 reg, ((Reg32 _ | Mem _ | Mem64_RIP _) as rm)) ->
+    (* LZCNT r16, r/m16 and LZCNT r32, r/m32 *)
+    buf_int8 b 0xF3;
+    emit_mod_rm_reg b no_rex [ 0x0F; 0xBD ] rm (rd_of_reg64 reg);
+  | (Reg64 reg, ((Reg64 _ | Mem _ | Mem64_RIP _) as rm)) ->
+    (* LZCNT r64, r/m64 *)
+    buf_int8 b 0xF3;
+    emit_mod_rm_reg b rexw [ 0x0F; 0xBD ] rm (rd_of_reg64 reg);
+  | _ -> assert false
+
 let rd_of_prefetch_hint = function
   | Nta -> 0
   | T0 -> 1
@@ -2022,6 +2048,8 @@ let assemble_instr b loc = function
   | PMULLD (src, dst) -> emit_pmulld b dst src
   | PEXT (src1, src0, dst) -> emit_pext b dst src0 src1
   | PDEP (src1, src0, dst) -> emit_pdep b dst src0 src1
+  | TZCNT (src, dst) -> emit_tzcnt b ~dst ~src
+  | LZCNT (src, dst) -> emit_lzcnt b ~dst ~src
 
 let assemble_line b loc ins =
   try

--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -379,6 +379,9 @@ module I = struct
 
   let pclmulqdq i x y = emit (PCLMULQDQ (i, x, y))
 
+  let lzcnt x y = emit (LZCNT (x, y))
+  let tzcnt x y = emit (TZCNT (x, y))
+
   let pext x y z = emit (PEXT (x, y, z))
   let pdep x y z = emit (PDEP (x, y, z))
 end

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -388,6 +388,11 @@ module I : sig
 
   val pclmulqdq: arg -> arg -> arg -> unit
 
+  (* BMI instructions *)
+
+  val lzcnt: arg -> arg -> unit
+  val tzcnt: arg -> arg -> unit
+
   (* BMI2 instructions *)
 
   val pext: arg -> arg -> arg -> unit

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -380,6 +380,8 @@ let print_instr b = function
   | PMULLD (arg1, arg2) -> i2 b "pmulld" arg1 arg2
   | PEXT (arg1, arg2, arg3) -> i3 b "pext" arg1 arg2 arg3
   | PDEP (arg1, arg2, arg3) -> i3 b "pdep" arg1 arg2 arg3
+  | LZCNT (arg1, arg2) -> i2_s b "lzcnt" arg1 arg2
+  | TZCNT (arg1, arg2) -> i2_s b "tzcnt" arg1 arg2
 
 (* bug:
    https://sourceware.org/binutils/docs-2.22/as/i386_002dBugs.html#i386_002dBugs

--- a/backend/x86_masm.ml
+++ b/backend/x86_masm.ml
@@ -377,6 +377,8 @@ let print_instr b = function
   | PMULLD (arg1, arg2) -> i2 b "pmulld" arg1 arg2
   | PEXT (arg1, arg2, arg3) -> i3 b "pext" arg1 arg2 arg3
   | PDEP (arg1, arg2, arg3) -> i3 b "pdep" arg1 arg2 arg3
+  | LZCNT (arg1, arg2) -> i2 b "lzcnt" arg1 arg2
+  | TZCNT (arg1, arg2) -> i2 b "tzcnt" arg1 arg2
 
 let print_line b = function
   | Ins instr -> print_instr b instr

--- a/tests/simd/scalar_ops.ml
+++ b/tests/simd/scalar_ops.ml
@@ -1,5 +1,4 @@
 
-
 external int64x2_of_int64s : int64 -> int64 -> int64x2 = "caml_vec128_unreachable" "vec128_of_int64s" [@@noalloc] [@@unboxed]
 external int64x2_low_int64 : int64x2 -> int64 = "caml_vec128_unreachable" "vec128_low_int64" [@@noalloc] [@@unboxed]
 external int64x2_high_int64 : int64x2 -> int64 = "caml_vec128_unreachable" "vec128_high_int64" [@@noalloc] [@@unboxed]
@@ -11,6 +10,10 @@ let eq lv hv l h =
 
 let eq' x y =
   if x <> y then Printf.printf "%016Lx <> %016Lx\n" x y
+;;
+
+let eqi x y =
+  if x <> y then Printf.printf "%d <> %d\n" x y
 ;;
 
 module Int64x2 = struct
@@ -34,6 +37,79 @@ module Int64x2 = struct
   ;;
 end
 
+module Int = struct
+
+  external count_leading_zeros
+    :  int
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int_clz_tagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external count_leading_zeros2
+    :  int
+    -> int
+    = "caml_vec128_unreachable" "caml_int_clz_untagged_to_untagged"
+  [@@untagged] [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external count_set_bits
+    :  int
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int_popcnt_tagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external count_set_bits2
+    :  int
+    -> int
+    = "caml_vec128_unreachable" "caml_int_popcnt_untagged_to_untagged"
+  [@@untagged] [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external count_trailing_zeros
+    :  int
+    -> int
+    = "caml_vec128_unreachable" "caml_int_ctz_untagged_to_untagged"
+  [@@untagged] [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  let check f g =
+      let open Int in
+      Random.set_state (Random.State.make [|1234567890|]);
+      eqi (f zero) (g zero);
+      eqi (f one) (g one);
+      eqi (f minus_one) (g minus_one);
+      eqi (f max_int) (g max_int);
+      eqi (f min_int) (g min_int);
+      for i = 0 to 100_000 do
+          let i = Random.full_int max_int in
+          let i = if Random.bool () then i else neg i in
+          eqi (f i) (g i)
+      done
+  ;;
+
+  let rec clz i =
+    if i = 0 then 63
+    else if (i land 0x4000000000000000) = 0x4000000000000000 then 0
+    else 1 + (clz (i lsl 1))
+  ;;
+
+  let rec ctz i =
+    if i = 0 then 63
+    else if (i land 1) = 1 then 0
+    else 1 + (ctz (i lsr 1))
+  ;;
+
+  let rec popcnt i =
+    if i = 0 then 0
+    else (i land 1) + (popcnt (i lsr 1))
+  ;;
+
+  let () =
+    check count_leading_zeros clz;
+    check count_leading_zeros2 clz;
+    check count_set_bits popcnt;
+    check count_set_bits2 popcnt;
+    check count_trailing_zeros ctz
+  ;;
+end
+
 module Int64 = struct
 
   type t = int64
@@ -48,5 +124,156 @@ module Int64 = struct
     eq' (bit_deposit 235L 522L) 0xAL;
     eq' (bit_extract 3L 4L) 0x0L;
     eq' (bit_extract 235L 522L) 0x3L
+  ;;
+
+  external count_leading_zeros
+    :  (int64[@unboxed])
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int64_clz_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external count_leading_zeros_nonzero_arg
+    :  (int64[@unboxed])
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int64_clz_nonzero_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external count_trailing_zeros
+    :  (int64[@unboxed])
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int64_ctz_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  (** Same as [count_trailing_zeros] except if the argument is zero,
+      then the result is undefined. Emits more efficient code. *)
+  external count_trailing_zeros_nonzero_arg
+    :  (int64[@unboxed])
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int64_ctz_nonzero_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  (** [count_set_bits n] returns the number of bits that are 1 in [n]. *)
+  external count_set_bits
+    :  (int64[@unboxed])
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int64_popcnt_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  let check ?nonzero f g =
+      let nz = Option.value ~default:false nonzero in
+      let open Stdlib.Int64 in
+      Random.set_state (Random.State.make [|1234567890|]);
+      if not nz then eqi (f zero) (g zero);
+      eqi (f one) (g one);
+      eqi (f minus_one) (g minus_one);
+      eqi (f max_int) (g max_int);
+      eqi (f min_int) (g min_int);
+      for i = 0 to 100_000 do
+          let i = Random.int64 max_int in
+          let i = if Random.bool () then i else neg i in
+          if not nz || i <> 0L then eqi (f i) (g i);
+      done
+  ;;
+
+  let rec clz i =
+    if i = 0L then 64
+    else if Int64.((logand i 0x8000000000000000L) = 0x8000000000000000L) then 0
+    else 1 + (clz (Int64.shift_left i 1))
+  ;;
+
+  let rec ctz i =
+    if i = 0L then 64
+    else if Int64.((logand i 1L) = 1L) then 0
+    else 1 + (ctz (Int64.shift_right_logical i 1))
+  ;;
+
+  let rec popcnt i =
+    if i = 0L then 0
+    else Int64.(logand i 1L |> to_int) + (popcnt Int64.(shift_right_logical i 1))
+  ;;
+
+  let () =
+    check count_leading_zeros clz;
+    check ~nonzero:true count_leading_zeros_nonzero_arg clz;
+    check count_trailing_zeros ctz;
+    check ~nonzero:true count_trailing_zeros_nonzero_arg ctz;
+    check count_set_bits popcnt
+  ;;
+end
+
+module Int32 = struct
+
+  external count_leading_zeros
+    :  (int32[@unboxed])
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int32_clz_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external count_leading_zeros_nonzero_arg
+    :  (int32[@unboxed])
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int32_clz_nonzero_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external count_trailing_zeros
+    :  (int32[@unboxed])
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int32_ctz_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  (** Same as [count_trailing_zeros] except if the argument is zero,
+      then the result is undefined. Emits more efficient code. *)
+  external count_trailing_zeros_nonzero_arg
+    :  (int32[@unboxed])
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int32_ctz_nonzero_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  (** [count_set_bits n] returns the number of bits that are 1 in [n]. *)
+  external count_set_bits
+    :  (int32[@unboxed])
+    -> (int[@untagged])
+    = "caml_vec128_unreachable" "caml_int32_popcnt_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  let check ?nonzero f g =
+      let nz = Option.value ~default:false nonzero in
+      let open Stdlib.Int32 in
+      Random.set_state (Random.State.make [|1234567890|]);
+      if not nz then eqi (f zero) (g zero);
+      eqi (f one) (g one);
+      eqi (f minus_one) (g minus_one);
+      eqi (f max_int) (g max_int);
+      eqi (f min_int) (g min_int);
+      for i = 0 to 100_000 do
+          let i = Random.int32 max_int in
+          let i = if Random.bool () then i else neg i in
+          if not nz || i <> 0l then eqi (f i) (g i);
+      done
+  ;;
+
+  let rec clz i =
+    if i = 0l then 32
+    else if Int32.((logand i 0x80000000l) = 0x80000000l) then 0
+    else 1 + (clz (Int32.shift_left i 1))
+  ;;
+
+  let rec ctz i =
+    if i = 0l then 32
+    else if Int32.((logand i 1l) = 1l) then 0
+    else 1 + (ctz (Int32.shift_right_logical i 1))
+  ;;
+
+  let rec popcnt i =
+    if i = 0l then 0
+    else Int32.(logand i 1l |> to_int) + (popcnt Int32.(shift_right_logical i 1))
+  ;;
+
+  let () =
+    check count_leading_zeros clz;
+    check ~nonzero:true count_leading_zeros_nonzero_arg clz;
+    check count_trailing_zeros ctz;
+    check ~nonzero:true count_trailing_zeros_nonzero_arg ctz;
+    check count_set_bits popcnt
   ;;
 end

--- a/tests/simd/stubs.c
+++ b/tests/simd/stubs.c
@@ -334,6 +334,22 @@ BUILTIN(caml_clmul_int64x2);
 BUILTIN(caml_bmi2_int64_extract_bits);
 BUILTIN(caml_bmi2_int64_deposit_bits);
 
+BUILTIN(caml_int64_ctz_nonzero_unboxed_to_untagged);
+BUILTIN(caml_int64_ctz_unboxed_to_untagged);
+BUILTIN(caml_int64_clz_nonzero_unboxed_to_untagged);
+BUILTIN(caml_int64_clz_unboxed_to_untagged);
+BUILTIN(caml_int64_popcnt_unboxed_to_untagged);
+BUILTIN(caml_int32_popcnt_unboxed_to_untagged);
+BUILTIN(caml_int32_ctz_nonzero_unboxed_to_untagged)
+BUILTIN(caml_int32_ctz_unboxed_to_untagged)
+BUILTIN(caml_int32_clz_nonzero_unboxed_to_untagged)
+BUILTIN(caml_int32_clz_unboxed_to_untagged)
+BUILTIN(caml_int_ctz_untagged_to_untagged);
+BUILTIN(caml_int_popcnt_untagged_to_untagged);
+BUILTIN(caml_int_popcnt_tagged_to_untagged);
+BUILTIN(caml_int_clz_untagged_to_untagged);
+BUILTIN(caml_int_clz_tagged_to_untagged);
+
 #include <float.h>
 #include <math.h>
 


### PR DESCRIPTION
The x86 backend now emits `inc`/`dec` even if the speed-over-size flag is enabled (these instructions are not actually slower, and they are smaller). This improves the popcnt intrinsic.

Additionally, there is now a BMI architecture flag. When it is set, the count leading/trailing zeroes intrinsics generate `lzcnt` and `tzcnt` instead of sequences using `bsr`/`bsf`. 

Added tests for ctz/clz/popcnt for int/int32/int64 in `tests/simd/scalar_ops.ml`.