### PR TITLE
Remove Cregion, Ctail and Regular Ctrywith handlers

### DIFF
--- a/backend/afl_instrument.ml
+++ b/backend/afl_instrument.ml
@@ -95,8 +95,6 @@ and instrument = function
      in
      Ccatch (isrec, cases, instrument body, kind)
   | Cexit (ex, args, traps) -> Cexit (ex, List.map instrument args, traps)
-  | Cregion e -> Cregion (instrument e)
-  | Ctail e -> Ctail (instrument e)
 
   (* these are base cases and have no logging *)
   | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_vec128 _

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -269,7 +269,6 @@ method! select_store is_assign addr exp =
   | Cassign (_, _) | Ctuple _ | Cop (_, _, _) | Csequence (_, _)
   | Cifthenelse (_, _, _, _, _, _, _) | Cswitch (_, _, _, _, _) | Ccatch (_, _, _, _)
   | Cexit (_, _, _) | Ctrywith (_, _, _, _, _, _)
-  | Cregion _ | Ctail _
     ->
       super#select_store is_assign addr exp
 

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -602,9 +602,6 @@ let rec add_blocks :
       let label_body = Cmm.new_label () in
       let label_handler, starts_with_pushtrap =
         match kind with
-        | Regular ->
-          let label = Cmm.new_label () in
-          label, Some label
         | Delayed handler_id ->
           let label = State.add_catch_handler state ~handler_id in
           label, None

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -32,10 +32,6 @@ module State : sig
 
   val get_next_instruction_id : t -> int
 
-  val add_iend_with_poptrap : t -> Mach.instruction -> unit
-
-  val is_iend_with_poptrap : t -> Mach.instruction -> bool
-
   val add_exception_handler : t -> Label.t -> unit
 
   val get_exception_handlers : t -> Label.t list
@@ -48,7 +44,6 @@ end = struct
       layout : Cfg_with_layout.layout;
       catch_handlers : Label.t Numbers.Int.Tbl.t;
       mutable next_instruction_id : int;
-      mutable iends_with_poptrap : Mach.instruction list;
       mutable exception_handlers : Label.t list
     }
 
@@ -56,7 +51,6 @@ end = struct
     let layout = DLL.make_empty () in
     let catch_handlers = Numbers.Int.Tbl.create 31 in
     let next_instruction_id = 0 in
-    let iends_with_poptrap = [] in
     let exception_handlers = [] in
     { fun_name;
       tailrec_label;
@@ -65,7 +59,6 @@ end = struct
       layout;
       catch_handlers;
       next_instruction_id;
-      iends_with_poptrap;
       exception_handlers
     }
 
@@ -107,21 +100,6 @@ end = struct
     let res = t.next_instruction_id in
     t.next_instruction_id <- succ res;
     res
-
-  let is_iend instr =
-    match instr.Mach.desc with
-    | Iend -> true
-    | Iop _ | Ireturn _ | Iifthenelse _ | Iswitch _ | Icatch _ | Iexit _
-    | Itrywith _ | Iraise _ ->
-      false
-
-  let add_iend_with_poptrap t iend =
-    assert (is_iend iend);
-    t.iends_with_poptrap <- iend :: t.iends_with_poptrap
-
-  let is_iend_with_poptrap t iend =
-    assert (is_iend iend);
-    List.memq iend t.iends_with_poptrap
 
   let add_exception_handler t lbl =
     t.exception_handlers <- lbl :: t.exception_handlers
@@ -387,14 +365,6 @@ let copy_instruction_no_reg :
     available_across
   }
 
-let rec get_end : Mach.instruction -> Mach.instruction =
- fun instr ->
-  match instr.Mach.desc with
-  | Iend -> instr
-  | Iop _ | Ireturn _ | Iifthenelse _ | Iswitch _ | Icatch _ | Iexit _
-  | Itrywith _ | Iraise _ ->
-    get_end instr.Mach.next
-
 type terminator_info =
   | Terminator of Cfg.terminator Cfg.instruction
   | With_next_label of (Label.t -> Cfg.terminator Cfg.instruction)
@@ -512,8 +482,6 @@ let rec add_blocks :
   in
   let prepare_next_block () =
     match last.next.desc with
-    | Iend when not (State.is_iend_with_poptrap state last.next) ->
-      next, fun () -> ()
     | Iend | Iop _ | Ireturn _ | Iifthenelse _ | Iswitch _ | Icatch _ | Iexit _
     | Itrywith _ | Iraise _ ->
       let start = Cmm.new_label () in
@@ -540,11 +508,7 @@ let rec add_blocks :
         terminate_block ~trap_actions:[]
           (copy_instruction_no_reg state last ~desc:Cfg.Never)
       else
-        terminate_block
-          ~trap_actions:
-            (if State.is_iend_with_poptrap state last
-            then [Cmm.Pop Pop_generic]
-            else [])
+        terminate_block ~trap_actions:[]
           (copy_instruction_no_reg state last ~desc:(Cfg.Always next))
     | Ireturn trap_actions ->
       terminate_block ~trap_actions
@@ -609,7 +573,6 @@ let rec add_blocks :
       terminate_block ~trap_actions:[]
         (copy_instruction_no_reg state last ~desc:(Cfg.Always label_body));
       let next, add_next_block = prepare_next_block () in
-      State.add_iend_with_poptrap state (get_end body);
       State.add_exception_handler state label_handler;
       add_blocks body state ~starts_with_pushtrap ~start:label_body ~next
         ~is_cold;

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -1115,7 +1115,7 @@ end = struct
       | Icatch (_rc, _ts, _, _body) ->
         report t next ~msg:"transform" ~desc:"catch" i.dbg;
         next
-      | Itrywith (_body, (Regular | Delayed _), (_trap_stack, _handler)) ->
+      | Itrywith (_body, Delayed _, (_trap_stack, _handler)) ->
         report t next ~msg:"transform" ~desc:"try-with" i.dbg;
         next
     in

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -1115,7 +1115,7 @@ end = struct
       | Icatch (_rc, _ts, _, _body) ->
         report t next ~msg:"transform" ~desc:"catch" i.dbg;
         next
-      | Itrywith (_body, Delayed _, (_trap_stack, _handler)) ->
+      | Itrywith (_body, _, (_trap_stack, _handler)) ->
         report t next ~msg:"transform" ~desc:"try-with" i.dbg;
         next
     in

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -172,7 +172,6 @@ type trap_action =
   | Pop of pop_action
 
 type trywith_kind =
-  | Regular
   | Delayed of trywith_shared_label
 
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
@@ -297,8 +296,6 @@ type expression =
   | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
       * expression * Debuginfo.t * kind_for_unboxing
-  | Cregion of expression
-  | Ctail of expression
 
 type property =
   | Zero_alloc
@@ -369,8 +366,6 @@ let iter_shallow_tail f = function
       true
   | Cexit _ | Cop (Craise _, _, _) ->
       true
-  | Cregion _
-  | Ctail _
   | Cconst_int _
   | Cconst_natint _
   | Cconst_float _
@@ -414,8 +409,6 @@ let map_shallow_tail ?kind f = function
               Option.value kind ~default:kind_before)
   | Cexit _ | Cop (Craise _, _, _) as cmm ->
       cmm
-  | Cregion _
-  | Ctail _
   | Cconst_int _
   | Cconst_natint _
   | Cconst_float _
@@ -428,8 +421,6 @@ let map_shallow_tail ?kind f = function
 
 let map_tail ?kind f =
   let rec loop = function
-    | Cregion _
-    | Ctail _
     | Cconst_int _
     | Cconst_natint _
     | Cconst_float _
@@ -469,10 +460,6 @@ let iter_shallow f = function
       List.iter f el
   | Ctrywith (e1, _kind, _id, e2, _dbg, _value_kind) ->
       f e1; f e2
-  | Cregion e ->
-      f e
-  | Ctail e ->
-      f e
   | Cconst_int _
   | Cconst_natint _
   | Cconst_float _
@@ -509,10 +496,6 @@ let map_shallow f = function
       Cexit (n, List.map f el, traps)
   | Ctrywith (e1, kind, id, e2, dbg, value_kind) ->
       Ctrywith (f e1, kind, id, f e2, dbg, value_kind)
-  | Cregion e ->
-      Cregion (f e)
-  | Ctail e ->
-      Ctail (f e)
   | Cconst_int _
   | Cconst_natint _
   | Cconst_float _

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -63,6 +63,7 @@ let lub_component comp1 comp2 =
   | (Float | Vec128), (Int | Addr | Val)
   | Float, Vec128
   | Vec128, Float ->
+    Printf.eprintf "%d %d\n%!" (Obj.magic comp1) (Obj.magic comp2);
     (* Float unboxing code must be sure to avoid this case. *)
     assert false
 
@@ -83,6 +84,7 @@ let ge_component comp1 comp2 =
   | (Float | Vec128), (Int | Addr | Val)
   | Float, Vec128
   | Vec128, Float ->
+    Printf.eprintf "GE: %d %d\n%!" (Obj.magic comp1) (Obj.magic comp2);
     assert false
 
 type exttype =

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -165,13 +165,9 @@ type phantom_defining_expr =
 
 type trywith_shared_label = int
 
-type pop_action =
-  | Pop_specific of trywith_shared_label
-[@@unboxed]
-
 type trap_action =
   | Push of trywith_shared_label
-  | Pop of pop_action
+  | Pop of trywith_shared_label
 
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -173,6 +173,7 @@ type trap_action =
 
 type trywith_kind =
   | Delayed of trywith_shared_label
+[@@unboxed]
 
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -173,10 +173,6 @@ type trap_action =
   | Push of trywith_shared_label
   | Pop of pop_action
 
-type trywith_kind =
-  | Delayed of trywith_shared_label
-[@@unboxed]
-
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
 type initialization_or_assignment =
@@ -297,8 +293,9 @@ type expression =
           * expression * Debuginfo.t * bool (* is_cold *)) list
         * expression * kind_for_unboxing
   | Cexit of exit_label * expression list * trap_action list
-  | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
-      * expression * Debuginfo.t * kind_for_unboxing
+  | Ctrywith of expression * trywith_shared_label
+      * Backend_var.With_provenance.t * expression * Debuginfo.t
+      * kind_for_unboxing
 
 type property =
   | Zero_alloc

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -166,8 +166,8 @@ type phantom_defining_expr =
 type trywith_shared_label = int
 
 type pop_action =
-  | Pop_generic
   | Pop_specific of trywith_shared_label
+[@@unboxed]
 
 type trap_action =
   | Push of trywith_shared_label

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -154,9 +154,6 @@ type trap_action =
   (** Remove the last handler from the trap stack. *)
 
 type trywith_kind =
-  | Regular
-  (** Regular trywith: an uncaught exception from the body will always be
-      handled by this handler. *)
   | Delayed of trywith_shared_label
   (** The body starts with the previous exception handler, and only after going
       through an explicit Push-annotated Cexit will this handler become active.
@@ -308,10 +305,6 @@ type expression =
   | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
       * expression * Debuginfo.t * kind_for_unboxing
-  (** Only if the [trywith_kind] is [Regular] will a region be inserted for
-      the "try" block. *)
-  | Cregion of expression
-  | Ctail of expression
 
 type property =
   | Zero_alloc

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -153,14 +153,6 @@ type trap_action =
   | Pop of pop_action
   (** Remove the last handler from the trap stack. *)
 
-type trywith_kind =
-  | Delayed of trywith_shared_label
-  (** The body starts with the previous exception handler, and only after going
-      through an explicit Push-annotated Cexit will this handler become active.
-      This allows for sharing a single handler in several places, or having
-      multiple entry and exit points to a single trywith block. *)
-[@@unboxed]
-
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
 type initialization_or_assignment =
@@ -304,8 +296,14 @@ type expression =
         * expression
         * kind_for_unboxing
   | Cexit of exit_label * expression list * trap_action list
-  | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
-      * expression * Debuginfo.t * kind_for_unboxing
+  | Ctrywith of expression * trywith_shared_label
+      * Backend_var.With_provenance.t * expression * Debuginfo.t
+      * kind_for_unboxing
+    (** Ctrywith uses "delayed handlers":
+        The body starts with the previous exception handler, and only after
+        going through an explicit Push-annotated Cexit will this handler become
+        active.  This allows for sharing a single handler in several places, or
+        having multiple entry and exit points to a single trywith block. *)
 
 type property =
   | Zero_alloc

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -159,6 +159,7 @@ type trywith_kind =
       through an explicit Push-annotated Cexit will this handler become active.
       This allows for sharing a single handler in several places, or having
       multiple entry and exit points to a single trywith block. *)
+[@@unboxed]
 
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -144,8 +144,8 @@ type phantom_defining_expr =
 type trywith_shared_label = Lambda.static_label (* Same as Ccatch handlers *)
 
 type pop_action =
-  | Pop_generic
   | Pop_specific of trywith_shared_label
+[@@unboxed]
 
 type trap_action =
   | Push of trywith_shared_label

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -143,14 +143,10 @@ type phantom_defining_expr =
 
 type trywith_shared_label = Lambda.static_label (* Same as Ccatch handlers *)
 
-type pop_action =
-  | Pop_specific of trywith_shared_label
-[@@unboxed]
-
 type trap_action =
   | Push of trywith_shared_label
   (** Add the corresponding handler to the trap stack. *)
-  | Pop of pop_action
+  | Pop of trywith_shared_label
   (** Remove the last handler from the trap stack. *)
 
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3296,8 +3296,8 @@ let sequence x y =
 let ite ~dbg ~then_dbg ~then_ ~else_dbg ~else_ cond =
   Cifthenelse (cond, then_dbg, then_, else_dbg, else_, dbg, Any)
 
-let trywith ~dbg ~kind ~body ~exn_var ~handler () =
-  Ctrywith (body, kind, exn_var, handler, dbg, Any)
+let trywith ~dbg ~body ~exn_var ~handler_cont ~handler () =
+  Ctrywith (body, handler_cont, exn_var, handler, dbg, Any)
 
 type static_handler =
   int

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -694,7 +694,7 @@ let test_bool dbg cmm =
 
 let box_float dbg m c = Cop (Calloc m, [alloc_float_header m dbg; c], dbg)
 
-let rec unbox_float dbg =
+let unbox_float dbg =
   map_tail ~kind:Any (function
     | Cop (Calloc _, [Cconst_natint (hdr, _); c], _)
       when Nativeint.equal hdr float_header
@@ -704,27 +704,13 @@ let rec unbox_float dbg =
       match Cmmgen_state.structured_constant_of_sym s.sym_name with
       | Some (Const_float x) -> Cconst_float (x, dbg) (* or keep _dbg? *)
       | _ -> Cop (mk_load_immut Double, [cmm], dbg))
-    | Cregion e as cmm -> (
-      (* It is valid to push unboxing inside a Cregion except when the extra
-         unboxing logic pushes a tail call out of tail position *)
-      match
-        map_tail ~kind:Any
-          (function
-            | Cop (Capply (_, Rc_close_at_apply), _, _) -> raise Exit
-            | Ctail e -> Ctail (unbox_float dbg e)
-            | e -> unbox_float dbg e)
-          e
-      with
-      | e -> Cregion e
-      | exception Exit -> Cop (mk_load_immut Double, [cmm], dbg))
-    | Ctail e -> Ctail (unbox_float dbg e)
     | cmm -> Cop (mk_load_immut Double, [cmm], dbg))
 
 (* Vectors *)
 
 let box_vec128 dbg m c = Cop (Calloc m, [alloc_boxedvec128_header m dbg; c], dbg)
 
-let rec unbox_vec128 dbg =
+let unbox_vec128 dbg =
   (* Boxed vectors are not 16-byte aligned by the GC, so we must use an
      unaligned load. *)
   map_tail ~kind:Any (function
@@ -737,21 +723,6 @@ let rec unbox_vec128 dbg =
       | Some (Const_vec128 { low; high }) ->
         Cconst_vec128 ({ low; high }, dbg) (* or keep _dbg? *)
       | _ -> Cop (mk_load_immut Onetwentyeight_unaligned, [cmm], dbg))
-    | Cregion e as cmm -> (
-      (* It is valid to push unboxing inside a Cregion except when the extra
-         unboxing logic pushes a tail call out of tail position *)
-      match
-        map_tail ~kind:Any
-          (function
-            | Cop (Capply (_, Rc_close_at_apply), _, _) -> raise Exit
-            | Ctail e -> Ctail (unbox_vec128 dbg e)
-            | e -> unbox_vec128 dbg e)
-          e
-      with
-      | e -> Cregion e
-      | exception Exit ->
-        Cop (mk_load_immut Onetwentyeight_unaligned, [cmm], dbg))
-    | Ctail e -> Ctail (unbox_vec128 dbg e)
     | cmm -> Cop (mk_load_immut Onetwentyeight_unaligned, [cmm], dbg))
 
 (* Complex *)
@@ -1575,7 +1546,7 @@ let alloc_matches_boxed_int bi ~hdr ~ops =
     && String.equal sym.sym_name caml_int64_ops
   | (Pnativeint | Pint32 | Pint64), _, _ -> false
 
-let rec unbox_int dbg bi =
+let unbox_int dbg bi =
   let default arg =
     let memory_chunk =
       if bi = Primitive.Pint32 then Thirtytwo_signed else Word_int
@@ -1611,20 +1582,6 @@ let rec unbox_int dbg bi =
       | Some (Const_int64 n), Primitive.Pint64 ->
         natint_const_untagged dbg (Int64.to_nativeint n)
       | _ -> default cmm)
-    | Cregion e as cmm -> (
-      (* It is valid to push unboxing inside a Cregion except when the extra
-         unboxing logic pushes a tail call out of tail position *)
-      match
-        map_tail ~kind:Any
-          (function
-            | Cop (Capply (_, Rc_close_at_apply), _, _) -> raise Exit
-            | Ctail e -> Ctail (unbox_int dbg bi e)
-            | e -> unbox_int dbg bi e)
-          e
-      with
-      | e -> Cregion e
-      | exception Exit -> default cmm)
-    | Ctail e -> Ctail (unbox_int dbg bi e)
     | cmm -> default cmm)
 
 let make_unsigned_int bi arg dbg =
@@ -2358,40 +2315,6 @@ let cache_public_method meths tag cache dbg =
                           [cache; Cvar tagged],
                           dbg ),
                       Cvar tagged ) ) ) ) )
-
-let has_local_allocs e =
-  let rec loop ~depth = function
-    | Cregion e -> loop ~depth:(depth + 1) e
-    | Ctail e -> if depth = 0 then () else loop ~depth:(depth - 1) e
-    | Cop ((Calloc Alloc_local | Cextcall _ | Capply _), _, _) when depth = 0 ->
-      raise Exit
-    | e -> iter_shallow (loop ~depth) e
-  in
-  match loop e ~depth:0 with () -> false | exception Exit -> true
-
-let remove_region_tail e =
-  let rec has_tail ~depth = function
-    | (Ctail _ | Cop (Capply (_, Rc_close_at_apply), _, _)) when depth = 0 ->
-      raise Exit
-    | Ctail e -> has_tail ~depth:(depth - 1) e
-    | Cregion e -> has_tail ~depth:(depth + 1) e
-    | e -> ignore (iter_shallow_tail (has_tail ~depth) e : bool)
-  in
-  let rec remove_tail ~depth = function
-    | Ctail e ->
-      if depth = 0 then e else Ctail (remove_tail ~depth:(depth - 1) e)
-    | Cop (Capply (mach, Rc_close_at_apply), args, dbg) when depth = 0 ->
-      Cop (Capply (mach, Rc_normal), args, dbg)
-    | Cregion e -> Cregion (remove_tail ~depth:(depth + 1) e)
-    | e -> map_shallow_tail (remove_tail ~depth) e
-  in
-  match has_tail e ~depth:0 with
-  | () -> e
-  | exception Exit -> remove_tail e ~depth:0
-
-let region e =
-  (* [Cregion e] is equivalent to [e] if [e] contains no local allocs *)
-  if has_local_allocs e then Cregion e else remove_region_tail e
 
 let placeholder_fun_dbg ~human_name:_ = Debuginfo.none
 
@@ -3357,7 +3280,7 @@ let letin v ~defining_expr ~body =
   | Cvar _ | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
   | Cconst_vec128 _ | Clet _ | Clet_mut _ | Cphantom_let _ | Cassign _
   | Ctuple _ | Cop _ | Csequence _ | Cifthenelse _ | Cswitch _ | Ccatch _
-  | Cexit _ | Ctrywith _ | Cregion _ | Ctail _ ->
+  | Cexit _ | Ctrywith _ ->
     Clet (v, defining_expr, body)
 
 let letin_mut v ty e body = Clet_mut (v, ty, e, body)
@@ -3643,8 +3566,7 @@ let cmm_arith_size (e : Cmm.expression) =
     Some 0
   | Cop _ -> Some (cmm_arith_size0 e)
   | Clet _ | Clet_mut _ | Cphantom_let _ | Cassign _ | Ctuple _ | Csequence _
-  | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ | Ctrywith _ | Cregion _
-  | Ctail _ ->
+  | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ | Ctrywith _ ->
     None
 
 let transl_property : Lambda.property -> Cmm.property = function

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -602,9 +602,9 @@ val ite :
     caught exception in the handler. *)
 val trywith :
   dbg:Debuginfo.t ->
-  kind:trywith_kind ->
   body:expression ->
   exn_var:Backend_var.With_provenance.t ->
+  handler_cont:trywith_shared_label ->
   handler:expression ->
   unit ->
   expression

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -473,9 +473,6 @@ val send :
   Debuginfo.t ->
   expression
 
-(** Construct [Cregion e], eliding some useless regions *)
-val region : expression -> expression
-
 (** Entry point *)
 val entry_point : Compilation_unit.t list -> phrase list
 

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -176,8 +176,6 @@ let rec check env (expr : Cmm.expression) =
        not reported as an error. *)
     check env body;
     check env handler
-  | Cregion e -> check env e
-  | Ctail e -> check env e
 
 let run ppf (fundecl : Cmm.fundecl) =
   let env = Env.init () in

--- a/backend/dataflow.ml
+++ b/backend/dataflow.ml
@@ -98,12 +98,6 @@ let analyze ?(exnhandler = fun x -> x) ?(exnescape = D.bot)
         transfer i ~next:b ~exn
     | Iexit (n, _trap_actions) ->
         transfer i ~next:(get_lbl n) ~exn
-    | Itrywith(body, Regular, (trap_stack, handler)) ->
-        let bx = before end_ exn i.next in
-        let exnh = exn_from_trap_stack exn trap_stack in
-        let bh = exnhandler (before bx exnh handler) in
-        let bb = before bx bh body in
-        transfer i ~next:bb ~exn
     | Itrywith(body, Delayed nfail, (trap_stack, handler)) ->
         let bx = before end_ exn i.next in
         let exnh = exn_from_trap_stack exn trap_stack in

--- a/backend/dataflow.ml
+++ b/backend/dataflow.ml
@@ -97,7 +97,7 @@ let analyze ?(exnhandler = fun x -> x) ?(exnescape = D.bot)
         transfer i ~next:b ~exn
     | Iexit (n, _trap_actions) ->
         transfer i ~next:(get_lbl n) ~exn
-    | Itrywith(body, Delayed nfail, (trap_stack, handler)) ->
+    | Itrywith(body, nfail, (trap_stack, handler)) ->
         let bx = before end_ exn i.next in
         let exnh = exn_from_trap_stack trap_stack in
         let bh = exnhandler (before bx exnh handler) in

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -121,7 +121,8 @@ and instruction_desc =
   | Iswitch of int array * instruction array
   | Icatch of Cmm.rec_flag * trap_stack * (int * trap_stack * instruction * bool) list * instruction
   | Iexit of int * Cmm.trap_action list
-  | Itrywith of instruction * Cmm.trywith_kind * (trap_stack * instruction)
+  | Itrywith of instruction * Cmm.trywith_shared_label
+      * (trap_stack * instruction)
   | Iraise of Lambda.raise_kind
 
 type fundecl =
@@ -280,13 +281,11 @@ let free_conts_for_handlers fundecl =
           S.remove nfail conts)
           conts handlers
       | Iexit (nfail, _) -> S.add nfail next_conts
-      | Itrywith (body, kind, (_ts, handler)) ->
+      | Itrywith (body, nfail, (_ts, handler)) ->
         let conts =
           S.union next_conts (S.union (free_conts body) (free_conts handler))
         in
-        begin match kind with
-        | Delayed nfail -> S.remove nfail conts
-        end
+        S.remove nfail conts
       | Iraise _ -> next_conts
   in
   let free = free_conts fundecl.fun_body in

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -287,7 +287,6 @@ let free_conts_for_handlers fundecl =
           S.union next_conts (S.union (free_conts body) (free_conts handler))
         in
         begin match kind with
-        | Regular -> conts
         | Delayed nfail -> S.remove nfail conts
         end
       | Iraise _ -> next_conts

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -18,8 +18,6 @@
 type trap_stack =
   | Uncaught
   (** Exceptions escape the current function *)
-  | Generic_trap of trap_stack
-  (** Current handler is a regular Trywith *)
   | Specific_trap of Cmm.trywith_shared_label * trap_stack
   (** Current handler is a delayed/shared Trywith *)
 

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -122,7 +122,8 @@ and instruction_desc =
   | Iswitch of int array * instruction array
   | Icatch of Cmm.rec_flag * trap_stack * (int * trap_stack * instruction * bool) list * instruction
   | Iexit of int * Cmm.trap_action list
-  | Itrywith of instruction * Cmm.trywith_kind * (trap_stack * instruction)
+  | Itrywith of instruction * Cmm.trywith_shared_label
+      * (trap_stack * instruction)
   | Iraise of Lambda.raise_kind
 
 type fundecl =

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -155,7 +155,6 @@ let exit_label ppf = function
 let trap_action ppf ta =
   match ta with
   | Push i -> fprintf ppf "push(%d)" i
-  | Pop Pop_generic -> fprintf ppf "pop"
   | Pop (Pop_specific i) -> fprintf ppf "pop(%d)" i
 
 let trap_action_list ppf traps =

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -155,7 +155,7 @@ let exit_label ppf = function
 let trap_action ppf ta =
   match ta with
   | Push i -> fprintf ppf "push(%d)" i
-  | Pop (Pop_specific i) -> fprintf ppf "pop(%d)" i
+  | Pop i -> fprintf ppf "pop(%d)" i
 
 let trap_action_list ppf traps =
   match traps with

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -168,7 +168,6 @@ let trap_action_list ppf traps =
 
 let trywith_kind ppf kind =
   match kind with
-  | Regular -> ()
   | Delayed i -> fprintf ppf "<delayed %d>" i
 
 let to_string msg =
@@ -375,10 +374,6 @@ let rec expr ppf = function
             trywith_kind kind sequence e1 VP.print id;
       with_location_mapping ~label:"Ctrywith" ~dbg ppf (fun () ->
             fprintf ppf "%a)@]" sequence e2);
-  | Cregion e ->
-      fprintf ppf "@[<2>(region@ %a)@]" sequence e
-  | Ctail e ->
-      fprintf ppf "@[<2>(tail@ %a)@]" sequence e
 
 and sequence ppf = function
   | Csequence(e1, e2) -> fprintf ppf "%a@ %a" sequence e1 sequence e2

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -165,10 +165,6 @@ let trap_action_list ppf traps =
       List.iter (fun t -> fprintf ppf " %a" trap_action t) rest;
       fprintf ppf ">"
 
-let trywith_kind ppf kind =
-  match kind with
-  | Delayed i -> fprintf ppf "<delayed %d>" i
-
 let to_string msg =
   let b = Buffer.create 17 in
   let ppf = Format.formatter_of_buffer b in
@@ -368,9 +364,9 @@ let rec expr ppf = function
       fprintf ppf "@[<2>(exit%a %a" trap_action_list traps exit_label i;
       List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
       fprintf ppf ")@]"
-  | Ctrywith(e1, kind, id, e2, dbg, _value_kind) ->
-      fprintf ppf "@[<2>(try%a@ %a@;<1 -2>with@ %a@ "
-            trywith_kind kind sequence e1 VP.print id;
+  | Ctrywith(e1, exn_cont, id, e2, dbg, _value_kind) ->
+      fprintf ppf "@[<2>(try@ %a@;<1 -2>with(%d)@ %a@ "
+            sequence e1 exn_cont VP.print id;
       with_location_mapping ~label:"Ctrywith" ~dbg ppf (fun () ->
             fprintf ppf "%a)@]" sequence e2);
 

--- a/backend/printcmm.mli
+++ b/backend/printcmm.mli
@@ -26,7 +26,6 @@ val extcall_signature : formatter -> Cmm.machtype option * Cmm.exttype list -> u
 val integer_comparison : Cmm.integer_comparison -> string
 val float_comparison : Cmm.float_comparison -> string
 val trap_action_list : formatter -> Cmm.trap_action list -> unit
-val trywith_kind : formatter -> Cmm.trywith_kind -> unit
 val chunk : Cmm.memory_chunk -> string
 val atomic_bitwidth : Cmm.atomic_bitwidth -> string
 val operation : Debuginfo.t -> Cmm.operation -> string

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -333,9 +333,9 @@ let rec instr ppf i =
       fprintf ppf "@;<0 -2>endcatch@]"
   | Iexit (i, traps) ->
       fprintf ppf "exit%a(%d)" Printcmm.trap_action_list traps i
-  | Itrywith(body, kind, (ts, handler)) ->
-      fprintf ppf "@[<v 2>try%a@,%a@;<0 -2>with%a@,%a@;<0 -2>endtry@]"
-             Printcmm.trywith_kind kind instr body trap_stack ts instr handler
+  | Itrywith(body, exn_cont, (ts, handler)) ->
+      fprintf ppf "@[<v 2>try@,%a@;<0 -2>with(%d)%a@,%a@;<0 -2>endtry@]"
+             instr body exn_cont trap_stack ts instr handler
   | Iraise k ->
       fprintf ppf "%s %a" (Lambda.raise_kind k) reg i.arg.(0)
   end;

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -88,15 +88,13 @@ let regsetaddr' ?(print_reg = reg) ppf s =
 let regsetaddr ppf s = regsetaddr' ppf s
 
 let trap_stack ppf (ts : Mach.trap_stack) =
-  let rec has_specific = function
+  let has_specific = function
     | Uncaught -> false
-    | Generic_trap ts -> has_specific ts
     | Specific_trap _ -> true
   in
   if has_specific ts then begin
     let rec p ppf = function
       | Uncaught -> Format.fprintf ppf "U"
-      | Generic_trap ts -> Format.fprintf ppf "G:%a" p ts
       | Specific_trap (lbl, ts) -> Format.fprintf ppf "S%d:%a" lbl p ts
     in
     Format.fprintf ppf "<%a>" p ts

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -1511,7 +1511,7 @@ method emit_tail (env:environment) exp =
      end
   | Cphantom_let (_var, _defining_expr, body) ->
       self#emit_tail env body
-  | Cop((Capply(ty, _)) as op, args, dbg) ->
+  | Cop((Capply(ty, Rc_normal)) as op, args, dbg) ->
       begin match self#emit_parts_list env args with
         None -> ()
       | Some(simple_args, env) ->

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -120,7 +120,7 @@ let set_traps_for_raise env =
   | Uncaught -> ()
   | Specific_trap (lbl, _) ->
     begin match env_find_static_exception lbl env with
-    | s -> set_traps lbl s.traps_ref ts [Pop (Pop_specific lbl)]
+    | s -> set_traps lbl s.traps_ref ts [Pop lbl]
     | exception Not_found -> Misc.fatal_errorf "Trap %d not registered in env" lbl
     end
 
@@ -132,7 +132,7 @@ let trap_stack_is_empty env =
 let pop_all_traps env =
   let rec pop_all acc = function
     | Uncaught -> acc
-    | Specific_trap (lbl, t) -> pop_all (Cmm.Pop (Pop_specific lbl) :: acc) t
+    | Specific_trap (lbl, t) -> pop_all (Pop lbl :: acc) t
   in
   pop_all [] env.trap_stack
 

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -28,47 +28,8 @@ type trap_stack_info =
   | Unreachable
   | Reachable of trap_stack
 
-module Region_stack : sig
-  (* A nested set of regions, with the innermost at the head *)
-  type t = Reg.t array list
-
-  val equal : t -> t -> bool
-
-  (* Given two region stacks that are suffixes of the same
-     original stack, return their common suffix.
-
-     (This is always the shorter of the two arguments) *)
-  val common_suffix : t -> t -> t
-
-  (* Given a region stack R and one of its suffixes S,
-     return the prefix P where R = P @ S *)
-  val strip_suffix : suffix:t -> t -> t
-end  = struct
-  type t = Reg.t array list
-
-  let equal a b =
-    (a == b) || List.equal (==) a b
-
-  let common_suffix xs ys =
-    if xs == ys || List.compare_lengths xs ys <= 0
-    then xs
-    else ys
-
-  let strip_suffix ~suffix t =
-    match suffix with
-    | [] -> t
-    | _ when suffix == t -> []
-    | suff ->
-       let pre, suff' =
-         Misc.Stdlib.List.split_at (List.length t - List.length suff) t
-       in
-       assert (equal suff' suff);
-       pre
-end
-
 type static_handler =
   { regs: Reg.t array list;
-    regions: Region_stack.t;
     traps_ref : trap_stack_info ref }
 
 type environment =
@@ -79,7 +40,6 @@ type environment =
     (** Which registers must be populated when jumping to the given
         handler. *)
     trap_stack : trap_stack;
-    regions : Region_stack.t;
   }
 
 let env_add ?(mut=Asttypes.Immutable) var regs env =
@@ -91,7 +51,6 @@ let env_add_static_exception id v env =
   let r = ref Unreachable in
   let s : static_handler =
     { regs = v;
-      regions = env.regions;
       traps_ref = r }
   in
   { env with static_exceptions = Int.Map.add id s env.static_exceptions }, r
@@ -119,7 +78,6 @@ let env_find_static_exception id env =
 
 let env_enter_trywith env kind =
   match kind with
-  | Regular -> { env with trap_stack = Generic_trap env.trap_stack; }
   | Delayed id -> let env, _ = env_add_static_exception id [] env in env
 
 let env_set_trap_stack env trap_stack =
@@ -186,7 +144,6 @@ let env_empty = {
   vars = V.Map.empty;
   static_exceptions = Int.Map.empty;
   trap_stack = Uncaught;
-  regions = [];
 }
 
 let select_mutable_flag : Asttypes.mutable_flag -> Mach.mutable_flag = function
@@ -338,7 +295,7 @@ let join env opt_r1 seq1 opt_r2 seq2 ~bound_name =
   match (opt_r1, opt_r2) with
     (None, _) -> opt_r2
   | (_, None) -> opt_r1
-  | (Some (r1, uncl1), Some (r2, uncl2)) ->
+  | (Some r1, Some r2) ->
       let l1 = Array.length r1 in
       assert (l1 = Array.length r2);
       let r = Array.make l1 Reg.dummy in
@@ -364,10 +321,7 @@ let join env opt_r1 seq1 opt_r2 seq2 ~bound_name =
           maybe_emit_naming_op seq2 [| r.(i) |]
         end
       done;
-      let suffix = Region_stack.common_suffix uncl1 uncl2 in
-      seq1#insert_endregions_until env ~suffix uncl1;
-      seq2#insert_endregions_until env ~suffix uncl2;
-      Some (r, suffix)
+      Some r
 
 (* Same, for N branches *)
 
@@ -378,19 +332,19 @@ let join_array env rs ~bound_name =
     let (r, _) = rs.(i) in
     match r with
     | None -> ()
-    | Some (r, uncl) ->
+    | Some r ->
       match !some_res with
       | None ->
-        some_res := Some (r, Array.map (fun r -> r.typ) r, uncl)
-      | Some (r', types, uncl') ->
+        some_res := Some (r, Array.map (fun r -> r.typ) r)
+      | Some (r', types) ->
         let types =
           Array.map2 (fun r typ -> Cmm.lub_component r.typ typ) r types
         in
-        some_res := Some (r', types, Region_stack.common_suffix uncl uncl')
+        some_res := Some (r', types)
   done;
   match !some_res with
     None -> None
-  | Some (template, types, regions) ->
+  | Some (template, types) ->
       let size_res = Array.length template in
       let res = Array.make size_res Reg.dummy in
       for i = 0 to size_res - 1 do
@@ -400,12 +354,11 @@ let join_array env rs ~bound_name =
         let (r, s) = rs.(i) in
         match r with
           None -> ()
-        | Some (r, uncl) ->
+        | Some r ->
            s#insert_moves env r res;
-           maybe_emit_naming_op s res;
-           s#insert_endregions_until env ~suffix:regions uncl;
+           maybe_emit_naming_op s res
       done;
-      Some (res, regions)
+      Some res
 
 (* Name of function being compiled *)
 let current_function_name = ref ""
@@ -543,7 +496,7 @@ method is_simple_expr = function
       | Ccmpf _ | Cdls_get -> List.for_all self#is_simple_expr args
       end
   | Cassign _ | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _
-  | Ctrywith _ | Cregion _ | Ctail _ -> false
+  | Ctrywith _ -> false
 
 (* Analyses the effects and coeffects of an expression.  This is used across
    a whole list of expressions with a view to determining which expressions
@@ -600,8 +553,7 @@ method effects_of exp =
         EC.none
     in
     EC.join from_op (EC.join_list_map args self#effects_of)
-  | Cassign _ | Cswitch _ | Ccatch _ | Cexit _ | Ctrywith _
-  | Cregion _ | Ctail _ ->
+  | Cassign _ | Cswitch _ | Ccatch _ | Cexit _ | Ctrywith _ ->
     EC.arbitrary
 
 (* Says whether an integer constant is a suitable immediate argument for
@@ -854,19 +806,7 @@ method insert_op_debug env op dbg rs rd =
 method insert_op env op rs rd =
   self#insert_op_debug env op Debuginfo.none rs rd
 
-method insert_endregions env regions =
-  match regions with
-  | [] -> ()
-  | regions ->
-     (* Coalesce multiple simultaneous Iendregion *)
-     let final_region = List.hd (List.rev regions) in
-     self#insert env (Iop Iendregion) final_region [| |]
-
-method insert_endregions_until env ~suffix regions =
-  self#insert_endregions env (Region_stack.strip_suffix ~suffix regions)
-
-(* Emit an expression, which is assumed not to end any regions early.
-   (This holds for any expression not in tail position of Cregion)
+(* Emit an expression.
 
    [bound_name] is the name that will be bound to the result of evaluating
    the expression, if such exists.  This is used for emitting debugging
@@ -876,11 +816,7 @@ method insert_endregions_until env ~suffix regions =
      - [None] if the expression does not finish normally (e.g. raises)
      - [Some rs] if the expression yields a result in registers [rs] *)
 method emit_expr (env:environment) exp ~bound_name =
-  match self#emit_expr_aux env exp ~bound_name with
-  | None -> None
-  | Some (res, unclosed) ->
-     assert (Region_stack.equal unclosed env.regions);
-     Some res
+  self#emit_expr_aux env exp ~bound_name
 
 (* Emit an expression which may end some regions early.
 
@@ -888,10 +824,9 @@ method emit_expr (env:environment) exp ~bound_name =
     - [None] if the expression does not finish normally (e.g. raises)
     - [Some (rs, unclosed)] if the expression yields a result in [rs],
       having left [unclosed] (a suffix of env.regions) regions open *)
-method emit_expr_aux (env:environment) exp ~bound_name :
-  (Reg.t array * Region_stack.t) option =
+method emit_expr_aux (env:environment) exp ~bound_name : Reg.t array option =
   (* Normal case of returning a value: no regions are closed *)
-  let ret res = Some (res, env.regions) in
+  let ret res = Some res in
   match exp with
     Cconst_int (n, _dbg) ->
       let r = self#regs_for typ_int in
@@ -1022,18 +957,12 @@ method emit_expr_aux (env:environment) exp ~bound_name :
               )
           in
           let ty = oper_result_type op in
-          let unclosed_regions =
-            match op with
-            | Capply (_, Rc_close_at_apply) -> List.tl env.regions
-            | _ -> env.regions
-          in
           let (new_op, new_args) = self#select_operation op simple_args dbg in
           match new_op with
             Icall_ind ->
               let r1 = self#emit_tuple env new_args in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               let rd = self#regs_for ty in
-              self#insert_endregions_until env ~suffix:unclosed_regions env.regions;
               let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv rarg) in
               let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
               let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
@@ -1047,11 +976,10 @@ method emit_expr_aux (env:environment) exp ~bound_name :
               add_naming_op_for_bound_name loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
-              Some (rd, unclosed_regions)
+              Some rd
           | Icall_imm _ ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
-              self#insert_endregions_until env ~suffix:unclosed_regions env.regions;
               let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv r1) in
               let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
               let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
@@ -1060,7 +988,7 @@ method emit_expr_aux (env:environment) exp ~bound_name :
               add_naming_op_for_bound_name loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
-              Some (rd, unclosed_regions)
+              Some rd
           | Iextcall ({ func; ty_args; returns; _} as r) ->
               let (loc_arg, stack_ofs) =
                 self#emit_extcall_args env ty_args new_args in
@@ -1081,7 +1009,6 @@ method emit_expr_aux (env:environment) exp ~bound_name :
               add_naming_op_for_bound_name loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
-              assert (Region_stack.equal unclosed_regions env.regions);
               if returns then ret rd else None
           | Ialloc { bytes = _; mode } ->
               let rd = self#regs_for typ_val in
@@ -1097,19 +1024,16 @@ method emit_expr_aux (env:environment) exp ~bound_name :
               add_naming_op_for_bound_name rd;
               self#emit_stores env new_args rd;
               set_traps_for_raise env;
-              assert (Region_stack.equal unclosed_regions env.regions);
               ret rd
           | Iprobe _ ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
               let rd = self#insert_op_debug env new_op dbg r1 rd in
               set_traps_for_raise env;
-              assert (Region_stack.equal unclosed_regions env.regions);
               ret rd
           | op ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
-              assert (Region_stack.equal unclosed_regions env.regions);
               add_naming_op_for_bound_name rd;
               ret (self#insert_op_debug env op dbg r1 rd)
       end
@@ -1265,7 +1189,6 @@ method emit_expr_aux (env:environment) exp ~bound_name :
               Array.iter (fun reg -> assert(reg.typ <> Addr)) src;
               self#insert_moves env src tmp_regs ;
               self#insert_moves env tmp_regs (Array.concat handler.regs) ;
-              self#insert_endregions_until env ~suffix:handler.regions env.regions;
               self#insert env (Iexit (nfail, traps)) [||] [||];
               set_traps nfail handler.traps_ref env.trap_stack traps;
               None
@@ -1282,21 +1205,6 @@ method emit_expr_aux (env:environment) exp ~bound_name :
           end
       end
   | Ctrywith(e1, kind, v, e2, dbg, _value_kind) ->
-      (* This region is used only to clean up local allocations in the
-         exceptional path. It must not be ended in the non-exception case
-         as local allocations may be returned from the body of the "try". *)
-      let end_region =
-        if Config.stack_allocation
-          && match kind with Regular -> true | Delayed _ -> false
-        then begin
-          let reg = self#regs_for typ_int in
-          self#insert env (Iop Ibeginregion) [| |] reg;
-          fun handler_instruction ->
-            instr_cons_debug (Iop Iendregion) reg [| |] dbg handler_instruction
-        end
-        else
-          fun handler_instruction -> handler_instruction
-      in
       let env_body = env_enter_trywith env kind in
       let (r1, s1) = self#emit_sequence env_body e1 ~bound_name in
       let rv = self#regs_for typ_val in
@@ -1325,13 +1233,12 @@ method emit_expr_aux (env:environment) exp ~bound_name :
                     (env_handler.trap_stack,
                      instr_cons_debug (Iop Imove) [|Proc.loc_exn_bucket|] rv
                        dbg
-                       (end_region s2#extract))))
+                       s2#extract)))
           [||] [||];
         r
       in
       let env = env_add v rv env in
       begin match kind with
-      | Regular -> with_handler env e2
       | Delayed lbl ->
         begin match env_find_static_exception lbl env_body with
         | { traps_ref = { contents = Reachable ts; }; _} ->
@@ -1349,31 +1256,6 @@ method emit_expr_aux (env:environment) exp ~bound_name :
           Misc.fatal_errorf "Selection.emit_expr: Unbound handler %d" lbl
         end
       end
-  | Cregion e ->
-     assert(Config.stack_allocation);
-     let old_regions = env.regions in
-     let reg = self#regs_for typ_int in
-     self#insert env (Iop Ibeginregion) [| |] reg;
-     let env = { env with regions = reg :: old_regions } in
-     begin match self#emit_expr_aux env e ~bound_name with
-     | None -> None
-     | Some (rd, reg' :: unclosed) when reg == reg' ->
-        (* Compiling e closed no regions *)
-        assert (Region_stack.equal unclosed old_regions);
-        self#insert_endregions env [reg];
-        Some (rd, unclosed)
-     | Some (rd, unclosed) ->
-        (* Compiling e closed [reg], and possibly other regions too *)
-        assert (List.length unclosed <= List.length old_regions);
-        Some (rd, unclosed)
-     end
-  | Ctail e ->
-     begin match env.regions with
-     | [] -> Misc.fatal_error "Selectgen.emit_expr: Ctail but not in tail of a region"
-     | cl :: rest ->
-       self#insert_endregions env [cl];
-       self#emit_expr_aux { env with regions = rest } e ~bound_name
-     end
 
 method private emit_sequence ?at_start (env:environment) exp ~bound_name
     : _ * 'self =
@@ -1593,23 +1475,13 @@ method emit_stores env data regs_addr =
 method private insert_return (env:environment) r (traps:trap_action list) =
   match r with
     None -> ()
-  | Some (r, unclosed_regions) ->
-      self#insert_endregions env unclosed_regions;
+  | Some r ->
       let loc = Proc.loc_results_return (Reg.typv r) in
       self#insert_moves env r loc;
       self#insert env (Ireturn traps) loc [||]
 
 method private emit_return (env:environment) exp traps =
   self#insert_return env (self#emit_expr_aux env exp ~bound_name:None) traps
-
-method private tail_call_possible (env:environment) (pos:Lambda.region_close) =
-  match pos, env.regions with
-  | (Rc_normal | Rc_nontail), [] -> true
-  | (Rc_normal | Rc_nontail), _ :: _ -> false
-  | Rc_close_at_apply, [] ->
-     Misc.fatal_error "Selectgen: Rc_close_at_apply with no region to close"
-  | Rc_close_at_apply, [_] -> true
-  | Rc_close_at_apply, _ :: _ :: _ -> false
 
 (* Emit an expression in tail position of a function,
    closing all regions in [env.regions] *)
@@ -1627,9 +1499,7 @@ method emit_tail (env:environment) exp =
      end
   | Cphantom_let (_var, _defining_expr, body) ->
       self#emit_tail env body
-  | Cop((Capply(ty, ((Rc_close_at_apply | Rc_normal) as pos))) as op,
-        args, dbg)
-       when self#tail_call_possible env pos ->
+  | Cop((Capply(ty, _)) as op, args, dbg) ->
       begin match self#emit_parts_list env args with
         None -> ()
       | Some(simple_args, env) ->
@@ -1639,7 +1509,6 @@ method emit_tail (env:environment) exp =
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
-              self#insert_endregions env env.regions;
               let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv rarg) in
               let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
               let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
@@ -1659,7 +1528,6 @@ method emit_tail (env:environment) exp =
           | Icall_imm { func; } ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
-              self#insert_endregions env env.regions;
               let (loc_arg, stack_ofs_args) = Proc.loc_arguments (Reg.typv r1) in
               let (loc_res, stack_ofs_res) = Proc.loc_results_call (Reg.typv rd) in
               let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
@@ -1782,18 +1650,6 @@ method emit_tail (env:environment) exp =
       self#insert env (Icatch(rec_flag, env.trap_stack, new_handlers, s_body))
         [||] [||]
   | Ctrywith(e1, kind, v, e2, dbg, _value_kind) ->
-      (* This region is used only to clean up local allocations in the
-         exceptional path. It need not be ended in the non-exception case. *)
-      let end_region =
-        if Config.stack_allocation && match kind with Regular -> true | Delayed _ -> false then begin
-          let reg = self#regs_for typ_int in
-          self#insert env (Iop Ibeginregion) [| |] reg;
-          fun handler_instruction ->
-            instr_cons_debug (Iop Iendregion) reg [| |] dbg handler_instruction
-        end
-        else
-          fun handler_instruction -> handler_instruction
-      in
       let env_body = env_enter_trywith env kind in
       let s1 = self#emit_tail_sequence env_body e1 in
       let rv = self#regs_for typ_val in
@@ -1821,12 +1677,11 @@ method emit_tail (env:environment) exp =
           (Itrywith(s1, kind,
                     (env_handler.trap_stack,
                      instr_cons_debug (Iop Imove) [|Proc.loc_exn_bucket|] rv dbg
-                       (end_region s2))))
+                       s2)))
           [||] [||]
       in
       let env = env_add v rv env in
       begin match kind with
-      | Regular -> with_handler env e2
       | Delayed lbl ->
         begin match env_find_static_exception lbl env_body with
         | { traps_ref = { contents = Reachable ts; }; _} ->
@@ -1843,18 +1698,6 @@ method emit_tail (env:environment) exp =
         | exception Not_found ->
           Misc.fatal_errorf "Selection.emit_expr: Unbound handler %d" lbl
         end
-      end
-  | Cregion e ->
-      assert (Config.stack_allocation);
-      let reg = self#regs_for typ_int in
-      self#insert env (Iop Ibeginregion) [| |] reg;
-      self#emit_tail {env with regions = reg::env.regions} e
-  | Ctail e ->
-      begin match env.regions with
-      | [] -> Misc.fatal_error "Selectgen.emit_tail: Ctail not inside Cregion"
-      | reg :: regions ->
-         self#insert_endregions env [reg];
-         self#emit_tail { env with regions } e
       end
   | Cop _
   | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _ | Cconst_vec128 _

--- a/backend/selectgen.mli
+++ b/backend/selectgen.mli
@@ -31,8 +31,6 @@ val size_expr : environment -> Cmm.expression -> int
 
 val select_mutable_flag : Asttypes.mutable_flag -> Mach.mutable_flag
 
-module Region_stack : sig type t end
-
 module Effect : sig
   type t =
     | None
@@ -167,10 +165,6 @@ class virtual selector_generic : object
   method insert_move_results :
     environment -> Reg.t array -> Reg.t array -> int -> unit
   method insert_moves : environment -> Reg.t array -> Reg.t array -> unit
-  method insert_endregions :
-    environment -> Reg.t array list -> unit
-  method insert_endregions_until :
-    environment -> suffix:Region_stack.t -> Region_stack.t -> unit
   method emit_expr
      : environment
     -> Cmm.expression
@@ -180,7 +174,7 @@ class virtual selector_generic : object
      : environment
     -> Cmm.expression
     -> bound_name:Backend_var.With_provenance.t option
-    -> (Reg.t array * Region_stack.t) option
+    -> Reg.t array option
   method emit_tail : environment -> Cmm.expression -> unit
 
   (* [contains_calls] is declared as a reference instance variable,

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -467,7 +467,6 @@ let find_spill_at_exit env k =
 let at_raise_from_trap_stack env ts =
   match ts with
   | Uncaught -> Reg.Set.empty
-  | Generic_trap _ -> env.last_regular_trywith_handler
   | Specific_trap (nfail, _) -> find_spill_at_exit env nfail
 
 let find_in_spill_cache nfail at_join env =

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -617,21 +617,19 @@ let rec spill :
         before))
   | Iexit (nfail, _traps) ->
       k i (find_spill_at_exit env nfail)
-  | Itrywith(body, kind, (ts, handler)) ->
+  | Itrywith(body, nfail, (ts, handler)) ->
     spill env i.next finally (fun new_next at_join ->
       let env_handler =
         { env with at_raise = at_raise_from_trap_stack env ts; }
       in
       spill env_handler handler at_join (fun new_handler before_handler ->
       let env_body =
-        match kind with
-        | Delayed nfail ->
-            { env with at_exit =
-                         (nfail, before_handler) :: env.at_exit;
-            }
+        { env with at_exit =
+                      (nfail, before_handler) :: env.at_exit;
+        }
       in
       spill env_body body at_join (fun new_body before_body ->
-      k (instr_cons_debug (Itrywith(new_body, kind, (ts, new_handler)))
+      k (instr_cons_debug (Itrywith(new_body, nfail, (ts, new_handler)))
          i.arg i.res i.dbg new_next)
         before_body)))
   | Iraise _ ->

--- a/backend/spill.ml
+++ b/backend/spill.ml
@@ -626,10 +626,6 @@ let rec spill :
       spill env_handler handler at_join (fun new_handler before_handler ->
       let env_body =
         match kind with
-        | Regular ->
-            { env with at_raise = before_handler;
-                       last_regular_trywith_handler = before_handler;
-            }
         | Delayed nfail ->
             { env with at_exit =
                          (nfail, before_handler) :: env.at_exit;

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -410,8 +410,7 @@ let is_cmm_simple cmm =
   | Cconst_symbol _ | Cvar _ ->
     true
   | Clet _ | Clet_mut _ | Cphantom_let _ | Cassign _ | Ctuple _ | Cop _
-  | Csequence _ | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ | Ctrywith _
-  | Cregion _ | Ctail _ ->
+  | Csequence _ | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ | Ctrywith _ ->
     false
 
 (* Helper function to create bindings *)

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -393,7 +393,7 @@ let translate_jump_to_continuation ~dbg_with_inlined:dbg env res apply types
       | None -> []
       | Some (Pop { exn_handler; _ }) ->
         let cont = Env.get_cmm_continuation env exn_handler in
-        [Cmm.Pop (Pop_specific cont)]
+        [Cmm.Pop cont]
       | Some (Push { exn_handler }) ->
         let cont = Env.get_cmm_continuation env exn_handler in
         [Cmm.Push cont]
@@ -421,7 +421,7 @@ let translate_jump_to_return_continuation ~dbg_with_inlined:dbg env res apply
   | Some (Pop { exn_handler; _ }) ->
     let cont = Env.get_cmm_continuation env exn_handler in
     let cmm, free_vars =
-      wrap (C.trap_return return_value [Cmm.Pop (Pop_specific cont)]) free_vars
+      wrap (C.trap_return return_value [Cmm.Pop cont]) free_vars
     in
     cmm, free_vars, res
   | Some (Push _) ->

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -686,7 +686,7 @@ and let_cont_exn_handler env res k body vars handler free_vars_of_handler
      Env.add_inlined_debuginfo to it *)
   let dbg = Debuginfo.none in
   let trywith =
-    C.trywith ~dbg ~kind:(Delayed catch_id) ~body ~exn_var ~handler ()
+    C.trywith ~dbg ~body ~exn_var ~handler_cont:catch_id ~handler ()
   in
   (* Define and initialize the mutable Cmm variables for extra args *)
   let cmm =

--- a/testsuite/tests/asmgen/catch-try-float.cmm
+++ b/testsuite/tests/asmgen/catch-try-float.cmm
@@ -7,6 +7,6 @@ arguments = "-DFLOAT_CATCH -DFUN=catch_try_float main.c"
 (function "catch_try_float" (b:float)
   (+f 10.0
   (catch
-    (try (exit(1) lbl 100.0)
+    (try float (exit(1) lbl 100.0)
      with var 456.0)
    with (lbl x:float) (+f x 1000.0))))

--- a/testsuite/tests/asmgen/catch-try-float.cmm
+++ b/testsuite/tests/asmgen/catch-try-float.cmm
@@ -7,6 +7,6 @@ arguments = "-DFLOAT_CATCH -DFUN=catch_try_float main.c"
 (function "catch_try_float" (b:float)
   (+f 10.0
   (catch
-    (try float (* (exit(1) lbl 100.0) *) 100.0
+    (try float (exit(1) lbl 100.0)
      with var 456.0)
    with (lbl x:float) (+f x 1000.0))))

--- a/testsuite/tests/asmgen/catch-try-float.cmm
+++ b/testsuite/tests/asmgen/catch-try-float.cmm
@@ -7,6 +7,6 @@ arguments = "-DFLOAT_CATCH -DFUN=catch_try_float main.c"
 (function "catch_try_float" (b:float)
   (+f 10.0
   (catch
-    (try float (exit(1) lbl 100.0)
+    (try float (* (exit(1) lbl 100.0) *) 100.0
      with var 456.0)
    with (lbl x:float) (+f x 1000.0))))

--- a/testsuite/tests/asmgen/catch-try.cmm
+++ b/testsuite/tests/asmgen/catch-try.cmm
@@ -7,6 +7,6 @@ arguments = "-DINT_INT -DFUN=catch_exit main.c"
 (function "catch_exit" (b:int)
   (+ 33
   (catch
-    (try (exit(1) lbl 12)
+    (try val (exit(1) lbl 12)
      with var 456)
    with (lbl x:val) (+ x 789))))

--- a/testsuite/tests/asmgen/soli.cmm
+++ b/testsuite/tests/asmgen/soli.cmm
@@ -47,7 +47,7 @@ arguments = "-DUNIT_INT -DFUN=solitaire main.c"
   (store int "counter" (+ (load int "counter") 1))
   (if (== m 31)
       (== (intaref (addraref "board" 4) 4) 2)
-    (try
+    (try val
      (if (== (mod (load int "counter") 500) 0)
           (extcall "printf_int" "format" (load int "counter") unit)
        [])

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -263,29 +263,29 @@ expr:
         List.iter (fun (x, _) -> unbind_ident x) l) handlers;
       Ccatch(Recursive, handlers, $3, Any) }
   | EXIT        { Cexit(Cmm.Lbl 0,[],[]) }
-  | LPAREN TRY sequence WITH bind_ident sequence RPAREN
+  | LPAREN TRY machtype sequence WITH bind_ident sequence RPAREN
       { let after_push_k = Lambda.next_raise_count () in
         let after_pop_k = Lambda.next_raise_count () in
         let exn_k = Lambda.next_raise_count () in
         let result = Backend_var.create_local "result" in
         let result' = Backend_var.With_provenance.create result in
-        unbind_ident $5;
+        unbind_ident $6;
         Ctrywith (
           Ccatch (Nonrecursive,
             [after_push_k, [],
              Ccatch (Nonrecursive,
-               [after_pop_k, [result', typ_val],
+               [after_pop_k, [result', $3],
                 Cvar result, debuginfo (), false],
                Cexit (Cmm.Lbl after_pop_k,
-                 [$3], (* original try body *)
+                 [$4], (* original try body *)
                  [Pop (Pop_specific exn_k)]),
                Any),
              debuginfo (), false],
             Cexit (Cmm.Lbl after_push_k, [], [Push exn_k]),
             Any),
           Delayed exn_k,
-          $5, (* exception parameter *)
-          $6, (* exception handler *)
+          $6, (* exception parameter *)
+          $7, (* exception handler *)
           debuginfo (),
           Any) }
   | LPAREN VAL expr expr RPAREN

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -283,7 +283,7 @@ expr:
              debuginfo (), false],
             Cexit (Cmm.Lbl after_push_k, [], [Push exn_k]),
             Any),
-          Delayed exn_k,
+          exn_k,
           $6, (* exception parameter *)
           $7, (* exception handler *)
           debuginfo (),

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -264,8 +264,30 @@ expr:
       Ccatch(Recursive, handlers, $3, Any) }
   | EXIT        { Cexit(Cmm.Lbl 0,[],[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
-      { unbind_ident $5; Ctrywith($3, Regular, $5, $6, debuginfo (),
-                                  Any) }
+      { let after_push_k = Lambda.next_raise_count () in
+        let after_pop_k = Lambda.next_raise_count () in
+        let exn_k = Lambda.next_raise_count () in
+        let result = Backend_var.create_local "result" in
+        let result' = Backend_var.With_provenance.create result in
+        unbind_ident $5;
+        Ctrywith (
+          Ccatch (Nonrecursive,
+            [after_push_k, [],
+             Ccatch (Nonrecursive,
+               [after_pop_k, [result', typ_val],
+                Cvar result, debuginfo (), false],
+               Cexit (Cmm.Lbl after_pop_k,
+                 [$3], (* original try body *)
+                 [Pop (Pop_specific exn_k)]),
+               Any),
+             debuginfo (), false],
+            Cexit (Cmm.Lbl after_push_k, [], [Push exn_k]),
+            Any),
+          Delayed exn_k,
+          $5, (* exception parameter *)
+          $6, (* exception handler *)
+          debuginfo (),
+          Any) }
   | LPAREN VAL expr expr RPAREN
       { let open Asttypes in
         Cop(Cload {memory_chunk=Word_val;

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -209,7 +209,7 @@ componentlist:
   | componentlist STAR component { $3 :: $1 }
 ;
 traps:
-    LPAREN INTCONST RPAREN       { List.init $2 (fun _ -> Pop Pop_generic) }
+    LPAREN INTCONST RPAREN       { List.init $2 (fun i -> Pop i) }
   | /**/                         { [] }
 expr:
     INTCONST    { Cconst_int ($1, debuginfo ()) }
@@ -278,7 +278,7 @@ expr:
                 Cvar result, debuginfo (), false],
                Cexit (Cmm.Lbl after_pop_k,
                  [$4], (* original try body *)
-                 [Pop (Pop_specific exn_k)]),
+                 [Pop exn_k]),
                Any),
              debuginfo (), false],
             Cexit (Cmm.Lbl after_push_k, [], [Push exn_k]),


### PR DESCRIPTION
This removes complexity from the Cmm language (in `backend/` only, not `ocaml/asmcomp/`) which is no longer needed after the removal of Closure and Flambda 1:
- `Cregion` expressions
- `Ctail` expressions
- The `Regular` case of `Ctrywith` handlers.