### PR TITLE
Move unboxed float literals to stable

### DIFF
--- a/ocaml/boot/menhir/parser.ml
+++ b/ocaml/boot/menhir/parser.ml
@@ -1181,7 +1181,7 @@ end = struct
 
   let assert_unboxed_literals ~loc =
     Language_extension.(
-      Jane_syntax_parsing.assert_extension_enabled ~loc Layouts Alpha)
+      Jane_syntax_parsing.assert_extension_enabled ~loc Layouts Stable)
 
   let unboxed ~loc x =
     assert_unboxed_literals ~loc:(make_loc loc);

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -956,7 +956,7 @@ end = struct
 
   let assert_unboxed_literals ~loc =
     Language_extension.(
-      Jane_syntax_parsing.assert_extension_enabled ~loc Layouts Alpha)
+      Jane_syntax_parsing.assert_extension_enabled ~loc Layouts Stable)
 
   let unboxed ~loc x =
     assert_unboxed_literals ~loc:(make_loc loc);

--- a/ocaml/testsuite/tests/typing-layouts-float64/alloc.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/alloc.ml
@@ -1,6 +1,6 @@
 (* TEST
    * flambda2
-   flags = "-extension layouts_alpha"
+   flags = "-extension layouts"
    ** native
 *)
 

--- a/ocaml/testsuite/tests/typing-layouts-float64/alloc.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/alloc.ml
@@ -66,17 +66,17 @@ struct
 
   let[@inline never] step n estimate =
     let new_term =
-      ((of_float (-1.)) ** n)
-      / ((n * (of_float 2.)) + (of_float 1.))
+      ((-#1.) ** n)
+      / ((n * #2.) + #1.)
     in
     estimate + new_term
 
   let rec go n est =
-    if n > (of_float 10000.) then est else go (n+ (of_float 1.)) (step n est)
+    if n > #10000. then est else go (n+ #1.) (step n est)
 
   let estimate () =
     let est =
-      measure_alloc (fun () -> go (of_float 0.) (of_float 0.))
+      measure_alloc (fun () -> go #0. #0.)
     in
     Printf.printf "Unboxed:\n  estimate: %f\n  allocations: %s\n"
       ((to_float est) *. 4.) (get_allocations ())
@@ -123,9 +123,9 @@ let print_record_and_allocs s r =
 (* Building a record should only allocate the box *)
 let[@inline never] build x =
   { a = x;
-    b = Float_u.of_float 42.0;
+    b = #42.0;
     c = consumer x x;
-    d = consumer x (Float_u.of_float 1.0) }
+    d = consumer x #1.0 }
 
 let[@inline never] project_a r = r.a
 let[@inline never] update_d r x = r.d <- x
@@ -136,11 +136,11 @@ let[@inline never] manipulate ({c; _} as r) =
   match r with
   | { b; _ } ->
     update_d r (consumer b (project_a r));
-    r.b <- Float_u.sub c (Float_u.of_float 21.1);
+    r.b <- Float_u.sub c #21.1;
     r.a
 
 let _ =
-  let r = measure_alloc_value (fun () -> build (Float_u.of_float 3.14)) in
+  let r = measure_alloc_value (fun () -> build #3.14) in
   print_record_and_allocs "Construction (40 bytes for record)" r;
   let _ = measure_alloc (fun () -> manipulate r) in
   print_record_and_allocs "Manipulation (0 bytes)" r
@@ -163,7 +163,7 @@ let[@inline never] cse_test b r =
     (0., 0.)
 
 let _ =
-  let r = build (Float_u.of_float 3.14) in
+  let r = build #3.14 in
   let _ = measure_alloc_value (fun () -> cse_test false r) in
   let allocs = get_exact_allocations () in
   Printf.printf "CSE test (0 bytes):\n  allocated bytes: %.2f\n" allocs

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -1,9 +1,10 @@
 (* TEST
-   * expect
+   * flambda2
+   ** expect
      flags = "-extension layouts_alpha"
-   * expect
+   ** expect
      flags = "-extension layouts_beta"
-   * expect
+   ** expect
      flags = "-extension layouts"
 *)
 
@@ -746,7 +747,7 @@ type t14_1 = { x : float#; y : float# }
 let f14_1 {x;y} = FU.sub x y
 
 (* construction *)
-let r14 = { x = FU.of_float 3.14; y = FU.of_float 2.72 }
+let r14 = { x = #3.14; y = #2.72 }
 
 let sum14_1 = FU.to_float (f14_1 r14)
 
@@ -759,14 +760,14 @@ type t14_2 = { mutable a : float#; b : float#; mutable c : float# }
 
 let f14_3 ({b; c; _} as r) =
   (* pure record update *)
-  let r' = { r with b = FU.of_float 20.0; c = r.a } in
+  let r' = { r with b = #20.0; c = r.a } in
   (* mutation *)
   r.a <- FU.sub r.a r'.b;
-  r'.a <- FU.of_float 42.0;
+  r'.a <- #42.0;
   r'
 
 let a, b, c, a', b', c' =
-  let r = {a = FU.of_float 3.1; b = FU.of_float (-0.42); c = FU.of_float 27.7 } in
+  let r = {a = #3.1; b = -#0.42; c = #27.7 } in
   let r' = f14_3 r in
   FU.to_float r.a,
   FU.to_float r.b,

--- a/ocaml/testsuite/tests/typing-layouts-float64/c_api.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/c_api.ml
@@ -19,7 +19,6 @@
 (* This file tests using external C functions with float#. *)
 
 external to_float : float# -> (float[@local_opt]) = "%box_float"
-external of_float : (float[@local_opt]) -> float# = "%unbox_float"
 
 let print_floatu s f = Printf.printf "%s: %.2f\n" s (to_float f)
 let print_float s f = Printf.printf "%s: %.2f\n" s f
@@ -33,7 +32,7 @@ external sin_BU_U : (float[@unboxed]) -> float# = "sin_byte" "sin_U_U"
 external sin_U_BU : float# -> (float[@unboxed]) = "sin_byte" "sin_U_U"
 
 let sin_two =
-  let f = sin_U_U (of_float 2.) in
+  let f = sin_U_U #2. in
   print_floatu "Test U -> U, sin two" f
 
 let sin_three =
@@ -41,7 +40,7 @@ let sin_three =
   print_floatu "Test B -> U, sin three" f
 
 let sin_four =
-  let f = sin_U_B (of_float 4.) in
+  let f = sin_U_B #4. in
   print_float "Test U -> B, sin four" f
 
 let sin_five =
@@ -49,7 +48,7 @@ let sin_five =
   print_floatu "Test (B[@unboxed]) -> U, sin five" f
 
 let sin_six =
-  let f = sin_U_BU (of_float 6.) in
+  let f = sin_U_BU #6. in
   print_float "Test U -> (B[@unboxed]), sin six" f
 
 (* If there are more than 5 args, you get an array in the bytecode version,
@@ -60,7 +59,7 @@ external sum_7 :
 
 let sum_of_one_to_seven =
   let f =
-    sum_7 (of_float 1.) 2. (of_float 3.) 4. (of_float 5.) 6. (of_float 7.)
+    sum_7 #1. 2. #3. 4. #5. 6. #7.
   in
   print_floatu "Function with many args, sum_of_one_to_seven" f
 
@@ -68,5 +67,5 @@ let sum_of_one_to_seven =
 let[@inline never] sin_U_U' x = sin_U_U x
 
 let sin_seven =
-  let f = sin_U_U' (of_float 7.) in
+  let f = sin_U_U' #7. in
   print_floatu "Test U -> U eta expansion, sin seven" f

--- a/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.ml
@@ -1,22 +1,23 @@
 (* TEST
+   * flambda2
    reference = "${test_source_directory}/unboxed_floats.reference"
-   * native
+   ** native
      flags = "-extension layouts_alpha"
-   * bytecode
+   ** bytecode
      flags = "-extension layouts_alpha"
-   * native
+   ** native
      flags = "-extension layouts_beta"
-   * bytecode
+   ** bytecode
      flags = "-extension layouts_beta"
-   * native
+   ** native
      flags = "-extension layouts"
-   * bytecode
+   ** bytecode
      flags = "-extension layouts"
-   * setup-ocamlc.byte-build-env
+   ** setup-ocamlc.byte-build-env
      ocamlc_byte_exit_status = "2"
-   ** ocamlc.byte
+   *** ocamlc.byte
      compiler_reference = "${test_source_directory}/unboxed_floats_disabled.compilers.reference"
-   *** check-ocamlc.byte-output
+   **** check-ocamlc.byte-output
 
 
 *)
@@ -55,19 +56,19 @@ let test1 () =
   (* CR layouts: When float64 defs are allowed at the module level, get rid of
      [test1] and move these definitions there. *)
   let open Float_u in
-  let pi = of_float 3.14 in
+  let pi = #3.14 in
   print_floatu "Test 1, pi" pi;
 
-  let twice_pi = pi + (of_float 3.14) in
+  let twice_pi = pi + #3.14 in
   print_floatu "Test 1, twice_pi" twice_pi;
 
-  let thrice_pi = (of_float 3.0) * pi in
+  let thrice_pi = #3.0 * pi in
   print_floatu "Test 1, thrice_pi" thrice_pi;
 
   let twice_pi_again = thrice_pi - pi in
   print_floatu "Test 1, twice_pi_again" twice_pi;
 
-  let pi_again = twice_pi_again / (of_float 2.0) in
+  let pi_again = twice_pi_again / #2.0 in
   print_floatu "Test 1, pi_again" pi_again;
 
   let twice_pi_to_the_pi = twice_pi ** pi in
@@ -78,7 +79,7 @@ let test1 () =
     twice_pi_greater_than_pi;
 
   let pi_with_effort =
-    ((of_float 3.14) + twice_pi) * (of_float 2.0) / (of_float 6.0) in
+    (#3.14 + twice_pi) * #2.0 / #6.0 in
   print_floatu "Test 1, pi_with_effort" pi_with_effort
 
 let _ = test1 ()
@@ -94,33 +95,33 @@ let[@inline never] twice f (x : 'a t_float64) = f (f x)
 let[@inline never] compose f g (x : 'a t_float64) = f (g x)
 
 let[@inline never] twice_on_pi f =
-  let pi = Float_u.of_float 3.14 in
+  let pi = #3.14 in
   twice f pi
 
-let times_four = twice Float_u.(fun x -> x * (of_float 2.0))
+let times_four = twice Float_u.(fun x -> x * #2.0)
 
 let _ =
   let open Float_u in
   print_floatu "Test 2, add pi twice"
-    (twice (fun x -> x + (of_float 3.14)) (of_float 0.0));
+    (twice (fun x -> x + #3.14) #0.0);
   print_floatu "Test 2, add pi four times"
-    (twice (twice (fun x -> x + (of_float 3.14))) (of_float 0.0));
+    (twice (twice (fun x -> x + #3.14)) #0.0);
   print_floatu "Test 2, increment pi twice"
-    (twice_on_pi (fun x -> (of_float 1.0) + x));
+    (twice_on_pi (fun x -> #1.0 + x));
   print_floatu "Test 2, increment pi four times"
-    (twice_on_pi (twice (fun x -> (of_float 1.0) + x)));
+    (twice_on_pi (twice (fun x -> #1.0 + x)));
   print_floatu "Test 2, e times four"
-    (times_four (of_float 2.72));
+    (times_four #2.72);
   print_floatu "Test 2, pi times sixteen"
     (twice_on_pi times_four);
   print_floatu "Test 2, pi times sixteen again"
-    (compose times_four times_four (of_float 3.14));
+    (compose times_four times_four #3.14);
   print_floatu "Test 2, pi minus four"
-    (let two = twice (fun x -> x + (of_float 1.0)) (of_float 0.0) in
+    (let two = twice (fun x -> x + #1.0) #0.0 in
      let add_two = Float_u.(+) two in
      let add_two_after = compose add_two in
-     let minus_four = add_two_after (twice (fun x -> x - (of_float 3.0))) in
-     minus_four (of_float 3.14))
+     let minus_four = add_two_after (twice (fun x -> x - #3.0)) in
+     minus_four #3.14)
 
 (******************************)
 (* Test 3: float# in closures *)
@@ -130,7 +131,7 @@ let _ =
 let[@inline never] f3 n m steps () =
   let[@inline never] rec go k =
     if k = n
-    then Float_u.of_float 0.
+    then #0.
     else begin
       let acc = go (k + 1) in
       steps.(k) <- Float_u.to_float acc;
@@ -144,7 +145,7 @@ let[@inline_never] f3_manyargs x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 steps () =
   let (start_k, end_k) = x0 in
   let[@inline never] rec go k =
     if k = end_k
-    then Float_u.of_float 0.
+    then #0.
     else begin
       let (x2_1, x2_2) = x2 in
       let (x4_1, x4_2) = x4 in
@@ -161,7 +162,7 @@ let[@inline_never] f3_manyargs x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 steps () =
 let test3 () =
   (* Test f3 *)
   let steps = Array.init 10 (fun _ -> 0.0) in
-  let five_pi = f3 5 (Float_u.of_float 3.14) steps in
+  let five_pi = f3 5 #3.14 steps in
   print_floatu "Test 3, 5 * pi: " (five_pi ());
   Array.iteri (Printf.printf "  Test 3, step %d: %.2f\n") steps;
 
@@ -175,11 +176,11 @@ let test3 () =
     ( but we expect some floating point error )
   *)
   let steps = Array.init 10 (fun _ -> 0.0) in
-  let x1 = Float_u.of_float 3.14 in
-  let x3 = Float_u.of_float 2.72 in
-  let x5 = Float_u.of_float 1.62 in
-  let x7 = Float_u.of_float 1.41 in
-  let x9 = Float_u.of_float 42.0 in
+  let x1 = #3.14 in
+  let x3 = #2.72 in
+  let x5 = #1.62 in
+  let x7 = #1.41 in
+  let x9 = #42.0 in
 
   (* these sum to 3 *)
   let x2 = (7, 42) in
@@ -199,7 +200,7 @@ let _ = test3 ()
 let[@inline never] test4 () =
   (* Simple indirect call *)
   let[@inline never] go f =
-    Float_u.to_float (f (Float_u.of_float 1.) (Float_u.of_float 2.))
+    Float_u.to_float (f #1. #2.)
   in
   let (x1, x2) = (go Float_u.(+), go Float_u.(-)) in
   print_floatu "Test 4, 1 + 2" (Float_u.of_float x1);
@@ -207,7 +208,7 @@ let[@inline never] test4 () =
 
   (* partial application to float# *)
   let steps = Array.init 10 (fun _ -> 0.0) in
-  let f = Sys.opaque_identity (f3 5 (Float_u.of_float 3.14)) in
+  let f = Sys.opaque_identity (f3 5 #3.14) in
   let five_pi = f steps in
   print_floatu "Test 4, 5 * pi: " (five_pi ());
   Array.iteri (Printf.printf "  Test 4, step %d: %.2f\n") steps;
@@ -215,7 +216,7 @@ let[@inline never] test4 () =
   (* partial application with float# remaining *)
   let steps = Array.init 10 (fun _ -> 0.0) in
   let f = Sys.opaque_identity (f3 6) in
-  let five_pi = f (Float_u.of_float 3.14) steps in
+  let five_pi = f #3.14 steps in
   print_floatu "Test 4, 6 * pi: " (five_pi ());
   Array.iteri (Printf.printf "  Test 4, step %d: %.2f\n") steps;
 
@@ -224,14 +225,14 @@ let[@inline never] test4 () =
   let f3 = Sys.opaque_identity f3 in
 
   let steps = Array.init 10 (fun _ -> 0.0) in
-  let f = Sys.opaque_identity (f3 5 (Float_u.of_float 3.14)) in
+  let f = Sys.opaque_identity (f3 5 #3.14) in
   let five_pi = f steps in
   print_floatu "Test 4, 5 * pi: " (five_pi ());
   Array.iteri (Printf.printf "  Test 4, step %d: %.2f\n") steps;
 
   let steps = Array.init 10 (fun _ -> 0.0) in
   let f = Sys.opaque_identity (f3 6) in
-  let five_pi = f (Float_u.of_float 3.14) steps in
+  let five_pi = f #3.14 steps in
   print_floatu "Test 4, 6 * pi: " (five_pi ());
   Array.iteri (Printf.printf "  Test 4, step %d: %.2f\n") steps
 
@@ -251,9 +252,9 @@ let[@inline never] f5 n m =
 let test5 () =
   let open Float_u in
   let _ : unit =
-    f5 (of_float 3.14) (of_float 2.72)
+    f5 #3.14 #2.72
       (fun n s m -> print_floatu s (n + m)) "Test 5, pi+e+1"
-      (of_float 1.0)
+      #1.0
   in
   ()
 
@@ -294,20 +295,20 @@ let test6 () =
   (* (3.14 - 2.72) / 2.5 = ~0.17 *)
   let o = (Sys.opaque_identity f6_1) () in
   print_floatu "Test 6, 0.17"
-    (o#f6_m1 (of_float 3.14) (of_float 2.72) (of_float 2.5));
+    (o#f6_m1 #3.14 #2.72 #2.5);
 
   (* 4.25 * 8 = 34 *)
   let o = (Sys.opaque_identity f6_2) (4,7) in
-  let result = o#f6_m2 8 (of_float 4.25) (fun x -> x * of_float 2.) in
+  let result = o#f6_m2 8 #4.25 (fun x -> x * #2.) in
   print_floatu "Test 6, 34.00" result;
 
   (* (1 + 2 + 3 + (-2) + (-12) + 4) * (2.72 + (-1) + 10) = -46.88 *)
   let o = (Sys.opaque_identity f6_3) (1,2) 3 in
   let result =
-    o#f6_m3 (-2) (of_float 2.72)
+    o#f6_m3 (-2) (#2.72)
       (fun[@inline never] i m1 m2 n m3 ->
          (of_float (Float.of_int (add3 i n))) * (m1 + m2 + m3))
-      (of_float (-1.)) (-12,4) (of_float 10.)
+      (-#1.) (-12,4) (#10.)
   in
   print_floatu "Test 6, -46.88" result
 
@@ -316,19 +317,19 @@ let _ = test6 ()
 (*****************************)
 (* Test 7: letop with floats *)
 
-let ( let* ) x f = f Float_u.(x + (of_float 1.5))
+let ( let* ) x f = f Float_u.(x + #1.5)
 
 let _ =
-  let* x = Float_u.of_float 42.0 in
-  print_floatu "Test 7, 36.50" Float_u.(x - of_float 7.0)
+  let* x = #42.0 in
+  print_floatu "Test 7, 36.50" Float_u.(x - #7.0)
 
 let ( let* ) x (f : _ -> float#) = f x
-let ( and* ) x y = Float_u.(x, to_float (y - (of_float 1.2)))
+let ( and* ) x y = Float_u.(x, to_float (y - #1.2))
 let _ =
   let result =
     let* x = 42.0
-    and* y = Float_u.of_float 3.3
-    and* z = Float_u.of_float (-10.7) in
+    and* y = #3.3
+    and* z = -#10.7 in
     Float_u.of_float (x +. y +. z)
   in
   print_floatu "Test 7, 32.20" result
@@ -344,7 +345,7 @@ let[@inline_never] f8 x0 x2 x4 x6 x8 steps ({ x1; x5; _ } as fargs) () =
   let (start_k, end_k) = x0 in
   let[@inline never] rec go k =
     if k = end_k
-    then Float_u.of_float 0.
+    then #0.
     else begin
       let (x2_1, x2_2) = x2 in
       let (x4_1, x4_2) = x4 in
@@ -362,11 +363,11 @@ let[@inline_never] f8 x0 x2 x4 x6 x8 steps ({ x1; x5; _ } as fargs) () =
 let test8 () =
   (* same math as f3_manyargs *)
   let steps = Array.init 10 (fun _ -> 0.0) in
-  let x1 = Float_u.of_float 3.14 in
-  let x3 = Float_u.of_float 2.72 in
-  let x5 = Float_u.of_float 1.62 in
-  let x7 = Float_u.of_float 1.41 in
-  let x9 = Float_u.of_float 42.0 in
+  let x1 = #3.14 in
+  let x3 = #2.72 in
+  let x5 = #1.62 in
+  let x7 = #1.41 in
+  let x9 = #42.0 in
 
   (* these sum to 3 *)
   let x2 = (7, 42) in
@@ -391,15 +392,15 @@ type t9 = { a : float#;
             mutable d : float# }
 
 (* Construction *)
-let t9_1 = { a = Float_u.of_float 3.14;
-             b = Float_u.of_float 2.72;
-             c = Float_u.of_float 1.62;
-             d = Float_u.of_float 1.41 }
+let t9_1 = { a = #3.14;
+             b = #2.72;
+             c = #1.62;
+             d = #1.41 }
 
-let t9_2 = { a = Float_u.of_float (-3.14);
-             b = Float_u.of_float (-2.72);
-             c = Float_u.of_float (-1.62);
-             d = Float_u.of_float (-1.41) }
+let t9_2 = { a = -#3.14;
+             b = -#2.72;
+             c = -#1.62;
+             d = -#1.41 }
 
 let print_t9 t9 =
   print_floatu "  a" t9.a;
@@ -427,10 +428,10 @@ let _ =
 
 (* Record update and mutation *)
 let f9_2 ({a; d; _} as r1) r2 =
-  r1.d <- Float_u.of_float 42.0;
-  let r3 = { r2 with c = r1.d; d = Float_u.of_float 25.0 } in
+  r1.d <- #42.0;
+  let r3 = { r2 with c = r1.d; d = #25.0 } in
   r3.b <- Float_u.(a + d);
-  r2.b <- Float_u.of_float 17.0;
+  r2.b <- #17.0;
   r3
 
 let _ =
@@ -445,19 +446,19 @@ let _ =
 
 let rec f r =
   r.d <- t10_1.b;
-  t10_2.b <- (Float_u.of_float 42.0);
+  t10_2.b <- #42.0;
   Float_u.(r.a + t10_2.a)
 
 
-and t10_1 = { a = Float_u.of_float 1.1;
-              b = Float_u.of_float 2.2;
-              c = Float_u.of_float 3.2;
-              d = Float_u.of_float 4.4 }
+and t10_1 = { a = #1.1;
+              b = #2.2;
+              c = #3.2;
+              d = #4.4 }
 
-and t10_2 = { a = Float_u.of_float (- 5.1);
-              b = Float_u.of_float (- 6.2);
-              c = Float_u.of_float (- 7.3);
-              d = Float_u.of_float (- 8.4) }
+and t10_2 = { a = -#5.1;
+              b = -#6.2;
+              c = -#7.3;
+              d = -#8.4 }
 
 let _ =
   Printf.printf "Test 10, float# records in recursive groups.\n";
@@ -476,7 +477,7 @@ type ex = Ex : 'a -> ex
 type t11_u = { xu : float#; yu : float# }
 type t11_b = { xb : float; yb : float }
 
-let ru = { xu = Float_u.of_float 3.14; yu = Float_u.of_float 42.0 }
+let ru = { xu = #3.14; yu = #42.0 }
 let rb = { xb = 3.14; yb = 42.0 }
 let rb' = { xb = 3.14; yb = 42.1 }
 
@@ -489,6 +490,6 @@ let _ =
 (* Test 12: If-then-else with float64 and assert *)
 
 let _ =
-  let a = if Sys.opaque_identity true then Float_u.of_int 1 else assert false in
+  let a = if Sys.opaque_identity true then #1. else assert false in
   Printf.printf "Test 12, If-then-else with assert and float64.\n";
   print_floatu "  result (1.00)" a

--- a/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats_disabled.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats_disabled.compilers.reference
@@ -1,4 +1,4 @@
-File "unboxed_floats.ml", line 58, characters 11-16:
-58 |   let pi = #3.14 in
+File "unboxed_floats.ml", line 59, characters 11-16:
+59 |   let pi = #3.14 in
                 ^^^^^
 Error: This construct requires the stable version of the extension "layouts", which is disabled and cannot be used

--- a/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats_disabled.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats_disabled.compilers.reference
@@ -1,4 +1,4 @@
-File "unboxed_floats.ml", line 325, characters 25-31:
-325 | let ( let* ) x (f : _ -> float#) = f x
-                               ^^^^^^
+File "unboxed_floats.ml", line 58, characters 11-16:
+58 |   let pi = #3.14 in
+                ^^^^^
 Error: This construct requires the stable version of the extension "layouts", which is disabled and cannot be used

--- a/ocaml/testsuite/tests/typing-layouts/literals.ml
+++ b/ocaml/testsuite/tests/typing-layouts/literals.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-extension layouts_alpha"
+   flags = "-extension layouts"
    * expect
 *)
 

--- a/ocaml/testsuite/tests/typing-layouts/literals_native.ml
+++ b/ocaml/testsuite/tests/typing-layouts/literals_native.ml
@@ -1,6 +1,6 @@
 (* TEST
    * flambda2
-   flags = "-extension layouts_alpha"
+   flags = "-extension layouts"
    ** native
    ** bytecode
 *)


### PR DESCRIPTION
#2062 and #2071 added proper middle/backend support for unboxed float literals which motivates moving it out of alpha.