### PR TITLE
Fix failure in closure_conversion.ml

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1348,9 +1348,11 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
             in
             Expr_with_acc.create_switch acc
               (Switch.create ~condition_dbg ~scrutinee ~arms)
-          | Some case ->
-            let acc, action = Targetint_31_63.Map.find case arms acc in
-            Expr_with_acc.create_apply_cont acc action)
+          | Some case -> (
+            match Targetint_31_63.Map.find case arms acc with
+            | acc, action -> Expr_with_acc.create_apply_cont acc action
+            | exception Not_found ->
+              Expr_with_acc.create_invalid acc Zero_switch_arms))
       in
       Let_with_acc.create acc
         (Bound_pattern.singleton untagged_scrutinee')


### PR DESCRIPTION
It was previously failing on:
```ocaml
external magic : 'a -> 'b = "%identity"
external opaque : 'a -> 'a = "%opaque"

type t = A | B | U of int
type t2 = C | D | E | F

let f x =
  let[@local] g (x : t) = match x with A -> B | B -> U 0 | U _ -> A in
  if x then g (magic E) else U 0
```