### PR TITLE
Add region in Call_kind for C calls

### DIFF
--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -936,9 +936,18 @@ let call_kinds env (call_kind1 : Call_kind.t) (call_kind2 : Call_kind.t) :
         { approximant =
             Call_kind.method_call kind1 ~obj:(subst_simple env obj1) alloc_mode1
         }
-  | ( C_call { alloc = alloc1; is_c_builtin = _ },
-      C_call { alloc = alloc2; is_c_builtin = _ } ) ->
-    if Bool.equal alloc1 alloc2
+  | ( C_call
+        { needs_caml_c_call = needs_caml_c_call1;
+          is_c_builtin = _;
+          alloc_mode = alloc_mode1
+        },
+      C_call
+        { needs_caml_c_call = needs_caml_c_call2;
+          is_c_builtin = _;
+          alloc_mode = alloc_mode2
+        } ) ->
+    if Bool.equal needs_caml_c_call1 needs_caml_c_call2
+       && Alloc_mode.For_allocations.compare alloc_mode1 alloc_mode2 = 0
     then Equivalent
     else Different { approximant = call_kind1 }
   | _, _ -> Different { approximant = call_kind1 }

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -414,17 +414,18 @@ module Inlining = struct
 end
 
 let close_c_call acc env ~loc ~let_bound_ids_with_kinds
-    ({ prim_name;
-       prim_arity;
-       prim_alloc;
-       prim_c_builtin;
-       prim_effects = _;
-       prim_coeffects = _;
-       prim_native_name;
-       prim_native_repr_args;
-       prim_native_repr_res
-     } :
-      Primitive.description) ~(args : Simple.t list list) exn_continuation dbg
+    (({ prim_name;
+        prim_arity;
+        prim_alloc;
+        prim_c_builtin;
+        prim_effects = _;
+        prim_coeffects = _;
+        prim_native_name;
+        prim_native_repr_args;
+        prim_native_repr_res
+      } :
+       Primitive.description) as prim_desc) ~(args : Simple.t list list)
+    exn_continuation dbg ~current_region
     (k : Acc.t -> Named.t list -> Expr_with_acc.t) : Expr_with_acc.t =
   let args =
     List.map
@@ -516,8 +517,17 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
   let return_arity =
     Flambda_arity.create_singletons [K.With_subkind.anything return_kind]
   in
+  let alloc_mode =
+    match Lambda.alloc_mode_of_primitive_description prim_desc with
+    | None ->
+      (* This happens when stack allocation is disabled. *)
+      Alloc_mode.For_allocations.heap
+    | Some alloc_mode ->
+      Alloc_mode.For_allocations.from_lambda alloc_mode ~current_region
+  in
   let call_kind =
-    Call_kind.c_call ~alloc:prim_alloc ~is_c_builtin:prim_c_builtin
+    Call_kind.c_call ~needs_caml_c_call:prim_alloc ~is_c_builtin:prim_c_builtin
+      alloc_mode
   in
   let call_symbol =
     let prim_name =
@@ -719,7 +729,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Some exn_continuation -> exn_continuation
     in
     close_c_call acc env ~loc ~let_bound_ids_with_kinds prim ~args
-      exn_continuation dbg k
+      exn_continuation dbg ~current_region k
   | Pgetglobal cu, [] ->
     if Compilation_unit.equal cu (Env.current_unit env)
     then

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -979,12 +979,13 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           ( Call_kind.indirect_function_call_unknown_arity alloc,
             params_arity,
             return_arity ))
-      | C_call { alloc } -> (
+      | C_call { alloc = needs_caml_c_call } -> (
         match arities with
         | Some { params_arity = Some params_arity; ret_arity } ->
           let params_arity = arity params_arity in
           let return_arity = arity ret_arity in
-          ( Call_kind.c_call ~alloc ~is_c_builtin:false,
+          ( Call_kind.c_call ~needs_caml_c_call ~is_c_builtin:false
+              Alloc_mode.For_allocations.heap,
             params_arity,
             return_arity )
         | None | Some { params_arity = None; ret_arity = _ } ->

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -1026,7 +1026,7 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
         } ->
       let alloc = alloc_mode_for_allocations env alloc_mode in
       Function (Indirect alloc)
-    | C_call { alloc; _ } -> C_call { alloc }
+    | C_call { needs_caml_c_call; _ } -> C_call { alloc = needs_caml_c_call }
     | Method _ -> Misc.fatal_error "TODO: Method call kind"
   in
   let param_arity = Apply_expr.args_arity app in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -1193,7 +1193,7 @@ let simplify_apply ~simplify_expr dacc apply ~down_to_up =
           apply
     in
     simplify_method_call dacc apply ~callee_ty ~kind ~obj ~arg_types ~down_to_up
-  | C_call { alloc = _; is_c_builtin = _ } ->
+  | C_call { needs_caml_c_call = _; is_c_builtin = _; alloc_mode = _ } ->
     let callee_ty =
       match callee_ty with
       | Some callee_ty -> callee_ty

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -76,6 +76,8 @@ type t =
     args_arity : [`Complex] Flambda_arity.t;
     return_arity : [`Unarized] Flambda_arity.t;
     call_kind : Call_kind.t;
+    (* CR mshinwell: we could move the [alloc_mode] out of [Call_kind] into
+       here *)
     dbg : Debuginfo.t;
     inlined : Inlined_attribute.t;
     inlining_state : Inlining_state.t;

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -83,7 +83,7 @@ let [@ocamlformat "disable"] print ppf t =
       Simple.print obj
       Method_kind.print kind
       Alloc_mode.For_allocations.print alloc_mode
-  | C_call { needs_caml_c_call; is_c_builtin;alloc_mode } ->
+  | C_call { needs_caml_c_call; is_c_builtin; alloc_mode } ->
     fprintf ppf "@[<hov 1>(C@ \
         @[<hov 1>(needs_caml_c_call@ %b)@]@ \
         @[<hov 1>(is_c_builtin@ %b)@]@ \

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -60,8 +60,9 @@ type t =
         alloc_mode : Alloc_mode.For_allocations.t
       }
   | C_call of
-      { alloc : bool;
-        is_c_builtin : bool
+      { needs_caml_c_call : bool;
+        is_c_builtin : bool;
+        alloc_mode : Alloc_mode.For_allocations.t
       }
 
 let [@ocamlformat "disable"] print ppf t =
@@ -82,13 +83,15 @@ let [@ocamlformat "disable"] print ppf t =
       Simple.print obj
       Method_kind.print kind
       Alloc_mode.For_allocations.print alloc_mode
-  | C_call { alloc; is_c_builtin; } ->
+  | C_call { needs_caml_c_call; is_c_builtin;alloc_mode } ->
     fprintf ppf "@[<hov 1>(C@ \
-        @[<hov 1>(alloc %b)@]@ \
-        @[<hov 1>(is_c_builtin %b)@]\
+        @[<hov 1>(needs_caml_c_call@ %b)@]@ \
+        @[<hov 1>(is_c_builtin@ %b)@]@ \
+        @[<hov 1>(alloc_mode@ %a)@]\
         )@]"
-      alloc
+      needs_caml_c_call
       is_c_builtin
+      Alloc_mode.For_allocations.print alloc_mode
 
 let direct_function_call code_id alloc_mode =
   Function { function_call = Direct code_id; alloc_mode }
@@ -101,7 +104,8 @@ let indirect_function_call_known_arity alloc_mode =
 
 let method_call kind ~obj alloc_mode = Method { kind; obj; alloc_mode }
 
-let c_call ~alloc ~is_c_builtin = C_call { alloc; is_c_builtin }
+let c_call ~needs_caml_c_call ~is_c_builtin alloc_mode =
+  C_call { needs_caml_c_call; is_c_builtin; alloc_mode }
 
 let free_names t =
   match t with
@@ -112,7 +116,8 @@ let free_names t =
   | Function { function_call = Indirect_unknown_arity; alloc_mode }
   | Function { function_call = Indirect_known_arity; alloc_mode } ->
     Alloc_mode.For_allocations.free_names alloc_mode
-  | C_call { alloc = _; is_c_builtin = _ } -> Name_occurrences.empty
+  | C_call { needs_caml_c_call = _; is_c_builtin = _; alloc_mode } ->
+    Alloc_mode.For_allocations.free_names alloc_mode
   | Method { kind = _; obj; alloc_mode } ->
     Name_occurrences.union (Simple.free_names obj)
       (Alloc_mode.For_allocations.free_names alloc_mode)
@@ -138,7 +143,13 @@ let apply_renaming t renaming =
     if alloc_mode == alloc_mode'
     then t
     else Function { function_call; alloc_mode = alloc_mode' }
-  | C_call { alloc = _; is_c_builtin = _ } -> t
+  | C_call { needs_caml_c_call; is_c_builtin; alloc_mode } ->
+    let alloc_mode' =
+      Alloc_mode.For_allocations.apply_renaming alloc_mode renaming
+    in
+    if alloc_mode == alloc_mode'
+    then t
+    else C_call { needs_caml_c_call; is_c_builtin; alloc_mode = alloc_mode' }
   | Method { kind; obj; alloc_mode } ->
     let obj' = Simple.apply_renaming obj renaming in
     let alloc_mode' =
@@ -157,7 +168,8 @@ let ids_for_export t =
   | Function { function_call = Indirect_unknown_arity; alloc_mode }
   | Function { function_call = Indirect_known_arity; alloc_mode } ->
     Alloc_mode.For_allocations.ids_for_export alloc_mode
-  | C_call { alloc = _; is_c_builtin = _ } -> Ids_for_export.empty
+  | C_call { needs_caml_c_call = _; is_c_builtin = _; alloc_mode } ->
+    Alloc_mode.For_allocations.ids_for_export alloc_mode
   | Method { kind = _; obj; alloc_mode } ->
     Ids_for_export.union
       (Ids_for_export.from_simple obj)

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -57,10 +57,11 @@ type t = private
         alloc_mode : Alloc_mode.For_allocations.t
       }
   | C_call of
-      { alloc : bool;
-        is_c_builtin : bool
+      { needs_caml_c_call : bool;
+        is_c_builtin : bool;
             (* CR mshinwell: This should have the effects and coeffects
                fields *)
+        alloc_mode : Alloc_mode.For_allocations.t
       }
 
 include Expr_std.S with type t := t
@@ -76,4 +77,8 @@ val indirect_function_call_known_arity : Alloc_mode.For_allocations.t -> t
 val method_call :
   Method_kind.t -> obj:Simple.t -> Alloc_mode.For_allocations.t -> t
 
-val c_call : alloc:bool -> is_c_builtin:bool -> t
+val c_call :
+  needs_caml_c_call:bool ->
+  is_c_builtin:bool ->
+  Alloc_mode.For_allocations.t ->
+  t

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -53,9 +53,9 @@ let direct_call_size = 4
 
 let indirect_call_size = 6
 
-let alloc_extcall_size = 10
+let needs_caml_c_call_extcall_size = 10
 
-let nonalloc_extcall_size = 4
+let does_not_need_caml_c_call_extcall_size = 4
 
 let array_length_size = 2
 
@@ -70,13 +70,14 @@ let unary_int_prim_size kind op =
   | Tagged_immediate, Swap_byte_endianness ->
     (* CR pchambart: size depends a lot of the architecture. If the backend
        handles it, this is a single arith op. *)
-    2 + nonalloc_extcall_size + 1
+    2 + does_not_need_caml_c_call_extcall_size + 1
   | Naked_immediate, Neg -> 1
-  | Naked_immediate, Swap_byte_endianness -> nonalloc_extcall_size + 1
-  | Naked_int64, Neg when arch32 -> nonalloc_extcall_size + 1
+  | Naked_immediate, Swap_byte_endianness ->
+    does_not_need_caml_c_call_extcall_size + 1
+  | Naked_int64, Neg when arch32 -> does_not_need_caml_c_call_extcall_size + 1
   | (Naked_int32 | Naked_int64 | Naked_nativeint), Neg -> 1
   | (Naked_int32 | Naked_int64 | Naked_nativeint), Swap_byte_endianness ->
-    nonalloc_extcall_size + 1
+    does_not_need_caml_c_call_extcall_size + 1
 
 let arith_conversion_size src dst =
   match
@@ -89,13 +90,13 @@ let arith_conversion_size src dst =
   | Naked_int64, (Naked_nativeint | Naked_immediate)
   | Naked_int64, Naked_float
     when arch32 ->
-    nonalloc_extcall_size + 1 (* arg *)
+    does_not_need_caml_c_call_extcall_size + 1 (* arg *)
   | Tagged_immediate, Naked_int64
   | Naked_int32, Naked_int64
   | (Naked_nativeint | Naked_immediate), Naked_int64
   | Naked_float, Naked_int64
     when arch32 ->
-    alloc_extcall_size + 1 (* arg *) + 1 (* unbox *)
+    needs_caml_c_call_extcall_size + 1 (* arg *) + 1 (* unbox *)
   | Naked_float, Naked_float -> 0
   | ( (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate),
       Tagged_immediate ) ->
@@ -146,13 +147,14 @@ let array_load (kind : Flambda_primitive.Array_kind.t) =
 let block_set (kind : Flambda_primitive.Block_access_kind.t)
     (init : Flambda_primitive.Init_or_assign.t) =
   match kind, init with
-  | Values _, Assignment Heap -> nonalloc_extcall_size (* caml_modify *)
+  | Values _, Assignment Heap ->
+    does_not_need_caml_c_call_extcall_size (* caml_modify *)
   | Values _, (Assignment Local | Initialization) -> 1 (* cadda + store *)
   | Naked_floats _, (Assignment _ | Initialization) -> 1
 
 let array_set (kind : Flambda_primitive.Array_set_kind.t) =
   match kind with
-  | Values (Assignment Heap) -> nonalloc_extcall_size
+  | Values (Assignment Heap) -> does_not_need_caml_c_call_extcall_size
   | Values (Assignment Local | Initialization) -> 1
   | Immediates | Naked_floats -> 1
 
@@ -173,7 +175,7 @@ let string_or_bigstring_load kind width =
     (* 7 (not allow_unaligned_access) *)
     | Thirty_two -> 2 (* add, load (allow_unaligned_access) *)
     (* 17 (not allow_unaligned_access) *)
-    | Sixty_four -> if arch32 then nonalloc_extcall_size else 2
+    | Sixty_four -> if arch32 then does_not_need_caml_c_call_extcall_size else 2
     (* add, load (allow_unaligned_access) *)
     (* 37 (not allow_unaligned_access) *)
     | One_twenty_eight _ -> 2 (* add, load (alignment handled explicitly) *)
@@ -201,10 +203,11 @@ let binary_int_arith_primitive kind op =
   with
   (* Int64 bits ints on 32-bit archs *)
   | (Naked_int64, Add | Naked_int64, Sub | Naked_int64, Mul) when arch32 ->
-    nonalloc_extcall_size + 2
-  | (Naked_int64, Div | Naked_int64, Mod) when arch32 -> alloc_extcall_size + 2
+    does_not_need_caml_c_call_extcall_size + 2
+  | (Naked_int64, Div | Naked_int64, Mod) when arch32 ->
+    needs_caml_c_call_extcall_size + 2
   | (Naked_int64, And | Naked_int64, Or | Naked_int64, Xor) when arch32 ->
-    nonalloc_extcall_size + 2
+    does_not_need_caml_c_call_extcall_size + 2
   (* Tagged integers *)
   | Tagged_immediate, Add -> 2
   | Tagged_immediate, Sub -> 2
@@ -234,7 +237,7 @@ let binary_int_shift_primitive kind op =
   with
   (* Int64 special case *)
   | (Naked_int64, Lsl | Naked_int64, Lsr | Naked_int64, Asr) when arch32 ->
-    nonalloc_extcall_size + 2
+    does_not_need_caml_c_call_extcall_size + 2
   (* Int32 special case *)
   | Naked_int32, Lsr when arch64 -> 2
   (* Tagged integers *)
@@ -260,11 +263,11 @@ let binary_int_comp_primitive kind cmp =
   | Naked_int64, Gt Signed
   | Naked_int64, Ge Signed
     when arch32 ->
-    alloc_extcall_size + 2
+    needs_caml_c_call_extcall_size + 2
   | ( Naked_int64,
       (Neq | Eq | Lt Unsigned | Le Unsigned | Gt Unsigned | Ge Unsigned) )
     when arch32 ->
-    alloc_extcall_size + 2
+    needs_caml_c_call_extcall_size + 2
   (* Tagged integers *)
   | Tagged_immediate, Neq
   | Tagged_immediate, Eq
@@ -316,7 +319,7 @@ let nullary_prim_size prim =
 
 let unary_prim_size prim =
   match (prim : Flambda_primitive.unary_primitive) with
-  | Duplicate_array _ | Duplicate_block _ -> alloc_extcall_size + 1
+  | Duplicate_array _ | Duplicate_block _ -> needs_caml_c_call_extcall_size + 1
   | Is_int _ -> 1
   | Get_tag -> 2
   | Array_length -> array_length_size
@@ -338,7 +341,7 @@ let unary_prim_size prim =
   | Is_boxed_float -> 4 (* tag load + comparison *)
   | Is_flat_float_array -> 4 (* tag load + comparison *)
   | End_region | End_try_region -> 1
-  | Obj_dup -> alloc_extcall_size + 1
+  | Obj_dup -> needs_caml_c_call_extcall_size + 1
   | Get_header -> 2
   | Atomic_load _ -> 1
 
@@ -361,7 +364,8 @@ let binary_prim_size prim =
   | Float_comp (Yielding_bool cmp) -> binary_float_comp_primitive cmp
   | Float_comp (Yielding_int_like_compare_functions ()) -> 8
   | Bigarray_get_alignment _ -> 3 (* load data + add index + and *)
-  | Atomic_exchange | Atomic_fetch_and_add -> nonalloc_extcall_size
+  | Atomic_exchange | Atomic_fetch_and_add ->
+    does_not_need_caml_c_call_extcall_size
 
 let ternary_prim_size prim =
   match (prim : Flambda_primitive.ternary_primitive) with
@@ -372,7 +376,7 @@ let ternary_prim_size prim =
     5 (* ~ 3 block_load + 2 block_set *)
   | Bigarray_set (_dims, _kind, _layout) -> 2
   (* ~ 1 block_load + 1 block_set *)
-  | Atomic_compare_and_set -> nonalloc_extcall_size
+  | Atomic_compare_and_set -> does_not_need_caml_c_call_extcall_size
 
 let variadic_prim_size prim args =
   match (prim : Flambda_primitive.variadic_primitive) with
@@ -404,8 +408,9 @@ let apply apply =
     indirect_call_size
   | Function { function_call = Indirect_known_arity; alloc_mode = _ } ->
     indirect_call_size
-  | C_call { alloc = true; _ } -> alloc_extcall_size
-  | C_call { alloc = false; _ } -> nonalloc_extcall_size
+  | C_call { needs_caml_c_call = true; _ } -> needs_caml_c_call_extcall_size
+  | C_call { needs_caml_c_call = false; _ } ->
+    does_not_need_caml_c_call_extcall_size
   | Method _ -> 8
 (* from flambda/inlining_cost.ml *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -218,7 +218,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         env,
         res,
         Ece.all )
-  | Call_kind.C_call { alloc; is_c_builtin } ->
+  | Call_kind.C_call { needs_caml_c_call; is_c_builtin; alloc_mode = _ } ->
     fail_if_probe apply;
     let callee =
       match callee_simple with
@@ -260,7 +260,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         |> List.map K.With_subkind.kind)
     in
     ( wrap dbg
-        (C.extcall ~dbg ~alloc ~is_c_builtin ~returns ~ty_args callee
+        (C.extcall ~dbg ~alloc:needs_caml_c_call ~is_c_builtin ~returns ~ty_args
+           callee
            (C.Extended_machtype.to_machtype return_ty)
            args),
       free_vars,

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1455,8 +1455,8 @@ let alloc_mode_of_primitive_description (p : Primitive.description) =
       Some alloc_local
     | Prim_global, _ ->
       (* For primitives that definitely do not allocate locally,
-         [p.prim_alloc] actually tells us precisely whether the primitive
-         allocates. *)
+         [p.prim_alloc = false] actually tells us that the primitive does
+         not allocate at all. *)
       if p.prim_alloc then Some alloc_heap else None
 
 (* Changes to this function may also require changes in Flambda 2 (e.g.

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1451,7 +1451,8 @@ let alloc_mode_of_primitive_description (p : Primitive.description) =
     | (Prim_local | Prim_poly), _ ->
       (* For primitives that might allocate locally, [p.prim_alloc] just says
          whether [caml_c_call] is required, without telling us anything
-         about allocation. *)
+         about local allocation.  (However if [p.prim_alloc = false] we
+         do actually know that the primitive does not allocate on the heap.) *)
       Some alloc_local
     | Prim_global, _ ->
       (* For primitives that definitely do not allocate locally,

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1443,6 +1443,16 @@ let mod_field ?(read_semantics=Reads_agree) pos =
 let mod_setfield pos =
   Psetfield (pos, Pointer, Root_initialization)
 
+let alloc_mode_of_primitive_description (p : Primitive.description) =
+  if not Config.stack_allocation then
+    if p.prim_alloc then Some alloc_heap else None
+  else
+    match p.prim_native_repr_res with
+    | (Prim_local | Prim_poly), _ -> Some alloc_local
+    | Prim_global, _ -> Some alloc_heap
+
+(* Changes to this function may also require changes in Flambda 2 (e.g.
+   closure_conversion.ml). *)
 let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pbytes_to_string | Pbytes_of_string
   | Parray_to_iarray | Parray_of_iarray
@@ -1458,12 +1468,7 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Psetufloatfield _ -> None
   | Pduprecord _ -> Some alloc_heap
   | Pmake_unboxed_product _ | Punboxed_product_field _ -> None
-  | Pccall p ->
-     if not p.prim_alloc then None
-     else begin match p.prim_native_repr_res with
-       | (Prim_local|Prim_poly), _ -> Some alloc_local
-       | Prim_global, _ -> Some alloc_heap
-     end
+  | Pccall p -> alloc_mode_of_primitive_description p
   | Praise _ -> None
   | Psequor | Psequand | Pnot
   | Pnegint | Paddint | Psubint | Pmulint

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1448,8 +1448,16 @@ let alloc_mode_of_primitive_description (p : Primitive.description) =
     if p.prim_alloc then Some alloc_heap else None
   else
     match p.prim_native_repr_res with
-    | (Prim_local | Prim_poly), _ -> Some alloc_local
-    | Prim_global, _ -> Some alloc_heap
+    | (Prim_local | Prim_poly), _ ->
+      (* For primitives that might allocate locally, [p.prim_alloc] just says
+         whether [caml_c_call] is required, without telling us anything
+         about allocation. *)
+      Some alloc_local
+    | Prim_global, _ ->
+      (* For primitives that definitely do not allocate locally,
+         [p.prim_alloc] actually tells us precisely whether the primitive
+         allocates. *)
+      if p.prim_alloc then Some alloc_heap else None
 
 (* Changes to this function may also require changes in Flambda 2 (e.g.
    closure_conversion.ml). *)

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -752,6 +752,10 @@ val primitive_may_allocate : primitive -> alloc_mode option
       revised.
   *)
 
+val alloc_mode_of_primitive_description :
+  Primitive.description -> alloc_mode option
+  (** Like [primitive_may_allocate], for [external] calls. *)
+
 (***********************)
 (* For static failures *)
 (***********************)

--- a/ocaml/testsuite/tests/typing-local/alloc.heap.reference
+++ b/ocaml/testsuite/tests/typing-local/alloc.heap.reference
@@ -23,6 +23,7 @@
       longarray: Allocation
   floatgenarray: Allocation
     longfgarray: Allocation
+    maniparray0: Allocation
      maniparray: Allocation
     manipfarray: Allocation
             ref: Allocation

--- a/ocaml/testsuite/tests/typing-local/alloc.ml
+++ b/ocaml/testsuite/tests/typing-local/alloc.ml
@@ -9,6 +9,19 @@
       reference = "${test_source_directory}/alloc.heap.reference"
  *)
 
+(* First test to ensure that noalloc externals that locally allocate
+   don't cause a crash in the middle end (originally seen on
+   flambda-backend PR2180). *)
+
+(* This will never be called, caml_alloc_dummy is just chosen as a primitive that
+   exists in the bytecode runtime too *)
+external foo : unit -> ('a[@local_opt]) =
+  "caml_alloc_dummy" "caml_alloc_dummy" [@@noalloc]
+
+let foo () = foo ()
+
+(* Remaining tests *)
+
 type t = int
 
 type smallrecord = {  a : t; b : t; c : t }
@@ -264,6 +277,16 @@ external array_blit :
 external array_fill :
   local_ 'a array -> int -> int -> 'a -> unit = "caml_array_fill"
 
+let maniparray0 =
+  let l = [42] in
+  fun arr ->
+    (* This function should only locally allocate in the C runtime function
+       for doing the array allocation, and not in the OCaml code, in order
+       to ensure that locally-allocating C calls hold onto regions. *)
+    let x = local_array 6 l in
+    assert (x = arr);
+    ()
+
 let maniparray arr =              (* arr = 1,2,3,1,2,3 *)
   let x = local_array 2 [2] in    (* 2,2 *)
   let x = array_append x x in     (* 2,2,2,2 *)
@@ -472,6 +495,7 @@ let () =
   run "longarray" makelongarray 42;
   run "floatgenarray" makeshortarray 42.;
   run "longfgarray" makelongarray 42.;
+  run "maniparray0" maniparray0 [| [42]; [42]; [42]; [42]; [42]; [42] |];
   run "maniparray" maniparray [| [1]; [2]; [3]; [1]; [2]; [3] |];
   run "manipfarray" manipfarray [| 1.; 2.; 3.; 1.; 2.; 3. |];
   run "ref" makeref 42;

--- a/ocaml/testsuite/tests/typing-local/alloc.stack.reference
+++ b/ocaml/testsuite/tests/typing-local/alloc.stack.reference
@@ -23,6 +23,7 @@
       longarray: No Allocation
   floatgenarray: No Allocation
     longfgarray: No Allocation
+    maniparray0: No Allocation
      maniparray: No Allocation
     manipfarray: No Allocation
             ref: No Allocation


### PR DESCRIPTION
The region was missing in the recently-refactored `Call_kind` for C calls, which means that locally-allocating C calls might not be in the correct region.  A new test has been added; in the existing test, allocations from the test itself rather than the C runtime code would cause the region concerned to be held live.