### PR TITLE
Run CI on pushes to branches whose names end in 'microbranch'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - '*microbranch'
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
This ensures that a CI build will be kicked off when we push changes to microbranches.

(I tried to be clever and get the CI to run on this branch by concluding its name in "microbranch", but it looks like this change won't take effect until it's merged into main.)