### PR TITLE
Remove unnecessary constructors from export_info handling

### DIFF
--- a/backend/asmlibrarian.ml
+++ b/backend/asmlibrarian.ml
@@ -26,9 +26,6 @@ type error =
 
 exception Error of error
 
-let default_ui_export_info =
-  Cmx_format.Flambda2 None
-
 let read_info name =
   let filename =
     try
@@ -41,7 +38,7 @@ let read_info name =
      since the compiler will go looking directly for .cmx files.
      The linker, which is the only one that reads .cmxa files, does not
      need the approximation. *)
-  info.ui_export_info <- default_ui_export_info;
+  info.ui_export_info <- None;
   (Filename.chop_suffix filename ".cmx" ^ ext_obj, (info, crc))
 
 let create_archive file_list lib_name =

--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -157,11 +157,6 @@ let make_package_object unix ~ppf_dump members targetobj targetname coercion
 
 (* Make the .cmx file for the package *)
 
-let get_export_info_flambda2 ui : Flambda2_cmx.Flambda_cmx_format.t option =
-  assert(Config.flambda2);
-  match ui.ui_export_info with
-  | Flambda2 info -> info
-
 let build_package_cmx members cmxfile =
   let unit_names =
     List.map (fun m -> m.pm_name) members in
@@ -180,14 +175,10 @@ let build_package_cmx members cmxfile =
       members [] in
   let ui = Compilenv.current_unit_infos() in
   let ui_export_info =
-    let flambda_export_info =
-      List.fold_left (fun acc info ->
-          Flambda2_cmx.Flambda_cmx_format.merge
-            (get_export_info_flambda2 info) acc)
-        (get_export_info_flambda2 ui)
-        units
-    in
-    Flambda2 flambda_export_info
+    List.fold_left (fun acc info ->
+        Flambda2_cmx.Flambda_cmx_format.merge info.ui_export_info acc)
+      ui.ui_export_info
+      units
   in
   let ui_checks = Checks.create () in
   List.iter (fun info -> Checks.merge info.ui_checks ~into:ui_checks) units;

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -31,12 +31,6 @@ open Misc
    The .cmx file contains these infos (as an externed record) plus a MD5
    of these infos *)
 
-type export_info =
-  | Flambda2 of Flambda2_cmx.Flambda_cmx_format.t option
-
-type export_info_raw =
-  | Flambda2_raw of Flambda2_cmx.Flambda_cmx_format.raw option
-
 (* Declare machtype here to avoid depending on [Cmm]. *)
 type machtype_component = Val | Addr | Int | Float | Vec128
 type machtype = machtype_component array
@@ -60,7 +54,7 @@ type unit_infos =
     mutable ui_imports_cmx: Import_info.t list;
                                           (* Infos imported *)
     mutable ui_generic_fns: generic_fns;  (* Generic functions needed *)
-    mutable ui_export_info: export_info;
+    mutable ui_export_info: Flambda2_cmx.Flambda_cmx_format.t option;
     mutable ui_checks: Checks.t;
     mutable ui_force_link: bool }         (* Always linked *)
 
@@ -70,7 +64,7 @@ type unit_infos_raw =
     uir_imports_cmi: Import_info.t array;
     uir_imports_cmx: Import_info.t array;
     uir_generic_fns: generic_fns;
-    uir_export_info: export_info_raw;
+    uir_export_info: Flambda2_cmx.Flambda_cmx_format.raw option;
     uir_checks: Checks.Raw.t;
     uir_force_link: bool;
     uir_section_toc: int array;    (* Byte offsets of sections in .cmx

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -30,15 +30,16 @@ val reset_info_tables: unit -> unit
 val current_unit_infos: unit -> unit_infos
         (* Return the infos for the unit being compiled *)
 
-val get_global_export_info : Compilation_unit.t -> Cmx_format.export_info option
+val get_global_export_info : Compilation_unit.t
+  -> Flambda2_cmx.Flambda_cmx_format.t option
         (* Means of getting the export info found in the
            .cmx file of the given unit. *)
 
 val get_unit_export_info
-  : Compilation_unit.t -> Cmx_format.export_info option
+  : Compilation_unit.t -> Flambda2_cmx.Flambda_cmx_format.t option
 
-val flambda2_set_export_info : Flambda2_cmx.Flambda_cmx_format.t -> unit
-        (* Set the export information for the current unit (Flambda 2 only). *)
+val set_export_info : Flambda2_cmx.Flambda_cmx_format.t -> unit
+        (* Set the export information for the current unit. *)
 
 val need_curry_fun:
   Lambda.function_kind -> Cmm.machtype list -> Cmm.machtype -> unit

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -30,10 +30,7 @@ let get_module_info comp_unit =
        (Flambda2_identifiers.Symbol.external_symbols_compilation_unit ()
        |> Compilation_unit.name)
   then None
-  else
-    match Compilenv.get_unit_export_info comp_unit with
-    | None | Some (Flambda2 None) -> None
-    | Some (Flambda2 (Some info)) -> Some info
+  else Compilenv.get_unit_export_info comp_unit
 
 let dump_to_target_if_any main_dump_ppf target ~header ~f a =
   match (target : Flambda_features.dump_target) with
@@ -165,7 +162,7 @@ let lambda_to_cmm ~ppf_dump:ppf ~prefixname ~filename:_ ~keep_symbol_tables
     (match cmx with
     | None ->
       () (* Either opaque was passed, or there is no need to export offsets *)
-    | Some cmx -> Compilenv.flambda2_set_export_info cmx);
+    | Some cmx -> Compilenv.set_export_info cmx);
     let cmm =
       Flambda2_to_cmm.To_cmm.unit flambda ~all_code ~offsets ~reachable_names
     in

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -193,9 +193,9 @@ let print_cmx_infos (uir, sections, crc) =
     (fun f -> Array.iter f uir.uir_imports_cmx);
   begin
     match uir.uir_export_info with
-    | Flambda2_raw None ->
+    | None ->
       printf "Flambda 2 unit (with no export information)\n"
-    | Flambda2_raw (Some cmx) ->
+    | Some cmx ->
       printf "Flambda 2 export information:\n";
       flush stdout;
       let cmx = Flambda2_cmx.Flambda_cmx_format.from_raw cmx ~sections in


### PR DESCRIPTION
This follows on from the Closure / Flambda 1 removal.