### PR TITLE
Ban Prim_poly from Lambda

### DIFF
--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -727,7 +727,7 @@ let transl_coeffects (ce : Primitive.coeffects) : Cmm.coeffects =
   match ce with No_coeffects -> No_coeffects | Has_coeffects -> Has_coeffects
 
 (* [cextcall] is called from [Cmmgen.transl_ccall] *)
-let cextcall (prim : Primitive.description) args dbg ret ty_args returns =
+let cextcall (prim : Lambda.external_call) args dbg ret ty_args returns =
   let name = Primitive.native_name prim in
   let default =
     Cop

--- a/backend/cmm_builtins.mli
+++ b/backend/cmm_builtins.mli
@@ -31,7 +31,7 @@ val extcall :
     corresponds to [prim]. If [prim] is a C builtin supported on the target,
     returns [Cmm.operation] variant for [prim]'s intrinsics. *)
 val cextcall :
-  Primitive.description ->
+  Lambda.external_call ->
   expression list ->
   Debuginfo.t ->
   machtype ->

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2060,7 +2060,7 @@ let box_sized size mode dbg exp =
 (* Simplification of some primitives into C calls *)
 
 let default_prim name =
-  Primitive.simple_on_values ~name ~arity:0 (*ignored*) ~alloc:true
+  Lambda.simple_on_values ~name ~arity:0 (*ignored*) ~alloc:true
 
 let simplif_primitive p : Clambda_primitives.primitive =
   match (p : Clambda_primitives.primitive) with

--- a/backend/cmmgen.ml
+++ b/backend/cmmgen.ml
@@ -667,7 +667,7 @@ let rec transl env e =
           transl_make_array dbg env kind alloc_heap args
       | (Pduparray _, [arg]) ->
           let prim_obj_dup =
-            Primitive.simple_on_values ~name:"caml_obj_dup" ~arity:1 ~alloc:true
+            Lambda.simple_on_values ~name:"caml_obj_dup" ~arity:1 ~alloc:true
           in
           transl_ccall env prim_obj_dup [arg] dbg
       | (Pmakearray _, []) ->

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -55,7 +55,7 @@ type primitive =
   | Presume
   | Preperform
   (* External call *)
-  | Pccall of Primitive.description
+  | Pccall of Lambda.external_call
   (* Exceptions *)
   | Praise of raise_kind
   (* Boolean operations *)

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -55,7 +55,7 @@ type primitive =
   | Presume
   | Preperform
   (* External call *)
-  | Pccall of Primitive.description
+  | Pccall of Lambda.external_call
   (* Exceptions *)
   | Praise of raise_kind
   (* Boolean operations *)

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -186,7 +186,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
       ~effects:Only_generative_effects
       ~coeffects:Has_coeffects
       ~native_name:"caml_obj_dup"
-      ~native_repr_args:[P.Prim_global, P.Same_as_ocaml_repr Jkind.Sort.Value]
+      ~native_repr_args:[(), P.Same_as_ocaml_repr Jkind.Sort.Value]
       ~native_repr_res:(Lambda.Prim_global, P.Same_as_ocaml_repr Jkind.Sort.Value))
   | Punbox_float -> Punbox_float
   | Pbox_float m -> Pbox_float m

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -56,7 +56,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pperform -> Pperform
   | Presume -> Presume
   | Preperform -> Preperform
-  | Pccall { prim_desc = prim } -> Pccall prim
+  | Pccall prim -> Pccall prim
   | Praise kind -> Praise kind
   | Psequand -> Psequand
   | Psequor -> Psequor
@@ -187,7 +187,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
       ~coeffects:Has_coeffects
       ~native_name:"caml_obj_dup"
       ~native_repr_args:[P.Prim_global, P.Same_as_ocaml_repr Jkind.Sort.Value]
-      ~native_repr_res:(P.Prim_global, P.Same_as_ocaml_repr Jkind.Sort.Value))
+      ~native_repr_res:(Lambda.Prim_global, P.Same_as_ocaml_repr Jkind.Sort.Value))
   | Punbox_float -> Punbox_float
   | Pbox_float m -> Pbox_float m
   | Punbox_int bi -> Punbox_int bi

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -56,7 +56,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pperform -> Pperform
   | Presume -> Presume
   | Preperform -> Preperform
-  | Pccall prim -> Pccall prim
+  | Pccall { prim_desc = prim } -> Pccall prim
   | Praise kind -> Praise kind
   | Psequand -> Psequand
   | Psequor -> Psequor

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -79,7 +79,7 @@ let check_closure t ulam named : Clambda.ulambda =
   if not !Clflags.clambda_checks then ulam
   else
     let desc =
-      Primitive.simple_on_values ~name:"caml_check_value_is_closure"
+      Lambda.simple_on_values ~name:"caml_check_value_is_closure"
         ~arity:2 ~alloc:false
     in
     let str = Format.asprintf "%a" Flambda.print_named named in
@@ -109,7 +109,7 @@ let check_field t ulam pos named_opt : Clambda.ulambda =
   if not !Clflags.clambda_checks then ulam
   else
     let desc =
-      Primitive.simple_on_values ~name:"caml_check_field_access"
+      Lambda.simple_on_values ~name:"caml_check_field_access"
         ~arity:3 ~alloc:false
     in
     let str =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -591,7 +591,7 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
   let call : Acc.t -> Expr_with_acc.t =
     List.fold_left2
       (fun (call : Simple.t list -> Acc.t -> Expr_with_acc.t) arg
-           (arg_repr : Primitive.mode * Primitive.native_repr) ->
+           (arg_repr : _ * Primitive.native_repr) ->
         let unbox_arg : P.unary_primitive option =
           match arg_repr with
           | _, Same_as_ocaml_repr _ -> None

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -424,7 +424,7 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
         prim_native_repr_args;
         prim_native_repr_res
       } :
-       Primitive.description) as prim_desc) ~(args : Simple.t list list)
+       Lambda.external_call) as prim_desc) ~(args : Simple.t list list)
     exn_continuation dbg ~current_region
     (k : Acc.t -> Named.t list -> Expr_with_acc.t) : Expr_with_acc.t =
   let args =
@@ -493,8 +493,7 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
       Apply_cont_expr.continuation apply_cont, false
     | _ -> Continuation.create (), true
   in
-  let kind_of_primitive_native_repr
-      ((_, repr) : Primitive.mode * Primitive.native_repr) =
+  let kind_of_primitive_native_repr ((_, repr) : _ * Primitive.native_repr) =
     match repr with
     | Same_as_ocaml_repr sort ->
       K.With_subkind.(
@@ -720,7 +719,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
   in
   let dbg = Debuginfo.from_location loc in
   match prim, args with
-  | Pccall { prim_desc = prim }, args ->
+  | Pccall prim, args ->
     let exn_continuation =
       match exn_continuation with
       | None ->

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -720,7 +720,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
   in
   let dbg = Debuginfo.from_location loc in
   match prim, args with
-  | Pccall prim, args ->
+  | Pccall { prim_desc = prim }, args ->
     let exn_continuation =
       match exn_continuation with
       | None ->

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -171,8 +171,7 @@ let lsequence (lam1, lam2) =
   [@@ocaml.warning "-fragile-match"]
 
 let caml_update_dummy_prim =
-  Primitive.simple_on_values ~name:"caml_update_dummy" ~arity:2 ~alloc:true
-  |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+  simple_on_values ~name:"caml_update_dummy" ~arity:2 ~alloc:true
 
 let update_dummy var expr =
   Lprim (Pccall caml_update_dummy_prim, [Lvar var; expr], Loc_unknown)
@@ -571,10 +570,7 @@ let dissect_letrec ~bindings ~body ~free_vars_kind =
           | Normal _tag -> "caml_alloc_dummy"
           | Flat_float_record -> "caml_alloc_dummy_float"
         in
-        let desc =
-          Primitive.simple_on_values ~name:fn ~arity:1 ~alloc:true
-          |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
-        in
+        let desc = simple_on_values ~name:fn ~arity:1 ~alloc:true in
         let size : lambda = Lconst (Const_base (Const_int size)) in
         id, Lprim (Pccall desc, [size], Loc_unknown))
       letrec.blocks

--- a/middle_end/flambda2/from_lambda/dissect_letrec.ml
+++ b/middle_end/flambda2/from_lambda/dissect_letrec.ml
@@ -172,6 +172,7 @@ let lsequence (lam1, lam2) =
 
 let caml_update_dummy_prim =
   Primitive.simple_on_values ~name:"caml_update_dummy" ~arity:2 ~alloc:true
+  |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
 
 let update_dummy var expr =
   Lprim (Pccall caml_update_dummy_prim, [Lvar var; expr], Loc_unknown)
@@ -570,7 +571,10 @@ let dissect_letrec ~bindings ~body ~free_vars_kind =
           | Normal _tag -> "caml_alloc_dummy"
           | Flat_float_record -> "caml_alloc_dummy_float"
         in
-        let desc = Primitive.simple_on_values ~name:fn ~arity:1 ~alloc:true in
+        let desc =
+          Primitive.simple_on_values ~name:fn ~arity:1 ~alloc:true
+          |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+        in
         let size : lambda = Lconst (Const_base (Const_int size)) in
         id, Lprim (Pccall desc, [size], Loc_unknown))
       letrec.blocks

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -298,7 +298,10 @@ let transform_primitive env (prim : L.primitive) args loc =
       then
         let arity = 1 + num_dimensions in
         let name = "caml_ba_get_" ^ string_of_int num_dimensions in
-        let desc = Primitive.simple_on_values ~name ~arity ~alloc:true in
+        let desc =
+          Primitive.simple_on_values ~name ~arity ~alloc:true
+          |> L.external_call ~ret_mode:L.alloc_heap
+        in
         Primitive (L.Pccall desc, args, loc)
       else
         Misc.fatal_errorf
@@ -315,7 +318,10 @@ let transform_primitive env (prim : L.primitive) args loc =
       then
         let arity = 2 + num_dimensions in
         let name = "caml_ba_set_" ^ string_of_int num_dimensions in
-        let desc = Primitive.simple_on_values ~name ~arity ~alloc:true in
+        let desc =
+          Primitive.simple_on_values ~name ~arity ~alloc:true
+          |> L.external_call ~ret_mode:L.alloc_heap
+        in
         Primitive (L.Pccall desc, args, loc)
       else
         Misc.fatal_errorf

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -298,9 +298,7 @@ let transform_primitive env (prim : L.primitive) args loc =
       then
         let arity = 1 + num_dimensions in
         let name = "caml_ba_get_" ^ string_of_int num_dimensions in
-        let desc =
-          L.simple_on_values ~name ~arity ~alloc:true
-        in
+        let desc = L.simple_on_values ~name ~arity ~alloc:true in
         Primitive (L.Pccall desc, args, loc)
       else
         Misc.fatal_errorf
@@ -317,9 +315,7 @@ let transform_primitive env (prim : L.primitive) args loc =
       then
         let arity = 2 + num_dimensions in
         let name = "caml_ba_set_" ^ string_of_int num_dimensions in
-        let desc =
-          L.simple_on_values ~name ~arity ~alloc:true
-        in
+        let desc = L.simple_on_values ~name ~arity ~alloc:true in
         Primitive (L.Pccall desc, args, loc)
       else
         Misc.fatal_errorf

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -299,8 +299,7 @@ let transform_primitive env (prim : L.primitive) args loc =
         let arity = 1 + num_dimensions in
         let name = "caml_ba_get_" ^ string_of_int num_dimensions in
         let desc =
-          Primitive.simple_on_values ~name ~arity ~alloc:true
-          |> L.external_call ~ret_mode:L.alloc_heap
+          L.simple_on_values ~name ~arity ~alloc:true
         in
         Primitive (L.Pccall desc, args, loc)
       else
@@ -319,8 +318,7 @@ let transform_primitive env (prim : L.primitive) args loc =
         let arity = 2 + num_dimensions in
         let name = "caml_ba_set_" ^ string_of_int num_dimensions in
         let desc =
-          Primitive.simple_on_values ~name ~arity ~alloc:true
-          |> L.external_call ~ret_mode:L.alloc_heap
+          L.simple_on_values ~name ~arity ~alloc:true
         in
         Primitive (L.Pccall desc, args, loc)
       else

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -1570,7 +1570,7 @@ let box_sized size mode dbg exp =
 (* Simplification of some primitives into C calls *)
 
 let default_prim name =
-  Primitive.simple_on_values ~name ~arity:0(*ignored*) ~alloc:true
+  Lambda.simple_on_values ~name ~arity:0(*ignored*) ~alloc:true
 
 let simplif_primitive p : Clambda_primitives.primitive =
   match (p : Clambda_primitives.primitive) with

--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -582,7 +582,7 @@ let rec transl env e =
           transl_make_array dbg env kind alloc_heap args
       | (Pduparray _, [arg]) ->
           let prim_obj_dup =
-            Primitive.simple_on_values ~name:"caml_obj_dup" ~arity:1 ~alloc:true
+            simple_on_values ~name:"caml_obj_dup" ~arity:1 ~alloc:true
           in
           transl_ccall env prim_obj_dup [arg] dbg
       | (Pmakearray _, []) ->

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -440,7 +440,7 @@ let comp_primitive stack_info p sz args =
   | Pufloatfield (n, _sem) -> Kgetfloatfield n
   | Psetufloatfield (n, _init) -> Ksetfloatfield n
   | Pduprecord _ -> Kccall("caml_obj_dup", 1)
-  | Pccall p -> Kccall(p.prim_name, p.prim_arity)
+  | Pccall { prim_desc = p } -> Kccall(p.prim_name, p.prim_arity)
   | Pperform ->
       check_stack stack_info (sz + 4);
       Kperform
@@ -868,6 +868,7 @@ let rec comp_expr stack_info env exp sz cont =
   | Lprim (Pduparray _, [arg], loc) ->
       let prim_obj_dup =
         Primitive.simple_on_values ~name:"caml_obj_dup" ~arity:1 ~alloc:true
+        |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
       in
       comp_expr stack_info env (Lprim (Pccall prim_obj_dup, [arg], loc)) sz cont
   | Lprim (Pduparray _, _, _) ->

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -440,7 +440,7 @@ let comp_primitive stack_info p sz args =
   | Pufloatfield (n, _sem) -> Kgetfloatfield n
   | Psetufloatfield (n, _init) -> Ksetfloatfield n
   | Pduprecord _ -> Kccall("caml_obj_dup", 1)
-  | Pccall { prim_desc = p } -> Kccall(p.prim_name, p.prim_arity)
+  | Pccall p -> Kccall(p.prim_name, p.prim_arity)
   | Pperform ->
       check_stack stack_info (sz + 4);
       Kperform

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -867,8 +867,7 @@ let rec comp_expr stack_info env exp sz cont =
         (Lprim (Pmakearray (kind, mutability, m), args, loc)) sz cont
   | Lprim (Pduparray _, [arg], loc) ->
       let prim_obj_dup =
-        Primitive.simple_on_values ~name:"caml_obj_dup" ~arity:1 ~alloc:true
-        |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+        Lambda.simple_on_values ~name:"caml_obj_dup" ~arity:1 ~alloc:true
       in
       comp_expr stack_info env (Lprim (Pccall prim_obj_dup, [arg], loc)) sz cont
   | Lprim (Pduparray _, _, _) ->

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1637,8 +1637,7 @@ let primitive_result_layout (p : primitive) =
   | Paddfloat _ | Psubfloat _ | Pmulfloat _ | Pdivfloat _
   | Pbox_float _ -> layout_boxed_float
   | Pufloatfield _ | Punbox_float -> Punboxed_float
-  | Pccall { prim_native_repr_res = _, repr_res } ->
-    layout_of_native_repr repr_res
+  | Pccall { prim_native_repr_res = _, repr_res } -> layout_of_native_repr repr_res
   | Praise _ -> layout_bottom
   | Psequor | Psequand | Pnot
   | Pnegint | Paddint | Psubint | Pmulint

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -355,13 +355,16 @@ and raise_kind =
   | Raise_reraise
   | Raise_notrace
 
-and external_call = prim_mode Primitive.description_gen
+and external_call = (unit, prim_mode) Primitive.description_gen
 
 let external_call (prim_desc : Primitive.description) ~(ret_mode : alloc_mode) =
-  let prim_native_repr_res =
+  let native_repr_args =
+    List.map (fun (_, repr) -> (), repr) prim_desc.prim_native_repr_args
+  in
+  let native_repr_res =
     match prim_desc.prim_native_repr_res with
-    | Prim_local, rep -> Prim_local, rep
-    | Prim_global, rep -> Prim_global, rep
+    | Prim_local, native_repr -> Prim_local, native_repr
+    | Prim_global, native_repr -> Prim_global, native_repr
     | Prim_poly, native_repr ->
       (* See comment in the .mli *)
       match ret_mode with
@@ -374,11 +377,12 @@ let external_call (prim_desc : Primitive.description) ~(ret_mode : alloc_mode) =
     ~effects:prim_desc.prim_effects
     ~coeffects:prim_desc.prim_coeffects
     ~native_name:prim_desc.prim_native_name
-    ~native_repr_args:prim_desc.prim_native_repr_args
-    ~native_repr_res:prim_native_repr_res
+    ~native_repr_args
+    ~native_repr_res
 
 let simple_on_values ~name ~arity ~alloc =
-  Primitive.simple_on_values_gen ~name ~arity ~alloc ~global:Prim_global
+  Primitive.simple_on_values_gen ~name ~arity ~alloc
+    ~arg_global:() ~ret_global:Prim_global
 
 let vec128_name = function
   | Unknown128 -> "unknown128"

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -121,7 +121,7 @@ type primitive =
   | Presume
   | Preperform
   (* External call *)
-  | Pccall of Primitive.description
+  | Pccall of external_call
   (* Exceptions *)
   | Praise of raise_kind
   (* Boolean operations *)
@@ -327,6 +327,17 @@ and raise_kind =
   | Raise_regular
   | Raise_reraise
   | Raise_notrace
+
+and external_call = private {
+  prim_desc : Primitive.description;
+  (** This is guaranteed never to be [Prim_poly].  This ensures that we can
+      precisely identify whether or not the frontend decided that this
+      particular primitive application needed an enclosing region or not.
+      Also see [alloc_mode_of_primitive_description]. *)
+}
+
+val external_call : Primitive.description -> ret_mode:alloc_mode
+  -> external_call
 
 val vec128_name: vec128_type -> string
 

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -772,8 +772,7 @@ val primitive_may_allocate : primitive -> alloc_mode option
       revised.
   *)
 
-val alloc_mode_of_primitive_description :
-  external_call -> alloc_mode option
+val alloc_mode_of_primitive_description : external_call -> alloc_mode option
   (** Like [primitive_may_allocate], for [external] calls. *)
 
 (***********************)

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -334,10 +334,11 @@ and raise_kind =
   | Raise_reraise
   | Raise_notrace
 
-and external_call = prim_mode Primitive.description_gen
+and external_call = (unit, prim_mode) Primitive.description_gen
   (** We cannot have [Prim_poly] in Lambda code. Changing the parameter
       on [Primitive.description_gen] from [Primitive.mode] to [prim_mode]
-      ensures this is the case. Avoiding [Prim_poly] ensures that we can
+      ensures this is the case. (We also have no need for argument modes
+      in Lambda, thus the [unit].) Avoiding [Prim_poly] ensures that we can
       precisely identify whether or not the frontend decided that this
       particular primitive application needed an enclosing region or not.
       Also see [alloc_mode_of_primitive_description]. *)

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -1907,8 +1907,7 @@ let get_pat_args_lazy p rem =
 *)
 
 let prim_obj_tag =
-  Primitive.simple_on_values ~name:"caml_obj_tag" ~arity:1 ~alloc:false
-  |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+  Lambda.simple_on_values ~name:"caml_obj_tag" ~arity:1 ~alloc:false
 
 let get_mod_field modname field =
   lazy
@@ -2249,17 +2248,15 @@ let strings_test_threshold = 8
 
 let prim_string_notequal =
   let external_call =
-    Primitive.simple_on_values ~name:"caml_string_notequal" ~arity:2
+    Lambda.simple_on_values ~name:"caml_string_notequal" ~arity:2
       ~alloc:false
-    |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
   in
   Pccall external_call
 
 let prim_string_compare =
   let external_call =
-    Primitive.simple_on_values ~name:"caml_string_compare" ~arity:2
+    Lambda.simple_on_values ~name:"caml_string_compare" ~arity:2
       ~alloc:false
-    |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
   in
   Pccall external_call
 

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -2247,18 +2247,12 @@ let divide_array ~scopes kind ctx pm =
 let strings_test_threshold = 8
 
 let prim_string_notequal =
-  let external_call =
-    Lambda.simple_on_values ~name:"caml_string_notequal" ~arity:2
-      ~alloc:false
-  in
-  Pccall external_call
+  Pccall (Lambda.simple_on_values ~name:"caml_string_notequal" ~arity:2
+            ~alloc:false)
 
 let prim_string_compare =
-  let external_call =
-    Lambda.simple_on_values ~name:"caml_string_compare" ~arity:2
-      ~alloc:false
-  in
-  Pccall external_call
+  Pccall (Lambda.simple_on_values ~name:"caml_string_compare" ~arity:2
+            ~alloc:false)
 
 let bind_sw arg layout k =
   match arg with

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -1908,6 +1908,7 @@ let get_pat_args_lazy p rem =
 
 let prim_obj_tag =
   Primitive.simple_on_values ~name:"caml_obj_tag" ~arity:1 ~alloc:false
+  |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
 
 let get_mod_field modname field =
   lazy
@@ -2247,12 +2248,20 @@ let divide_array ~scopes kind ctx pm =
 let strings_test_threshold = 8
 
 let prim_string_notequal =
-  Pccall (Primitive.simple_on_values ~name:"caml_string_notequal" ~arity:2
-            ~alloc:false)
+  let external_call =
+    Primitive.simple_on_values ~name:"caml_string_notequal" ~arity:2
+      ~alloc:false
+    |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+  in
+  Pccall external_call
 
 let prim_string_compare =
-  Pccall (Primitive.simple_on_values ~name:"caml_string_compare" ~arity:2
-            ~alloc:false)
+  let external_call =
+    Primitive.simple_on_values ~name:"caml_string_compare" ~arity:2
+      ~alloc:false
+    |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+  in
+  Pccall external_call
 
 let bind_sw arg layout k =
   match arg with

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -373,7 +373,7 @@ let primitive ppf = function
   | Punboxed_product_field (n, layouts) ->
       fprintf ppf "unboxed_product_field %d [%a]" n
         (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ", ") layout) layouts
-  | Pccall p -> fprintf ppf "%s" p.prim_name
+  | Pccall { prim_desc = p } -> fprintf ppf "%s" p.prim_name
   | Praise k -> fprintf ppf "%s" (Lambda.raise_kind k)
   | Psequand -> fprintf ppf "&&"
   | Psequor -> fprintf ppf "||"

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -373,7 +373,7 @@ let primitive ppf = function
   | Punboxed_product_field (n, layouts) ->
       fprintf ppf "unboxed_product_field %d [%a]" n
         (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ", ") layout) layouts
-  | Pccall { prim_desc = p } -> fprintf ppf "%s" p.prim_name
+  | Pccall p -> fprintf ppf "%s" p.prim_name
   | Praise k -> fprintf ppf "%s" (Lambda.raise_kind k)
   | Psequand -> fprintf ppf "&&"
   | Psequor -> fprintf ppf "||"

--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -246,11 +246,11 @@ let simplify_exits lam =
     let ll = List.map (simplif ~layout:None ~try_depth) ll in
     match p, ll with
         (* Simplify Obj.with_tag *)
-      | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
+      | Pccall { prim_desc = { Primitive.prim_name = "caml_obj_with_tag"; _ } },
         [Lconst (Const_base (Const_int tag));
          Lprim (Pmakeblock (_, mut, shape, mode), fields, loc)] ->
          Lprim (Pmakeblock(tag, mut, shape, mode), fields, loc)
-      | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
+      | Pccall { prim_desc = { Primitive.prim_name = "caml_obj_with_tag"; _ } },
         [Lconst (Const_base (Const_int tag));
          Lconst (Const_block (_, fields))] ->
          Lconst (Const_block (tag, fields))

--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -246,11 +246,11 @@ let simplify_exits lam =
     let ll = List.map (simplif ~layout:None ~try_depth) ll in
     match p, ll with
         (* Simplify Obj.with_tag *)
-      | Pccall { prim_desc = { Primitive.prim_name = "caml_obj_with_tag"; _ } },
+      | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
          Lprim (Pmakeblock (_, mut, shape, mode), fields, loc)] ->
          Lprim (Pmakeblock(tag, mut, shape, mode), fields, loc)
-      | Pccall { prim_desc = { Primitive.prim_name = "caml_obj_with_tag"; _ } },
+      | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
          Lconst (Const_block (_, fields))] ->
          Lconst (Const_block (tag, fields))

--- a/ocaml/lambda/transl_comprehension_utils.ml
+++ b/ocaml/lambda/transl_comprehension_utils.ml
@@ -114,7 +114,11 @@ module Lambda_utils = struct
     (** The Lambda primitive for calling a simple C primitive *)
     (* CR layouts v4: To change when non-values are allowed in arrays. *)
     let c_prim name arity =
-      Pccall (Primitive.simple_on_values ~name ~arity ~alloc:true)
+      let external_call =
+        Primitive.simple_on_values ~name ~arity ~alloc:true
+        |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+      in
+      Pccall external_call
 
     (** Create a function that produces the Lambda representation for a
         one-argument C primitive when provided with a Lambda argument *)

--- a/ocaml/lambda/transl_comprehension_utils.ml
+++ b/ocaml/lambda/transl_comprehension_utils.ml
@@ -114,10 +114,7 @@ module Lambda_utils = struct
     (** The Lambda primitive for calling a simple C primitive *)
     (* CR layouts v4: To change when non-values are allowed in arrays. *)
     let c_prim name arity =
-      let external_call =
-        Lambda.simple_on_values ~name ~arity ~alloc:true
-      in
-      Pccall external_call
+      Pccall (Lambda.simple_on_values ~name ~arity ~alloc:true)
 
     (** Create a function that produces the Lambda representation for a
         one-argument C primitive when provided with a Lambda argument *)

--- a/ocaml/lambda/transl_comprehension_utils.ml
+++ b/ocaml/lambda/transl_comprehension_utils.ml
@@ -115,8 +115,7 @@ module Lambda_utils = struct
     (* CR layouts v4: To change when non-values are allowed in arrays. *)
     let c_prim name arity =
       let external_call =
-        Primitive.simple_on_values ~name ~arity ~alloc:true
-        |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+        Lambda.simple_on_values ~name ~arity ~alloc:true
       in
       Pccall external_call
 

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -98,8 +98,7 @@ let declare_probe_handlers lam =
 
 let prim_fresh_oo_id =
   Pccall
-    (Primitive.simple_on_values ~name:"caml_fresh_oo_id" ~arity:1 ~alloc:false
-     |> Lambda.external_call ~ret_mode:Lambda.alloc_heap)
+    (Lambda.simple_on_values ~name:"caml_fresh_oo_id" ~arity:1 ~alloc:false)
 
 let transl_extension_constructor ~scopes env path ext =
   let path =

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -98,7 +98,8 @@ let declare_probe_handlers lam =
 
 let prim_fresh_oo_id =
   Pccall
-    (Primitive.simple_on_values ~name:"caml_fresh_oo_id" ~arity:1 ~alloc:false)
+    (Primitive.simple_on_values ~name:"caml_fresh_oo_id" ~arity:1 ~alloc:false
+     |> Lambda.external_call ~ret_mode:Lambda.alloc_heap)
 
 let transl_extension_constructor ~scopes env path ext =
   let path =
@@ -374,9 +375,10 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         if extra_args = [] then transl_apply_position pos
         else Rc_normal
       in
+      let mode = transl_locality_mode ap_mode in
       let lam =
         Translprim.transl_primitive_application
-          (of_location ~scopes e.exp_loc) p e.exp_env prim_type pmode
+          (of_location ~scopes e.exp_loc) p e.exp_env prim_type pmode mode
           path prim_exp args (List.map fst arg_exps) position
       in
       if extra_args = [] then lam
@@ -385,7 +387,6 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         let inlined = Translattribute.get_inlined_attribute funct in
         let specialised = Translattribute.get_specialised_attribute funct in
         let position = transl_apply_position pos in
-        let mode = transl_locality_mode ap_mode in
         let result_layout = layout_exp sort e in
         event_after ~scopes e
           (transl_apply ~scopes ~tailcall ~inlined ~specialised ~position ~mode

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -268,8 +268,7 @@ let record_primitive = function
 let preallocate_letrec ~bindings ~body =
   assert (Clflags.is_flambda2 ());
   let caml_update_dummy_prim =
-    Primitive.simple_on_values ~name:"caml_update_dummy" ~arity:2 ~alloc:true
-    |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+    simple_on_values ~name:"caml_update_dummy" ~arity:2 ~alloc:true
   in
   let update_dummy var expr =
     Lprim (Pccall caml_update_dummy_prim, [Lvar var; expr], Loc_unknown)
@@ -283,9 +282,7 @@ let preallocate_letrec ~bindings ~body =
   List.fold_left
     (fun body (id, _def, size) ->
        let desc =
-         Primitive.simple_on_values ~name:"caml_alloc_dummy" ~arity:1
-           ~alloc:true
-         |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+         simple_on_values ~name:"caml_alloc_dummy" ~arity:1 ~alloc:true
        in
        let size : lambda = Lconst (Const_base (Const_int size)) in
        Llet (Strict, Lambda.layout_block, id,

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -269,6 +269,7 @@ let preallocate_letrec ~bindings ~body =
   assert (Clflags.is_flambda2 ());
   let caml_update_dummy_prim =
     Primitive.simple_on_values ~name:"caml_update_dummy" ~arity:2 ~alloc:true
+    |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
   in
   let update_dummy var expr =
     Lprim (Pccall caml_update_dummy_prim, [Lvar var; expr], Loc_unknown)
@@ -284,6 +285,7 @@ let preallocate_letrec ~bindings ~body =
        let desc =
          Primitive.simple_on_values ~name:"caml_alloc_dummy" ~arity:1
            ~alloc:true
+         |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
        in
        let size : lambda = Lconst (Const_base (Const_int size)) in
        Llet (Strict, Lambda.layout_block, id,

--- a/ocaml/lambda/translobj.ml
+++ b/ocaml/lambda/translobj.ml
@@ -85,6 +85,7 @@ let int n = Lconst (Const_base (Const_int n))
 (* CR layouts v5: To change when we have arrays of other sorts *)
 let prim_makearray =
   Primitive.simple_on_values ~name:"caml_make_vect" ~arity:2 ~alloc:true
+  |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
 
 (* Also use it for required globals *)
 let transl_label_init_general f =

--- a/ocaml/lambda/translobj.ml
+++ b/ocaml/lambda/translobj.ml
@@ -84,8 +84,7 @@ let int n = Lconst (Const_base (Const_int n))
 
 (* CR layouts v5: To change when we have arrays of other sorts *)
 let prim_makearray =
-  Primitive.simple_on_values ~name:"caml_make_vect" ~arity:2 ~alloc:true
-  |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+  Lambda.simple_on_values ~name:"caml_make_vect" ~arity:2 ~alloc:true
 
 (* Also use it for required globals *)
 let transl_label_init_general f =

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -1057,8 +1057,7 @@ let primitive_needs_event_after = function
   | Primitive (prim,_) -> lambda_primitive_needs_event_after prim
   | External _ | Sys_argv -> true
   | Comparison(comp, knd) ->
-      lambda_primitive_needs_event_after
-        (comparison_primitive comp knd)
+      lambda_primitive_needs_event_after (comparison_primitive comp knd)
   | Lazy_force _ | Send _ | Send_self _ | Send_cache _
   | Apply _ | Revapply _ -> true
   | Raise _ | Raise_with_backtrace | Loc _ | Frame_pointers | Identity -> false

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -122,7 +122,7 @@ let gen_array_set_kind mode =
 let prim_sys_argv =
   Primitive.simple_on_values ~name:"caml_sys_argv" ~arity:1 ~alloc:true
 
-let to_locality ~poly = function
+let to_locality ~poly : Primitive.mode * _ -> _ = function
   | Prim_global, _ -> alloc_heap
   | Prim_local, _ -> alloc_local
   | Prim_poly, _ ->
@@ -130,7 +130,7 @@ let to_locality ~poly = function
     | None -> assert false
     | Some locality -> transl_locality_mode locality
 
-let to_modify_mode ~poly = function
+let to_modify_mode ~poly : Primitive.mode * _ -> _ = function
   | Prim_global, _ -> modify_heap
   | Prim_local, _ -> modify_maybe_stack
   | Prim_poly, _ ->
@@ -910,7 +910,7 @@ let lambda_of_prim prim_name prim loc args arg_exps ~ret_mode =
     | Apply _ | Revapply _), _ ->
       raise(Error(to_location loc, Wrong_arity_builtin_primitive prim_name))
 
-let check_primitive_arity loc p =
+let check_primitive_arity loc (p : Primitive.description) =
   let mode =
     match p.prim_native_repr_res with
     | Prim_global, _ | Prim_poly, _ -> Some Mode.Locality.global

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -120,7 +120,7 @@ let gen_array_set_kind mode =
   if Config.flat_float_array then Pgenarray_set mode else Paddrarray_set mode
 
 let prim_sys_argv =
-  Primitive.simple_on_values ~name:"caml_sys_argv" ~arity:1 ~alloc:true
+  simple_on_values ~name:"caml_sys_argv" ~arity:1 ~alloc:true
 
 let to_locality ~poly : Primitive.mode * _ -> _ = function
   | Prim_global, _ -> alloc_heap
@@ -665,108 +665,107 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
   | _ -> None
 
 let caml_equal =
-  Primitive.simple_on_values ~name:"caml_equal" ~arity:2 ~alloc:true
+  simple_on_values ~name:"caml_equal" ~arity:2 ~alloc:true
 let caml_string_equal =
-  Primitive.simple_on_values ~name:"caml_string_equal" ~arity:2 ~alloc:false
+  simple_on_values ~name:"caml_string_equal" ~arity:2 ~alloc:false
 let caml_bytes_equal =
-  Primitive.simple_on_values ~name:"caml_bytes_equal" ~arity:2 ~alloc:false
+  simple_on_values ~name:"caml_bytes_equal" ~arity:2 ~alloc:false
 let caml_notequal =
-  Primitive.simple_on_values ~name:"caml_notequal" ~arity:2 ~alloc:true
+  simple_on_values ~name:"caml_notequal" ~arity:2 ~alloc:true
 let caml_string_notequal =
-  Primitive.simple_on_values ~name:"caml_string_notequal" ~arity:2 ~alloc:false
+  simple_on_values ~name:"caml_string_notequal" ~arity:2 ~alloc:false
 let caml_bytes_notequal =
-  Primitive.simple_on_values ~name:"caml_bytes_notequal" ~arity:2 ~alloc:false
+  simple_on_values ~name:"caml_bytes_notequal" ~arity:2 ~alloc:false
 let caml_lessequal =
-  Primitive.simple_on_values ~name:"caml_lessequal" ~arity:2 ~alloc:true
+  simple_on_values ~name:"caml_lessequal" ~arity:2 ~alloc:true
 let caml_string_lessequal =
-  Primitive.simple_on_values ~name:"caml_string_lessequal" ~arity:2 ~alloc:false
+  simple_on_values ~name:"caml_string_lessequal" ~arity:2 ~alloc:false
 let caml_bytes_lessequal =
-  Primitive.simple_on_values ~name:"caml_bytes_lessequal" ~arity:2 ~alloc:false
+  simple_on_values ~name:"caml_bytes_lessequal" ~arity:2 ~alloc:false
 let caml_lessthan =
-  Primitive.simple_on_values ~name:"caml_lessthan" ~arity:2 ~alloc:true
+  simple_on_values ~name:"caml_lessthan" ~arity:2 ~alloc:true
 let caml_string_lessthan =
-  Primitive.simple_on_values ~name:"caml_string_lessthan" ~arity:2 ~alloc:false
+  simple_on_values ~name:"caml_string_lessthan" ~arity:2 ~alloc:false
 let caml_bytes_lessthan =
-  Primitive.simple_on_values ~name:"caml_bytes_lessthan" ~arity:2 ~alloc:false
+  simple_on_values ~name:"caml_bytes_lessthan" ~arity:2 ~alloc:false
 let caml_greaterequal =
-  Primitive.simple_on_values ~name:"caml_greaterequal" ~arity:2 ~alloc:true
+  simple_on_values ~name:"caml_greaterequal" ~arity:2 ~alloc:true
 let caml_string_greaterequal =
-  Primitive.simple_on_values ~name:"caml_string_greaterequal" ~arity:2
+  simple_on_values ~name:"caml_string_greaterequal" ~arity:2
     ~alloc:false
 let caml_bytes_greaterequal =
-  Primitive.simple_on_values ~name:"caml_bytes_greaterequal" ~arity:2
+  simple_on_values ~name:"caml_bytes_greaterequal" ~arity:2
     ~alloc:false
 let caml_greaterthan =
-  Primitive.simple_on_values ~name:"caml_greaterthan" ~arity:2 ~alloc:true
+  simple_on_values ~name:"caml_greaterthan" ~arity:2 ~alloc:true
 let caml_string_greaterthan =
-  Primitive.simple_on_values ~name:"caml_string_greaterthan" ~arity:2
+  simple_on_values ~name:"caml_string_greaterthan" ~arity:2
     ~alloc:false
 let caml_bytes_greaterthan =
-  Primitive.simple_on_values ~name:"caml_bytes_greaterthan" ~arity:2
+  simple_on_values ~name:"caml_bytes_greaterthan" ~arity:2
     ~alloc:false
 let caml_compare =
-  Primitive.simple_on_values ~name:"caml_compare" ~arity:2 ~alloc:true
+  simple_on_values ~name:"caml_compare" ~arity:2 ~alloc:true
 let caml_string_compare =
-  Primitive.simple_on_values ~name:"caml_string_compare" ~arity:2 ~alloc:false
+  simple_on_values ~name:"caml_string_compare" ~arity:2 ~alloc:false
 let caml_bytes_compare =
-  Primitive.simple_on_values ~name:"caml_bytes_compare" ~arity:2 ~alloc:false
+  simple_on_values ~name:"caml_bytes_compare" ~arity:2 ~alloc:false
 
-let comparison_primitive comparison comparison_kind ~ret_mode =
-  let pccall prim_desc = Pccall (Lambda.external_call prim_desc ~ret_mode) in
+let comparison_primitive comparison comparison_kind =
   match comparison, comparison_kind with
-  | Equal, Compare_generic -> pccall caml_equal
+  | Equal, Compare_generic -> Pccall caml_equal
   | Equal, Compare_ints -> Pintcomp Ceq
   | Equal, Compare_floats -> Pfloatcomp CFeq
-  | Equal, Compare_strings -> pccall caml_string_equal
-  | Equal, Compare_bytes -> pccall caml_bytes_equal
+  | Equal, Compare_strings -> Pccall caml_string_equal
+  | Equal, Compare_bytes -> Pccall caml_bytes_equal
   | Equal, Compare_nativeints -> Pbintcomp(Pnativeint, Ceq)
   | Equal, Compare_int32s -> Pbintcomp(Pint32, Ceq)
   | Equal, Compare_int64s -> Pbintcomp(Pint64, Ceq)
-  | Not_equal, Compare_generic -> pccall caml_notequal
+  | Not_equal, Compare_generic -> Pccall caml_notequal
   | Not_equal, Compare_ints -> Pintcomp Cne
   | Not_equal, Compare_floats -> Pfloatcomp CFneq
-  | Not_equal, Compare_strings -> pccall caml_string_notequal
-  | Not_equal, Compare_bytes -> pccall caml_bytes_notequal
+  | Not_equal, Compare_strings -> Pccall caml_string_notequal
+  | Not_equal, Compare_bytes -> Pccall caml_bytes_notequal
   | Not_equal, Compare_nativeints -> Pbintcomp(Pnativeint, Cne)
   | Not_equal, Compare_int32s -> Pbintcomp(Pint32, Cne)
   | Not_equal, Compare_int64s -> Pbintcomp(Pint64, Cne)
-  | Less_equal, Compare_generic -> pccall caml_lessequal
+  | Less_equal, Compare_generic -> Pccall caml_lessequal
   | Less_equal, Compare_ints -> Pintcomp Cle
   | Less_equal, Compare_floats -> Pfloatcomp CFle
-  | Less_equal, Compare_strings -> pccall caml_string_lessequal
-  | Less_equal, Compare_bytes -> pccall caml_bytes_lessequal
+  | Less_equal, Compare_strings -> Pccall caml_string_lessequal
+  | Less_equal, Compare_bytes -> Pccall caml_bytes_lessequal
   | Less_equal, Compare_nativeints -> Pbintcomp(Pnativeint, Cle)
   | Less_equal, Compare_int32s -> Pbintcomp(Pint32, Cle)
   | Less_equal, Compare_int64s -> Pbintcomp(Pint64, Cle)
-  | Less_than, Compare_generic -> pccall caml_lessthan
+  | Less_than, Compare_generic -> Pccall caml_lessthan
   | Less_than, Compare_ints -> Pintcomp Clt
   | Less_than, Compare_floats -> Pfloatcomp CFlt
-  | Less_than, Compare_strings -> pccall caml_string_lessthan
-  | Less_than, Compare_bytes -> pccall caml_bytes_lessthan
+  | Less_than, Compare_strings -> Pccall caml_string_lessthan
+  | Less_than, Compare_bytes -> Pccall caml_bytes_lessthan
   | Less_than, Compare_nativeints -> Pbintcomp(Pnativeint, Clt)
   | Less_than, Compare_int32s -> Pbintcomp(Pint32, Clt)
   | Less_than, Compare_int64s -> Pbintcomp(Pint64, Clt)
-  | Greater_equal, Compare_generic -> pccall caml_greaterequal
+  | Greater_equal, Compare_generic -> Pccall caml_greaterequal
   | Greater_equal, Compare_ints -> Pintcomp Cge
   | Greater_equal, Compare_floats -> Pfloatcomp CFge
-  | Greater_equal, Compare_strings -> pccall caml_string_greaterequal
-  | Greater_equal, Compare_bytes -> pccall caml_bytes_greaterequal
+  | Greater_equal, Compare_strings -> Pccall caml_string_greaterequal
+  | Greater_equal, Compare_bytes -> Pccall caml_bytes_greaterequal
   | Greater_equal, Compare_nativeints -> Pbintcomp(Pnativeint, Cge)
   | Greater_equal, Compare_int32s -> Pbintcomp(Pint32, Cge)
   | Greater_equal, Compare_int64s -> Pbintcomp(Pint64, Cge)
-  | Greater_than, Compare_generic -> pccall caml_greaterthan
+  | Greater_than, Compare_generic -> Pccall caml_greaterthan
   | Greater_than, Compare_ints -> Pintcomp Cgt
   | Greater_than, Compare_floats -> Pfloatcomp CFgt
-  | Greater_than, Compare_strings -> pccall caml_string_greaterthan
-  | Greater_than, Compare_bytes -> pccall caml_bytes_greaterthan
+  | Greater_than, Compare_strings -> Pccall caml_string_greaterthan
+  | Greater_than, Compare_bytes -> Pccall caml_bytes_greaterthan
   | Greater_than, Compare_nativeints -> Pbintcomp(Pnativeint, Cgt)
   | Greater_than, Compare_int32s -> Pbintcomp(Pint32, Cgt)
   | Greater_than, Compare_int64s -> Pbintcomp(Pint64, Cgt)
-  | Compare, Compare_generic -> pccall caml_compare
+  | Compare, Compare_generic -> Pccall caml_compare
   | Compare, Compare_ints -> Pcompare_ints
   | Compare, Compare_floats -> Pcompare_floats
-  | Compare, Compare_strings -> pccall caml_string_compare
-  | Compare, Compare_bytes -> pccall caml_bytes_compare
+  | Compare, Compare_strings -> Pccall caml_string_compare
+  | Compare, Compare_bytes -> Pccall caml_bytes_compare
   | Compare, Compare_nativeints -> Pcompare_bints Pnativeint
   | Compare, Compare_int32s -> Pcompare_bints Pint32
   | Compare, Compare_int64s -> Pcompare_bints Pint64
@@ -811,9 +810,7 @@ let lambda_of_loc kind sloc =
     Lconst (Const_immstring scope_name)
 
 let caml_restore_raw_backtrace =
-  Primitive.simple_on_values ~name:"caml_restore_raw_backtrace" ~arity:2
-    ~alloc:false
-  |> Lambda.external_call ~ret_mode:Lambda.alloc_heap
+  simple_on_values ~name:"caml_restore_raw_backtrace" ~arity:2 ~alloc:false
 
 let try_ids = Hashtbl.create 8
 
@@ -828,13 +825,12 @@ let lambda_of_prim prim_name prim loc args arg_exps ~ret_mode =
   | Primitive (prim, arity), args when arity = List.length args ->
       Lprim(prim, args, loc)
   | Sys_argv, [] ->
-      let prim_sys_argv = Lambda.external_call prim_sys_argv ~ret_mode in
       Lprim(Pccall prim_sys_argv, [Lconst (const_int 0)], loc)
   | External prim, args ->
       let prim = Lambda.external_call prim ~ret_mode in
       Lprim(Pccall prim, args, loc)
   | Comparison(comp, knd), ([_;_] as args) ->
-      let prim = comparison_primitive comp knd ~ret_mode in
+      let prim = comparison_primitive comp knd in
       Lprim(prim, args, loc)
   | Raise kind, [arg] ->
       let kind =
@@ -1062,8 +1058,7 @@ let primitive_needs_event_after = function
   | External _ | Sys_argv -> true
   | Comparison(comp, knd) ->
       lambda_primitive_needs_event_after
-        (comparison_primitive comp knd
-          ~ret_mode:Lambda.alloc_heap (* arbitrary *) )
+        (comparison_primitive comp knd)
   | Lazy_force _ | Send _ | Send_self _ | Send_cache _
   | Apply _ | Revapply _ -> true
   | Raise _ | Raise_with_backtrace | Loc _ | Frame_pointers | Identity -> false

--- a/ocaml/lambda/translprim.mli
+++ b/ocaml/lambda/translprim.mli
@@ -41,7 +41,8 @@ val transl_primitive :
 
 val transl_primitive_application :
   Lambda.scoped_location -> Primitive.description -> Env.t ->
-  Types.type_expr -> Mode.Locality.t option -> Path.t ->
+  Types.type_expr -> Mode.Locality.t option ->
+  Lambda.locality_mode -> Path.t ->
   Typedtree.expression option ->
   Lambda.lambda list -> Typedtree.expression list ->
   Lambda.region_close -> Lambda.lambda

--- a/ocaml/middle_end/clambda_primitives.ml
+++ b/ocaml/middle_end/clambda_primitives.ml
@@ -54,7 +54,7 @@ type primitive =
   | Presume
   | Preperform
   (* External call *)
-  | Pccall of Primitive.description
+  | Pccall of Lambda.external_call
   (* Exceptions *)
   | Praise of raise_kind
   (* Boolean operations *)

--- a/ocaml/middle_end/clambda_primitives.mli
+++ b/ocaml/middle_end/clambda_primitives.mli
@@ -54,7 +54,7 @@ type primitive =
   | Presume
   | Preperform
   (* External call *)
-  | Pccall of Primitive.description
+  | Pccall of Lambda.external_call
   (* Exceptions *)
   | Praise of raise_kind
   (* Boolean operations *)

--- a/ocaml/middle_end/convert_primitives.ml
+++ b/ocaml/middle_end/convert_primitives.ml
@@ -175,8 +175,9 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
       ~effects:Only_generative_effects
       ~coeffects:Has_coeffects
       ~native_name:"caml_obj_dup"
-      ~native_repr_args:[P.Prim_global, P.Same_as_ocaml_repr Jkind.Sort.Value]
-      ~native_repr_res:(P.Prim_global, P.Same_as_ocaml_repr Jkind.Sort.Value))
+      ~native_repr_args:[(), P.Same_as_ocaml_repr Jkind.Sort.Value]
+      ~native_repr_res:(Lambda.Prim_global,
+                        P.Same_as_ocaml_repr Jkind.Sort.Value))
   | Punbox_float -> Punbox_float
   | Pbox_float m -> Pbox_float m
   | Punbox_int bi -> Punbox_int bi

--- a/ocaml/middle_end/flambda/flambda_to_clambda.ml
+++ b/ocaml/middle_end/flambda/flambda_to_clambda.ml
@@ -79,7 +79,7 @@ let check_closure t ulam named : Clambda.ulambda =
   if not !Clflags.clambda_checks then ulam
   else
     let desc =
-      Primitive.simple_on_values ~name:"caml_check_value_is_closure"
+      Lambda.simple_on_values ~name:"caml_check_value_is_closure"
         ~arity:2 ~alloc:false
     in
     let str = Format.asprintf "%a" Flambda.print_named named in
@@ -108,7 +108,7 @@ let check_field t ulam pos named_opt : Clambda.ulambda =
   if not !Clflags.clambda_checks then ulam
   else
     let desc =
-      Primitive.simple_on_values ~name:"caml_check_field_access"
+      Lambda.simple_on_values ~name:"caml_check_field_access"
         ~arity:3 ~alloc:false
     in
     let str =

--- a/ocaml/testsuite/tests/typing-local/external.ml
+++ b/ocaml/testsuite/tests/typing-local/external.ml
@@ -1,0 +1,18 @@
+(* TEST
+   * flambda2
+   ** native
+*)
+
+module M : sig
+  val bits_of_float : float -> int64
+end = struct
+  external bits_of_float
+    :  (float[@local_opt])
+    -> (int64[@local_opt])
+    = "caml_int64_bits_of_float" "caml_int64_bits_of_float_unboxed"
+end
+
+let go_m f =
+  let i = M.bits_of_float f in
+  assert (i = 4L);
+  ()

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -102,8 +102,7 @@ let simple_on_values_gen ~name ~arity ~alloc ~arg_global ~ret_global =
    prim_coeffects = Has_coeffects;
    prim_native_name = "";
    prim_native_repr_args =
-     make_native_repr_args arity
-       (arg_global, Same_as_ocaml_repr Jkind.Sort.Value);
+     make_native_repr_args arity (arg_global, Same_as_ocaml_repr Jkind.Sort.Value);
    prim_native_repr_res = (ret_global, Same_as_ocaml_repr Jkind.Sort.Value) }
 
 let make ~name ~alloc ~c_builtin ~effects ~coeffects

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -106,10 +106,6 @@ let simple_on_values_gen ~name ~arity ~alloc ~arg_global ~ret_global =
        (arg_global, Same_as_ocaml_repr Jkind.Sort.Value);
    prim_native_repr_res = (ret_global, Same_as_ocaml_repr Jkind.Sort.Value) }
 
-let simple_on_values ~name ~arity ~alloc =
-  simple_on_values_gen ~name ~arity ~alloc
-    ~arg_global:Prim_global ~ret_global:Prim_global
-
 let make ~name ~alloc ~c_builtin ~effects ~coeffects
       ~native_name ~native_repr_args ~native_repr_res =
   {prim_name = name;

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -39,7 +39,7 @@ type mode =
   | Prim_global
   | Prim_poly
 
-type description =
+type 'ret_mode description_gen =
   { prim_name: string;         (* Name of primitive  or C function *)
     prim_arity: int;           (* Number of arguments *)
     prim_alloc: bool;          (* Does it allocates or raise? *)
@@ -48,7 +48,9 @@ type description =
     prim_coeffects: coeffects;
     prim_native_name: string;  (* Name of C function for the nat. code gen. *)
     prim_native_repr_args: (mode * native_repr) list;
-    prim_native_repr_res: mode * native_repr }
+    prim_native_repr_res: 'ret_mode * native_repr }
+
+type description = mode description_gen
 
 type error =
   | Old_style_float_with_native_repr_attribute
@@ -91,7 +93,7 @@ let rec make_native_repr_args arity x =
   else
     x :: make_native_repr_args (arity - 1) x
 
-let simple_on_values ~name ~arity ~alloc =
+let simple_on_values_gen ~name ~arity ~alloc ~global =
   {prim_name = name;
    prim_arity = arity;
    prim_alloc = alloc;
@@ -100,8 +102,12 @@ let simple_on_values ~name ~arity ~alloc =
    prim_coeffects = Has_coeffects;
    prim_native_name = "";
    prim_native_repr_args =
-     make_native_repr_args arity (Prim_global, Same_as_ocaml_repr Jkind.Sort.Value);
-   prim_native_repr_res = (Prim_global, Same_as_ocaml_repr Jkind.Sort.Value) }
+     make_native_repr_args arity
+       (Prim_global, Same_as_ocaml_repr Jkind.Sort.Value);
+   prim_native_repr_res = (global, Same_as_ocaml_repr Jkind.Sort.Value) }
+
+let simple_on_values ~name ~arity ~alloc =
+  simple_on_values_gen ~name ~arity ~alloc ~global:Prim_global
 
 let make ~name ~alloc ~c_builtin ~effects ~coeffects
       ~native_name ~native_repr_args ~native_repr_res =

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -39,7 +39,7 @@ type mode =
   | Prim_global
   | Prim_poly
 
-type 'ret_mode description_gen =
+type ('arg_mode, 'ret_mode) description_gen =
   { prim_name: string;         (* Name of primitive  or C function *)
     prim_arity: int;           (* Number of arguments *)
     prim_alloc: bool;          (* Does it allocates or raise? *)
@@ -47,10 +47,10 @@ type 'ret_mode description_gen =
     prim_effects: effects;
     prim_coeffects: coeffects;
     prim_native_name: string;  (* Name of C function for the nat. code gen. *)
-    prim_native_repr_args: (mode * native_repr) list;
+    prim_native_repr_args: ('arg_mode * native_repr) list;
     prim_native_repr_res: 'ret_mode * native_repr }
 
-type description = mode description_gen
+type description = (mode, mode) description_gen
 
 type error =
   | Old_style_float_with_native_repr_attribute
@@ -93,7 +93,7 @@ let rec make_native_repr_args arity x =
   else
     x :: make_native_repr_args (arity - 1) x
 
-let simple_on_values_gen ~name ~arity ~alloc ~global =
+let simple_on_values_gen ~name ~arity ~alloc ~arg_global ~ret_global =
   {prim_name = name;
    prim_arity = arity;
    prim_alloc = alloc;
@@ -103,11 +103,12 @@ let simple_on_values_gen ~name ~arity ~alloc ~global =
    prim_native_name = "";
    prim_native_repr_args =
      make_native_repr_args arity
-       (Prim_global, Same_as_ocaml_repr Jkind.Sort.Value);
-   prim_native_repr_res = (global, Same_as_ocaml_repr Jkind.Sort.Value) }
+       (arg_global, Same_as_ocaml_repr Jkind.Sort.Value);
+   prim_native_repr_res = (ret_global, Same_as_ocaml_repr Jkind.Sort.Value) }
 
 let simple_on_values ~name ~arity ~alloc =
-  simple_on_values_gen ~name ~arity ~alloc ~global:Prim_global
+  simple_on_values_gen ~name ~arity ~alloc
+    ~arg_global:Prim_global ~ret_global:Prim_global
 
 let make ~name ~alloc ~c_builtin ~effects ~coeffects
       ~native_name ~native_repr_args ~native_repr_res =

--- a/ocaml/typing/primitive.mli
+++ b/ocaml/typing/primitive.mli
@@ -41,7 +41,8 @@ type mode =
 (* [Prim_poly] arguments and results are subject to mode inference,
    allowing e.g. (+.) to work on local or global floats. After
    typechecking, all [Prim_poly] modes on a given primitive application
-   will be instantiated either all to [Local] or all to [Global] *)
+   will be instantiated either all to [Local] or all to [Global].
+   [Prim_poly] never appears in [Lambda] terms. *)
 
 type description = private
   { prim_name: string;         (* Name of primitive  or C function *)

--- a/ocaml/typing/primitive.mli
+++ b/ocaml/typing/primitive.mli
@@ -44,7 +44,7 @@ type mode =
    will be instantiated either all to [Local] or all to [Global].
    [Prim_poly] never appears in [Lambda] terms. *)
 
-type description = private
+type 'ret_mode description_gen = private
   { prim_name: string;         (* Name of primitive  or C function *)
     prim_arity: int;           (* Number of arguments *)
     prim_alloc: bool;          (* Does it allocates or raise? *)
@@ -58,9 +58,18 @@ type description = private
     prim_coeffects: coeffects;
     prim_native_name: string;  (* Name of C function for the nat. code gen. *)
     prim_native_repr_args: (mode * native_repr) list;
-    prim_native_repr_res: mode * native_repr }
+    prim_native_repr_res: 'ret_mode * native_repr }
 
 (* Invariant [List.length d.prim_native_repr_args = d.prim_arity] *)
+
+type description = mode description_gen
+
+val simple_on_values_gen
+  :  name:string
+  -> arity:int
+  -> alloc:bool
+  -> global:'ret_mode
+  -> 'ret_mode description_gen
 
 val simple_on_values
   :  name:string
@@ -76,8 +85,8 @@ val make
   -> coeffects:coeffects
   -> native_name:string
   -> native_repr_args: (mode * native_repr) list
-  -> native_repr_res: mode * native_repr
-  -> description
+  -> native_repr_res: 'ret_mode * native_repr
+  -> 'ret_mode description_gen
 
 val parse_declaration
   :  Parsetree.value_description
@@ -90,7 +99,7 @@ val print
   -> Outcometree.out_val_decl
   -> Outcometree.out_val_decl
 
-val native_name: description -> string
+val native_name: 'ret_mode description_gen -> string
 val byte_name: description -> string
 val vec128_name: vec128_type -> string
 

--- a/ocaml/typing/primitive.mli
+++ b/ocaml/typing/primitive.mli
@@ -72,12 +72,6 @@ val simple_on_values_gen
   -> ret_global:'ret_mode
   -> ('arg_mode, 'ret_mode) description_gen
 
-val simple_on_values
-  :  name:string
-  -> arity:int
-  -> alloc:bool
-  -> description
-
 val make
   :  name:string
   -> alloc:bool

--- a/ocaml/typing/primitive.mli
+++ b/ocaml/typing/primitive.mli
@@ -44,7 +44,7 @@ type mode =
    will be instantiated either all to [Local] or all to [Global].
    [Prim_poly] never appears in [Lambda] terms. *)
 
-type 'ret_mode description_gen = private
+type ('arg_mode, 'ret_mode) description_gen = private
   { prim_name: string;         (* Name of primitive  or C function *)
     prim_arity: int;           (* Number of arguments *)
     prim_alloc: bool;          (* Does it allocates or raise? *)
@@ -57,19 +57,20 @@ type 'ret_mode description_gen = private
     prim_effects: effects;
     prim_coeffects: coeffects;
     prim_native_name: string;  (* Name of C function for the nat. code gen. *)
-    prim_native_repr_args: (mode * native_repr) list;
+    prim_native_repr_args: ('arg_mode * native_repr) list;
     prim_native_repr_res: 'ret_mode * native_repr }
 
 (* Invariant [List.length d.prim_native_repr_args = d.prim_arity] *)
 
-type description = mode description_gen
+type description = (mode, mode) description_gen
 
 val simple_on_values_gen
   :  name:string
   -> arity:int
   -> alloc:bool
-  -> global:'ret_mode
-  -> 'ret_mode description_gen
+  -> arg_global:'arg_mode
+  -> ret_global:'ret_mode
+  -> ('arg_mode, 'ret_mode) description_gen
 
 val simple_on_values
   :  name:string
@@ -84,9 +85,9 @@ val make
   -> effects:effects
   -> coeffects:coeffects
   -> native_name:string
-  -> native_repr_args: (mode * native_repr) list
+  -> native_repr_args: ('arg_mode * native_repr) list
   -> native_repr_res: 'ret_mode * native_repr
-  -> 'ret_mode description_gen
+  -> ('arg_mode, 'ret_mode) description_gen
 
 val parse_declaration
   :  Parsetree.value_description
@@ -99,7 +100,7 @@ val print
   -> Outcometree.out_val_decl
   -> Outcometree.out_val_decl
 
-val native_name: 'ret_mode description_gen -> string
+val native_name: ('arg_mode, 'ret_mode) description_gen -> string
 val byte_name: description -> string
 val vec128_name: vec128_type -> string
 


### PR DESCRIPTION
In #2180 there were really two fixes:
- changes to `Call_kind` in Flambda 2 to deal with the accidental omission of the region variable for C calls during a recent improvement/refactoring PR (#1871).
- a change in `Lambda.primitive_may_allocate` to correctly handle the case when `prim_alloc` is `false` but in fact the external function locally allocates.  This appears to have been a pre-existing bug.  (It is permitted to write such code iff you are certain the compiler used will always be configured with stack allocation.)

Unfortunately the second change has revealed another problem.  Some primitives, for example one declared like this:
```
external float_of_bits : (int64[@local_opt]) -> (float[@local_opt])
  = "caml_int64_float_of_bits" "caml_int64_float_of_bits_unboxed"
  [@@unboxed] [@@noalloc]
```
end up appearing in Lambda as `Prim_poly` (the comment in `primitive.mli` is kind of misleading here).  However this isn't ok from the point of view of `Lambda.primitive_may_allocate` and in particular its new helper function `Lambda.alloc_mode_of_primitive_description` (which is also used by Flambda 2).  For example, the above primitive might get eta-expanded by the code in `Translprim`, in conjunction with a judgement that effectively turns `Prim_poly` (plus some extra information, the `poly_mode`) into `Alloc_heap`.  This is then used to avoid inserting a region, correctly, but is not propagated further (there is nowhere to put it on the `Lambda` terms).  We thereby end up in a situation where the Lambda code says `Prim_poly`, so `alloc_mode_of_primitive_description` says "might allocate locally" -- but the `Translprim` code had not inserted a region.  This then causes a fatal error in Flambda 2, because if a external call might allocate locally, its applications will contain region variables.  These will be unbound if the frontend failed to insert the appropriate regions (or marked the enclosing function as allowing local allocations to escape, in which case the implicit `my_region` function parameter would be used).

The idea of this PR is to ban `Prim_poly` from appearing in Lambda terms at all.  It does this by making the argument of the `Pccall` constructor `private`, which necessitates only minor changes, and insisting that all constructions of it are done by supplying the return mode.  This then rewrites `Prim_poly` into either `Prim_global` or `Prim_local` as appropriate, avoiding the above problem.  It seems better than an alternative solution I considered, namely causing regions to be inserted for all `Prim_poly` primitive calls.