### PR TITLE
Silence the debug runtime by default (runtime5 only)

### DIFF
--- a/ocaml/runtime/startup_aux.c
+++ b/ocaml/runtime/startup_aux.c
@@ -57,7 +57,9 @@ static void init_startup_params(void)
   params.runtime_events_log_wsize = Default_runtime_events_log_wsize;
 
 #ifdef DEBUG
-  atomic_store_relaxed(&caml_verb_gc, 0x3F);
+  // Silenced in flambda-backend to make it easier to run tests that
+  // check program output.
+  // atomic_store_relaxed(&caml_verb_gc, 0x3F);
 #endif
 #ifndef NATIVE_CODE
   cds_file = caml_secure_getenv(T("CAML_DEBUG_FILE"));

--- a/ocaml/runtime/startup_byt.c
+++ b/ocaml/runtime/startup_byt.c
@@ -468,7 +468,9 @@ CAMLexport void caml_main(char_os **argv)
   caml_parse_ocamlrunparam();
 
 #ifdef DEBUG
-  caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
+  // Silenced in flambda-backend to make it easier to run tests that
+  // check program output.
+  // caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
 #endif
   if (!caml_startup_aux(/* pooling */ caml_params->cleanup_on_exit))
     return;
@@ -609,7 +611,9 @@ CAMLexport value caml_startup_code_exn(
   caml_parse_ocamlrunparam();
 
 #ifdef DEBUG
-  caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
+  // Silenced in flambda-backend to make it easier to run tests that
+  // check program output.
+  // caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
 #endif
   if (caml_params->cleanup_on_exit)
     pooling = 1;

--- a/ocaml/runtime/startup_nat.c
+++ b/ocaml/runtime/startup_nat.c
@@ -94,7 +94,9 @@ value caml_startup_common(char_os **argv, int pooling)
   caml_parse_ocamlrunparam();
 
 #ifdef DEBUG
-  caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
+  // Silenced in flambda-backend to make it easier to run tests that
+  // check program output.
+  // caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
 #endif
   if (caml_params->cleanup_on_exit)
     pooling = 1;


### PR DESCRIPTION
This should make it a drop-in replacement for the normal runtime, which will be valuable when running tests that check program output.