### PR TITLE
Implement layout histories

### DIFF
--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -2,7 +2,7 @@ open Typedtree
 open Types
 open Mode
 
-let dummy_jkind = Jkind.value ~why:Type_argument
+let dummy_jkind = Jkind.value ~why:(Unknown "dummy_layout")
 let dummy_value_mode = Value.legacy
 let mkTvar name = Tvar { name; jkind = dummy_jkind }
 

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -4151,7 +4151,7 @@ let report_error ppf = function
       fprintf ppf
         "Non-value detected in translation:@ Please report this error to \
          the Jane Street compilers team.@ %a"
-        (Jkind.Violation.report_with_name ~name:"This expression") err
+        (Jkind.Violation.report_with_name ~name:"this expression") err
   | Illegal_record_field c ->
       fprintf ppf
         "Sort %s detected where value was expected in a record field:@ Please \

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -105,7 +105,8 @@ let builtin_attrs =
   ; "builtin"; "ocaml.builtin"
   ; "no_effects"; "ocaml.no_effects"
   ; "no_coeffects"; "ocaml.no_coeffects"
-  ; "only_generative_effects"; "ocaml.only_generative_effects";
+  ; "only_generative_effects"; "ocaml.only_generative_effects"
+  ; "error_message"; "ocaml.error_message"
   ]
 
 (* nroberts: When we upstream the builtin-attribute whitelisting, we shouldn't
@@ -696,3 +697,18 @@ let tailcall attr =
           (Warnings.Attribute_payload
              (t.attr_name.txt, "Only 'hint' is supported"));
         Ok (Some `Tail_if_possible)
+
+let error_message_attr l =
+  let inner x =
+    match x.attr_name.txt with
+    | "ocaml.error_message"|"error_message" ->
+      begin match string_of_payload x.attr_payload with
+      | Some _ as r ->
+        mark_used x.attr_name;
+        r
+      | None -> warn_payload x.attr_loc x.attr_name.txt
+                  "error_message attribute expects a string argument";
+        None
+      end
+    | _ -> None in
+  List.find_map inner l

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -208,3 +208,10 @@ val jkind_attribute_of_string : string -> jkind_attribute option
    as the attribute mechanism predates layouts.
 *)
 val jkind : Parsetree.attributes -> jkind_attribute Location.loc option
+
+(** Finds the first "error_message" attribute, marks it as used, and returns its
+    string payload. Returns [None] if no such attribute is present.
+
+    There should be at most one "error_message" attribute, additional ones are sliently
+    ignored. **)
+val error_message_attr : Parsetree.attributes -> string option

--- a/ocaml/parsing/location.ml
+++ b/ocaml/parsing/location.ml
@@ -261,7 +261,7 @@ let print_filename ppf file =
    Some of the information (filename, line number or characters numbers) in the
    location might be invalid; in which case we do not print it.
  *)
-let print_loc ppf loc =
+let print_loc ~capitalize_first ppf loc =
   setup_colors ();
   let file_valid = function
     | "_none_" ->
@@ -287,7 +287,8 @@ let print_loc ppf loc =
 
   let first = ref true in
   let capitalize s =
-    if !first then (first := false; String.capitalize_ascii s)
+    if !first then (first := false;
+                    if capitalize_first then String.capitalize_ascii s else s)
     else s in
   let comma () =
     if !first then () else Format.fprintf ppf ", " in
@@ -315,6 +316,9 @@ let print_loc ppf loc =
   );
 
   Format.fprintf ppf "@}"
+
+let print_loc_in_lowercase = print_loc ~capitalize_first:false
+let print_loc = print_loc ~capitalize_first:true
 
 (* Print a comma-separated list of locations *)
 let print_locs ppf locs =

--- a/ocaml/parsing/location.mli
+++ b/ocaml/parsing/location.mli
@@ -202,6 +202,7 @@ val show_filename: string -> string
 val print_filename: formatter -> string -> unit
 
 val print_loc: formatter -> t -> unit
+val print_loc_in_lowercase: formatter -> t -> unit
 val print_locs: formatter -> t list -> unit
 
 

--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -143,8 +143,14 @@ end;;
 Line 2, characters 2-31:
 2 |   type t = string [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type string has layout value, which is not a sublayout of immediate.
+Error: The layout of type string is value, because
+         it is the primitive value type string.
+       But the layout of type string must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-31.
 |}];;
+(* CR layouts v2.9: The "of the definition of t ..." part is not great and it
+   should only refer to definitions that type check. Fixing it will involve
+   building a second [final_env] in [transl_type_decl] which is costly.  *)
 
 (* Cannot directly declare a non-immediate type as immediate (variant) *)
 module B = struct
@@ -154,7 +160,10 @@ end;;
 Line 2, characters 2-41:
 2 |   type t = Foo of int | Bar [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type t has layout value, which is not a sublayout of immediate.
+Error: The layout of type t is value, because
+         it's a boxed variant type.
+       But the layout of type t must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
 |}];;
 
 (* Cannot directly declare a non-immediate type as immediate (record) *)
@@ -165,7 +174,10 @@ end;;
 Line 2, characters 2-38:
 2 |   type t = { foo : int } [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type t has layout value, which is not a sublayout of immediate.
+Error: The layout of type t is value, because
+         it's a boxed record type.
+       But the layout of type t must be a sublayout of immediate, because
+         of the annotation on the declaration of the type t.
 |}];;
 
 (* Not guaranteed that t is immediate, so this is an invalid declaration *)
@@ -177,7 +189,10 @@ end;;
 Line 3, characters 2-26:
 3 |   type s = t [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type t has layout value, which is not a sublayout of immediate.
+Error: The layout of type t is value, because
+         of the definition of t at line 2, characters 2-8.
+       But the layout of type t must be a sublayout of immediate, because
+         of the definition of s at line 3, characters 2-26.
 |}];;
 
 (* Can't ascribe to an immediate type signature with a non-immediate type *)
@@ -198,12 +213,14 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         it is the primitive value type string.
+       But the layout of the first must be a sublayout of immediate, because
+         of the definition of t at line 1, characters 15-35.
 |}];;
 
 (* Same as above but with explicit signature *)
 module M_invalid : S = struct type t = string end;;
-module FM_invalid = F (struct type t = string end);;
 [%%expect{|
 Line 1, characters 23-49:
 1 | module M_invalid : S = struct type t = string end;;
@@ -214,7 +231,27 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         it is the primitive value type string.
+       But the layout of the first must be a sublayout of immediate, because
+         of the definition of t at line 1, characters 20-40.
+|}];;
+
+module FM_invalid = F (struct type t = string end);;
+[%%expect{|
+Line 1, characters 20-50:
+1 | module FM_invalid = F (struct type t = string end);;
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Modules do not match: sig type t = string end is not included in
+       S
+     Type declarations do not match:
+       type t = string
+     is not included in
+       type t : immediate
+     The layout of the first is value, because
+       it is the primitive value type string.
+     But the layout of the first must be a sublayout of immediate, because
+       of the definition of t at line 1, characters 20-40.
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)
@@ -226,7 +263,10 @@ end;;
 Line 2, characters 2-26:
 2 |   type t = s [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type s has layout value, which is not a sublayout of immediate.
+Error: The layout of type s is value, because
+         it is the primitive value type string.
+       But the layout of type s must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-26.
 |}];;
 
 

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha_beta.ml
@@ -57,8 +57,8 @@ let x3_1 : t_bits32 = assert false;;
 Line 1, characters 4-8:
 1 | let x3_1 : t_bits32 = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_1 has layout
-       bits32.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_1 has layout bits32.
 |}];;
 
 let x3_2 : 'a t_bits32_id = assert false;;
@@ -66,8 +66,8 @@ let x3_2 : 'a t_bits32_id = assert false;;
 Line 1, characters 4-8:
 1 | let x3_2 : 'a t_bits32_id = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_2 has layout
-       bits32.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_2 has layout bits32.
 |}];;
 
 let x3_3 : int32# = assert false;;
@@ -75,8 +75,8 @@ let x3_3 : int32# = assert false;;
 Line 1, characters 4-8:
 1 | let x3_3 : int32# = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_3 has layout
-       bits32.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_3 has layout bits32.
 |}];;
 
 module M3_4 = struct
@@ -86,8 +86,8 @@ end
 Line 2, characters 6-7:
 2 |   let x : t_bits32 = assert false
           ^
-Error: Top-level module bindings must have layout value, but x has layout
-       bits32.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x has layout bits32.
 |}];;
 
 module M3_5 = struct
@@ -99,8 +99,8 @@ end
 Line 4, characters 6-7:
 4 |   let y = f (assert false)
           ^
-Error: Top-level module bindings must have layout value, but y has layout
-       bits32.
+Error: Types of top-level module bindings must have layout value, but
+       the type of y has layout bits32.
 |}];;
 
 (*************************************)
@@ -113,7 +113,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_bits32_id) = x, false;;
@@ -123,7 +126,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value)
-       'a t_bits32_id has layout bits32, which does not overlap with value.
+       The layout of 'a t_bits32_id is bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : int32#) = x, false;;
@@ -133,7 +139,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_bits32 * string;;
@@ -142,7 +151,10 @@ Line 1, characters 12-20:
 1 | type t4_4 = t_bits32 * string;;
                 ^^^^^^^^
 Error: Tuple element types must have layout value.
-        t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * int32#;;
@@ -151,7 +163,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * int32#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-        int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : bits32) t4_6 = 'a * 'a
@@ -160,7 +175,10 @@ Line 1, characters 26-28:
 1 | type ('a : bits32) t4_6 = 'a * 'a
                               ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       'a has layout bits32, which does not overlap with value.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -170,7 +188,10 @@ Line 1, characters 31-33:
 1 | type ('a : bits32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits32)
-       'a has layout bits32, which does not overlap with value.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -264,7 +285,10 @@ Line 1, characters 31-39:
 1 | module type S6_1 = sig val x : t_bits32 end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout bits32, which is not a sublayout of value.
+       The layout of type t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of type t_bits32 must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_bits32_id end
@@ -273,7 +297,10 @@ Line 1, characters 31-45:
 1 | module type S6_2 = sig val x : 'a t_bits32_id end
                                    ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout bits32, which does not overlap with value.
+       The layout of type 'a t_bits32_id is bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of type 'a t_bits32_id must overlap with value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : int32# end
@@ -282,7 +309,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : int32# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout bits32, which is not a sublayout of value.
+       The layout of type int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of type int32# must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -295,7 +325,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_bits32_id) = `A x;;
@@ -305,7 +338,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value)
-       'a t_bits32_id has layout bits32, which does not overlap with value.
+       The layout of 'a t_bits32_id is bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : int32#) = `A x;;
@@ -315,7 +351,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_bits32 ];;
@@ -324,7 +363,10 @@ Line 1, characters 20-28:
 1 | type f7_4 = [ `A of t_bits32 ];;
                         ^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-        t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : bits32) f7_5 = [ `A of 'a ];;
@@ -333,9 +375,11 @@ Line 1, characters 34-36:
 1 | type ('a : bits32) f7_5 = [ `A of 'a ];;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       'a has layout bits32, which does not overlap with value.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
-(* CR layouts v2.9: This error could be improved *)
 
 (************************************************************)
 (* Test 8: Normal polymorphic functions don't work on them. *)
@@ -359,7 +403,10 @@ Line 1, characters 20-38:
                         ^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_bits32_id ());;
@@ -369,7 +416,10 @@ Line 1, characters 20-41:
                         ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value)
-       'a t_bits32_id has layout bits32, which does not overlap with value.
+       The layout of 'a t_bits32_id is bits32, because
+         of the definition of make_t_bits32_id at line 2, characters 21-55.
+       But the layout of 'a t_bits32_id must overlap with value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_int32u ());;
@@ -379,7 +429,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -505,7 +558,10 @@ Line 1, characters 15-27:
 1 | type t12_1 = < x : t_bits32 >;;
                    ^^^^^^^^^^^^
 Error: Object field types must have layout value.
-        t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : bits32) t12_2 = < x : 'a >;;
@@ -514,7 +570,10 @@ Line 1, characters 33-35:
 1 | type ('a : bits32) t12_2 = < x : 'a >;;
                                      ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       'a has layout bits32, which does not overlap with value.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_bits32 = assert false end;;
@@ -524,7 +583,10 @@ Line 1, characters 21-55:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_bits32 but is expected to have type
          ('a : value)
-       t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -535,9 +597,11 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_bits32_id -> 'a t_bits32_id = assert false
                  ^^
 Error: This type ('a : bits32) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with bits32.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
 |}];;
-(* CR layouts v2.9: Error could be improved *)
 
 class c12_5 = object val x : t_bits32 = assert false end;;
 [%%expect{|
@@ -545,7 +609,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_bits32 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       x has layout bits32, which is not a sublayout of value.
+       The layout of x is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : int32# end;;
@@ -554,9 +621,11 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : int32# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type int32# but is expected to have type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
-(* CR layouts v2.9: Error could be improved *)
 
 class type c12_7 = object val x : int32# end
 [%%expect{|
@@ -564,7 +633,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : int32# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       x has layout bits32, which is not a sublayout of value.
+       The layout of x is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -575,7 +647,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_bits32_id -> 'a t_bits32_id
               ^^
 Error: This type ('a : bits32) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with bits32.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -611,7 +686,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_bits32
-       t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_bits32) (m2 : t_bits32) = object
@@ -625,7 +703,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -641,7 +722,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_bits32) = compare x x;;
@@ -651,7 +735,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_bits32) = Marshal.to_bytes x;;
@@ -661,7 +748,10 @@ Line 1, characters 44-45:
                                                 ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_bits32) = Hashtbl.hash x;;
@@ -671,5 +761,8 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       t_bits32 has layout bits32, which is not a sublayout of value.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits32/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/parsing.ml
@@ -43,7 +43,10 @@ Line 1, characters 9-15:
 1 | type t = int32# list;;
              ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let f (_ : int32# list) = ();;
@@ -52,7 +55,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int32# list) = ();;
                ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C of int32# list;;
@@ -61,7 +67,10 @@ Line 1, characters 14-20:
 1 | type t = C of int32# list;;
                   ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C : int32# list -> t;;
@@ -70,7 +79,10 @@ Line 1, characters 13-19:
 1 | type t = C : int32# list -> t;;
                  ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* Syntax: int32#c
@@ -89,7 +101,10 @@ Line 1, characters 9-15:
 1 | type t = int32#c;;
              ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int32#c) = ();;
@@ -98,7 +113,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int32#c) = ();;
                ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of int32#c;;
@@ -107,7 +125,10 @@ Line 1, characters 14-20:
 1 | type t = C of int32#c;;
                   ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : int32#c -> t;;
@@ -116,7 +137,10 @@ Line 1, characters 13-19:
 1 | type t = C : int32#c -> t;;
                  ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int32# c
@@ -128,7 +152,10 @@ Line 1, characters 9-15:
 1 | type t = int32# c;;
              ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int32# c) = ();;
@@ -137,7 +164,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int32# c) = ();;
                ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of int32# c;;
@@ -146,7 +176,10 @@ Line 1, characters 14-20:
 1 | type t = C of int32# c;;
                   ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : int32# c -> t;;
@@ -155,7 +188,10 @@ Line 1, characters 13-19:
 1 | type t = C : int32# c -> t;;
                  ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       int32# has layout bits32, which is not a sublayout of value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int32 #c

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha_beta.ml
@@ -57,8 +57,8 @@ let x3_1 : t_bits64 = assert false;;
 Line 1, characters 4-8:
 1 | let x3_1 : t_bits64 = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_1 has layout
-       bits64.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_1 has layout bits64.
 |}];;
 
 let x3_2 : 'a t_bits64_id = assert false;;
@@ -66,8 +66,8 @@ let x3_2 : 'a t_bits64_id = assert false;;
 Line 1, characters 4-8:
 1 | let x3_2 : 'a t_bits64_id = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_2 has layout
-       bits64.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_2 has layout bits64.
 |}];;
 
 let x3_3 : int64# = assert false;;
@@ -75,8 +75,8 @@ let x3_3 : int64# = assert false;;
 Line 1, characters 4-8:
 1 | let x3_3 : int64# = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_3 has layout
-       bits64.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_3 has layout bits64.
 |}];;
 
 module M3_4 = struct
@@ -86,8 +86,8 @@ end
 Line 2, characters 6-7:
 2 |   let x : t_bits64 = assert false
           ^
-Error: Top-level module bindings must have layout value, but x has layout
-       bits64.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x has layout bits64.
 |}];;
 
 module M3_5 = struct
@@ -99,8 +99,8 @@ end
 Line 4, characters 6-7:
 4 |   let y = f (assert false)
           ^
-Error: Top-level module bindings must have layout value, but y has layout
-       bits64.
+Error: Types of top-level module bindings must have layout value, but
+       the type of y has layout bits64.
 |}];;
 
 (*************************************)
@@ -113,7 +113,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_bits64_id) = x, false;;
@@ -123,7 +126,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value)
-       'a t_bits64_id has layout bits64, which does not overlap with value.
+       The layout of 'a t_bits64_id is bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : int64#) = x, false;;
@@ -133,7 +139,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_bits64 * string;;
@@ -142,7 +151,10 @@ Line 1, characters 12-20:
 1 | type t4_4 = t_bits64 * string;;
                 ^^^^^^^^
 Error: Tuple element types must have layout value.
-        t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * int64#;;
@@ -151,7 +163,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * int64#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-        int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : bits64) t4_6 = 'a * 'a
@@ -160,7 +175,10 @@ Line 1, characters 26-28:
 1 | type ('a : bits64) t4_6 = 'a * 'a
                               ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       'a has layout bits64, which does not overlap with value.
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -170,7 +188,10 @@ Line 1, characters 31-33:
 1 | type ('a : bits64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits64)
-       'a has layout bits64, which does not overlap with value.
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -264,7 +285,10 @@ Line 1, characters 31-39:
 1 | module type S6_1 = sig val x : t_bits64 end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout bits64, which is not a sublayout of value.
+       The layout of type t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of type t_bits64 must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_bits64_id end
@@ -273,7 +297,10 @@ Line 1, characters 31-45:
 1 | module type S6_2 = sig val x : 'a t_bits64_id end
                                    ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout bits64, which does not overlap with value.
+       The layout of type 'a t_bits64_id is bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of type 'a t_bits64_id must overlap with value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : int64# end
@@ -282,7 +309,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : int64# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout bits64, which is not a sublayout of value.
+       The layout of type int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of type int64# must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -295,7 +325,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_bits64_id) = `A x;;
@@ -305,7 +338,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value)
-       'a t_bits64_id has layout bits64, which does not overlap with value.
+       The layout of 'a t_bits64_id is bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : int64#) = `A x;;
@@ -315,7 +351,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_bits64 ];;
@@ -324,7 +363,10 @@ Line 1, characters 20-28:
 1 | type f7_4 = [ `A of t_bits64 ];;
                         ^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-        t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : bits64) f7_5 = [ `A of 'a ];;
@@ -333,9 +375,11 @@ Line 1, characters 34-36:
 1 | type ('a : bits64) f7_5 = [ `A of 'a ];;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       'a has layout bits64, which does not overlap with value.
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
-(* CR layouts v2.9: This error could be improved *)
 
 (************************************************************)
 (* Test 8: Normal polymorphic functions don't work on them. *)
@@ -359,7 +403,10 @@ Line 1, characters 20-38:
                         ^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_bits64_id ());;
@@ -369,7 +416,10 @@ Line 1, characters 20-41:
                         ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value)
-       'a t_bits64_id has layout bits64, which does not overlap with value.
+       The layout of 'a t_bits64_id is bits64, because
+         of the definition of make_t_bits64_id at line 2, characters 21-55.
+       But the layout of 'a t_bits64_id must overlap with value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_int64u ());;
@@ -379,7 +429,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -505,7 +558,10 @@ Line 1, characters 15-27:
 1 | type t12_1 = < x : t_bits64 >;;
                    ^^^^^^^^^^^^
 Error: Object field types must have layout value.
-        t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : bits64) t12_2 = < x : 'a >;;
@@ -514,7 +570,10 @@ Line 1, characters 33-35:
 1 | type ('a : bits64) t12_2 = < x : 'a >;;
                                      ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       'a has layout bits64, which does not overlap with value.
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_bits64 = assert false end;;
@@ -524,7 +583,10 @@ Line 1, characters 21-55:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_bits64 but is expected to have type
          ('a : value)
-       t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -535,9 +597,11 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_bits64_id -> 'a t_bits64_id = assert false
                  ^^
 Error: This type ('a : bits64) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with bits64.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
 |}];;
-(* CR layouts v2.9: Error could be improved *)
 
 class c12_5 = object val x : t_bits64 = assert false end;;
 [%%expect{|
@@ -545,7 +609,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_bits64 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       x has layout bits64, which is not a sublayout of value.
+       The layout of x is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : int64# end;;
@@ -554,9 +621,11 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : int64# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type int64# but is expected to have type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
-(* CR layouts v2.9: Error could be improved *)
 
 class type c12_7 = object val x : int64# end
 [%%expect{|
@@ -564,7 +633,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : int64# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       x has layout bits64, which is not a sublayout of value.
+       The layout of x is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -575,7 +647,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_bits64_id -> 'a t_bits64_id
               ^^
 Error: This type ('a : bits64) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with bits64.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -611,7 +686,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_bits64
-       t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_bits64) (m2 : t_bits64) = object
@@ -625,7 +703,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -641,7 +722,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_bits64) = compare x x;;
@@ -651,7 +735,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_bits64) = Marshal.to_bytes x;;
@@ -661,7 +748,10 @@ Line 1, characters 44-45:
                                                 ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_bits64) = Hashtbl.hash x;;
@@ -671,5 +761,8 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       t_bits64 has layout bits64, which is not a sublayout of value.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/parsing.ml
@@ -43,7 +43,10 @@ Line 1, characters 9-15:
 1 | type t = int64# list;;
              ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let f (_ : int64# list) = ();;
@@ -52,7 +55,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int64# list) = ();;
                ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C of int64# list;;
@@ -61,7 +67,10 @@ Line 1, characters 14-20:
 1 | type t = C of int64# list;;
                   ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C : int64# list -> t;;
@@ -70,7 +79,10 @@ Line 1, characters 13-19:
 1 | type t = C : int64# list -> t;;
                  ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* Syntax: int64#c
@@ -89,7 +101,10 @@ Line 1, characters 9-15:
 1 | type t = int64#c;;
              ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int64#c) = ();;
@@ -98,7 +113,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int64#c) = ();;
                ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of int64#c;;
@@ -107,7 +125,10 @@ Line 1, characters 14-20:
 1 | type t = C of int64#c;;
                   ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : int64#c -> t;;
@@ -116,7 +137,10 @@ Line 1, characters 13-19:
 1 | type t = C : int64#c -> t;;
                  ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int64# c
@@ -128,7 +152,10 @@ Line 1, characters 9-15:
 1 | type t = int64# c;;
              ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int64# c) = ();;
@@ -137,7 +164,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int64# c) = ();;
                ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of int64# c;;
@@ -146,7 +176,10 @@ Line 1, characters 14-20:
 1 | type t = C of int64# c;;
                   ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : int64# c -> t;;
@@ -155,7 +188,10 @@ Line 1, characters 13-19:
 1 | type t = C : int64# c -> t;;
                  ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       int64# has layout bits64, which is not a sublayout of value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int64 #c

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/a.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/a.ml
@@ -1,0 +1,5 @@
+type 'a t = 'a
+type ('a ,'b) t2 = 'a
+type ('a ,'b,'c,'d,'e) t5 = 'a
+let f x = x + 1
+let f2 x = x

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/annots.ml
@@ -1,0 +1,111 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * expect
+*)
+
+(*********************)
+(* Annotation errors *)
+
+type ('a : value) value = unit
+
+(* Type_declaration *)
+type t_void : void
+and t = t_void value
+
+[%%expect{|
+type 'a value = unit
+Line 5, characters 8-14:
+5 | and t = t_void value
+            ^^^^^^
+Error: This type t_void = ('a : void) should be an instance of type
+         ('b : value)
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must overlap with value, because
+         of the definition of value at line 1, characters 0-30.
+|}]
+
+(* Type_parameter *)
+type ('a : void) t = 'a value
+
+[%%expect{|
+Line 1, characters 21-23:
+1 | type ('a : void) t = 'a value
+                         ^^
+Error: This type ('a : value) should be an instance of type ('a0 : void)
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value, because
+         of the definition of value at line 1, characters 0-30.
+|}]
+
+(* Newtype_declaration *)
+let f (type a : void) (x: a value) = x
+
+[%%expect{|
+Line 1, characters 26-27:
+1 | let f (type a : void) (x: a value) = x
+                              ^
+Error: This type a should be an instance of type ('a : value)
+       The layout of a is void, because
+         of the annotation on the abstract type declaration for a.
+       But the layout of a must be a sublayout of value, because
+         of the definition of value at line 1, characters 0-30.
+|}]
+
+(* Constructor_type_parameter *)
+type _ g = A : ('a: void) . 'a value -> unit g
+
+[%%expect{|
+Line 1, characters 28-30:
+1 | type _ g = A : ('a: void) . 'a value -> unit g
+                                ^^
+Error: This type ('a : void) should be an instance of type ('b : value)
+       The layout of 'a is void, because
+         of the annotation on a in the declaration of constructor A.
+       But the layout of 'a must overlap with value, because
+         of the definition of value at line 1, characters 0-30.
+|}]
+
+(* Univar *)
+let f : ('a : void). 'a -> 'a value = assert false
+
+[%%expect{|
+Line 1, characters 27-29:
+1 | let f : ('a : void). 'a -> 'a value = assert false
+                               ^^
+Error: This type ('a : void) should be an instance of type ('b : value)
+       The layout of 'a is void, because
+         of the annotation on the universal variable 'a.
+       But the layout of 'a must overlap with value, because
+         of the definition of value at line 1, characters 0-30.
+|}]
+
+(* Type_variable *)
+type t = 'a -> int as ('b : void)
+
+[%%expect{|
+Line 1, characters 9-33:
+1 | type t = 'a -> int as ('b : void)
+             ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This alias is bound to type 'a -> int
+       but is used as an instance of type ('b : void)
+       The layout of 'a -> int is value, because
+         it's a function type.
+       But the layout of 'a -> int must be a sublayout of void, because
+         of the annotation on the type variable 'b.
+|}]
+
+(* Type_wildcard *)
+type t = 'a -> int as (_ : void)
+
+[%%expect{|
+Line 1, characters 27-31:
+1 | type t = 'a -> int as (_ : void)
+                               ^^^^
+Error: Bad layout annotation:
+         The layout of 'a -> int is value, because
+           it's a function type.
+         But the layout of 'a -> int must be a sublayout of void, because
+           of the annotation on the wildcard _ at line 1, characters 27-31.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/any.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/any.ml
@@ -1,0 +1,25 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * expect
+*)
+
+(*********************)
+(* Any layout errors *)
+
+(* Missing_cmi *)
+(* See [any_missing_cmi.ml] *)
+
+(* Wildcard *)
+(* Unable to produce this error *)
+
+(* Unification_var *)
+(* Unable to produce this error *)
+
+(* Initial_typedecl_env *)
+(* Unable to produce this error *)
+
+(* Dummy_layout *)
+(* Unable to produce this error *)
+
+(* Type_expression_call *)
+(* Unable to produce this error *)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi.ml
@@ -1,0 +1,29 @@
+(* TEST
+
+readonly_files = "any_missing_cmi_lib.ml any_missing_cmi_lib2.ml"
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+module = "any_missing_cmi_lib2.ml"
+*** ocamlc.byte
+module = "any_missing_cmi_lib.ml"
+**** script
+script = "rm -f any_missing_cmi_lib2.cmi"
+***** expect
+*)
+
+#directory "ocamlc.byte";;
+#load "any_missing_cmi_lib.cmo";;
+
+let f = Any_missing_cmi_lib.f (assert false)
+[%%expect{|
+Line 1, characters 30-44:
+1 | let f = Any_missing_cmi_lib.f (assert false)
+                                  ^^^^^^^^^^^^^^
+Error: Function arguments and returns must be representable.
+       The layout of Any_missing_cmi_lib2.t is any, because
+         the .cmi file for Any_missing_cmi_lib2.t is missing.
+       But the layout of Any_missing_cmi_lib2.t must be representable, because
+         it's the type of a function argument.
+       No .cmi file found containing Any_missing_cmi_lib2.t.
+       Hint: Adding "any_missing_cmi_lib2" to your dependencies might help.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi_lib.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi_lib.ml
@@ -1,0 +1,1 @@
+let f (a: Any_missing_cmi_lib2.t) = a

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi_lib2.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi_lib2.ml
@@ -1,0 +1,1 @@
+type t = Mk of int

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete.ml
@@ -1,0 +1,179 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * expect
+*)
+
+(**************************)
+(* Concrete layout errors *)
+
+type t_any : any
+type t_void : void
+
+(* Match *)
+let () = match (assert false : t_any) with _ -> ()
+
+[%%expect{|
+type t_any : any
+type t_void : void
+Line 5, characters 15-37:
+5 | let () = match (assert false : t_any) with _ -> ()
+                   ^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type t_any but an expression was expected of type
+         ('a : '_representable_layout_1)
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         a value of this type is matched against a pattern.
+|}]
+
+(* Constructor_declaration *)
+type t = A of t_any
+
+[%%expect{|
+Line 1, characters 9-19:
+1 | type t = A of t_any
+             ^^^^^^^^^^
+Error: Constructor argument types must have a representable layout.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
+|}]
+
+(* Label_declaration *)
+type t = {a: t_any}
+
+[%%expect{|
+Line 1, characters 10-18:
+1 | type t = {a: t_any}
+              ^^^^^^^^
+Error: Record element types must have a representable layout.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field a.
+|}]
+
+(* Unannotated_type_parameter *)
+type 'a t = 'a
+and t2 = t_any t
+
+[%%expect{|
+Line 2, characters 9-14:
+2 | and t2 = t_any t
+             ^^^^^
+Error: This type t_any should be an instance of type
+         ('a : '_representable_layout_2)
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it instantiates an unannotated type parameter of t.
+|}]
+
+(* Record_projection *)
+(* Can't have a type with layout any in a record *)
+
+(* Record_assignment *)
+(* Can't have a type with layout any in a record *)
+
+(* Let_binding *)
+let x: t_any = assert false
+
+[%%expect{|
+Line 1, characters 4-5:
+1 | let x: t_any = assert false
+        ^
+Error: This pattern matches values of type t_any
+       but a pattern was expected which matches values of type
+         ('a : '_representable_layout_3)
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a variable bound by a `let`.
+|}]
+
+(* Function_argument *)
+let f (x: t_any) = ()
+
+[%%expect{|
+Line 1, characters 6-16:
+1 | let f (x: t_any) = ()
+          ^^^^^^^^^^
+Error: This pattern matches values of type t_any
+       but a pattern was expected which matches values of type
+         ('a : '_representable_layout_4)
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a function argument.
+|}]
+
+(* Function_result *)
+let f (): t_any = assert false
+
+[%%expect{|
+Line 1, characters 18-30:
+1 | let f (): t_any = assert false
+                      ^^^^^^^^^^^^
+Error: This expression has type t_any but an expression was expected of type
+         ('a : '_representable_layout_5)
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a function result.
+|}]
+
+(* Structure_item_expression *)
+(* See [concrete_struct_item_expr.ml] *)
+
+(* V1_safety_check *)
+(* See [concrete_v1_check.ml] *)
+
+(* External_argument *)
+external eq : t_any -> 'a -> bool = "%equal"
+[%%expect{|
+Line 1, characters 14-19:
+1 | external eq : t_any -> 'a -> bool = "%equal"
+                  ^^^^^
+Error: External types must have a representable layout.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of an argument in an external declaration.
+|}]
+(* Shadowed by Function_argument *)
+
+(* External_result *)
+external eq : 'a -> 'a -> t_any = "%equal"
+[%%expect{|
+Line 1, characters 26-31:
+1 | external eq : 'a -> 'a -> t_any = "%equal"
+                              ^^^^^
+Error: External types must have a representable layout.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of the result of an external declaration.
+|}]
+(* Shadowed by Function_result *)
+
+(* Statement *)
+let _ = (assert false : t_any); ()
+
+[%%expect{|
+Line 1, characters 8-30:
+1 | let _ = (assert false : t_any); ()
+            ^^^^^^^^^^^^^^^^^^^^^^
+Warning 10 [non-unit-statement]: this expression should have type unit.
+
+Line 1, characters 9-21:
+1 | let _ = (assert false : t_any); ()
+             ^^^^^^^^^^^^
+Error: This expression has type t_any but an expression was expected of type
+         ('a : '_representable_layout_6)
+       because it is in the left-hand side of a sequence
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_struct_item_expr.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_struct_item_expr.compilers.reference
@@ -1,0 +1,11 @@
+type t_any : any
+Line 1, characters 0-22:
+1 | (assert false : t_any);;
+    ^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type t_any but an expression was expected of type
+         ('a : '_representable_layout_1)
+       The layout of t_any is any, because
+         of the definition of t_any at line 6, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of an expression in a structure.
+

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_struct_item_expr.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_struct_item_expr.ml
@@ -1,0 +1,7 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * toplevel
+*)
+
+type t_any : any;;
+(assert false : t_any);;

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_v1_check.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_v1_check.compilers.reference
@@ -1,0 +1,5 @@
+type t_void : void
+File "_none_", line 1:
+Error: Non-value sort void detected in [translmod] in type t_void:
+       Please report this error to the Jane Street compilers team.
+

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_v1_check.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_v1_check.ml
@@ -1,0 +1,7 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * toplevel
+*)
+
+type t_void : void;;
+(assert false : t_void);;

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/debug_printer.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/debug_printer.compilers.reference
@@ -1,0 +1,4 @@
+type ('a : float64) t = 'a
+val f : 'b ('a : float64). 'b -> 'a t -> unit = <fun>
+f has the wrong type for a printing function.
+

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/debug_printer.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/debug_printer.ml
@@ -1,0 +1,8 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * toplevel
+*)
+type ('a : float64) t = 'a
+let f ppf (x : 'a t) = ();;
+#install_printer f;;
+(* Always shows the "??? has the wrong type for a printing function" message on exception *)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/float64.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/float64.ml
@@ -1,0 +1,21 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * expect
+*)
+
+(*************************)
+(* Float64 layout errors *)
+
+(* Primitive *)
+let f (x: float#): ('a : value) = x
+[%%expect{|
+Line 1, characters 34-35:
+1 | let f (x: float#): ('a : value) = x
+                                      ^
+Error: This expression has type float# but an expression was expected of type
+         ('a : value)
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the type variable 'a.
+|}];;

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
@@ -1,0 +1,9 @@
+File "gadt_existential.ml", line 13, characters 61-62:
+13 | let f = function Dyn (type a) (w, x : a ty * a) -> ignore (f x)
+                                                                  ^
+Error: This expression has type a but an expression was expected of type
+         'a t = ('a : void)
+       The layout of a is value, because
+         it's an unannotated existential type variable.
+       But the layout of a must be a sublayout of void, because
+         of the definition of f at file "gadt_existential.ml", line 10, characters 6-17.

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.ml
@@ -1,0 +1,13 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   ocamlc_byte_exit_status = "2"
+   * setup-ocamlc.byte-build-env
+   ** ocamlc.byte
+   *** check-ocamlc.byte-output
+*)
+
+type ('a: void) t = 'a
+let f x: 'a t = x
+type _ ty = Int : int ty
+type dyn = Dyn : 'a ty * 'a -> dyn
+let f = function Dyn (type a) (w, x : a ty * a) -> ignore (f x)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/immediate.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/immediate.ml
@@ -1,0 +1,70 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * expect
+*)
+
+(***************************)
+(* Immediate layout errors *)
+
+(* Empty_record *)
+type ('a: void) t: void = { a: 'a }
+[%%expect{|
+Line 1, characters 0-35:
+1 | type ('a: void) t: void = { a: 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Records must contain at least one runtime value.
+|}]
+(* Records with all void fields are not yet supported *)
+
+(* Enumeration *)
+type ('a: void) t = 'a
+type v = unit
+let f (x: v): 'a t = x
+[%%expect{|
+type ('a : void) t = 'a
+type v = unit
+Line 3, characters 21-22:
+3 | let f (x: v): 'a t = x
+                         ^
+Error: This expression has type v = unit
+       but an expression was expected of type 'a t = ('a : void)
+       The layout of unit is immediate, because
+         it's an enumeration variant type (all constructors are constant).
+       But the layout of unit must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
+|}]
+
+(* Primitive *)
+type ('a: void) t = 'a
+let f (x: int): 'a t = x
+[%%expect{|
+type ('a : void) t = 'a
+Line 2, characters 23-24:
+2 | let f (x: int): 'a t = x
+                           ^
+Error: This expression has type int but an expression was expected of type
+         'a t = ('a : void)
+       The layout of int is immediate, because
+         it is the primitive immediate type int.
+       But the layout of int must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
+|}];;
+
+(* Immediate_polymorphic_variant *)
+type ('a: void) t = 'a
+let f (x: [`A | `B]): 'a t = x
+[%%expect{|
+type ('a : void) t = 'a
+Line 2, characters 29-30:
+2 | let f (x: [`A | `B]): 'a t = x
+                                 ^
+Error: This expression has type [ `A | `B ]
+       but an expression was expected of type 'a t = ('a : void)
+       The layout of [ `A | `B ] is immediate, because
+         it's an enumeration variant type (all constructors are constant).
+       But the layout of [ `A | `B ] must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
+|}]
+
+(* Gc_ignorable_check *)
+(* Only used within [Result.is_ok] and not thrown as an exception *)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/immediate64.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/immediate64.ml
@@ -1,0 +1,16 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * expect
+*)
+
+(*****************************)
+(* Immediate64 layout errors *)
+
+(* Local_mode_cross_check *)
+(* Only used within [Result.is_ok] and not thrown as an exception *)
+
+(* Gc_ignorable_check *)
+(* Only used within [Result.is_ok] and not thrown as an exception *)
+
+(* Separability_check *)
+(* Only used within [Result.is_ok] and not thrown as an exception *)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/probe.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/probe.ml
@@ -1,0 +1,14 @@
+(* TEST
+   * setup-ocamlopt.opt-build-env
+   ** ocamlopt.opt
+   flags = "-extension layouts_alpha"
+   compiler_reference2 = "${test_source_directory}/probe.reference"
+   ocamlopt_opt_exit_status = "2"
+   compile_only = "true"
+   *** check-ocamlopt.opt-output
+*)
+
+let f (x: float#) = [%probe "a" (
+  let f () = x in
+  ()
+)]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/probe.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/probe.reference
@@ -1,0 +1,11 @@
+File "probe.ml", line 12, characters 6-7:
+12 |   let f () = x in
+           ^
+Warning 26 [unused-var]: unused variable f.
+
+File "probe.ml", lines 11-14, characters 20-2:
+11 | ....................[%probe "a" (
+12 |   let f () = x in
+13 |   ()
+14 | )]
+Error: Variables in probe handlers must have jkind value, but x in this handler does not.

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -1,0 +1,252 @@
+(* TEST
+   readonly_files = "a.ml"
+   flags = "-extension layouts_alpha"
+   * setup-ocamlc.byte-build-env
+   ** ocamlc.byte
+   module = "a.ml"
+   *** expect
+*)
+
+#directory "ocamlc.byte";;
+#load "a.cmo";;
+module B = A
+type t_void : void
+type t_value : value
+
+[%%expect{|
+module B = A
+type t_void : void
+type t_value : value
+|}]
+
+let f (x : t_void): 'a A.t = x
+
+[%%expect{|
+Line 1, characters 29-30:
+1 | let f (x : t_void): 'a A.t = x
+                                 ^
+Error: This expression has type t_void but an expression was expected of type
+         'a A.t = ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of A.t has this layout.
+|}]
+
+type t = t_void A.t
+
+[%%expect{|
+Line 1, characters 9-15:
+1 | type t = t_void A.t
+             ^^^^^^
+Error: This type t_void should be an instance of type ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of A.t has this layout.
+|}]
+
+
+let f (x : t_void): 'a B.t = x
+
+[%%expect{|
+Line 1, characters 29-30:
+1 | let f (x : t_void): 'a B.t = x
+                                 ^
+Error: This expression has type t_void but an expression was expected of type
+         'a B.t = ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of B.t has this layout.
+|}]
+
+type t = t_void B.t
+
+[%%expect{|
+Line 1, characters 9-15:
+1 | type t = t_void B.t
+             ^^^^^^
+Error: This type t_void should be an instance of type ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of B.t has this layout.
+|}]
+
+let f (x : t_void): ('a, 'b) A.t2 = x
+
+[%%expect{|
+Line 1, characters 36-37:
+1 | let f (x : t_void): ('a, 'b) A.t2 = x
+                                        ^
+Error: This expression has type t_void but an expression was expected of type
+         ('a, 'b) A.t2 = ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 1st type argument of A.t2 has this layout.
+|}]
+
+type t = (t_void, t_value) A.t2
+
+[%%expect{|
+Line 1, characters 10-16:
+1 | type t = (t_void, t_value) A.t2
+              ^^^^^^
+Error: This type t_void should be an instance of type ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 1st type argument of A.t2 has this layout.
+|}]
+
+type t = (t_value, t_void, t_void, t_void, t_void) A.t5
+
+[%%expect{|
+Line 1, characters 19-25:
+1 | type t = (t_value, t_void, t_void, t_void, t_void) A.t5
+                       ^^^^^^
+Error: This type t_void should be an instance of type ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 2nd type argument of A.t5 has this layout.
+|}]
+
+type t = (t_value, t_value, t_void, t_void, t_void) A.t5
+
+[%%expect{|
+Line 1, characters 28-34:
+1 | type t = (t_value, t_value, t_void, t_void, t_void) A.t5
+                                ^^^^^^
+Error: This type t_void should be an instance of type ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 3rd type argument of A.t5 has this layout.
+|}]
+
+type t = (t_value, t_value, t_value, t_void, t_void) A.t5
+
+[%%expect{|
+Line 1, characters 37-43:
+1 | type t = (t_value, t_value, t_value, t_void, t_void) A.t5
+                                         ^^^^^^
+Error: This type t_void should be an instance of type ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 4th type argument of A.t5 has this layout.
+|}]
+
+
+type t = (t_value, t_value, t_value, t_value, t_void) A.t5
+
+[%%expect{|
+Line 1, characters 46-52:
+1 | type t = (t_value, t_value, t_value, t_value, t_void) A.t5
+                                                  ^^^^^^
+Error: This type t_void should be an instance of type ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 5th type argument of A.t5 has this layout.
+|}]
+
+let f (x: t_void) = A.f x
+
+[%%expect{|
+Line 1, characters 24-25:
+1 | let f (x: t_void) = A.f x
+                            ^
+Error: This expression has type t_void but an expression was expected of type
+         int
+|}]
+
+let f2 (x: t_void) = A.f2 x
+
+[%%expect{|
+Line 1, characters 26-27:
+1 | let f2 (x: t_void) = A.f2 x
+                              ^
+Error: This expression has type t_void but an expression was expected of type
+         ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         of layout requirements from an imported definition.
+|}]
+
+type ('a : value) t_v = 'a
+type ('a : void) t_vv = 'a
+let f x: 'a t_v = x
+let f2 = f
+let () = ignore (f2 (assert false : 'a t_vv))
+
+[%%expect{|
+type 'a t_v = 'a
+type ('a : void) t_vv = 'a
+val f : 'a t_v -> 'a t_v = <fun>
+val f2 : 'a t_v -> 'a t_v = <fun>
+Line 5, characters 20-44:
+5 | let () = ignore (f2 (assert false : 'a t_vv))
+                        ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type 'a t_vv = ('a : void)
+       but an expression was expected of type 'b t_v = ('b : value)
+       The layout of 'a is value, because
+         of the definition of f2 at line 4, characters 9-10.
+       But the layout of 'a must overlap with void, because
+         of the definition of t_vv at line 2, characters 0-26.
+|}]
+
+type ('a : value) t_v = 'a
+type ('a : void) t_v1 = 'a
+type 'a t_v2 = 'a t_v1
+let f x: 'a t_v = x
+
+let () = ignore (f (assert false : 'a t_v2))
+
+[%%expect{|
+type 'a t_v = 'a
+type ('a : void) t_v1 = 'a
+type ('a : void) t_v2 = 'a t_v1
+val f : 'a t_v -> 'a t_v = <fun>
+Line 6, characters 19-43:
+6 | let () = ignore (f (assert false : 'a t_v2))
+                       ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type 'a t_v2 = ('a : void)
+       but an expression was expected of type 'b t_v = ('b : value)
+       The layout of 'a is value, because
+         of the definition of f at line 4, characters 6-19.
+       But the layout of 'a must overlap with void, because
+         of the definition of t_v2 at line 3, characters 0-22.
+|}]
+
+
+module type S1 = sig
+  type ('a : void) t = 'a
+end
+
+module type S2 = S1
+
+module M : S2 = struct
+  type 'a t = 'a
+end
+
+[%%expect{|
+module type S1 = sig type ('a : void) t = 'a end
+module type S2 = S1
+Lines 7-9, characters 16-3:
+7 | ................struct
+8 |   type 'a t = 'a
+9 | end
+Error: Signature mismatch:
+       Modules do not match: sig type 'a t = 'a end is not included in S2
+       Type declarations do not match:
+         type 'a t = 'a
+       is not included in
+         type ('a : void) t = 'a
+       The type ('a : value) is not equal to the type ('a0 : void)
+       because their layouts are different.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -1,0 +1,444 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * expect
+*)
+
+(***********************)
+(* Value layout errors *)
+
+type t_any   : any
+type t_value : value
+type t_imm   : immediate
+type t_imm64 : immediate64
+type t_float64 : float64
+type t_void  : void
+
+type void_variant = VV of t_void
+[%%expect{|
+type t_any : any
+type t_value : value
+type t_imm : immediate
+type t_imm64 : immediate64
+type t_float64 : float64
+type t_void : void
+type void_variant = VV of t_void
+|}];;
+
+(* Class_let_binding *)
+let f (): t_float64 = assert false
+class foo () =
+  let v = f () in
+  object end;;
+[%%expect{|
+val f : unit -> t_float64 = <fun>
+Line 3, characters 6-7:
+3 |   let v = f () in
+          ^
+Error: The types of variables bound by a 'let' in a class function
+       must have layout value. Instead, v's type has layout float64.
+|}];;
+
+(* Tuple_element *)
+type t = t_any * t_any
+[%%expect{|
+Line 1, characters 9-14:
+1 | type t = t_any * t_any
+             ^^^^^
+Error: Tuple element types must have layout value.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be a sublayout of value, because
+         it's the type of a tuple element.
+|}];;
+
+(* Probe *)
+(* See [probe.ml] *)
+
+(* Package_hack *)
+module type S = sig
+  type t : immediate
+end
+
+module type S2 = sig
+  val m : (module S with type t = string)
+end
+[%%expect{|
+module type S = sig type t : immediate end
+Line 6, characters 10-41:
+6 |   val m : (module S with type t = string)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this `with' constraint, the new definition of t
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : immediate
+       The layout of the first is value, because
+         it's a type declaration in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-20.
+|}];;
+
+(* Object *)
+let f: ('a : void) -> 'b = fun x -> x # baz
+[%%expect{|
+Line 1, characters 36-37:
+1 | let f: ('a : void) -> 'b = fun x -> x # baz
+                                        ^
+Error: Object types must have layout value.
+       The layout of the type of this expression is void, because
+         of the annotation on the type variable 'a.
+       But the layout of the type of this expression must overlap with value, because
+         it's the type of an object.
+|}];;
+
+(* Instance_variable *)
+module type S = sig
+  class foo :
+    object
+      val baz : t_void
+    end
+end;;
+[%%expect{|
+Line 4, characters 6-22:
+4 |       val baz : t_void
+          ^^^^^^^^^^^^^^^^
+Error: Variables bound in a class must have layout value.
+       The layout of baz is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of baz must be a sublayout of value, because
+         it's the type of an instance variable.
+|}];;
+
+(* Object_field *)
+let f x: t_void = x # baz
+[%%expect{|
+Line 1, characters 18-25:
+1 | let f x: t_void = x # baz
+                      ^^^^^^^
+Error: This expression has type ('a : value)
+       but an expression was expected of type t_void
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of an object field.
+|}];;
+
+(* Class_field *)
+class foo () =
+  object
+    val bar: t_void = assert false
+  end
+[%%expect{|
+Line 3, characters 8-11:
+3 |     val bar: t_void = assert false
+            ^^^
+Error: Variables bound in a class must have layout value.
+       The layout of bar is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of bar must be a sublayout of value, because
+         it's the type of a class field.
+|}];;
+
+(* Boxed_record *)
+type r : void = {a:string}
+[%%expect{|
+Line 1, characters 0-26:
+1 | type r : void = {a:string}
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type r is value, because
+         it's a boxed record type.
+       But the layout of type r must be a sublayout of void, because
+         of the annotation on the declaration of the type r.
+|}];;
+
+(* Boxed_variant *)
+type v : void = A of t_value
+[%%expect{|
+Line 1, characters 0-28:
+1 | type v : void = A of t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type v is value, because
+         it's a boxed variant type.
+       But the layout of type v must be a sublayout of void, because
+         of the annotation on the declaration of the type v.
+|}];;
+
+(* Extensible_variant *)
+type attr : void = ..
+[%%expect{|
+Line 1, characters 0-21:
+1 | type attr : void = ..
+    ^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type attr is value, because
+         it's an extensible variant type.
+       But the layout of type attr must be a sublayout of void, because
+         of the annotation on the declaration of the type attr.
+|}]
+
+(* Primitive *)
+let f : unit -> ('a : void) = fun () -> "abc"
+[%%expect{|
+Line 1, characters 40-45:
+1 | let f : unit -> ('a : void) = fun () -> "abc"
+                                            ^^^^^
+Error: This expression has type string but an expression was expected of type
+         ('a : void)
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of void, because
+         of the annotation on the type variable 'a.
+|}];;
+
+(* Type_argument *)
+let f (x: t_void) = [x]
+[%%expect{|
+Line 1, characters 21-22:
+1 | let f (x: t_void) = [x]
+                         ^
+Error: This expression has type t_void but an expression was expected of type
+         ('a : value)
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of list has layout value.
+|}];;
+
+(* Tuple *)
+let f : unit -> ('a : void) = fun () -> (1,2)
+[%%expect{|
+Line 1, characters 40-45:
+1 | let f : unit -> ('a : void) = fun () -> (1,2)
+                                            ^^^^^
+Error: This expression has type 'b * 'c
+       but an expression was expected of type ('a : void)
+       The layout of 'a * 'b is value, because
+         it's a tuple type.
+       But the layout of 'a * 'b must be a sublayout of void, because
+         of the annotation on the type variable 'a.
+|}];;
+
+(* Row_variable *)
+(* Unable to produce this error *)
+
+(* Polymorphic_variant *)
+type ('a: void) t = 'a
+let f (x: [`A of int | `B]): 'a t = x
+[%%expect{|
+type ('a : void) t = 'a
+Line 2, characters 36-37:
+2 | let f (x: [`A of int | `B]): 'a t = x
+                                        ^
+Error: This expression has type [ `A of int | `B ]
+       but an expression was expected of type 'a t = ('a : void)
+       The layout of [ `A of int | `B ] is value, because
+         it's a polymorphic variant type.
+       But the layout of [ `A of int | `B ] must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
+|}]
+
+(* Arrow *)
+type ('a: void) t = 'a
+let f (x : int -> int): 'a t = x
+[%%expect{|
+type ('a : void) t = 'a
+Line 2, characters 31-32:
+2 | let f (x : int -> int): 'a t = x
+                                   ^
+Error: This expression has type int -> int
+       but an expression was expected of type 'a t = ('a : void)
+       The layout of int -> int is value, because
+         it's a function type.
+       But the layout of int -> int must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
+|}]
+
+(* Tfield *)
+(* Unable to produce this error *)
+
+(* Tnil *)
+(* Unable to produce this error *)
+
+(* First_class_module *)
+type ('a: void) t = 'a
+module type X_int = sig val x : int end;;
+module Three : X_int = struct let x = 3 end;;
+let f (): 'a t = (module Three : X_int)
+[%%expect{|
+type ('a : void) t = 'a
+module type X_int = sig val x : int end
+module Three : X_int
+Line 4, characters 17-39:
+4 | let f (): 'a t = (module Three : X_int)
+                     ^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type (module X_int)
+       but an expression was expected of type 'a t = ('a : void)
+       The layout of (module X_int) is value, because
+         it's a first-class module type.
+       But the layout of (module X_int) must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
+|}]
+
+(* Separability_check *)
+(* Only used within [Result.is_error] and not thrown as an exception *)
+
+(* Univar *)
+let f: 'a. 'a -> ('b : void) = fun x -> x
+[%%expect{|
+Line 1, characters 40-41:
+1 | let f: 'a. 'a -> ('b : void) = fun x -> x
+                                            ^
+Error: This expression has type ('a : value)
+       but an expression was expected of type ('b : void)
+       The layout of 'b is void, because
+         of the annotation on the type variable 'b.
+       But the layout of 'b must overlap with value, because
+         it is or unifies with an unannotated universal variable.
+|}];;
+
+(* Polymorphic_variant_field *)
+let f (x : t_float64) = `A x;;
+[%%expect{|
+Line 1, characters 27-28:
+1 | let f (x : t_float64) = `A x;;
+                               ^
+Error: This expression has type t_float64
+       but an expression was expected of type ('a : value)
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
+|}];;
+
+(* Default_type_jkind *)
+type ('a : immediate) t2 = {a: 'a} and t3 = t t2 and t
+[%%expect{|
+Line 1, characters 49-54:
+1 | type ('a : immediate) t2 = {a: 'a} and t3 = t t2 and t
+                                                     ^^^^^
+Error:
+       The layout of t is value, because
+         an abstract type has the value layout by default.
+       But the layout of t must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t2.
+|}];;
+
+(* Float_record_field *)
+(* The type is restricted to float which always has layout value.
+   Can't generate an error *)
+
+(* Existential_type_variable *)
+(* See [gadt_existential.ml] *)
+
+(* Array_element *)
+let f (x : t_float64) = [| x |]
+[%%expect{|
+Line 1, characters 27-28:
+1 | let f (x : t_float64) = [| x |]
+                               ^
+Error: This expression has type t_float64
+       but an expression was expected of type ('a : value)
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an array element.
+|}];;
+
+(* Lazy_expression *)
+let f (x : t_float64) = lazy x
+[%%expect{|
+Line 1, characters 29-30:
+1 | let f (x : t_float64) = lazy x
+                                 ^
+Error: This expression has type t_float64
+       but an expression was expected of type ('a : value)
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a lazy expression.
+|}];;
+
+(* Class_type_argument *)
+module M = struct
+  type ('a : void) t
+
+  class virtual ['a] foo =
+    object
+      val virtual baz : 'a t
+    end
+end
+[%%expect{|
+Line 6, characters 24-26:
+6 |       val virtual baz : 'a t
+                            ^^
+Error: This type ('a : void) should be an instance of type ('a0 : value)
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void, because
+         of the definition of t at line 2, characters 2-20.
+|}];;
+
+(* Class_term_argument *)
+class foo (x : t_float64) =
+  object end;;
+[%%expect{|
+Line 1, characters 10-25:
+1 | class foo (x : t_float64) =
+              ^^^^^^^^^^^^^^^
+Error: This pattern matches values of type t_float64
+       but a pattern was expected which matches values of type ('a : value)
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a term-level argument to a class constructor.
+|}];;
+
+(* Structure_element *)
+module type S = sig val x : t_void end
+[%%expect{|
+Line 1, characters 28-34:
+1 | module type S = sig val x : t_void end
+                                ^^^^^^
+Error: This type signature for x is not a value type.
+       The layout of type t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of type t_void must be a sublayout of value, because
+         it's the type of something stored in a module structure.
+|}];;
+
+(* Debug_printer_argument *)
+(* See [debug_printer.ml] *)
+
+(* V1_safety_check *)
+type t = {a: t_void; b: int}
+let f (x: t) = match x with | {a; b} -> a
+[%%expect {|
+type t = { a : t_void; b : int; }
+Line 2, characters 6-41:
+2 | let f (x: t) = match x with | {a; b} -> a
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
+|}]
+
+(* Captured_in_object *)
+let f (m1 : t_float64) = object
+  val f = fun () -> m1
+end;;
+[%%expect{|
+Line 2, characters 20-22:
+2 |   val f = fun () -> m1
+                        ^^
+Error: m1 must have a type of layout value because it is captured by an object.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
+|}];;
+
+(* Unknown *)
+(* Unable to produce this error *)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -414,15 +414,11 @@ type t = {a: t_void; b: int}
 let f (x: t) = match x with | {a; b} -> a
 [%%expect {|
 type t = { a : t_void; b : int; }
-Line 2, characters 6-41:
+Line 2, characters 15-41:
 2 | let f (x: t) = match x with | {a; b} -> a
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Non-value layout void detected in [Typeopt.layout] as sort for type
+       t_void. Please report this error to the Jane Street compilers team.
 |}]
 
 (* Captured_in_object *)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/void.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/void.ml
@@ -1,0 +1,8 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+   * expect
+*)
+
+(**********************)
+(* Void layout errors *)
+

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -59,8 +59,8 @@ let x3_1 : t_float64 = assert false;;
 Line 1, characters 4-8:
 1 | let x3_1 : t_float64 = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_1 has layout
-       float64.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_1 has layout float64.
 |}];;
 
 let x3_2 : 'a t_float64_id = assert false;;
@@ -68,8 +68,8 @@ let x3_2 : 'a t_float64_id = assert false;;
 Line 1, characters 4-8:
 1 | let x3_2 : 'a t_float64_id = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_2 has layout
-       float64.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_2 has layout float64.
 |}];;
 
 let x3_3 : float# = assert false;;
@@ -77,8 +77,8 @@ let x3_3 : float# = assert false;;
 Line 1, characters 4-8:
 1 | let x3_3 : float# = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_3 has layout
-       float64.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_3 has layout float64.
 |}];;
 
 module M3_4 = struct
@@ -88,8 +88,8 @@ end
 Line 2, characters 6-7:
 2 |   let x : t_float64 = assert false
           ^
-Error: Top-level module bindings must have layout value, but x has layout
-       float64.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x has layout float64.
 |}];;
 
 module M3_5 = struct
@@ -101,8 +101,8 @@ end
 Line 4, characters 6-7:
 4 |   let y = f (assert false)
           ^
-Error: Top-level module bindings must have layout value, but y has layout
-       float64.
+Error: Types of top-level module bindings must have layout value, but
+       the type of y has layout float64.
 |}];;
 
 (*************************************)
@@ -115,7 +115,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_float64_id) = x, false;;
@@ -125,7 +128,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       'a t_float64_id has layout float64, which does not overlap with value.
+       The layout of 'a t_float64_id is float64, because
+         of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of 'a t_float64_id must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : float#) = x, false;;
@@ -135,7 +141,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_float64 * string;;
@@ -144,7 +153,10 @@ Line 1, characters 12-21:
 1 | type t4_4 = t_float64 * string;;
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * float#;;
@@ -153,7 +165,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * float#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-        float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : float64) t4_6 = 'a * 'a
@@ -162,7 +177,10 @@ Line 1, characters 27-29:
 1 | type ('a : float64) t4_6 = 'a * 'a
                                ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -172,7 +190,10 @@ Line 1, characters 32-34:
 1 | type ('a : float64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float64)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (******************************************************************************)
@@ -266,7 +287,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         'a has layout float64, which does not overlap with value.
+         The layout of 'a is float64, because
+           of the definition of t_float64_id at line 2, characters 0-37.
+         But the layout of 'a must overlap with value, because
+           it instantiates an unannotated type parameter of t5_11, defaulted to layout value.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;
@@ -299,7 +323,10 @@ Line 1, characters 31-40:
 1 | module type S6_1 = sig val x : t_float64 end
                                    ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout float64, which is not a sublayout of value.
+       The layout of type t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_float64_id end
@@ -308,7 +335,10 @@ Line 1, characters 31-46:
 1 | module type S6_2 = sig val x : 'a t_float64_id end
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout float64, which does not overlap with value.
+       The layout of type 'a t_float64_id is float64, because
+         of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of type 'a t_float64_id must overlap with value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : float# end
@@ -317,7 +347,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : float# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout float64, which is not a sublayout of value.
+       The layout of type float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of type float# must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -330,7 +363,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_float64_id) = `A x;;
@@ -340,7 +376,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       'a t_float64_id has layout float64, which does not overlap with value.
+       The layout of 'a t_float64_id is float64, because
+         of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of 'a t_float64_id must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : float#) = `A x;;
@@ -350,7 +389,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_float64 ];;
@@ -359,7 +401,10 @@ Line 1, characters 20-29:
 1 | type f7_4 = [ `A of t_float64 ];;
                         ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : float64) f7_5 = [ `A of 'a ];;
@@ -368,9 +413,11 @@ Line 1, characters 35-37:
 1 | type ('a : float64) f7_5 = [ `A of 'a ];;
                                        ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
-(* CR layouts v2.9: This error could be improved *)
 
 (************************************************************)
 (* Test 8: Normal polymorphic functions don't work on them. *)
@@ -394,7 +441,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -404,7 +454,10 @@ Line 1, characters 20-42:
                         ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       'a t_float64_id has layout float64, which does not overlap with value.
+       The layout of 'a t_float64_id is float64, because
+         of the definition of make_t_float64_id at line 2, characters 22-57.
+       But the layout of 'a t_float64_id must overlap with value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -414,7 +467,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -567,7 +623,10 @@ Line 1, characters 15-28:
 1 | type t12_1 = < x : t_float64 >;;
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : float64) t12_2 = < x : 'a >;;
@@ -576,7 +635,10 @@ Line 1, characters 34-36:
 1 | type ('a : float64) t12_2 = < x : 'a >;;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_float64 = assert false end;;
@@ -586,7 +648,10 @@ Line 1, characters 21-56:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_float64 but is expected to have type
          ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -597,9 +662,11 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_float64_id -> 'a t_float64_id = assert false
                  ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with float64.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t_float64_id at line 2, characters 0-37.
 |}];;
-(* CR layouts v2.9: Error could be improved *)
 
 class c12_5 = object val x : t_float64 = assert false end;;
 [%%expect{|
@@ -607,7 +674,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_float64 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       x has layout float64, which is not a sublayout of value.
+       The layout of x is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : float# end;;
@@ -616,9 +686,11 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : float# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type float# but is expected to have type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
-(* CR layouts v2.9: Error could be improved *)
 
 class type c12_7 = object val x : float# end
 [%%expect{|
@@ -626,7 +698,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : float# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       x has layout float64, which is not a sublayout of value.
+       The layout of x is float64, because
+         it is the primitive float64 type float#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -637,7 +712,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_float64_id -> 'a t_float64_id
               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with float64.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t_float64_id at line 2, characters 0-37.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -673,7 +751,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_float64) (m2 : t_float64) = object
@@ -687,7 +768,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -703,7 +787,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_float64) = compare x x;;
@@ -713,7 +800,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_float64) = Marshal.to_bytes x;;
@@ -723,7 +813,10 @@ Line 1, characters 45-46:
                                                  ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_float64) = Hashtbl.hash x;;
@@ -733,7 +826,10 @@ Line 1, characters 41-42:
                                              ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 (***********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -45,7 +45,10 @@ Line 1, characters 9-15:
 1 | type t = float# list;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let f (_ : float# list) = ();;
@@ -54,7 +57,10 @@ Line 1, characters 11-17:
 1 | let f (_ : float# list) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C of float# list;;
@@ -63,7 +69,10 @@ Line 1, characters 14-20:
 1 | type t = C of float# list;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C : float# list -> t;;
@@ -72,7 +81,10 @@ Line 1, characters 13-19:
 1 | type t = C : float# list -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* Syntax: float#c
@@ -91,7 +103,10 @@ Line 1, characters 9-15:
 1 | type t = float#c;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : float#c) = ();;
@@ -100,7 +115,10 @@ Line 1, characters 11-17:
 1 | let f (_ : float#c) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of float#c;;
@@ -109,7 +127,10 @@ Line 1, characters 14-20:
 1 | type t = C of float#c;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : float#c -> t;;
@@ -118,7 +139,10 @@ Line 1, characters 13-19:
 1 | type t = C : float#c -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: float# c
@@ -130,7 +154,10 @@ Line 1, characters 9-15:
 1 | type t = float# c;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : float# c) = ();;
@@ -139,7 +166,10 @@ Line 1, characters 11-17:
 1 | let f (_ : float# c) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of float# c;;
@@ -148,7 +178,10 @@ Line 1, characters 14-20:
 1 | type t = C of float# c;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : float# c -> t;;
@@ -157,7 +190,10 @@ Line 1, characters 13-19:
 1 | type t = C : float# c -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: float #c

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
@@ -3,4 +3,7 @@ File "insert.ml", line 5, characters 47-48:
                                                    ^
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at file "insert.ml", line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         of layout requirements from an imported definition.

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
@@ -3,4 +3,7 @@ File "insert_extensible.ml", line 5, characters 58-59:
                                                               ^
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at file "insert_extensible.ml", line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         of layout requirements from an imported definition.

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -45,8 +45,10 @@ Line 1, characters 12-19:
                 ^^^^^^^
 Error: This type B.b_value = A.a_value should be an instance of type
          ('a : immediate)
-       B.b_value has an unknown layout,
-         which might not be a sublayout of immediate.
+       The layout of B.b_value is value, because
+         the .cmi file for A.a_value is missing.
+       But the layout of B.b_value must be a sublayout of immediate, because
+         of the definition of imm_arg at line 3, characters 0-29.
        No .cmi file found containing A.a_value.
        Hint: Adding "a" to your dependencies might help.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
@@ -24,7 +24,10 @@ Line 1, characters 40-54:
 1 | let f0 (g : Function_b.fun_t) = g ~arg1:(assert false)
                                             ^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         it's the type of a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -36,7 +39,10 @@ Line 1, characters 34-36:
 1 | let f1 (g : Function_b.fun_t) = g ()
                                       ^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         it's the type of a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -48,7 +54,10 @@ Line 1, characters 28-56:
 1 | let f2 : Function_b.fun_t = fun ~arg1:_ ~arg2 () -> arg2
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         it's the type of a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -60,7 +69,10 @@ Line 1, characters 31-53:
 1 | let f3 : Function_b.return_t = fun () -> assert false
                                    ^^^^^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         it's the type of a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -74,7 +86,10 @@ Line 2, characters 12-28:
 2 | let x1 = f4 Function_b.f_opt
                 ^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         it's the type of a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -88,7 +103,10 @@ Line 2, characters 12-30:
 2 | let x2 = f5 Function_b.f_opt_2
                 ^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       Function_a.t has an unknown layout, which might not be representable.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         it's the type of a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-word/basics_alpha_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics_alpha_beta.ml
@@ -57,8 +57,8 @@ let x3_1 : t_word = assert false;;
 Line 1, characters 4-8:
 1 | let x3_1 : t_word = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_1 has layout
-       word.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_1 has layout word.
 |}];;
 
 let x3_2 : 'a t_word_id = assert false;;
@@ -66,8 +66,8 @@ let x3_2 : 'a t_word_id = assert false;;
 Line 1, characters 4-8:
 1 | let x3_2 : 'a t_word_id = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_2 has layout
-       word.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_2 has layout word.
 |}];;
 
 let x3_3 : nativeint# = assert false;;
@@ -75,8 +75,8 @@ let x3_3 : nativeint# = assert false;;
 Line 1, characters 4-8:
 1 | let x3_3 : nativeint# = assert false;;
         ^^^^
-Error: Top-level module bindings must have layout value, but x3_3 has layout
-       word.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x3_3 has layout word.
 |}];;
 
 module M3_4 = struct
@@ -86,8 +86,8 @@ end
 Line 2, characters 6-7:
 2 |   let x : t_word = assert false
           ^
-Error: Top-level module bindings must have layout value, but x has layout
-       word.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x has layout word.
 |}];;
 
 module M3_5 = struct
@@ -99,8 +99,8 @@ end
 Line 4, characters 6-7:
 4 |   let y = f (assert false)
           ^
-Error: Top-level module bindings must have layout value, but y has layout
-       word.
+Error: Types of top-level module bindings must have layout value, but
+       the type of y has layout word.
 |}];;
 
 (*************************************)
@@ -113,7 +113,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_word_id) = x, false;;
@@ -123,7 +126,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value)
-       'a t_word_id has layout word, which does not overlap with value.
+       The layout of 'a t_word_id is word, because
+         of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : nativeint#) = x, false;;
@@ -133,7 +139,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_word * string;;
@@ -142,7 +151,10 @@ Line 1, characters 12-18:
 1 | type t4_4 = t_word * string;;
                 ^^^^^^
 Error: Tuple element types must have layout value.
-        t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * nativeint#;;
@@ -151,7 +163,10 @@ Line 1, characters 18-28:
 1 | type t4_5 = int * nativeint#;;
                       ^^^^^^^^^^
 Error: Tuple element types must have layout value.
-        nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : word) t4_6 = 'a * 'a
@@ -160,7 +175,10 @@ Line 1, characters 24-26:
 1 | type ('a : word) t4_6 = 'a * 'a
                             ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       'a has layout word, which does not overlap with value.
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -170,7 +188,10 @@ Line 1, characters 29-31:
 1 | type ('a : word, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                  ^^
 Error: This type ('b : value) should be an instance of type ('a : word)
-       'a has layout word, which does not overlap with value.
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -264,7 +285,10 @@ Line 1, characters 31-37:
 1 | module type S6_1 = sig val x : t_word end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout word, which is not a sublayout of value.
+       The layout of type t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of type t_word must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_word_id end
@@ -273,7 +297,10 @@ Line 1, characters 31-43:
 1 | module type S6_2 = sig val x : 'a t_word_id end
                                    ^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout word, which does not overlap with value.
+       The layout of type 'a t_word_id is word, because
+         of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of type 'a t_word_id must overlap with value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : nativeint# end
@@ -282,7 +309,10 @@ Line 1, characters 31-41:
 1 | module type S6_3 = sig val x : nativeint# end
                                    ^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout word, which is not a sublayout of value.
+       The layout of type nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of type nativeint# must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -295,7 +325,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_word_id) = `A x;;
@@ -305,7 +338,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value)
-       'a t_word_id has layout word, which does not overlap with value.
+       The layout of 'a t_word_id is word, because
+         of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : nativeint#) = `A x;;
@@ -315,7 +351,10 @@ Line 1, characters 31-32:
                                    ^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_word ];;
@@ -324,7 +363,10 @@ Line 1, characters 20-26:
 1 | type f7_4 = [ `A of t_word ];;
                         ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-        t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : word) f7_5 = [ `A of 'a ];;
@@ -333,9 +375,11 @@ Line 1, characters 32-34:
 1 | type ('a : word) f7_5 = [ `A of 'a ];;
                                     ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       'a has layout word, which does not overlap with value.
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
-(* CR layouts v2.9: This error could be improved *)
 
 (************************************************************)
 (* Test 8: Normal polymorphic functions don't work on them. *)
@@ -359,7 +403,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_word_id ());;
@@ -369,7 +416,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value)
-       'a t_word_id has layout word, which does not overlap with value.
+       The layout of 'a t_word_id is word, because
+         of the definition of make_t_word_id at line 2, characters 19-51.
+       But the layout of 'a t_word_id must overlap with value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_nativeintu ());;
@@ -379,7 +429,10 @@ Line 1, characters 20-40:
                         ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -504,7 +557,10 @@ Line 1, characters 15-25:
 1 | type t12_1 = < x : t_word >;;
                    ^^^^^^^^^^
 Error: Object field types must have layout value.
-        t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : word) t12_2 = < x : 'a >;;
@@ -513,7 +569,10 @@ Line 1, characters 31-33:
 1 | type ('a : word) t12_2 = < x : 'a >;;
                                    ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       'a has layout word, which does not overlap with value.
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_word = assert false end;;
@@ -522,7 +581,10 @@ Line 1, characters 21-53:
 1 | class c12_3 = object method x : t_word = assert false end;;
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_word but is expected to have type ('a : value)
-       t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -533,9 +595,11 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_word_id -> 'a t_word_id = assert false
                  ^^
 Error: This type ('a : word) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with word.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with word, because
+         of the definition of t_word_id at line 2, characters 0-31.
 |}];;
-(* CR layouts v2.9: Error could be improved *)
 
 class c12_5 = object val x : t_word = assert false end;;
 [%%expect{|
@@ -543,7 +607,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_word = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       x has layout word, which is not a sublayout of value.
+       The layout of x is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : nativeint# end;;
@@ -553,9 +620,11 @@ Line 1, characters 26-47:
                               ^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type nativeint# but is expected to have type
          ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
-(* CR layouts v2.9: Error could be improved *)
 
 class type c12_7 = object val x : nativeint# end
 [%%expect{|
@@ -563,7 +632,10 @@ Line 1, characters 26-44:
 1 | class type c12_7 = object val x : nativeint# end
                               ^^^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       x has layout word, which is not a sublayout of value.
+       The layout of x is word, because
+         it is the primitive word type nativeint#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -574,7 +646,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_word_id -> 'a t_word_id
               ^^
 Error: This type ('a : word) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with word.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with word, because
+         of the definition of t_word_id at line 2, characters 0-31.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -610,7 +685,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_word
-       t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_word) (m2 : t_word) = object
@@ -624,7 +702,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -640,7 +721,10 @@ Line 1, characters 25-26:
                              ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_word) = compare x x;;
@@ -650,7 +734,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_word) = Marshal.to_bytes x;;
@@ -660,7 +747,10 @@ Line 1, characters 42-43:
                                               ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_word) = Hashtbl.hash x;;
@@ -670,5 +760,8 @@ Line 1, characters 38-39:
                                           ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       t_word has layout word, which is not a sublayout of value.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-word/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/parsing.ml
@@ -43,7 +43,10 @@ Line 1, characters 9-19:
 1 | type t = nativeint# list;;
              ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let f (_ : nativeint# list) = ();;
@@ -52,7 +55,10 @@ Line 1, characters 11-21:
 1 | let f (_ : nativeint# list) = ();;
                ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C of nativeint# list;;
@@ -61,7 +67,10 @@ Line 1, characters 14-24:
 1 | type t = C of nativeint# list;;
                   ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C : nativeint# list -> t;;
@@ -70,7 +79,10 @@ Line 1, characters 13-23:
 1 | type t = C : nativeint# list -> t;;
                  ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* Syntax: nativeint#c
@@ -89,7 +101,10 @@ Line 1, characters 9-19:
 1 | type t = nativeint#c;;
              ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : nativeint#c) = ();;
@@ -98,7 +113,10 @@ Line 1, characters 11-21:
 1 | let f (_ : nativeint#c) = ();;
                ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of nativeint#c;;
@@ -107,7 +125,10 @@ Line 1, characters 14-24:
 1 | type t = C of nativeint#c;;
                   ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : nativeint#c -> t;;
@@ -116,7 +137,10 @@ Line 1, characters 13-23:
 1 | type t = C : nativeint#c -> t;;
                  ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: nativeint# c
@@ -128,7 +152,10 @@ Line 1, characters 9-19:
 1 | type t = nativeint# c;;
              ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : nativeint# c) = ();;
@@ -137,7 +164,10 @@ Line 1, characters 11-21:
 1 | let f (_ : nativeint# c) = ();;
                ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of nativeint# c;;
@@ -146,7 +176,10 @@ Line 1, characters 14-24:
 1 | type t = C of nativeint# c;;
                   ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : nativeint# c -> t;;
@@ -155,7 +188,10 @@ Line 1, characters 13-23:
 1 | type t = C : nativeint# c -> t;;
                  ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       nativeint# has layout word, which is not a sublayout of value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: nativeint #c

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -49,7 +49,10 @@ Line 1, characters 8-29:
             ^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int but is used as an instance of type
          ('a : float64)
-       int has layout immediate, which is not a sublayout of float64.
+       The layout of int is immediate, because
+         it is the primitive immediate type int.
+       But the layout of int must be a sublayout of float64, because
+         of the annotation on the type variable 'a.
 |}]
 
 let x : (int as ('a : immediate)) list as ('b : value) = [3;4;5]
@@ -66,7 +69,10 @@ Line 1, characters 8-36:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : immediate)
-       int list has layout value, which is not a sublayout of immediate.
+       The layout of int list is value, because
+         it's a boxed variant type.
+       But the layout of int list must be a sublayout of immediate, because
+         of the annotation on the type variable 'a.
 |}]
 (* CR layouts: error message could be phrased better *)
 
@@ -151,7 +157,10 @@ Line 1, characters 9-15:
 1 | type t = string t2_imm
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 let f : 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -184,8 +193,9 @@ let f : ('a : value). 'a t2_imm -> 'a t2_imm = fun x -> x
 Line 1, characters 8-44:
 1 | let f : ('a : value). 'a t2_imm -> 'a t2_imm = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was declared to have
-       layout value, but was inferred to have layout immediate.
+Error: The universal type variable 'a was declared to have layout value.
+       But it was inferred to have layout immediate, because
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 type 'a t = 'a t2_imm
@@ -247,7 +257,10 @@ Line 1, characters 31-41:
                                    ^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          ('a : any). 'a -> 'a
-       'a has layout any, which is not representable.
+       The layout of 'a is any, because
+         of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable, because
+         it's the type of a function argument.
 |}]
 (* CR layouts v2.9: This error message is not great. Check later if layout history
    is able to improve it. *)
@@ -284,7 +297,10 @@ Line 1, characters 24-31:
                             ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of r at line 1, characters 0-47.
 |}]
 
 let r = { field = fun x -> x }
@@ -317,7 +333,10 @@ Line 2, characters 18-55:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because
+         of the definition of r_value at line 1, characters 0-39.
+       But the layout of 'a must be a sublayout of immediate, because
+         of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
 
@@ -336,7 +355,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         'a has layout value, which is not a sublayout of immediate.
+         The layout of 'a is value, because
+           of the annotation on the universal variable 'a.
+         But the layout of 'a must be a sublayout of immediate, because
+           of the definition of t_imm at line 1, characters 0-27.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -375,7 +397,10 @@ Line 1, characters 29-36:
 Error: This pattern matches values of type a
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_1)
-       a has layout any, which is not representable.
+       The layout of a is any, because
+         of the annotation on the abstract type declaration for a.
+       But the layout of a must be representable, because
+         it's the type of a function argument.
 |}]
 
 (****************************************)
@@ -406,7 +431,10 @@ Line 1, characters 33-43:
 1 | let f : type (a : any). a -> a = fun x -> x
                                      ^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       a has layout any, which is not representable.
+       The layout of a is any, because
+         of the annotation on the abstract type declaration for a.
+       But the layout of a must be representable, because
+         it's the type of a function argument.
 |}]
 
 (**************************************************)
@@ -420,8 +448,9 @@ end
 Line 2, characters 10-36:
 2 |   val f : 'a. 'a t2_imm -> 'a t2_imm
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was defaulted to have
-       layout value, but was inferred to have layout immediate.
+Error: The universal type variable 'a was defaulted to have layout value.
+       But it was inferred to have layout immediate, because
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -430,8 +459,9 @@ let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
 Line 1, characters 8-34:
 1 | let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was defaulted to have
-       layout value, but was inferred to have layout immediate.
+Error: The universal type variable 'a was defaulted to have layout value.
+       But it was inferred to have layout immediate, because
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 (********************************************)
@@ -453,8 +483,9 @@ end
 Line 2, characters 10-46:
 2 |   val f : ('a : value). 'a t2_imm -> 'a t2_imm
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was declared to have
-       layout value, but was inferred to have layout immediate.
+Error: The universal type variable 'a was declared to have layout value.
+       But it was inferred to have layout immediate, because
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 module type S = sig
@@ -501,7 +532,10 @@ Line 1, characters 43-51:
                                                ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on the universal variable 'a.
 |}]
 
 (**************************************)
@@ -603,7 +637,10 @@ Line 1, characters 37-53:
                                          ^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because
+         of the annotation on the universal variable 'a.
+       But the layout of 'a must be a sublayout of immediate, because
+         of the definition of f_imm at line 1, characters 4-9.
 |}]
 
 type (_ : value) g =

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -71,7 +71,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_1) is not compatible with type t
-       t has layout any, which is not representable.
+       The layout of t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable, because
+         it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -241,7 +244,10 @@ Line 4, characters 53-54:
                                                          ^
 Error: This expression has type ('a : value)
        but an expression was expected of type float#
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the definition of s at line 2, characters 2-55.
 |}]
 
 module type S1 = sig
@@ -272,7 +278,10 @@ Line 4, characters 48-49:
                                                     ^
 Error: This expression has type ('a : value)
        but an expression was expected of type float#
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the definition of s at line 2, characters 2-50.
 |}]
 
 module M1 = struct
@@ -287,7 +296,10 @@ Line 4, characters 55-56:
                                                            ^
 Error: This expression has type ('a : value)
        but an expression was expected of type float#
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the definition of s at line 2, characters 2-70.
 |}]
 
 module M1 = struct
@@ -302,7 +314,10 @@ Line 4, characters 50-51:
                                                       ^
 Error: This expression has type ('a : value)
        but an expression was expected of type float#
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the definition of s at line 2, characters 2-65.
 |}]
 
 module type S1 = sig
@@ -316,7 +331,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_2) is not compatible with type t
-       t has layout any, which is not representable.
+       The layout of t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable, because
+         it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -330,7 +348,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_3) is not compatible with type t
-       t has layout any, which is not representable.
+       The layout of t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable, because
+         it instantiates an unannotated type parameter of s.
 |}]
 
 let f1 () : t_any = assert false;;
@@ -340,7 +361,10 @@ Line 1, characters 20-32:
                         ^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_4)
-       t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -351,7 +375,10 @@ Line 1, characters 7-18:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_5)
-       t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a function argument.
 |}];;
 
 (*****************************************************)
@@ -415,7 +442,10 @@ Line 1, characters 27-36:
 1 | module F2 (X : sig val x : t_float64 end) = struct
                                ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout float64, which is not a sublayout of value.
+       The layout of type t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 (* CR layouts v5: the test above should be made to work *)
 
@@ -452,7 +482,10 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -472,7 +505,10 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -485,7 +521,10 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}];;
 
 type s4 = string t4
@@ -496,7 +535,10 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type s4 = int t4
@@ -526,9 +568,11 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       s5 has layout value, which is not a sublayout of immediate.
+       The layout of s5 is value, because
+         it is the primitive value type string.
+       But the layout of s5 must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
-(* CR layouts v2.9: improve error, which requires layout histories *)
 
 type ('a : any) t4 = 'a
 and s4 = string t4;;
@@ -587,7 +631,10 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because
+         it is or unifies with an unannotated universal variable.
+       But the layout of 'a must be a sublayout of immediate, because
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -600,7 +647,10 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because
+         it is or unifies with an unannotated universal variable.
+       But the layout of 'a must be a sublayout of immediate, because
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -618,7 +668,10 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       int * int has layout value, which is not a sublayout of immediate.
+       The layout of int * int is value, because
+         it's a tuple type.
+       But the layout of int * int must be a sublayout of immediate, because
+         of the definition of t7 at line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -634,7 +687,10 @@ Line 2, characters 40-49:
 2 |   type foo1 = [ `Foo1 of int | `Baz1 of t_float64 | `Bar1 of string ];;
                                             ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_2f = struct
@@ -650,7 +706,10 @@ Line 5, characters 16-17:
                     ^
 Error: This expression has type ('a : value)
        but an expression was expected of type float#
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_3f = struct
@@ -663,7 +722,10 @@ Line 4, characters 13-22:
 4 |   type bad = t_float64 t
                  ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-42.
 |}];;
 
 module M8_4f = struct
@@ -675,7 +737,10 @@ Line 2, characters 54-68:
                                                           ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 module type S8_5f = sig
@@ -686,7 +751,10 @@ Line 2, characters 17-26:
 2 |   val x : [`A of t_float64]
                      ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}]
 
 (************************************************)
@@ -701,7 +769,10 @@ Line 2, characters 20-29:
 2 |   type foo1 = int * t_float64 * [ `Foo1 of int | `Bar1 of string ];;
                         ^^^^^^^^^
 Error: Tuple element types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_2f = struct
@@ -712,7 +783,10 @@ Line 2, characters 31-40:
 2 |   type result = V of (string * t_float64) | I of int
                                    ^^^^^^^^^
 Error: Tuple element types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_4f = struct
@@ -728,7 +802,10 @@ Line 6, characters 21-22:
                          ^
 Error: This expression has type ('a : value)
        but an expression was expected of type float#
-       float# has layout float64, which is not a sublayout of value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_5f = struct
@@ -741,7 +818,10 @@ Line 4, characters 13-22:
 4 |   type bad = t_float64 t
                  ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-24.
 |}];;
 
 module M9_6f = struct
@@ -753,7 +833,10 @@ Line 2, characters 34-48:
                                       ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module type S9_7f = sig
@@ -764,7 +847,10 @@ Line 2, characters 16-25:
 2 |   val x : int * t_float64
                     ^^^^^^^^^
 Error: Tuple element types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 (*************************************************)
@@ -804,7 +890,10 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of x at line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -842,7 +931,10 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of x at line 8, characters 10-26.
 |}]
 
 (**********************************************************************)
@@ -873,8 +965,11 @@ end;;
 Line 5, characters 4-5:
 5 |     x # baz11
         ^
-Error: Method types must have layout value.
-       This expression has layout float64, which does not overlap with value.
+Error: Object types must have layout value.
+       The layout of the type of this expression is float64, because
+         of the definition of t at line 2, characters 2-28.
+       But the layout of the type of this expression must overlap with value, because
+         it's the type of an object.
 |}]
 
 module M11_2f = struct
@@ -888,7 +983,10 @@ Line 4, characters 19-33:
                        ^^^^^^^^^^^^^^
 Error: This expression has type ('a : value)
        but an expression was expected of type 'b t = ('b : float64)
-       'a t has layout float64, which does not overlap with value.
+       The layout of 'a t is float64, because
+         of the definition of f_id at line 3, characters 11-25.
+       But the layout of 'a t must overlap with value, because
+         it's the type of an object field.
 |}];;
 
 module M11_3f = struct
@@ -912,7 +1010,10 @@ Line 2, characters 12-25:
 2 |   val x : < l : t_float64 >
                 ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 module M11_5f = struct
@@ -924,7 +1025,10 @@ Line 3, characters 2-27:
 3 |   and ('a : float64) s = 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       'a s has layout float64, which does not overlap with value.
+       The layout of 'a s is float64, because
+         of the annotation on 'a in the declaration of the type s.
+       But the layout of 'a s must overlap with value, because
+         it's the type of an object field.
 |}];;
 
 module M11_6f = struct
@@ -936,7 +1040,10 @@ Line 2, characters 36-50:
                                         ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 (*******************************************************************)
@@ -974,7 +1081,10 @@ Line 5, characters 10-13:
 5 |       val bar = f u
               ^^^
 Error: Variables bound in a class must have layout value.
-       bar has layout float64, which does not overlap with value.
+       The layout of bar is float64, because
+         of the definition of f at line 2, characters 6-7.
+       But the layout of bar must overlap with value, because
+         it's the type of a class field.
 |}];;
 
 (* Hits the Cfk_virtual case of Pcf_val *)
@@ -989,7 +1099,10 @@ Line 4, characters 18-21:
 4 |       val virtual bar : t_float64
                       ^^^
 Error: Variables bound in a class must have layout value.
-       bar has layout float64, which is not a sublayout of value.
+       The layout of bar is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of bar must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 module M12_4f = struct
@@ -1005,7 +1118,10 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with float64.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t at line 2, characters 2-23.
 |}];;
 
 module M12_5f = struct
@@ -1021,7 +1137,10 @@ Line 6, characters 26-28:
 6 |       method void_id (a : 'a t) : 'a t = a
                               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with float64.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t at line 2, characters 2-28.
 |}];;
 
 module type S12_6f = sig
@@ -1038,7 +1157,10 @@ Line 5, characters 4-6:
 5 |     'a t ->
         ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with float64.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t at line 2, characters 2-28.
 |}];;
 
 module type S12_7f = sig
@@ -1052,7 +1174,10 @@ Line 4, characters 6-25:
 4 |       val baz : t_float64
           ^^^^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       baz has layout float64, which is not a sublayout of value.
+       The layout of baz is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of baz must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 (***********************************************************)
@@ -1067,7 +1192,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 Lazy.t;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of Lazy.t has this layout.
 |}];;
 
 let x13f (v : t_float64) = lazy v;;
@@ -1077,7 +1205,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a lazy expression.
 |}];;
 
 let f_id (x : t_float64) = x
@@ -1091,7 +1222,10 @@ Line 4, characters 19-20:
                        ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a lazy expression.
 |}];;
 
 (* option *)
@@ -1102,7 +1236,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 option;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 let x13f (v : t_float64) = Some v;;
@@ -1112,7 +1249,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 let x13f v =
@@ -1125,7 +1265,10 @@ Line 3, characters 19-20:
                        ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 (* list *)
@@ -1135,7 +1278,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 list;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let x13 (v : t_float64) = [v];;
@@ -1145,7 +1291,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let x13 v =
@@ -1158,7 +1307,10 @@ Line 3, characters 16-17:
                     ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* array *)
@@ -1168,7 +1320,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 array;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of array has layout value.
 |}];;
 
 let x13f (v : t_float64) = [| v |];;
@@ -1178,7 +1333,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an array element.
 |}];;
 
 let x13f v =
@@ -1191,7 +1349,10 @@ Line 3, characters 20-21:
                         ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an array element.
 |}];;
 
 (****************************************************************************)
@@ -1213,7 +1374,10 @@ Line 2, characters 0-21:
 2 | and foo14 = t_float64;;
     ^^^^^^^^^^^^^^^^^^^^^
 Error:
-       foo14 has layout float64, which is not a sublayout of value.
+       The layout of foo14 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of foo14 must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (****************************************************)
@@ -1366,8 +1530,10 @@ Line 15, characters 4-8:
 Error: This pattern matches values of type (Mf.t_float64, Mf.t_float64) eq
        but a pattern was expected which matches values of type
          (Mf.t_float64, Mf.t_imm) eq
-       Mf.t_float64 has layout float64,
-         which does not overlap with immediate.
+       The layout of Mf.t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 2-26.
+       But the layout of Mf.t_float64 must overlap with immediate, because
+         of the definition of t_imm at line 5, characters 2-24.
 |}]
 
 (*****************************************************)
@@ -1398,7 +1564,10 @@ Line 2, characters 15-16:
                    ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of option has layout value.
 |}]
 
 (*********************************************************)
@@ -1538,7 +1707,10 @@ Line 4, characters 9-22:
              ^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}]
 
 (*******************************************)
@@ -1558,7 +1730,10 @@ Line 3, characters 14-29:
                   ^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of eq at line 1, characters 0-41.
 |}]
 
 (**************************************)
@@ -1581,7 +1756,10 @@ Line 7, characters 28-29:
                                 ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of f at line 2, characters 2-18.
 |}]
 
 (**************************************************)
@@ -1598,7 +1776,10 @@ Line 1, characters 44-46:
 1 | type ('a : float64) poly_var = [`A of int * 'a | `B]
                                                 ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type poly_var.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (*********************************************************)
@@ -1614,7 +1795,10 @@ Line 1, characters 14-40:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}]
 
 (******************************************************)
@@ -1627,7 +1811,10 @@ Line 1, characters 17-22:
 1 | external foo33 : t_any = "foo33";;
                      ^^^^^
 Error: This type signature for foo33 is not a value type.
-       foo33 has layout any, which is not a sublayout of value.
+       The layout of type t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of type t_any must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}]
 
 (****************************************************)
@@ -1648,7 +1835,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         'a has layout value, which is not a sublayout of immediate.
+         The layout of 'a is value, because
+           of the annotation on the universal variable 'a.
+         But the layout of 'a must be a sublayout of immediate, because
+           of the definition of t2_imm at line 1, characters 0-28.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -1665,7 +1855,10 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       'a -> 'b has layout value, which is not a sublayout of immediate.
+       The layout of 'a -> 'b is value, because
+         it's a function type.
+       But the layout of 'a -> 'b must be a sublayout of immediate, because
+         of the definition of t35 at line 1, characters 0-30.
 |}]
 
 (**************************************************)
@@ -1684,7 +1877,10 @@ Line 1, characters 10-22:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_6)
        because it is in the left-hand side of a sequence
-       t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 let () = while false do (assert false : t_any); done
@@ -1700,7 +1896,10 @@ Line 1, characters 25-37:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_7)
        because it is in the body of a while-loop
-       t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 let () = for i = 0 to 0 do (assert false : t_any); done
@@ -1716,7 +1915,10 @@ Line 1, characters 28-40:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_8)
        because it is in the body of a for-loop
-       t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 (******************************************************)
@@ -1743,7 +1945,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       'a has layout any, which is not representable.
+       The layout of 'a is any, because
+         of the definition of f at line 2, characters 2-30.
+       But the layout of 'a must be representable, because
+         of the definition of f at line 4, characters 8-13.
 |}]
 
 module M1 : sig
@@ -1796,7 +2001,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       'a has layout any, which is not a sublayout of value.
+       The layout of 'a is any, because
+         of the definition of f at line 2, characters 2-30.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of f at line 6, characters 2-18.
 |}]
 
 module F (X : S_value) : S_float64 = X
@@ -1815,7 +2023,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : float64). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       'a has layout float64, which is not a sublayout of value.
+       The layout of 'a is float64, because
+         of the definition of f at line 10, characters 2-34.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of f at line 6, characters 2-18.
 |}]
 
 module M2 : sig
@@ -2100,4 +2311,23 @@ let rec f : ('a : any). unit -> 'a -> 'a = fun () -> f ()
 
 [%%expect{|
 val f : ('a : any). unit -> 'a -> 'a = <fun>
+|}]
+
+(****************************************************************)
+(* Test 40: unannotated type parameter defaults to layout value *)
+
+type 'a t40 = 'a
+let f40 (x: t_float64): 'a t40 = x
+
+[%%expect{|
+type 'a t40 = 'a
+Line 2, characters 33-34:
+2 | let f40 (x: t_float64): 'a t40 = x
+                                     ^
+Error: This expression has type t_float64
+       but an expression was expected of type 'a t40 = ('a : value)
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of t40 at line 1, characters 0-16.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -71,7 +71,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_1) is not compatible with type t
-       t has layout any, which is not representable.
+       The layout of t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable, because
+         it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -85,7 +88,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_2) is not compatible with type t
-       t has layout any, which is not representable.
+       The layout of t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable, because
+         it instantiates an unannotated type parameter of s.
 |}]
 
 let f1 () : t_any = assert false;;
@@ -95,7 +101,10 @@ Line 1, characters 20-32:
                         ^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_3)
-       t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -106,7 +115,10 @@ Line 1, characters 7-18:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_4)
-       t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a function argument.
 |}];;
 
 (*****************************************************)
@@ -184,7 +196,10 @@ Line 1, characters 27-33:
 1 | module F2 (X : sig val x : t_void end) = struct
                                ^^^^^^
 Error: This type signature for x is not a value type.
-       x has layout void, which is not a sublayout of value.
+       The layout of type t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of type t_void must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 (* CR layouts v5: the test above should be made to work *)
 
@@ -224,7 +239,10 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -244,7 +262,10 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -257,7 +278,10 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}];;
 
 type s4 = string t4
@@ -268,7 +292,10 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type s4 = int t4
@@ -298,9 +325,11 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       s5 has layout value, which is not a sublayout of immediate.
+       The layout of s5 is value, because
+         it is the primitive value type string.
+       But the layout of s5 must be a sublayout of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
-(* CR layouts v2.9: improve error, which will require jkind histories *)
 
 type ('a : any) t4 = 'a
 and s4 = string t4;;
@@ -351,7 +380,10 @@ Line 5, characters 15-22:
                    ^^^^^^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       'a has layout void, which is not a sublayout of value.
+       The layout of 'a is void, because
+         of the definition of void5 at line 1, characters 0-37.
+       But the layout of 'a must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}];;
 
 (* disallowed attempts to use f5 and Void5 on non-voids *)
@@ -361,7 +393,10 @@ Line 1, characters 12-15:
 1 | let h5 (x : int void5) = f5 x
                 ^^^
 Error: This type int should be an instance of type ('a : void)
-       int has layout immediate, which is not a sublayout of void.
+       The layout of int is immediate, because
+         it is the primitive immediate type int.
+       But the layout of int must be a sublayout of void, because
+         of the definition of void5 at line 1, characters 0-37.
 |}];;
 
 let h5' (x : int any5) = Void5 x
@@ -371,7 +406,10 @@ Line 1, characters 31-32:
                                    ^
 Error: This expression has type int any5
        but an expression was expected of type ('a : void)
-       int any5 has layout value, which is not a sublayout of void.
+       The layout of int any5 is value, because
+         of the definition of any5 at line 2, characters 0-33.
+       But the layout of int any5 must be a sublayout of void, because
+         of the definition of void5 at line 1, characters 0-37.
 |}];;
 
 (* disallowed - tries to return void *)
@@ -382,8 +420,21 @@ let g (x : 'a void5) =
 Lines 2-3, characters 2-16:
 2 | ..match x with
 3 |   | Void5 x -> x..
+<<<<<<< HEAD
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        'a. Please report this error to the Jane Street compilers team.
+||||||| parent of c77b6af8 (Enable layout histories (#1823))
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       'a has layout void, which is not a sublayout of value.
+=======
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of 'a is void, because
+         of the definition of void5 at line 1, characters 0-37.
+       But the layout of 'a must be a sublayout of value, because
+         it has to be value for the V1 safety check.
+>>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 
 (****************************************)
@@ -409,7 +460,10 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because
+         it is or unifies with an unannotated universal variable.
+       But the layout of 'a must be a sublayout of immediate, because
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -422,7 +476,10 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       'a has layout value, which is not a sublayout of immediate.
+       The layout of 'a is value, because
+         it is or unifies with an unannotated universal variable.
+       But the layout of 'a must be a sublayout of immediate, because
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -441,7 +498,10 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       int * int has layout value, which is not a sublayout of immediate.
+       The layout of int * int is value, because
+         it's a tuple type.
+       But the layout of int * int must be a sublayout of immediate, because
+         of the definition of t7 at line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -457,7 +517,10 @@ Line 2, characters 40-46:
 2 |   type foo1 = [ `Foo1 of int | `Baz1 of t_void | `Bar1 of string ];;
                                             ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_2 = struct
@@ -487,7 +550,10 @@ Line 4, characters 13-19:
 4 |   type bad = t_void t
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-42.
 |}];;
 
 module M8_4 = struct
@@ -499,8 +565,10 @@ Line 2, characters 54-78:
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
-       void_unboxed_record has layout void,
-         which is not a sublayout of value.
+       The layout of void_unboxed_record is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 module type S8_5 = sig
@@ -511,7 +579,10 @@ Line 2, characters 17-23:
 2 |   val x : [`A of t_void]
                      ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}]
 
 (************************************************)
@@ -526,7 +597,10 @@ Line 2, characters 20-26:
 2 |   type foo1 = int * t_void * [ `Foo1 of int | `Bar1 of string ];;
                         ^^^^^^
 Error: Tuple element types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_2 = struct
@@ -537,8 +611,10 @@ Line 2, characters 31-50:
 2 |   type result = V of (string * void_unboxed_record) | I of int
                                    ^^^^^^^^^^^^^^^^^^^
 Error: Tuple element types must have layout value.
-        void_unboxed_record has layout void,
-          which is not a sublayout of value.
+       The layout of void_unboxed_record is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_3 = struct
@@ -555,8 +631,10 @@ Line 7, characters 13-14:
                  ^
 Error: This expression has type void_unboxed_record
        but an expression was expected of type ('a : value)
-       void_unboxed_record has layout void,
-         which is not a sublayout of value.
+       The layout of void_unboxed_record is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_4 = struct
@@ -570,8 +648,10 @@ Line 4, characters 8-16:
             ^^^^^^^^
 Error: The record field vur_void belongs to the type void_unboxed_record
        but is mixed here with fields of type ('a : value)
-       void_unboxed_record has layout void,
-         which is not a sublayout of value.
+       The layout of void_unboxed_record is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's a boxed record type.
 |}];;
 
 module M9_5 = struct
@@ -584,7 +664,10 @@ Line 4, characters 13-19:
 4 |   type bad = t_void t
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-24.
 |}];;
 
 module M9_6 = struct
@@ -596,8 +679,10 @@ Line 2, characters 34-58:
                                       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
-       void_unboxed_record has layout void,
-         which is not a sublayout of value.
+       The layout of void_unboxed_record is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module type S9_7 = sig
@@ -608,7 +693,10 @@ Line 2, characters 16-22:
 2 |   val x : int * t_void
                     ^^^^^^
 Error: Tuple element types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_9 (X : sig
@@ -624,7 +712,10 @@ Line 5, characters 11-23:
                ^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 (*************************************************)
@@ -664,7 +755,10 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of x at line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -702,7 +796,10 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of x at line 8, characters 10-26.
 |}]
 
 (**************************************************************)
@@ -717,8 +814,11 @@ end;;
 Line 5, characters 4-7:
 5 |     t.v # baz11
         ^^^
-Error: Method types must have layout value.
-       This expression has layout void, which does not overlap with value.
+Error: Object types must have layout value.
+       The layout of the type of this expression is void, because
+         of the definition of t at line 2, characters 2-42.
+       But the layout of the type of this expression must overlap with value, because
+         it's the type of an object.
 |}]
 
 module M11_2 = struct
@@ -730,7 +830,10 @@ Line 2, characters 17-30:
                      ^^^^^^^^^^^^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 module M11_3 = struct
@@ -741,9 +844,24 @@ end;;
 [%%expect{|
 Line 4, characters 32-33:
 4 |   let foo o (A x) = o # usevoid x
+<<<<<<< HEAD
                                     ^
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        'a. Please report this error to the Jane Street compilers team.
+||||||| parent of c77b6af8 (Enable layout histories (#1823))
+                ^^^^^^^^^^^^^^^^^^^^^
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       'a has layout void, which is not a sublayout of value.
+=======
+                ^^^^^^^^^^^^^^^^^^^^^
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of 'a is void, because
+         of the definition of t at line 2, characters 2-30.
+       But the layout of 'a must be a sublayout of value, because
+         it has to be value for the V1 safety check.
+>>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}];;
 
 module M11_4 = struct
@@ -754,7 +872,10 @@ Line 2, characters 12-22:
 2 |   val x : < l : t_void >
                 ^^^^^^^^^^
 Error: Object field types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 module M11_5 = struct
@@ -766,7 +887,10 @@ Line 3, characters 2-24:
 3 |   and ('a : void) s = 'a
       ^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       'a s has layout void, which does not overlap with value.
+       The layout of 'a s is void, because
+         of the annotation on 'a in the declaration of the type s.
+       But the layout of 'a s must overlap with value, because
+         it's the type of an object field.
 |}];;
 
 module M11_6 = struct
@@ -778,7 +902,10 @@ Line 2, characters 36-47:
                                         ^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 (*******************************************************************)
@@ -812,7 +939,10 @@ Line 4, characters 10-13:
 4 |       val bar = v.vr_void
               ^^^
 Error: Variables bound in a class must have layout value.
-       bar has layout void, which is not a sublayout of value.
+       The layout of bar is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of bar must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 (* Hits the Cfk_virtual case of Pcf_val *)
@@ -827,7 +957,10 @@ Line 4, characters 18-21:
 4 |       val virtual bar : t_void
                       ^^^
 Error: Variables bound in a class must have layout value.
-       bar has layout void, which is not a sublayout of value.
+       The layout of bar is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of bar must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 module M12_4 = struct
@@ -843,7 +976,10 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with void.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module M12_5 = struct
@@ -859,7 +995,10 @@ Line 6, characters 29-31:
 6 |       method void_id (A a) : 'a t = a
                                  ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with void.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void, because
+         of the definition of t at line 2, characters 2-30.
 |}];;
 
 module type S12_6 = sig
@@ -876,7 +1015,10 @@ Line 5, characters 4-6:
 5 |     'a t ->
         ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       'a has layout value, which does not overlap with void.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void, because
+         of the definition of t at line 2, characters 2-30.
 |}];;
 
 module type S12_7 = sig
@@ -890,7 +1032,10 @@ Line 4, characters 6-22:
 4 |       val baz : t_void
           ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       baz has layout void, which is not a sublayout of value.
+       The layout of baz is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of baz must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 (***********************************************************)
@@ -903,7 +1048,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void Lazy.t;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of Lazy.t has this layout.
 |}];;
 
 let x13 (VV v) = lazy v;;
@@ -913,7 +1061,10 @@ Line 1, characters 22-23:
                           ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a lazy expression.
 |}];;
 
 let x13 v =
@@ -925,7 +1076,10 @@ Line 3, characters 17-18:
                      ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a lazy expression.
 |}];;
 
 (* option *)
@@ -936,7 +1090,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void option;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 let x13 (VV v) = Some v;;
@@ -946,7 +1103,10 @@ Line 1, characters 22-23:
                           ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 let x13 v =
@@ -959,7 +1119,10 @@ Line 3, characters 17-18:
                      ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 (* list *)
@@ -970,7 +1133,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void list;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let x13 (VV v) = [v];;
@@ -980,7 +1146,10 @@ Line 1, characters 18-19:
                       ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let x13 v =
@@ -993,7 +1162,10 @@ Line 3, characters 14-15:
                   ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* array *)
@@ -1004,7 +1176,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void array;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of array has layout value.
 |}];;
 
 let x13 (VV v) = [| v |];;
@@ -1014,7 +1189,10 @@ Line 1, characters 20-21:
                         ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of an array element.
 |}];;
 
 let x13 v =
@@ -1027,7 +1205,10 @@ Line 3, characters 18-19:
                       ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of an array element.
 |}];;
 
 (****************************************************************************)
@@ -1046,7 +1227,10 @@ Line 2, characters 0-18:
 2 | and foo14 = t_void;;
     ^^^^^^^^^^^^^^^^^^
 Error:
-       foo14 has layout void, which is not a sublayout of value.
+       The layout of foo14 is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of foo14 must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (****************************************************)
@@ -1167,7 +1351,10 @@ Lines 6-7, characters 2-20:
 7 |   g (failwith "foo")..
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       'a has layout void, which is not a sublayout of value.
+       The layout of 'a is void, because
+         of the definition of r at line 3, characters 0-40.
+       But the layout of 'a must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}];;
 
 (********************************************************************)
@@ -1198,11 +1385,11 @@ Line 15, characters 4-8:
 Error: This pattern matches values of type (M.t_void, M.t_void) eq
        but a pattern was expected which matches values of type
          (M.t_void, M.t_imm) eq
-       M.t_void has layout void, which does not overlap with immediate.
+       The layout of M.t_void is void, because
+         of the definition of t_void at line 4, characters 2-20.
+       But the layout of M.t_void must overlap with immediate, because
+         of the definition of t_imm at line 5, characters 2-24.
 |}]
-(* CR layouts v2.9: error message is OK, but it could probably be better.
-   But a similar case without jkinds is already pretty bad, so try
-   that before spending too much time here. *)
 
 (*****************************************************)
 (* Test 24: Polymorphic parameter with exotic layout *)
@@ -1234,7 +1421,10 @@ Line 2, characters 15-16:
                    ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of option has layout value.
 |}]
 
 (*********************************************************)
@@ -1484,7 +1674,10 @@ Line 4, characters 9-19:
              ^^^^^^^^^^
 Error: This pattern matches values of type t_void
        but a pattern was expected which matches values of type ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a tuple element.
 |}]
 
 let ( let* ) x f = ()
@@ -1503,7 +1696,10 @@ Line 4, characters 9-22:
              ^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
-       t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}]
 
 
@@ -1526,7 +1722,10 @@ Line 4, characters 16-28:
                     ^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         of the definition of eq at line 2, characters 2-43.
 |}]
 
 (**************************************)
@@ -1552,7 +1751,10 @@ Line 8, characters 27-28:
                                ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         of the definition of f at line 3, characters 4-20.
 |}]
 
 (**************************************************)
@@ -1567,7 +1769,10 @@ Line 1, characters 41-43:
 1 | type ('a : void) poly_var = [`A of int * 'a | `B]
                                              ^^
 Error: This type ('a : value) should be an instance of type ('a0 : void)
-       'a has layout void, which does not overlap with value.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type poly_var.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (* CR layouts bug: this should be accepted (or maybe we should reject
@@ -1586,7 +1791,10 @@ Line 1, characters 14-37:
                   ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}]
 
 (******************************************************)
@@ -1598,7 +1806,10 @@ Line 1, characters 17-22:
 1 | external foo33 : t_any = "foo33";;
                      ^^^^^
 Error: This type signature for foo33 is not a value type.
-       foo33 has layout any, which is not a sublayout of value.
+       The layout of type t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of type t_any must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}]
 
 
@@ -1619,7 +1830,10 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       'a -> 'b has layout value, which is not a sublayout of immediate.
+       The layout of 'a -> 'b is value, because
+         it's a function type.
+       But the layout of 'a -> 'b must be a sublayout of immediate, because
+         of the definition of t35 at line 1, characters 0-30.
 |}]
 
 (**************************************************)
@@ -1638,7 +1852,10 @@ Line 1, characters 10-22:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_5)
        because it is in the left-hand side of a sequence
-       t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 let () = while false do (assert false : t_any); done
@@ -1654,7 +1871,10 @@ Line 1, characters 25-37:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_6)
        because it is in the body of a while-loop
-       t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 let () = for i = 0 to 0 do (assert false : t_any); done
@@ -1670,7 +1890,10 @@ Line 1, characters 28-40:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_7)
        because it is in the body of a for-loop
-       t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 (******************************************************)
@@ -1687,5 +1910,10 @@ Error: This expression has type t_any but an expression was expected of type
 
 (*************************************************************)
 (* Test 39: Inference of functions that don't bind arguments *)
+
+(* Doesn't need layouts_alpha. *)
+
+(****************************************************)
+(* Test 40: unannotated type parameter defaults to layout value *)
 
 (* Doesn't need layouts_alpha. *)

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -212,7 +212,10 @@ Line 2, characters 16-44:
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}];;
 
 (**************************************)
@@ -420,21 +423,8 @@ let g (x : 'a void5) =
 Lines 2-3, characters 2-16:
 2 | ..match x with
 3 |   | Void5 x -> x..
-<<<<<<< HEAD
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        'a. Please report this error to the Jane Street compilers team.
-||||||| parent of c77b6af8 (Enable layout histories (#1823))
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       'a has layout void, which is not a sublayout of value.
-=======
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of 'a is void, because
-         of the definition of void5 at line 1, characters 0-37.
-       But the layout of 'a must be a sublayout of value, because
-         it has to be value for the V1 safety check.
->>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 
 (****************************************)
@@ -844,24 +834,9 @@ end;;
 [%%expect{|
 Line 4, characters 32-33:
 4 |   let foo o (A x) = o # usevoid x
-<<<<<<< HEAD
                                     ^
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        'a. Please report this error to the Jane Street compilers team.
-||||||| parent of c77b6af8 (Enable layout histories (#1823))
-                ^^^^^^^^^^^^^^^^^^^^^
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       'a has layout void, which is not a sublayout of value.
-=======
-                ^^^^^^^^^^^^^^^^^^^^^
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of 'a is void, because
-         of the definition of t at line 2, characters 2-30.
-       But the layout of 'a must be a sublayout of value, because
-         it has to be value for the V1 safety check.
->>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}];;
 
 module M11_4 = struct

--- a/ocaml/testsuite/tests/typing-layouts/datatypes.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes.ml
@@ -41,7 +41,10 @@ Line 1, characters 15-31:
 1 | type t2_any1 = T2_any1 of t_any
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t2_any2 = T2_any2 of t_immediate * t_any
@@ -50,7 +53,10 @@ Line 1, characters 15-45:
 1 | type t2_any2 = T2_any2 of t_immediate * t_any
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t2_any3 = T2_any3 of t_any * t_value
@@ -59,7 +65,10 @@ Line 1, characters 15-41:
 1 | type t2_any3 = T2_any3 of t_any * t_value
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type 'a t1_constraint = T1_con of 'a constraint 'a = 'b t1_constraint'
@@ -69,7 +78,10 @@ Line 2, characters 0-29:
 2 | and 'b t1_constraint' = t_any
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       'b t1_constraint' has layout any, which is not representable.
+       The layout of 'b t1_constraint' is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of 'b t1_constraint' must be representable, because
+         it instantiates an unannotated type parameter of t1_constraint.
 |}]
 
 (******************************************************)
@@ -87,7 +99,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -96,7 +111,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -105,7 +123,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -114,7 +135,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -123,7 +147,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -132,7 +159,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -145,7 +175,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -154,7 +187,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -163,7 +199,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -172,7 +211,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -181,7 +223,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -190,7 +235,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -217,7 +265,10 @@ Line 1, characters 11-24:
 1 | type t5 += T5_7 of t_any
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_8 of t_immediate * t_any
@@ -226,7 +277,10 @@ Line 1, characters 11-38:
 1 | type t5 += T5_8 of t_immediate * t_any
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_9 of t_any * t_value
@@ -235,7 +289,10 @@ Line 1, characters 11-34:
 1 | type t5 += T5_9 of t_any * t_value
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_11 of { x : t_value }
@@ -254,7 +311,10 @@ Line 1, characters 39-48:
 1 | type t5 += T5_17 of { x : t_immediate; y : t_any }
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 (**************************************************************************)
@@ -277,7 +337,10 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       float has layout value, which is not a sublayout of immediate.
+       The layout of float is value, because
+         it is the primitive value type float.
+       But the layout of float must be a sublayout of immediate, because
+         of the definition of s6 at line 2, characters 0-35.
 |}];;
 
 (*****************************************************)
@@ -326,7 +389,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         'a has layout float64, which does not overlap with value.
+         The layout of 'a is float64, because
+           of the definition of float64_t at line 2, characters 0-29.
+         But the layout of 'a must overlap with value, because
+           it instantiates an unannotated type parameter of t8_5, defaulted to layout value.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -387,7 +453,10 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       t_any has layout any, which is not a sublayout of value.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value, because
+         of the definition of t1 at line 2, characters 2-42.
 |}]
 
 module M : sig
@@ -409,7 +478,10 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       t_any has layout any, which is not a sublayout of value.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value, because
+         of the definition of t1 at line 3, characters 2-41.
 |}]
 
 module M : sig
@@ -431,6 +503,9 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       t_any has layout any, which is not a sublayout of value.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value, because
+         of the definition of t1 at line 3, characters 2-42.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -49,7 +49,10 @@ Line 1, characters 15-31:
 1 | type t2_any1 = T2_any1 of t_any
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t2_any2 = T2_any2 of t_immediate * t_any
@@ -58,7 +61,10 @@ Line 1, characters 15-45:
 1 | type t2_any2 = T2_any2 of t_immediate * t_any
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t2_any3 = T2_any3 of t_any * t_value
@@ -67,7 +73,10 @@ Line 1, characters 15-41:
 1 | type t2_any3 = T2_any3 of t_any * t_value
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type 'a t1_constraint = T1_con of 'a constraint 'a = 'b t1_constraint'
@@ -77,7 +86,10 @@ Line 2, characters 0-29:
 2 | and 'b t1_constraint' = t_any
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       'b t1_constraint' has layout any, which is not representable.
+       The layout of 'b t1_constraint' is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of 'b t1_constraint' must be representable, because
+         it instantiates an unannotated type parameter of t1_constraint.
 |}]
 (* CR layouts errors: this error is blamed on the wrong piece *)
 
@@ -135,7 +147,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -144,7 +159,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -153,7 +171,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -162,7 +183,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -171,7 +195,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -180,7 +207,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -211,7 +241,10 @@ Line 1, characters 11-24:
 1 | type t5 += T5_7 of t_any
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_8 of t_immediate * t_any
@@ -220,7 +253,10 @@ Line 1, characters 11-38:
 1 | type t5 += T5_8 of t_immediate * t_any
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_9 of t_any * t_value
@@ -229,7 +265,10 @@ Line 1, characters 11-34:
 1 | type t5 += T5_9 of t_any * t_value
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_11 of { x : t_value }
@@ -260,7 +299,10 @@ Line 1, characters 39-48:
 1 | type t5 += T5_17 of { x : t_immediate; y : t_any }
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-        t_any has layout any, which is not representable.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 (**************************************************************************)
@@ -283,7 +325,10 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       float has layout value, which is not a sublayout of immediate.
+       The layout of float is value, because
+         it is the primitive value type float.
+       But the layout of float must be a sublayout of immediate, because
+         of the definition of s6 at line 2, characters 0-35.
 |}];;
 
 (*****************************************************)
@@ -339,7 +384,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         'a has layout void, which does not overlap with value.
+         The layout of 'a is void, because
+           of the definition of void_t at line 1, characters 0-23.
+         But the layout of 'a must overlap with value, because
+           it instantiates an unannotated type parameter of t8_5, defaulted to layout value.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -358,7 +406,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         'a has layout value, which is not a sublayout of immediate.
+         The layout of 'a is value, because
+           it instantiates an unannotated type parameter of t10, defaulted to layout value.
+         But the layout of 'a must be a sublayout of immediate, because
+           of the definition of imm_t at line 1, characters 0-27.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -375,7 +426,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         float# has layout float64, which is not a sublayout of void.
+         The layout of float# is float64, because
+           it is the primitive float64 type float#.
+         But the layout of float# must be a sublayout of void, because
+           of the annotation on the universal variable 'b.
        The fix will likely be to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -1,0 +1,283 @@
+(* TEST
+   flags = "-extension layouts_alpha"
+ * expect
+*)
+
+module Float_u = Stdlib__Float_u
+
+[%%expect{|
+module Float_u = Stdlib__Float_u
+|}]
+
+(* Needs a string payload *)
+
+let f (v: float#): ((_ : value)[@error_message]) = v
+[%%expect{|
+Line 1, characters 31-47:
+1 | let f (v: float#): ((_ : value)[@error_message]) = v
+                                   ^^^^^^^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'error_message'.
+error_message attribute expects a string argument
+
+Line 1, characters 51-52:
+1 | let f (v: float#): ((_ : value)[@error_message]) = v
+                                                       ^
+Error: This expression has type float# but an expression was expected of type
+         ('a : value)
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 1, characters 20-31.
+|}]
+
+let f (v: float#): ((_ : value)[@error_message 1]) = v
+[%%expect{|
+Line 1, characters 31-49:
+1 | let f (v: float#): ((_ : value)[@error_message 1]) = v
+                                   ^^^^^^^^^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'error_message'.
+error_message attribute expects a string argument
+
+Line 1, characters 53-54:
+1 | let f (v: float#): ((_ : value)[@error_message 1]) = v
+                                                         ^
+Error: This expression has type float# but an expression was expected of type
+         ('a : value)
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 1, characters 20-31.
+|}]
+
+(* Ltyp_var { name = None; layout } case *)
+let f (v: float#): ((_ : value)[@error_message "Custom message"]) = v
+[%%expect{|
+Line 1, characters 68-69:
+1 | let f (v: float#): ((_ : value)[@error_message "Custom message"]) = v
+                                                                        ^
+Error: This expression has type float# but an expression was expected of type
+         ('a : value)
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 1, characters 20-31.
+         Custom message
+|}]
+
+let f x =
+  ignore ((x : (_ : value)[@error_message "Custom message"]));
+  Float_u.to_float x
+[%%expect{|
+Line 3, characters 19-20:
+3 |   Float_u.to_float x
+                       ^
+Error: This expression has type ('a : value)
+       but an expression was expected of type float#
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 2, characters 15-26.
+         Custom message
+|}]
+
+(* Ltyp_var { name = Some name; layout } case *)
+module type a = sig
+  type ('a : float64) t = 'a
+  val f : (('a : value)[@error_message "Custom message"]) -> 'a t
+end
+
+[%%expect{|
+Line 3, characters 61-63:
+3 |   val f : (('a : value)[@error_message "Custom message"]) -> 'a t
+                                                                 ^^
+Error: This type ('a : value) should be an instance of type ('b : float64)
+       The layout of 'a is value, because
+         of the annotation on the type variable 'a.
+         Custom message
+       But the layout of 'a must overlap with float64, because
+         of the definition of t at line 2, characters 2-28.
+|}]
+
+
+(* Ltyp_alias { aliased_type; name; layout } case *)
+
+(* First call to [layout_of_annotation] in [transl_type_alias] *)
+module type a = sig
+  type t : float64
+  val f : 'a -> t -> (t as ('a : value)[@error_message "Custom message"])
+end
+[%%expect{|
+Line 3, characters 33-38:
+3 |   val f : 'a -> t -> (t as ('a : value)[@error_message "Custom message"])
+                                     ^^^^^
+Error: Bad layout annotation:
+         The layout of t is float64, because
+           of the definition of t at line 2, characters 2-18.
+         But the layout of t must be a sublayout of value, because
+           of the annotation on the type variable 'a.
+           Custom message
+|}]
+
+(* Second call to [layout_of_annotation] in the Not_found case
+   of [transl_type_alias] *)
+module type a = sig
+  type t : float64
+  val f : t -> (t as ('a : value)[@error_message "Custom message"])
+end
+[%%expect{|
+Line 3, characters 16-33:
+3 |   val f : t -> (t as ('a : value)[@error_message "Custom message"])
+                    ^^^^^^^^^^^^^^^^^
+Error: This alias is bound to type t but is used as an instance of type
+         ('a : value)
+       The layout of t is float64, because
+         of the definition of t at line 2, characters 2-18.
+       But the layout of t must be a sublayout of value, because
+         of the annotation on the type variable 'a.
+         Custom message
+|}]
+
+(* Third call to [layout_of_annotation] in the None case
+   of [transl_type_alias] *)
+module type a = sig
+  type t : float64
+  val f : t -> (t as (_ : value)[@error_message "Custom message"])
+end
+[%%expect{|
+Line 3, characters 26-31:
+3 |   val f : t -> (t as (_ : value)[@error_message "Custom message"])
+                              ^^^^^
+Error: Bad layout annotation:
+         The layout of t/2 is float64, because
+           of the definition of t at line 2, characters 2-18.
+         But the layout of t/2 must be a sublayout of value, because
+           of the annotation on the wildcard _ at line 3, characters 26-31.
+           Custom message
+|}]
+
+(* Currently it's not possible to attach attributes to Ltyp_poly *)
+
+(* *************************************************************** *)
+(* Tests for [@error_message] applied to [Pexp_constraint].
+   Seperate implementation from when it's applied to layout annotations. *)
+
+(* Needs a string body *)
+let f (x : bool) = (x : int)[@error_message]
+[%%expect{|
+Line 1, characters 28-44:
+1 | let f (x : bool) = (x : int)[@error_message]
+                                ^^^^^^^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'error_message'.
+error_message attribute expects a string argument
+
+Line 1, characters 20-21:
+1 | let f (x : bool) = (x : int)[@error_message]
+                        ^
+Error: This expression has type bool but an expression was expected of type
+         int
+|}]
+
+(* Can only be applied once *)
+let f (x : bool) = (x : int)[@error_message "A"][@error_message "B"]
+[%%expect{|
+Line 1, characters 20-21:
+1 | let f (x : bool) = (x : int)[@error_message "A"][@error_message "B"]
+                        ^
+Error: This expression has type bool but an expression was expected of type
+         int
+       A
+|}]
+
+(* Simple test case *)
+let f (x : bool) = (x : int)[@error_message "custom message"]
+[%%expect{|
+Line 1, characters 20-21:
+1 | let f (x : bool) = (x : int)[@error_message "custom message"]
+                        ^
+Error: This expression has type bool but an expression was expected of type
+         int
+       custom message
+|}]
+
+(* Doesn't work when the type mismatch happens later. This differs from
+   the layout annotation case. *)
+let f x: bool = (x : int)[@error_message "custom message"]
+[%%expect{|
+Line 1, characters 16-25:
+1 | let f x: bool = (x : int)[@error_message "custom message"]
+                    ^^^^^^^^^
+Error: This expression has type int but an expression was expected of type
+         bool
+|}]
+
+(* Doesn't apply when the type error is from elsewhere within the expression *)
+let g (x : int) = x
+let f (x : bool) = (let y = false in g y : int)[@error_message "custom message"]
+[%%expect{|
+val g : int -> int = <fun>
+Line 2, characters 39-40:
+2 | let f (x : bool) = (let y = false in g y : int)[@error_message "custom message"]
+                                           ^
+Error: This expression has type bool but an expression was expected of type
+         int
+|}]
+
+(* Can be used to enforce layouts but not great *)
+let f (x : string) = (x : (_ : immediate))[@error_message "custom message"]
+[%%expect{|
+Line 1, characters 22-23:
+1 | let f (x : string) = (x : (_ : immediate))[@error_message "custom message"]
+                          ^
+Error: This expression has type string but an expression was expected of type
+         ('a : immediate)
+       custom message
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the annotation on the wildcard _ at line 1, characters 26-41.
+|}]
+
+(* Doesn't apply when the mismatch is deep *)
+let f () = (fun (x: int) -> x : string -> string)[@error_message "custom message"]
+[%%expect{|
+Line 1, characters 16-24:
+1 | let f () = (fun (x: int) -> x : string -> string)[@error_message "custom message"]
+                    ^^^^^^^^
+Error: This pattern matches values of type int
+       but a pattern was expected which matches values of type string
+|}]
+
+let f () = (fun (x: int) -> x : string)[@error_message "custom message"]
+[%%expect{|
+Line 1, characters 12-29:
+1 | let f () = (fun (x: int) -> x : string)[@error_message "custom message"]
+                ^^^^^^^^^^^^^^^^^
+Error: This expression should not be a function, the expected type is
+       string
+       custom message
+|}]
+
+(* Same when the function is not declared inline *)
+let g (x: int) = x
+let f () = (g : (string -> string))[@error_message "custom message"]
+[%%expect{|
+val g : int -> int = <fun>
+Line 2, characters 12-13:
+2 | let f () = (g : (string -> string))[@error_message "custom message"]
+                ^
+Error: This expression has type int -> int
+       but an expression was expected of type string -> string
+       Type int is not compatible with type string
+|}]
+
+let g (x: int) = x
+let f () = (g : string)[@error_message "custom message"]
+[%%expect{|
+val g : int -> int = <fun>
+Line 2, characters 12-13:
+2 | let f () = (g : string)[@error_message "custom message"]
+                ^
+Error: This expression has type int -> int
+       but an expression was expected of type string
+       custom message
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr_w53.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr_w53.compilers.reference
@@ -1,0 +1,14 @@
+File "error_message_attr_w53.ml", line 16, characters 43-56:
+16 |     (int as ('a:value)[@error_message ""][@error_message ""]) (* reject second *)
+                                                ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "error_message_attr_w53.ml", line 20, characters 45-58:
+20 |   let f1 v: ((_ : value)[@error_message ""][@error_message ""]) = v (* reject second *)
+                                                  ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "error_message_attr_w53.ml", line 21, characters 46-59:
+21 |   let f2 v: (('a : value)[@error_message ""][@error_message ""]) = v (* reject second *)
+                                                   ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr_w53.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr_w53.ml
@@ -1,0 +1,22 @@
+(* TEST
+
+flags = "-w +A-60-70 -extension layouts"
+
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+compile_only = "true"
+*** check-ocamlc.byte-output
+
+*)
+
+(* CR layouts v1.5: move this to [warnings/w53.ml] when layout annotation is generally avaliable
+   without the layouts extension flag. *)
+module type TestErrorMessageSig = sig
+  val f : int ->
+    (int as ('a:value)[@error_message ""][@error_message ""]) (* reject second *)
+end
+
+module TestErrorMessageStruct = struct
+  let f1 v: ((_ : value)[@error_message ""][@error_message ""]) = v (* reject second *)
+  let f2 v: (('a : value)[@error_message ""][@error_message ""]) = v (* reject second *)
+end

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -67,7 +67,10 @@ Line 1, characters 34-36:
                                       ^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : float64)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the definition of t at line 2, characters 2-23.
+       But the layout of 'a must overlap with value, because
+         the type argument of list has layout value.
 |}];;
 
 module type S1f'' = S1f with type s = t_float64;;
@@ -76,7 +79,10 @@ module type S1f'' = S1f with type s = t_float64;;
 Line 1, characters 29-47:
 1 | module type S1f'' = S1f with type s = t_float64;;
                                  ^^^^^^^^^^^^^^^^^^
-Error: Type t_float64 has layout float64, which is not a sublayout of value.
+Error: The layout of type t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value, because
+         of the definition of s at line 3, characters 2-8.
 |}]
 
 module type S1_2 = sig
@@ -179,7 +185,10 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -253,7 +262,10 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type Bar3.t has layout value, which is not a sublayout of immediate.
+Error: The layout of type Bar3.t is value, because
+         of the annotation on the declaration of the type t.
+       But the layout of type Bar3.t must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -288,7 +300,10 @@ Line 2, characters 27-29:
 2 |   type 'a t = 'a Bar3f.t * 'a list
                                ^^
 Error: This type ('a : float64) should be an instance of type ('b : value)
-       'a has layout float64, which does not overlap with value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value, because
+         the type argument of list has layout value.
 |}];;
 
 type t3f : float64
@@ -313,7 +328,10 @@ Line 12, characters 11-18:
 12 |   type s = Foo3f.t t
                 ^^^^^^^
 Error: This type Foo3f.t should be an instance of type ('a : float64)
-       Foo3f.t has layout value, which is not a sublayout of float64.
+       The layout of Foo3f.t is value, because
+         an abstract type has the value layout by default.
+       But the layout of Foo3f.t must be a sublayout of float64, because
+         of the definition of t at line 10, characters 2-23.
 |}];;
 
 (* Previous example works with annotation *)
@@ -365,7 +383,10 @@ Line 2, characters 12-16:
 2 | type t4f' = M4.s t4_float64;;
                 ^^^^
 Error: This type M4.s should be an instance of type ('a : float64)
-       M4.s has layout value, which is not a sublayout of float64.
+       The layout of M4.s is value, because
+         of the definition of s at line 2, characters 2-21.
+       But the layout of M4.s must be a sublayout of float64, because
+         of the definition of t4_float64 at line 1, characters 0-30.
 |}]
 
 module F4'(X : sig type t : immediate end) = struct
@@ -392,7 +413,10 @@ Line 1, characters 10-15:
 1 | type t4 = M4'.s t4_float64;;
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : float64)
-       M4'.s has layout immediate, which is not a sublayout of float64.
+       The layout of M4'.s is immediate, because
+         of the definition of s at line 2, characters 2-45.
+       But the layout of M4'.s must be a sublayout of float64, because
+         of the definition of t4_float64 at line 1, characters 0-30.
 |}];;
 
 
@@ -423,7 +447,10 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of f at line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig
@@ -436,7 +463,10 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: Type string has layout value, which is not a sublayout of immediate.
+Error: The layout of type string is value, because
+         it is the primitive value type string.
+       But the layout of type string must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -472,7 +502,10 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : float64
-       the first has layout value, which is not a sublayout of float64.
+       The layout of the first is value, because
+         it's a type declaration in a first-class module.
+       But the layout of the first must be a sublayout of float64, because
+         of the definition of t at line 2, characters 2-18.
 |}];;
 
 module type S6_3 = sig
@@ -488,7 +521,10 @@ Line 6, characters 33-34:
 6 |   val m : (module S6_3 with type t = t_float64)
                                      ^
 Error: Signature package constraint types must have layout value.
-        t_float64 has layout float64, which is not a sublayout of value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's a type declaration in a first-class module.
 |}];;
 
 module type S6_5 = sig
@@ -509,7 +545,10 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         it's a type declaration in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -526,7 +565,10 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         it's a type declaration in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (* CR layouts: S6_6'' should be fixed *)
@@ -544,7 +586,10 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         it's a type declaration in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (*****************************************)
@@ -570,7 +615,10 @@ Line 1, characters 28-33:
 1 | module type S = sig val x : t_any end
                                 ^^^^^
 Error: This type signature for x is not a value type.
-       x has layout any, which is not a sublayout of value.
+       The layout of type t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of type t_any must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}]
 
 (****************************************************************)
@@ -663,6 +711,9 @@ Line 4, characters 29-39:
 4 |   let print_one () = X.print (X.one ())
                                  ^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       X.t has layout any, which is not representable.
+       The layout of X.t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of X.t must be representable, because
+         it's the type of a function argument.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -37,7 +37,10 @@ Line 1, characters 32-34:
                                     ^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : void)
-       'a has layout void, which does not overlap with value.
+       The layout of 'a is void, because
+         of the definition of t at line 10, characters 2-20.
+       But the layout of 'a must overlap with value, because
+         the type argument of list has layout value.
 |}];;
 
 module type S1'' = S1 with type s = t_void;;
@@ -46,7 +49,10 @@ module type S1'' = S1 with type s = t_void;;
 Line 1, characters 27-42:
 1 | module type S1'' = S1 with type s = t_void;;
                                ^^^^^^^^^^^^^^^
-Error: Type t_void has layout void, which is not a sublayout of value.
+Error: The layout of type t_void is void, because
+         of the definition of t_void at line 5, characters 0-19.
+       But the layout of type t_void must be a sublayout of value, because
+         of the definition of s at line 11, characters 2-8.
 |}]
 
 module type S1_2 = sig
@@ -127,7 +133,10 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -182,7 +191,10 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type Bar3.t has layout value, which is not a sublayout of immediate.
+Error: The layout of type Bar3.t is value, because
+         of the annotation on the declaration of the type t.
+       But the layout of type Bar3.t must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -217,7 +229,10 @@ Line 2, characters 26-28:
 2 |   type 'a t = 'a Bar3.t * 'a list
                               ^^
 Error: This type ('a : void) should be an instance of type ('b : value)
-       'a has layout void, which does not overlap with value.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value, because
+         the type argument of list has layout value.
 |}];;
 
 (* One downside of the current approach - this could be allowed, but isn't.  You
@@ -245,7 +260,10 @@ Line 12, characters 11-17:
 12 |   type s = Foo3.t t
                 ^^^^^^
 Error: This type Foo3.t should be an instance of type ('a : void)
-       Foo3.t has layout value, which is not a sublayout of void.
+       The layout of Foo3.t is value, because
+         an abstract type has the value layout by default.
+       But the layout of Foo3.t must be a sublayout of void, because
+         of the definition of t at line 10, characters 2-20.
 |}];;
 
 (* Previous example works with annotation *)
@@ -295,7 +313,10 @@ Line 1, characters 11-15:
 1 | type t4' = M4.s t4_void;;
                ^^^^
 Error: This type M4.s should be an instance of type ('a : void)
-       M4.s has layout value, which is not a sublayout of void.
+       The layout of M4.s is value, because
+         of the definition of s at line 2, characters 2-21.
+       But the layout of M4.s must be a sublayout of void, because
+         of the definition of t4_void at line 8, characters 0-24.
 |}]
 
 module F4'(X : sig type t : immediate end) = struct
@@ -322,7 +343,10 @@ Line 1, characters 10-15:
 1 | type t4 = M4'.s t4_void;;
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : void)
-       M4'.s has layout immediate, which is not a sublayout of void.
+       The layout of M4'.s is immediate, because
+         of the definition of s at line 2, characters 2-45.
+       But the layout of M4'.s must be a sublayout of void, because
+         of the definition of t4_void at line 8, characters 0-24.
 |}];;
 
 (************************************)
@@ -352,7 +376,10 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       string has layout value, which is not a sublayout of immediate.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of immediate, because
+         of the definition of f at line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig
@@ -365,7 +392,10 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: Type string has layout value, which is not a sublayout of immediate.
+Error: The layout of type string is value, because
+         it is the primitive value type string.
+       But the layout of type string must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -388,7 +418,10 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : void
-       the first has layout value, which is not a sublayout of void.
+       The layout of the first is value, because
+         it's a type declaration in a first-class module.
+       But the layout of the first must be a sublayout of void, because
+         of the definition of t at line 2, characters 2-15.
 |}];;
 
 module type S6_3 = sig
@@ -404,7 +437,10 @@ Line 6, characters 33-34:
 6 |   val m : (module S6_3 with type t = t_void)
                                      ^
 Error: Signature package constraint types must have layout value.
-        t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 5, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's a type declaration in a first-class module.
 |}];;
 
 module type S6_5 = sig
@@ -425,7 +461,10 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         it's a type declaration in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -442,7 +481,10 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         it's a type declaration in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (* CR layouts: S6_6'' should be fixed *)
@@ -460,7 +502,10 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t : immediate
-       the first has layout value, which is not a sublayout of immediate.
+       The layout of the first is value, because
+         it's a type declaration in a first-class module.
+       But the layout of the first must be a sublayout of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (*****************************************)
@@ -486,7 +531,10 @@ Line 1, characters 28-33:
 1 | module type S = sig val x : t_any end
                                 ^^^^^
 Error: This type signature for x is not a value type.
-       x has layout any, which is not a sublayout of value.
+       The layout of type t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of type t_any must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}]
 
 (****************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
@@ -4,7 +4,10 @@ Line 2, characters 22-24:
 2 | type ('a : void) t0 = 'a list;;
                           ^^
 Error: This type ('a : value) should be an instance of type ('a0 : void)
-       'a has layout void, which does not overlap with value.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type t0.
+       But the layout of 'a must overlap with value, because
+         the type argument of list has layout value.
 Line 2, characters 11-15:
 2 | type ('a : valu) t0 = 'a list;;
                ^^^^

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -73,7 +73,10 @@ Lines 14-21, characters 2-3:
 21 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       void_rec has layout void, which is not a sublayout of value.
+       The layout of void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -132,7 +135,10 @@ Lines 4-11, characters 2-3:
 11 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       void_rec has layout void, which is not a sublayout of value.
+       The layout of void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -215,7 +221,10 @@ Lines 19-25, characters 5-23:
 25 |         (cons_r 1; b2))
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -316,8 +325,8 @@ let x : t_void = assert false;;
 Line 1, characters 4-5:
 1 | let x : t_void = assert false;;
         ^
-Error: Top-level module bindings must have layout value, but x has layout
-       void.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x has layout void.
 |}];;
 
 module M3_1 = struct
@@ -327,8 +336,8 @@ end;;
 Line 2, characters 6-7:
 2 |   let x : t_void = assert false;;
           ^
-Error: Top-level module bindings must have layout value, but x has layout
-       void.
+Error: Types of top-level module bindings must have layout value, but
+       the type of x has layout void.
 |}];;
 
 module M3_2 = struct
@@ -426,7 +435,10 @@ Line 5, characters 4-6:
         ^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -469,7 +481,16 @@ Lines 4-11, characters 2-24:
 11 |    b2 = (cons_r 2; {v})}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
+<<<<<<< HEAD
        void_rec has layout void, which is not a sublayout of value.
+||||||| parent of c77b6af8 (Enable layout histories (#1823))
+       t_void has layout void, which is not a sublayout of value.
+=======
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
+>>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -495,7 +516,16 @@ Lines 2-3, characters 2-32:
 3 |   (x, V b2.v, V b1.v, z, V a1.v)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
+<<<<<<< HEAD
        t_void has layout void, which is not a sublayout of value.
+||||||| parent of c77b6af8 (Enable layout histories (#1823))
+       void_rec has layout void, which is not a sublayout of value.
+=======
+       The layout of void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value, because
+         it has to be value for the V1 safety check.
+>>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -591,12 +621,47 @@ let [@warning "-10"] exnmatch1 (V v) =
 
 let _ = assert ((exnmatch1 vh) = 1);;
 [%%expect{|
+<<<<<<< HEAD
 Lines 3-5, characters 4-46:
 3 | ....{v = (if true then raise (Ex1 42); v)};
 4 |     if true then raise (Ex2 "test");
 5 |     {v = ((if true then raise (Ex3 true)); v)}
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        void_rec. Please report this error to the Jane Street compilers team.
+||||||| parent of c77b6af8 (Enable layout histories (#1823))
+Lines 1-13, characters 31-24:
+ 1 | ...............................(V v) =
+ 2 |   match
+ 3 |     {v = (if true then raise (Ex1 42); v)};
+ 4 |     if true then raise (Ex2 "test");
+ 5 |     {v = ((if true then raise (Ex3 true)); v)}
+...
+10 |   | exception Ex2 "test" -> 3
+11 |   | exception Ex2 _ -> 4
+12 |   | exception Ex3 true -> 5
+13 |   | exception Ex3 _ -> 6
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       t_void has layout void, which is not a sublayout of value.
+=======
+Lines 1-13, characters 31-24:
+ 1 | ...............................(V v) =
+ 2 |   match
+ 3 |     {v = (if true then raise (Ex1 42); v)};
+ 4 |     if true then raise (Ex2 "test");
+ 5 |     {v = ((if true then raise (Ex3 true)); v)}
+...
+10 |   | exception Ex2 "test" -> 3
+11 |   | exception Ex2 _ -> 4
+12 |   | exception Ex3 true -> 5
+13 |   | exception Ex3 _ -> 6
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
+>>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -622,12 +687,47 @@ let [@warning "-10"] exnmatch2 (V v) =
 
 let _ = assert ((exnmatch2 vh) = 3);;
 [%%expect{|
+<<<<<<< HEAD
 Lines 3-5, characters 4-46:
 3 | ....{v = v};
 4 |     if true then raise (Ex2 "test");
 5 |     {v = ((if true then raise (Ex3 true)); v)}
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        void_rec. Please report this error to the Jane Street compilers team.
+||||||| parent of c77b6af8 (Enable layout histories (#1823))
+Lines 1-13, characters 31-24:
+ 1 | ...............................(V v) =
+ 2 |   match
+ 3 |     {v = v};
+ 4 |     if true then raise (Ex2 "test");
+ 5 |     {v = ((if true then raise (Ex3 true)); v)}
+...
+10 |   | exception Ex2 "test" -> 3
+11 |   | exception Ex2 _ -> 4
+12 |   | exception Ex3 true -> 5
+13 |   | exception Ex3 _ -> 6
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       t_void has layout void, which is not a sublayout of value.
+=======
+Lines 1-13, characters 31-24:
+ 1 | ...............................(V v) =
+ 2 |   match
+ 3 |     {v = v};
+ 4 |     if true then raise (Ex2 "test");
+ 5 |     {v = ((if true then raise (Ex3 true)); v)}
+...
+10 |   | exception Ex2 "test" -> 3
+11 |   | exception Ex2 _ -> 4
+12 |   | exception Ex3 true -> 5
+13 |   | exception Ex3 _ -> 6
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
+>>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -652,11 +752,46 @@ let [@warning "-10"] exnmatch3 (V v) =
 
 let _ = assert ((exnmatch3 vh) = 5);;
 [%%expect{|
+<<<<<<< HEAD
 Lines 3-4, characters 4-46:
 3 | ....{v = v};
 4 |     {v = ((if true then raise (Ex3 true)); v)}
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        void_rec. Please report this error to the Jane Street compilers team.
+||||||| parent of c77b6af8 (Enable layout histories (#1823))
+Lines 1-12, characters 31-24:
+ 1 | ...............................(V v) =
+ 2 |   match
+ 3 |     {v = v};
+ 4 |     {v = ((if true then raise (Ex3 true)); v)}
+ 5 |   with
+...
+ 9 |   | exception Ex2 "test" -> 3
+10 |   | exception Ex2 _ -> 4
+11 |   | exception Ex3 true -> 5
+12 |   | exception Ex3 _ -> 6
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       t_void has layout void, which is not a sublayout of value.
+=======
+Lines 1-12, characters 31-24:
+ 1 | ...............................(V v) =
+ 2 |   match
+ 3 |     {v = v};
+ 4 |     {v = ((if true then raise (Ex3 true)); v)}
+ 5 |   with
+...
+ 9 |   | exception Ex2 "test" -> 3
+10 |   | exception Ex2 _ -> 4
+11 |   | exception Ex3 true -> 5
+12 |   | exception Ex3 _ -> 6
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
+>>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -681,11 +816,46 @@ let [@warning "-10"] exnmatch4 (V v) =
 
 let _ = assert ((exnmatch4 vh) = 0);;
 [%%expect{|
+<<<<<<< HEAD
 Lines 3-4, characters 4-11:
 3 | ....{v = v};
 4 |     {v = v}
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        void_rec. Please report this error to the Jane Street compilers team.
+||||||| parent of c77b6af8 (Enable layout histories (#1823))
+Lines 1-12, characters 31-24:
+ 1 | ...............................(V v) =
+ 2 |   match
+ 3 |     {v = v};
+ 4 |     {v = v}
+ 5 |   with
+...
+ 9 |   | exception Ex2 "test" -> 3
+10 |   | exception Ex2 _ -> 4
+11 |   | exception Ex3 true -> 5
+12 |   | exception Ex3 _ -> 6
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       t_void has layout void, which is not a sublayout of value.
+=======
+Lines 1-12, characters 31-24:
+ 1 | ...............................(V v) =
+ 2 |   match
+ 3 |     {v = v};
+ 4 |     {v = v}
+ 5 |   with
+...
+ 9 |   | exception Ex2 "test" -> 3
+10 |   | exception Ex2 _ -> 4
+11 |   | exception Ex3 true -> 5
+12 |   | exception Ex3 _ -> 6
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
+>>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -764,8 +934,17 @@ Lines 9-18, characters 2-29:
 18 |   cons_r uivrh.uivrh_x; uivrh
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
+<<<<<<< HEAD
        unboxed_inlined_void_rec has layout void,
          which is not a sublayout of value.
+||||||| parent of c77b6af8 (Enable layout histories (#1823))
+       t_void has layout void, which is not a sublayout of value.
+=======
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
+>>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -811,7 +990,10 @@ Lines 6-11, characters 2-7:
 11 |     end
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -876,7 +1058,10 @@ Lines 4-11, characters 2-11:
 11 |   (y, V v')
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -917,7 +1102,10 @@ Lines 4-12, characters 2-23:
 12 |   (x, V v1, V v2, V v3)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -481,16 +481,10 @@ Lines 4-11, characters 2-24:
 11 |    b2 = (cons_r 2; {v})}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-<<<<<<< HEAD
-       void_rec has layout void, which is not a sublayout of value.
-||||||| parent of c77b6af8 (Enable layout histories (#1823))
-       t_void has layout void, which is not a sublayout of value.
-=======
-       The layout of t_void is void, because
+       The layout of void_rec is void, because
          of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
+       But the layout of void_rec must be a sublayout of value, because
          it has to be value for the V1 safety check.
->>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -516,16 +510,10 @@ Lines 2-3, characters 2-32:
 3 |   (x, V b2.v, V b1.v, z, V a1.v)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-<<<<<<< HEAD
-       t_void has layout void, which is not a sublayout of value.
-||||||| parent of c77b6af8 (Enable layout histories (#1823))
-       void_rec has layout void, which is not a sublayout of value.
-=======
-       The layout of void_rec is void, because
+       The layout of t_void is void, because
          of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value, because
+       But the layout of t_void must be a sublayout of value, because
          it has to be value for the V1 safety check.
->>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -621,47 +609,12 @@ let [@warning "-10"] exnmatch1 (V v) =
 
 let _ = assert ((exnmatch1 vh) = 1);;
 [%%expect{|
-<<<<<<< HEAD
 Lines 3-5, characters 4-46:
 3 | ....{v = (if true then raise (Ex1 42); v)};
 4 |     if true then raise (Ex2 "test");
 5 |     {v = ((if true then raise (Ex3 true)); v)}
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        void_rec. Please report this error to the Jane Street compilers team.
-||||||| parent of c77b6af8 (Enable layout histories (#1823))
-Lines 1-13, characters 31-24:
- 1 | ...............................(V v) =
- 2 |   match
- 3 |     {v = (if true then raise (Ex1 42); v)};
- 4 |     if true then raise (Ex2 "test");
- 5 |     {v = ((if true then raise (Ex3 true)); v)}
-...
-10 |   | exception Ex2 "test" -> 3
-11 |   | exception Ex2 _ -> 4
-12 |   | exception Ex3 true -> 5
-13 |   | exception Ex3 _ -> 6
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
-=======
-Lines 1-13, characters 31-24:
- 1 | ...............................(V v) =
- 2 |   match
- 3 |     {v = (if true then raise (Ex1 42); v)};
- 4 |     if true then raise (Ex2 "test");
- 5 |     {v = ((if true then raise (Ex3 true)); v)}
-...
-10 |   | exception Ex2 "test" -> 3
-11 |   | exception Ex2 _ -> 4
-12 |   | exception Ex3 true -> 5
-13 |   | exception Ex3 _ -> 6
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
->>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -687,47 +640,12 @@ let [@warning "-10"] exnmatch2 (V v) =
 
 let _ = assert ((exnmatch2 vh) = 3);;
 [%%expect{|
-<<<<<<< HEAD
 Lines 3-5, characters 4-46:
 3 | ....{v = v};
 4 |     if true then raise (Ex2 "test");
 5 |     {v = ((if true then raise (Ex3 true)); v)}
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        void_rec. Please report this error to the Jane Street compilers team.
-||||||| parent of c77b6af8 (Enable layout histories (#1823))
-Lines 1-13, characters 31-24:
- 1 | ...............................(V v) =
- 2 |   match
- 3 |     {v = v};
- 4 |     if true then raise (Ex2 "test");
- 5 |     {v = ((if true then raise (Ex3 true)); v)}
-...
-10 |   | exception Ex2 "test" -> 3
-11 |   | exception Ex2 _ -> 4
-12 |   | exception Ex3 true -> 5
-13 |   | exception Ex3 _ -> 6
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
-=======
-Lines 1-13, characters 31-24:
- 1 | ...............................(V v) =
- 2 |   match
- 3 |     {v = v};
- 4 |     if true then raise (Ex2 "test");
- 5 |     {v = ((if true then raise (Ex3 true)); v)}
-...
-10 |   | exception Ex2 "test" -> 3
-11 |   | exception Ex2 _ -> 4
-12 |   | exception Ex3 true -> 5
-13 |   | exception Ex3 _ -> 6
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
->>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -752,46 +670,11 @@ let [@warning "-10"] exnmatch3 (V v) =
 
 let _ = assert ((exnmatch3 vh) = 5);;
 [%%expect{|
-<<<<<<< HEAD
 Lines 3-4, characters 4-46:
 3 | ....{v = v};
 4 |     {v = ((if true then raise (Ex3 true)); v)}
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        void_rec. Please report this error to the Jane Street compilers team.
-||||||| parent of c77b6af8 (Enable layout histories (#1823))
-Lines 1-12, characters 31-24:
- 1 | ...............................(V v) =
- 2 |   match
- 3 |     {v = v};
- 4 |     {v = ((if true then raise (Ex3 true)); v)}
- 5 |   with
-...
- 9 |   | exception Ex2 "test" -> 3
-10 |   | exception Ex2 _ -> 4
-11 |   | exception Ex3 true -> 5
-12 |   | exception Ex3 _ -> 6
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
-=======
-Lines 1-12, characters 31-24:
- 1 | ...............................(V v) =
- 2 |   match
- 3 |     {v = v};
- 4 |     {v = ((if true then raise (Ex3 true)); v)}
- 5 |   with
-...
- 9 |   | exception Ex2 "test" -> 3
-10 |   | exception Ex2 _ -> 4
-11 |   | exception Ex3 true -> 5
-12 |   | exception Ex3 _ -> 6
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
->>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -816,46 +699,11 @@ let [@warning "-10"] exnmatch4 (V v) =
 
 let _ = assert ((exnmatch4 vh) = 0);;
 [%%expect{|
-<<<<<<< HEAD
 Lines 3-4, characters 4-11:
 3 | ....{v = v};
 4 |     {v = v}
 Error: Non-value layout void detected in [Typeopt.layout] as sort for type
        void_rec. Please report this error to the Jane Street compilers team.
-||||||| parent of c77b6af8 (Enable layout histories (#1823))
-Lines 1-12, characters 31-24:
- 1 | ...............................(V v) =
- 2 |   match
- 3 |     {v = v};
- 4 |     {v = v}
- 5 |   with
-...
- 9 |   | exception Ex2 "test" -> 3
-10 |   | exception Ex2 _ -> 4
-11 |   | exception Ex3 true -> 5
-12 |   | exception Ex3 _ -> 6
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       t_void has layout void, which is not a sublayout of value.
-=======
-Lines 1-12, characters 31-24:
- 1 | ...............................(V v) =
- 2 |   match
- 3 |     {v = v};
- 4 |     {v = v}
- 5 |   with
-...
- 9 |   | exception Ex2 "test" -> 3
-10 |   | exception Ex2 _ -> 4
-11 |   | exception Ex3 true -> 5
-12 |   | exception Ex3 _ -> 6
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
->>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -934,17 +782,10 @@ Lines 9-18, characters 2-29:
 18 |   cons_r uivrh.uivrh_x; uivrh
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-<<<<<<< HEAD
-       unboxed_inlined_void_rec has layout void,
-         which is not a sublayout of value.
-||||||| parent of c77b6af8 (Enable layout histories (#1823))
-       t_void has layout void, which is not a sublayout of value.
-=======
-       The layout of t_void is void, because
+       The layout of unboxed_inlined_void_rec is void, because
          of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
+       But the layout of unboxed_inlined_void_rec must be a sublayout of value, because
          it has to be value for the V1 safety check.
->>>>>>> c77b6af8 (Enable layout histories (#1823))
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after

--- a/ocaml/testsuite/tests/typing-missing-cmi-2/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-2/test.compilers.reference
@@ -3,6 +3,9 @@ File "baz.ml", line 1, characters 8-18:
             ^^^^^^^^^^
 Error: This expression has type 'a Foo.t
        but an expression was expected of type ('b : '_representable_layout_1)
-       'a Foo.t has an unknown layout, which might not be representable.
+       The layout of 'a Foo.t is any, because
+         the .cmi file for Foo.t is missing.
+       But the layout of 'a Foo.t must be representable, because
+         it's the type of a variable bound by a `let`.
        No .cmi file found containing Foo.t.
        Hint: Adding "foo" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi-3/middle.ml
+++ b/ocaml/testsuite/tests/typing-missing-cmi-3/middle.ml
@@ -20,3 +20,5 @@ type ('a,'b) gadt =
 | G: ('a, 'a ti) gadt
 
 type 'a is_int = 'a Original.is_int = Is_int : int is_int
+
+type u = { y: Original.u } [@@unboxed]

--- a/ocaml/testsuite/tests/typing-missing-cmi-3/original.ml
+++ b/ocaml/testsuite/tests/typing-missing-cmi-3/original.ml
@@ -8,3 +8,5 @@ type s = S
 let s = S
 
 type _ is_int = Is_int : int is_int
+
+type u = int

--- a/ocaml/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/ocaml/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -116,3 +116,8 @@ let g : bool Middle.is_int -> 'a = function _ -> .
 val f : 'a Middle.is_int -> 'a -> int = <fun>
 val g : bool Middle.is_int -> 'a = <fun>
 |}]
+
+let f (x: Middle.u) = x
+[%%expect {|
+val f : Middle.u -> Middle.u = <fun>
+|}]

--- a/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
@@ -2,6 +2,9 @@ File "client.ml", line 2, characters 0-19:
 2 | and alias = missing
     ^^^^^^^^^^^^^^^^^^^
 Error: 
-       alias has an unknown layout, which might not be a sublayout of value.
+       The layout of alias is any, because
+         the .cmi file for Missing.t is missing.
+       But the layout of alias must be a sublayout of value, because
+         the type argument of list has layout value.
        No .cmi file found containing Missing.t.
        Hint: Adding "missing" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi/main.ml.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi/main.ml.reference
@@ -1,5 +1,0 @@
-File "main.ml", line 1, characters 14-17:
-Error: This expression has type M.b but an expression was expected of type
-         M.a
-M.b is abstract because no corresponding cmi file was found in path.
-M.a is abstract because no corresponding cmi file was found in path.

--- a/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -3,6 +3,9 @@ File "main.ml", line 1, characters 8-11:
             ^^^
 Error: This expression has type M.a but an expression was expected of type
          ('a : value)
-       M.a has an unknown layout, which might not be a sublayout of value.
+       The layout of M.a is any, because
+         the .cmi file for M.a is missing.
+       But the layout of M.a must be a sublayout of value, because
+         of layout requirements from an imported definition.
        No .cmi file found containing M.a.
        Hint: Adding "m" to your dependencies might help.

--- a/ocaml/testsuite/tests/warnings/w53.compilers.reference
+++ b/ocaml/testsuite/tests/warnings/w53.compilers.reference
@@ -927,3 +927,63 @@ File "w53.ml", line 427, characters 58-81:
 427 |   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
+
+File "w53.ml", line 432, characters 21-34:
+432 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
+                           ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 433, characters 19-32:
+433 |   type s1 = Foo1 [@error_message ""] (* rejected *)
+                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 434, characters 17-30:
+434 |   val x : int [@@error_message ""] (* rejected *)
+                       ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 436, characters 22-35:
+436 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 436, characters 51-64:
+436 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                                                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 438, characters 39-52:
+438 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+                                             ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 442, characters 21-34:
+442 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
+                           ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 443, characters 19-32:
+443 |   type s1 = Foo1 [@error_message ""] (* rejected *)
+                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 444, characters 22-35:
+444 |   let x : int = 42 [@@error_message ""] (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 446, characters 22-35:
+446 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 446, characters 51-64:
+446 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                                                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 448, characters 39-52:
+448 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+                                             ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/warnings/w53.ml
+++ b/ocaml/testsuite/tests/warnings/w53.ml
@@ -427,3 +427,23 @@ module TestOnlyGenerativeEffectsStruct = struct
   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
   external z : int -> int = "x" "y" [@@only_generative_effects] (* accepted *)
 end
+
+module type TestErrorMessageSig = sig
+  type 'a t1 = 'a [@@error_message ""] (* rejected *)
+  type s1 = Foo1 [@error_message ""] (* rejected *)
+  val x : int [@@error_message ""] (* rejected *)
+
+  external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+    "x" "y"
+  external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+end
+
+module TestErrorMessageStruct = struct
+  type 'a t1 = 'a [@@error_message ""] (* rejected *)
+  type s1 = Foo1 [@error_message ""] (* rejected *)
+  let x : int = 42 [@@error_message ""] (* rejected *)
+
+  external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+    "x" "y"
+  external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+end

--- a/ocaml/testsuite/tests/warnings/w53_marshalled.compilers.reference
+++ b/ocaml/testsuite/tests/warnings/w53_marshalled.compilers.reference
@@ -922,3 +922,63 @@ File "w53.ml", line 427, characters 58-81:
 427 |   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
+
+File "w53.ml", line 432, characters 21-34:
+432 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
+                           ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 433, characters 19-32:
+433 |   type s1 = Foo1 [@error_message ""] (* rejected *)
+                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 434, characters 17-30:
+434 |   val x : int [@@error_message ""] (* rejected *)
+                       ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 436, characters 22-35:
+436 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 436, characters 51-64:
+436 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                                                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 438, characters 39-52:
+438 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+                                             ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 442, characters 21-34:
+442 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
+                           ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 443, characters 19-32:
+443 |   type s1 = Foo1 [@error_message ""] (* rejected *)
+                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 444, characters 22-35:
+444 |   let x : int = 42 [@@error_message ""] (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 446, characters 22-35:
+446 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                            ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 446, characters 51-64:
+446 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+                                                         ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
+
+File "w53.ml", line 448, characters 39-52:
+448 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+                                             ^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -555,6 +555,29 @@ val check_type_jkind :
 val constrain_type_jkind :
   Env.t -> type_expr -> Jkind.t -> (unit, Jkind.Violation.t) result
 
+(* Update the jkind reason of all generalized type vars inside the given [type_expr]
+
+   Consider some code like
+
+    {[
+      let f : ('a : immediate). 'a -> 'a = fun x -> x in
+      let y = f "hello" in ...
+    ]}
+
+   This should be rejected, because a string is not immediate. But how should
+   we explain how the requirement to pass an immediate arises? We could point
+   the user to the [: immediate] annotation within the definition for [f]. But this
+   definition might be arbitrarily far away (including in another file), and the inference
+   to produce the fact that the type it works on must be immediate might be complex.
+
+   The design decision here is not to look within well-typed definitions for further
+   information about how jkind decisions arose. Other tooling -- such as merlin --
+   is more well suited for discovering properties of well-typed definitions. Instead,
+   once a definition is done being type-checked -- that is, once it is generalized --
+   we update the histories of all of its types' jkinds to just refer to the definition
+   itself. *)
+val update_generalized_ty_jkind_reason : type_expr -> Jkind.creation_reason -> unit
+
 (* False if running in principal mode and the type is not principal.
    True otherwise. *)
 val is_principal : type_expr -> bool

--- a/ocaml/typing/errortrace.ml
+++ b/ocaml/typing/errortrace.ml
@@ -112,6 +112,7 @@ type ('a, 'variety) elt =
   | Bad_jkind_sort : type_expr * Jkind.Violation.t -> ('a, _) elt
   | Unequal_var_jkinds :
       type_expr * Jkind.t * type_expr * Jkind.t -> ('a, _) elt
+  | Unequal_var_jkinds_with_no_history
 
 type ('a, 'variety) t = ('a, 'variety) elt list
 
@@ -128,6 +129,7 @@ let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
   | Bad_jkind _ as x -> x
   | Bad_jkind_sort _ as x -> x
   | Unequal_var_jkinds _ as x -> x
+  | Unequal_var_jkinds_with_no_history as x -> x
 
 let map f t = List.map (map_elt f) t
 

--- a/ocaml/typing/errortrace.mli
+++ b/ocaml/typing/errortrace.mli
@@ -97,6 +97,7 @@ type ('a, 'variety) elt =
   | Bad_jkind_sort : type_expr * Jkind.Violation.t -> ('a, _) elt
   | Unequal_var_jkinds :
       type_expr * Jkind.t * type_expr * Jkind.t -> ('a, _) elt
+  | Unequal_var_jkinds_with_no_history
 
 type ('a, 'variety) t = ('a, 'variety) elt list
 

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -636,14 +636,13 @@ type concrete_jkind_reason =
   | Match
   | Constructor_declaration of int
   | Label_declaration of Ident.t
-  | Unannotated_type_parameter
+  | Unannotated_type_parameter of Path.t
   | Record_projection
   | Record_assignment
   | Let_binding
   | Function_argument
   | Function_result
   | Structure_item_expression
-  | V1_safety_check
   | External_argument
   | External_result
   | Statement
@@ -664,7 +663,12 @@ type value_creation_reason =
   | Boxed_variant
   | Extensible_variant
   | Primitive of Ident.t
-  | Type_argument
+  | Type_argument of
+      { parent_path : Path.t;
+        position : int;
+        arity : int
+      }
+    (* [position] is 1-indexed *)
   | Tuple
   | Row_variable
   | Polymorphic_variant
@@ -680,7 +684,8 @@ type value_creation_reason =
   | Existential_type_variable
   | Array_element
   | Lazy_expression
-  | Class_argument
+  | Class_type_argument
+  | Class_term_argument
   | Structure_element
   | Debug_printer_argument
   | V1_safety_check
@@ -694,14 +699,13 @@ type immediate_creation_reason =
   | Primitive of Ident.t
   | Immediate_polymorphic_variant
   | Gc_ignorable_check
-  | Value_kind
 
 type immediate64_creation_reason =
   | Local_mode_cross_check
   | Gc_ignorable_check
   | Separability_check
 
-type void_creation_reason = V1_safety_check
+type void_creation_reason = |
 
 type any_creation_reason =
   | Missing_cmi of Path.t
@@ -723,15 +727,16 @@ type bits64_creation_reason = Primitive of Ident.t
 type annotation_context =
   | Type_declaration of Path.t
   | Type_parameter of Path.t * string option
-  | With_constraint of string
   | Newtype_declaration of string
   | Constructor_type_parameter of Path.t * string
   | Univar of string
   | Type_variable of string
   | Type_wildcard of Location.t
+  | With_error_message of string * annotation_context
 
 type creation_reason =
   | Annotated of annotation_context * Location.t
+  | Missing_cmi of Path.t
   | Value_creation of value_creation_reason
   | Immediate_creation of immediate_creation_reason
   | Immediate64_creation of immediate64_creation_reason
@@ -743,6 +748,13 @@ type creation_reason =
   | Bits64_creation of bits64_creation_reason
   | Concrete_creation of concrete_jkind_reason
   | Imported
+  | Imported_type_argument of
+      { parent_path : Path.t;
+        position : int;
+        arity : int
+      }
+  (* [position] is 1-indexed *)
+  | Generalized of Ident.t option * Location.t
 
 type interact_reason =
   | Gadt_equation of Path.t
@@ -966,6 +978,10 @@ let format ppf t = Format.fprintf ppf "%s" (to_string t)
 
 (***********************************)
 (* jkind histories *)
+let has_imported_history t =
+  match t with { history = Creation Imported } -> true | _ -> false
+
+let update_reason t reason = { t with history = Creation reason }
 
 let printtyp_path = ref (fun _ _ -> assert false)
 
@@ -1004,8 +1020,8 @@ end = struct
 
   let report_missing_cmi ppf = function
     | Some p ->
-      fprintf ppf "@,No .cmi file found containing %a." !printtyp_path p;
-      missing_cmi_hint ppf p
+      fprintf ppf "@,@[No .cmi file found containing %a.%a@]" !printtyp_path p
+        missing_cmi_hint p
     | None -> ()
 end
 
@@ -1015,7 +1031,7 @@ include Report_missing_cmi
    may want to change these to experiment / debug. *)
 
 (* should we print histories at all? *)
-let display_histories = false
+let display_histories = true
 
 (* should we print histories in a way users can understand?
    The alternative is to print out all the data, which may be useful
@@ -1033,41 +1049,63 @@ end = struct
 
   open Format
 
+  let format_with_notify_js ppf str =
+    fprintf ppf
+      "@[%s.@ Please notify the Jane Street compilers group if you see this \
+       output@]"
+      str
+
+  let format_position ~arity position =
+    let to_ordinal num = Int.to_string num ^ Misc.ordinal_suffix num in
+    match arity with 1 -> "" | _ -> to_ordinal position ^ " "
+
   let format_concrete_jkind_reason ppf : concrete_jkind_reason -> unit =
     function
-    | Match -> fprintf ppf "matched on"
-    | Constructor_declaration idx ->
-      fprintf ppf "used as constructor field %d" idx
+    | Match -> fprintf ppf "a value of this type is matched against a pattern"
+    | Constructor_declaration _ ->
+      fprintf ppf "it's the type of a constructor field"
     | Label_declaration lbl ->
-      fprintf ppf "used in the declaration of the record field \"%a\""
-        Ident.print lbl
-    | Unannotated_type_parameter ->
-      fprintf ppf "appears as an unannotated type parameter"
-    | Record_projection -> fprintf ppf "used as the record in a projection"
-    | Record_assignment -> fprintf ppf "used as the record in an assignment"
-    | Let_binding -> fprintf ppf "bound by a `let`"
-    | Function_argument -> fprintf ppf "used as a function argument"
-    | Function_result -> fprintf ppf "used as a function result"
+      fprintf ppf "it is the type of record field %s" (Ident.name lbl)
+    | Unannotated_type_parameter path ->
+      fprintf ppf "it instantiates an unannotated type parameter of %a"
+        !printtyp_path path
+    | Record_projection ->
+      fprintf ppf "it's the record type used in a projection"
+    | Record_assignment ->
+      fprintf ppf "it's the record type used in an assignment"
+    | Let_binding -> fprintf ppf "it's the type of a variable bound by a `let`"
+    | Function_argument -> fprintf ppf "it's the type of a function argument"
+    | Function_result -> fprintf ppf "it's the type of a function result"
     | Structure_item_expression ->
-      fprintf ppf "used in an expression in a structure"
-    | V1_safety_check -> fprintf ppf "part of the v1 safety check"
+      fprintf ppf "it's the type of an expression in a structure"
     | External_argument ->
-      fprintf ppf "used as an argument in an external declaration"
+      fprintf ppf "it's the type of an argument in an external declaration"
     | External_result ->
+<<<<<<< HEAD
       fprintf ppf "used as the result of an external declaration"
     | Statement -> fprintf ppf "used as a statement"
     | Optional_arg_default -> fprintf ppf "used as an optional argument default"
     | Wildcard -> fprintf ppf "a _ in a type"
     | Unification_var -> fprintf ppf "a fresh unification variable"
+||||||| parent of c77b6af8 (Enable layout histories (#1823))
+      fprintf ppf "used as the result of an external declaration"
+    | Statement -> fprintf ppf "used as a statement"
+    | Wildcard -> fprintf ppf "a _ in a type"
+    | Unification_var -> fprintf ppf "a fresh unification variable"
+=======
+      fprintf ppf "it's the type of the result of an external declaration"
+    | Statement -> fprintf ppf "it's the type of a statement"
+    | Wildcard -> fprintf ppf "it's a _ in the type"
+    | Unification_var -> fprintf ppf "it's a fresh unification variable"
+>>>>>>> c77b6af8 (Enable layout histories (#1823))
 
-  let format_annotation_context ppf : annotation_context -> unit = function
+  let rec format_annotation_context ppf : annotation_context -> unit = function
     | Type_declaration p ->
       fprintf ppf "the declaration of the type %a" !printtyp_path p
     | Type_parameter (path, var) ->
       let var_string = match var with None -> "_" | Some v -> "'" ^ v in
       fprintf ppf "@[%s@ in the declaration of the type@ %a@]" var_string
         !printtyp_path path
-    | With_constraint s -> fprintf ppf "the `with` constraint for %s" s
     | Newtype_declaration name ->
       fprintf ppf "the abstract type declaration for %s" name
     | Constructor_type_parameter (cstr, name) ->
@@ -1076,36 +1114,43 @@ end = struct
     | Univar name -> fprintf ppf "the universal variable %s" name
     | Type_variable name -> fprintf ppf "the type variable %s" name
     | Type_wildcard loc ->
-      fprintf ppf "the wildcard _ at %a" Location.print_loc loc
+      fprintf ppf "the wildcard _ at %a" Location.print_loc_in_lowercase loc
+    | With_error_message (_message, context) ->
+      (* message gets printed in [format_flattened_history] so we ignore it here *)
+      format_annotation_context ppf context
 
   let format_any_creation_reason ppf : any_creation_reason -> unit = function
-    | Missing_cmi p -> fprintf ppf "a missing .cmi file for %a" !printtyp_path p
+    | Missing_cmi p ->
+      fprintf ppf "the .cmi file for %a is missing" !printtyp_path p
+    | Wildcard -> format_with_notify_js ppf "there's a _ in the type"
+    | Unification_var ->
+      format_with_notify_js ppf "it's a fresh unification variable"
     | Initial_typedecl_env ->
-      fprintf ppf "a dummy layout used in checking mutually recursive datatypes"
+      format_with_notify_js ppf
+        "a dummy layout of any is used to check mutually recursive datatypes"
     | Dummy_jkind ->
-      fprintf ppf
-        "@[a dummy layout that should have been overwritten;@ Please notify \
-         the Jane Street compilers group if you see this output."
+      format_with_notify_js ppf
+        "it's assigned a dummy layout that should have been overwritten"
     (* CR layouts: Improve output or remove this constructor ^^ *)
     | Type_expression_call ->
-      fprintf ppf "a call to [type_expression] via the ocaml API"
+      format_with_notify_js ppf
+        "there's a call to [type_expression] via the ocaml API"
     | Inside_of_Tarrow -> fprintf ppf "argument or result of a function type"
-    | Wildcard -> fprintf ppf "a _ in a type"
-    | Unification_var -> fprintf ppf "a fresh unification variable"
 
   let format_immediate_creation_reason ppf : immediate_creation_reason -> _ =
     function
-    | Empty_record -> fprintf ppf "a record containing all void elements"
+    | Empty_record ->
+      fprintf ppf "it's a record type containing all void elements"
     | Enumeration ->
-      fprintf ppf "an enumeration variant (all constructors are constant)"
+      fprintf ppf
+        "it's an enumeration variant type (all constructors are constant)"
     | Primitive id ->
-      fprintf ppf "it equals the primitive immediate type %s" (Ident.name id)
+      fprintf ppf "it is the primitive immediate type %s" (Ident.name id)
     | Immediate_polymorphic_variant ->
-      fprintf ppf "an immediate polymorphic variant"
+      fprintf ppf
+        "it's an enumeration variant type (all constructors are constant)"
     | Gc_ignorable_check ->
       fprintf ppf "the check to see whether a value can be ignored by GC"
-    | Value_kind ->
-      fprintf ppf "the check to see whether a polymorphic variant is immediate"
 
   let format_immediate64_creation_reason ppf = function
     | Local_mode_cross_check ->
@@ -1116,63 +1161,76 @@ end = struct
       fprintf ppf "the check that a type is definitely not `float`"
 
   let format_value_creation_reason ppf : value_creation_reason -> _ = function
-    | Class_let_binding -> fprintf ppf "let-bound in a class expression"
-    | Tuple_element -> fprintf ppf "a tuple element"
-    | Probe -> fprintf ppf "a probe"
-    | Package_hack -> fprintf ppf "used as an element in a first-class module"
-    | Object -> fprintf ppf "an object"
-    | Instance_variable -> fprintf ppf "an instance variable"
-    | Object_field -> fprintf ppf "an object field"
-    | Class_field -> fprintf ppf "an class field"
-    | Boxed_record -> fprintf ppf "a boxed record"
-    | Boxed_variant -> fprintf ppf "a boxed variant"
-    | Extensible_variant -> fprintf ppf "an extensible variant"
+    | Class_let_binding ->
+      fprintf ppf "it's the type of a let-bound variable in a class expression"
+    | Tuple_element -> fprintf ppf "it's the type of a tuple element"
+    | Probe -> format_with_notify_js ppf "it's a probe"
+    | Package_hack ->
+      fprintf ppf "it's a type declaration in a first-class module"
+    | Object -> fprintf ppf "it's the type of an object"
+    | Instance_variable -> fprintf ppf "it's the type of an instance variable"
+    | Object_field -> fprintf ppf "it's the type of an object field"
+    | Class_field -> fprintf ppf "it's the type of a class field"
+    | Boxed_record -> fprintf ppf "it's a boxed record type"
+    | Boxed_variant -> fprintf ppf "it's a boxed variant type"
+    | Extensible_variant -> fprintf ppf "it's an extensible variant type"
     | Primitive id ->
-      fprintf ppf "it equals the primitive value type %s" (Ident.name id)
-    | Type_argument ->
-      fprintf ppf "a type argument defaulted to have layout value"
-    | Tuple -> fprintf ppf "a tuple type"
-    | Row_variable -> fprintf ppf "a row variable"
-    | Polymorphic_variant -> fprintf ppf "a polymorphic variant"
-    | Arrow -> fprintf ppf "a function type"
-    | Tfield -> fprintf ppf "an internal Tfield type (you shouldn't see this)"
-    | Tnil -> fprintf ppf "an internal Tnil type (you shouldn't see this)"
-    | First_class_module -> fprintf ppf "a first-class module type"
+      fprintf ppf "it is the primitive value type %s" (Ident.name id)
+    | Type_argument { parent_path; position; arity } ->
+      fprintf ppf "the %stype argument of %a has layout value"
+        (format_position ~arity position)
+        !printtyp_path parent_path
+    | Tuple -> fprintf ppf "it's a tuple type"
+    | Row_variable -> format_with_notify_js ppf "it's a row variable"
+    | Polymorphic_variant -> fprintf ppf "it's a polymorphic variant type"
+    | Arrow -> fprintf ppf "it's a function type"
+    | Tfield ->
+      format_with_notify_js ppf
+        "it's an internal Tfield type (you shouldn't see this)"
+    | Tnil ->
+      format_with_notify_js ppf
+        "it's an internal Tnil type (you shouldn't see this)"
+    | First_class_module -> fprintf ppf "it's a first-class module type"
     | Separability_check ->
       fprintf ppf "the check that a type is definitely not `float`"
-    | Univar -> fprintf ppf "an unannotated universal variable"
+    | Univar ->
+      fprintf ppf "it is or unifies with an unannotated universal variable"
     | Polymorphic_variant_field ->
-      fprintf ppf "a field of a polymorphic variant"
+      fprintf ppf "it's the type of the field of a polymorphic variant"
     | Default_type_jkind ->
-      fprintf ppf "the default layout for an abstract type"
-    | Float_record_field -> fprintf ppf "a field of a float record"
+      fprintf ppf "an abstract type has the value layout by default"
+    | Float_record_field -> fprintf ppf "it's the type of a float record field"
     | Existential_type_variable ->
-      fprintf ppf "an unannotated existential type variable"
-    | Array_element -> fprintf ppf "an array element"
-    | Lazy_expression -> fprintf ppf "a lazy expression"
-    | Class_argument ->
-      fprintf ppf "a term-level argument to a class constructor"
-    | Structure_element -> fprintf ppf "stored in a module structure"
+      fprintf ppf "it's an unannotated existential type variable"
+    | Array_element -> fprintf ppf "it's the type of an array element"
+    | Lazy_expression -> fprintf ppf "it's the type of a lazy expression"
+    | Class_type_argument ->
+      fprintf ppf "it's a type argument to a class constructor"
+    | Class_term_argument ->
+      fprintf ppf
+        "it's the type of a term-level argument to a class constructor"
+    | Structure_element ->
+      fprintf ppf "it's the type of something stored in a module structure"
     | Debug_printer_argument ->
-      fprintf ppf "used as the argument to a debugger printer function"
-    | V1_safety_check -> fprintf ppf "to be value for the V1 safety check"
-    | Captured_in_object -> fprintf ppf "captured in an object"
+      format_with_notify_js ppf
+        "it's the type of an argument to a debugger printer function"
+    | V1_safety_check ->
+      fprintf ppf "it has to be value for the V1 safety check"
+    | Captured_in_object ->
+      fprintf ppf "it's the type of a variable captured in an object"
     | Recmod_fun_arg ->
       fprintf ppf
-        "used as the first argument to a function in a recursive module"
+        "it's the type of the first argument to a function in a recursive \
+         module"
     | Unknown s ->
       fprintf ppf
         "unknown @[(please alert the Jane Street@;\
          compilers team with this message: %s)@]" s
 
-  let format_void_creation_reason ppf : void_creation_reason -> _ = function
-    | V1_safety_check -> fprintf ppf "check to make sure there are no voids"
-  (* CR layouts: remove this when we remove its uses *)
-
   let format_float64_creation_reason ppf : float64_creation_reason -> _ =
     function
     | Primitive id ->
-      fprintf ppf "it equals the primitive value type %s" (Ident.name id)
+      fprintf ppf "it is the primitive float64 type %s" (Ident.name id)
 
   let format_word_creation_reason ppf : word_creation_reason -> _ = function
     | Primitive id ->
@@ -1189,19 +1247,33 @@ end = struct
   let format_creation_reason ppf : creation_reason -> unit = function
     | Annotated (ctx, _) ->
       fprintf ppf "of the annotation on %a" format_annotation_context ctx
+    | Missing_cmi p ->
+      fprintf ppf "the .cmi file for %a is missing" !printtyp_path p
     | Any_creation any -> format_any_creation_reason ppf any
     | Immediate_creation immediate ->
       format_immediate_creation_reason ppf immediate
     | Immediate64_creation immediate64 ->
       format_immediate64_creation_reason ppf immediate64
-    | Void_creation void -> format_void_creation_reason ppf void
+    | Void_creation _ -> .
     | Value_creation value -> format_value_creation_reason ppf value
     | Float64_creation float -> format_float64_creation_reason ppf float
     | Word_creation word -> format_word_creation_reason ppf word
     | Bits32_creation bits32 -> format_bits32_creation_reason ppf bits32
     | Bits64_creation bits64 -> format_bits64_creation_reason ppf bits64
     | Concrete_creation concrete -> format_concrete_jkind_reason ppf concrete
-    | Imported -> fprintf ppf "imported from another compilation unit"
+    | Imported ->
+      fprintf ppf "of layout requirements from an imported definition"
+    | Imported_type_argument { parent_path; position; arity } ->
+      fprintf ppf "the %stype argument of %a has this layout"
+        (format_position ~arity position)
+        !printtyp_path parent_path
+    | Generalized (id, loc) ->
+      let format_id ppf = function
+        | Some id -> fprintf ppf " of %s" (Ident.name id)
+        | None -> ()
+      in
+      fprintf ppf "of the definition%a at %a" format_id id
+        Location.print_loc_in_lowercase loc
 
   let format_interact_reason ppf = function
     | Gadt_equation name ->
@@ -1209,76 +1281,29 @@ end = struct
     | Tyvar_refinement_intersection -> fprintf ppf "updating a type variable"
     | Subjkind -> fprintf ppf "sublayout check"
 
-  (* a flattened_history describes the history of a jkind L. That
-     jkind has been constrained to be a subjkind of jkinds L1..Ln.
-     Each element in a flattened_history includes a jkind desc Li and the
-     set of circumstances that gave rise to a constraint of that jkind.
-     Any jkinds Lk such that an Li < Lk doesn't contribute to the choice
-     of L and is thus omitted from a flattened_history.
+  (* CR layouts: An older implementation of format_flattened_history existed
+      which displays more information not limited to one layout and one creation_reason
+      around commit 66a832d70bf61d9af3b0ec6f781dcf0a188b324d in main.
 
-     INVARIANT: the creation_reasons within a list all are reasons for
-     the jkind they are paired with.
-     INVARIANT: L is a subjkind of all the Li in a flattened_history.
-     INVARIANT: If Li and Lj are stored in different entries in a
-     flattened_history, then not (Li <= Lj) and not (Lj <= Li).
-     This implies that no two elements in a flattened_history have the
-     same jkind in them.
-     INVARIANT: no list in this structure is empty
-
-     Both levels of list are unordered.
-
-     Because a flattened_history stores [desc]s, it should be discarded
-     promptly after use.
-
-     This type could be more efficient in several ways, but there is
-     little incentive to do so. *)
-  type flattened_row = Desc.t * creation_reason list
-
-  type flattened_history = flattened_row list
-
-  (* first arg is the jkind L whose history we are flattening *)
-  let flatten_history : Jkind_desc.t -> history -> flattened_history =
-    let add jkind reason =
-      let jkind_desc = Jkind_desc.get jkind in
-      let rec go acc = function
-        | ((key, value) as row) :: rest -> (
-          match Desc.sub jkind_desc key with
-          | Sub -> go acc rest
-          | Equal -> ((key, reason :: value) :: acc) @ rest
-          | Not_sub -> go (row :: acc) rest)
-        | [] -> (jkind_desc, [reason]) :: acc
-      in
-      go []
-    in
-    let rec history acc internal = function
-      | Interact { reason = _; lhs_jkind; lhs_history; rhs_jkind; rhs_history }
-        ->
-        let fh1 = history acc lhs_jkind lhs_history in
-        let fh2 = history fh1 rhs_jkind rhs_history in
-        fh2
-      | Creation reason -> add internal reason acc
-    in
-    fun internal hist -> history [] internal hist
-
-  let format_flattened_row ppf (lay, reasons) =
-    fprintf ppf "%a, because" Desc.format lay;
-    match reasons with
-    | [reason] -> fprintf ppf "@ %a." format_creation_reason reason
-    | _ ->
-      fprintf ppf " all of the following:@ @[<v 2>  %a@]"
-        (pp_print_list format_creation_reason)
-        reasons
+      Consider revisiting that if the current implementation becomes insufficient. *)
 
   let format_flattened_history ~intro ppf t =
-    let fh = flatten_history t.jkind t.history in
-    fprintf ppf "@[<v 2>%t " intro;
-    (match fh with
-    | [row] -> format_flattened_row ppf row
-    | _ ->
-      fprintf ppf "a sublayout of all of the following:@ @[<v 2>  %a@]"
-        (pp_print_list format_flattened_row)
-        fh);
-    fprintf ppf "@]@;"
+    let jkind_desc = Jkind_desc.get t.jkind in
+    fprintf ppf "@[<v 2>%t" intro;
+    (match t.history with
+    | Creation reason -> (
+      fprintf ppf ", because@ %a" format_creation_reason reason;
+      match reason, jkind_desc with
+      | Concrete_creation _, Const _ ->
+        fprintf ppf ", defaulted to layout %a" Desc.format jkind_desc
+      | _ -> ())
+    | _ -> assert false);
+    fprintf ppf ".";
+    (match t.history with
+    | Creation (Annotated (With_error_message (message, _), _)) ->
+      fprintf ppf "@ @[%s@]" message
+    | _ -> ());
+    fprintf ppf "@]"
 
   (* this isn't really formatted for user consumption *)
   let format_history_tree ~intro ppf t =
@@ -1322,10 +1347,7 @@ module Violation = struct
      the choice of error message. (Though the [Path.t] payload *is*
      indeed just about the payload.) *)
 
-  let of_ violation = { violation; missing_cmi = None }
-
-  let record_missing_cmi ~missing_cmi_for t =
-    { t with missing_cmi = Some missing_cmi_for }
+  let of_ ?missing_cmi violation = { violation; missing_cmi }
 
   let is_missing_cmi { missing_cmi } = Option.is_some missing_cmi
 
@@ -1338,6 +1360,15 @@ module Violation = struct
     let l1, l2, fmt_l1, fmt_l2, missing_cmi_option =
       match t with
       | { violation = Not_a_subjkind (l1, l2); missing_cmi } -> (
+        let missing_cmi =
+          match missing_cmi with
+          | None -> (
+            match l1.history with
+            | Creation (Missing_cmi p) -> Some p
+            | Creation (Any_creation (Missing_cmi p)) -> Some p
+            | _ -> None)
+          | Some _ -> missing_cmi
+        in
         match missing_cmi with
         | None ->
           ( l1,
@@ -1362,16 +1393,18 @@ module Violation = struct
     if display_histories
     then
       let connective =
-        match t.violation with
-        | Not_a_subjkind _ -> "be a sublayout of"
-        | No_intersection _ -> "overlap with"
+        match t.violation, get l2 with
+        | Not_a_subjkind _, Const _ -> dprintf "be a sublayout of %a" format l2
+        | No_intersection _, Const _ -> dprintf "overlap with %a" format l2
+        | _, Var _ -> dprintf "be representable"
       in
-      fprintf ppf "%a%a"
-        (format_history ~intro:(dprintf "The layout of %a is" pp_former former))
+      fprintf ppf "@[<v>%a@;%a@]"
+        (format_history
+           ~intro:(dprintf "The layout of %a is %a" pp_former former format l1))
         l1
         (format_history
            ~intro:
-             (dprintf "But the layout of %a must %s" pp_former former connective))
+             (dprintf "But the layout of %a must %t" pp_former former connective))
         l2
     else
       fprintf ppf "@[<hov 2>%s%a has %t,@ which %t.@]" preamble pp_former former
@@ -1400,14 +1433,38 @@ let equal = equate_or_equal ~allow_mutation:true
 
 let equate = equate_or_equal ~allow_mutation:true
 
+(* Not all jkind history reasons are created equal. Some are more helpful than others.
+    This function encodes that information.
+
+    The reason with higher score should get preserved when combined with one of lower
+    score. *)
+let score_reason = function
+  (* error_message annotated by the user should always take priority *)
+  | Creation (Annotated (With_error_message _, _)) -> 1
+  (* Concrete creation is quite vague, prefer more specific reasons *)
+  | Creation (Concrete_creation _) -> -1
+  | _ -> 0
+
 let combine_histories reason lhs rhs =
-  Interact
-    { reason;
-      lhs_jkind = lhs.jkind;
-      lhs_history = lhs.history;
-      rhs_jkind = rhs.jkind;
-      rhs_history = rhs.history
-    }
+  if flattened_histories
+  then
+    match Desc.sub (Jkind_desc.get lhs.jkind) (Jkind_desc.get rhs.jkind) with
+    | Sub -> lhs.history
+    | Not_sub ->
+      rhs.history
+      (* CR layouts: this will be wrong if we ever have a non-trivial meet in the layout lattice *)
+    | Equal ->
+      if score_reason lhs.history >= score_reason rhs.history
+      then lhs.history
+      else rhs.history
+  else
+    Interact
+      { reason;
+        lhs_jkind = lhs.jkind;
+        lhs_history = lhs.history;
+        rhs_jkind = rhs.jkind;
+        rhs_history = rhs.history
+      }
 
 let intersection ~reason t1 t2 =
   match Jkind_desc.intersection t1.jkind t2.jkind with
@@ -1446,14 +1503,14 @@ module Debug_printers = struct
       fprintf ppf "Constructor_declaration %d" idx
     | Label_declaration lbl ->
       fprintf ppf "Label_declaration %a" Ident.print lbl
-    | Unannotated_type_parameter -> fprintf ppf "Unannotated_type_parameter"
+    | Unannotated_type_parameter path ->
+      fprintf ppf "Unannotated_type_parameter %a" !printtyp_path path
     | Record_projection -> fprintf ppf "Record_projection"
     | Record_assignment -> fprintf ppf "Record_assignment"
     | Let_binding -> fprintf ppf "Let_binding"
     | Function_argument -> fprintf ppf "Function_argument"
     | Function_result -> fprintf ppf "Function_result"
     | Structure_item_expression -> fprintf ppf "Structure_item_expression"
-    | V1_safety_check -> fprintf ppf "V1_safety_check"
     | External_argument -> fprintf ppf "External_argument"
     | External_result -> fprintf ppf "External_result"
     | Statement -> fprintf ppf "Statement"
@@ -1461,13 +1518,12 @@ module Debug_printers = struct
     | Unification_var -> fprintf ppf "Unification_var"
     | Optional_arg_default -> fprintf ppf "Optional_arg_default"
 
-  let annotation_context ppf : annotation_context -> unit = function
+  let rec annotation_context ppf : annotation_context -> unit = function
     | Type_declaration p -> fprintf ppf "Type_declaration %a" Path.print p
     | Type_parameter (p, var) ->
       fprintf ppf "Type_parameter (%a, %a)" Path.print p
         (Misc.Stdlib.Option.print Misc.Stdlib.String.print)
         var
-    | With_constraint s -> fprintf ppf "With_constraint %S" s
     | Newtype_declaration name -> fprintf ppf "Newtype_declaration %s" name
     | Constructor_type_parameter (cstr, name) ->
       fprintf ppf "Constructor_type_parameter (%a, %S)" Path.print cstr name
@@ -1475,6 +1531,9 @@ module Debug_printers = struct
     | Type_variable name -> fprintf ppf "Type_variable %S" name
     | Type_wildcard loc ->
       fprintf ppf "Type_wildcard (%a)" Location.print_loc loc
+    | With_error_message (message, context) ->
+      fprintf ppf "With_error_message (%s, %a)" message annotation_context
+        context
 
   let any_creation_reason ppf : any_creation_reason -> unit = function
     | Missing_cmi p -> fprintf ppf "Missing_cmi %a" Path.print p
@@ -1492,7 +1551,6 @@ module Debug_printers = struct
     | Immediate_polymorphic_variant ->
       fprintf ppf "Immediate_polymorphic_variant"
     | Gc_ignorable_check -> fprintf ppf "Gc_ignorable_check"
-    | Value_kind -> fprintf ppf "Value_kind"
 
   let immediate64_creation_reason ppf = function
     | Local_mode_cross_check -> fprintf ppf "Local_mode_cross_check"
@@ -1512,7 +1570,9 @@ module Debug_printers = struct
     | Boxed_variant -> fprintf ppf "Boxed_variant"
     | Extensible_variant -> fprintf ppf "Extensible_variant"
     | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
-    | Type_argument -> fprintf ppf "Type_argument"
+    | Type_argument { parent_path; position; arity } ->
+      fprintf ppf "Type_argument (pos %d, arity %d) of %a" position arity
+        !printtyp_path parent_path
     | Tuple -> fprintf ppf "Tuple"
     | Row_variable -> fprintf ppf "Row_variable"
     | Polymorphic_variant -> fprintf ppf "Polymorphic_variant"
@@ -1528,16 +1588,14 @@ module Debug_printers = struct
     | Existential_type_variable -> fprintf ppf "Existential_type_variable"
     | Array_element -> fprintf ppf "Array_element"
     | Lazy_expression -> fprintf ppf "Lazy_expression"
-    | Class_argument -> fprintf ppf "Class_argument"
+    | Class_type_argument -> fprintf ppf "Class_type_argument"
+    | Class_term_argument -> fprintf ppf "Class_term_argument"
     | Structure_element -> fprintf ppf "Structure_element"
     | Debug_printer_argument -> fprintf ppf "Debug_printer_argument"
     | V1_safety_check -> fprintf ppf "V1_safety_check"
     | Captured_in_object -> fprintf ppf "Captured_in_object"
     | Recmod_fun_arg -> fprintf ppf "Recmod_fun_arg"
     | Unknown s -> fprintf ppf "Unknown %s" s
-
-  let void_creation_reason ppf : void_creation_reason -> _ = function
-    | V1_safety_check -> fprintf ppf "V1_safety_check"
 
   let float64_creation_reason ppf : float64_creation_reason -> _ = function
     | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
@@ -1555,6 +1613,7 @@ module Debug_printers = struct
     | Annotated (ctx, loc) ->
       fprintf ppf "Annotated (%a,%a)" annotation_context ctx Location.print_loc
         loc
+    | Missing_cmi p -> fprintf ppf "Missing_cmi %a" !printtyp_path p
     | Any_creation any -> fprintf ppf "Any_creation %a" any_creation_reason any
     | Immediate_creation immediate ->
       fprintf ppf "Immediate_creation %a" immediate_creation_reason immediate
@@ -1563,8 +1622,7 @@ module Debug_printers = struct
         immediate64
     | Value_creation value ->
       fprintf ppf "Value_creation %a" value_creation_reason value
-    | Void_creation void ->
-      fprintf ppf "Void_creation %a" void_creation_reason void
+    | Void_creation _ -> .
     | Float64_creation float ->
       fprintf ppf "Float64_creation %a" float64_creation_reason float
     | Word_creation word ->
@@ -1576,6 +1634,13 @@ module Debug_printers = struct
     | Concrete_creation concrete ->
       fprintf ppf "Concrete_creation %a" concrete_jkind_reason concrete
     | Imported -> fprintf ppf "Imported"
+    | Imported_type_argument { parent_path; position; arity } ->
+      fprintf ppf "Imported_type_argument (pos %d, arity %d) of %a" position
+        arity !printtyp_path parent_path
+    | Generalized (id, loc) ->
+      fprintf ppf "Generalized (%s, %a)"
+        (match id with Some id -> Ident.unique_name id | None -> "")
+        Location.print_loc loc
 
   let interact_reason ppf = function
     | Gadt_equation p -> fprintf ppf "Gadt_equation %a" Path.print p

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1081,23 +1081,11 @@ end = struct
     | External_argument ->
       fprintf ppf "it's the type of an argument in an external declaration"
     | External_result ->
-<<<<<<< HEAD
-      fprintf ppf "used as the result of an external declaration"
-    | Statement -> fprintf ppf "used as a statement"
-    | Optional_arg_default -> fprintf ppf "used as an optional argument default"
-    | Wildcard -> fprintf ppf "a _ in a type"
-    | Unification_var -> fprintf ppf "a fresh unification variable"
-||||||| parent of c77b6af8 (Enable layout histories (#1823))
-      fprintf ppf "used as the result of an external declaration"
-    | Statement -> fprintf ppf "used as a statement"
-    | Wildcard -> fprintf ppf "a _ in a type"
-    | Unification_var -> fprintf ppf "a fresh unification variable"
-=======
       fprintf ppf "it's the type of the result of an external declaration"
     | Statement -> fprintf ppf "it's the type of a statement"
     | Wildcard -> fprintf ppf "it's a _ in the type"
     | Unification_var -> fprintf ppf "it's a fresh unification variable"
->>>>>>> c77b6af8 (Enable layout histories (#1823))
+    | Optional_arg_default -> fprintf ppf "it's the type of an optional argument default"
 
   let rec format_annotation_context ppf : annotation_context -> unit = function
     | Type_declaration p ->

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1085,7 +1085,8 @@ end = struct
     | Statement -> fprintf ppf "it's the type of a statement"
     | Wildcard -> fprintf ppf "it's a _ in the type"
     | Unification_var -> fprintf ppf "it's a fresh unification variable"
-    | Optional_arg_default -> fprintf ppf "it's the type of an optional argument default"
+    | Optional_arg_default ->
+      fprintf ppf "it's the type of an optional argument default"
 
   let rec format_annotation_context ppf : annotation_context -> unit = function
     | Type_declaration p ->

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -185,14 +185,13 @@ type concrete_jkind_reason =
   | Match
   | Constructor_declaration of int
   | Label_declaration of Ident.t
-  | Unannotated_type_parameter
+  | Unannotated_type_parameter of Path.t
   | Record_projection
   | Record_assignment
   | Let_binding
   | Function_argument
   | Function_result
   | Structure_item_expression
-  | V1_safety_check
   | External_argument
   | External_result
   | Statement
@@ -203,12 +202,12 @@ type concrete_jkind_reason =
 type annotation_context =
   | Type_declaration of Path.t
   | Type_parameter of Path.t * string option
-  | With_constraint of string
   | Newtype_declaration of string
   | Constructor_type_parameter of Path.t * string
   | Univar of string
   | Type_variable of string
   | Type_wildcard of Location.t
+  | With_error_message of string * annotation_context
 
 type value_creation_reason =
   | Class_let_binding
@@ -223,7 +222,12 @@ type value_creation_reason =
   | Boxed_variant
   | Extensible_variant
   | Primitive of Ident.t
-  | Type_argument (* CR layouts: Should this take a Path.t? *)
+  | Type_argument of
+      { parent_path : Path.t;
+        position : int;
+        arity : int
+      }
+  (* [position] is 1-indexed *)
   | Tuple
   | Row_variable
   | Polymorphic_variant
@@ -239,7 +243,8 @@ type value_creation_reason =
   | Existential_type_variable
   | Array_element
   | Lazy_expression
-  | Class_argument
+  | Class_type_argument
+  | Class_term_argument
   | Structure_element
   | Debug_printer_argument
   | V1_safety_check
@@ -253,14 +258,17 @@ type immediate_creation_reason =
   | Primitive of Ident.t
   | Immediate_polymorphic_variant
   | Gc_ignorable_check
-  | Value_kind
+(* CR layouts v2.8: Remove Gc_ignorable_check after the check uses modal kinds *)
 
 type immediate64_creation_reason =
   | Local_mode_cross_check
+  (* CR layouts v2.8: Remove Local_mode_cross_check after the check uses modal kinds *)
   | Gc_ignorable_check
+  (* CR layouts v2.8: Remove Gc_ignorable_check after the check uses modal kinds *)
   | Separability_check
 
-type void_creation_reason = V1_safety_check
+(* CR layouts v5: make new void_creation_reasons *)
+type void_creation_reason = |
 
 type any_creation_reason =
   | Missing_cmi of Path.t
@@ -284,6 +292,7 @@ type bits64_creation_reason = Primitive of Ident.t
 
 type creation_reason =
   | Annotated of annotation_context * Location.t
+  | Missing_cmi of Path.t
   | Value_creation of value_creation_reason
   | Immediate_creation of immediate_creation_reason
   | Immediate64_creation of immediate64_creation_reason
@@ -295,6 +304,13 @@ type creation_reason =
   | Bits64_creation of bits64_creation_reason
   | Concrete_creation of concrete_jkind_reason
   | Imported
+  | Imported_type_argument of
+      { parent_path : Path.t;
+        position : int;
+        arity : int
+      }
+  (* [position] is 1-indexed *)
+  | Generalized of Ident.t option * Location.t
 
 type interact_reason =
   | Gadt_equation of Path.t
@@ -309,10 +325,9 @@ module Violation : sig
 
   type t
 
-  val of_ : violation -> t
+  (** Set [?missing_cmi] to mark [t] as having arisen from a missing cmi *)
 
-  (** Mark a [t] as having arisen from a missing cmi *)
-  val record_missing_cmi : missing_cmi_for:Path.t -> t -> t
+  val of_ : ?missing_cmi:Path.t -> violation -> t
 
   (** Is this error from a missing cmi? *)
   val is_missing_cmi : t -> bool
@@ -504,6 +519,13 @@ val format_history :
 (** Provides the [Printtyp.path] formatter back up the dependency chain to
     this module. *)
 val set_printtyp_path : (Format.formatter -> Path.t -> unit) -> unit
+
+(******************************)
+(* history *)
+
+val has_imported_history : t -> bool
+
+val update_reason : t -> creation_reason -> t
 
 (******************************)
 (* relations *)

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -188,6 +188,12 @@ let predef_jkind_annotation const =
        const, user_written)
     const
 
+let option_argument_jkind = Jkind.value ~why:(
+  Type_argument {parent_path = path_option; position = 1; arity = 1})
+
+let list_argument_jkind = Jkind.value ~why:(
+  Type_argument {parent_path = path_list; position = 1; arity = 1})
+
 let mk_add_type add_type
       ?manifest type_ident
       ?(kind=Type_abstract Abstract_def)
@@ -229,7 +235,8 @@ let build_initial_env add_type add_extension empty_env =
         *)
         ?jkind_annotation
       ~variance ~separability env =
-    let param = newgenvar (Jkind.value ~why:Type_argument) in
+    let param = newgenvar (Jkind.value ~why:(
+      Type_argument {parent_path = Path.Pident type_ident; position = 1; arity = 1})) in
     let decl =
       {type_params = [param];
        type_arity = 1;
@@ -301,7 +308,7 @@ let build_initial_env add_type add_extension empty_env =
          variant [cstr ident_nil [];
                   cstr ident_cons [tvar, Unrestricted;
                                    type_list tvar, Unrestricted]]
-           [| [| |]; [| Jkind.value ~why:Type_argument;
+           [| [| |]; [| list_argument_jkind;
                         Jkind.value ~why:Boxed_variant |] |] )
        ~jkind:(Jkind.value ~why:Boxed_variant)
   |> add_type ident_nativeint
@@ -310,7 +317,7 @@ let build_initial_env add_type add_extension empty_env =
        ~separability:Separability.Ind
        ~kind:(fun tvar ->
          variant [cstr ident_none []; cstr ident_some [tvar, Unrestricted]]
-           [| [| |]; [| Jkind.value ~why:Type_argument |] |])
+           [| [| |]; [| option_argument_jkind |] |])
        ~jkind:(Jkind.value ~why:Boxed_variant)
   |> add_type ident_string
   |> add_type ident_unboxed_float

--- a/ocaml/typing/predef.mli
+++ b/ocaml/typing/predef.mli
@@ -87,6 +87,11 @@ val ident_cons : Ident.t
 val ident_none : Ident.t
 val ident_some : Ident.t
 
+(* The jkind used for optional function argument types *)
+val option_argument_jkind : Jkind.t
+(* The jkind used for list argument types *)
+val list_argument_jkind : Jkind.t
+
 (* To build the initial environment. Since there is a nasty mutual
    recursion between predef and env, we break it by parameterizing
    over Env.t, Env.add_type and Env.add_extension. *)

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -2825,11 +2825,14 @@ let explanation (type variety) intro prev env
               (Jkind.Violation.report_with_offender_sort
                  ~offender:(fun ppf -> type_expr ppf t)) e)
   | Errortrace.Unequal_var_jkinds (t1,l1,t2,l2) ->
-      let fmt_history t =
-        Jkind.format_history ~intro:(fun ppf -> type_expr ppf t)
+      let fmt_history t l ppf =
+        Jkind.(format_history ~intro:(
+          dprintf "The layout of %a is %a" type_expr t format l) ppf l)
       in
-      Some (dprintf "@ because their layouts are different.@[<v>%a%a@]"
-              (fmt_history t1) l1 (fmt_history t2) l2)
+      Some (dprintf "@ because their layouts are different.@ @[<v>%t@;%t@]"
+              (fmt_history t1 l1) (fmt_history t2 l2))
+  | Errortrace.Unequal_var_jkinds_with_no_history ->
+      Some (dprintf "@ because their layouts are different.")
 
 let mismatch intro env trace =
   Errortrace.explain trace (fun ~prev h -> explanation intro prev env h)
@@ -2892,7 +2895,8 @@ let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
       tr
   in
   let jkind_error = match Misc.last tr with
-    | Some (Bad_jkind _ | Bad_jkind_sort _ | Unequal_var_jkinds _) ->
+    | Some (Bad_jkind _ | Bad_jkind_sort _ | Unequal_var_jkinds _
+           | Unequal_var_jkinds_with_no_history) ->
         true
     | Some (Diff _ | Escape _ | Variant _ | Obj _ | Incompatible_fields _
            | Rec_occur _)

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -47,6 +47,7 @@ type type_forcing_context =
   | Comprehension_for_start
   | Comprehension_for_stop
   | Comprehension_when
+  | Error_message_attr of string
 
 (* The combination of a type and a "type forcing context". The intent is that it
    describes a type that is "expected" (required) by the context. If unifying

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -80,7 +80,7 @@ type error =
       ; err : Jkind.Violation.t
       }
   | Jkind_empty_record
-  | Non_value_in_sig of Jkind.Violation.t * string
+  | Non_value_in_sig of Jkind.Violation.t * string * type_expr
   | Invalid_jkind_in_block of type_expr * Jkind.Sort.const * jkind_sort_loc
   | Mixed_block
   | Separability of Typedecl_separability.error
@@ -1220,6 +1220,20 @@ let update_decl_jkind env dpath decl =
     end;
   new_decl
 
+let update_decls_jkind_reason decls =
+  List.map
+    (fun (id, decl) ->
+       let reason = Jkind.(Generalized (Some id, decl.type_loc)) in
+       let update_generalized ty = Ctype.update_generalized_ty_jkind_reason ty reason in
+       List.iter update_generalized decl.type_params;
+       Btype.iter_type_expr_kind update_generalized decl.type_kind;
+       Option.iter update_generalized decl.type_manifest;
+       let new_decl = {decl with type_jkind =
+                                   Jkind.(update_reason decl.type_jkind reason)} in
+       (id, new_decl)
+    )
+    decls
+
 let update_decls_jkind env decls =
   List.map
     (fun (id, decl) -> (id, update_decl_jkind env (Pident id) decl))
@@ -1778,6 +1792,7 @@ let transl_type_decl env rec_flag sdecl_list =
       |> Typedecl_variance.update_decls env sdecl_list
       |> Typedecl_separability.update_decls env
       |> update_decls_jkind new_env
+      |> update_decls_jkind_reason
     with
     | Typedecl_variance.Error (loc, err) ->
         raise (Error (loc, Variance err))
@@ -2273,7 +2288,7 @@ let transl_value_decl env loc valdecl =
                 (Jkind.value ~why:Structure_element) with
   | Ok () -> ()
   | Error err ->
-    raise(Error(cty.ctyp_loc, Non_value_in_sig(err, valdecl.pval_name.txt)))
+    raise(Error(cty.ctyp_loc, Non_value_in_sig(err,valdecl.pval_name.txt,cty.ctyp_type)))
   end;
   let ty = cty.ctyp_type in
   let v =
@@ -2318,6 +2333,8 @@ let transl_value_decl env loc valdecl =
     Env.enter_value valdecl.pval_name.txt v env
       ~check:(fun s -> Warnings.Unused_value_declaration s)
   in
+  let reason = Jkind.Generalized (Some id, loc) in
+  Ctype.update_generalized_ty_jkind_reason ty reason;
   let desc =
     {
      val_id = id;
@@ -2699,6 +2716,7 @@ let report_error ppf = function
       let get_jkind_error : _ Errortrace.elt -> _ = function
       | Bad_jkind (ty, violation) | Bad_jkind_sort (ty, violation) ->
         Some (ty, violation)
+      | Unequal_var_jkinds_with_no_history
       | Unequal_var_jkinds _ | Diff _ | Variant _ | Obj _
       | Escape _ | Incompatible_fields _ | Rec_occur _ -> None
       in
@@ -2900,10 +2918,10 @@ let report_error ppf = function
   | Jkind_mismatch_of_path (dpath,v) ->
     (* the type is always printed just above, so print out just the head of the
        path instead of something like [t/3] *)
-    let offender ppf = fprintf ppf "Type %s" (Ident.name (Path.head dpath)) in
+    let offender ppf = fprintf ppf "type %s" (Ident.name (Path.head dpath)) in
     Jkind.Violation.report_with_offender ~offender ppf v
   | Jkind_mismatch_of_type (ty,v) ->
-    let offender ppf = fprintf ppf "Type %a" Printtyp.type_expr ty in
+    let offender ppf = fprintf ppf "type %a" Printtyp.type_expr ty in
     Jkind.Violation.report_with_offender ~offender ppf v
   | Jkind_sort {kloc; typ; err} ->
     let s =
@@ -2913,14 +2931,15 @@ let report_error ppf = function
       | Unboxed_record -> "Unboxed record element"
       | External -> "External"
     in
-    fprintf ppf "@[%s types must have a representable layout.@ \ %a@]" s
+    fprintf ppf "@[%s types must have a representable layout.@ %a@]" s
       (Jkind.Violation.report_with_offender
          ~offender:(fun ppf -> Printtyp.type_expr ppf typ)) err
   | Jkind_empty_record ->
     fprintf ppf "@[Records must contain at least one runtime value.@]"
-  | Non_value_in_sig (err, val_name) ->
+  | Non_value_in_sig (err, val_name, ty) ->
+    let offender ppf = fprintf ppf "type %a" Printtyp.type_expr ty in
     fprintf ppf "@[This type signature for %s is not a value type.@ %a@]"
-      val_name (Jkind.Violation.report_with_name ~name:val_name) err
+      val_name (Jkind.Violation.report_with_offender ~offender) err
   | Invalid_jkind_in_block (typ, sort_const, lloc) ->
     let struct_desc =
       match lloc with

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -121,7 +121,7 @@ type error =
       ; err : Jkind.Violation.t
       }
   | Jkind_empty_record
-  | Non_value_in_sig of Jkind.Violation.t * string
+  | Non_value_in_sig of Jkind.Violation.t * string * type_expr
   | Invalid_jkind_in_block of type_expr * Jkind.Sort.const * jkind_sort_loc
   | Mixed_block
   | Separability of Typedecl_separability.error

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3775,8 +3775,8 @@ let report_error ~loc _env = function
         (Path.name p)
   | Toplevel_nonvalue (id, sort) ->
       Location.errorf ~loc
-        "@[Top-level module bindings must have layout value, but@ \
-         %s has layout@ %a.@]" id Jkind.Sort.format sort
+        "@[Types of top-level module bindings must have layout value, but@ \
+         the type of %s has layout@ %a.@]" id Jkind.Sort.format sort
  | Strengthening_mismatch(lid, explanation) ->
       let main = Includemod_errorprinter.err_msgs explanation in
       Location.errorf ~loc

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -553,7 +553,7 @@ let transl_type_param env path styp =
    to ask for it with an annotation.  Some restriction here seems necessary
    for backwards compatibility (e.g., we wouldn't want [type 'a id = 'a] to
    have jkind any).  But it might be possible to infer [any] in some cases. *)
-  let jkind = Jkind.of_new_sort ~why:Unannotated_type_parameter in
+  let jkind = Jkind.of_new_sort ~why:(Unannotated_type_parameter path) in
   let attrs = styp.ptyp_attributes in
   match styp.ptyp_desc with
     Ptyp_any -> transl_type_param_var env loc attrs None jkind None
@@ -569,7 +569,7 @@ let transl_type_param env path styp =
 
 let get_type_param_jkind path styp =
   match Jane_syntax.Core_type.of_ast styp with
-  | None -> Jkind.of_new_sort ~why:Unannotated_type_parameter
+  | None -> Jkind.of_new_sort ~why:(Unannotated_type_parameter path)
   | Some (Jtyp_layout (Ltyp_var { name; jkind }), _attrs) ->
     let jkind, _ =
       Jkind.of_annotation
@@ -634,13 +634,21 @@ let check_arg_type styp =
     | _ -> ()
   end
 
+let enrich_with_attributes attrs annotation_context =
+  match Builtin_attributes.error_message_attr attrs with
+  | Some msg -> Jkind.With_error_message (msg, annotation_context)
+  | None -> annotation_context
+
+let jkind_of_annotation annotation_context attrs jkind =
+  Jkind.of_annotation ~context:(enrich_with_attributes attrs annotation_context) jkind
+
 (* translate the ['a 'b ('c : immediate) .] part of a polytype,
    returning a [poly_univars] *)
 let transl_bound_vars : (_, _) Either.t -> _ =
   function
   | Left vars_only -> TyVarEnv.make_poly_univars vars_only
   | Right vars_jkinds -> TyVarEnv.make_poly_univars_jkinds
-                           ~context:(fun v -> Univar v) vars_jkinds
+                           ~context:(fun v -> Univar ("'" ^ v)) vars_jkinds
 
 let rec transl_type env ~policy ?(aliased=false) ~row_context mode styp =
   Builtin_attributes.warning_scope styp.ptyp_attributes
@@ -664,7 +672,8 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
      ctyp (Ttyp_var (None, None)) ty
   | Ptyp_var name ->
       let desc, typ =
-        transl_type_var env ~policy ~row_context styp.ptyp_loc name None
+        transl_type_var env ~policy ~row_context
+          styp.ptyp_attributes styp.ptyp_loc name None
       in
       ctyp desc typ
   | Ptyp_arrow _ ->
@@ -740,13 +749,28 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
         | Some ty ->
             if get_level ty = Btype.generic_level then unify_var else unify
       in
-      List.iter2
-        (fun (sty, cty) ty' ->
+      let arity = List.length params in
+      List.iteri
+        (fun idx ((sty, cty), ty') ->
+           begin match Types.get_desc ty' with
+           | Tvar {jkind; _} when Jkind.has_imported_history jkind ->
+             (* In case of a Tvar with imported jkind history, we can improve
+                the jkind reason using the in scope [path] to the parent type.
+
+                Basic benchmarking suggests this change doesn't have that big
+                of a performance impact: compiling [types.ml] resulted in 13k
+                extra alloc (~0.01% increase) and building the core library had
+                no statistically significant increase in build time. *)
+             let reason = Jkind.Imported_type_argument
+                            {parent_path = path; position = idx + 1; arity} in
+             Types.set_var_jkind ty' (Jkind.update_reason jkind reason)
+           | _ -> ()
+           end;
            try unify_param env ty' cty.ctyp_type with Unify err ->
              let err = Errortrace.swap_unification_error err in
              raise (Error(sty.ptyp_loc, env, Type_mismatch err))
         )
-        (List.combine stl args) params;
+        (List.combine (List.combine stl args) params);
       let constr =
         newconstr path (List.map (fun ctyp -> ctyp.ctyp_type) args) in
       ctyp (Ttyp_constr (path, lid, args)) constr
@@ -801,7 +825,8 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       ctyp (Ttyp_class (path, lid, args)) ty
   | Ptyp_alias(st, alias) ->
     let desc, typ =
-      transl_type_alias env ~policy ~row_context mode loc st (Some alias) None
+      transl_type_alias env ~policy ~row_context
+        mode styp.ptyp_attributes loc st (Some alias) None
     in
     ctyp desc typ
   | Ptyp_variant(fields, closed, present) ->
@@ -979,35 +1004,35 @@ and transl_type_aux_jst env ~policy ~row_context mode attrs loc
   let ctyp_desc, ctyp_type =
     match jtyp with
     | Jtyp_layout typ ->
-      transl_type_aux_jst_layout env ~policy ~row_context mode loc typ
+      transl_type_aux_jst_layout env ~policy ~row_context mode attrs loc typ
     | Jtyp_tuple x ->
       transl_type_aux_tuple env ~policy ~row_context x
   in
   { ctyp_desc; ctyp_type; ctyp_env = env; ctyp_loc = loc;
     ctyp_attributes = attrs }
 
-and transl_type_aux_jst_layout env ~policy ~row_context mode loc :
+and transl_type_aux_jst_layout env ~policy ~row_context mode attrs loc :
       Jane_syntax.Layouts.core_type -> _ = function
   | Ltyp_var { name = None; jkind } ->
     let tjkind, tjkind_annot =
-      Jkind.of_annotation ~context:(Type_wildcard loc) jkind
+      jkind_of_annotation (Type_wildcard loc) attrs jkind
     in
     Ttyp_var (None, Some tjkind_annot),
     TyVarEnv.new_any_var loc env tjkind policy
   | Ltyp_var { name = Some name; jkind } ->
-    transl_type_var env ~policy ~row_context loc name (Some jkind)
+    transl_type_var env ~policy ~row_context attrs loc name (Some jkind)
   | Ltyp_poly { bound_vars; inner_type } ->
     transl_type_poly env ~policy ~row_context mode loc (Either.Right bound_vars)
       inner_type
   | Ltyp_alias { aliased_type; name; jkind } ->
-    transl_type_alias env ~policy ~row_context mode loc aliased_type name
+    transl_type_alias env ~policy ~row_context mode attrs loc aliased_type name
       (Some jkind)
 
-and transl_type_var env ~policy ~row_context loc name jkind_annot_opt =
+and transl_type_var env ~policy ~row_context attrs loc name jkind_annot_opt =
   let print_name = "'" ^ name in
   if not (valid_tyvar_name name) then
     raise (Error (loc, env, Invalid_variable_name print_name));
-  let of_annot = Jkind.of_annotation ~context:(Type_variable print_name) in
+  let of_annot = jkind_of_annotation (Type_variable print_name) attrs in
   let ty = try
       TyVarEnv.lookup_local ~row_context name
     with Not_found ->
@@ -1048,7 +1073,7 @@ and transl_type_poly env ~policy ~row_context mode loc (vars : (_, _) Either.t)
   unify_var env (newvar (Jkind.any ~why:Dummy_jkind)) ty';
   Ttyp_poly (typed_vars, cty), ty'
 
-and transl_type_alias env ~row_context ~policy mode alias_loc styp name_opt
+and transl_type_alias env ~row_context ~policy mode attrs alias_loc styp name_opt
       jkind_annot_opt =
   let cty, jkind_annot = match name_opt with
     | Some alias ->
@@ -1065,7 +1090,7 @@ and transl_type_alias env ~row_context ~policy mode alias_loc styp name_opt
         | None -> None
         | Some jkind_annot ->
           let jkind, annot =
-            Jkind.of_annotation ~context:(Type_variable alias) jkind_annot
+            jkind_of_annotation (Type_variable ("'" ^ alias)) attrs jkind_annot
           in
           begin match constrain_type_jkind env t jkind with
           | Ok () -> ()
@@ -1079,10 +1104,13 @@ and transl_type_alias env ~row_context ~policy mode alias_loc styp name_opt
         let t, ty, jkind_annot =
           with_local_level_if_principal begin fun () ->
             let jkind, jkind_annot =
-              Jkind.(of_annotation_option_default
-                ~default:(any ~why:Dummy_jkind)
-                ~context:(Type_variable alias)
-                jkind_annot_opt)
+              match jkind_annot_opt with
+              | None -> Jkind.any ~why:Dummy_jkind, None
+              | Some jkind_annot ->
+                let jkind, annot =
+                  jkind_of_annotation (Type_variable ("'" ^ alias)) attrs jkind_annot
+                in
+                jkind, Some annot
             in
             let t = newvar jkind in
             TyVarEnv.remember_used alias t alias_loc;
@@ -1114,8 +1142,7 @@ and transl_type_alias env ~row_context ~policy mode alias_loc styp name_opt
         | Some jkind_annot -> jkind_annot
       in
       let jkind, annot =
-          Jkind.of_annotation
-            ~context:(Type_wildcard jkind_annot.loc) jkind_annot
+        jkind_of_annotation (Type_wildcard jkind_annot.loc) attrs jkind_annot
       in
       begin match constrain_type_jkind env cty_expr jkind with
       | Ok () -> ()
@@ -1449,14 +1476,16 @@ let report_error env ppf = function
       fprintf ppf ".@]";
   | Bad_univar_jkind { name; jkind_info; inferred_jkind } ->
       fprintf ppf
-        "@[<hov>The universal type variable %a was %s to have@ \
-         layout %a, but was inferred to have %t.@]"
+        "@[<hov>The universal type variable %a was %s to have layout %a.@;%a@]"
         Pprintast.tyvar name
         (if jkind_info.defaulted then "defaulted" else "declared")
         Jkind.format jkind_info.original_jkind
-        (fun ppf -> match Jkind.get inferred_jkind with
-           | Const c -> fprintf ppf "layout %s" (Jkind.string_of_const c)
-           | Var _ -> fprintf ppf "a representable layout")
+        (Jkind.format_history ~intro:(
+          dprintf "But it was inferred to have %t"
+            (fun ppf -> match Jkind.get inferred_jkind with
+            | Const c -> fprintf ppf "layout %s" (Jkind.string_of_const c)
+            | Var _ -> fprintf ppf "a representable layout")))
+        inferred_jkind
   | Multiple_constraints_on_type s ->
       fprintf ppf "Multiple constraints for type %a" longident s
   | Method_mismatch (l, ty, ty') ->
@@ -1486,7 +1515,7 @@ let report_error env ppf = function
       | Package_constraint -> "Signature package constraint"
       | Object_field -> "Object field"
     in
-    fprintf ppf "@[%s types must have layout value.@ \ %a@]"
+    fprintf ppf "@[%s types must have layout value.@ %a@]"
       s (Jkind.Violation.report_with_offender
            ~offender:(fun ppf -> Printtyp.type_expr ppf typ)) err
   | Non_sort {vloc; typ; err} ->
@@ -1495,7 +1524,7 @@ let report_error env ppf = function
       | Fun_arg -> "Function argument"
       | Fun_ret -> "Function return"
     in
-    fprintf ppf "@[%s types must have a representable layout.@ \ %a@]"
+    fprintf ppf "@[%s types must have a representable layout.@ %a@]"
       s (Jkind.Violation.report_with_offender
            ~offender:(fun ppf -> Printtyp.type_expr ppf typ)) err
   | Bad_jkind_annot(ty, violation) ->


### PR DESCRIPTION
This is the `layout-histories` branch rebased over the tip of `main`.

This is done by:
- rebasing on top of the [commit right before the layout to jkind rename](https://github.com/ocaml-flambda/flambda-backend/commit/88f75c4221b11accd361e060473979e4df97fe7c) - merge conflict resolution can be found [here](https://github.com/alanechang/flambda-backend/commit/559b0f41578bfc9b8bd7cb97676f2bc4f0fd0959)
-  rebasing another time over just the jkind rename commits [1](https://github.com/ocaml-flambda/flambda-backend/commit/93be0a1ed2c5a314c9f7992509059e27635ab8b8) [2](https://github.com/ocaml-flambda/flambda-backend/commit/d2c9b3ec180e8e79ad424a437409eba74b544224)
- finally rebasing again over the tip of main

The merge conflicts from the last step are kept and will be resolved via a PR to the `layout-histories-rebased` branch.