### PR TITLE
Propagate effect and coeffect attributes on C calls through flambda2

### DIFF
--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -718,7 +718,8 @@ let transl_builtin name args dbg typ_res =
     bigstring_cas Thirtytwo (four_args name args) dbg
   | _ -> transl_vec128_builtin name args dbg typ_res
 
-let extcall ~dbg ~returns ~alloc ~is_c_builtin ~ty_args name typ_res args =
+let extcall ~dbg ~returns ~alloc ~is_c_builtin ~effects ~coeffects ~ty_args name
+    typ_res args =
   if not returns then assert (typ_res = typ_void);
   let default =
     Cop
@@ -729,8 +730,8 @@ let extcall ~dbg ~returns ~alloc ~is_c_builtin ~ty_args name typ_res args =
             ty_args;
             returns;
             builtin = is_c_builtin;
-            effects = Arbitrary_effects;
-            coeffects = Has_coeffects
+            effects;
+            coeffects
           },
         args,
         dbg )

--- a/backend/cmm_builtins.mli
+++ b/backend/cmm_builtins.mli
@@ -21,6 +21,8 @@ val extcall :
   returns:bool ->
   alloc:bool ->
   is_c_builtin:bool ->
+  effects:Cmm.effects ->
+  coeffects:Cmm.coeffects ->
   ty_args:exttype list ->
   string ->
   machtype ->

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -951,10 +951,10 @@ let call_kinds env (call_kind1 : Call_kind.t) (call_kind2 : Call_kind.t) :
           alloc_mode = alloc_mode2
         } ) ->
     if Bool.equal needs_caml_c_call1 needs_caml_c_call2
-    && Alloc_mode.For_allocations.compare alloc_mode1 alloc_mode2 = 0
-    && Bool.equal is_c_builtin1 is_c_builtin2
-    && Effects.compare effects1 effects2 = 0
-    && Coeffects.compare coeffects1 coeffects2 = 0
+       && Alloc_mode.For_allocations.compare alloc_mode1 alloc_mode2 = 0
+       && Bool.equal is_c_builtin1 is_c_builtin2
+       && Effects.compare effects1 effects2 = 0
+       && Coeffects.compare coeffects1 coeffects2 = 0
     then Equivalent
     else Different { approximant = call_kind1 }
   | _, _ -> Different { approximant = call_kind1 }

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -938,16 +938,23 @@ let call_kinds env (call_kind1 : Call_kind.t) (call_kind2 : Call_kind.t) :
         }
   | ( C_call
         { needs_caml_c_call = needs_caml_c_call1;
-          is_c_builtin = _;
+          is_c_builtin = is_c_builtin1;
+          effects = effects1;
+          coeffects = coeffects1;
           alloc_mode = alloc_mode1
         },
       C_call
         { needs_caml_c_call = needs_caml_c_call2;
-          is_c_builtin = _;
+          is_c_builtin = is_c_builtin2;
+          effects = effects2;
+          coeffects = coeffects2;
           alloc_mode = alloc_mode2
         } ) ->
     if Bool.equal needs_caml_c_call1 needs_caml_c_call2
-       && Alloc_mode.For_allocations.compare alloc_mode1 alloc_mode2 = 0
+    && Alloc_mode.For_allocations.compare alloc_mode1 alloc_mode2 = 0
+    && Bool.equal is_c_builtin1 is_c_builtin2
+    && Effects.compare effects1 effects2 = 0
+    && Coeffects.compare coeffects1 coeffects2 = 0
     then Equivalent
     else Different { approximant = call_kind1 }
   | _, _ -> Different { approximant = call_kind1 }

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -554,8 +554,7 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
   let coeffects = Coeffects.from_lambda prim_coeffects in
   let call_kind =
     Call_kind.c_call ~needs_caml_c_call:prim_alloc ~is_c_builtin:prim_c_builtin
-      ~effects ~coeffects
-      alloc_mode
+      ~effects ~coeffects alloc_mode
   in
   let call_symbol =
     let prim_name =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -443,8 +443,8 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
         prim_arity;
         prim_alloc;
         prim_c_builtin;
-        prim_effects = _;
-        prim_coeffects = _;
+        prim_effects;
+        prim_coeffects;
         prim_native_name;
         prim_native_repr_args;
         prim_native_repr_res
@@ -550,8 +550,11 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
     | Some alloc_mode ->
       Alloc_mode.For_allocations.from_lambda alloc_mode ~current_region
   in
+  let effects = Effects.from_lambda prim_effects in
+  let coeffects = Coeffects.from_lambda prim_coeffects in
   let call_kind =
     Call_kind.c_call ~needs_caml_c_call:prim_alloc ~is_c_builtin:prim_c_builtin
+      ~effects ~coeffects
       alloc_mode
   in
   let call_symbol =

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -985,6 +985,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           let params_arity = arity params_arity in
           let return_arity = arity ret_arity in
           ( Call_kind.c_call ~needs_caml_c_call ~is_c_builtin:false
+              ~effects:Arbitrary_effects ~coeffects:Has_coeffects
               Alloc_mode.For_allocations.heap,
             params_arity,
             return_arity )

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -1193,8 +1193,13 @@ let simplify_apply ~simplify_expr dacc apply ~down_to_up =
           apply
     in
     simplify_method_call dacc apply ~callee_ty ~kind ~obj ~arg_types ~down_to_up
-  | C_call { needs_caml_c_call = _; is_c_builtin = _; effects = _; coeffects = _ ;
-             alloc_mode = _ } ->
+  | C_call
+      { needs_caml_c_call = _;
+        is_c_builtin = _;
+        effects = _;
+        coeffects = _;
+        alloc_mode = _
+      } ->
     let callee_ty =
       match callee_ty with
       | Some callee_ty -> callee_ty

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -1193,7 +1193,8 @@ let simplify_apply ~simplify_expr dacc apply ~down_to_up =
           apply
     in
     simplify_method_call dacc apply ~callee_ty ~kind ~obj ~arg_types ~down_to_up
-  | C_call { needs_caml_c_call = _; is_c_builtin = _; alloc_mode = _ } ->
+  | C_call { needs_caml_c_call = _; is_c_builtin = _; effects = _; coeffects = _ ;
+             alloc_mode = _ } ->
     let callee_ty =
       match callee_ty with
       | Some callee_ty -> callee_ty

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -63,7 +63,7 @@ type t =
       { needs_caml_c_call : bool;
         is_c_builtin : bool;
         effects : Effects.t;
-        coeffects: Coeffects.t;
+        coeffects : Coeffects.t;
         alloc_mode : Alloc_mode.For_allocations.t
       }
 
@@ -122,7 +122,13 @@ let free_names t =
   | Function { function_call = Indirect_unknown_arity; alloc_mode }
   | Function { function_call = Indirect_known_arity; alloc_mode } ->
     Alloc_mode.For_allocations.free_names alloc_mode
-  | C_call { needs_caml_c_call = _; is_c_builtin = _; effects = _; coeffects = _; alloc_mode } ->
+  | C_call
+      { needs_caml_c_call = _;
+        is_c_builtin = _;
+        effects = _;
+        coeffects = _;
+        alloc_mode
+      } ->
     Alloc_mode.For_allocations.free_names alloc_mode
   | Method { kind = _; obj; alloc_mode } ->
     Name_occurrences.union (Simple.free_names obj)
@@ -149,14 +155,21 @@ let apply_renaming t renaming =
     if alloc_mode == alloc_mode'
     then t
     else Function { function_call; alloc_mode = alloc_mode' }
-  | C_call { needs_caml_c_call; is_c_builtin; effects; coeffects; alloc_mode } ->
+  | C_call { needs_caml_c_call; is_c_builtin; effects; coeffects; alloc_mode }
+    ->
     let alloc_mode' =
       Alloc_mode.For_allocations.apply_renaming alloc_mode renaming
     in
     if alloc_mode == alloc_mode'
     then t
-    else C_call { needs_caml_c_call; is_c_builtin; effects; coeffects;
-                  alloc_mode = alloc_mode' }
+    else
+      C_call
+        { needs_caml_c_call;
+          is_c_builtin;
+          effects;
+          coeffects;
+          alloc_mode = alloc_mode'
+        }
   | Method { kind; obj; alloc_mode } ->
     let obj' = Simple.apply_renaming obj renaming in
     let alloc_mode' =
@@ -175,8 +188,13 @@ let ids_for_export t =
   | Function { function_call = Indirect_unknown_arity; alloc_mode }
   | Function { function_call = Indirect_known_arity; alloc_mode } ->
     Alloc_mode.For_allocations.ids_for_export alloc_mode
-  | C_call { needs_caml_c_call = _; is_c_builtin = _; effects = _; coeffects = _;
-             alloc_mode } ->
+  | C_call
+      { needs_caml_c_call = _;
+        is_c_builtin = _;
+        effects = _;
+        coeffects = _;
+        alloc_mode
+      } ->
     Alloc_mode.For_allocations.ids_for_export alloc_mode
   | Method { kind = _; obj; alloc_mode } ->
     Ids_for_export.union

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -60,7 +60,7 @@ type t = private
       { needs_caml_c_call : bool;
         is_c_builtin : bool;
         effects : Effects.t;
-        coeffects: Coeffects.t;
+        coeffects : Coeffects.t;
         alloc_mode : Alloc_mode.For_allocations.t
       }
 

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -59,8 +59,8 @@ type t = private
   | C_call of
       { needs_caml_c_call : bool;
         is_c_builtin : bool;
-            (* CR mshinwell: This should have the effects and coeffects
-               fields *)
+        effects : Effects.t;
+        coeffects: Coeffects.t;
         alloc_mode : Alloc_mode.For_allocations.t
       }
 
@@ -80,5 +80,7 @@ val method_call :
 val c_call :
   needs_caml_c_call:bool ->
   is_c_builtin:bool ->
+  effects:Effects.t ->
+  coeffects:Coeffects.t ->
   Alloc_mode.For_allocations.t ->
   t

--- a/middle_end/flambda2/terms/coeffects.ml
+++ b/middle_end/flambda2/terms/coeffects.ml
@@ -39,3 +39,8 @@ let join co1 co2 =
   | Has_coeffects, Has_coeffects
   | Has_coeffects, No_coeffects ->
     Has_coeffects
+
+let from_lambda (ce : Primitive.coeffects) : t =
+  match ce with
+  | No_coeffects -> No_coeffects
+  | Has_coeffects -> Has_coeffects

--- a/middle_end/flambda2/terms/coeffects.ml
+++ b/middle_end/flambda2/terms/coeffects.ml
@@ -41,6 +41,4 @@ let join co1 co2 =
     Has_coeffects
 
 let from_lambda (ce : Primitive.coeffects) : t =
-  match ce with
-  | No_coeffects -> No_coeffects
-  | Has_coeffects -> Has_coeffects
+  match ce with No_coeffects -> No_coeffects | Has_coeffects -> Has_coeffects

--- a/middle_end/flambda2/terms/coeffects.mli
+++ b/middle_end/flambda2/terms/coeffects.mli
@@ -38,3 +38,5 @@ val compare : t -> t -> int
 
 (** Join two coeffects. *)
 val join : t -> t -> t
+
+val from_lambda : Primitive.coeffects -> t

--- a/middle_end/flambda2/terms/effects.ml
+++ b/middle_end/flambda2/terms/effects.ml
@@ -56,3 +56,14 @@ let join eff1 eff2 =
   | Arbitrary_effects, Only_generative_effects _
   | Arbitrary_effects, Arbitrary_effects ->
     eff1
+
+let from_lambda (e : Primitive.effects) : t =
+  match e with
+  | No_effects -> No_effects
+  | Only_generative_effects -> Only_generative_effects Mutable
+  (* CR-someday gyorsh: propagate mutability from attributes.
+     Currently, it does not matter, because this is only used for
+     C calls in the backend, which does not distinguish
+     between Only_generative_effects and Arbitrary_effects.  *)
+  | Arbitrary_effects -> Arbitrary_effects
+

--- a/middle_end/flambda2/terms/effects.ml
+++ b/middle_end/flambda2/terms/effects.ml
@@ -61,9 +61,8 @@ let from_lambda (e : Primitive.effects) : t =
   match e with
   | No_effects -> No_effects
   | Only_generative_effects -> Only_generative_effects Mutable
-  (* CR-someday gyorsh: propagate mutability from attributes.
-     Currently, it does not matter, because this is only used for
-     C calls in the backend, which does not distinguish
-     between Only_generative_effects and Arbitrary_effects.  *)
+  (* CR-someday gyorsh: propagate mutability from attributes. Currently, it does
+     not matter, because this is only used for C calls in the backend, which
+     does not distinguish between Only_generative_effects and
+     Arbitrary_effects. *)
   | Arbitrary_effects -> Arbitrary_effects
-

--- a/middle_end/flambda2/terms/effects.mli
+++ b/middle_end/flambda2/terms/effects.mli
@@ -58,3 +58,5 @@ val compare : t -> t -> int
 (** join two effects, effectively computing the maximum of the two given
     effects. *)
 val join : t -> t -> t
+
+val from_lambda : Primitive.effects -> t

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.ml
@@ -101,3 +101,12 @@ let classify_continuation_handler k handler ~num_free_occurrences
      && cont_is_known_to_have_exactly_one_occurrence k num_free_occurrences
   then May_inline
   else Regular
+
+(* CR gyorsh: currently only used to reorder C calls in the backend. *)
+let transl_c_call_effects (e : Effects.t) : Cmm.effects =
+  match e with
+  | No_effects -> No_effects
+  | Only_generative_effects _ | Arbitrary_effects -> Arbitrary_effects
+
+let transl_c_call_coeffects (ce : Coeffects.t) : Cmm.coeffects =
+  match ce with No_coeffects -> No_coeffects | Has_coeffects -> Has_coeffects

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.mli
@@ -78,6 +78,6 @@ val classify_continuation_handler :
 
 (** Effects and coeffects of C calls  *)
 
-val transl_c_call_effects : Effects.t ->  Cmm.effects
+val transl_c_call_effects : Effects.t -> Cmm.effects
 
 val transl_c_call_coeffects : Coeffects.t -> Cmm.coeffects

--- a/middle_end/flambda2/to_cmm/to_cmm_effects.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_effects.mli
@@ -75,3 +75,9 @@ val classify_continuation_handler :
   num_free_occurrences:Num_occurrences.t Or_unknown.t ->
   is_applied_with_traps:bool ->
   continuation_handler_classification
+
+(** Effects and coeffects of C calls  *)
+
+val transl_c_call_effects : Effects.t ->  Cmm.effects
+
+val transl_c_call_coeffects : Coeffects.t -> Cmm.coeffects

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -218,7 +218,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         env,
         res,
         Ece.all )
-  | Call_kind.C_call { needs_caml_c_call; is_c_builtin; effects; coeffects; alloc_mode = _ } ->
+  | Call_kind.C_call
+      { needs_caml_c_call; is_c_builtin; effects; coeffects; alloc_mode = _ } ->
     fail_if_probe apply;
     let callee =
       match callee_simple with
@@ -262,9 +263,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     let effects = To_cmm_effects.transl_c_call_effects effects in
     let coeffects = To_cmm_effects.transl_c_call_coeffects coeffects in
     ( wrap dbg
-        (C.extcall ~dbg ~alloc:needs_caml_c_call ~is_c_builtin ~effects ~coeffects
-           ~returns ~ty_args
-           callee
+        (C.extcall ~dbg ~alloc:needs_caml_c_call ~is_c_builtin ~effects
+           ~coeffects ~returns ~ty_args callee
            (C.Extended_machtype.to_machtype return_ty)
            args),
       free_vars,

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -218,7 +218,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         env,
         res,
         Ece.all )
-  | Call_kind.C_call { needs_caml_c_call; is_c_builtin; alloc_mode = _ } ->
+  | Call_kind.C_call { needs_caml_c_call; is_c_builtin; effects; coeffects; alloc_mode = _ } ->
     fail_if_probe apply;
     let callee =
       match callee_simple with
@@ -259,8 +259,11 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         (Flambda_arity.unarize (Apply.args_arity apply)
         |> List.map K.With_subkind.kind)
     in
+    let effects = To_cmm_effects.transl_c_call_effects effects in
+    let coeffects = To_cmm_effects.transl_c_call_coeffects coeffects in
     ( wrap dbg
-        (C.extcall ~dbg ~alloc:needs_caml_c_call ~is_c_builtin ~returns ~ty_args
+        (C.extcall ~dbg ~alloc:needs_caml_c_call ~is_c_builtin ~effects ~coeffects
+           ~returns ~ty_args
            callee
            (C.Extended_machtype.to_machtype return_ty)
            args),

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -539,7 +539,8 @@ let unary_primitive env res dbg f arg =
   | Duplicate_array _ | Duplicate_block _ | Obj_dup ->
     ( None,
       res,
-      C.extcall ~dbg ~alloc:true ~returns:true ~is_c_builtin:false ~ty_args:[]
+      C.extcall ~dbg ~alloc:true ~returns:true ~is_c_builtin:false
+        ~effects:Arbitrary_effects ~coeffects:Has_coeffects ~ty_args:[]
         "caml_obj_dup" Cmm.typ_val [arg] )
   | Is_int _ -> None, res, C.and_int arg (C.int ~dbg 1) dbg
   | Get_tag -> None, res, C.get_tag arg dbg
@@ -568,6 +569,7 @@ let unary_primitive env res dbg f arg =
     ( None,
       res,
       C.extcall ~dbg ~alloc:false ~returns:true ~is_c_builtin:false
+        ~effects:Arbitrary_effects ~coeffects:Has_coeffects
         ~ty_args:[C.exttype_of_kind K.naked_int64]
         "caml_int64_float_of_bits_unboxed" Cmm.typ_float [arg] )
   | Unbox_number kind -> None, res, unbox_number ~dbg kind arg

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -242,7 +242,9 @@ let invalid res ~message =
     | Some message_sym -> message_sym, res
   in
   let call_expr =
-    extcall ~dbg ~alloc:false ~is_c_builtin:false ~returns:false ~ty_args:[XInt]
+    extcall ~dbg ~alloc:false ~is_c_builtin:false
+      ~effects:Arbitrary_effects ~coeffects:Has_coeffects
+      ~returns:false ~ty_args:[XInt]
       Cmm.caml_flambda2_invalid Cmm.typ_void
       [symbol ~dbg (To_cmm_result.symbol res message_sym)]
   in

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -242,9 +242,8 @@ let invalid res ~message =
     | Some message_sym -> message_sym, res
   in
   let call_expr =
-    extcall ~dbg ~alloc:false ~is_c_builtin:false
-      ~effects:Arbitrary_effects ~coeffects:Has_coeffects
-      ~returns:false ~ty_args:[XInt]
+    extcall ~dbg ~alloc:false ~is_c_builtin:false ~effects:Arbitrary_effects
+      ~coeffects:Has_coeffects ~returns:false ~ty_args:[XInt]
       Cmm.caml_flambda2_invalid Cmm.typ_void
       [symbol ~dbg (To_cmm_result.symbol res message_sym)]
   in


### PR DESCRIPTION
Address https://github.com/ocaml-flambda/flambda-backend/issues/2198/

This PR only propagates the attributes to the backend (similarly to the way it was in closure and flambda1) so they can be used in selection, but does not make this information available to optimizations in the middle-end. 
