### PR TITLE
Disable some SIMD tests when running under Rosetta2

### DIFF
--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -1,3 +1,10 @@
+; Helpers
+
+(library
+ (name simd_test_helpers)
+ (wrapped false)
+ (modules test_helpers))
+
 ; Stubs
 
 (foreign_library
@@ -11,7 +18,8 @@
 
 (executables
  (names basic ops arrays scalar_ops)
- (modules basic ops arrays scalar_ops test_helpers)
+ (modules basic ops arrays scalar_ops)
+ (libraries simd_test_helpers)
  (foreign_archives stubs)
  (ocamlopt_flags
   (:standard -extension simd)))
@@ -95,8 +103,7 @@
   ops_internal.ml
   consts_internal.ml
   arrays_internal.ml
-  scalar_ops_internal.ml
-  test_helpers_internal.ml)
+  scalar_ops_internal.ml)
  (deps basic.ml ops.ml consts.ml scalar_ops.ml)
  (action
   (progn
@@ -104,8 +111,7 @@
    (copy ops.ml ops_internal.ml)
    (copy consts.ml consts_internal.ml)
    (copy arrays.ml arrays_internal.ml)
-   (copy scalar_ops.ml scalar_ops_internal.ml)
-   (copy test_helpers.ml test_helpers_internal.ml))))
+   (copy scalar_ops.ml scalar_ops_internal.ml))))
 
 (executables
  (names
@@ -119,8 +125,8 @@
   ops_internal
   consts_internal
   arrays_internal
-  scalar_ops_internal
-  test_helpers_internal)
+  scalar_ops_internal)
+ (libraries simd_test_helpers)
  (enabled_if
   (<> %{system} macosx))
  (foreign_archives stubs)

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -11,7 +11,7 @@
 
 (executables
  (names basic ops arrays scalar_ops)
- (modules basic ops arrays scalar_ops)
+ (modules basic ops arrays scalar_ops test_helpers)
  (foreign_archives stubs)
  (ocamlopt_flags
   (:standard -extension simd)))

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -95,7 +95,8 @@
   ops_internal.ml
   consts_internal.ml
   arrays_internal.ml
-  scalar_ops_internal.ml)
+  scalar_ops_internal.ml
+  test_helpers_internal.ml)
  (deps basic.ml ops.ml consts.ml scalar_ops.ml)
  (action
   (progn

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -117,8 +117,7 @@
   ops_internal
   consts_internal
   arrays_internal
-  scalar_ops_internal
-  test_helpers)
+  scalar_ops_internal)
  (enabled_if
   (<> %{system} macosx))
  (foreign_archives stubs)

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -117,7 +117,8 @@
   ops_internal
   consts_internal
   arrays_internal
-  scalar_ops_internal)
+  scalar_ops_internal
+  test_helpers)
  (enabled_if
   (<> %{system} macosx))
  (foreign_archives stubs)

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -103,7 +103,8 @@
    (copy ops.ml ops_internal.ml)
    (copy consts.ml consts_internal.ml)
    (copy arrays.ml arrays_internal.ml)
-   (copy scalar_ops.ml scalar_ops_internal.ml))))
+   (copy scalar_ops.ml scalar_ops_internal.ml)
+   (copy test_helpers.ml test_helpers_internal.ml))))
 
 (executables
  (names
@@ -117,7 +118,8 @@
   ops_internal
   consts_internal
   arrays_internal
-  scalar_ops_internal)
+  scalar_ops_internal
+  test_helpers_internal)
  (enabled_if
   (<> %{system} macosx))
  (foreign_archives stubs)

--- a/tests/simd/ops.ml
+++ b/tests/simd/ops.ml
@@ -833,6 +833,7 @@ module Float32x4 = struct
         [@@noalloc] [@@unboxed] [@@builtin]
 
     let () =
+      Test_helpers.run_if_not_under_rosetta2 ~f:(fun () ->
         Float32.check_floats (fun f0 f1 ->
             failmsg := (fun () -> Printf.printf "%f | %f\n%!" (Int32.float_of_bits f0) (Int32.float_of_bits f1));
             let fv0 = Float32.to_float32x4 f0 f0 f1 f1 in
@@ -860,6 +861,7 @@ module Float32x4 = struct
             eq (float32x4_low_int64 result) (float32x4_high_int64 result)
                (float32x4_low_int64 expect) (float32x4_high_int64 expect)
         );
+      )
     ;;
 
     external dp : (int [@untagged]) -> (t [@unboxed]) -> (t [@unboxed]) -> (t [@unboxed]) = "caml_vec128_unreachable" "caml_sse41_float32x4_dp"
@@ -1036,6 +1038,7 @@ module Float64x2 = struct
         [@@noalloc] [@@unboxed] [@@builtin]
 
     let () =
+      Test_helpers.run_if_not_under_rosetta2 ~f:(fun () ->
         Float64.check_floats (fun f0 f1 ->
             failmsg := (fun () -> Printf.printf "%f | %f\n%!" f0 f1);
             let fv0 = to_float64x2 f0 f0 in
@@ -1063,6 +1066,7 @@ module Float64x2 = struct
             eq (float64x2_low_int64 result) (float64x2_high_int64 result)
                (float64x2_low_int64 expect) (float64x2_high_int64 expect)
         );
+      )
     ;;
 
     external dp : (int [@untagged]) -> (t [@unboxed]) -> (t [@unboxed]) -> (t [@unboxed]) = "caml_vec128_unreachable" "caml_sse41_float64x2_dp"

--- a/tests/simd/scalar_ops.ml
+++ b/tests/simd/scalar_ops.ml
@@ -44,9 +44,10 @@ module Int64 = struct
       [@@noalloc] [@@unboxed] [@@builtin]
 
   let () =
-    eq' (bit_deposit 3L 4L) 0x4L;
-    eq' (bit_deposit 235L 522L) 0xAL;
-    eq' (bit_extract 3L 4L) 0x0L;
-    eq' (bit_extract 235L 522L) 0x3L
+    Test_helpers.run_if_not_under_rosetta2 ~f:(fun () ->
+        eq' (bit_deposit 3L 4L) 0x4L;
+        eq' (bit_deposit 235L 522L) 0xAL;
+        eq' (bit_extract 3L 4L) 0x0L;
+        eq' (bit_extract 235L 522L) 0x3L)
   ;;
 end

--- a/tests/simd/test_helpers.ml
+++ b/tests/simd/test_helpers.ml
@@ -1,0 +1,28 @@
+type rosetta2_status =
+  | Unknown
+  | Off
+  | On
+
+let get_rosetta2_status () =
+  let file_path = Filename.temp_file "ocaml-rosetta2" "sysctl" in
+  let command = Printf.sprintf "/usr/sbin/sysctl -n sysctl.proc_translated > %S 2> /dev/null" file_path in
+  let exit_code = Sys.command command in
+  match exit_code with
+  | 0 ->
+    begin try
+        let file_chan = open_in file_path in
+        let first_line = input_line file_chan in
+        match first_line with
+        | "0" -> Off
+        | "1" -> On
+        | _ -> Unknown
+      with _ ->
+        Unknown
+    end
+  | _ ->
+    Unknown
+
+let run_if_not_under_rosetta2 ~f =
+  match get_rosetta2_status () with
+  | Unknown | On -> ()
+  | Off -> f ()

--- a/tests/simd/test_helpers.mli
+++ b/tests/simd/test_helpers.mli
@@ -1,0 +1,8 @@
+type rosetta2_status =
+  | Unknown
+  | Off
+  | On
+
+val get_rosetta2_status : unit -> rosetta2_status
+
+val run_if_not_under_rosetta2 : f:(unit -> unit) -> unit


### PR DESCRIPTION
This pull request disables the SIMD tests
failing when using Rosetta2 (determined
by running the test suite on an M2 box).

Rosetta2 is macOS' emulation layer that
allows one to run `amd64` binaries on
Apple Silicon boxes.