### PR TITLE
Fix caml_alloc_shr_check_gc for tags >= No_scan_tag

### DIFF
--- a/ocaml/runtime/alloc.c
+++ b/ocaml/runtime/alloc.c
@@ -35,7 +35,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
   value result;
   mlsize_t i;
 
-  CAMLassert (tag < 256);
+  CAMLassert (tag < Num_tags);
   CAMLassert (tag != Infix_tag);
   if (wosize <= Max_young_wosize){
     if (wosize == 0){

--- a/ocaml/runtime/alloc.c
+++ b/ocaml/runtime/alloc.c
@@ -67,7 +67,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
 #ifdef NATIVE_CODE
 CAMLexport value caml_alloc_shr_check_gc (mlsize_t wosize, tag_t tag)
 {
-  CAMLassert (tag < 256);
+  CAMLassert (tag < Num_tags);
   CAMLassert (tag != Infix_tag);
   caml_check_urgent_gc (Val_unit);
   value result = caml_alloc_shr (wosize, tag);

--- a/ocaml/runtime/alloc.c
+++ b/ocaml/runtime/alloc.c
@@ -67,10 +67,13 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
 #ifdef NATIVE_CODE
 CAMLexport value caml_alloc_shr_check_gc (mlsize_t wosize, tag_t tag)
 {
-  CAMLassert(tag < No_scan_tag);
+  CAMLassert (tag < 256);
+  CAMLassert (tag != Infix_tag);
   caml_check_urgent_gc (Val_unit);
   value result = caml_alloc_shr (wosize, tag);
-  for (mlsize_t i = 0; i < wosize; i++) Field (result, i) = Val_unit;
+  if (tag < No_scan_tag) {
+    for (mlsize_t i = 0; i < wosize; i++) Field (result, i) = Val_unit;
+  }
   return result;
 }
 #endif


### PR DESCRIPTION
The assertions in the new `caml_alloc_shr_check_gc` function don't match those in `caml_alloc`, which causes debug runtime5 builds to fail under flambda2 (and for there to be unnecessary block initialization).