### PR TITLE
Reorder call to caml_domain_external_interrupt_hook

### DIFF
--- a/ocaml/runtime/domain.c
+++ b/ocaml/runtime/domain.c
@@ -1681,10 +1681,12 @@ void caml_poll_gc_work(void)
        caml_poll_gc_work is called. */
   }
 
+  caml_reset_young_limit(d);
+
   if (atomic_load_acquire(&d->requested_external_interrupt)) {
+    /* This function might allocate (e.g. upon a systhreads yield). */
     caml_domain_external_interrupt_hook();
   }
-  caml_reset_young_limit(d);
 }
 
 void caml_handle_gc_interrupt(void)


### PR DESCRIPTION
I saw a test case failure where this assertion failed:
```
void caml_reset_young_limit(caml_domain_state * dom_st)
{
  CAMLassert ((uintnat)dom_st->young_ptr > (uintnat)dom_st->young_trigger);
```
The function `caml_reset_young_limit` had been called from `caml_poll_gc_work`.

The other facts were as follows:

1. `young_end` - `young_start` = 16384 bytes (this is not a typo)

2. `young_ptr`
  = `young_trigger`
  = `young_limit`
  = `young_start` + 8192 bytes
So the pointer is exactly at the halfway point, which is also the trigger.

3. The assertion claims the pointer should be at a strictly higher address (earlier in the heap).

4. The minor heap has not just been emptied, as otherwise it would contain `Debug_free_minor`, which it did not.

I couldn't see how this could happen in the first part of `caml_poll_gc_work`, so I started investigating the call to `caml_domain_external_interrupt_hook`.  When the systhreads library is used, a hook is installed here, which does a forced yield.  This releases the systhread-specific lock and appears therefore to allow other threads to proceed, potentially doing allocation as a result.  It is such an allocation which I was seeing when observing fact 4 above, I suspect - the contents of the heap (various `Nano_mutex` and `Thread_pool` references in particular) also kind of corroborate this.

I think we should do the resetting of the young limit prior to running this hook, to ensure everything is in a consistent state beforehand.

I am unclear whether `global_major_slice_callback` is allowed to allocate, but if it is, that probably needs fixing too (assuming this fix is correct).