### PR TITLE
Record toplevel attributes in cms files

### DIFF
--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -63,7 +63,10 @@ let typecheck_intf info ast =
   Profile.(record_call typing) @@ fun () ->
   let tsg =
     ast
-    |> Typemod.type_interface info.source_file info.module_name info.env
+    |> Typemod.type_interface
+        ~sourcefile:info.source_file
+        info.module_name
+        info.env
     |> print_if info.ppf_dump Clflags.dump_typedtree Printtyped.interface
   in
   let sg = tsg.Typedtree.sig_type in
@@ -117,7 +120,7 @@ let typecheck_impl i parsetree =
   parsetree
   |> Profile.(record typing)
     (Typemod.type_implementation
-       i.source_file i.output_prefix i.module_name i.env)
+       ~sourcefile:i.source_file i.output_prefix i.module_name i.env)
   |> print_if i.ppf_dump Clflags.dump_typedtree
     Printtyped.implementation_with_coercion
   |> print_if i.ppf_dump Clflags.dump_shape

--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -63,7 +63,7 @@ let typecheck_intf info ast =
   Profile.(record_call typing) @@ fun () ->
   let tsg =
     ast
-    |> Typemod.type_interface info.module_name info.env
+    |> Typemod.type_interface info.source_file info.module_name info.env
     |> print_if info.ppf_dump Clflags.dump_typedtree Printtyped.interface
   in
   let sg = tsg.Typedtree.sig_type in

--- a/ocaml/ocamldoc/odoc_analyse.ml
+++ b/ocaml/ocamldoc/odoc_analyse.ml
@@ -122,7 +122,7 @@ let process_interface_file sourcefile =
     Pparse.file ~tool_name inputfile
       (no_docstring Parse.interface) Pparse.Signature
   in
-  let sg = Typemod.type_interface sourcefile compilation_unit (initial_env()) ast in
+  let sg = Typemod.type_interface ~sourcefile compilation_unit (initial_env()) ast in
   Warnings.check_fatal ();
   (ast, sg, inputfile)
 

--- a/ocaml/ocamldoc/odoc_analyse.ml
+++ b/ocaml/ocamldoc/odoc_analyse.ml
@@ -122,7 +122,7 @@ let process_interface_file sourcefile =
     Pparse.file ~tool_name inputfile
       (no_docstring Parse.interface) Pparse.Signature
   in
-  let sg = Typemod.type_interface compilation_unit (initial_env()) ast in
+  let sg = Typemod.type_interface sourcefile compilation_unit (initial_env()) ast in
   Warnings.check_fatal ();
   (ast, sg, inputfile)
 

--- a/ocaml/ocamldoc/odoc_analyse.ml
+++ b/ocaml/ocamldoc/odoc_analyse.ml
@@ -88,7 +88,7 @@ let process_implementation_file sourcefile =
     in
     let typedtree =
       Typemod.type_implementation
-        sourcefile prefixname compilation_unit env parsetree
+        ~sourcefile prefixname compilation_unit env parsetree
     in
     (Some (parsetree, typedtree), inputfile)
   with

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3314,12 +3314,17 @@ let cms_register_toplevel_attributes ~sourcefile ~uid ~f ast =
     Generally `Pstr_attribute` and `Psig_attribute` are not needed by Merlin,
     except if it is the first element of the compilation unit structure or
     signature. *)
-    match List.find_map f ast with
-    | None -> ()
-    | Some attr ->
-      Env.register_uid uid
-        ~loc:(Location.in_file sourcefile)
-        ~attributes:[ attr ]
+  let attr =
+    match ast with
+    | x :: _ -> f x
+    | [] -> None
+  in
+  match attr with
+  | None -> ()
+  | Some attr ->
+    Env.register_uid uid
+      ~loc:(Location.in_file sourcefile)
+      ~attributes:[ attr ]
 
 let cms_register_toplevel_struct_attributes ~sourcefile ~uid ast =
   cms_register_toplevel_attributes ~sourcefile ~uid ast

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -39,10 +39,14 @@ val type_toplevel_phrase:
   Typedtree.structure * Types.signature * Signature_names.t * Shape.t *
   Env.t
 val type_implementation:
-  string -> string -> Compilation_unit.t -> Env.t ->
+  sourcefile:string -> string -> Compilation_unit.t -> Env.t ->
   Parsetree.structure -> Typedtree.implementation
 val type_interface:
-  string -> Compilation_unit.t -> Env.t -> Parsetree.signature -> Typedtree.signature
+  sourcefile:string
+  -> Compilation_unit.t
+  -> Env.t
+  -> Parsetree.signature
+  -> Typedtree.signature
 val transl_signature:
         Env.t -> Parsetree.signature -> Typedtree.signature
 val check_nongen_signature:

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -42,7 +42,7 @@ val type_implementation:
   string -> string -> Compilation_unit.t -> Env.t ->
   Parsetree.structure -> Typedtree.implementation
 val type_interface:
-        Compilation_unit.t -> Env.t -> Parsetree.signature -> Typedtree.signature
+  string -> Compilation_unit.t -> Env.t -> Parsetree.signature -> Typedtree.signature
 val transl_signature:
         Env.t -> Parsetree.signature -> Typedtree.signature
 val check_nongen_signature:


### PR DESCRIPTION
This is a fix for https://github.com/janestreet/merlin-jst/pull/35

Cms files were designed to be a lightweight alternative to cmt files. The main difference is that they do not contain the full ast but instead rely on the compiler tracking associations between shape's uid and locations / attributes.
This association was missing for top-level attributes - thus breaking merlin in the presence of top level `[@@@ocaml.doc]` or `[@@@ocaml.text]` comments.