### PR TITLE
Add more accessors to Shape to make it compatible with ocaml-uideps

### DIFF
--- a/ocaml/typing/shape.ml
+++ b/ocaml/typing/shape.ml
@@ -306,6 +306,8 @@ let app ?uid f ~arg =
 let comp_unit ?uid s =
       { uid; desc = Comp_unit s; hash = Hashtbl.hash (hash_comp_unit, uid, s) }
 
+let no_fuel_left ?uid s = { s with uid }
+
 let decompose_abs t =
   match t.desc with
   | Abs (x, t) -> Some (x, t)
@@ -591,7 +593,7 @@ end) = struct
       proj ?uid t item
   | NLeaf -> leaf' uid
   | NComp_unit s -> comp_unit ?uid s
-  | NoFuelLeft t -> { t with uid }
+  | NoFuelLeft t -> no_fuel_left ?uid t
 
   let reduce global_env t =
     let fuel = ref Params.fuel in

--- a/ocaml/typing/shape.mli
+++ b/ocaml/typing/shape.mli
@@ -88,6 +88,9 @@ val app : ?uid:Uid.t -> t -> arg:t -> t
 val str : ?uid:Uid.t -> t Item.Map.t -> t
 val proj : ?uid:Uid.t -> t -> Item.t -> t
 val leaf : Uid.t -> t
+val leaf' : Uid.t option -> t
+val no_fuel_left : ?uid:Uid.t -> t -> t
+val comp_unit : ?uid:Uid.t -> string -> t
 
 val decompose_abs : t -> (var * t) option
 


### PR DESCRIPTION
Code constructing instances of `Shape.t` needs updating after making `Shape.t` private.
ocaml-uideps is one such example - this PR exposes the missing constructors