### PR TITLE
Simplify csel builtin when condition is known

### DIFF
--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -490,7 +490,11 @@ let transl_builtin name args dbg typ_res =
     let op = Ccsel typ_res in
     let cond, ifso, ifnot = three_args name args in
     if_operation_supported op ~f:(fun () ->
-        Cop (op, [test_bool dbg cond; ifso; ifnot], dbg))
+        let cond = test_bool dbg cond in
+        match cond with
+        | Cconst_int (0, _) -> ifnot
+        | Cconst_int (1, _) -> ifso
+        | _ -> Cop (op, [cond; ifso; ifnot], dbg))
   (* Native_pointer: handled as unboxed nativeint *)
   | "caml_ext_pointer_as_native_pointer" ->
     Some (int_as_pointer (one_arg name args) dbg)

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -490,6 +490,9 @@ let transl_builtin name args dbg typ_res =
     let op = Ccsel typ_res in
     let cond, ifso, ifnot = three_args name args in
     if_operation_supported op ~f:(fun () ->
+        (* Here is an example to show how csel is compiled:
+         *   (csel val (!= cond/306 1) ifso/304 ifnot/305))
+         * [test_bool] goes from a tagged to an untagged bool. *)
         let cond = test_bool dbg cond in
         match cond with
         | Cconst_int (0, _) -> ifnot


### PR DESCRIPTION
So for example the following two functions:
```
external select : bool -> 'a -> 'a -> 'a = "caml_csel_value"
[@@noalloc] [@@no_effects] [@@no_coeffects] [@@builtin]

let csel x y z =
  let a = select true x y in
  let b = select false x y in
  select z a b

let csel2 x y z =
  select z x y
```
both now compile to:
```
        movq    %rax, %rsi
        movq    %rbx, %rax
        cmpq    $1, %rdi
        cmovne  %rsi, %rax
        ret
```
Previously for the first one we produced:
```
        movq    %rax, %rsi
        movq    %rbx, %rax
        movl    $1, %ebx
        movq    %rax, %rdx
        testq   %rbx, %rbx
        cmovne  %rsi, %rdx
        xorl    %ebx, %ebx
        testq   %rbx, %rbx
        cmovne  %rsi, %rax
        cmpq    $1, %rdi
        cmovne  %rdx, %rax
```
@TheNumbat could you review?