### PR TITLE
Always use x86 inc/dec for add/sub with 1

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1443,9 +1443,9 @@ let emit_instr fallthrough i =
       instr_for_intop op (arg i 1) (res i 0)
   | Lop(Iintop_imm(Iadd, n)) when i.arg.(0).loc <> i.res.(0).loc ->
       I.lea (mem64 NONE n (arg64 i 0)) (res i 0)
-  | Lop(Iintop_imm(Iadd, 1) | Iintop_imm(Isub, -1)) when not !fastcode_flag ->
+  | Lop(Iintop_imm(Iadd, 1) | Iintop_imm(Isub, -1)) ->
       I.inc (res i 0)
-  | Lop(Iintop_imm(Iadd, -1) | Iintop_imm(Isub, 1)) when not !fastcode_flag ->
+  | Lop(Iintop_imm(Iadd, -1) | Iintop_imm(Isub, 1)) ->
       I.dec (res i 0)
   | Lop(Iintop_imm(op, n)) ->
       (* We have i.arg.(0) = i.res.(0) *)


### PR DESCRIPTION
The x86 backend now emits inc/dec instead of add/sub with 1, even if the speed-over-size flag is enabled. 
The encoding of inc/dec is smaller than the full add/sub, so this reduces code size. 
In particular, the popcount intrinsic codegen is improved.

In general, inc/dec can be slower than add/sub, as it doesn't reset all flags (so there can be a data dependency on cf).
They're also extra slow on [recent Intel efficiency cores](https://stackoverflow.com/questions/36510095/inc-instruction-vs-add-1-does-it-matter), but this doesn't apply to most CPUs, so reduced code size should be a win.