### PR TITLE
Cleanup simd regalloc flag

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -55,9 +55,6 @@ let bmi_support = ref true
 (* Bit manipulation 2 (Haswell+) *)
 let bmi2_support = ref true
 
-(* Enable SIMD register allocation features. *)
-let simd_regalloc = ref false
-
 (* Machine-specific command-line options *)
 
 let command_line_options =
@@ -109,12 +106,12 @@ let command_line_options =
     "-fbmi2", Arg.Set bmi2_support,
       " Enable BMI2 intrinsics (default)";
     "-fno-bmi2", Arg.Clear bmi2_support,
-      " Disable BMI2 intrinsics";
-    "-fsimd-regalloc", Arg.Set simd_regalloc,
-      " Enable SIMD register allocation (implied by -extension SIMD)";
-    "-fno-simd-regalloc", Arg.Clear simd_regalloc,
-      " Disable SIMD register allocation (overridden by -extension SIMD) (default)";
+      " Disable BMI2 intrinsics"
   ]
+
+let assert_simd_enabled () =
+  if not (Language_extension.is_enabled SIMD) then
+  Misc.fatal_error "SIMD is not enabled."
 
 (* Specific operations for the AMD64 processor *)
 

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -27,8 +27,8 @@ val sse3_support : bool ref
 val ssse3_support : bool ref
 val sse41_support : bool ref
 val sse42_support : bool ref
-val simd_regalloc : bool ref
 val command_line_options : (string * Arg.spec * string) list
+val assert_simd_enabled : unit -> unit
 
 (* Specific operations for the AMD64 processor *)
 

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -41,8 +41,6 @@ let _label s = D.label ~typ:QWORD s
 
 (* Override proc.ml *)
 
-let simd_frontend_disabled () = not (Language_extension.is_enabled SIMD)
-
 let int_reg_name =
   [| RAX; RBX; RDI; RSI; RDX; RCX; R8; R9;
      R12; R13; R10; R11; RBP; |]
@@ -53,10 +51,7 @@ let register_name typ r =
   match typ with
   | Int | Val | Addr -> Reg64 (int_reg_name.(r))
   | Float -> Regf (float_reg_name.(r - 100))
-  | Vec128 ->
-    if simd_frontend_disabled ()
-    then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 register.";
-    Regf (float_reg_name.(r - 100))
+  | Vec128 -> assert_simd_enabled (); Regf (float_reg_name.(r - 100))
 
 let phys_rax = phys_reg Int 0
 let phys_rdx = phys_reg Int 4
@@ -111,8 +106,7 @@ let frame_required = ref false
 
 let frame_size () =                     (* includes return address *)
   if !frame_required then begin
-    if simd_frontend_disabled () && (num_stack_slots.(2) > 0)
-    then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 stack slot.";
+    if num_stack_slots.(2) > 0 then assert_simd_enabled ();
     let sz =
       (!stack_offset
        + 8
@@ -128,8 +122,7 @@ let slot_offset loc cl =
   match loc with
   | Incoming n -> frame_size() + n
   | Local n ->
-      if simd_frontend_disabled () && (num_stack_slots.(2) > 0 || cl >= 2)
-      then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 stack slot.";
+      if num_stack_slots.(2) > 0 || cl >= 2 then assert_simd_enabled ();
       (!stack_offset +
         (* Preserves original ordering (int -> float) *)
         match cl with
@@ -1989,9 +1982,7 @@ let make_stack_loc ~offset n (r : Reg.t) =
   (* Manufacture stack entry with this register's type *)
   (match r.typ with
    | Int | Val | Addr | Float -> ()
-   | Vec128 ->
-     if simd_frontend_disabled ()
-     then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 register.");
+   | Vec128 -> assert_simd_enabled ());
   Reg.at_location r.typ loc
 
 (* CR mshinwell: Not now, but after code review, it would be better to


### PR DESCRIPTION
Deletes the `-fsimd-regalloc` amd64 backend flag, as we no longer need it for testing.
SIMD registers are now enabled whenever the SIMD language extension is enabled.