### PR TITLE
Abstract amd64 ISA extension flags

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -55,9 +55,6 @@ let bmi_support = ref true
 (* Bit manipulation 2 (Haswell+) *)
 let bmi2_support = ref true
 
-(* Enable SIMD register allocation features. *)
-let simd_regalloc = ref false
-
 (* Machine-specific command-line options *)
 
 let command_line_options =
@@ -109,12 +106,12 @@ let command_line_options =
     "-fbmi2", Arg.Set bmi2_support,
       " Enable BMI2 intrinsics (default)";
     "-fno-bmi2", Arg.Clear bmi2_support,
-      " Disable BMI2 intrinsics";
-    "-fsimd-regalloc", Arg.Set simd_regalloc,
-      " Enable SIMD register allocation (implied by -extension SIMD)";
-    "-fno-simd-regalloc", Arg.Clear simd_regalloc,
-      " Disable SIMD register allocation (overridden by -extension SIMD) (default)";
+      " Disable BMI2 intrinsics"
   ]
+
+let assert_simd_enabled () =
+  if not (Language_extension.is_enabled SIMD) then
+  Misc.fatal_error "SIMD is not enabled."
 
 (* Specific operations for the AMD64 processor *)
 

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -16,17 +16,28 @@
 
 (* Machine-specific command-line options *)
 
-val popcnt_support : bool ref
-val prefetchw_support : bool ref
-val prefetchwt1_support : bool ref
+module Extension : sig
+  (* CR-soon mslater: cpuid support should be checked at startup *)
+
+  type t =
+    | POPCNT
+    | PREFETCHW
+    | PREFETCHWT1
+    | SSE3
+    | SSSE3
+    | SSE4_1
+    | SSE4_2
+    | CLMUL
+    | BMI (* IMPORTANT: LZCNT/TZCNT are interpreted as BSR/BSF on architectures prior
+             to Haswell, i.e. they do not cause an illegal instruction fault.
+             That means code using LZCNT/TZCNT will silently produce wrong results. *)
+    | BMI2
+
+  val enabled : t -> bool
+  val disabled : t -> bool
+end
+
 val trap_notes : bool ref
-val clmul_support : bool ref
-val bmi_support : bool ref
-val bmi2_support : bool ref
-val sse3_support : bool ref
-val ssse3_support : bool ref
-val sse41_support : bool ref
-val sse42_support : bool ref
 val command_line_options : (string * Arg.spec * string) list
 val assert_simd_enabled : unit -> unit
 

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -27,8 +27,8 @@ val sse3_support : bool ref
 val ssse3_support : bool ref
 val sse41_support : bool ref
 val sse42_support : bool ref
-val simd_regalloc : bool ref
 val command_line_options : (string * Arg.spec * string) list
+val assert_simd_enabled : unit -> unit
 
 (* Specific operations for the AMD64 processor *)
 

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -34,7 +34,6 @@ module Extension : sig
     | BMI2
 
   val enabled : t -> bool
-  val disabled : t -> bool
 end
 
 val trap_notes : bool ref

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -41,8 +41,6 @@ let _label s = D.label ~typ:QWORD s
 
 (* Override proc.ml *)
 
-let simd_frontend_disabled () = not (Language_extension.is_enabled SIMD)
-
 let int_reg_name =
   [| RAX; RBX; RDI; RSI; RDX; RCX; R8; R9;
      R12; R13; R10; R11; RBP; |]
@@ -53,10 +51,7 @@ let register_name typ r =
   match typ with
   | Int | Val | Addr -> Reg64 (int_reg_name.(r))
   | Float -> Regf (float_reg_name.(r - 100))
-  | Vec128 ->
-    if simd_frontend_disabled ()
-    then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 register.";
-    Regf (float_reg_name.(r - 100))
+  | Vec128 -> assert_simd_enabled (); Regf (float_reg_name.(r - 100))
 
 let phys_rax = phys_reg Int 0
 let phys_rdx = phys_reg Int 4
@@ -111,8 +106,7 @@ let frame_required = ref false
 
 let frame_size () =                     (* includes return address *)
   if !frame_required then begin
-    if simd_frontend_disabled () && (num_stack_slots.(2) > 0)
-    then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 stack slot.";
+    if num_stack_slots.(2) > 0 then assert_simd_enabled ();
     let sz =
       (!stack_offset
        + 8
@@ -128,8 +122,7 @@ let slot_offset loc cl =
   match loc with
   | Incoming n -> frame_size() + n
   | Local n ->
-      if simd_frontend_disabled () && (num_stack_slots.(2) > 0 || cl >= 2)
-      then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 stack slot.";
+      if num_stack_slots.(2) > 0 || cl >= 2 then assert_simd_enabled ();
       (!stack_offset +
         (* Preserves original ordering (int -> float) *)
         match cl with
@@ -1989,9 +1982,7 @@ let make_stack_loc ~offset n (r : Reg.t) =
   (* Manufacture stack entry with this register's type *)
   (match r.typ with
    | Int | Val | Addr | Float -> ()
-   | Vec128 ->
-     if simd_frontend_disabled ()
-     then Misc.fatal_error "SIMD types are not enabled, but got a Vec128 register.");
+   | Vec128 -> assert_simd_enabled ());
   Reg.at_location r.typ loc
 
 (* CR mshinwell: Not now, but after code review, it would be better to

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1526,7 +1526,7 @@ let emit_instr fallthrough i =
          previous experience with similar things, but maybe the change
          should be left for later.
          mshinwell: The current situation is fine for now. *)
-      if !Arch.bmi_support then begin
+      if Arch.Extension.enabled BMI then begin
         I.lzcnt (arg i 0) (res i 0)
       end else if arg_is_non_zero then begin
         (* No need to handle that bsr is undefined on 0 input. *)
@@ -1546,7 +1546,7 @@ let emit_instr fallthrough i =
       end
   | Lop(Iintop(Ictz { arg_is_non_zero; })) ->
     (* CR-someday gyorsh: can we do it at selection? *)
-    if !Arch.bmi_support then begin
+    if Arch.Extension.enabled BMI then begin
       I.tzcnt (arg i 0) (res i 0)
     end else if arg_is_non_zero then begin
       (* No need to handle that bsf is undefined on 0 input. *)
@@ -1559,7 +1559,7 @@ let emit_instr fallthrough i =
       def_label lbl_nz
     end
   | Lop(Iintop Ipopcnt) ->
-      assert (!popcnt_support);
+      assert (Arch.Extension.enabled POPCNT);
       I.popcnt (arg i 0) (res i 0)
   | Lop(Icsel tst) ->
     let len = Array.length i.arg in

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -696,7 +696,7 @@ let precolored_regs () =
   if fp then Reg.Set.remove rbp phys_regs else phys_regs
 
 let operation_supported = function
-  | Cpopcnt -> !popcnt_support
+  | Cpopcnt -> Arch.Extension.enabled POPCNT
   | Cprefetch _ | Catomic _
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -376,13 +376,13 @@ method! select_operation op args dbg =
       (* Emit prefetch for read hint when prefetchw is not supported.
          Matches the behavior of gcc's __builtin_prefetch *)
       let is_write =
-        if is_write && (Arch.Extension.disabled PREFETCHW)
+        if is_write && not (Arch.Extension.enabled PREFETCHW)
         then false
         else is_write
       in
       let locality : Arch.prefetch_temporal_locality_hint =
         match select_locality locality with
-        | Moderate when is_write && (Arch.Extension.disabled PREFETCHWT1) -> High
+        | Moderate when is_write && not (Arch.Extension.enabled PREFETCHWT1) -> High
         | l -> l
       in
       let addr, eloc =

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -376,13 +376,13 @@ method! select_operation op args dbg =
       (* Emit prefetch for read hint when prefetchw is not supported.
          Matches the behavior of gcc's __builtin_prefetch *)
       let is_write =
-        if is_write && not !prefetchw_support
+        if is_write && (Arch.Extension.disabled PREFETCHW)
         then false
         else is_write
       in
       let locality : Arch.prefetch_temporal_locality_hint =
         match select_locality locality with
-        | Moderate when is_write && not !prefetchwt1_support -> High
+        | Moderate when is_write && (Arch.Extension.disabled PREFETCHWT1) -> High
         | l -> l
       in
       let addr, eloc =

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -74,7 +74,7 @@ let float_rounding_of_int = function
   | i -> bad_immediate "Invalid float rounding immediate: %d" i
 
 let select_operation_clmul op args =
-  if Arch.Extension.disabled CLMUL
+  if not (Arch.Extension.enabled CLMUL)
   then None
   else
     match op with
@@ -84,7 +84,7 @@ let select_operation_clmul op args =
     | _ -> None
 
 let select_operation_bmi2 op args =
-  if Arch.Extension.disabled BMI2
+  if not (Arch.Extension.enabled BMI2)
   then None
   else
     match op with
@@ -243,7 +243,7 @@ let select_operation_sse2 op args =
   | _ -> None
 
 let select_operation_sse3 op args =
-  if Arch.Extension.disabled SSE3
+  if not (Arch.Extension.enabled SSE3)
   then None
   else
     match op with
@@ -259,7 +259,7 @@ let select_operation_sse3 op args =
     | _ -> None
 
 let select_operation_ssse3 op args =
-  if Arch.Extension.disabled SSSE3
+  if not (Arch.Extension.enabled SSSE3)
   then None
   else
     match op with
@@ -284,7 +284,7 @@ let select_operation_ssse3 op args =
     | _ -> None
 
 let select_operation_sse41 op args =
-  if Arch.Extension.disabled SSE4_1
+  if not (Arch.Extension.enabled SSE4_1)
   then None
   else
     match op with
@@ -368,7 +368,7 @@ let select_operation_sse41 op args =
     | _ -> None
 
 let select_operation_sse42 op args =
-  if Arch.Extension.disabled SSE4_2
+  if not (Arch.Extension.enabled SSE4_2)
   then None
   else
     match op with

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -74,7 +74,7 @@ let float_rounding_of_int = function
   | i -> bad_immediate "Invalid float rounding immediate: %d" i
 
 let select_operation_clmul op args =
-  if not !Arch.clmul_support
+  if Arch.Extension.disabled CLMUL
   then None
   else
     match op with
@@ -84,7 +84,7 @@ let select_operation_clmul op args =
     | _ -> None
 
 let select_operation_bmi2 op args =
-  if not !Arch.bmi2_support
+  if Arch.Extension.disabled BMI2
   then None
   else
     match op with
@@ -243,7 +243,7 @@ let select_operation_sse2 op args =
   | _ -> None
 
 let select_operation_sse3 op args =
-  if not !Arch.sse3_support
+  if Arch.Extension.disabled SSE3
   then None
   else
     match op with
@@ -259,7 +259,7 @@ let select_operation_sse3 op args =
     | _ -> None
 
 let select_operation_ssse3 op args =
-  if not !Arch.ssse3_support
+  if Arch.Extension.disabled SSSE3
   then None
   else
     match op with
@@ -284,7 +284,7 @@ let select_operation_ssse3 op args =
     | _ -> None
 
 let select_operation_sse41 op args =
-  if not !Arch.sse41_support
+  if Arch.Extension.disabled SSE4_1
   then None
   else
     match op with
@@ -368,7 +368,7 @@ let select_operation_sse41 op args =
     | _ -> None
 
 let select_operation_sse42 op args =
-  if not !Arch.sse42_support
+  if Arch.Extension.disabled SSE4_2
   then None
   else
     match op with


### PR DESCRIPTION
Deletes the global bool refs used to indicate x86 extension support and replaces them with an abstract interface.
The implementation auto-generates CLI flags for each extension.

New output (the flag names are unchanged but the descriptions have been modified):
```
  -fbmi2 Enable BMI2 instructions (Haswell+) (default)
  -fno-bmi2 Disable BMI2 instructions (Haswell+)
  -fbmi Enable BMI instructions (Haswell+) (default)
  -fno-bmi Disable BMI instructions (Haswell+)
  -fclmul Enable CLMUL instructions (Westmere+) (default)
  -fno-clmul Disable CLMUL instructions (Westmere+)
  -fsse42 Enable SSE42 instructions (Nehalem+) (default)
  -fno-sse42 Disable SSE42 instructions (Nehalem+)
  -fsse41 Enable SSE41 instructions (Penryn+) (default)
  -fno-sse41 Disable SSE41 instructions (Penryn+)
  -fssse3 Enable SSSE3 instructions (Core+) (default)
  -fno-ssse3 Disable SSSE3 instructions (Core+)
  -fsse3 Enable SSE3 instructions (Prescott+) (default)
  -fno-sse3 Disable SSE3 instructions (Prescott+)
  -fprefetchwt1 Enable PREFETCHWT1 instructions (Xeon Phi)
  -fno-prefetchwt1 Disable PREFETCHWT1 instructions (Xeon Phi) (default)
  -fprefetchw Enable PREFETCHW instructions (Broadwell+) (default)
  -fno-prefetchw Disable PREFETCHW instructions (Broadwell+)
  -fpopcnt Enable POPCNT instructions (Nehalem+) (default)
  -fno-popcnt Disable POPCNT instructions (Nehalem+)
```