### PR TITLE
Delete int64->float CR

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -583,9 +583,6 @@ let unary_primitive env res dbg f arg =
     extra, res, expr
   | Boolean_not -> None, res, C.mk_not dbg arg
   | Reinterpret_int64_as_float ->
-    (* CR-someday mshinwell: We should add support for this operation in the
-       backend. It isn't the identity as there may need to be a move between
-       different register kinds (e.g. integer to XMM registers on x86-64). *)
     ( None,
       res,
       C.extcall ~dbg ~alloc:false ~returns:true ~is_c_builtin:false

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -583,6 +583,7 @@ let unary_primitive env res dbg f arg =
     extra, res, expr
   | Boolean_not -> None, res, C.mk_not dbg arg
   | Reinterpret_int64_as_float ->
+    (* Will be translated to MOVQ by backend/amd64/selection.ml. *)
     ( None,
       res,
       C.extcall ~dbg ~alloc:false ~returns:true ~is_c_builtin:false


### PR DESCRIPTION
This is handled by the backend [here](https://github.com/ocaml-flambda/flambda-backend/blob/main/backend/amd64/selection.ml#L305), so we can delete the CR.

Selection overriding non-`@@builtin` C stubs is a bit hacky, so it might be a better idea to add an actual cmm instruction for this (another `scalar_cast` case). Doing so would also fix [this](https://github.com/ocaml-flambda/flambda-backend/blob/main/backend/amd64/emit.mlp#L762) cr.