### PR TITLE
Add missing stdlib modules to toplevel

### DIFF
--- a/ocaml/toplevel/byte/dune
+++ b/ocaml/toplevel/byte/dune
@@ -50,15 +50,20 @@
                     stdlib__Ephemeron
                     stdlib__Filename
                     stdlib__Float
+                    stdlib__Float_u
                     stdlib__Format
                     stdlib__Fun
                     stdlib__Gc
                     stdlib__Genlex
                     stdlib__Hashtbl
+                    stdlib__Iarray
+                    stdlib__IarrayLabels
                     stdlib__In_channel
                     stdlib__Int
                     stdlib__Int32
+                    stdlib__Int32_u
                     stdlib__Int64
+                    stdlib__Int64_u
                     stdlib__Lazy
                     stdlib__Lexing
                     stdlib__List
@@ -67,6 +72,7 @@
                     stdlib__Marshal
                     stdlib__MoreLabels
                     stdlib__Nativeint
+                    stdlib__Nativeint_u
                     stdlib__Obj
                     stdlib__Oo
                     stdlib__Option


### PR DESCRIPTION
Currently using `Stdlib__Float_u` in `ocaml` toplevel results in error:

```
$ ./out/bin/ocaml -extension layouts
...
# Stdlib__Float_u.of_int 10;;
Error: Reference to undefined global `Stdlib__Float_u'
Hint: This means that the interface of a module is loaded, but its implementation is not.
      Did you mean to load a compiled implementation of the module 
      using #load or by passing it as an argument to the toplevel?
```

This PR modifies the dune file to add
- `stdlib__Float_u`
- `stdlib__Iarray`
- `stdlib__IarrayLabels`
- `stdlib__Int32_u`
- `stdlib__Int64_u`
- `stdlib__Nativeint_u`

