### PR TITLE
Optimise [diff_domains] for stdlib map.

### DIFF
--- a/middle_end/flambda2/algorithms/container_types.ml
+++ b/middle_end/flambda2/algorithms/container_types.ml
@@ -66,14 +66,17 @@ module Make_map (T : Thing) (Set : Set_plus_stdlib with type elt = T.t) = struct
   let of_set f set = Set.fold (fun e map -> add e (f e) map) set empty
 
   let diff_domains t1 t2 =
-    merge
-      (fun _key datum1 datum2 ->
-        match datum1, datum2 with
-        | None, None -> None
-        | Some datum1, None -> Some datum1
-        | None, Some _datum2 -> None
-        | Some _datum1, Some _datum2 -> None)
-      t1 t2
+    if is_empty t2
+    then t1
+    else
+      merge
+        (fun _key datum1 datum2 ->
+          match datum1, datum2 with
+          | None, None -> None
+          | Some datum1, None -> Some datum1
+          | None, Some _datum2 -> None
+          | Some _datum1, Some _datum2 -> None)
+        t1 t2
 
   let inter f t1 t2 =
     merge


### PR DESCRIPTION
There is a quadratic behaviour in the construction of name occurrences when rebuilding flambda2 terms, due to `diff_domains` being linear in the total size of the maps, even when the second one is empty. Since this second map is always empty for value slots and function_slots (which use stdlib maps and not patricia trees), it is easy to optimise this special case.
On `typecore.ml`, a mean of 30 runs shows `simplify` takes 3.39s and allocates 3.46GB without this PR, and takes 3.16s and allocates 2.41GB with this PR, for a total compilation time of around 7s, meaning we get a ~3% speedup, and we get from a total of 5.71GB allocated to 4.66GB, a ~20% reduction.