### PR TITLE
Small bug fixes for middle/backend unboxed array support

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1055,10 +1055,11 @@ let unboxed_int32_array_ref arr index dbg =
   bind "arr" arr (fun arr ->
       bind "index" index (fun index ->
           let index =
-            (* Need to skip the custom_operations field. We add 2 not 1 since
-               the call to [array_indexing], below, is in terms of 32-bit
-               words. *)
-            add_int index (int ~dbg 2) dbg
+            (* Need to skip the custom_operations field. We add 2 element
+               offsets not 1 since the call to [array_indexing], below, is in
+               terms of 32-bit words. Then we multiply the offset by 2 to get 4
+               since we are manipulating a tagged int. *)
+            add_int index (int ~dbg 4) dbg
           in
           let log2_size_addr = 2 in
           (* N.B. The resulting value will be sign extended by the code
@@ -1072,8 +1073,9 @@ let unboxed_int64_or_nativeint_array_ref arr index dbg =
   bind "arr" arr (fun arr ->
       bind "index" index (fun index ->
           let index =
-            (* Need to skip the custom_operations field *)
-            add_int index (int ~dbg 1) dbg
+            (* Need to skip the custom_operations field. 2 not 1 since we are
+               manipulating a tagged int. *)
+            add_int index (int ~dbg 2) dbg
           in
           int_array_ref arr index dbg))
 
@@ -1083,7 +1085,7 @@ let unboxed_int32_array_set arr ~index ~new_value dbg =
           bind "new_value" new_value (fun new_value ->
               let index =
                 (* See comment in [unboxed_int32_array_ref]. *)
-                add_int index (int ~dbg 2) dbg
+                add_int index (int ~dbg 4) dbg
               in
               let log2_size_addr = 2 in
               Cop
@@ -1097,7 +1099,7 @@ let unboxed_int64_or_nativeint_array_set arr ~index ~new_value dbg =
           bind "new_value" new_value (fun new_value ->
               let index =
                 (* See comment in [unboxed_int64_or_nativeint_array_ref]. *)
-                add_int index (int ~dbg 1) dbg
+                add_int index (int ~dbg 2) dbg
               in
               int_array_set arr index new_value dbg)))
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -892,16 +892,20 @@ let array_indexing ?typ log2size ptr ofs dbg =
 let int ~dbg i = natint_const_untagged dbg (Nativeint.of_int i)
 
 let custom_ops_unboxed_int32_odd_array =
-  Cconst_symbol (Cmm.global_symbol "_unboxed_int32_odd_array", Debuginfo.none)
+  Cconst_symbol
+    (Cmm.global_symbol "caml_unboxed_int32_odd_array_ops", Debuginfo.none)
 
 let custom_ops_unboxed_int32_even_array =
-  Cconst_symbol (Cmm.global_symbol "_unboxed_int32_even_array", Debuginfo.none)
+  Cconst_symbol
+    (Cmm.global_symbol "caml_unboxed_int32_even_array_ops", Debuginfo.none)
 
 let custom_ops_unboxed_int64_array =
-  Cconst_symbol (Cmm.global_symbol "_unboxed_int64_array", Debuginfo.none)
+  Cconst_symbol
+    (Cmm.global_symbol "caml_unboxed_int64_array_ops", Debuginfo.none)
 
 let custom_ops_unboxed_nativeint_array =
-  Cconst_symbol (Cmm.global_symbol "_unboxed_nativeint_array", Debuginfo.none)
+  Cconst_symbol
+    (Cmm.global_symbol "caml_unboxed_nativeint_array_ops", Debuginfo.none)
 
 let unboxed_int32_array_length arr dbg =
   (* A dynamic test is needed to determine if the array contains an odd or even


### PR DESCRIPTION
This PR contains fixes for three bugs found when adding frontend support:

1. array length output needs to be tagged
2. ref/set operations receive tagged ints as inputs. the process of skipping the custom field needs to be updated
3. correct symbol names for the custom ops

Each fix is its own commit. Might be easier to review one commit at a time.