### PR TITLE
add region around Texp_probe

### DIFF
--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -976,7 +976,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
              probes. *)
           ~params:(List.map (fun name -> { name; layout = layout_probe_arg; attributes = Lambda.default_param_attribute; mode = alloc_heap }) param_idents)
           ~return:return_layout
-          ~body
+          ~body:(maybe_region_layout return_layout body)
           ~loc:(of_location ~scopes exp.exp_loc)
           ~attr
           ~mode:alloc_heap

--- a/tests/backend/probes/dune
+++ b/tests/backend/probes/dune
@@ -4,7 +4,7 @@
   (and (= %{context_name} "main")
        (= %{system} "linux")
        (= %{architecture} "amd64")))
- (deps t1.ml)
+ (deps t1.ml region.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -warn-error "+190" -c)))
 
 (executable

--- a/tests/backend/probes/dune
+++ b/tests/backend/probes/dune
@@ -4,8 +4,17 @@
   (and (= %{context_name} "main")
        (= %{system} "linux")
        (= %{architecture} "amd64")))
- (deps t1.ml region.ml)
+ (deps t1.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -warn-error "+190" -c)))
+
+(rule
+ (alias runtest)
+ (enabled_if
+  (and (= %{context_name} "main")
+       (= %{system} "linux")
+       (= %{architecture} "amd64")))
+ (deps region.ml)
+ (action (run %{bin:ocamlopt.opt} %{deps} -c)))
 
 (executable
  (name t2)

--- a/tests/backend/probes/region.ml
+++ b/tests/backend/probes/region.ml
@@ -1,0 +1,6 @@
+(* minimal BUG example from alanechang *)
+let _ =
+  (fun f -> [%probe "" (
+    let local_ a = "abc" in
+    f a; ()
+  )]) (fun x -> ())


### PR DESCRIPTION
Adds a potential region around the body (handler) of `Texp_probe` if there are local allocation inside the body.