### PR TITLE
Add missing case for `Ltyp_poly` in Pprintast

### DIFF
--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -453,6 +453,17 @@ and core_type_jane_syntax ctxt attrs f (x : Jane_syntax.Core_type.t) =
       (core_type1 ctxt) aliased_type
       tyvar_option name
       jkind_annotation jkind
+  | Jtyp_layout (Ltyp_poly {bound_vars = []; inner_type}) ->
+    core_type ctxt f inner_type
+  | Jtyp_layout (Ltyp_poly {bound_vars; inner_type}) ->
+    let jkind_poly_var f (name, jkind_opt) =
+      match jkind_opt with
+      | Some jkind -> pp f "(%a@;:@;%a)" tyvar_loc name jkind_annotation jkind
+      | None -> tyvar_loc f name
+    in
+    pp f "@[<2>%a@;.@;%a@]"
+        (list jkind_poly_var ~sep:"@;") bound_vars
+        (core_type ctxt) inner_type
   | _ -> pp f "@[<2>%a@]" (core_type1_jane_syntax ctxt attrs) x
 
 

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -464,7 +464,8 @@ and core_type_jane_syntax ctxt attrs f (x : Jane_syntax.Core_type.t) =
     pp f "@[<2>%a@;.@;%a@]"
         (list jkind_poly_var ~sep:"@;") bound_vars
         (core_type ctxt) inner_type
-  | _ -> pp f "@[<2>%a@]" (core_type1_jane_syntax ctxt attrs) x
+  | Jtyp_tuple _ | Jtyp_layout (Ltyp_var _) ->
+    pp f "@[<2>%a@]" (core_type1_jane_syntax ctxt attrs) x
 
 
 and core_type1_jane_syntax ctxt attrs f (x : Jane_syntax.Core_type.t) =
@@ -474,7 +475,8 @@ and core_type1_jane_syntax ctxt attrs f (x : Jane_syntax.Core_type.t) =
     | Jtyp_layout (Ltyp_var { name; jkind }) ->
       pp f "(%a@;:@;%a)" tyvar_option name jkind_annotation jkind
     | Jtyp_tuple x -> core_type1_labeled_tuple ctxt attrs f x
-    | _ -> paren true (core_type_jane_syntax ctxt attrs) f x
+    | Jtyp_layout (Ltyp_alias _ | Ltyp_poly _) ->
+      paren true (core_type_jane_syntax ctxt attrs) f x
 
 and tyvar_option f = function
   | None -> pp f "_"

--- a/ocaml/testsuite/tests/parsetree/source_jane_street.ml
+++ b/ocaml/testsuite/tests/parsetree/source_jane_street.ml
@@ -27,6 +27,10 @@ module type S_for_layouts = sig
   type t : float64
 
   type variant = A : ('a : immediate). 'a -> variant
+
+  val f1: ('a : float64) ('b : immediate) 'c . 'a -> 'b -> 'c
+  val f2: ('a : float64) 'b ('c : bits64) . 'a -> 'b -> 'c
+  val f3: 'a 'b ('c : word) . 'a -> 'b -> 'c
 end;;
 
 type ('a : immediate) for_layouts = 'a;;


### PR DESCRIPTION
`module type S = sig val f1 : ('a : float64) ('b : immediate) 'c. 'a -> 'b -> 'c end;;` currently causes an infinite loop in `Pprintast`.

This is due to a missing case match for `Ltyp_poly`. This PR adds the missing case, removes the use of wildcard match cases, and provides regression tests.