### PR TITLE
Refine assertion in caml_modify_local

### DIFF
--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -358,8 +358,9 @@ CAMLexport int caml_is_stack (value v)
 CAMLexport void caml_modify_local (value obj, intnat i, value val)
 {
   if (Color_hd(Hd_val(obj)) == NOT_MARKABLE) {
-    /* This function should not be used on external values */
-    CAMLassert(caml_is_stack(obj));
+    /* This function should not be used on external values, but it ends up
+       being used like that -- for the moment, just allow this. */
+    // CAMLassert(caml_is_stack(obj));
     Field(obj, i) = val;
   } else {
     caml_modify(&Field(obj, i), val);

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -362,7 +362,7 @@ CAMLexport void caml_modify_local (value obj, intnat i, value val)
        some cases where it has been, in safe contexts where only immediate
        values are involved. */
     CAMLassert(caml_is_stack(obj)
-      || (!Is_block(val) && !Is_block(Field(obj, i)));
+      || (!Is_block(val) && !Is_block(Field(obj, i))));
     Field(obj, i) = val;
   } else {
     caml_modify(&Field(obj, i), val);

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -358,9 +358,8 @@ CAMLexport int caml_is_stack (value v)
 CAMLexport void caml_modify_local (value obj, intnat i, value val)
 {
   if (Color_hd(Hd_val(obj)) == NOT_MARKABLE) {
-    /* This function should not be used on external values, but it ends up
-       being used like that -- for the moment, just allow this. */
-    // CAMLassert(caml_is_stack(obj));
+    CAMLassert(caml_is_stack(obj)
+      || (!Is_block(val) && !Is_block(Field(obj, i)));
     Field(obj, i) = val;
   } else {
     caml_modify(&Field(obj, i), val);

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -358,6 +358,9 @@ CAMLexport int caml_is_stack (value v)
 CAMLexport void caml_modify_local (value obj, intnat i, value val)
 {
   if (Color_hd(Hd_val(obj)) == NOT_MARKABLE) {
+    /* This function should not be used on external values, but we have seen
+       some cases where it has been, in safe contexts where only immediate
+       values are involved. */
     CAMLassert(caml_is_stack(obj)
       || (!Is_block(val) && !Is_block(Field(obj, i)));
     Field(obj, i) = val;


### PR DESCRIPTION
It is unfortunately the case that one can end up with `caml_modify_local` calls on blocks outside of the OCaml heap.  This trips an assertion when using the debug runtime.  For the moment I'd like to disable this assertion, since the semantics of the function are correct for external values, and decide later how we should proceed in the medium term.