### PR TITLE
Allocate pools for the shared heap in batches rather than one at a time

### DIFF
--- a/ocaml/runtime/platform.c
+++ b/ocaml/runtime/platform.c
@@ -22,19 +22,36 @@
 #include "caml/osdeps.h"
 #include "caml/platform.h"
 #include "caml/fail.h"
-#include "caml/lf_skiplist.h"
 #ifdef HAS_SYS_MMAN_H
 #include <sys/mman.h>
 #endif
 #ifdef _WIN32
 #include <windows.h>
 #endif
-#ifdef DEBUG
-#include "caml/domain.h"
-#endif
 
 #include "caml/alloc.h"
 #include "sync_posix.h"
+
+#ifdef _WIN32
+/* CR ocaml 5 compactor:
+
+   The runtime does not currently guarantee that memory is released to the OS in
+   the same block sizes as it was allocated, making it incompatible with
+   Windows.
+
+   This incompatibility arises from the batch-mmap patch at:
+
+       https://github.com/ocaml-flambda/flambda-backend/pull/2248
+
+   which does large memory allocations to acquire new pools. However, the
+   compactor releases pools one at a time. Until the compactor is updated
+   to be aware of large mappings, this will not work on Windows.
+
+   So, for now, Windows compatibility is broken. The assertions ensuring that
+   mapping and unmapping sizes agree (ocaml/ocaml PR#10908) have been reverted,
+   and should be restored once the compactor is updated */
+#error "Windows compatibility currently broken due to mmap sizing"
+#endif
 
 /* Error reporting */
 
@@ -144,24 +161,8 @@ uintnat caml_mem_round_up_pages(uintnat size)
 
 #define Is_page_aligned(size) ((size & (caml_plat_pagesize - 1)) == 0)
 
-#ifdef DEBUG
-static struct lf_skiplist mmap_blocks = {NULL};
-#endif
-
-#ifndef _WIN32
-#endif
-
 void* caml_mem_map(uintnat size, int reserve_only)
 {
-#ifdef DEBUG
-  if (mmap_blocks.head == NULL) {
-    /* The first call to caml_mem_map should be during caml_init_domains, called
-       by caml_init_gc during startup - i.e. before any domains have started. */
-    CAMLassert(atomic_load_acquire(&caml_num_domains_running) <= 1);
-    caml_lf_skiplist_init(&mmap_blocks);
-  }
-#endif
-
   void* mem = caml_plat_mem_map(size, reserve_only);
 
   if (mem == 0) {
@@ -172,10 +173,6 @@ void* caml_mem_map(uintnat size, int reserve_only)
 
   caml_gc_message(0x1000, "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
                           " bytes at %p for heaps\n", size, mem);
-
-#ifdef DEBUG
-  caml_lf_skiplist_insert(&mmap_blocks, (uintnat)mem, size);
-#endif
 
   return mem;
 }
@@ -199,17 +196,9 @@ void caml_mem_decommit(void* mem, uintnat size)
 
 void caml_mem_unmap(void* mem, uintnat size)
 {
-#ifdef DEBUG
-  uintnat data;
-  CAMLassert(caml_lf_skiplist_find(&mmap_blocks, (uintnat)mem, &data) != 0);
-  CAMLassert(data == size);
-#endif
   caml_gc_message(0x1000, "munmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
                           " bytes at %p for heaps\n", size, mem);
   caml_plat_mem_unmap(mem, size);
-#ifdef DEBUG
-  caml_lf_skiplist_remove(&mmap_blocks, (uintnat)mem);
-#endif
 }
 
 #define Min_sleep_ns       10000 // 10 us

--- a/ocaml/runtime/shared_heap.c
+++ b/ocaml/runtime/shared_heap.c
@@ -74,8 +74,10 @@ static struct {
   uintnat fresh_pools;
   char* next_fresh_pool;
 
-  /* Counts pools in some domain's heap, or in the global list below.
-     Does not count free or fresh pools above */
+  /* Count of all pools in use across all domains and the global lists below.
+
+     Does not include unused pools ('free' above) or freshly allocated pools
+     ('next_fresh_pool' above). */
   uintnat active_pools;
 
   /* these only contain swept memory of terminated domains*/

--- a/ocaml/runtime/shared_heap.c
+++ b/ocaml/runtime/shared_heap.c
@@ -70,6 +70,14 @@ static struct {
   caml_plat_mutex lock;
   pool* free;
 
+  /* Mapped but not yet active pools */
+  uintnat fresh_pools;
+  char* next_fresh_pool;
+
+  /* Counts pools in some domain's heap, or in the global list below.
+     Does not count free or fresh pools above */
+  uintnat active_pools;
+
   /* these only contain swept memory of terminated domains*/
   struct heap_stats stats;
   pool* global_avail_pools[NUM_SIZECLASSES];
@@ -78,6 +86,9 @@ static struct {
 } pool_freelist = {
   CAML_PLAT_MUTEX_INITIALIZER,
   NULL,
+  0,
+  NULL,
+  0,
   { 0, },
   { 0, },
   { 0, },
@@ -183,24 +194,34 @@ static pool* pool_acquire(struct caml_heap_state* local) {
   pool* r;
 
   caml_plat_lock(&pool_freelist.lock);
-  if (!pool_freelist.free) {
-    void* mem = caml_mem_map(Bsize_wsize(POOL_WSIZE), 0);
+  r = pool_freelist.free;
+  if (r) {
+    pool_freelist.free = r->next;
+  } else {
+    if (pool_freelist.fresh_pools == 0) {
+      uintnat new_pools = pool_freelist.active_pools * 15 / 100;
+      if (new_pools < 8) new_pools = 8;
 
-    if (mem) {
-      CAMLassert(pool_freelist.free == NULL);
-
-      r = (pool*)mem;
-      r->next = pool_freelist.free;
+      void* mem = caml_mem_map(Bsize_wsize(POOL_WSIZE) * new_pools, 0);
+      if (mem) {
+        pool_freelist.fresh_pools = new_pools;
+        pool_freelist.next_fresh_pool = mem;
+      }
+    }
+    if (pool_freelist.fresh_pools > 0) {
+      r = (pool*)pool_freelist.next_fresh_pool;
+      pool_freelist.next_fresh_pool += Bsize_wsize(POOL_WSIZE);
+      pool_freelist.fresh_pools --;
+      r->next = NULL;
       r->owner = NULL;
-      pool_freelist.free = r;
     }
   }
-  r = pool_freelist.free;
-  if (r)
-    pool_freelist.free = r->next;
+  if (r) {
+    pool_freelist.active_pools ++;
+    CAMLassert(r->owner == NULL);
+  }
   caml_plat_unlock(&pool_freelist.lock);
 
-  if (r) CAMLassert (r->owner == NULL);
   return r;
 }
 
@@ -216,6 +237,7 @@ static void pool_release(struct caml_heap_state* local,
   caml_plat_lock(&pool_freelist.lock);
   pool->next = pool_freelist.free;
   pool_freelist.free = pool;
+  pool_freelist.active_pools--;
   caml_plat_unlock(&pool_freelist.lock);
 }
 
@@ -1244,6 +1266,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
       remaining pools have been filled up by evacuated blocks. */
 
   pool* cur_pool = evacuated_pools;
+  uintnat freed_pools = 0;
   while (cur_pool) {
     pool* next_pool = cur_pool->next;
 
@@ -1256,7 +1279,11 @@ void caml_compact_heap(caml_domain_state* domain_state,
 
     pool_free(heap, cur_pool, cur_pool->sz);
     cur_pool = next_pool;
+    freed_pools++;
   }
+  caml_plat_lock(&pool_freelist.lock);
+  pool_freelist.active_pools -= freed_pools;
+  caml_plat_unlock(&pool_freelist.lock);
 
   CAML_EV_END(EV_COMPACT_RELEASE);
   caml_global_barrier();


### PR DESCRIPTION
This patch changes the major heap allocator to request memory for new pools in large batches rather than one pool at a time. It currently grows the heap by 15% of the current size each time, with a minimum of 8 new pools.

The 15% number is used because that's the default in OCaml 4 - in a future patch, I'll restore the plumbing from OCaml 4 to make this configurable using the `major_heap_increment` / `i` parameter.

In programs with rapidly-growing heaps, this speeds things up by reducing the amount of time spent kernel-side in `mmap` calls. In a [synthetic benchmark](https://gist.github.com/stedolan/06fb028a6d6b3be38a67433d4f9ec7d5), which allocates more than it collects (i.e. `promotion_rate` high, `collection_rate` below 100) and grows the heap to about a gigabyte, this patch improves performance:
```
runtime4:
            time (s): 3.98
    heap before (mb): 109
     heap after (mb): 1558
  heap growth (mb/s): 364
              minors: 445
              majors: 8

runtime5:
            time (s): 4.04
    heap before (mb): 106
     heap after (mb): 1579
  heap growth (mb/s): 365
              minors: 445
              majors: 8

runtime5+this:
            time (s): 3.71
    heap before (mb): 106
     heap after (mb): 1579
  heap growth (mb/s): 397
              minors: 445
              majors: 8
```

The time difference is mostly explained by spending less time in the kernel (i.e. system time improves much more than user).

The large allocations also seem to improve TLB performance on this benchmark. Here are the TLB walk counts from a server-class Intel Skylake processor:

```
runtime4:
           417,452      dtlb_load_misses.walk_completed_4k                                   
           179,418      dtlb_store_misses.walk_completed_4k                                   
            15,186      dtlb_load_misses.walk_completed_2m_4m                                   
             1,597      dtlb_store_misses.walk_completed_2m_4m                                   

runtime5:
         1,714,417      dtlb_load_misses.walk_completed_4k                                   
         2,648,033      dtlb_store_misses.walk_completed_4k                                   
            41,662      dtlb_load_misses.walk_completed_2m_4m                                   
             2,221      dtlb_store_misses.walk_completed_2m_4m                                   

runtime5+this:
           303,186      dtlb_load_misses.walk_completed_4k                                   
           156,856      dtlb_store_misses.walk_completed_4k                                   
            23,515      dtlb_load_misses.walk_completed_2m_4m                                   
             1,603      dtlb_store_misses.walk_completed_2m_4m                                   
```

However, the current implementation of compaction frees pools in an arbitrary pattern. This will make holes in the large allocation blocks, so some of these benefits may disappear in programs which compact. (The benchmark measured here does not).