### PR TITLE
Simple fix for PR1515

### DIFF
--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -826,12 +826,6 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
     map_result
       ~f:TG.Head_of_kind_naked_immediate.create_naked_immediates_non_empty
       (set_meet (module I.Set) env is1 is2 ~of_set:Fun.id)
-  | Is_int ty1, Is_int ty2 ->
-    map_result ~f:TG.Head_of_kind_naked_immediate.create_is_int
-      (meet env ty1 ty2)
-  | Get_tag ty1, Get_tag ty2 ->
-    map_result ~f:TG.Head_of_kind_naked_immediate.create_get_tag
-      (meet env ty1 ty2)
   | Is_int is_int_ty, Naked_immediates immediates ->
     is_int_immediate ~is_int_ty ~immediates ~is_int_side:Left
   | Naked_immediates immediates, Is_int is_int_ty ->
@@ -841,6 +835,13 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
   | Naked_immediates immediates, Get_tag get_tag_ty ->
     get_tag_immediate ~get_tag_ty ~immediates ~get_tag_side:Right
   | (Is_int _ | Get_tag _), (Is_int _ | Get_tag _) ->
+    (* CR mshinwell: introduce improved handling for
+     *   Is_int meet Is_int
+     *   Get_tag meet Get_tag
+     * i.e. a better fix for PR1515, at which point we might also be able
+     * to consider improving:
+     *   Is_int meet Get_tag
+     * and vice-versa. *)
     (* We can't return Bottom, as it would be unsound, so we need to either do
        the actual meet with Naked_immediates, or just give up and return one of
        the arguments. *)


### PR DESCRIPTION
We think it is highly likely that this bug can't be triggered without the advanced meet algorithm, as otherwise we would have seen it.  This is the most straightforward fix to recover correctness.

The bug is sensitive to iteration order; naming the following file `better_meet_repro.ml` may work:
```
type 'a new_or_old = New of 'a | Old of 'a

type t = {
  foo : string new_or_old;
}

let foobar (orig : t) (update : t) =
  (* The order of these next two lines is important. *)
  let orig_f = orig.foo in
  let update_f = update.foo in
  match orig_f, update_f with
  | New _, Old _ | Old _, New _ -> orig_f
  | Old _, Old _ | New _, New _ -> update_f
```
Build with:
```
./_build/_bootinstall/bin/ocamlopt -O3 -dflambda -drawflambda -flambda2-advanced-meet -c better_meet_repro.ml
```
If the bug hits, the function will always return `orig_f`.