### PR TITLE
Fix choice of meet and join been evaluated before flags were parsed

### DIFF
--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -18,18 +18,18 @@ module Typing_env = struct
   include Typing_env
 
   let add_equation t name ty =
-    add_equation t name ty ~meet_type:Meet_and_join.meet_type
+    add_equation t name ty ~meet_type:(Meet_and_join.meet_type ())
 
   let add_equations_on_params t ~params ~param_types =
     add_equations_on_params t ~params ~param_types
-      ~meet_type:Meet_and_join.meet_type
+      ~meet_type:(Meet_and_join.meet_type ())
 
   let add_env_extension t extension =
-    add_env_extension t extension ~meet_type:Meet_and_join.meet_type
+    add_env_extension t extension ~meet_type:(Meet_and_join.meet_type ())
 
   let add_env_extension_with_extra_variables t extension =
     add_env_extension_with_extra_variables t extension
-      ~meet_type:Meet_and_join.meet_type
+      ~meet_type:(Meet_and_join.meet_type ())
 
   module Alias_set = Aliases.Alias_set
 end
@@ -55,7 +55,7 @@ module Code_age_relation = Code_age_relation
 
 let join ?bound_name central_env ~left_env ~left_ty ~right_env ~right_ty =
   let join_env = Typing_env.Join_env.create central_env ~left_env ~right_env in
-  match join ?bound_name join_env left_ty right_ty with
+  match (join ()) ?bound_name join_env left_ty right_ty with
   | Unknown -> unknown_like left_ty
   | Known ty -> ty
 

--- a/middle_end/flambda2/types/join_levels.ml
+++ b/middle_end/flambda2/types/join_levels.ml
@@ -86,7 +86,7 @@ let join_types ~env_at_fork envs_with_levels =
            could do better. *)
         TE.add_env_extension_maybe_bottom base_env
           (TEE.from_map joined_types)
-          ~meet_type:Meet_and_join.meet_type
+          ~meet_type:(Meet_and_join.meet_type ())
       in
       let join_types name joined_ty use_ty =
         let same_unit =
@@ -143,7 +143,7 @@ let join_types ~env_at_fork envs_with_levels =
             Join_env.create base_env ~left_env ~right_env:env_at_use
           in
           match
-            Meet_and_join.join ~bound_name:name join_env joined_ty use_ty
+            (Meet_and_join.join ()) ~bound_name:name join_env joined_ty use_ty
           with
           | Known joined_ty -> Some joined_ty
           | Unknown -> None
@@ -329,4 +329,4 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
       ~extra_lifted_consts_in_use_envs ~extra_allowed_names
   in
   TE.add_env_extension_from_level definition_typing_env level
-    ~meet_type:Meet_and_join.meet_type
+    ~meet_type:(Meet_and_join.meet_type ())

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -17,7 +17,7 @@ let meet env t1 t2 =
   then Meet_and_join_new.meet env t1 t2
   else Meet_and_join_old.meet (Typing_env.Meet_env.create env) t1 t2
 
-let meet_type =
+let[@inline] meet_type () =
   if Flambda_features.use_better_meet ()
   then Typing_env.New Meet_and_join_new.meet_type
   else Typing_env.Old Meet_and_join_old.meet
@@ -33,7 +33,7 @@ let meet_env_extension env t1 t2 =
   else
     Meet_and_join_old.meet_env_extension (Typing_env.Meet_env.create env) t1 t2
 
-let join =
+let[@inline] join () =
   if Flambda_features.use_better_meet ()
   then Meet_and_join_new.join
   else Meet_and_join_old.join

--- a/middle_end/flambda2/types/meet_and_join.mli
+++ b/middle_end/flambda2/types/meet_and_join.mli
@@ -18,7 +18,7 @@ val meet :
   Type_grammar.t ->
   (Type_grammar.t * Typing_env_extension.t) Or_bottom.t
 
-val meet_type : Typing_env.meet_type
+val meet_type : unit -> Typing_env.meet_type
 
 val meet_shape :
   Typing_env.t ->
@@ -35,6 +35,7 @@ val meet_env_extension :
   Typing_env_extension.t Or_bottom.t
 
 val join :
+  unit ->
   ?bound_name:Name.t ->
   Typing_env.Join_env.t ->
   Type_grammar.t ->


### PR DESCRIPTION
This was leading us to use the old meet and join algorithms even with the `-flambda2-advanced-meet` flag.