### PR TITLE
Adjustments of sharing to improve unboxing

### DIFF
--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -938,3 +938,5 @@ val unboxed_int64_or_nativeint_array_set :
   new_value:expression ->
   Debuginfo.t ->
   expression
+
+val simple_and_equal_exprs : expression -> expression -> bool

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -837,6 +837,7 @@ let make_key e =
         let ex = tr_rec env ex in
         let y = make_key x in
         Lmutlet (k,y,ex,tr_rec (Ident.add x (Lmutvar y) env) e)
+    | Lprim (Pfield _, _, _) -> raise Not_simple
     | Lprim (p,es,_) ->
         Lprim (p,tr_recs env es, Loc_unknown)
     | Lswitch (e,sw,loc,kind) ->

--- a/unboxing.ml
+++ b/unboxing.ml
@@ -1,0 +1,50 @@
+let[@inline] some_if_pos x = if x > 0 then Some x else None
+let[@cold] match_in_match x =
+  match some_if_pos x with
+  | Some x -> x * 2
+  | None -> 17
+;;
+
+let[@inline] some_if_pos' x = if x > 0 then Some (x + 1) else None
+let[@cold] match_in_match' x =
+  match some_if_pos' x with
+  | Some x -> x * 2
+  | None -> 17
+;;
+
+
+type t =
+  | C
+  | D
+  | E
+
+type s =
+  | A of int
+  | B of int
+
+let foo c a b =
+  let m =
+    match c with
+    | C -> A a
+    | D -> B b
+    | E -> B (b + 1)
+  in
+  match m with
+  | A x -> x
+  | B y -> y
+
+let bar m =
+  match m with
+  | A x -> x
+  | B y -> y
+
+let baz c a b =
+  let m =
+    match c with
+    | C -> A a
+    | D -> B b
+    | E -> B (b + 1)
+  in
+  match Sys.opaque_identity m with
+  | A x -> x
+  | B y -> y


### PR DESCRIPTION
The following example (which I must admit I thought used to work, but maybe a mistake was made back then) fails to unbox because sharing of `Lambda` terms causes the final `match` to be collapsed into a single `Pfield`.  This means that, even though there is a continuation available for unboxing in Flambda 2, we fail to unbox as the "reconstruction" `Switch` is absent:
```
type t =
  | C
  | D
  | E

type s =
  | A of int
  | B of int

let foo c a b =
  let m =
    match c with
    | C -> A a
    | D -> B b
    | E -> B (b + 1)
  in
  match m with
  | A x -> x
  | B y -> y
```

@lthls and I discussed this.  The proposed solution is to:
- stop sharing `Pfield` at the `Lambda` level
- allow sharing of `Pfield` (and indeed other operations) at the Cmm level.

Another way might have been to adjust the Flambda 2 unboxing code to have a variable per field (not per tag+field combination).  However this seems worse, since it loses precision in some cases (e.g. it would fail to propagate that the final return of `x` should actually just return `a`, not some unboxing parameter), and is also a more complicated change.  (Care would need to be taken in case the same field indexes were of different kinds for different tags, etc.)

This PR illustrates the use of a new function `Cmm_helpers.simple_and_equal_exprs` to implement the above strategy.  We started adjusting the `Cmm_helpers.transl_switch_clambda` code too, but wanted to discuss further before finishing this part.

Some further examples to try, following on from the above fragment:
```
let bar m =
  match m with
  | A x -> x
  | B y -> y

let baz c a b =
  let m =
    match c with
    | C -> A a
    | D -> B b
    | E -> B (b + 1)
  in
  match Sys.opaque_identity m with
  | A x -> x
  | B y -> y
```

This change should probably be put behind a flag.

@Gbury We await your opinions!