### PR TITLE
Zero alloc: slightly better error messages

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -70,7 +70,7 @@ module Witness = struct
       fprintf ppf "direct tailcall %s" callee
     | Missing_summary { callee } -> fprintf ppf "missing summary for %s" callee
     | Forward_call { callee } ->
-      fprintf ppf "foward call or tailcall (conservatively handled) %s" callee
+      fprintf ppf "forward call or tailcall (conservatively handled) %s" callee
     | Extcall { callee } -> fprintf ppf "external call to %s" callee
     | Arch_specific -> fprintf ppf "arch specific operation"
     | Probe { name; handler_code_sym } ->

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -468,7 +468,8 @@ end = struct
     in
     let print_comballoc (w : Witness.t) =
       match Witness.get_alloc_dbginfo w.kind with
-      | None | Some [] | Some [_] -> "", []
+      | None -> " may allocate", []
+      | Some [] | Some [_] -> "", []
       | Some alloc_dbginfo ->
         (* If one Ialloc is a result of combining multiple allocations, print
            details of each location. Currently, this cannot happen because
@@ -501,8 +502,8 @@ end = struct
         else " on a path to " ^ component
       in
       let pp ppf () =
-        Format.fprintf ppf "Unexpected %a%a%s%s" Witness.print_kind w.kind
-          pp_inlined_dbg w.dbg component_msg comballoc_msg
+        Format.fprintf ppf "%a%s%s%a" Witness.print_kind w.kind component_msg
+          comballoc_msg pp_inlined_dbg w.dbg
       in
       Location.error_of_printer ~loc ~sub pp ()
     in

--- a/tests/backend/checkmach/fail22.output
+++ b/tests/backend/checkmach/fail22.output
@@ -2,4 +2,4 @@ File "fail22.ml", line 2, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail22.foo (camlFail22.foo_HIDE_STAMP)
 
 File "fail22.ml", line 2, characters 29-34:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/fail24.output
+++ b/tests/backend/checkmach/fail24.output
@@ -2,7 +2,7 @@ File "fail24.ml", line 2, characters 7-17:
 Error: Annotation check for zero_alloc failed on function Fail24.f.unsafe_set_int64 (camlFail24.unsafe_set_int64_HIDE_STAMP)
 
 File "fail24.ml", line 6, characters 4-54:
-Error: Unexpected external call to caml_ba_set_1
+Error: external call to caml_ba_set_1 may allocate
 
 File "fail24.ml", line 6, characters 38-54:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/fail24.output
+++ b/tests/backend/checkmach/fail24.output
@@ -2,7 +2,7 @@ File "fail24.ml", line 2, characters 7-17:
 Error: Annotation check for zero_alloc failed on function Fail24.f.unsafe_set_int64 (camlFail24.unsafe_set_int64_HIDE_STAMP)
 
 File "fail24.ml", line 6, characters 4-54:
-Error: external call to caml_ba_set_1 may allocate
+Error: called function may allocate (external call to caml_ba_set_1)
 
 File "fail24.ml", line 6, characters 38-54:
 Error: allocation of 24 bytes

--- a/tests/backend/checkmach/filter.sh
+++ b/tests/backend/checkmach/filter.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 # CR ocaml 5 all-runtime5: remove __ mangling once we're always using the 5 runtime
-sed -r 's/Error: Annotation check for zero_alloc( strict | )failed on function ([^ ]*) \(caml(.*)_[0-9]+(_[0-9]+_code)?\)$/Error: Annotation check for zero_alloc\1failed on function \2 \(caml\3_HIDE_STAMP\)/' | \
-    sed -r 's/Error: direct (tail)?call caml(.*)_[0-9]+(_[0-9]+_code)?( may allocate)?( on a path to .*)?$/Error: direct \1call caml\2_HIDE_STAMP\4\5/' | sed -r 's/Error: probe (test)? handler caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/Error: probe \1 handler caml\2_HIDE_STAMP\4/' | \
+sed -r 's/caml(.*)_[0-9]+_[0-9]+_code?/caml\1_HIDE_STAMP/' \
+| \
     sed 's/__/./'

--- a/tests/backend/checkmach/filter.sh
+++ b/tests/backend/checkmach/filter.sh
@@ -2,5 +2,5 @@
 
 # CR ocaml 5 all-runtime5: remove __ mangling once we're always using the 5 runtime
 sed -r 's/Error: Annotation check for zero_alloc( strict | )failed on function ([^ ]*) \(caml(.*)_[0-9]+(_[0-9]+_code)?\)$/Error: Annotation check for zero_alloc\1failed on function \2 \(caml\3_HIDE_STAMP\)/' | \
-    sed -r 's/Error: Unexpected direct (tail)?call caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/Error: Unexpected direct \1call caml\2_HIDE_STAMP\4/' | sed -r 's/Error: Unexpected probe (test)? handler caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/Error: Unexpected probe \1 handler caml\2_HIDE_STAMP\4/' | \
+    sed -r 's/Error: direct (tail)?call caml(.*)_[0-9]+(_[0-9]+_code)?( may allocate)?( on a path to .*)?$/Error: direct \1call caml\2_HIDE_STAMP\4\5/' | sed -r 's/Error: probe (test)? handler caml(.*)_[0-9]+(_[0-9]+_code)?( on a path to .*)?$/Error: probe \1 handler caml\2_HIDE_STAMP\4/' | \
     sed 's/__/./'

--- a/tests/backend/checkmach/test_assume_fail.output
+++ b/tests/backend/checkmach/test_assume_fail.output
@@ -2,13 +2,13 @@ File "test_assume_fail.ml", line 5, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.foo (camlTest_assume_fail.foo_HIDE_STAMP)
 
 File "test_assume_fail.ml", line 5, characters 32-37:
-Error: direct tailcall camlTest_assume_fail.bar_HIDE_STAMP on a path to exceptional return may allocate
+Error: called function may allocate on a path to exceptional return (direct tailcall camlTest_assume_fail.bar_HIDE_STAMP)
 
 File "test_assume_fail.ml", line 12, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.foo' (camlTest_assume_fail.foo'_HIDE_STAMP)
 
 File "test_assume_fail.ml", line 12, characters 33-39:
-Error: direct call camlCamlinternalFormat.make_printf_HIDE_STAMP on a path to exceptional return may allocate (test_assume_fail.ml:12,33--39;test_assume_fail.ml:9,25--53;printf.ml:47,18--43;printf.ml:45,2--31)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP) (test_assume_fail.ml:12,33--39;test_assume_fail.ml:9,25--53;printf.ml:47,18--43;printf.ml:45,2--31)
 
 File "test_assume_fail.ml", line 12, characters 33-39:
-Error: indirect call on a path to exceptional return may allocate (test_assume_fail.ml:12,33--39;test_assume_fail.ml:9,25--53)
+Error: called function may allocate on a path to exceptional return (indirect call) (test_assume_fail.ml:12,33--39;test_assume_fail.ml:9,25--53)

--- a/tests/backend/checkmach/test_assume_fail.output
+++ b/tests/backend/checkmach/test_assume_fail.output
@@ -2,13 +2,13 @@ File "test_assume_fail.ml", line 5, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.foo (camlTest_assume_fail.foo_HIDE_STAMP)
 
 File "test_assume_fail.ml", line 5, characters 32-37:
-Error: Unexpected direct tailcall camlTest_assume_fail.bar_HIDE_STAMP on a path to exceptional return
+Error: direct tailcall camlTest_assume_fail.bar_HIDE_STAMP on a path to exceptional return may allocate
 
 File "test_assume_fail.ml", line 12, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.foo' (camlTest_assume_fail.foo'_HIDE_STAMP)
 
 File "test_assume_fail.ml", line 12, characters 33-39:
-Error: Unexpected direct call camlCamlinternalFormat.make_printf_120_401_code (test_assume_fail.ml:12,33--39;test_assume_fail.ml:9,25--53;printf.ml:47,18--43;printf.ml:45,2--31) on a path to exceptional return
+Error: direct call camlCamlinternalFormat.make_printf_HIDE_STAMP on a path to exceptional return may allocate (test_assume_fail.ml:12,33--39;test_assume_fail.ml:9,25--53;printf.ml:47,18--43;printf.ml:45,2--31)
 
 File "test_assume_fail.ml", line 12, characters 33-39:
-Error: Unexpected indirect call (test_assume_fail.ml:12,33--39;test_assume_fail.ml:9,25--53) on a path to exceptional return
+Error: indirect call on a path to exceptional return may allocate (test_assume_fail.ml:12,33--39;test_assume_fail.ml:9,25--53)

--- a/tests/backend/checkmach/test_assume_on_call.output
+++ b/tests/backend/checkmach/test_assume_on_call.output
@@ -11,16 +11,16 @@ File "test_assume_on_call.ml", line 7, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test1 (camlTest_assume_on_call.test1_HIDE_STAMP)
 
 File "test_assume_on_call.ml", line 8, characters 2-22:
-Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:8,2--22;test_assume_on_call.ml:1,28--33)
+Error: allocation of 24 bytes (test_assume_on_call.ml:8,2--22;test_assume_on_call.ml:1,28--33)
 
 File "test_assume_on_call.ml", line 10, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test2 (camlTest_assume_on_call.test2_HIDE_STAMP)
 
 File "test_assume_on_call.ml", line 11, characters 2-36:
-Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:11,2--36;test_assume_on_call.ml:1,28--33)
+Error: allocation of 24 bytes (test_assume_on_call.ml:11,2--36;test_assume_on_call.ml:1,28--33)
 
 File "test_assume_on_call.ml", line 13, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test3 (camlTest_assume_on_call.test3_HIDE_STAMP)
 
 File "test_assume_on_call.ml", line 14, characters 2-52:
-Error: Unexpected allocation of 24 bytes (test_assume_on_call.ml:14,2--52;test_assume_on_call.ml:1,28--33)
+Error: allocation of 24 bytes (test_assume_on_call.ml:14,2--52;test_assume_on_call.ml:1,28--33)

--- a/tests/backend/checkmach/test_attr_check.output
+++ b/tests/backend/checkmach/test_attr_check.output
@@ -2,4 +2,4 @@ File "test_attr_check.ml", line 2, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_attr_check.test (camlTest_attr_check.test_HIDE_STAMP)
 
 File "test_attr_check.ml", line 2, characters 26-31:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/test_attr_check_all.output
+++ b/tests/backend/checkmach/test_attr_check_all.output
@@ -2,10 +2,10 @@ File "test_attr_check_all.ml", line 2, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_attr_check_all.test (camlTest_attr_check_all.test_HIDE_STAMP)
 
 File "test_attr_check_all.ml", line 2, characters 26-31:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes
 
 File "test_attr_check_all.ml", line 3, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_attr_check_all.test_opt (camlTest_attr_check_all.test_opt_HIDE_STAMP)
 
 File "test_attr_check_all.ml", line 3, characters 34-39:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/test_attr_check_opt.output
+++ b/tests/backend/checkmach/test_attr_check_opt.output
@@ -2,4 +2,4 @@ File "test_attr_check_opt.ml", line 3, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_attr_check_opt.test_opt (camlTest_attr_check_opt.test_opt_HIDE_STAMP)
 
 File "test_attr_check_opt.ml", line 3, characters 34-39:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/test_misplaced_assume.output
+++ b/tests/backend/checkmach/test_misplaced_assume.output
@@ -5,4 +5,4 @@ File "test_misplaced_assume.ml", line 5, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_misplaced_assume.foo (camlTest_misplaced_assume.foo_HIDE_STAMP)
 
 File "test_misplaced_assume.ml", line 6, characters 2-31:
-Error: direct tailcall camlTest_misplaced_assume.bar_HIDE_STAMP may allocate
+Error: called function may allocate (direct tailcall camlTest_misplaced_assume.bar_HIDE_STAMP)

--- a/tests/backend/checkmach/test_misplaced_assume.output
+++ b/tests/backend/checkmach/test_misplaced_assume.output
@@ -5,4 +5,4 @@ File "test_misplaced_assume.ml", line 5, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_misplaced_assume.foo (camlTest_misplaced_assume.foo_HIDE_STAMP)
 
 File "test_misplaced_assume.ml", line 6, characters 2-31:
-Error: Unexpected direct tailcall camlTest_misplaced_assume.bar_HIDE_STAMP
+Error: direct tailcall camlTest_misplaced_assume.bar_HIDE_STAMP may allocate


### PR DESCRIPTION
Instead of
```
Error: Unexpected direct tailcall camlTest_misplaced_assume.bar_0_2_code
```
print 
```
Error: direct tailcall camlTest_misplaced_assume.bar_0_2_code may allocate
```