### PR TITLE
Don't enable -fprefetchw by default

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -60,10 +60,9 @@ module Extension = struct
     | BMI2 -> "Haswell+"
 
   let enabled_by_default = function
-    | POPCNT | PREFETCHW
     | SSE3 | SSSE3 | SSE4_1 | SSE4_2
-    | CLMUL | BMI | BMI2 -> true
-    | PREFETCHWT1 -> false
+    | POPCNT | CLMUL | BMI | BMI2 -> true
+    | PREFETCHW | PREFETCHWT1 -> false
 
   let all = Set.of_list [ POPCNT; PREFETCHW; PREFETCHWT1; SSE3; SSSE3; SSE4_1; SSE4_2; CLMUL; BMI; BMI2 ]
   let config = ref (Set.filter enabled_by_default all)


### PR DESCRIPTION
We want to target Haswell as a baseline architecture; `PREFETCHW` was introduced with Broadwell.
The architecture check (#2220) will currently cause default binaries to abort on Haswell, so we should remove `PREFETCHW` from the default flags.

When `PREFETCHW` is not available, the prefetch intrinsics will simply ignore whether the user intends to write to the address, so no other changes should be necessary. 