### PR TITLE
remove duplicated modality functions

### DIFF
--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -424,22 +424,6 @@ let check_tail_call_local_returning loc env ap_mode {region_mode; _} =
 
 (* Describes how a modality affects field projection. Returns the mode
    of the projection given the mode of the record. *)
-let _modality_unbox_left global_flag mode =
-  match global_flag with
-  | Global ->
-      mode |> Value.to_global |> Value.to_shared |> Value.to_many
-  | Unrestricted -> mode
-
-(* Describes how a modality affects record construction. Gives the
-   expected mode of the field given the expected mode of the record. *)
-let _modality_box_right global_flag mode =
-  match global_flag with
-  | Global ->
-      mode |> Value.to_global |> Value.to_shared |> Value.to_many
-  | Unrestricted -> mode
-
-(* Describes how a modality affects field projection. Returns the mode
-   of the projection given the mode of the record. *)
 let modality_unbox_left global_flag mode =
   match global_flag with
   | Global ->


### PR DESCRIPTION
It seems there are four functions about modalities worth defining here:
For constructions:
1. Given the expected mode (right mode) of record, return the expected mode of field.
2. Given the left mode of field, return the left mode of record. Note that the latter will be used as a lower bound, not directly.

For projection:
3. Given the left mode of record, return the left mode of field.
4. Given the expected mode of field, return the expected mode of record. The latter will be used as an upper bound, not directly.

Currently the type checker only needs 1 and 3. We thought we will need 2 and 4 at some point, but currently I don't see how. In fact, I conjecture that 1 and 2 are equivalent, and 3 and 4 are equivalent (in terms of their use in type checker)
(EDIT: Leo corrected me that they are some sort of adjoints rather than equivalent, which I agree)

Everything aside, it seems that currently we are simply implementing 1 and 3 twice.

Request review from @lpw25 