### PR TITLE
Weak symbol support in x86 binary emitter

### DIFF
--- a/backend/internal_assembler/relocation_entry.ml
+++ b/backend/internal_assembler/relocation_entry.ml
@@ -49,7 +49,7 @@ let get_reloc_info ~relocation_type ~addend name symbol_table string_table =
       | Some i -> i
       | None ->
         Symbol_table.make_undef_symbol symbol_table name string_table;
-        Symbol_table.num_symbols symbol_table - 1
+        Symbol_table.get_symbol_idx_opt symbol_table name |> Option.get
     in
     relocation_type, symbol, addend
 

--- a/backend/internal_assembler/symbol_entry.ml
+++ b/backend/internal_assembler/symbol_entry.ml
@@ -36,6 +36,7 @@ type t =
 type bind =
   | Local
   | Global
+  | Weak
 
 type symbol_type =
   | NoType
@@ -88,10 +89,15 @@ let create_symbol (symbol : X86_binary_emitter.symbol) symbol_table sections
     | Some s -> failwith ("Unknown symbol type" ^ s)
     | None -> 0
   in
-  let global = Bool.to_int symbol.sy_global in
+  let locality =
+    match symbol.sy_locality with
+    | Sy_local -> 0
+    | Sy_global -> 1
+    | Sy_weak -> 2
+  in
   let symbol_entry =
     { st_name = String_table.current_length string_table;
-      st_info = (global lsl 4) lor bind;
+      st_info = (locality lsl 4) lor bind;
       st_other = if symbol.sy_protected then 3 else 0;
       st_shndx =
         Section_table.get_sec_idx sections
@@ -112,6 +118,7 @@ let get_bind t =
   match t.st_info lsr 4 with
   | 0 -> Local
   | 1 -> Global
+  | 2 -> Weak
   | _ -> failwith "Invalid bind"
 
 let get_type t =

--- a/backend/internal_assembler/symbol_entry.ml
+++ b/backend/internal_assembler/symbol_entry.ml
@@ -78,7 +78,7 @@ let create_symbol (symbol : X86_binary_emitter.symbol) symbol_table sections
     string_table =
   let value = Option.value ~default:0 symbol.sy_pos in
   let size = Option.value ~default:0 symbol.sy_size in
-  let bind =
+  let st_type =
     match symbol.sy_type with
     (* CR mcollins - modify types to avoid string comparisons *)
     | Some "@function" -> 2
@@ -89,15 +89,15 @@ let create_symbol (symbol : X86_binary_emitter.symbol) symbol_table sections
     | Some s -> failwith ("Unknown symbol type" ^ s)
     | None -> 0
   in
-  let locality =
-    match symbol.sy_locality with
+  let st_binding =
+    match symbol.sy_binding with
     | Sy_local -> 0
     | Sy_global -> 1
     | Sy_weak -> 2
   in
   let symbol_entry =
     { st_name = String_table.current_length string_table;
-      st_info = (locality lsl 4) lor bind;
+      st_info = (st_binding lsl 4) lor st_type;
       st_other = if symbol.sy_protected then 3 else 0;
       st_shndx =
         Section_table.get_sec_idx sections

--- a/backend/internal_assembler/symbol_entry.mli
+++ b/backend/internal_assembler/symbol_entry.mli
@@ -25,6 +25,7 @@ type t
 type bind =
   | Local
   | Global
+  | Weak
 
 type symbol_type =
   | NoType

--- a/backend/internal_assembler/symbol_table.ml
+++ b/backend/internal_assembler/symbol_table.ml
@@ -37,9 +37,12 @@ end)
 type t =
   { mutable global_symbols : Symbol_entry.t list;
     mutable global_num_symbols : int;
+    mutable weak_symbols : Symbol_entry.t list;
+    mutable weak_num_symbols : int;
     mutable local_symbols : Symbol_entry.t list;
     mutable local_num_symbols : int;
     global_symbols_tbl : int String.Tbl.t;
+    weak_symbols_tbl : int String.Tbl.t;
     local_symbols_tbl : int String.Tbl.t;
     labels_tbl : (X86_binary_emitter.symbol * Symbol_entry.t) String.Tbl.t;
     section_symbol_tbl : int IntTbl.t
@@ -49,6 +52,9 @@ let create () =
   { global_symbols = [];
     global_num_symbols = 0;
     global_symbols_tbl = String.Tbl.create 100;
+    weak_symbols = [];
+    weak_num_symbols = 0;
+    weak_symbols_tbl = String.Tbl.create 100;
     local_symbols = [];
     local_num_symbols = 0;
     local_symbols_tbl = String.Tbl.create 100;
@@ -76,6 +82,12 @@ let add_symbol t symbol =
       t.global_num_symbols;
     t.global_num_symbols <- t.global_num_symbols + 1;
     t.global_symbols <- symbol :: t.global_symbols
+  | Weak ->
+    String.Tbl.add t.weak_symbols_tbl
+      (Symbol_entry.get_name_str symbol)
+      t.weak_num_symbols;
+    t.weak_num_symbols <- t.weak_num_symbols + 1;
+    t.weak_symbols <- symbol :: t.weak_symbols
 
 let add_label t label symbol =
   String.Tbl.add t.labels_tbl label.sy_name (label, symbol)
@@ -90,9 +102,15 @@ let get_label_idx t name =
 let get_symbol_idx_opt t name =
   match String.Tbl.find_opt t.global_symbols_tbl name with
   | Some idx -> Some (t.local_num_symbols + idx + 1)
-  | None -> String.Tbl.find_opt t.local_symbols_tbl name |> Option.map succ
+  | None ->
+    begin match String.Tbl.find_opt t.weak_symbols_tbl name with
+    | Some idx -> Some (t.local_num_symbols + t.global_num_symbols + idx + 1)
+    | None ->
+      String.Tbl.find_opt t.local_symbols_tbl name |> Option.map succ
+    end
 
-let num_symbols t = t.local_num_symbols + t.global_num_symbols + 1
+let num_symbols t =
+  t.local_num_symbols + t.global_num_symbols + t.weak_num_symbols + 1
 
 let num_locals t = t.local_num_symbols + 1
 
@@ -123,4 +141,4 @@ let write t sh_offset buf =
     (fun i symbol ->
       let idx = ((i + 1) * 24) + Int64.to_int sh_offset in
       Symbol_entry.write symbol (Compiler_owee.Owee_buf.cursor buf ~at:idx))
-    (List.rev t.local_symbols @ List.rev t.global_symbols)
+    (List.rev t.local_symbols @ List.rev t.global_symbols @ List.rev t.weak_symbols)

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -192,6 +192,7 @@ let eval_const b current_pos cst =
     | Const n -> Rint n
     | ConstThis -> Rabs ("", 0L)
     | ConstLabel lbl -> Rabs (lbl, 0L)
+    | ConstLabelOffset (lbl, o) -> Rabs (lbl, Int64.of_int o)
     | ConstSub (c1, c2) -> (
         let c1 = eval c1 and c2 = eval c2 in
         match (c1, c2) with

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -64,13 +64,13 @@ module Relocation = struct
   type t = { offset_from_section_beginning : int; kind : Kind.t }
 end
 
-type symbol_locality = Sy_local | Sy_global | Sy_weak
+type symbol_binding = Sy_local | Sy_global | Sy_weak
 
 type symbol = {
   sy_name : string;
   mutable sy_type : string option;
   mutable sy_size : int option;
-  mutable sy_locality : symbol_locality;
+  mutable sy_binding : symbol_binding;
   mutable sy_protected : bool;
   mutable sy_sec : section;
   mutable sy_pos : int option;
@@ -114,7 +114,7 @@ let get_symbol b s =
         sy_type = None;
         sy_size = None;
         sy_pos = None;
-        sy_locality = Sy_local;
+        sy_binding = Sy_local;
         sy_protected = false;
         sy_num = None;
         sy_sec = b.sec;
@@ -2063,8 +2063,8 @@ let assemble_line b loc ins =
         assemble_instr b loc instr;
         incr loc
     | Comment _ -> ()
-    | Global sym -> (get_symbol b sym).sy_locality <- Sy_global
-    | Weak sym -> (get_symbol b sym).sy_locality <- Sy_weak
+    | Global sym -> (get_symbol b sym).sy_binding <- Sy_global
+    | Weak sym -> (get_symbol b sym).sy_binding <- Sy_weak
     | Protected sym -> (get_symbol b sym).sy_protected <- true
     | Quad (Const n) -> buf_int64L b n
     | Quad cst ->

--- a/backend/x86_binary_emitter.mli
+++ b/backend/x86_binary_emitter.mli
@@ -19,11 +19,13 @@ type section = { sec_name : string; mutable sec_instrs : asm_line array }
 
 type data_size = B8 | B16 | B32 | B64
 
+type symbol_locality = Sy_local | Sy_global | Sy_weak
+
 type symbol = {
   sy_name : string;
   mutable sy_type : string option;
   mutable sy_size : int option;
-  mutable sy_global : bool;
+  mutable sy_locality : symbol_locality;
   mutable sy_protected : bool;
   mutable sy_sec : section;
   mutable sy_pos : int option;

--- a/backend/x86_binary_emitter.mli
+++ b/backend/x86_binary_emitter.mli
@@ -19,13 +19,13 @@ type section = { sec_name : string; mutable sec_instrs : asm_line array }
 
 type data_size = B8 | B16 | B32 | B64
 
-type symbol_locality = Sy_local | Sy_global | Sy_weak
+type symbol_binding = Sy_local | Sy_global | Sy_weak
 
 type symbol = {
   sy_name : string;
   mutable sy_type : string option;
   mutable sy_size : int option;
-  mutable sy_locality : symbol_locality;
+  mutable sy_binding : symbol_binding;
   mutable sy_protected : bool;
   mutable sy_sec : section;
   mutable sy_pos : int option;


### PR DESCRIPTION
Adds support for weak symbols. For use (and testing) in #2220.