### PR TITLE
Request ISA extension checks from C stubs

### DIFF
--- a/ocaml/runtime/caml/isa.h
+++ b/ocaml/runtime/caml/isa.h
@@ -17,6 +17,92 @@
 
 #include "misc.h"
 
+// This file is included by mlvalues.h, so should be visible
+// to all user-defined C bindings. When compiling C stubs to
+// x86_64/ELF, this detects which ISA extensions are enabled and
+// requests the OCaml runtime to check for support at startup.
+
+#if defined __x86_64__ && defined __ELF__
+
+#define CAML_REQUIRE_ARCH_POPCNT \
+    CAMLweakdef intnat caml_arch_popcnt;
+
+#define CAML_REQUIRE_ARCH_PREFETCHW \
+    CAMLweakdef intnat caml_arch_prefetchw;
+
+#define CAML_REQUIRE_ARCH_PREFETCHWT1 \
+    CAMLweakdef intnat caml_arch_prefetchwt1;
+
+#define CAML_REQUIRE_ARCH_SSE3 \
+    CAMLweakdef intnat caml_arch_sse3;
+
+#define CAML_REQUIRE_ARCH_SSSE3 \
+    CAMLweakdef intnat caml_arch_ssse3;
+
+#define CAML_REQUIRE_ARCH_SSE4_1 \
+    CAMLweakdef intnat caml_arch_sse4_1;
+
+#define CAML_REQUIRE_ARCH_SSE4_2 \
+    CAMLweakdef intnat caml_arch_sse4_2;
+
+#define CAML_REQUIRE_ARCH_CLMUL \
+    CAMLweakdef intnat caml_arch_clmul;
+
+#define CAML_REQUIRE_ARCH_LZCNT \
+    CAMLweakdef intnat caml_arch_lzcnt;
+
+#define CAML_REQUIRE_ARCH_BMI \
+    CAMLweakdef intnat caml_arch_bmi;
+
+#define CAML_REQUIRE_ARCH_BMI2 \
+    CAMLweakdef intnat caml_arch_bmi2;
+
+#ifdef __POPCNT__
+CAML_REQUIRE_ARCH_POPCNT
+#endif
+
+#ifdef __PRFCHW__
+CAML_REQUIRE_ARCH_PREFETCHW
+#endif
+
+#ifdef __PREFETCHWT1__
+CAML_REQUIRE_ARCH_PREFETCHWT1
+#endif
+
+#ifdef __SSE3__
+CAML_REQUIRE_ARCH_SSE3
+#endif
+
+#ifdef __SSSE3__
+CAML_REQUIRE_ARCH_SSSE3
+#endif
+
+#ifdef __SSE4_1__
+CAML_REQUIRE_ARCH_SSE4_1
+#endif
+
+#ifdef __SSE4_2__
+CAML_REQUIRE_ARCH_SSE4_2
+#endif
+
+#ifdef __PCLMUL__
+CAML_REQUIRE_ARCH_CLMUL
+#endif
+
+#ifdef __LZCNT__
+CAML_REQUIRE_ARCH_LZCNT
+#endif
+
+#ifdef __BMI__
+CAML_REQUIRE_ARCH_BMI
+#endif
+
+#ifdef __BMI2__
+CAML_REQUIRE_ARCH_BMI2
+#endif
+
+#endif
+
 #ifdef CAML_INTERNALS
 CAMLextern void caml_assert_arch_extensions(void);
 extern uintnat caml_skip_arch_extension_check;

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -18,6 +18,7 @@
 
 #include "config.h"
 #include "misc.h"
+#include "isa.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/ocaml/runtime4/caml/isa.h
+++ b/ocaml/runtime4/caml/isa.h
@@ -17,6 +17,92 @@
 
 #include "misc.h"
 
+// This file is included by mlvalues.h, so should be visible
+// to all user-defined C bindings. When compiling C stubs to
+// x86_64/ELF, this detects which ISA extensions are enabled and
+// requests the OCaml runtime to check for support at startup.
+
+#if defined __x86_64__ && defined __ELF__
+
+#define CAML_REQUIRE_ARCH_POPCNT \
+    CAMLweakdef intnat caml_arch_popcnt;
+
+#define CAML_REQUIRE_ARCH_PREFETCHW \
+    CAMLweakdef intnat caml_arch_prefetchw;
+
+#define CAML_REQUIRE_ARCH_PREFETCHWT1 \
+    CAMLweakdef intnat caml_arch_prefetchwt1;
+
+#define CAML_REQUIRE_ARCH_SSE3 \
+    CAMLweakdef intnat caml_arch_sse3;
+
+#define CAML_REQUIRE_ARCH_SSSE3 \
+    CAMLweakdef intnat caml_arch_ssse3;
+
+#define CAML_REQUIRE_ARCH_SSE4_1 \
+    CAMLweakdef intnat caml_arch_sse4_1;
+
+#define CAML_REQUIRE_ARCH_SSE4_2 \
+    CAMLweakdef intnat caml_arch_sse4_2;
+
+#define CAML_REQUIRE_ARCH_CLMUL \
+    CAMLweakdef intnat caml_arch_clmul;
+
+#define CAML_REQUIRE_ARCH_LZCNT \
+    CAMLweakdef intnat caml_arch_lzcnt;
+
+#define CAML_REQUIRE_ARCH_BMI \
+    CAMLweakdef intnat caml_arch_bmi;
+
+#define CAML_REQUIRE_ARCH_BMI2 \
+    CAMLweakdef intnat caml_arch_bmi2;
+
+#ifdef __POPCNT__
+CAML_REQUIRE_ARCH_POPCNT
+#endif
+
+#ifdef __PRFCHW__
+CAML_REQUIRE_ARCH_PREFETCHW
+#endif
+
+#ifdef __PREFETCHWT1__
+CAML_REQUIRE_ARCH_PREFETCHWT1
+#endif
+
+#ifdef __SSE3__
+CAML_REQUIRE_ARCH_SSE3
+#endif
+
+#ifdef __SSSE3__
+CAML_REQUIRE_ARCH_SSSE3
+#endif
+
+#ifdef __SSE4_1__
+CAML_REQUIRE_ARCH_SSE4_1
+#endif
+
+#ifdef __SSE4_2__
+CAML_REQUIRE_ARCH_SSE4_2
+#endif
+
+#ifdef __PCLMUL__
+CAML_REQUIRE_ARCH_CLMUL
+#endif
+
+#ifdef __LZCNT__
+CAML_REQUIRE_ARCH_LZCNT
+#endif
+
+#ifdef __BMI__
+CAML_REQUIRE_ARCH_BMI
+#endif
+
+#ifdef __BMI2__
+CAML_REQUIRE_ARCH_BMI2
+#endif
+
+#endif
+
 #ifdef CAML_INTERNALS
 CAMLextern void caml_assert_arch_extensions(void);
 extern uintnat caml_skip_arch_extension_check;

--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -21,6 +21,7 @@
 #endif
 #include "config.h"
 #include "misc.h"
+#include "isa.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
User-defined C bindings will now include `isa.h` by default (via `mlvalues.h`). 

Based on the C compiler flags (e.g. gcc defines `__SSE3__` when SSE3 is enabled), this file defines weak symbols corresponding to each enabled extension. These symbols cause the CPUID check (see #2220)  to also check for any extensions used in C stubs.