### PR TITLE
Zero alloc: enable "closure" tests in "flambda2"

### DIFF
--- a/tests/backend/checkmach/dep19.ml
+++ b/tests/backend/checkmach/dep19.ml
@@ -1,1 +1,1 @@
-let[@inline always] inline_always x = [|x;x;x;x;x;|]
+let[@inline always] inline_always x = Array.make (Sys.opaque_identity 5) x

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -5,33 +5,3 @@
 (rule
  (alias  runtest)
  (action (diff dune.inc dune.inc.gen)))
-
-
-;; Tests that work on in flambda2 only.
-;; This condition is not expressible in "enable_if" clause
-;; because dune does not  support %{config:flamba2} yet.
-
- (rule
-  (enabled_if (= %{context_name} "main"))
-  (targets fail24.output.corrected)
-  (deps (:ml fail24.ml) filter.sh (:expected fail24.output))
-  (action
-    (with-outputs-to fail24.output.corrected
-     (pipe-outputs
-     (with-accepted-exit-codes 2
-      (bash
-         "if %{bin:ocamlopt.opt} -config | grep -q \"flambda2: true\" ;
-         then
-          %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
-           -zero-alloc-check default -checkmach-details-cutoff 20 -O3 ;
-         else
-         # fake it for flambda1 and closure
-          (cat %{expected}; exit 2);
-         fi"))
-     (run "./filter.sh")))))
-
-(rule
- (alias   runtest)
- (enabled_if (and (= %{context_name} "main")))
- (deps fail24.output fail24.output.corrected)
- (action (diff fail24.output fail24.output.corrected)))

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -730,3 +730,22 @@
  (enabled_if (= %{context_name} "main"))
  (deps test_attr_check_none.output test_attr_check_none.output.corrected)
  (action (diff test_attr_check_none.output test_attr_check_none.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail24.output.corrected)
+ (deps (:ml fail24.ml) filter.sh)
+ (action
+   (with-outputs-to fail24.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail24.output fail24.output.corrected)
+ (action (diff fail24.output fail24.output.corrected)))

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -473,10 +473,23 @@
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dcheckmach -dump-into-file -O3 -warn-error +a)))
 
 (rule
+ (enabled_if (= %{context_name} "main"))
+ (targets t1.output.corrected)
+ (deps (:ml t1.ml) filter.sh)
+ (action
+   (with-outputs-to t1.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
  (alias   runtest)
  (enabled_if (= %{context_name} "main"))
- (deps t1.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dcheckmach -dump-into-file -O3 -warn-error +a)))
+ (deps t1.output t1.output.corrected)
+ (action (diff t1.output t1.output.corrected)))
 
 (rule
  (enabled_if (= %{context_name} "main"))

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -19,7 +19,7 @@
 
 (rule
  (alias   runtest)
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (deps test_flambda.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dcheckmach -dump-into-file -O3 -warn-error +a)))
 
@@ -214,7 +214,7 @@
  (action (diff fail10.output fail10.output.corrected)))
 
 (rule
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (targets fail12.output.corrected)
  (deps (:ml fail12.ml) filter.sh)
  (action
@@ -228,7 +228,7 @@
 
 (rule
  (alias   runtest)
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (deps fail12.output fail12.output.corrected)
  (action (diff fail12.output fail12.output.corrected)))
 
@@ -347,7 +347,7 @@
  (action (diff fail18.output fail18.output.corrected)))
 
 (rule
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (targets fail19.output.corrected)
  (deps (:ml dep19.ml fail19.ml) filter.sh)
  (action
@@ -361,12 +361,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (deps fail19.output fail19.output.corrected)
  (action (diff fail19.output fail19.output.corrected)))
 
 (rule
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (targets fail20.output.corrected)
  (deps (:ml fail20.ml) filter.sh)
  (action
@@ -380,12 +380,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (deps fail20.output fail20.output.corrected)
  (action (diff fail20.output fail20.output.corrected)))
 
 (rule
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (targets fail21.output.corrected)
  (deps (:ml fail21.ml) filter.sh)
  (action
@@ -399,7 +399,7 @@
 
 (rule
  (alias   runtest)
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (deps fail21.output fail21.output.corrected)
  (action (diff fail21.output fail21.output.corrected)))
 
@@ -423,13 +423,13 @@
  (action (diff test_attribute_error_duplicate.output test_attribute_error_duplicate.output.corrected)))
 
 (rule
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (targets test_attr_unused.output.corrected)
  (deps (:ml test_attr_unused.ml) filter.sh)
  (action
    (with-outputs-to test_attr_unused.output.corrected
     (pipe-outputs
-    (with-accepted-exit-codes 0
+    (with-accepted-exit-codes 2
      (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
           -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
     (run "./filter.sh")
@@ -437,7 +437,7 @@
 
 (rule
  (alias   runtest)
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (deps test_attr_unused.output test_attr_unused.output.corrected)
  (action (diff test_attr_unused.output test_attr_unused.output.corrected)))
 
@@ -474,12 +474,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (deps t1.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dcheckmach -dump-into-file -O3 -warn-error +a)))
 
 (rule
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (targets test_warning199.output.corrected)
  (deps (:ml test_warning199.mli test_warning199.ml) filter.sh)
  (action
@@ -493,12 +493,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (deps test_warning199.output test_warning199.output.corrected)
  (action (diff test_warning199.output test_warning199.output.corrected)))
 
 (rule
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (targets test_never_returns_normally.output.corrected)
  (deps (:ml test_never_returns_normally.ml) filter.sh)
  (action
@@ -512,7 +512,7 @@
 
 (rule
  (alias   runtest)
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (deps test_never_returns_normally.output test_never_returns_normally.output.corrected)
  (action (diff test_never_returns_normally.output test_never_returns_normally.output.corrected)))
 
@@ -536,7 +536,7 @@
  (action (diff fail22.output fail22.output.corrected)))
 
 (rule
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (targets fail23.output.corrected)
  (deps (:ml fail23.ml) filter.sh)
  (action
@@ -550,7 +550,7 @@
 
 (rule
  (alias   runtest)
- (enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))
+ (enabled_if (= %{context_name} "main"))
  (deps fail23.output fail23.output.corrected)
  (action (diff fail23.output fail23.output.corrected)))
 

--- a/tests/backend/checkmach/fail11.output
+++ b/tests/backend/checkmach/fail11.output
@@ -1,2 +1,0 @@
-File "fail11.ml", line 14, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail11.f (camlFail11.f_HIDE_STAMP)

--- a/tests/backend/checkmach/fail12.output
+++ b/tests/backend/checkmach/fail12.output
@@ -1,5 +1,5 @@
 File "fail12.ml", line 5, characters 47-57:
-Error: Annotation check for zero_alloc failed on function Fail12.Inner.bar.(fun) (camlFail12.anon_fn[fail12.ml:5,40--70]_HIDE_STAMP)
+Error: Annotation check for zero_alloc failed on function Fail12.Inner.bar.(fun) (camlFail12.fn[fail12.ml:5,40--70]_HIDE_STAMP)
 
 File "fail12.ml", line 5, characters 64-69:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/fail19.output
+++ b/tests/backend/checkmach/fail19.output
@@ -2,31 +2,29 @@ File "fail19.ml", line 7, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail19.foo (camlFail19.foo_HIDE_STAMP)
 
 File "fail19.ml", line 18, characters 5-26:
-Error: Unexpected allocation of 48 bytes (fail19.ml:18,5--26;dep19.ml:1,38--52)
-
-File "fail19.ml", line 18, characters 5-26:
-Error: Unexpected external call to caml_make_array (fail19.ml:18,5--26;dep19.ml:1,38--52)
+Error: called function may allocate (external call to caml_make_vect) (fail19.ml:18,5--26;dep19.ml:1,38--74)
 
 File "fail19.ml", line 10, characters 12-17:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes
 
 File "fail19.ml", line 12, characters 10-15:
-Error: Unexpected direct call camlFail19.bar_HIDE_STAMP
+Error: called function may allocate (direct call camlFail19.bar_HIDE_STAMP)
 
 File "fail19.ml", line 13, characters 13-16:
-Error: Unexpected indirect call
+Error: called function may allocate (indirect call)
 
 File "fail19.ml", line 14, characters 15-44:
-Error: Unexpected probe test handler camlFail19.probe_handler_test_HIDE_STAMP
+Error: expression may allocate
+       (probe test handler camlFail19.probe_handler_test_HIDE_STAMP)
 
 File "fail19.ml", line 14, characters 46-54:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes
 
 File "fail19.ml", line 15, characters 11-20:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes
 
 File "fail19.ml", line 17, characters 10-15:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes
 
 File "fail19.ml", line 18, characters 2-27:
-Error: Unexpected allocation of 24 bytes
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/fail20.output
+++ b/tests/backend/checkmach/fail20.output
@@ -1,8 +1,8 @@
 File "fail20.ml", line 7, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Fail20.foo (camlFail20.foo_HIDE_STAMP)
 
-File "fail20.ml", line 10, characters 13-24:
-Error: Unexpected direct call camlFail20.div_36 (fail20.ml:10,13--24;fail20.ml:4,30--41)
-
 File "fail20.ml", line 8, characters 16-25:
-Error: Unexpected allocation of 32 bytes (fail20.ml:8,16--25;fail20.ml:3,18--29) on a path to exceptional return
+Error: allocation of 32 bytes on a path to exceptional return (fail20.ml:8,16--25;fail20.ml:3,18--29)
+
+File "fail20.ml", line 10, characters 13-24:
+Error: called function may allocate on a path to exceptional return (direct call camlFail20.div_HIDE_STAMP)

--- a/tests/backend/checkmach/fail21.output
+++ b/tests/backend/checkmach/fail21.output
@@ -2,4 +2,4 @@ File "fail21.ml", line 10, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail21.test4 (camlFail21.test4_HIDE_STAMP)
 
 File "fail21.ml", line 12, characters 2-9:
-Error: Unexpected allocation of 24 bytes (fail21.ml:12,2--9;fail21.ml:3,30--35)
+Error: allocation of 24 bytes (fail21.ml:12,2--9;fail21.ml:3,30--35)

--- a/tests/backend/checkmach/fail23.output
+++ b/tests/backend/checkmach/fail23.output
@@ -2,4 +2,4 @@ File "fail23.ml", line 3, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Fail23.test1 (camlFail23.test1_HIDE_STAMP)
 
 File "fail23.ml", line 7, characters 10-40:
-Error: Unexpected allocation of 32 bytes on a path to exceptional return
+Error: allocation of 32 bytes on a path to exceptional return

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -96,10 +96,8 @@ let () =
 
   print_test_expected_output ~cutoff:0 ~extra_dep:None
     ~exit_code:2 "test_attribute_error_duplicate";
-  (* Closure does not optimize the function away, so the unchecked attribute
-     warning is only with flambda and flambda2. *)
   print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None
-    ~exit_code:0 "test_attr_unused";
+    ~exit_code:2 "test_attr_unused";
   (* Checks that the warning is printed and compilation is successful. *)
   print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None
     ~exit_code:0 "t6";
@@ -107,10 +105,9 @@ let () =
   print_test "t7.ml";
   (* Check that compiler generated stubs are ignored with [@@@zero_alloc all] *)
   print_test "test_stub_dep.ml test_stub.ml";
-  (* flambda2 generates an indirect call but we don't yet have a way to exclude it
-     without excluding closure. *)
-  print_test "t1.ml";
-  (* closure does not delete dead functions *)
+  (* generates an indirect call. *)
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "t1";
+  (* deleting dead functions works *)
   print_test_expected_output ~cutoff:default_cutoff ~extra_dep:(Some "test_warning199.mli") ~exit_code:0 "test_warning199";
   print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_never_returns_normally";
   print_test_expected_output ~extra_flags:"-zero-alloc-check opt" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail22";

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -1,15 +1,9 @@
 let () =
-  let enabled_if flambda_only =
-    if flambda_only then
-      (* CR-soon: what we really want to say if dune knew about flambda2:
-         (or %{ocaml-config:flambda} %{ocaml-config:flambda2}) *)
-      {|(enabled_if (and (= %{context_name} "main") %{ocaml-config:flambda}))|}
-    else
+  let enabled_if =
       {|(enabled_if (= %{context_name} "main"))|}
   in
   let buf = Buffer.create 1000 in
-  let print_test ?(extra_flags="-zero-alloc-check default") ~flambda_only deps =
-    let enabled_if = enabled_if flambda_only in
+  let print_test ?(extra_flags="-zero-alloc-check default") deps =
     let subst = function
       | "enabled_if" -> enabled_if
       | "deps" -> deps
@@ -27,8 +21,7 @@ let () =
 |};
     Buffer.output_buffer Out_channel.stdout buf
   in
-  let print_test_expected_output ?(extra_flags="-zero-alloc-check default") ~cutoff ~flambda_only ~extra_dep ~exit_code name =
-    let enabled_if = enabled_if flambda_only in
+  let print_test_expected_output ?(extra_flags="-zero-alloc-check default") ~cutoff ~extra_dep ~exit_code name =
     let ml_deps =
       let s =
         match extra_dep with
@@ -71,65 +64,65 @@ let () =
     Buffer.output_buffer Out_channel.stdout buf
   in
   let default_cutoff = 20 in
-  print_test ~flambda_only:false "s.ml t.ml";
-  print_test ~flambda_only:false "t5.ml test_assume.ml";
-  print_test ~flambda_only:false "test_match_on_mutable_state.ml";
-  print_test ~flambda_only:true "test_flambda.ml";
+  print_test "s.ml t.ml";
+  print_test "t5.ml test_assume.ml";
+  print_test "test_match_on_mutable_state.ml";
+  print_test "test_flambda.ml";
 
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail1";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail2";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:(Some "t3.ml")
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail1";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail2";
+  print_test_expected_output ~cutoff:0 ~extra_dep:(Some "t3.ml")
     ~exit_code:2 "fail3";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:(Some "t4.ml")
+  print_test_expected_output ~cutoff:0 ~extra_dep:(Some "t4.ml")
     ~exit_code:2 "fail4";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail5";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail6";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail7";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail8";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail9";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail10";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true  ~extra_dep:None ~exit_code:2 "fail12";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail13";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail14";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail15";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail16";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail17";
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail18";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail5";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail6";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail7";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail8";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail9";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail10";
+  print_test_expected_output ~cutoff:default_cutoff  ~extra_dep:None ~exit_code:2 "fail12";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail13";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail14";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail15";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail16";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail17";
+  print_test_expected_output ~cutoff:0 ~extra_dep:None ~exit_code:2 "fail18";
   (* test printing detailed error message only in flambda because the exact output depends
      on optimization level. *)
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:(Some "dep19.ml") ~exit_code:2 "fail19";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "fail20";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "fail21";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:(Some "dep19.ml") ~exit_code:2 "fail19";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail20";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail21";
 
-  print_test_expected_output ~cutoff:0 ~flambda_only:false ~extra_dep:None
+  print_test_expected_output ~cutoff:0 ~extra_dep:None
     ~exit_code:2 "test_attribute_error_duplicate";
   (* Closure does not optimize the function away, so the unchecked attribute
      warning is only with flambda and flambda2. *)
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None
     ~exit_code:0 "test_attr_unused";
   (* Checks that the warning is printed and compilation is successful. *)
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None
     ~exit_code:0 "t6";
   (* Check that entry function and functors are ignored with  [@@@zero_alloc all] *)
-  print_test ~flambda_only:false "t7.ml";
+  print_test "t7.ml";
   (* Check that compiler generated stubs are ignored with [@@@zero_alloc all] *)
-  print_test ~flambda_only:false "test_stub_dep.ml test_stub.ml";
+  print_test "test_stub_dep.ml test_stub.ml";
   (* flambda2 generates an indirect call but we don't yet have a way to exclude it
      without excluding closure. *)
-  print_test ~flambda_only:true "t1.ml";
+  print_test "t1.ml";
   (* closure does not delete dead functions *)
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:(Some "test_warning199.mli") ~exit_code:0 "test_warning199";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "test_never_returns_normally";
-  print_test_expected_output ~extra_flags:"-zero-alloc-check opt" ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "fail22";
-  print_test_expected_output ~extra_flags:"-zero-alloc-check opt" ~cutoff:default_cutoff ~flambda_only:true ~extra_dep:None ~exit_code:2 "fail23";
-  print_test ~extra_flags:"-zero-alloc-check opt" ~flambda_only:false "test_zero_alloc_opt1.ml";
-  print_test ~extra_flags:"-zero-alloc-check opt" ~flambda_only:false "test_zero_alloc_opt2.ml";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_assume_fail";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_assume_on_call";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_misplaced_assume";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:0 "test_misplaced_attr";
-  print_test_expected_output ~extra_flags:"-zero-alloc-check all" ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_attr_check";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_attr_check_all";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:2 "test_attr_check_opt";
-  print_test_expected_output ~cutoff:default_cutoff ~flambda_only:false ~extra_dep:None ~exit_code:0 "test_attr_check_none";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:(Some "test_warning199.mli") ~exit_code:0 "test_warning199";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_never_returns_normally";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check opt" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail22";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check opt" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail23";
+  print_test ~extra_flags:"-zero-alloc-check opt" "test_zero_alloc_opt1.ml";
+  print_test ~extra_flags:"-zero-alloc-check opt" "test_zero_alloc_opt2.ml";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_assume_fail";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_assume_on_call";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_misplaced_assume";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:0 "test_misplaced_attr";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check all" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_attr_check";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_attr_check_all";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_attr_check_opt";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:0 "test_attr_check_none";
   ()

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -122,4 +122,5 @@ let () =
   print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_attr_check_all";
   print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_attr_check_opt";
   print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:0 "test_attr_check_none";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail24";
   ()

--- a/tests/backend/checkmach/t1.output
+++ b/tests/backend/checkmach/t1.output
@@ -1,0 +1,8 @@
+File "t1.ml", line 6, characters 7-17:
+Error: Annotation check for zero_alloc failed on function T1.Params.test12 (camlT1.test12_HIDE_STAMP)
+
+File "_none_", line 1:
+Error: called function may allocate (indirect tailcall)
+
+File "t1.ml", line 6, characters 31-45:
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/test_attr_unused.output
+++ b/tests/backend/checkmach/test_attr_unused.output
@@ -2,11 +2,11 @@ File "test_attr_unused.ml", line 5, characters 0-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 A constant payload of type ident was expected
 
-File "test_attr_unused.ml", line 3, characters 5-15:
-Warning 199 [unchecked-property-attribute]: the "zero_alloc" attribute cannot be checked.
-The function it is attached to was optimized away. 
-You can try to mark this function as [@inline never] 
-or move the attribute to the relevant callers of this function.
-
 File "test_attr_unused.ml", line 6, characters 27-37:
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "test_attr_unused.ml", line 3, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_attr_unused.g (camlTest_attr_unused.g_HIDE_STAMP)
+
+File "test_attr_unused.ml", line 3, characters 28-34:
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/test_never_returns_normally.output
+++ b/tests/backend/checkmach/test_never_returns_normally.output
@@ -2,10 +2,10 @@ File "test_never_returns_normally.ml", line 9, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.foo (camlTest_never_returns_normally.foo_HIDE_STAMP)
 
 File "test_never_returns_normally.ml", line 9, characters 25-41:
-Error: Unexpected indirect tailcall
+Error: called function may allocate (indirect tailcall)
 
 File "test_never_returns_normally.ml", line 10, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_never_returns_normally.bar (camlTest_never_returns_normally.bar_HIDE_STAMP)
 
 File "test_never_returns_normally.ml", line 10, characters 27-50:
-Error: Unexpected indirect tailcall
+Error: called function may allocate (indirect tailcall)

--- a/tests/backend/checkmach/test_warning199.output
+++ b/tests/backend/checkmach/test_warning199.output
@@ -1,5 +1,0 @@
-File "test_warning199.ml", line 1, characters 5-15:
-Warning 199 [unchecked-property-attribute]: the "zero_alloc" attribute cannot be checked.
-The function it is attached to was optimized away. 
-You can try to mark this function as [@inline never] 
-or move the attribute to the relevant callers of this function.


### PR DESCRIPTION
Clean up tests after removing `closure` and `flambda`. 

More tests can be enabled, some have slightly different output due to recent PRs that have been merged or different behavior with flambda2 comapred to flambda1. I inspected the diff in test outputs and everything is as expected.