### PR TITLE
Random heuristics for testing greedy regalloc

### DIFF
--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -68,6 +68,7 @@ let priority_heuristics : Reg.t -> Interval.t -> int =
  fun _reg itv ->
   match Lazy.force Priority_heuristics.value with
   | Priority_heuristics.Interval_length -> Interval.length itv
+  | Priority_heuristics.Random_for_testing -> Priority_heuristics.random ()
 
 let make_hardware_registers_and_prio_queue (cfg_with_infos : Cfg_with_infos.t) :
     Hardware_registers.t * prio_queue =
@@ -126,6 +127,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
     match Lazy.force Spilling_heuristics.value with
     | Flat_uses -> true
     | Hierarchical_uses -> false
+    | Random_for_testing -> Spilling_heuristics.random ()
   in
   update_spill_cost cfg_with_infos ~flat ();
   State.iter_introduced_temporaries state ~f:(fun (reg : Reg.t) ->

--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -112,8 +112,8 @@ let max_rounds = 32
 (* CR xclerc for xclerc: the `round` parameter is temporary; this is an hybrid
    version of "greedy" using the `rewrite` function from IRC when it needs to
    spill. *)
-let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
- fun ~round state cfg_with_infos ->
+let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
+ fun ~round ~flat state cfg_with_infos ->
   if round > max_rounds
   then
     fatal "register allocation was not succesful after %d rounds (%s)"
@@ -123,12 +123,6 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
     log ~indent:0 "main, round #%d" round;
     log_cfg_with_infos ~indent:0 cfg_with_infos);
   if gi_debug then log ~indent:0 "updating spilling costs";
-  let flat =
-    match Lazy.force Spilling_heuristics.value with
-    | Flat_uses -> true
-    | Hierarchical_uses -> false
-    | Random_for_testing -> Spilling_heuristics.random ()
-  in
   update_spill_cost cfg_with_infos ~flat ();
   State.iter_introduced_temporaries state ~f:(fun (reg : Reg.t) ->
       reg.Reg.spill_cost <- reg.Reg.spill_cost + 10_000);
@@ -234,7 +228,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
         ~spilled_nodes:(List.map spilled_nodes ~f:fst)
     with
     | false -> if gi_debug then log ~indent:1 "(end of main)"
-    | true -> main ~round:(succ round) state cfg_with_infos)
+    | true -> main ~round:(succ round) ~flat state cfg_with_infos)
 
 let run : Cfg_with_infos.t -> Cfg_with_infos.t =
  fun cfg_with_infos ->
@@ -263,7 +257,13 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
        work list and set the field to unknown. *)
     let (_ : bool) = rewrite state cfg_with_infos ~spilled_nodes in
     Cfg_with_infos.invalidate_liveness cfg_with_infos);
-  main ~round:1 state cfg_with_infos;
+  let flat =
+    match Lazy.force Spilling_heuristics.value with
+    | Flat_uses -> true
+    | Hierarchical_uses -> false
+    | Random_for_testing -> Spilling_heuristics.random ()
+  in
+  main ~round:1 ~flat state cfg_with_infos;
   if gi_debug then log_cfg_with_infos ~indent:1 cfg_with_infos;
   Regalloc_rewrite.postlude
     (module State)

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -94,10 +94,12 @@ module Selection_heuristics = struct
     | Worst_fit -> "worst_fit"
     | Random_for_testing -> "random"
 
-  let not_random = function Random_for_testing -> false | _ -> true
+  let include_in_random = function
+    | Random_for_testing | Worst_fit -> false
+    | _ -> true
 
   let random =
-    let all = List.filter all ~f:not_random in
+    let all = List.filter all ~f:include_in_random in
     let len = List.length all in
     fun () -> List.nth all (Random.State.int gi_rng len)
 

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -96,7 +96,7 @@ module Selection_heuristics = struct
 
   let include_in_random = function
     | Random_for_testing | Worst_fit -> false
-    | _ -> true
+    | First_available | Best_fit -> true
 
   let random =
     let all = List.filter all ~f:include_in_random in

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -135,7 +135,7 @@ module Spilling_heuristics = struct
     | Hierarchical_uses
     | Random_for_testing
 
-  let all = [Flat_uses; Hierarchical_uses]
+  let all = [Flat_uses; Hierarchical_uses; Random_for_testing]
 
   let to_string = function
     | Flat_uses -> "flat_uses"

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -99,9 +99,7 @@ module Selection_heuristics = struct
     | Worst_fit -> "worst_fit"
     | Random_for_testing -> "random"
 
-  let not_random = function
-    | Random_for_testing -> false
-    | _ -> true
+  let not_random = function Random_for_testing -> false | _ -> true
 
   let random =
     let all = List.filter all ~f:not_random in
@@ -597,7 +595,7 @@ module Hardware_registers = struct
     Array.init Proc.num_register_classes ~f:(fun reg_class ->
         let num_hardware_regs = Proc.num_available_registers.(reg_class) in
         let num_available_regs =
-          match (Lazy.force gi_limit_regs) with
+          match Lazy.force gi_limit_regs with
           | None -> num_hardware_regs
           | Some l -> Int.min l num_hardware_regs
         in
@@ -757,7 +755,8 @@ module Hardware_registers = struct
         | Selection_heuristics.Worst_fit ->
           if gi_debug
           then
-            log ~indent:3 "trying to find an available register with 'worst-fit'";
+            log ~indent:3
+              "trying to find an available register with 'worst-fit'";
           find_using_length t reg interval ~better:( < )
       in
       select (Lazy.force Selection_heuristics.value)

--- a/backend/regalloc/regalloc_gi_utils.mli
+++ b/backend/regalloc/regalloc_gi_utils.mli
@@ -21,11 +21,15 @@ val log_body_and_terminator :
 val log_cfg_with_infos : indent:int -> Cfg_with_infos.t -> unit
 
 module Priority_heuristics : sig
-  type t = Interval_length
+  type t =
+    | Interval_length
+    | Random_for_testing
 
   val all : t list
 
   val to_string : t -> string
+
+  val random : unit -> int
 
   val value : t Lazy.t
 end
@@ -35,10 +39,13 @@ module Selection_heuristics : sig
     | First_available
     | Best_fit
     | Worst_fit
+    | Random_for_testing
 
   val all : t list
 
   val to_string : t -> string
+
+  val random : unit -> t
 
   val value : t Lazy.t
 end
@@ -47,10 +54,13 @@ module Spilling_heuristics : sig
   type t =
     | Flat_uses
     | Hierarchical_uses
+    | Random_for_testing
 
   val all : t list
 
   val to_string : t -> string
+
+  val random : unit -> bool
 
   val value : t Lazy.t
 end


### PR DESCRIPTION
Adds a random option to each greedy register allocator parameter:

- `GI_PRIORITY_HEURISTICS:random`: chooses a random priority in `[0,10_000)`
- `GI_SELECTION_HEURISTICS:random`: chooses one of the other options (first, best fit) at random
- `GI_SPILLING_HEURISTICS:random`: chooses between flat or hierarchical at random

These options are intended for testing the allocator.