### PR TITLE
Interpret `[@inlined]` as `[@unrolled 1]` on recursive functions

### DIFF
--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -232,12 +232,30 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
            ramifications of treating unknown-ness as an observable property this
            way. Are we relying on monotonicity somewhere? *)
         let apply_inlining_state = Apply.inlining_state apply in
+        let recursive =
+          Code_metadata.recursive
+            (Code_or_metadata.code_metadata code_or_metadata)
+        in
         if Inlining_state.is_depth_exceeded apply_inlining_state
         then Max_inlining_depth_exceeded
         else
-          match inlined with
-          | Never_inlined -> assert false
-          | Default_inlined ->
+          let policy =
+            match inlined with
+            | Never_inlined -> assert false
+            | Default_inlined -> `Heuristic
+            | Unroll (to_, _) -> `Unroll to_
+            | Always_inlined _ | Hint_inlined -> (
+              (* Treat [@inlined] and [@inlined hint] the same as [@unrolled 1]
+                 whenever the function is recursive. This is particularly
+                 important when the annotation is on a parameter and the
+                 function is _usually_ non-recursive: we'd rather behave well in
+                 the odd case where it isn't. *)
+              match recursive with
+              | Recursive -> `Unroll 1
+              | Non_recursive -> `Always)
+          in
+          match policy with
+          | `Heuristic ->
             let max_rec_depth =
               Flambda_features.Inlining.max_rec_depth
                 (Round (DE.round (DA.denv dacc)))
@@ -248,7 +266,7 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
             else
               might_inline dacc ~apply ~code_or_metadata ~function_type
                 ~simplify_expr ~return_arity
-          | Unroll (unroll_to, _) ->
+          | `Unroll unroll_to ->
             if Simplify_rec_info_expr.can_unroll dacc rec_info
             then
               (* This sets off step 1 in the comment above; see
@@ -256,4 +274,4 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
                  handled. *)
               Begin_unrolling unroll_to
             else Unrolling_depth_exceeded
-          | Always_inlined _ | Hint_inlined -> Attribute_always))
+          | `Always -> Attribute_always))

--- a/middle_end/flambda2/tests/mlexamples/dune
+++ b/middle_end/flambda2/tests/mlexamples/dune
@@ -8,6 +8,7 @@
   (progn
    (with-stdout-to generated-rules.inc.new
     (run tools/gen_dune_rules.exe
+         inlined_rec
          local
          tests0
          tests2

--- a/middle_end/flambda2/tests/mlexamples/generated-rules.inc
+++ b/middle_end/flambda2/tests/mlexamples/generated-rules.inc
@@ -7,6 +7,49 @@
  (alias runtest)
  (action
   (progn
+   (run ../tools/flexpect.exe inlined_rec.flt)
+   (diff? inlined_rec.flt inlined_rec.flt.corrected))))
+
+(rule
+ (alias runtest)
+ (action
+  (progn
+   (run ../tools/roundtrip.exe inlined_rec_in.fl)
+   (diff? inlined_rec_in.fl inlined_rec_in.fl.corrected))))
+
+(rule
+ (alias runtest)
+ (action
+  (progn
+   (run ../tools/roundtrip.exe inlined_rec_out.fl)
+   (diff? inlined_rec_out.fl inlined_rec_out.fl.corrected))))
+
+(rule
+ (alias regen)
+ (targets inlined_rec.flt.new inlined_rec_in.fl.new inlined_rec_out.fl.new)
+ (deps inlined_rec.ml)
+ (action
+   (run ocamlopt -c inlined_rec.ml -nopervasives -nostdlib
+        -drawfexpr-to inlined_rec_in.fl.new
+        -dfexpr-to inlined_rec_out.fl.new
+        -dflexpect-to inlined_rec.flt.new)))
+
+(rule
+ (alias regen)
+ (action (diff inlined_rec_in.fl inlined_rec_in.fl.new)))
+
+(rule
+ (alias regen)
+ (action (diff inlined_rec_out.fl inlined_rec_out.fl.new)))
+
+(rule
+ (alias regen)
+ (action (diff inlined_rec.flt inlined_rec.flt.new)))
+
+(rule
+ (alias runtest)
+ (action
+  (progn
    (run ../tools/flexpect.exe local.flt)
    (diff? local.flt local.flt.corrected))))
 

--- a/middle_end/flambda2/tests/mlexamples/inlined_rec.flt
+++ b/middle_end/flambda2/tests/mlexamples/inlined_rec.flt
@@ -1,0 +1,85 @@
+let $camlInlined_rec__first_const28 = Block 0 () in
+let code inline(always) size(6)
+      apply_0 (f, i) my_closure my_region my_depth -> k * k1 =
+  apply inlined(hint) f (i) -> k * k1
+in
+let code rec size(27)
+      fact_1 (n : imm tagged)
+        my_closure my_region my_depth
+        -> k * k1
+        : imm tagged =
+  let next_depth = rec_info (succ my_depth) in
+  let `apply` = %project_value_slot fact.`apply` my_closure in
+  let prim = %phys_ne (n, 0) in
+  let Pintcomp = %Tag_imm prim in
+  (let untagged = %untag_imm Pintcomp in
+   switch untagged
+     | 0 -> k (1)
+     | 1 -> k2)
+    where k2 =
+      ((let Psubint = n - 1 in
+        apply direct(apply_0)
+          (`apply` : _ -> imm tagged)
+            (my_closure ~ depth my_depth -> next_depth, Psubint)
+            -> k2 * k1)
+         where k2 (apply_result : imm tagged) =
+           let Pmulint = n * apply_result in
+           cont k (Pmulint))
+in
+(let `apply` = closure apply_0 @`apply` in
+ let fact = closure fact_1 @fact with { `apply` = `apply` } in
+ apply direct(fact_1) (fact : _ -> imm tagged) (1000000) -> k1 * error
+   where k1 (i : imm tagged) =
+     let Pmakeblock = %Block 0 (`apply`, fact, i) in
+     cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load tag(0) size(3) (module_block, 0) in
+    let field_1 = %block_load tag(0) size(3) (module_block, 1) in
+    let field_2 = %block_load tag(0) size(3) (module_block, 2) in
+    let $camlInlined_rec = Block 0 (field_0, field_1, field_2) in
+    cont done ($camlInlined_rec)
+===>
+let code apply_0 deleted in
+let code fact_1 deleted in
+let code inline(always) loopify(never) size(6) newer_version_of(apply_0)
+      apply_0_1 (f, i) my_closure my_region my_depth -> k * k1 =
+  apply inlined(hint) f (i) -> k * k1
+in
+let $camlInlined_rec__apply_2 = closure apply_0_1 @`apply` in
+let code rec loopify(never) size(42) newer_version_of(fact_1)
+      fact_1_1 (n : imm tagged)
+        my_closure my_region my_depth
+        -> k * k1
+        : imm tagged =
+  let prim = %phys_ne (n, 0) in
+  switch prim
+    | 0 -> k (1)
+    | 1 -> k2
+    where k2 =
+      ((let Psubint = n - 1 in
+        let prim_1 = %phys_ne (Psubint, 0) in
+        switch prim_1
+          | 0 -> k2 (1)
+          | 1 -> k3
+          where k3 =
+            ((let Psubint_1 = Psubint - 1 in
+              apply direct(fact_1_1) inlining_state(depth(12))
+                $camlInlined_rec__fact_3 ~ depth my_depth -> succ (unroll 1 (succ my_depth))
+                  (Psubint_1)
+                  -> k3 * k1)
+               where k3 (apply_result : imm tagged) =
+                 let Pmulint = Psubint * apply_result in
+                 cont k2 (Pmulint)))
+         where k2 (apply_result : imm tagged) =
+           let Pmulint = n * apply_result in
+           cont k (Pmulint))
+and $camlInlined_rec__fact_3 =
+  closure fact_1_1 @fact
+in
+apply direct(fact_1_1)
+  ($camlInlined_rec__fact_3 : _ -> imm tagged) (1000000) -> k * error
+  where k (i : imm tagged) =
+    let $camlInlined_rec =
+      Block 0 ($camlInlined_rec__apply_2, $camlInlined_rec__fact_3, i)
+    in
+    cont done ($camlInlined_rec)

--- a/middle_end/flambda2/tests/mlexamples/inlined_rec.ml
+++ b/middle_end/flambda2/tests/mlexamples/inlined_rec.ml
@@ -1,0 +1,16 @@
+external ( - ) : int -> int -> int = "%subint"
+
+external ( * ) : int -> int -> int = "%mulint"
+
+let[@inline] apply ~f i = (f [@inlined hint]) i
+
+let rec fact n =
+  match n with
+  | 0 -> 1
+  | _ ->
+    (* If [@inlined] isn't careful, this recursive call will get unfolded no
+       matter what the max rec depth is set to. In more complicated cases in the
+       wild, this has led to infinite unfolding. *)
+    n * apply ~f:fact (n - 1)
+
+let i = fact 1_000_000

--- a/middle_end/flambda2/tests/mlexamples/inlined_rec_in.fl
+++ b/middle_end/flambda2/tests/mlexamples/inlined_rec_in.fl
@@ -1,0 +1,40 @@
+let $camlInlined_rec__first_const28 = Block 0 () in
+let code inline(always) size(6)
+      apply_0 (f, i) my_closure my_region my_depth -> k * k1 =
+  apply inlined(hint) f (i) -> k * k1
+in
+let code rec size(27)
+      fact_1 (n : imm tagged)
+        my_closure my_region my_depth
+        -> k * k1
+        : imm tagged =
+  let next_depth = rec_info (succ my_depth) in
+  let `apply` = %project_value_slot fact.`apply` my_closure in
+  let prim = %phys_ne (n, 0) in
+  let Pintcomp = %Tag_imm prim in
+  (let untagged = %untag_imm Pintcomp in
+   switch untagged
+     | 0 -> k (1)
+     | 1 -> k2)
+    where k2 =
+      ((let Psubint = n - 1 in
+        apply direct(apply_0)
+          (`apply` : _ -> imm tagged)
+            (my_closure ~ depth my_depth -> next_depth, Psubint)
+            -> k2 * k1)
+         where k2 (apply_result : imm tagged) =
+           let Pmulint = n * apply_result in
+           cont k (Pmulint))
+in
+(let `apply` = closure apply_0 @`apply` in
+ let fact = closure fact_1 @fact with { `apply` = `apply` } in
+ apply direct(fact_1) (fact : _ -> imm tagged) (1000000) -> k1 * error
+   where k1 (i : imm tagged) =
+     let Pmakeblock = %Block 0 (`apply`, fact, i) in
+     cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load tag(0) size(3) (module_block, 0) in
+    let field_1 = %block_load tag(0) size(3) (module_block, 1) in
+    let field_2 = %block_load tag(0) size(3) (module_block, 2) in
+    let $camlInlined_rec = Block 0 (field_0, field_1, field_2) in
+    cont done ($camlInlined_rec)

--- a/middle_end/flambda2/tests/mlexamples/inlined_rec_out.fl
+++ b/middle_end/flambda2/tests/mlexamples/inlined_rec_out.fl
@@ -1,0 +1,44 @@
+let code apply_0 deleted in
+let code fact_1 deleted in
+let code inline(always) loopify(never) size(6) newer_version_of(apply_0)
+      apply_0_1 (f, i) my_closure my_region my_depth -> k * k1 =
+  apply inlined(hint) f (i) -> k * k1
+in
+let $camlInlined_rec__apply_2 = closure apply_0_1 @`apply` in
+let code rec loopify(never) size(42) newer_version_of(fact_1)
+      fact_1_1 (n : imm tagged)
+        my_closure my_region my_depth
+        -> k * k1
+        : imm tagged =
+  let prim = %phys_ne (n, 0) in
+  switch prim
+    | 0 -> k (1)
+    | 1 -> k2
+    where k2 =
+      ((let Psubint = n - 1 in
+        let prim_1 = %phys_ne (Psubint, 0) in
+        switch prim_1
+          | 0 -> k2 (1)
+          | 1 -> k3
+          where k3 =
+            ((let Psubint_1 = Psubint - 1 in
+              apply direct(fact_1_1) inlining_state(depth(12))
+                $camlInlined_rec__fact_3 ~ depth my_depth -> succ (unroll 1 (succ my_depth))
+                  (Psubint_1)
+                  -> k3 * k1)
+               where k3 (apply_result : imm tagged) =
+                 let Pmulint = Psubint * apply_result in
+                 cont k2 (Pmulint)))
+         where k2 (apply_result : imm tagged) =
+           let Pmulint = n * apply_result in
+           cont k (Pmulint))
+and $camlInlined_rec__fact_3 =
+  closure fact_1_1 @fact
+in
+apply direct(fact_1_1)
+  ($camlInlined_rec__fact_3 : _ -> imm tagged) (1000000) -> k * error
+  where k (i : imm tagged) =
+    let $camlInlined_rec =
+      Block 0 ($camlInlined_rec__apply_2, $camlInlined_rec__fact_3, i)
+    in
+    cont done ($camlInlined_rec)


### PR DESCRIPTION
This keeps things in line with expectations if a function `outer` calls a higher-order parameter `f` with `[@inlined hint]` and someone calls `outer` with `f` set to a recursive function. Previously, this could cause the interpreter to loop (or blow up, at any rate) because `[@inlined]` bypassed most limitations on inlining of recursive functions. Using `[@unrolled 1]` honours the intent that the call site be inlined but makes sure things don't get out of hand.

Specifically, the existing behaviour is to treat any `[@inlined]` as very nearly the final authority: it is only ever ignored if either we're already unrolling or we've hit the max overall inlining depth (counting _everything_ being inlined). In the case of a recursive function, this is fine if the call is external but disastrous in any code that's mutually recursive with the function.

With this patch, after we find the function that we would be inlining, we consult its metadata to find whether it's recursive, and if so, we interpret any `[@inlined]` the same as `[@unrolled 1]`. For an external call, this should have basically the same effect as `[@inlined]`. For a recursive call, we'll inline only one copy of the body.

Caveats:

* This relies on the function being correctly identified as recursive in the metadata, which isn't 100% but the known cases hitting this problem all involve a conventional `let rec`.

* There could be some sort of second-order effect from the fact that the inlined body's recursive calls will carry rec info saying they're fully unrolled.