### PR TITLE
Add flag limiting registers available for allocation

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -95,6 +95,9 @@ let trap_notes = ref true
 (* Emit extension symbols for CPUID startup check  *)
 let arch_check_symbols = ref true
 
+(* Limit hardware registers available for allocation *)
+let limit_regalloc = ref Int.max_int
+
 (* Machine-specific command-line options *)
 
 let command_line_options =
@@ -110,6 +113,8 @@ let command_line_options =
       " Emit ISA extension symbols for CPUID check (default)";
     "-fno-arch-check", Arg.Clear arch_check_symbols,
       " Do not emit ISA extension symbols for CPUID check";
+    "-flimit-regalloc", Arg.Set_int limit_regalloc,
+      " Maximum number of hardware registers available for allocation";
   ] @ Extension.args
 
 let assert_simd_enabled () =

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -40,6 +40,7 @@ end
 
 val trap_notes : bool ref
 val arch_check_symbols : bool ref
+val limit_regalloc : int ref
 val command_line_options : (string * Arg.spec * string) list
 val assert_simd_enabled : unit -> unit
 

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -250,9 +250,9 @@ let outgoing ofs =
 let not_supported _ofs = fatal_error "Proc.loc_results: cannot call"
 
 let ocaml_arg_regs =
-  (* We need up to 8 (float) registers to pass arguments to C calls. *)
-  if !Arch.limit_regalloc < 8
-  then Misc.fatal_error "At least eight hardware registers are required.";
+  (* We need up to 8 (float) registers to pass arguments to C calls, plus one scratch. *)
+  if !Arch.limit_regalloc < 9
+  then Misc.fatal_error "At least nine hardware registers are required.";
   Int.min (!Arch.limit_regalloc - 1) 10
 
 let first_int_arg = 0

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -250,10 +250,9 @@ let outgoing ofs =
 let not_supported _ofs = fatal_error "Proc.loc_results: cannot call"
 
 let ocaml_arg_regs =
-  (* caml_callbacks assume the first four parameters are registers, and
-     we need at least one free register that's not a parameter. *)
-  if !Arch.limit_regalloc < 5
-  then Misc.fatal_error "At least five hardware registers are required.";
+  (* We need up to 8 (float) registers to pass arguments to C calls. *)
+  if !Arch.limit_regalloc < 8
+  then Misc.fatal_error "At least eight hardware registers are required.";
   Int.min (!Arch.limit_regalloc - 1) 10
 
 let first_int_arg = 0

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -253,6 +253,8 @@ let ocaml_arg_regs =
   (* We need up to 8 (float) registers to pass arguments to C calls, plus one scratch. *)
   if !Arch.limit_regalloc < 9
   then Misc.fatal_error "At least nine hardware registers are required.";
+  if !Arch.limit_regalloc <> Int.max_int && fp
+  then Misc.fatal_error "Cannot limit registers when frame pointers are enabled.";
   Int.min (!Arch.limit_regalloc - 1) 10
 
 let first_int_arg = 0

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -25,6 +25,8 @@ let macosx = (Config.system = "macosx")
 
 let command_line_options = []
 
+let limit_regalloc = ref Int.max_int
+
 (* Addressing modes *)
 
 type addressing_mode =

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -24,6 +24,8 @@ val macosx : bool
 
 val command_line_options : (string * Arg.spec * string) list
 
+val limit_regalloc : int ref
+
 (* Addressing modes *)
 
 type addressing_mode =


### PR DESCRIPTION
The `-flimit-regalloc=N` flag specifies that only the first `N` hardware registers should be used for normal register allocation. 
Pre-allocated registers (C calls, etc.) are not effected.

Currently only the greedy allocator respects the flag, as it is intended for testing GI.