### PR TITLE
Fix build (float32 renaming conflict)

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1487,7 +1487,10 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
               field_kinds))
     | Pvalue (Pvariant { consts = []; non_consts = [(tag, field_kinds)] })
       when tag = Obj.double_array_tag ->
-      assert (List.for_all (fun kind -> kind = Lambda.(Pboxedfloatval Pfloat64)) field_kinds);
+      assert (
+        List.for_all
+          (fun kind -> kind = Lambda.(Pboxedfloatval Pfloat64))
+          field_kinds);
       Some (Unboxed_float_record (List.length field_kinds))
     | Pvalue (Pboxedfloatval Pfloat64) -> Some (Unboxed_number Naked_float)
     | Pvalue (Pboxedfloatval Pfloat32) ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1487,9 +1487,12 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
               field_kinds))
     | Pvalue (Pvariant { consts = []; non_consts = [(tag, field_kinds)] })
       when tag = Obj.double_array_tag ->
-      assert (List.for_all (fun kind -> kind = Lambda.Pfloatval) field_kinds);
+      assert (List.for_all (fun kind -> kind = Lambda.(Pboxedfloatval Pfloat64)) field_kinds);
       Some (Unboxed_float_record (List.length field_kinds))
-    | Pvalue Pfloatval -> Some (Unboxed_number Naked_float)
+    | Pvalue (Pboxedfloatval Pfloat64) -> Some (Unboxed_number Naked_float)
+    | Pvalue (Pboxedfloatval Pfloat32) ->
+      (* CR mslater: (float32) middle end support *)
+      assert false
     | Pvalue (Pboxedintval bi) ->
       let bn : Flambda_kind.Boxable_number.t =
         match bi with
@@ -1504,7 +1507,7 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
       in
       Some (Unboxed_number bn)
     | Pvalue (Pgenval | Pintval | Pvariant _ | Parrayval _)
-    | Ptop | Pbottom | Punboxed_float | Punboxed_int _ | Punboxed_vector _
+    | Ptop | Pbottom | Punboxed_float _ | Punboxed_int _ | Punboxed_vector _
     | Punboxed_product _ ->
       Location.prerr_warning
         (Debuginfo.Scoped_location.to_location loc)


### PR DESCRIPTION
Updates #1271 to compile with the recently added `Pfloat32` case.