### PR TITLE
Zero alloc: more precise handling of recursive functions

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -1024,13 +1024,15 @@ end = struct
         Unit_info.record unit_info fun_name res f.fun_dbg a saved_body;
         report_unit_info ppf unit_info ~msg:"after record"
       in
-      let really_check ~keep_witnesses =
+      let really_check () =
         if !Flambda_backend_flags.disable_checkmach
         then
           (* Do not analyze the body of the function, conservatively assume that
              the summary is top. *)
-          Unit_info.join_value unit_info fun_name (Value.top Witnesses.empty)
-        else really_check ~keep_witnesses
+          Unit_info.record unit_info fun_name
+            (Value.top Witnesses.empty)
+            f.fun_dbg a None
+        else really_check ()
       in
       match a with
       | Some a when Annotation.is_assume a ->

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -606,8 +606,12 @@ end = struct
       String.Tbl.replace t name func_info
 end
 
-(** Check one function. *)
+(** The analysis involved some fixed point computations.
+    Termination: [Value.t] is a finite height domain and
+    [transfer] is a monotone function w.r.t. [Value.lessequal] order.
+*)
 module Analysis (S : Spec) : sig
+  (** Check one function. *)
   val fundecl :
     Mach.fundecl ->
     future_funcnames:String.Set.t ->
@@ -615,6 +619,8 @@ module Analysis (S : Spec) : sig
     Format.formatter ->
     unit
 
+  (** Resolve all function summaries, check them against user-provided assertions,
+      and record the summaries in Compilenv to be saved in .cmx files *)
   val record_unit : Unit_info.t -> Format.formatter -> unit
 end = struct
   (** Information about the current function under analysis. *)

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -775,9 +775,14 @@ end = struct
           unresolved (Value.top w)
             "(missing summary: callee compiled without checks)"
         | Some v -> resolved v)
-      | Some callee_info ->
+      | Some callee_info -> (
         (* Callee defined earlier in the same compilation unit. *)
-        resolved callee_info.value
+        match callee_info.saved_body with
+        | None -> resolved callee_info.value
+        | Some _ ->
+          (* callee was unresolved, mark caller as unresolved *)
+          t.unresolved <- true;
+          unresolved callee_info.value "unresolved callee")
 
   let transform_return ~(effect : V.t) dst =
     match effect with

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -959,7 +959,7 @@ end = struct
            will be recomputed simultaneously at the end of the compilation
            unit. *)
         if t.unresolved
-        then approx
+        then new_value
         else if Value.lessequal new_value approx
         then approx
         else (
@@ -976,10 +976,7 @@ end = struct
       match func_info.saved_body with
       | None -> ()
       | Some b ->
-        let t =
-          create ppf func_info.name String.Set.empty unit_info
-            (Some func_info.value)
-        in
+        let t = create ppf func_info.name String.Set.empty unit_info None in
         let new_value = analyze_body t b in
         if not (Value.lessequal new_value func_info.value)
         then (

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -23,7 +23,7 @@
  * SOFTWARE.                                                                      *
  *                                                                                *
  **********************************************************************************)
-[@@@ocaml.warning "+a-30-40-41-42-32"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 module String = Misc.Stdlib.String
 
@@ -585,8 +585,6 @@ module Unit_info : sig
     Mach.instruction option ->
     unit
 
-  val update : t -> string -> Value.t -> unit
-
   val iter : t -> f:(Func_info.t -> unit) -> unit
 
   val should_keep_witnesses : bool -> bool
@@ -614,11 +612,6 @@ end = struct
     | None ->
       let func_info = Func_info.create name value dbg annotation saved_body in
       String.Tbl.replace t name func_info
-
-  let update t name value =
-    match String.Tbl.find_opt t name with
-    | None -> Misc.fatal_errorf "Cannot find symbol %s" name
-    | Some func_info -> Func_info.update func_info value
 end
 
 (** Check one function. *)

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -495,20 +495,50 @@ end = struct
     | _ -> None
 end
 
-module Func_info = struct
+module Func_info : sig
+  type t = private
+    { name : string;  (** function name *)
+      dbg : Debuginfo.t;  (** debug info associated with the function *)
+      mutable value : Value.t;  (** the result of the check *)
+      annotation : Annotation.t option;
+          (** [value] must be lessequal than the expected value
+          if there is user-defined annotation on this function. *)
+      saved_body : Mach.instruction option
+          (** If the function has callees that haven't been analyzed yet, keep function body
+          so it can be reanalyzed when the callees are available.  *)
+    }
+
+  val create :
+    string ->
+    Value.t ->
+    Debuginfo.t ->
+    Annotation.t option ->
+    Mach.instruction option ->
+    t
+
+  val print : witnesses:bool -> msg:string -> Format.formatter -> t -> unit
+
+  val update : t -> Value.t -> unit
+end = struct
   type t =
     { name : string;  (** function name *)
       dbg : Debuginfo.t;  (** debug info associated with the function *)
-      value : Value.t;  (** the result of the check *)
-      annotation : Annotation.t option
+      mutable value : Value.t;  (** the result of the check *)
+      annotation : Annotation.t option;
           (** [value] must be lessequal than the expected value
           if there is user-defined annotation on this function. *)
+      saved_body : Mach.instruction option
+          (** If the function has callees that haven't been analyzed yet, keep function body
+          so it can be reanalyzed when the callees are available.  *)
     }
 
-  let create name value dbg annotation = { name; dbg; value; annotation }
+  let create name value dbg annotation saved_body =
+    { name; dbg; value; annotation; saved_body }
 
   let print ~witnesses ~msg ppf t =
     Format.fprintf ppf "%s %s %a@." msg t.name (Value.print ~witnesses) t.value
+
+  let update t value = t.value <- value
 end
 
 module type Spec = sig
@@ -547,7 +577,15 @@ module Unit_info : sig
   (** [recod t name v dbg a] name must be in the current compilation unit,
       and not previously recorded.  *)
   val record :
-    t -> string -> Value.t -> Debuginfo.t -> Annotation.t option -> unit
+    t ->
+    string ->
+    Value.t ->
+    Debuginfo.t ->
+    Annotation.t option ->
+    Mach.instruction option ->
+    unit
+
+  val update : t -> string -> Value.t -> unit
 
   val iter : t -> f:(Func_info.t -> unit) -> unit
 
@@ -570,12 +608,17 @@ end = struct
 
   let iter t ~f = String.Tbl.iter (fun _ func_info -> f func_info) t
 
-  let record t name value dbg annotation =
+  let record t name value dbg annotation saved_body =
     match String.Tbl.find_opt t name with
     | Some _ -> Misc.fatal_errorf "Duplicate symbol %s" name
     | None ->
-      let func_info = Func_info.create name value dbg annotation in
+      let func_info = Func_info.create name value dbg annotation saved_body in
       String.Tbl.replace t name func_info
+
+  let update t name value =
+    match String.Tbl.find_opt t name with
+    | None -> Misc.fatal_errorf "Cannot find symbol %s" name
+    | Some func_info -> Func_info.update func_info value
 end
 
 (** Check one function. *)
@@ -595,16 +638,19 @@ end = struct
       current_fun_name : string;
       future_funcnames : String.Set.t;
       mutable approx : Value.t option;
-          (** Used for computing fixpoint for self calls. *)
+          (** Used for computing for self calls. *)
+      mutable unresolved : bool;
+          (** the current function contains calls to other unresolved functions (not including self calls) *)
       unit_info : Unit_info.t;  (** must be the current compilation unit.  *)
       mutable keep_witnesses : bool
     }
 
-  let create ppf current_fun_name future_funcnames unit_info =
+  let create ppf current_fun_name future_funcnames unit_info approx =
     { ppf;
       current_fun_name;
       future_funcnames;
-      approx = None;
+      approx;
+      unresolved = false;
       unit_info;
       keep_witnesses = false
     }
@@ -644,7 +690,7 @@ end = struct
       let msg = Printf.sprintf "%s %s:" analysis_name msg in
       Func_info.print ~witnesses:true ppf ~msg func_info
 
-  let record_unit unit_info ppf =
+  let record_unit ppf unit_info =
     let errors = ref [] in
     let record (func_info : Func_info.t) =
       (match func_info.annotation with
@@ -685,10 +731,6 @@ end = struct
     | [] -> ()
     | errors -> raise (Report.Fail (errors, S.property))
 
-  let record_unit unit_info ppf =
-    Profile.record_call ~accumulate:true ("record_unit " ^ analysis_name)
-      (fun () -> record_unit unit_info ppf)
-
   let[@inline always] create_witnesses t kind dbg =
     if t.keep_witnesses then Witnesses.create kind dbg else Witnesses.empty
 
@@ -719,10 +761,11 @@ end = struct
           unresolved v "self-call init"
         | Some approx -> unresolved approx "self-call approx"
       else
-        (* Call is defined later in the current compilation unit. Summary of
-           this callee is not yet computed, conservatively return Top. Won't be
-           able to prove any recursive functions as non-allocating. *)
-        unresolved (Value.top w)
+        ((* Call is defined later in the current compilation unit. Summary of
+            this callee is not yet computed, conservatively return Top. Won't be
+            able to prove any recursive functions as non-allocating. *)
+         t.unresolved <- true;
+         unresolved Value.safe)
           "conservative handling of forward or recursive call\nor tailcall"
     else
       (* CR gyorsh: unresolved case here is impossible in the conservative
@@ -900,16 +943,23 @@ end = struct
        To check divergent loops, the initial value of "div" component of all
        Iexit labels of recurisve Icatch handlers is set to "Safe" instead of
        "Bot". *)
+    D.analyze ~exnescape:Value.exn_escape ~init_rc_lbl:Value.diverges ~transfer
+      body
+    |> fst
+
+  let analyze_body t body =
     let rec fixpoint () =
-      let new_value =
-        D.analyze ~exnescape:Value.exn_escape ~init_rc_lbl:Value.diverges
-          ~transfer body
-        |> fst
-      in
+      let new_value = check_instr t body in
       match t.approx with
       | None -> new_value
       | Some approx ->
-        if Value.lessequal new_value approx
+        (* Fixpoint here is only for the common case of "self" recursive
+           functions that do not have other unresolved dependencies. Other cases
+           will be recomputed simultaneously at the end of the compilation
+           unit. *)
+        if t.unresolved
+        then approx
+        else if Value.lessequal new_value approx
         then approx
         else (
           t.approx <- Some (Value.join new_value approx);
@@ -917,16 +967,47 @@ end = struct
     in
     fixpoint ()
 
+  let fixpoint ppf unit_info =
+    report_unit_info ppf unit_info ~msg:"before fixpoint";
+    (* CR gyorsh: this is a really dumb iteration strategy. *)
+    let change = ref true in
+    let analyze_func (func_info : Func_info.t) =
+      match func_info.saved_body with
+      | None -> ()
+      | Some b ->
+        let t =
+          create ppf func_info.name String.Set.empty unit_info
+            (Some func_info.value)
+        in
+        let new_value = analyze_body t b in
+        if not (Value.lessequal new_value func_info.value)
+        then (
+          change := true;
+          Func_info.update func_info new_value)
+    in
+    while !change do
+      change := false;
+      Unit_info.iter unit_info ~f:analyze_func;
+      report_unit_info ppf unit_info ~msg:"computing fixpoint"
+    done
+
+  let record_unit unit_info ppf =
+    Profile.record_call ~accumulate:true ("record_unit " ^ analysis_name)
+      (fun () ->
+        fixpoint ppf unit_info;
+        record_unit ppf unit_info)
+
   let fundecl (f : Mach.fundecl) ~future_funcnames unit_info ppf =
     let check () =
       let fun_name = f.fun_name in
-      let t = create ppf fun_name future_funcnames unit_info in
+      let t = create ppf fun_name future_funcnames unit_info None in
       let a =
         Annotation.find f.fun_codegen_options S.property fun_name f.fun_dbg
       in
       let really_check ~keep_witnesses =
         t.keep_witnesses <- Unit_info.should_keep_witnesses keep_witnesses;
-        let res = check_instr t f.fun_body in
+        let res = analyze_body t f.fun_body in
+        let saved_body = if t.unresolved then Some f.fun_body else None in
         report t res ~msg:"finished" ~desc:"fundecl" f.fun_dbg;
         if not t.keep_witnesses
         then (
@@ -934,8 +1015,7 @@ end = struct
           assert (Witnesses.is_empty nor);
           assert (Witnesses.is_empty exn);
           assert (Witnesses.is_empty div));
-        report_unit_info ppf unit_info ~msg:"before record";
-        Unit_info.record unit_info fun_name res f.fun_dbg a;
+        Unit_info.record unit_info fun_name res f.fun_dbg a saved_body;
         report_unit_info ppf unit_info ~msg:"after record"
       in
       let really_check ~keep_witnesses =
@@ -950,7 +1030,7 @@ end = struct
       | Some a when Annotation.is_assume a ->
         let expected_value = Annotation.expected_value a Witnesses.empty in
         report t expected_value ~msg:"assumed" ~desc:"fundecl" f.fun_dbg;
-        Unit_info.record unit_info fun_name expected_value f.fun_dbg None
+        Unit_info.record unit_info fun_name expected_value f.fun_dbg None None
       | None -> really_check ~keep_witnesses:false
       | Some a ->
         let expected_value = Annotation.expected_value a Witnesses.empty in

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -586,8 +586,6 @@ module Unit_info : sig
     unit
 
   val iter : t -> f:(Func_info.t -> unit) -> unit
-
-  val should_keep_witnesses : bool -> bool
 end = struct
   (** map function name to the information about it *)
   type t = Func_info.t String.Tbl.t
@@ -597,12 +595,6 @@ end = struct
   let reset t = String.Tbl.reset t
 
   let find_opt t name = String.Tbl.find_opt t name
-
-  let should_keep_witnesses keep =
-    match !Flambda_backend_flags.checkmach_details_cutoff with
-    | Keep_all -> true
-    | No_details -> false
-    | At_most _ -> keep
 
   let iter t ~f = String.Tbl.iter (fun _ func_info -> f func_info) t
 
@@ -635,17 +627,24 @@ end = struct
       mutable unresolved : bool;
           (** the current function contains calls to other unresolved functions (not including self calls) *)
       unit_info : Unit_info.t;  (** must be the current compilation unit.  *)
-      mutable keep_witnesses : bool
+      keep_witnesses : bool
     }
 
-  let create ppf current_fun_name future_funcnames unit_info approx =
+  let should_keep_witnesses keep =
+    match !Flambda_backend_flags.checkmach_details_cutoff with
+    | Keep_all -> true
+    | No_details -> false
+    | At_most _ -> keep
+
+  let create ppf current_fun_name future_funcnames unit_info approx annot =
+    let keep_witnesses = should_keep_witnesses (Option.is_some annot) in
     { ppf;
       current_fun_name;
       future_funcnames;
       approx;
       unresolved = false;
       unit_info;
-      keep_witnesses = false
+      keep_witnesses
     }
 
   let analysis_name = Printcmm.property_to_string S.property
@@ -976,7 +975,10 @@ end = struct
       match func_info.saved_body with
       | None -> ()
       | Some b ->
-        let t = create ppf func_info.name String.Set.empty unit_info None in
+        let t =
+          create ppf func_info.name String.Set.empty unit_info None
+            func_info.annotation
+        in
         let new_value = analyze_body t b in
         if not (Value.lessequal new_value func_info.value)
         then (
@@ -999,12 +1001,11 @@ end = struct
   let fundecl (f : Mach.fundecl) ~future_funcnames unit_info ppf =
     let check () =
       let fun_name = f.fun_name in
-      let t = create ppf fun_name future_funcnames unit_info None in
       let a =
         Annotation.find f.fun_codegen_options S.property fun_name f.fun_dbg
       in
-      let really_check ~keep_witnesses =
-        t.keep_witnesses <- Unit_info.should_keep_witnesses keep_witnesses;
+      let t = create ppf fun_name future_funcnames unit_info None a in
+      let really_check () =
         let res = analyze_body t f.fun_body in
         let saved_body = if t.unresolved then Some f.fun_body else None in
         report t res ~msg:"finished" ~desc:"fundecl" f.fun_dbg;
@@ -1030,12 +1031,12 @@ end = struct
         let expected_value = Annotation.expected_value a Witnesses.empty in
         report t expected_value ~msg:"assumed" ~desc:"fundecl" f.fun_dbg;
         Unit_info.record unit_info fun_name expected_value f.fun_dbg None None
-      | None -> really_check ~keep_witnesses:false
+      | None -> really_check ()
       | Some a ->
         let expected_value = Annotation.expected_value a Witnesses.empty in
         report t expected_value ~msg:"assert" ~desc:"fundecl" f.fun_dbg;
         (* Only keep witnesses for functions that need checking. *)
-        really_check ~keep_witnesses:true
+        really_check ()
     in
     Profile.record_call ~accumulate:true ("check " ^ analysis_name) check
 end

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -740,7 +740,10 @@ end = struct
       let msg = Printf.sprintf "unresolved %s (%s)" callee reason in
       return ~msg v
     in
-    let resolved v = return ~msg:"resolved %s" v in
+    let resolved v =
+      let msg = Printf.sprintf "resolved  %s" callee in
+      return ~msg v
+    in
     if is_future_funcname t callee
     then
       if String.equal callee t.current_fun_name
@@ -976,6 +979,7 @@ end = struct
         if not (Value.lessequal new_value func_info.value)
         then (
           change := true;
+          report t new_value ~msg:"update" ~desc:"fixpoint" func_info.dbg;
           Func_info.update func_info new_value)
     in
     while !change do

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -777,7 +777,7 @@ end = struct
         match S.get_value_opt callee with
         | None ->
           unresolved (Value.top w)
-            "(missign summary: callee compiled without checks)"
+            "(missing summary: callee compiled without checks)"
         | Some v -> resolved v)
       | Some callee_info ->
         (* Callee defined earlier in the same compilation unit. *)

--- a/backend/checkmach.mli
+++ b/backend/checkmach.mli
@@ -53,8 +53,6 @@ module Witness : sig
     | Indirect_tailcall
     | Direct_call of { callee : string }
     | Direct_tailcall of { callee : string }
-    | Missing_summary of { callee : string }
-    | Forward_call of { callee : string }
     | Extcall of { callee : string }
     | Arch_specific
     | Probe of

--- a/tests/backend/checkmach/fail19.output
+++ b/tests/backend/checkmach/fail19.output
@@ -15,7 +15,7 @@ Error: called function may allocate (indirect call)
 
 File "fail19.ml", line 14, characters 15-44:
 Error: expression may allocate
-       (probe test handler camlFail19.probe_handler_test_HIDE_STAMP)
+       (probe "test" handler camlFail19.probe_handler_test_HIDE_STAMP)
 
 File "fail19.ml", line 14, characters 46-54:
 Error: allocation of 24 bytes

--- a/tests/backend/checkmach/fail20.ml
+++ b/tests/backend/checkmach/fail20.ml
@@ -9,3 +9,11 @@ let[@zero_alloc strict] foo x =
   else if x < 0 then
     List.nth (div (x+2)) x
   else nor x
+
+let[@zero_alloc][@inline never][@local never]  foo x =
+  let[@inline never][@local never] bar x y =
+    (Sys.opaque_identity (x + y), x)
+  in
+  fst (bar x (x*x))
+
+let[@zero_alloc] zee x f = foo (Sys.opaque_identity x+1)

--- a/tests/backend/checkmach/fail20.output
+++ b/tests/backend/checkmach/fail20.output
@@ -6,3 +6,9 @@ Error: allocation of 32 bytes on a path to exceptional return (fail20.ml:8,16--2
 
 File "fail20.ml", line 10, characters 13-24:
 Error: called function may allocate on a path to exceptional return (direct call camlFail20.div_HIDE_STAMP)
+
+File "fail20.ml", line 13, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Fail20.foo (camlFail20.foo_HIDE_STAMP)
+
+File "fail20.ml", line 19, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Fail20.zee (camlFail20.zee_HIDE_STAMP)

--- a/tests/backend/checkmach/fail20.output
+++ b/tests/backend/checkmach/fail20.output
@@ -10,5 +10,11 @@ Error: called function may allocate on a path to exceptional return (direct call
 File "fail20.ml", line 13, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail20.foo (camlFail20.foo_HIDE_STAMP)
 
+File "fail20.ml", line 17, characters 6-19:
+Error: called function may allocate (direct call camlFail20.bar_HIDE_STAMP)
+
 File "fail20.ml", line 19, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail20.zee (camlFail20.zee_HIDE_STAMP)
+
+File "fail20.ml", line 19, characters 27-56:
+Error: called function may allocate (direct tailcall camlFail20.foo_HIDE_STAMP)


### PR DESCRIPTION
The analysis of recursive functions is precise with respect to the abstraction but not efficient.  The intent is to make it easy to review for correctness. The idea is to save the body of `Mach` functions that contain unresolved calls (i.e., calls to functions that appears later in the same compilation unit and hence have not yet have a summary). Then, at the end of the compilation unit, computed the fixed point by reanalyzing these functions. 

This PR may be easier to read commit-by-commit. The first commit deletes complicated tracking of dependencies for unresolved functions and conservative treats all unreasolved calls as Top. The second commit adds a very simple tracking of unresolved functions (no dependency tracking) and fixed point computation.



