### PR TITLE
Abort if greedy introduces too many temporaries

### DIFF
--- a/backend/regalloc/regalloc_gi_state.ml
+++ b/backend/regalloc/regalloc_gi_state.ml
@@ -36,6 +36,9 @@ let[@inline] mem_introduced_temporaries state reg =
 let[@inline] iter_introduced_temporaries state ~f =
   Reg.Set.iter f state.introduced_temporaries
 
+let[@inline] introduced_temporary_count state =
+  Reg.Set.cardinal state.introduced_temporaries
+
 let[@inline] stack_slots state = state.stack_slots
 
 let[@inline] get_and_incr_instruction_id state =

--- a/backend/regalloc/regalloc_gi_state.mli
+++ b/backend/regalloc/regalloc_gi_state.mli
@@ -22,6 +22,8 @@ val mem_introduced_temporaries : t -> Reg.t -> bool
 
 val iter_introduced_temporaries : t -> f:(Reg.t -> unit) -> unit
 
+val introduced_temporary_count : t -> int
+
 val stack_slots : t -> Regalloc_stack_slots.t
 
 val get_and_incr_instruction_id : t -> Instruction.id


### PR DESCRIPTION
Adds a second termination condition: if a round introduces more than 10 times the number of temporaries we started with.