### PR TITLE
Inline stubs more aggressively

### DIFF
--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
@@ -130,6 +130,14 @@ let report fmt t =
     | Must_be_inlined -> "must")
     report_decision t
 
+let is_stub t =
+  match t with
+  | Stub -> true
+  | Not_yet_decided | Never_inline_attribute | Function_body_too_large _
+  | Attribute_inline | Small_function _ | Speculatively_inlinable _ | Functor _
+  | Recursive ->
+    false
+
 let must_be_inlined t =
   match behaviour t with
   | Must_be_inlined -> true

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
@@ -36,6 +36,8 @@ val print : Format.formatter -> t -> unit
 
 val report : Format.formatter -> t -> unit
 
+val is_stub : t -> bool
+
 val must_be_inlined : t -> bool
 
 val has_attribute_inline : t -> bool


### PR DESCRIPTION
This PR is intended to fix the `optargs` test, which ensures that recursive functions with default parameters do not allocate options when calling themselves recursively.
The test itself is still inactive, but will be restored by #2289, which this commit is cherry-picked from.