### PR TITLE
Fix confusingly-named function `depth_may_be_at_least`

### DIFF
--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -242,7 +242,7 @@ let make_decision dacc ~simplify_expr ~function_type ~apply ~return_arity :
               Flambda_features.Inlining.max_rec_depth
                 (Round (DE.round (DA.denv dacc)))
             in
-            if Simplify_rec_info_expr.depth_may_be_at_least dacc rec_info
+            if Simplify_rec_info_expr.depth_may_exceed dacc rec_info
                  max_rec_depth
             then Recursion_depth_exceeded
             else

--- a/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_rec_info_expr.ml
@@ -113,11 +113,11 @@ let evaluate_rec_info_expr dacc rec_info_expr =
     Misc.fatal_errorf "Unable to evaluate@ %a@ with@ dacc@ %a"
       Rec_info_expr.print rec_info_expr DA.print dacc
 
-let depth_may_be_at_least dacc rec_info_expr bound =
+let depth_may_exceed dacc rec_info_expr bound =
   let { Evaluated_rec_info_expr.depth; _ } =
     evaluate_rec_info_expr dacc rec_info_expr
   in
-  Or_infinity.compare ~f:Int.compare depth (Finite bound) >= 1
+  Or_infinity.compare ~f:Int.compare depth (Finite bound) > 0
 
 let known_remaining_unrolling_depth dacc rec_info_expr =
   match evaluate_rec_info_expr dacc rec_info_expr with

--- a/middle_end/flambda2/simplify/simplify_rec_info_expr.mli
+++ b/middle_end/flambda2/simplify/simplify_rec_info_expr.mli
@@ -31,7 +31,7 @@ end
 val evaluate_rec_info_expr :
   Downwards_acc.t -> Rec_info_expr.t -> Evaluated_rec_info_expr.t
 
-val depth_may_be_at_least : Downwards_acc.t -> Rec_info_expr.t -> int -> bool
+val depth_may_exceed : Downwards_acc.t -> Rec_info_expr.t -> int -> bool
 
 val known_remaining_unrolling_depth :
   Downwards_acc.t -> Rec_info_expr.t -> int option


### PR DESCRIPTION
The function actually computes a (possible) _strict_ inequality, which is crucial for inlining heuristics: since the depth of a non-recursive function is zero and the default max rec depth is zero, if we were allowing equality here, we would inline nothing automatically.

Renamed to `depth_may_exceed`, which makes the calling code obviously correct.

Also changed `>= 1` to `> 0` to be more idiomatic (so that it also _looks_ like it's computing a strict inequality).