### PR TITLE
Define Hd_val separately on x86-64

### DIFF
--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -155,8 +155,13 @@ where 0 <= R <= 31 is HEADER_RESERVED_BITS, set with the
 #define Hd_with_color(hd, color) (((hd) &~ HEADER_COLOR_MASK) | (color))
 
 #define Hp_atomic_val(val) ((atomic_uintnat *)(val) - 1)
+#ifdef __x86_64__
+/* Separate definition for x86 to avoid disturbing inlining heuristics */
+#define Hd_val(val) (((header_t *) (val)) [-1])        /* Also an l-value. */
+#else
 #define Hd_val(val) ((header_t) \
   (atomic_load_explicit(Hp_atomic_val(val), memory_order_relaxed)))
+#endif
 
 #define Color_val(val) (Color_hd (Hd_val (val)))
 


### PR DESCRIPTION
The runtime5 definition of `Hd_val` has been shown to disturb inlining heuristics on at least one C compiler.  On x86-64, I believe the relaxed atomic definition compiles to the same thing as the runtime4 version of this macro, so this patch uses the latter for runtime5.

I checked manually that the effects on `caml_string_compare` previously seen with runtime5 (in particular part of it being moved out into another function) did not appear after this patch.