### PR TITLE
Allow equations on parameters in result types

### DIFF
--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -276,9 +276,11 @@ let compute_result_types ~is_a_functor ~is_opaque ~return_cont_uses
         ~is_recursive:false ~params:return_cont_params ~env_at_fork
         ~consts_lifted_during_body:lifted_consts_this_function
     in
+    let bound_params_and_results =
+      Bound_parameters.append params return_cont_params
+    in
     let params_and_results =
-      Bound_parameters.var_set
-        (Bound_parameters.append params return_cont_params)
+      Bound_parameters.var_set bound_params_and_results
     in
     let typing_env = DE.typing_env join.handler_env in
     let typing_env =
@@ -287,12 +289,12 @@ let compute_result_types ~is_a_functor ~is_opaque ~return_cont_uses
     in
     let results_and_types =
       List.map
-        (fun result ->
-          let name = BP.name result in
-          let kind = K.With_subkind.kind (BP.kind result) in
+        (fun result_or_param ->
+          let name = BP.name result_or_param in
+          let kind = K.With_subkind.kind (BP.kind result_or_param) in
           let ty = TE.find typing_env name (Some kind) in
           name, ty)
-        (Bound_parameters.to_list return_cont_params)
+        (Bound_parameters.to_list bound_params_and_results)
     in
     let env_extension =
       (* This call is important for compilation time performance, to cut down


### PR DESCRIPTION
This PR increases the amount of information we store in result types.
Previously we would only store the equations on the result variables (made suitable for any environment), with this patch we also add equations on parameters.
This change can be observed on the following examples:
```ocaml
type t = A of int
let f (A x) = x

let swap p = (snd p, fst p)
```
Without this PR the result type for `f` is any immediate, and for `swap` it is a tuple with arbitrary contents.
With this PR the relations between parameters and results are fully expressed in the result types.

This is not complete, of course: if equations on intermediary variables are needed, they are still discarded at the moment.
This can be seen on the following example:
``` ocaml
let g x =
  let tmp = (x, x) in
  tmp, tmp
```
Here we will likely get a result type of the form `∃tmp. result = (tmp, tmp)`, but without equations on `tmp`.

Whether this PR is actually useful is practice is not completely clear, but for #2213 we were looking at what happens in corner cases and this PR makes it easier to generate tricky examples.