### PR TITLE
Hoist Wosize_val from end conditions of loops

### DIFF
--- a/ocaml/runtime/backtrace.c
+++ b/ocaml/runtime/backtrace.c
@@ -278,7 +278,9 @@ CAMLprim value caml_convert_raw_backtrace(value bt)
   if (!caml_debug_info_available())
     caml_failwith("No debug information available");
 
-  for (i = 0, index = 0; i < Wosize_val(bt); ++i)
+  mlsize_t bt_size = Wosize_val(bt);
+
+  for (i = 0, index = 0; i < bt_size; ++i)
   {
     debuginfo dbg;
     for (dbg = caml_debuginfo_extract(Backtrace_slot_val(Field(bt, i)));
@@ -289,7 +291,7 @@ CAMLprim value caml_convert_raw_backtrace(value bt)
 
   array = caml_alloc(index, 0);
 
-  for (i = 0, index = 0; i < Wosize_val(bt); ++i)
+  for (i = 0, index = 0; i < bt_size; ++i)
   {
     debuginfo dbg;
     for (dbg = caml_debuginfo_extract(Backtrace_slot_val(Field(bt, i)));
@@ -359,8 +361,9 @@ CAMLprim value caml_get_exception_backtrace(value unit)
   } else {
     backtrace = caml_get_exception_raw_backtrace(Val_unit);
 
-    arr = caml_alloc(Wosize_val(backtrace), 0);
-    for (i = 0; i < Wosize_val(backtrace); i++) {
+    mlsize_t backtrace_size = Wosize_val(backtrace);
+    arr = caml_alloc(backtrace_size, 0);
+    for (i = 0; i < backtrace_size; i++) {
       backtrace_slot slot = Backtrace_slot_val(Field(backtrace, i));
       debuginfo dbg = caml_debuginfo_extract(slot);
       Store_field(arr, i, caml_convert_debuginfo(dbg));

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -172,6 +172,12 @@ where 0 <= R <= 31 is HEADER_RESERVED_BITS, set with the
 #define Num_tags (1ull << HEADER_TAG_BITS)
 #define Max_wosize ((1ull << HEADER_WOSIZE_BITS) - 1ull)
 
+// Note that Wosize_val and the other macros that read headers will not
+// be optimized by common subexpression elimination, because of the
+// atomic header loads.  It is best to bind the results of such macros
+// to variables if they will be tested repeatedly, e.g. as the end condition
+// in a for-loop.
+
 #define Wosize_val(val) (Wosize_hd (Hd_val (val)))
 #define Wosize_op(op) (Wosize_val (op))
 #define Wosize_bp(bp) (Wosize_val (bp))

--- a/ocaml/runtime/globroots.c
+++ b/ocaml/runtime/globroots.c
@@ -251,7 +251,8 @@ static void scan_native_globals(scanning_action f, void* fdata)
     for(glob = caml_globals[i]; *glob != 0; glob++) {
       glob_block = *glob;
       compute_index_for_global_root_scan(&glob_block, &start);
-      for (j = start; j < Wosize_val(glob_block); j++) {
+      mlsize_t size = Wosize_val(glob_block);
+      for (j = start; j < size; j++) {
         f(fdata, Field(glob_block, j), &Field(glob_block, j));
       }
     }
@@ -262,7 +263,8 @@ static void scan_native_globals(scanning_action f, void* fdata)
     for(glob = (value *) lnk->data; *glob != 0; glob++) {
       glob_block = *glob;
       compute_index_for_global_root_scan(&glob_block, &start);
-      for (j = start; j < Wosize_val(glob_block); j++) {
+      mlsize_t size = Wosize_val(glob_block);
+      for (j = start; j < size; j++) {
         f(fdata, Field(glob_block, j), &Field(glob_block, j));
       }
     }

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -328,7 +328,8 @@ CAMLexport void caml_set_fields (value obj, value v)
   int i;
   CAMLassert (Is_block(obj));
 
-  for (i = 0; i < Wosize_val(obj); i++) {
+  mlsize_t size = Wosize_val(obj);
+  for (i = 0; i < size; i++) {
     caml_modify(&Field(obj, i), v);
   }
 }

--- a/ocaml/runtime/meta.c
+++ b/ocaml/runtime/meta.c
@@ -67,14 +67,15 @@ static char* buffer_of_bytes_array(value ls, asize_t *len)
   int i;
 
   *len = 0;
-  for (i = 0; i < Wosize_val(ls); i++) {
+  mlsize_t ls_size = Wosize_val(ls);
+  for (i = 0; i < ls_size; i++) {
     s = Field(ls, i);
     *len += caml_string_length(s);
   }
 
   ret = caml_stat_alloc(*len);
   off = 0;
-  for (i = 0; i < Wosize_val(ls); i++) {
+  for (i = 0; i < ls_size; i++) {
     size_t s_len;
     s = Field(ls, i);
     s_len = caml_string_length(s);

--- a/ocaml/runtime/minor_gc.c
+++ b/ocaml/runtime/minor_gc.c
@@ -416,7 +416,8 @@ again:
     if (Is_block (f) && Is_young(f)) {
       oldify_one (st, f, Op_val (new_v));
     }
-    for (i = 1; i < Wosize_val (new_v); i++){
+    mlsize_t new_v_size = Wosize_val (new_v);
+    for (i = 1; i < new_v_size; i++){
       f = Field(v, i);
       CAMLassert (!Is_debug_tag(f));
       if (Is_block (f) && Is_young(f)) {

--- a/ocaml/runtime/printexc.c
+++ b/ocaml/runtime/printexc.c
@@ -74,7 +74,8 @@ CAMLexport char * caml_format_exception(value exn)
       start = 1;
     }
     add_char(&buf, '(');
-    for (i = start; i < Wosize_val(bucket); i++) {
+    mlsize_t bucket_size = Wosize_val(bucket);
+    for (i = start; i < bucket_size; i++) {
       if (i > start) add_string(&buf, ", ");
       v = Field(bucket, i);
       if (Is_long(v)) {

--- a/ocaml/runtime/shared_heap.c
+++ b/ocaml/runtime/shared_heap.c
@@ -808,7 +808,8 @@ static void verify_object(struct heap_verify_state* st, value v) {
     if (Tag_val(v) == Closure_tag) {
       i = Start_env_closinfo(Closinfo_val(v));
     }
-    for (; i < Wosize_val(v); i++) {
+    mlsize_t size = Wosize_val(v);
+    for (; i < size; i++) {
       value f = Field(v, i);
       if (Is_block(f)) verify_push(st, f, Op_val(v)+i);
     }

--- a/ocaml/runtime/weak.c
+++ b/ocaml/runtime/weak.c
@@ -304,7 +304,8 @@ static void ephe_copy_and_darken(value from, value to)
 
   /* Copy and darken scannable fields */
   caml_domain_state* domain_state = Caml_state;
-  while (i < Wosize_val(to)) {
+  mlsize_t to_size = Wosize_val(to);
+  while (i < to_size) {
     value field = Field(from, i);
     caml_darken (domain_state, field, 0);
     Store_field(to, i, field);


### PR DESCRIPTION
Header loads are relaxed atomic in runtime5.  This means that CSE will rarely, if ever, apply to them in order to maintain the read-read coherence required by the C memory model.  As such, if header contents are tested repeatedly -- such as for the end condition of a loop -- they should be manually hoisted for performance.  I checked the other similar macros to `Wosize_val` but in the end, all occurrences ended up being of that one macro.

Some of the places I changed aren't performance critical, but I thought it best to be consistent.