### PR TITLE
Add type-directed disambiguation for `local_ expr` expressions

### DIFF
--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -2806,11 +2806,11 @@ let foo () =
   let _bar : int -> int -> int = local_ (fun x y -> x + y) in
   ()
 [%%expect{|
-Line 2, characters 33-58:
+Line 2, characters 40-58:
 2 |   let _bar : int -> int -> int = local_ (fun x y -> x + y) in
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type int -> local_ (int -> int)
-       but an expression was expected of type int -> (int -> int)
+                                            ^^^^^^^^^^^^^^^^^^
+Error: This function or one of its parameters escape their region
+       when it is partially applied.
 |}];;
 
 (* test that [function] checks all its branches either for local_ or the
@@ -2888,8 +2888,4 @@ let () = foo (local_ M_constructor)
 
 let () = foo_f (local_ (fun M_constructor -> ()))
 [%%expect{|
-Line 1, characters 28-41:
-1 | let () = foo_f (local_ (fun M_constructor -> ()))
-                                ^^^^^^^^^^^^^
-Error: Unbound constructor M_constructor
 |}]

--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -2859,3 +2859,37 @@ Line 1, characters 16-22:
                     ^^^^^^
 Error: The locality axis has already been specified.
 |}]
+
+(* type-directed disambiguation *)
+
+module M = struct
+  type t = M_constructor
+end
+
+let foo (local_ _ : M.t) = ();;
+let foo_f (local_ _ : M.t -> unit) = ();;
+[%%expect{|
+module M : sig type t = M_constructor end
+val foo : local_ M.t -> unit = <fun>
+val foo_f : local_ (M.t -> unit) -> unit = <fun>
+|}]
+
+let () = foo M_constructor
+[%%expect{|
+|}]
+
+let () = foo_f (fun M_constructor -> ())
+[%%expect{|
+|}]
+
+let () = foo (local_ M_constructor)
+[%%expect{|
+|}]
+
+let () = foo_f (local_ (fun M_constructor -> ()))
+[%%expect{|
+Line 1, characters 28-41:
+1 | let () = foo_f (local_ (fun M_constructor -> ()))
+                                ^^^^^^^^^^^^^
+Error: Unbound constructor M_constructor
+|}]

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -4610,6 +4610,10 @@ let rec is_inferred sexp =
   match Jane_syntax.Expression.of_ast sexp with
   | Some (jexp, _attrs) -> is_inferred_jane_syntax jexp
   | None      -> match sexp.pexp_desc with
+  | Pexp_apply
+      ({ pexp_desc = Pexp_extension({txt; _}, _) },
+       [Nolabel, exp]) when txt = Jane_syntax.Mode_expr.extension_name ->
+      is_inferred exp
   | Pexp_ident _ | Pexp_apply _ | Pexp_field _ | Pexp_constraint _
   | Pexp_coerce _ | Pexp_send _ | Pexp_new _ -> true
   | Pexp_sequence (_, e) | Pexp_open (_, e) -> is_inferred e


### PR DESCRIPTION
Make it so that type-directed disambiguation works for `local_ expr` expressions. The way we do this is by changing the way `is_inferred` is computed for `local_ expr` expressions, which helps `type_argument` decide to pass the expected type inward rather than trying to infer the type of a function argument.

The relevant comment above `is_inferred`:
```ocaml
(* If [is_inferred e] is true, [e] will be typechecked without using
   the "expected type" provided by the context. *)
```

In metaquot syntax:
  * Prior to this PR, `is_inferred ([%expr local_ [%e e]]) = true` for any `e`.
  * Now, `is_inferred ([%expr local_ [%e e]]) = is_inferred e`

In particular, we now make `is_inferred (local_ expr)` return `false` in some circumstances.

I think the prior state of the world was not intentional. `Pexp_apply` (the choice of encoding for local expressions) happened to map to `true`.

One related error message changes, for constructs like `let pat : _ -> _ -> _ = local_ (fun p1 p2 -> body)`. The new error message seems fine. It's the same error message you get as `let pat = local_ ((fun p1 p2 -> body) : _ -> _ -> _)`, and the error message doesn't appear to be any less relevant in the new place it shows up.

Review:
  * I suggest @riaqn 
  * You can look at the first commit for a test that demonstrates the behavior prior to the code change.