### PR TITLE
Speed up compile time for dev builds

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -3,3 +3,4 @@ dune = @dune@
 middle_end = @middle_end@
 coverage = @coverage@
 legacy_layout = @legacy_layout@
+main_build_profile = @main_build_profile@

--- a/configure.ac
+++ b/configure.ac
@@ -66,10 +66,11 @@ AC_ARG_ENABLE([legacy-library-layout],
   [legacy_layout=yes],
   [legacy_layout=no])
 
-AC_ARG_ENABLE([dev-build],
-  [AS_HELP_STRING([--enable-dev-build],
+AC_ARG_ENABLE([dev],
+  [AS_HELP_STRING([--enable-dev],
     [Use the dev build profile for dune when building the 2nd stage.
-     Can speed up the compile time by a lot.])],
+     Can speed up the compile time by a lot. (WARNING: do not use for
+     production compiler deployments)])],
   [main_build_profile=dev],
   [main_build_profile=main])
 

--- a/configure.ac
+++ b/configure.ac
@@ -66,11 +66,19 @@ AC_ARG_ENABLE([legacy-library-layout],
   [legacy_layout=yes],
   [legacy_layout=no])
 
+AC_ARG_ENABLE([dev-build],
+  [AS_HELP_STRING([--enable-dev-build],
+    [Use the dev build profile for dune when building the 2nd stage.
+     Can speed up the compile time by a lot.])],
+  [main_build_profile=dev],
+  [main_build_profile=main])
+
 AC_SUBST([prefix])
 AC_SUBST([middle_end])
 AC_SUBST([dune])
 AC_SUBST([coverage])
 AC_SUBST([legacy_layout])
+AC_SUBST([main_build_profile])
 
 # Don't error on options that this configure script doesn't understand but
 # the ocaml/ one does.

--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -94,7 +94,7 @@ type directive_info = {
 
 let remembered = ref Ident.empty
 
-let rec remember phrase_name signature =
+let remember phrase_name signature =
   let exported = List.filter Includemod.is_runtime_component signature in
   List.iteri (fun i sg ->
     match sg with

--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -42,7 +42,7 @@ define dune_main_context
 (lang dune 2.8)
 (context (default
   (name main)
-  (profile main)
+  (profile $(main_build_profile))
   (paths
     (PATH ("$(CURDIR)/_build/_bootinstall/bin" :standard))
     (OCAMLLIB ("$(CURDIR)/_build/install/runtime_stdlib/lib/ocaml_runtime_stdlib")))

--- a/tools/merge_archives.ml
+++ b/tools/merge_archives.ml
@@ -80,9 +80,9 @@ let merge_cmxa0 ~archives =
                   incr ncmxs
                 end));
   let cmis = Array.make !ncmis Import_info.dummy in
-  Hashtbl.iter (fun name (import, i) -> cmis.(i) <- import) cmi_table;
+  Hashtbl.iter (fun _name (import, i) -> cmis.(i) <- import) cmi_table;
   let cmxs = Array.make !ncmxs Import_info.dummy in
-  Hashtbl.iter (fun name (import, i) -> cmxs.(i) <- import) cmx_table;
+  Hashtbl.iter (fun _name (import, i) -> cmxs.(i) <- import) cmx_table;
   let genfns = Generic_fns.Tbl.make () in
   let _, lib_units, lib_ccobjs, lib_ccopts =
     List.fold_left


### PR DESCRIPTION
Currently running `make compiler` in a fresh clone of the repo takes more than 2mins.

This PR seeks to introduces a `--enable-dev-build` autoconf flag that changes the dune build profile for the second stage from `main` to `dev`. This results in a large speed up in terms of compile time. After this change, `make compiler` takes less than a minute and the concurrent jobs count consistently hovers at a higher value.

`make runtest_upstream` is also faster. Result on my box:

```
--- before ---
real	2m52.009s
user	15m24.579s
sys	2m36.192s
--- after ---
real	1m22.176s
user	14m30.707s
sys	2m35.240s
```