### PR TITLE
Allow `[@unboxed]` on non-value layouts

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -485,17 +485,17 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (int32#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f10_6 : int32# -> bool -> string = "foo" "bar"
+external f10_6 : (int32# [@unboxed]) -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (int32#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-external f10_7 : string -> int32# = "foo" "bar"
+external f10_7 : string -> (int32# [@unboxed]) = "foo" "bar"
 |}];;
 
 external f10_8 : int32 -> int32#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-external f10_8 : (int32 [@unboxed]) -> int32# = "foo" "bar"
+external f10_8 : int32 -> int32# = "foo" "bar" [@@unboxed]
 |}];;
 
 external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -461,7 +461,8 @@ val f9_3 : unit -> int32# t_bits32_id = <fun>
    for uses the typechecker should reject.  In particular
    - if using a non-value layout in an external, you must supply separate
      bytecode and native code implementations,
-   - unboxed types can't be unboxed more.
+   - [@unboxed] is allowed on unboxed types but has no effect. Same is not
+     true for [@untagged].
 *)
 
 external f10_1 : int -> bool -> int32# = "foo";;
@@ -484,29 +485,33 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (int32#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-Line 1, characters 18-24:
-1 | external f10_6 : (int32#[@unboxed]) -> bool -> string  = "foo" "bar";;
-                      ^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_6 : int32# -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (int32#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-Line 1, characters 28-34:
-1 | external f10_7 : string -> (int32#[@unboxed])  = "foo" "bar";;
-                                ^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_7 : string -> int32# = "foo" "bar"
 |}];;
 
 external f10_8 : int32 -> int32#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-Line 1, characters 26-32:
-1 | external f10_8 : int32 -> int32#  = "foo" "bar" [@@unboxed];;
-                              ^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_8 : (int32 [@unboxed]) -> int32# = "foo" "bar"
+|}];;
+
+external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 18-24:
+1 | external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
+                      ^^^^^^
+Error: Don't know how to untag this type. Only int can be untagged.
+|}];;
+
+external f10_10 : string -> (int32#[@untagged])  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 29-35:
+1 | external f10_10 : string -> (int32#[@untagged])  = "foo" "bar";;
+                                 ^^^^^^
+Error: Don't know how to untag this type. Only int can be untagged.
 |}];;
 
 (*******************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -485,17 +485,17 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (int32#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f10_6 : (int32# [@unboxed]) -> bool -> string = "foo" "bar"
+external f10_6 : int32# -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (int32#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-external f10_7 : string -> (int32# [@unboxed]) = "foo" "bar"
+external f10_7 : string -> int32# = "foo" "bar"
 |}];;
 
 external f10_8 : int32 -> int32#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-external f10_8 : int32 -> int32# = "foo" "bar" [@@unboxed]
+external f10_8 : (int32 [@unboxed]) -> int32# = "foo" "bar"
 |}];;
 
 external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -485,17 +485,17 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (int64#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f10_6 : int64# -> bool -> string = "foo" "bar"
+external f10_6 : (int64# [@unboxed]) -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (int64#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-external f10_7 : string -> int64# = "foo" "bar"
+external f10_7 : string -> (int64# [@unboxed]) = "foo" "bar"
 |}];;
 
 external f10_8 : int64 -> int64#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-external f10_8 : (int64 [@unboxed]) -> int64# = "foo" "bar"
+external f10_8 : int64 -> int64# = "foo" "bar" [@@unboxed]
 |}];;
 
 external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -485,17 +485,17 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (int64#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f10_6 : (int64# [@unboxed]) -> bool -> string = "foo" "bar"
+external f10_6 : int64# -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (int64#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-external f10_7 : string -> (int64# [@unboxed]) = "foo" "bar"
+external f10_7 : string -> int64# = "foo" "bar"
 |}];;
 
 external f10_8 : int64 -> int64#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-external f10_8 : int64 -> int64# = "foo" "bar" [@@unboxed]
+external f10_8 : (int64 [@unboxed]) -> int64# = "foo" "bar"
 |}];;
 
 external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -461,7 +461,8 @@ val f9_3 : unit -> int64# t_bits64_id = <fun>
    for uses the typechecker should reject.  In particular
    - if using a non-value layout in an external, you must supply separate
      bytecode and native code implementations,
-   - unboxed types can't be unboxed more.
+   - [@unboxed] is allowed on unboxed types but has no effect. Same is not
+     true for [@untagged].
 *)
 
 external f10_1 : int -> bool -> int64# = "foo";;
@@ -484,29 +485,33 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (int64#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-Line 1, characters 18-24:
-1 | external f10_6 : (int64#[@unboxed]) -> bool -> string  = "foo" "bar";;
-                      ^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_6 : int64# -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (int64#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-Line 1, characters 28-34:
-1 | external f10_7 : string -> (int64#[@unboxed])  = "foo" "bar";;
-                                ^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_7 : string -> int64# = "foo" "bar"
 |}];;
 
 external f10_8 : int64 -> int64#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-Line 1, characters 26-32:
-1 | external f10_8 : int64 -> int64#  = "foo" "bar" [@@unboxed];;
-                              ^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_8 : (int64 [@unboxed]) -> int64# = "foo" "bar"
+|}];;
+
+external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 18-24:
+1 | external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;
+                      ^^^^^^
+Error: Don't know how to untag this type. Only int can be untagged.
+|}];;
+
+external f10_10 : string -> (int64#[@untagged])  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 29-35:
+1 | external f10_10 : string -> (int64#[@untagged])  = "foo" "bar";;
+                                 ^^^^^^
+Error: Don't know how to untag this type. Only int can be untagged.
 |}];;
 
 (*******************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -548,17 +548,17 @@ Error: Cannot use "float" in conjunction with types of non-value layouts.
 
 external f10_6 : (float#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f10_6 : float# -> bool -> string = "foo" "bar"
+external f10_6 : (float# [@unboxed]) -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (float#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-external f10_7 : string -> float# = "foo" "bar"
+external f10_7 : string -> (float# [@unboxed]) = "foo" "bar"
 |}];;
 
 external f10_8 : float -> float#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-external f10_8 : (float [@unboxed]) -> float# = "foo" "bar"
+external f10_8 : float -> float# = "foo" "bar" [@@unboxed]
 |}];;
 
 external f10_9 : (float#[@untagged]) -> bool -> string  = "foo" "bar";;

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -548,17 +548,17 @@ Error: Cannot use "float" in conjunction with types of non-value layouts.
 
 external f10_6 : (float#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f10_6 : (float# [@unboxed]) -> bool -> string = "foo" "bar"
+external f10_6 : float# -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (float#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-external f10_7 : string -> (float# [@unboxed]) = "foo" "bar"
+external f10_7 : string -> float# = "foo" "bar"
 |}];;
 
 external f10_8 : float -> float#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-external f10_8 : float -> float# = "foo" "bar" [@@unboxed]
+external f10_8 : (float [@unboxed]) -> float# = "foo" "bar"
 |}];;
 
 external f10_9 : (float#[@untagged]) -> bool -> string  = "foo" "bar";;

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -500,7 +500,8 @@ val f9_3 : unit -> float# t_float64_id = <fun>
      bytecode and native code implementations,
    - if using a non-value layout in an external, you may not use the old-style
      unboxed float directive, and
-   - unboxed types can't be unboxed more.
+   - [@unboxed] is allowed on unboxed types but has no effect. Same is not
+     true for [@untagged].
 *)
 
 external f10_1 : int -> bool -> float# = "foo";;
@@ -547,29 +548,33 @@ Error: Cannot use "float" in conjunction with types of non-value layouts.
 
 external f10_6 : (float#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-Line 1, characters 18-24:
-1 | external f10_6 : (float#[@unboxed]) -> bool -> string  = "foo" "bar";;
-                      ^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_6 : float# -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (float#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-Line 1, characters 28-34:
-1 | external f10_7 : string -> (float#[@unboxed])  = "foo" "bar";;
-                                ^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_7 : string -> float# = "foo" "bar"
 |}];;
 
 external f10_8 : float -> float#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-Line 1, characters 26-32:
-1 | external f10_8 : float -> float#  = "foo" "bar" [@@unboxed];;
-                              ^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_8 : (float [@unboxed]) -> float# = "foo" "bar"
+|}];;
+
+external f10_9 : (float#[@untagged]) -> bool -> string  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 18-24:
+1 | external f10_9 : (float#[@untagged]) -> bool -> string  = "foo" "bar";;
+                      ^^^^^^
+Error: Don't know how to untag this type. Only int can be untagged.
+|}];;
+
+external f10_10 : string -> (float#[@untagged])  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 29-35:
+1 | external f10_10 : string -> (float#[@untagged])  = "foo" "bar";;
+                                 ^^^^^^
+Error: Don't know how to untag this type. Only int can be untagged.
 |}];;
 
 (*******************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-word/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics.ml
@@ -460,7 +460,8 @@ val f9_3 : unit -> nativeint# t_word_id = <fun>
    for uses the typechecker should reject.  In particular
    - if using a non-value layout in an external, you must supply separate
      bytecode and native code implementations,
-   - unboxed types can't be unboxed more.
+   - [@unboxed] is allowed on unboxed types but has no effect. Same is not
+     true for [@untagged].
 *)
 
 external f10_1 : int -> bool -> nativeint# = "foo";;
@@ -483,29 +484,33 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (nativeint#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-Line 1, characters 18-28:
-1 | external f10_6 : (nativeint#[@unboxed]) -> bool -> string  = "foo" "bar";;
-                      ^^^^^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_6 : nativeint# -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (nativeint#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-Line 1, characters 28-38:
-1 | external f10_7 : string -> (nativeint#[@unboxed])  = "foo" "bar";;
-                                ^^^^^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_7 : string -> nativeint# = "foo" "bar"
 |}];;
 
 external f10_8 : nativeint -> nativeint#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-Line 1, characters 30-40:
-1 | external f10_8 : nativeint -> nativeint#  = "foo" "bar" [@@unboxed];;
-                                  ^^^^^^^^^^
-Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+external f10_8 : (nativeint [@unboxed]) -> nativeint# = "foo" "bar"
+|}];;
+
+external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 18-28:
+1 | external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;
+                      ^^^^^^^^^^
+Error: Don't know how to untag this type. Only int can be untagged.
+|}];;
+
+external f10_10 : string -> (nativeint#[@untagged])  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 29-39:
+1 | external f10_10 : string -> (nativeint#[@untagged])  = "foo" "bar";;
+                                 ^^^^^^^^^^
+Error: Don't know how to untag this type. Only int can be untagged.
 |}];;
 
 (*******************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-word/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics.ml
@@ -484,17 +484,17 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (nativeint#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f10_6 : nativeint# -> bool -> string = "foo" "bar"
+external f10_6 : (nativeint# [@unboxed]) -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (nativeint#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-external f10_7 : string -> nativeint# = "foo" "bar"
+external f10_7 : string -> (nativeint# [@unboxed]) = "foo" "bar"
 |}];;
 
 external f10_8 : nativeint -> nativeint#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-external f10_8 : (nativeint [@unboxed]) -> nativeint# = "foo" "bar"
+external f10_8 : nativeint -> nativeint# = "foo" "bar" [@@unboxed]
 |}];;
 
 external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;

--- a/ocaml/testsuite/tests/typing-layouts-word/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics.ml
@@ -484,17 +484,17 @@ Error: The native code version of the primitive is mandatory
 
 external f10_6 : (nativeint#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f10_6 : (nativeint# [@unboxed]) -> bool -> string = "foo" "bar"
+external f10_6 : nativeint# -> bool -> string = "foo" "bar"
 |}];;
 
 external f10_7 : string -> (nativeint#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-external f10_7 : string -> (nativeint# [@unboxed]) = "foo" "bar"
+external f10_7 : string -> nativeint# = "foo" "bar"
 |}];;
 
 external f10_8 : nativeint -> nativeint#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-external f10_8 : nativeint -> nativeint# = "foo" "bar" [@@unboxed]
+external f10_8 : (nativeint [@unboxed]) -> nativeint# = "foo" "bar"
 |}];;
 
 external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -2470,8 +2470,7 @@ Error: The primitive [%obj_magic] is used in an invalid declaration.
    but the middle end should error in this case *)
 external f : (float# -> int32#) -> int32# -> int32# = "%apply";;
 [%%expect{|
-external f : (float# -> int32#) -> (int32# [@unboxed]) -> (int32# [@unboxed])
-  = "%apply"
+external f : (float# -> int32#) -> int32# -> int32# = "%apply"
 |}]
 
 external f : float# -> int -> int = "%send";;
@@ -2499,14 +2498,4 @@ Line 1, characters 13-47:
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [%sendcache] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
-|}]
-
-(************************************************************)
-(* Test 43: [@unboxed] gets printed with non-value layouts. *)
-
-(* Not ideal but also shouldn't be a big problem. This only happens
-   with [Printtyp] not [Pprintast] used for [-dsource] *)
-external f : float# -> float# = "%identity";;
-[%%expect{|
-external f : float# -> float# = "%identity" [@@unboxed]
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -2470,7 +2470,8 @@ Error: The primitive [%obj_magic] is used in an invalid declaration.
    but the middle end should error in this case *)
 external f : (float# -> int32#) -> int32# -> int32# = "%apply";;
 [%%expect{|
-external f : (float# -> int32#) -> int32# -> int32# = "%apply"
+external f : (float# -> int32#) -> (int32# [@unboxed]) -> (int32# [@unboxed])
+  = "%apply"
 |}]
 
 external f : float# -> int -> int = "%send";;
@@ -2498,4 +2499,14 @@ Line 1, characters 13-47:
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive [%sendcache] is used in an invalid declaration.
        The declaration contains argument/return types with the wrong layout.
+|}]
+
+(************************************************************)
+(* Test 43: [@unboxed] gets printed with non-value layouts. *)
+
+(* Not ideal but also shouldn't be a big problem. This only happens
+   with [Printtyp] not [Pprintast] used for [-dsource] *)
+external f : float# -> float# = "%identity";;
+[%%expect{|
+external f : float# -> float# = "%identity" [@@unboxed]
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -280,17 +280,17 @@ Error: [@unboxed] attribute must be added to external declaration
 
 external f_3 : (float#[@unboxed]) -> bool -> string  = "foo" "bar";;
 [%%expect{|
-external f_3 : float# -> bool -> string = "foo" "bar"
+external f_3 : (float# [@unboxed]) -> bool -> string = "foo" "bar"
 |}];;
 
 external f_4 : string -> (nativeint#[@unboxed])  = "foo" "bar";;
 [%%expect{|
-external f_4 : string -> nativeint# = "foo" "bar"
+external f_4 : string -> (nativeint# [@unboxed]) = "foo" "bar"
 |}];;
 
 external f_5 : int64 -> int64#  = "foo" "bar" [@@unboxed];;
 [%%expect{|
-external f_5 : (int64 [@unboxed]) -> int64# = "foo" "bar"
+external f_5 : int64 -> int64# = "foo" "bar" [@@unboxed]
 |}];;
 
 external f_6 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
@@ -375,5 +375,5 @@ end
 external f_3 : M2.t -> M2.t = "%identity" [@@unboxed];;
 [%%expect{|
 module M2 : sig type t = float# end
-external f_3 : M2.t -> M2.t = "%identity"
+external f_3 : M2.t -> M2.t = "%identity" [@@unboxed]
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -323,7 +323,8 @@ Line 1, characters 40-42:
 1 | external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@unboxed]
                                             ^^
 Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+       Only float, int32, int64, nativeint, vector primitives, and
+       concrete unboxed types can be marked unboxed.
 |}];;
 
 
@@ -333,7 +334,8 @@ Line 1, characters 41-43:
 1 | external[@layout_poly] id : ('a : any). ('a[@unboxed]) -> 'a = "%identity"
                                              ^^
 Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+       Only float, int32, int64, nativeint, vector primitives, and
+       concrete unboxed types can be marked unboxed.
 |}];;
 
 (* module and abstract types *)
@@ -376,4 +378,17 @@ external f_3 : M2.t -> M2.t = "%identity" [@@unboxed];;
 [%%expect{|
 module M2 : sig type t = float# end
 external f_3 : M2.t -> M2.t = "%identity" [@@unboxed]
+|}];;
+
+(* should also work with private types *)
+module M3 : sig
+  type t = private float#
+end = struct
+  type t = float#
+end
+
+external f_4 : M3.t -> M3.t = "%identity" [@@unboxed]
+[%%expect{|
+module M3 : sig type t = private float# end
+external f_4 : M3.t -> M3.t = "%identity" [@@unboxed]
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -335,3 +335,45 @@ Line 1, characters 41-43:
 Error: Don't know how to unbox this type.
        Only float, int32, int64, nativeint, and vector primitives can be unboxed.
 |}];;
+
+(* module and abstract types *)
+module M : sig
+  type t : float64
+end = struct
+  type t = float#
+end
+
+external f_1 : M.t -> M.t = "%identity";;
+[%%expect{|
+module M : sig type t : float64 end
+Line 7, characters 15-18:
+7 | external f_1 : M.t -> M.t = "%identity";;
+                   ^^^
+Error: [@unboxed] attribute must be added to external declaration
+       argument type with layout float64. This error is produced
+       due to the use of -only-erasable-extensions.
+|}];;
+
+external f_2 : M.t -> M.t = "%identity" [@@unboxed];;
+[%%expect{|
+Line 1, characters 15-18:
+1 | external f_2 : M.t -> M.t = "%identity" [@@unboxed];;
+                   ^^^
+Error: External declaration here is not upstream compatible.
+       The only types with non-value layouts allowed are float#,
+       int32#, int64#, and nativeint#. Unknown type with layout
+       float64 encountered. This error is produced due to
+       the use of -only-erasable-extensions.
+|}];;
+
+module M2 : sig
+  type t = float#
+end = struct
+  type t = float#
+end
+
+external f_3 : M2.t -> M2.t = "%identity" [@@unboxed];;
+[%%expect{|
+module M2 : sig type t = float# end
+external f_3 : M2.t -> M2.t = "%identity"
+|}];;

--- a/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -308,3 +308,30 @@ Line 1, characters 26-32:
                               ^^^^^^
 Error: Don't know how to untag this type. Only int can be untagged.
 |}];;
+
+(* With [@layout_poly] *)
+
+external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity"
+[%%expect{|
+external id : ('a : any). 'a -> 'a = "%identity" [@@layout_poly]
+|}];;
+
+
+external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@unboxed]
+[%%expect{|
+Line 1, characters 40-42:
+1 | external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@unboxed]
+                                            ^^
+Error: Don't know how to unbox this type.
+       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+|}];;
+
+
+external[@layout_poly] id : ('a : any). ('a[@unboxed]) -> 'a = "%identity"
+[%%expect{|
+Line 1, characters 41-43:
+1 | external[@layout_poly] id : ('a : any). ('a[@unboxed]) -> 'a = "%identity"
+                                             ^^
+Error: Don't know how to unbox this type.
+       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+|}];;

--- a/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -255,3 +255,56 @@ module M :
     val f_word : unit
   end
 |}];;
+
+(* Externals *)
+
+external f_1 : int -> bool -> int64# = "foo" "bar";;
+[%%expect{|
+Line 1, characters 30-36:
+1 | external f_1 : int -> bool -> int64# = "foo" "bar";;
+                                  ^^^^^^
+Error: [@unboxed] attribute must be added to external declaration
+       argument type with layout bits64. This error is produced
+       due to the use of -only-erasable-extensions.
+|}];;
+
+external f_2 : int32# -> bool -> int = "foo" "bar";;
+[%%expect{|
+Line 1, characters 15-21:
+1 | external f_2 : int32# -> bool -> int = "foo" "bar";;
+                   ^^^^^^
+Error: [@unboxed] attribute must be added to external declaration
+       argument type with layout bits32. This error is produced
+       due to the use of -only-erasable-extensions.
+|}];;
+
+external f_3 : (float#[@unboxed]) -> bool -> string  = "foo" "bar";;
+[%%expect{|
+external f_3 : float# -> bool -> string = "foo" "bar"
+|}];;
+
+external f_4 : string -> (nativeint#[@unboxed])  = "foo" "bar";;
+[%%expect{|
+external f_4 : string -> nativeint# = "foo" "bar"
+|}];;
+
+external f_5 : int64 -> int64#  = "foo" "bar" [@@unboxed];;
+[%%expect{|
+external f_5 : (int64 [@unboxed]) -> int64# = "foo" "bar"
+|}];;
+
+external f_6 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 16-22:
+1 | external f_6 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
+                    ^^^^^^
+Error: Don't know how to untag this type. Only int can be untagged.
+|}];;
+
+external f_7 : string -> (int64#[@untagged])  = "foo" "bar";;
+[%%expect{|
+Line 1, characters 26-32:
+1 | external f_7 : string -> (int64#[@untagged])  = "foo" "bar";;
+                              ^^^^^^
+Error: Don't know how to untag this type. Only int can be untagged.
+|}];;

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
@@ -555,7 +555,8 @@ Line 1, characters 40-42:
 1 | external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@unboxed]
                                             ^^
 Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+       Only float, int32, int64, nativeint, vector primitives, and
+       concrete unboxed types can be marked unboxed.
 |}]
 
 external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@untagged]

--- a/ocaml/testsuite/tests/typing-unboxed/test.ml
+++ b/ocaml/testsuite/tests/typing-unboxed/test.ml
@@ -644,7 +644,8 @@ Line 1, characters 14-17:
 1 | external h : (int [@unboxed]) -> float = "h" "h_nat";;
                   ^^^
 Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+       Only float, int32, int64, nativeint, vector primitives, and
+       concrete unboxed types can be marked unboxed.
 |}]
 
 (* Bad: unboxing the function type *)
@@ -654,7 +655,8 @@ Line 1, characters 13-25:
 1 | external i : int -> float [@unboxed] = "i" "i_nat";;
                  ^^^^^^^^^^^^
 Error: Don't know how to unbox this type.
-       Only float, int32, int64, nativeint, and vector primitives can be unboxed.
+       Only float, int32, int64, nativeint, vector primitives, and
+       concrete unboxed types can be marked unboxed.
 |}]
 
 (* Bad: unboxing a "deep" sub-type. *)

--- a/ocaml/typing/predef.mli
+++ b/ocaml/typing/predef.mli
@@ -68,6 +68,9 @@ val path_lazy_t: Path.t
 val path_extension_constructor: Path.t
 val path_floatarray: Path.t
 val path_unboxed_float: Path.t
+val path_unboxed_nativeint: Path.t
+val path_unboxed_int32: Path.t
+val path_unboxed_int64: Path.t
 
 val path_int8x16: Path.t
 val path_int16x8: Path.t

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -80,31 +80,6 @@ let check_ocaml_value = function
   | _, Unboxed_integer _
   | _, Untagged_int -> Bad_attribute
 
-let is_unboxed = function
-  | _, Same_as_ocaml_repr Value
-  | _, Repr_poly
-  | _, Untagged_int -> false
-  | _, Unboxed_float _
-  | _, Unboxed_vector _
-  | _, Unboxed_integer _ -> true
-  | _, Same_as_ocaml_repr _ ->
-    (* We require [@unboxed] for non-value types in
-       upstream-compatible code, but treat it as optional otherwise.
-
-       [is_unboxed] here is used to print the primitive. We want to
-       print the [@unboxed] attribute only in the case it's required
-       and leave it out when it's not. That's why we call
-       [erasable_extensions_only] here. *)
-    Language_extension.erasable_extensions_only ()
-
-let is_untagged = function
-  | _, Untagged_int -> true
-  | _, Same_as_ocaml_repr _
-  | _, Unboxed_float _
-  | _, Unboxed_vector _
-  | _, Unboxed_integer _
-  | _, Repr_poly -> false
-
 let is_builtin_prim_name name = String.length name > 0 && name.[0] = '%'
 
 let rec make_prim_repr_args arity x =
@@ -276,6 +251,28 @@ let print p osig_val_decl =
   in
   let for_all f =
     List.for_all f p.prim_native_repr_args && f p.prim_native_repr_res
+  in
+  let is_unboxed = function
+    | _, Same_as_ocaml_repr Value
+    | _, Repr_poly
+    | _, Untagged_int -> false
+    | _, Unboxed_float _
+    | _, Unboxed_vector _
+    | _, Unboxed_integer _ -> true
+    | _, Same_as_ocaml_repr _ ->
+      (* We require [@unboxed] for non-value types in upstream-compatible code,
+         but treat it as optional otherwise. We thus print the [@unboxed]
+         attribute only in the case it's required and leave it out when it's
+         not. That's why we call [erasable_extensions_only] here. *)
+      Language_extension.erasable_extensions_only ()
+  in
+  let is_untagged = function
+    | _, Untagged_int -> true
+    | _, Same_as_ocaml_repr _
+    | _, Unboxed_float _
+    | _, Unboxed_vector _
+    | _, Unboxed_integer _
+    | _, Repr_poly -> false
   in
   let all_unboxed = for_all is_unboxed in
   let all_untagged = for_all is_untagged in

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -81,9 +81,14 @@ let check_ocaml_value = function
   | _, Untagged_int -> Bad_attribute
 
 let is_unboxed = function
-  | _, Same_as_ocaml_repr _
+  | _, Same_as_ocaml_repr Value
   | _, Repr_poly
   | _, Untagged_int -> false
+  (* We consider non-value layouts to always be unboxed. This means
+     the attribute will be printed even when it's not specified on
+     non-value types, but that should be fine. The alternative of
+     adding a new constructor doesn't seem worth it.*)
+  | _, Same_as_ocaml_repr _
   | _, Unboxed_float _
   | _, Unboxed_vector _
   | _, Unboxed_integer _ -> true
@@ -301,8 +306,9 @@ let print p osig_val_decl =
      | Prim_poly -> [oattr_local_opt])
     @
     (match repr with
-     | Same_as_ocaml_repr _
+     | Same_as_ocaml_repr Value
      | Repr_poly -> []
+     | Same_as_ocaml_repr _
      | Unboxed_float _
      | Unboxed_vector _
      | Unboxed_integer _ -> if all_unboxed then [] else [oattr_unboxed]

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2160,7 +2160,7 @@ let get_native_repr_attribute attrs ~global_repr =
   | _, Some { Location.loc }, _ ->
     raise (Error (loc, Multiple_native_repr_attributes))
 
-let native_repr_usage_is_upstream_compatible env ty =
+let is_upstream_compatible_non_value_unbox env ty =
   match get_desc (Ctype.expand_head_opt env ty) with
   | Tconstr (path, _, _) ->
     List.exists
@@ -2285,7 +2285,7 @@ let make_native_repr env core_type ty ~global_repr ~is_layout_poly ~why =
   | Native_repr_attr_present Unboxed, (Sort sort) ->
     (* We allow [@unboxed] on non-value sorts. *)
     if Language_extension.erasable_extensions_only ()
-       && not (native_repr_usage_is_upstream_compatible env ty)
+       && not (is_upstream_compatible_non_value_unbox env ty)
     then
       (* There are additional requirements if we are operating in
          upstream compatible mode. *)

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -146,6 +146,7 @@ type error =
   | Unexpected_jkind_any_in_primitive of string
   | Useless_layout_poly
   | Modalities_on_value_description
+  | Missing_unboxed_attribute_on_non_value_sort of Jkind.Sort.const
 
 exception Error of Location.t * error
 

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -147,6 +147,7 @@ type error =
   | Useless_layout_poly
   | Modalities_on_value_description
   | Missing_unboxed_attribute_on_non_value_sort of Jkind.Sort.const
+  | Non_value_sort_not_upstream_compatible of Jkind.Sort.const
 
 exception Error of Location.t * error
 


### PR DESCRIPTION
Allow `[@unboxed]` on non-value layouts for better upstream compatiablity: after erasing layout annotations, external c stubs should still do the right thing.

The `[@unboxed]` attribute is optional by default, but becomes mandatory when `-only-erasable-extensions` is provided.

Type variables marked `[@layout_poly]` don't need and can't have `[@unboxed]`.

~~Merge after #2229~~ merged