### PR TITLE
[draft ]Implicit source positions object system support

### DIFF
--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -20,26 +20,6 @@ type nonrec apply_arg = apply_arg
 type texp_apply_identifier = apply_position * Locality.t
 
 let mkTexp_apply ?id:(pos, mode = (Default, Locality.legacy)) (exp, args) =
-  (* XXX jrodri: Question! I am unsure if my approach for fixing
-     this subdirectory is sane. It seems like chamelon needs to run on both a "JST" version
-     and an "upstream" version. The JST version changes Typedtree with a new arg_label,
-     while the upstream version still does not have this new arg_label type.
-
-     jrodri: My first approach was to make this entire subdirectory use
-     [Typedtree.arg_label] which made `make minimizer` build fine, but
-     sadly made `make minimizer-upstream` fail. I then made the mli's keep
-     using [Asttypes.arg_label], and only perform the conversion here in
-     [compat.jst.ml] like in the diff below; however, I think this sadly means
-     that - since I always send in None/don't have access to the [core_type]/the
-     original AST pattern with the [(... : [%src_pos])] constraint, I may not
-     be able to retrieve things here...
-
-     jrodriguez: In the context of chamelon, is the below segment correct?
-     jrodriguez: Should my approach for fixing the [make minimizer] <-> [make
-     minimizer-upstream] compatibility relationship be different? (e.g. maybe changing the
-     dune.upstream/dune.jst files to be aware of the Typedtree change?/something else?)
-     Thanks!
-  *)
   let args =
     List.map (fun (label, x) -> (Typetexp.transl_label label None, x)) args
   in

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
@@ -2,105 +2,89 @@
    * expect
 *)
 
-type t = [%src_pos]
-[%%expect {|
-Line 1, characters 11-18:
-1 | type t = [%src_pos]
-               ^^^^^^^
-Error: Uninterpreted extension 'src_pos'.
-|}]
-(* CR src_pos: Improve this error message to notify that [%src_pos] may only
-   be used in arguments *)
-
-type t = unit -> unit -> [%src_pos]
-[%%expect {|
-Line 1, characters 27-34:
-1 | type t = unit -> unit -> [%src_pos]
-                               ^^^^^^^
-Error: Uninterpreted extension 'src_pos'.
-|}]
-
-let f ~(src_pos:[%src_pos]) () : [%src_pos] = src_pos
+let object_with_a_method_with_a_positional_parameter = object 
+  method m ~(src_pos : [%src_pos]) () = src_pos
+end
 
 [%%expect{|
-Line 1, characters 35-42:
-1 | let f ~(src_pos:[%src_pos]) () : [%src_pos] = src_pos
-                                       ^^^^^^^
-Error: Uninterpreted extension 'src_pos'.
+val object_with_a_method_with_a_positional_parameter :
+  < m : src_pos:[%src_pos] -> unit -> lexing_position > = <obj>
 |}]
 
-let apply f = f ~src_pos:Lexing.dummy_pos () ;;
-[%%expect {|
-val apply : (src_pos:Lexing.position -> unit -> 'a) -> 'a = <fun>
-|}]
-
-let g = fun ~(src_pos:[%src_pos]) () -> ()
-[%%expect{|
-val g : src_pos:[%src_pos] -> unit -> unit = <fun>
-|}]
-
-let _ = apply g ;;
-[%%expect{|
-Line 1, characters 14-15:
-1 | let _ = apply g ;;
-                  ^
-Error: This expression has type src_pos:[%src_pos] -> unit -> unit
-       but an expression was expected of type
-         src_pos:Lexing.position -> (unit -> 'a)
-|}]
-
-let h ?(src_pos:[%src_pos]) () = ()
-[%%expect{|
-Line 1, characters 16-26:
-1 | let h ?(src_pos:[%src_pos]) () = ()
-                    ^^^^^^^^^^
-Error: A position argument must not be optional.
-|}]
-
-let j (src_pos:[%src_pos]) () = ()
-[%%expect{|
-Line 1, characters 15-25:
-1 | let j (src_pos:[%src_pos]) () = ()
-                   ^^^^^^^^^^
-Error: A position argument must not be unlabelled.
-|}]
-
-let k : src_pos:[%src_pos] -> unit -> unit =
-   fun ~src_pos () -> ()
-(* CR src_pos: Improve this error message *)
-[%%expect{|
-Line 2, characters 3-24:
-2 |    fun ~src_pos () -> ()
-       ^^^^^^^^^^^^^^^^^^^^^
-Error: This function should have type src_pos:[%src_pos] -> unit -> unit
-       but its first argument is labeled ~src_pos
-       instead of ~(src_pos:[%src_pos])
-|}]
-
-let n = fun ~(src_pos:[%src_pos]) () -> src_pos
-[%%expect{|
-val n : src_pos:[%src_pos] -> unit -> lexing_position = <fun>
-|}]
-
-let _ = n Lexing.dummy_pos ();;
-[%%expect {|
-Line 1, characters 27-29:
-1 | let _ = n Lexing.dummy_pos ();;
-                               ^^
-Error: The function applied to this argument has type
-         src_pos:[%src_pos] -> lexing_position
-This argument cannot be applied without label
-|}]
-
-
-class this_class_has_an_unerasable_argument ~(pos : [%src_pos]) = object end
-
+let position = object_with_a_method_with_a_positional_parameter#m ();;
 
 [%%expect{|
-Line 1, characters 46-49:
-1 | class this_class_has_an_unerasable_argument ~(pos : [%src_pos]) = object end
-                                                  ^^^
-Warning 188 [unerasable-position-argument]: this position argument cannot be erased.
+val position : lexing_position =
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 276; pos_cnum = 291}
+|}]
 
-class this_class_has_an_unerasable_argument : pos:[%src_pos] -> object  end
+class class_with_a_method_with_a_positional_parameter = object 
+  method m ~(src_pos : [%src_pos]) () = src_pos
+end
+
+[%%expect{|
+class class_with_a_method_with_a_positional_parameter :
+  object method m : src_pos:[%src_pos] -> unit -> lexing_position end
+|}]
+
+let o = new class_with_a_method_with_a_positional_parameter;;
+
+[%%expect{|
+val o : class_with_a_method_with_a_positional_parameter = <obj>
+|}]
+
+let position = o#m ();;
+
+[%%expect{|
+val position : lexing_position =
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 866; pos_cnum = 881}
+|}]
+
+let position = (new class_with_a_method_with_a_positional_parameter)#m ();;
+
+(* XXX jrodriguez: Hmm I don't know what the Principal block means, but from skimming
+   docs, this seems to indicate that there are different results when compiled under
+   a different mode? *)
+[%%expect{|
+val position : lexing_position =
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 1005; pos_cnum = 1020}
+|}]
+
+
+class class_with_positional_parameter ~(src_pos : [%src_pos]) () = object 
+  method src_pos = src_pos
+end
+
+[%%expect{|
+class class_with_positional_parameter :
+  src_pos:[%src_pos] -> unit -> object method src_pos : lexing_position end
+|}]
+
+let o = new class_with_positional_parameter ()
+let position = o#src_pos
+
+[%%expect{|
+val o : class_with_positional_parameter = <obj>
+val position : lexing_position =
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 1634; pos_cnum = 1642}
+|}]
+
+
+(* Different kinds of shadowed parameters (both a class parameter is shadowed and a
+   method parameter is shadowed) *)
+
+class c ~(src_pos : [%src_pos]) () = object 
+  method m ~(src_pos : [%src_pos]) () = src_pos
+end
+[%%expect{|
+class c :
+  src_pos:[%src_pos] ->
+  unit -> object method m : src_pos:[%src_pos] -> unit -> lexing_position end
+|}]
+
+let _ = (new c ())#m()
+
+[%%expect{|
+- : lexing_position =
+{pos_fname = ""; pos_lnum = 1; pos_bol = 2219; pos_cnum = 2227}
 |}]

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
@@ -91,3 +91,16 @@ Error: The function applied to this argument has type
          src_pos:[%src_pos] -> lexing_position
 This argument cannot be applied without label
 |}]
+
+
+class this_class_has_an_unerasable_argument ~(pos : [%src_pos]) = object end
+
+
+[%%expect{|
+Line 1, characters 46-49:
+1 | class this_class_has_an_unerasable_argument ~(pos : [%src_pos]) = object end
+                                                  ^^^
+Warning 188 [unerasable-position-argument]: this position argument cannot be erased.
+
+class this_class_has_an_unerasable_argument : pos:[%src_pos] -> object  end
+|}]

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/let_operators.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/let_operators.ml
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 (* TEST
    * expect
 *)
@@ -50,3 +51,58 @@ val ( >>| ) : src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b =
 - : lexing_position =
 {pos_fname = ""; pos_lnum = 3; pos_bol = 1108; pos_cnum = 1110}
 |}]
+||||||| parent of 6b207b13 (Implicit Source Positions Conflict resolution)
+=======
+(* TEST
+   * expect
+*)
+
+let ( let+ ) ~(src_pos : [%src_pos]) a f = f (src_pos, a);;
+[%%expect{|
+val ( let+ ) : src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b =
+  <fun>
+|}]
+
+(* Would be nice to add support for implicit position parameters and (also maybe optional
+   arguments) for let operators. *)
+let _ = 
+  let+ (src_pos, a) = 1 in
+  src_pos
+
+[%%expect{|
+Line 2, characters 2-6:
+2 |   let+ (src_pos, a) = 1 in
+      ^^^^
+Error: The operator let+ has type
+         src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b
+       but it was expected to have type 'c -> ('d -> 'e) -> 'f
+|}]
+
+let ( let* ) ?(src_pos = 1) a g = g (src_pos, a);; 
+
+let _ =
+  let* (src_pos, a) = 1 in
+  src_pos
+
+[%%expect{|
+val ( let* ) : ?src_pos:int -> 'a -> (int * 'a -> 'b) -> 'b = <fun>
+Line 4, characters 2-6:
+4 |   let* (src_pos, a) = 1 in
+      ^^^^
+Error: The operator let* has type
+         ?src_pos:int -> 'a -> (int * 'a -> 'b) -> 'b
+       but it was expected to have type 'c -> ('d -> 'e) -> 'f
+|}]
+
+(* Infix operators work! *)
+let ( >>| ) ~(src_pos : [%src_pos]) x f = f (src_pos, x)
+let _ =
+  1 >>| fun (src_pos, a) -> src_pos
+
+[%%expect{|
+val ( >>| ) : src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b =
+  <fun>
+- : lexing_position =
+{pos_fname = ""; pos_lnum = 3; pos_bol = 1108; pos_cnum = 1110}
+|}]
+>>>>>>> 6b207b13 (Implicit Source Positions Conflict resolution)

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/let_operators.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/let_operators.ml
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 (* TEST
    * expect
 *)
@@ -51,58 +50,4 @@ val ( >>| ) : src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b =
 - : lexing_position =
 {pos_fname = ""; pos_lnum = 3; pos_bol = 1108; pos_cnum = 1110}
 |}]
-||||||| parent of 6b207b13 (Implicit Source Positions Conflict resolution)
-=======
-(* TEST
-   * expect
-*)
 
-let ( let+ ) ~(src_pos : [%src_pos]) a f = f (src_pos, a);;
-[%%expect{|
-val ( let+ ) : src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b =
-  <fun>
-|}]
-
-(* Would be nice to add support for implicit position parameters and (also maybe optional
-   arguments) for let operators. *)
-let _ = 
-  let+ (src_pos, a) = 1 in
-  src_pos
-
-[%%expect{|
-Line 2, characters 2-6:
-2 |   let+ (src_pos, a) = 1 in
-      ^^^^
-Error: The operator let+ has type
-         src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b
-       but it was expected to have type 'c -> ('d -> 'e) -> 'f
-|}]
-
-let ( let* ) ?(src_pos = 1) a g = g (src_pos, a);; 
-
-let _ =
-  let* (src_pos, a) = 1 in
-  src_pos
-
-[%%expect{|
-val ( let* ) : ?src_pos:int -> 'a -> (int * 'a -> 'b) -> 'b = <fun>
-Line 4, characters 2-6:
-4 |   let* (src_pos, a) = 1 in
-      ^^^^
-Error: The operator let* has type
-         ?src_pos:int -> 'a -> (int * 'a -> 'b) -> 'b
-       but it was expected to have type 'c -> ('d -> 'e) -> 'f
-|}]
-
-(* Infix operators work! *)
-let ( >>| ) ~(src_pos : [%src_pos]) x f = f (src_pos, x)
-let _ =
-  1 >>| fun (src_pos, a) -> src_pos
-
-[%%expect{|
-val ( >>| ) : src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b =
-  <fun>
-- : lexing_position =
-{pos_fname = ""; pos_lnum = 3; pos_bol = 1108; pos_cnum = 1110}
-|}]
->>>>>>> 6b207b13 (Implicit Source Positions Conflict resolution)

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/let_operators.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/let_operators.ml
@@ -50,4 +50,3 @@ val ( >>| ) : src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b =
 - : lexing_position =
 {pos_fname = ""; pos_lnum = 3; pos_bol = 1108; pos_cnum = 1110}
 |}]
-

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
@@ -1,0 +1,76 @@
+(* TEST
+   * expect
+*)
+
+let o = object 
+  method m ~(src_pos : [%src_pos]) () = src_pos
+end
+
+[%%expect{|
+val o : < m : src_pos:[%src_pos] -> unit -> lexing_position > = <obj>
+|}]
+
+let x = o#m ();;
+
+[%%expect{|
+val x : lexing_position =
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 180; pos_cnum = 188}
+|}]
+
+class c = object 
+  method m ~(src_pos : [%src_pos]) () = src_pos
+end
+
+let o2 = new c;;
+
+[%%expect{|
+class c : object method m : src_pos:[%src_pos] -> unit -> lexing_position end
+val o2 : c = <obj>
+|}]
+
+let x = o2#m ();;
+
+[%%expect{|
+val x : lexing_position =
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 508; pos_cnum = 516}
+|}]
+
+(* CR src_pos: This should probably work... *)
+class this_one ~(foo : [%src_pos]) () = object 
+  method m = foo
+end
+
+[%%expect{|
+Lines 1-3, characters 0-3:
+1 | class this_one ~(foo : [%src_pos]) () = object
+2 |   method m = foo
+3 | end
+Error: Some type variables are unbound in this type:
+         class this_one : foo:[%src_pos] -> unit -> object method m : 'a end
+       The method m has type 'a where 'a is unbound
+|}]
+
+class this_one_but_optional ?(bar = 1) () = object 
+  method m = bar
+end
+
+[%%expect{|
+class this_one_but_optional : ?bar:int -> unit -> object method m : int end
+|}]
+
+class c ~(foo : int) = object 
+  method m = foo
+end
+
+[%%expect{|
+class c : foo:int -> object method m : int end
+|}]
+
+let o = new c ~foo:1
+let o_m = o#m
+
+[%%expect{|
+val o : c = <obj>
+val o_m : int = 1
+|}]
+

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
@@ -117,6 +117,17 @@ Error: This class expression is not a class structure; it has type
        src_pos:[%src_pos] -> parent
 |}]
 
+let o ~(src_pos : [%src_pos]) () = object 
+  inherit parent ~src_pos ()
+end
+let position = (o ())#pos
+[%%expect{|
+val o : src_pos:[%src_pos] -> unit -> parent = <fun>
+val position : lexing_position =
+  {pos_fname = ""; pos_lnum = 4; pos_bol = 3063; pos_cnum = 3078}
+|}]
+
+
 class parent ?(i = 1) () = object
   method i = i
 end

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
@@ -139,7 +139,7 @@ Warning 6 [labels-omitted]: label src_pos was omitted in the application of this
 
 val o : src_pos:[%src_pos] -> unit -> parent = <fun>
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 4; pos_bol = 3417; pos_cnum = 3432}
+  {pos_fname = ""; pos_lnum = 4; pos_bol = 3249; pos_cnum = 3264}
 |}]
 
 
@@ -159,3 +159,40 @@ val o : parent = <obj>
 val position : int = 1
 |}]
 
+(* Partially applying a class *)
+class c ~(a : [%src_pos]) ~(b : [%src_pos]) () =
+  object 
+    method a = a
+    method b = b
+  end
+
+[%%expect{|
+class c :
+  a:[%src_pos] ->
+  b:[%src_pos] ->
+  unit -> object method a : lexing_position method b : lexing_position end
+|}]
+
+let pos_a : lexing_position = {Lexing.dummy_pos with pos_fname = "a"};;
+let partially_applied_class = new c ~a:pos_a
+
+[%%expect{|
+val pos_a : lexing_position =
+  {pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
+val partially_applied_class : b:[%src_pos] -> unit -> c = <fun>
+|}]
+
+let fully_applied_class = partially_applied_class ()
+
+[%%expect{|
+val fully_applied_class : c = <obj>
+|}]
+
+let a, b = fully_applied_class#a, fully_applied_class#b
+
+[%%expect{|
+val a : lexing_position =
+  {pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
+val b : lexing_position =
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 4427; pos_cnum = 4453}
+|}]

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
@@ -110,11 +110,9 @@ let position = o#pos
 [%%expect{|
 class parent :
   src_pos:[%src_pos] -> unit -> object method pos : lexing_position end
-Line 6, characters 2-19:
-6 |   inherit parent ()
-      ^^^^^^^^^^^^^^^^^
-Error: This class expression is not a class structure; it has type
-       src_pos:[%src_pos] -> parent
+val o : parent = <obj>
+val position : lexing_position =
+  {pos_fname = ""; pos_lnum = 6; pos_bol = 2661; pos_cnum = 2671}
 |}]
 
 let o ~(src_pos : [%src_pos]) () = object 
@@ -125,6 +123,35 @@ let position = (o ())#pos
 val o : src_pos:[%src_pos] -> unit -> parent = <fun>
 val position : lexing_position =
   {pos_fname = ""; pos_lnum = 4; pos_bol = 3063; pos_cnum = 3078}
+|}, Principal{|
+val o : src_pos:[%src_pos] -> unit -> parent = <fun>
+val position : lexing_position =
+  {pos_fname = ""; pos_lnum = 4; pos_bol = 3288; pos_cnum = 3303}
+|}]
+
+(* Applying an src_pos argument without a label. *)
+let o ~(src_pos : [%src_pos]) () = object 
+  inherit parent src_pos ()
+end
+let position = (o ())#pos
+[%%expect{|
+Line 2, characters 10-16:
+2 |   inherit parent src_pos ()
+              ^^^^^^
+Warning 6 [labels-omitted]: label src_pos was omitted in the application of this function.
+
+val o : src_pos:[%src_pos] -> unit -> parent = <fun>
+val position : lexing_position =
+  {pos_fname = ""; pos_lnum = 4; pos_bol = 3385; pos_cnum = 3400}
+|}, Principal{|
+Line 2, characters 10-16:
+2 |   inherit parent src_pos ()
+              ^^^^^^
+Warning 6 [labels-omitted]: label src_pos was omitted in the application of this function.
+
+val o : src_pos:[%src_pos] -> unit -> parent = <fun>
+val position : lexing_position =
+  {pos_fname = ""; pos_lnum = 4; pos_bol = 3610; pos_cnum = 3625}
 |}]
 
 

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
@@ -97,7 +97,6 @@ val from_class_param : lexing_position =
   {pos_fname = ""; pos_lnum = 1; pos_bol = 2167; pos_cnum = 2175}
 |}]
 
-(* XXX jrodri: This should probably work... due to the segment below working... *)
 class parent ~(src_pos : [%src_pos]) () = object
   method pos = src_pos
 end
@@ -112,21 +111,18 @@ class parent :
   src_pos:[%src_pos] -> unit -> object method pos : lexing_position end
 val o : parent = <obj>
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 6; pos_bol = 2661; pos_cnum = 2671}
+  {pos_fname = ""; pos_lnum = 6; pos_bol = 2578; pos_cnum = 2588}
 |}]
 
 let o ~(src_pos : [%src_pos]) () = object 
   inherit parent ~src_pos ()
 end
 let position = (o ())#pos
+
 [%%expect{|
 val o : src_pos:[%src_pos] -> unit -> parent = <fun>
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 4; pos_bol = 3063; pos_cnum = 3078}
-|}, Principal{|
-val o : src_pos:[%src_pos] -> unit -> parent = <fun>
-val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 4; pos_bol = 3288; pos_cnum = 3303}
+  {pos_fname = ""; pos_lnum = 4; pos_bol = 2926; pos_cnum = 2941}
 |}]
 
 (* Applying an src_pos argument without a label. *)
@@ -134,6 +130,7 @@ let o ~(src_pos : [%src_pos]) () = object
   inherit parent src_pos ()
 end
 let position = (o ())#pos
+
 [%%expect{|
 Line 2, characters 10-16:
 2 |   inherit parent src_pos ()
@@ -142,19 +139,11 @@ Warning 6 [labels-omitted]: label src_pos was omitted in the application of this
 
 val o : src_pos:[%src_pos] -> unit -> parent = <fun>
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 4; pos_bol = 3385; pos_cnum = 3400}
-|}, Principal{|
-Line 2, characters 10-16:
-2 |   inherit parent src_pos ()
-              ^^^^^^
-Warning 6 [labels-omitted]: label src_pos was omitted in the application of this function.
-
-val o : src_pos:[%src_pos] -> unit -> parent = <fun>
-val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 4; pos_bol = 3610; pos_cnum = 3625}
+  {pos_fname = ""; pos_lnum = 4; pos_bol = 3417; pos_cnum = 3432}
 |}]
 
 
+(* Same behavior as optional parameters. *)
 class parent ?(i = 1) () = object
   method i = i
 end

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
@@ -194,5 +194,28 @@ let a, b = fully_applied_class#a, fully_applied_class#b
 val a : lexing_position =
   {pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
 val b : lexing_position =
-  {pos_fname = ""; pos_lnum = 1; pos_bol = 4427; pos_cnum = 4453}
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 4459; pos_cnum = 4485}
+|}]
+
+class c :
+  x:[%src_pos] -> y:lexing_position -> unit -> object
+    method xy : lexing_position * lexing_position
+  end = fun ~(x : [%src_pos]) ~y () -> object
+    method xy = x, y
+  end
+
+[%%expect{|
+class c :
+  x:[%src_pos] ->
+  y:lexing_position ->
+  unit -> object method xy : lexing_position * lexing_position end
+|}]
+
+let x, y = (new c ~y:pos_a ())#xy
+
+[%%expect{|
+val x : lexing_position =
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 5143; pos_cnum = 5154}
+val y : lexing_position =
+  {pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
 |}]

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/shadowing.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/shadowing.ml
@@ -30,3 +30,31 @@ let _ = h 5;;
 [%%expect {|
 - : lexing_position = 5
 |}]
+
+(* Works with class parameters *)
+class c ~(src_pos : [%src_pos]) () = object end
+
+[%%expect {|
+class c : src_pos:[%src_pos] -> unit -> object  end
+|}]
+
+let _ = new c ~src_pos:Lexing.dummy_pos ();;
+
+[%%expect{|
+- : c = <obj>
+|}]
+
+(* Works with object method parameters *)
+let o = object
+   method m ~(src_pos : [%src_pos]) () = ()
+end
+
+[%%expect {|
+val o : < m : src_pos:[%src_pos] -> unit -> unit > = <obj>
+|}]
+
+let _ = o#m ~src_pos:Lexing.dummy_pos ()
+
+[%%expect{|
+- : unit = ()
+|}]

--- a/ocaml/testsuite/tests/typing-unique/unique.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique.ml
@@ -616,3 +616,30 @@ Line 5, characters 16-17:
                     ^
 
 |}]
+
+
+(* Uniqueness is unbroken by the implicit positional argument. *)
+let f ~(src_pos : [%src_pos]) () =
+  let unique_ x = src_pos in
+  (x, x)
+;;
+[%%expect{|
+val f : src_pos:[%src_pos] -> unit -> lexing_position * lexing_position =
+  <fun>
+|}]
+
+
+let f ~(src_pos : [%src_pos]) () =
+  unique_ (src_pos, src_pos)
+;;
+[%%expect{|
+Line 2, characters 20-27:
+2 |   unique_ (src_pos, src_pos)
+                        ^^^^^^^
+Error: This value is used here, but it has already been used as unique:
+Line 2, characters 11-18:
+2 |   unique_ (src_pos, src_pos)
+               ^^^^^^^
+
+|}]
+

--- a/ocaml/testsuite/tests/typing-unique/unique.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique.ml
@@ -617,7 +617,6 @@ Line 5, characters 16-17:
 
 |}]
 
-
 (* Uniqueness is unbroken by the implicit positional argument. *)
 let f ~(src_pos : [%src_pos]) () =
   let unique_ x = src_pos in
@@ -627,7 +626,6 @@ let f ~(src_pos : [%src_pos]) () =
 val f : src_pos:[%src_pos] -> unit -> lexing_position * lexing_position =
   <fun>
 |}]
-
 
 let f ~(src_pos : [%src_pos]) () =
   unique_ (src_pos, src_pos)

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1366,9 +1366,9 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                 | None ->
                     let is_erased = lazy (List.mem_assoc Nolabel sargs) in
                     sargs,
-                    if Btype.is_optional l && force is_erased then
+                    if Btype.is_optional l && Lazy.force is_erased then
                       eliminate_optional_arg ()
-                    else if Btype.is_position l && force is_erased then
+                    else if Btype.is_position l && Lazy.force is_erased then
                       eliminate_position_arg ()
                     else begin
                       let mode_closure = Mode.Alloc.legacy in

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1525,9 +1525,12 @@ let rec approx_declaration cl =
     Pcl_fun (l, _, pat, cl) ->
       let l, _ = Typetexp.transl_label_from_pat l pat in
       let arg =
-        if Btype.is_optional l then Ctype.instance var_option
-        else Ctype.newvar (Jkind.value ~why:Class_term_argument)
-        (* CR layouts: use of value here may be relaxed when we update
+        match l with
+        | Optional _ -> Ctype.instance var_option
+        | Position _ -> Ctype.instance Predef.type_lexing_position
+        | Labelled _ | Nolabel ->
+          Ctype.newvar (Jkind.value ~why:Class_term_argument)
+          (* CR layouts: use of value here may be relaxed when we update
            classes to work with jkinds *)
       in
       let arg = Ctype.newmono arg in

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -437,8 +437,17 @@ and class_type_aux env virt self_scope scty =
       cltyp (Tcty_signature clsig) typ
 
   | Pcty_arrow (l, sty, scty) ->
+      let ctyp ctyp_desc ctyp_type =
+        { ctyp_desc; ctyp_type; ctyp_env = env;
+          ctyp_loc = sty.ptyp_loc; ctyp_attributes = sty.ptyp_attributes }
+      in
       let l = transl_label l (Some sty) in
-      let cty = transl_simple_type ~new_var_jkind:Any env ~closed:false Alloc.Const.legacy sty in
+      let cty =
+        match l with
+        | Position _ -> ctyp Ttyp_src_pos (Ctype.newconstr Predef.path_lexing_position [])
+        | Optional _ | Labelled _ | Nolabel ->
+          transl_simple_type ~new_var_jkind:Any env ~closed:false Alloc.Const.legacy sty 
+      in
       let ty = cty.ctyp_type in
       let ty =
         if Btype.is_optional l

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -327,3 +327,5 @@ val constant: Parsetree.constant -> (Typedtree.constant, error) result
 val check_recursive_bindings : Env.t -> Typedtree.value_binding list -> unit
 val check_recursive_class_bindings :
   Env.t -> Ident.t list -> Typedtree.class_expr list -> unit
+
+val src_pos : Location.t -> Typedtree.attributes -> Env.t -> Typedtree.expression 


### PR DESCRIPTION
[DRAFT] feature.

This feature adds support for "implicit source positions" (`[%src_pos]` arguments) to OCaml's object system.

Testing
----------
- New tests added to the `typing-implicit-source-positions` test directory
- Additional "drive-by" testing from the "conflict resolution" in the parent feature to sanity check that the unique_ keyword interacts nicely with the src_pos argument.

For reviewers
------------------
There were some place in typeclass.ml that are a bit code duplicate-ey between how src_pos arguments and optional arguments are erased. In places where it was trivial/localized to de-duplicated I de-duplicated, but in typeclass.ml there were a couple of places where making things use a `match` would've involved larger changes and I am unsure if we prefer to make smaller, self contained changes to avoid merge conflicts with upstream OCaml. Please let me know if this is reasonable/isn't.