### PR TITLE
Fix uses of polymorphic comparison in Flambda 2

### DIFF
--- a/middle_end/flambda2/algorithms/dune
+++ b/middle_end/flambda2/algorithms/dune
@@ -7,5 +7,5 @@
  (flags
   (:standard -principal))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries ocamlcommon))

--- a/middle_end/flambda2/algorithms/lmap.ml
+++ b/middle_end/flambda2/algorithms/lmap.ml
@@ -78,7 +78,7 @@ module Make (T : Thing) : S with type key = T.t = struct
 
   let empty = []
 
-  let is_empty m = m = []
+  let is_empty m = match m with [] -> true | _ :: _ -> false
 
   let add k v m = (k, v) :: m
 
@@ -147,9 +147,9 @@ module Make (T : Thing) : S with type key = T.t = struct
   let of_seq m = List.of_seq m
 
   let print_assoc print_key print_datum ppf l =
-    if l = []
-    then Format.fprintf ppf "{}"
-    else
+    match l with
+    | [] -> Format.fprintf ppf "{}"
+    | _ :: _ ->
       Format.fprintf ppf "@[<hov 1>{%a}@]"
         (Format.pp_print_list ~pp_sep:Format.pp_print_space
            (fun ppf (key, datum) ->

--- a/middle_end/flambda2/algorithms/patricia_tree.ml
+++ b/middle_end/flambda2/algorithms/patricia_tree.ml
@@ -12,8 +12,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Int_replace_polymorphic_compare
-
 (* The following is a "little endian" implementation. *)
 
 (* CR-someday mshinwell: Can we fix the traversal order by swapping endianness?

--- a/middle_end/flambda2/bound_identifiers/dune
+++ b/middle_end/flambda2/bound_identifiers/dune
@@ -18,7 +18,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_algorithms

--- a/middle_end/flambda2/classic_mode_types/dune
+++ b/middle_end/flambda2/classic_mode_types/dune
@@ -17,7 +17,7 @@
    -open
    Flambda2_term_basics))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_identifiers

--- a/middle_end/flambda2/cmx/dune
+++ b/middle_end/flambda2/cmx/dune
@@ -32,7 +32,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda_backend_utils

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -1,6 +1,5 @@
 [@@@ocaml.warning "-fragile-match"]
 
-open! Int_replace_polymorphic_compare
 open! Flambda
 
 (* General notes on comparison

--- a/middle_end/flambda2/compare/dune
+++ b/middle_end/flambda2/compare/dune
@@ -24,5 +24,5 @@
    -open
    Flambda2_terms))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries ocamlcommon flambda2_algorithms flambda2_terms))

--- a/middle_end/flambda2/dune
+++ b/middle_end/flambda2/dune
@@ -32,7 +32,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (modules flambda2)
  (libraries
   ocamlcommon

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -16,7 +16,6 @@
 
 [@@@ocaml.warning "-fragile-match"]
 
-open! Int_replace_polymorphic_compare
 open! Flambda
 module BP = Bound_parameter
 module IR = Closure_conversion_aux.IR

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -308,10 +308,10 @@ module Env = struct
     try Variable.Map.find var t.value_approximations
     with Not_found -> Value_approximation.Value_unknown
 
-  let set_path_to_root t path_to_root =
-    if path_to_root = Debuginfo.Scoped_location.Loc_unknown
-    then t
-    else { t with path_to_root }
+  let set_path_to_root t (path_to_root : Debuginfo.Scoped_location.t) =
+    match path_to_root with
+    | Loc_unknown -> t
+    | Loc_known _ -> { t with path_to_root }
 
   let path_to_root { path_to_root; _ } = path_to_root
 

--- a/middle_end/flambda2/from_lambda/dune
+++ b/middle_end/flambda2/from_lambda/dune
@@ -34,7 +34,7 @@
    -open
    Flambda2_simplify_shared))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_algorithms

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1372,9 +1372,12 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
              (Targetint_31_63.of_int
                 ((1 lsl ((8 * size_int) - (10 + Config.reserved_header_bits)))
                 - 1))) ]
-    | Ostype_unix -> [Simple (Simple.const_bool (Sys.os_type = "Unix"))]
-    | Ostype_win32 -> [Simple (Simple.const_bool (Sys.os_type = "Win32"))]
-    | Ostype_cygwin -> [Simple (Simple.const_bool (Sys.os_type = "Cygwin"))]
+    | Ostype_unix ->
+      [Simple (Simple.const_bool (String.equal Sys.os_type "Unix"))]
+    | Ostype_win32 ->
+      [Simple (Simple.const_bool (String.equal Sys.os_type "Win32"))]
+    | Ostype_cygwin ->
+      [Simple (Simple.const_bool (String.equal Sys.os_type "Cygwin"))]
     | Backend_type ->
       [Simple Simple.const_zero] (* constructor 0 is the same as Native here *)
     | Runtime5 -> [Simple (Simple.const_bool Config.runtime5)])

--- a/middle_end/flambda2/identifiers/dune
+++ b/middle_end/flambda2/identifiers/dune
@@ -16,7 +16,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_algorithms

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -14,8 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Int_replace_polymorphic_compare
-
 let hash_seed =
   let seed = Random.bits () in
   if seed mod 2 = 0 then seed + 1 else seed

--- a/middle_end/flambda2/identifiers/rec_info_expr0.ml
+++ b/middle_end/flambda2/identifiers/rec_info_expr0.ml
@@ -14,8 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Int_replace_polymorphic_compare
-
 module type S = sig
   type variable
 

--- a/middle_end/flambda2/import/dune
+++ b/middle_end/flambda2/import/dune
@@ -4,5 +4,5 @@
  (name flambda2_import)
  (instrumentation (backend bisect_ppx))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries ocamlcommon))

--- a/middle_end/flambda2/kinds/dune
+++ b/middle_end/flambda2/kinds/dune
@@ -14,7 +14,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_algorithms

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -32,7 +32,18 @@ module Naked_number_kind = struct
     | Naked_nativeint -> Format.pp_print_string ppf "Naked_nativeint"
     | Naked_vec128 -> Format.pp_print_string ppf "Naked_vec128"
 
-  let equal (t1 : t) t2 = t1 = t2
+  let equal t1 t2 =
+    match t1, t2 with
+    | Naked_immediate, Naked_immediate -> true
+    | Naked_float, Naked_float -> true
+    | Naked_int32, Naked_int32 -> true
+    | Naked_int64, Naked_int64 -> true
+    | Naked_nativeint, Naked_nativeint -> true
+    | Naked_vec128, Naked_vec128 -> true
+    | ( ( Naked_immediate | Naked_float | Naked_int32 | Naked_int64
+        | Naked_nativeint | Naked_vec128 ),
+        _ ) ->
+      false
 end
 
 type t =

--- a/middle_end/flambda2/lattices/dune
+++ b/middle_end/flambda2/lattices/dune
@@ -14,7 +14,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_algorithms

--- a/middle_end/flambda2/nominal/dune
+++ b/middle_end/flambda2/nominal/dune
@@ -14,7 +14,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_algorithms

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -389,43 +389,6 @@ let empty =
     newer_version_of_code_ids = For_code_ids.empty
   }
 
-let [@ocamlformat "disable"] print ppf
-      ({ names;
-         continuations;
-         continuations_with_traps;
-         continuations_in_trap_actions;
-         function_slots_in_projections;
-         value_slots_in_projections;
-         function_slots_in_declarations;
-         value_slots_in_declarations;
-         code_ids;
-         newer_version_of_code_ids } as t) =
-  if t = empty then
-    Format.fprintf ppf "no_occurrences"
-  else
-  Format.fprintf ppf "@[<hov 1>\
-      @[<hov 1>(names %a)@]@ \
-      @[<hov 1>(continuations %a)@]@ \
-      @[<hov 1>(continuations_with_traps %a)@]@ \
-      @[<hov 1>(continuations_in_trap_actions %a)@]@ \
-      @[<hov 1>(function_slots_in_projections %a)@]@ \
-      @[<hov 1>(value_slots_in_projections %a)@]@ \
-      @[<hov 1>(function_slots_in_declarations %a)@]@ \
-      @[<hov 1>(value_slots_in_declarations %a)@]@ \
-      @[<hov 1>(code_ids %a)@] \
-      @[<hov 1>(newer_version_of_code_ids %a)@]@ \
-      @]"
-    For_names.print names
-    For_continuations.print continuations
-    For_continuations.print continuations_with_traps
-    For_continuations.print continuations_in_trap_actions
-    For_function_slots.print function_slots_in_projections
-    For_value_slots.print value_slots_in_projections
-    For_function_slots.print function_slots_in_declarations
-    For_value_slots.print value_slots_in_declarations
-    For_code_ids.print code_ids
-    For_code_ids.print newer_version_of_code_ids
-
 let singleton_continuation cont =
   { empty with
     continuations = For_continuations.singleton cont Name_mode.normal
@@ -1191,3 +1154,40 @@ let increase_counts
     code_ids;
     newer_version_of_code_ids
   }
+
+let [@ocamlformat "disable"] print ppf
+      ({ names;
+         continuations;
+         continuations_with_traps;
+         continuations_in_trap_actions;
+         function_slots_in_projections;
+         value_slots_in_projections;
+         function_slots_in_declarations;
+         value_slots_in_declarations;
+         code_ids;
+         newer_version_of_code_ids } as t) =
+  if is_empty t then
+    Format.fprintf ppf "no_occurrences"
+  else
+  Format.fprintf ppf "@[<hov 1>\
+      @[<hov 1>(names %a)@]@ \
+      @[<hov 1>(continuations %a)@]@ \
+      @[<hov 1>(continuations_with_traps %a)@]@ \
+      @[<hov 1>(continuations_in_trap_actions %a)@]@ \
+      @[<hov 1>(function_slots_in_projections %a)@]@ \
+      @[<hov 1>(value_slots_in_projections %a)@]@ \
+      @[<hov 1>(function_slots_in_declarations %a)@]@ \
+      @[<hov 1>(value_slots_in_declarations %a)@]@ \
+      @[<hov 1>(code_ids %a)@] \
+      @[<hov 1>(newer_version_of_code_ids %a)@]@ \
+      @]"
+    For_names.print names
+    For_continuations.print continuations
+    For_continuations.print continuations_with_traps
+    For_continuations.print continuations_in_trap_actions
+    For_function_slots.print function_slots_in_projections
+    For_value_slots.print value_slots_in_projections
+    For_function_slots.print function_slots_in_declarations
+    For_value_slots.print value_slots_in_declarations
+    For_code_ids.print code_ids
+    For_code_ids.print newer_version_of_code_ids

--- a/middle_end/flambda2/numbers/dune
+++ b/middle_end/flambda2/numbers/dune
@@ -12,5 +12,5 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries ocamlcommon flambda2_algorithms flambda2_ui))

--- a/middle_end/flambda2/numbers/numeric_types.ml
+++ b/middle_end/flambda2/numbers/numeric_types.ml
@@ -72,22 +72,6 @@ module Int16 = struct
   let to_int t = t
 end
 
-module Float = struct
-  type t = float
-
-  include Container_types.Make (struct
-    type t = float
-
-    let compare x y = Stdlib.compare x y
-
-    let hash f = Hashtbl.hash f
-
-    let equal (i : float) j = i = j
-
-    let print = Format.pp_print_float
-  end)
-end
-
 module Float_by_bit_pattern = struct
   let create f = Int64.bits_of_float f
 

--- a/middle_end/flambda2/numbers/numeric_types.mli
+++ b/middle_end/flambda2/numbers/numeric_types.mli
@@ -50,8 +50,6 @@ module Int16 : sig
   val to_int : t -> int
 end
 
-module Float : Container_types.S with type t = float
-
 module Float_by_bit_pattern : sig
   (** Floating point numbers whose comparison and equality relations are the
       usual [Int64] relations on the bit patterns of the floats. This in

--- a/middle_end/flambda2/numbers/one_bit_fewer.ml
+++ b/middle_end/flambda2/numbers/one_bit_fewer.ml
@@ -43,6 +43,8 @@ module type S = sig
 
   val ( < ) : t -> t -> bool
 
+  val ( > ) : t -> t -> bool
+
   val bottom_byte_to_int : t -> int
 
   val of_char : char -> t
@@ -149,6 +151,8 @@ module Make (I : S) : S with type t = I.t = struct
   let ( >= ) = I.( >= )
 
   let ( < ) = I.( < )
+
+  let ( > ) = I.( > )
 
   let is_in_range n = I.( >= ) n min_value && I.( <= ) n max_value
 

--- a/middle_end/flambda2/numbers/one_bit_fewer.ml
+++ b/middle_end/flambda2/numbers/one_bit_fewer.ml
@@ -39,6 +39,8 @@ module type S = sig
 
   val ( <= ) : t -> t -> bool
 
+  val ( >= ) : t -> t -> bool
+
   val ( < ) : t -> t -> bool
 
   val bottom_byte_to_int : t -> int
@@ -144,9 +146,11 @@ module Make (I : S) : S with type t = I.t = struct
 
   let ( <= ) = I.( <= )
 
+  let ( >= ) = I.( >= )
+
   let ( < ) = I.( < )
 
-  let is_in_range n = n >= min_value && n <= max_value
+  let is_in_range n = I.( >= ) n min_value && I.( <= ) n max_value
 
   let bottom_byte_to_int = I.bottom_byte_to_int
 

--- a/middle_end/flambda2/numbers/one_bit_fewer.mli
+++ b/middle_end/flambda2/numbers/one_bit_fewer.mli
@@ -29,6 +29,8 @@ module type S = sig
 
   val ( < ) : t -> t -> bool
 
+  val ( > ) : t -> t -> bool
+
   val bottom_byte_to_int : t -> int
 
   val of_char : char -> t

--- a/middle_end/flambda2/numbers/one_bit_fewer.mli
+++ b/middle_end/flambda2/numbers/one_bit_fewer.mli
@@ -25,6 +25,8 @@ module type S = sig
 
   val ( <= ) : t -> t -> bool
 
+  val ( >= ) : t -> t -> bool
+
   val ( < ) : t -> t -> bool
 
   val bottom_byte_to_int : t -> int

--- a/middle_end/flambda2/numbers/targetint_31_63.ml
+++ b/middle_end/flambda2/numbers/targetint_31_63.ml
@@ -71,6 +71,8 @@ module T0 = struct
 
   let ( < ) t1 t2 = Stdlib.( < ) (Int64.compare t1 t2) 0
 
+  let ( > ) t1 t2 = Stdlib.( > ) (Int64.compare t1 t2) 0
+
   let to_int_option t =
     let min_int_as_int64 = Int64.of_int Stdlib.min_int in
     let max_int_as_int64 = Int64.of_int Stdlib.max_int in

--- a/middle_end/flambda2/parser/dune
+++ b/middle_end/flambda2/parser/dune
@@ -123,7 +123,7 @@
    -open
    Flambda2_nominal))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (modules
   (:standard \ flambda_parser_in))
  ; ignore inputs to sed

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -725,9 +725,11 @@ type scope =
   | Continuation_body
 
 let parens ~if_scope_is scope ppf f =
-  if if_scope_is = scope
-  then Format.fprintf ppf "(%t)" (f Outer)
-  else f scope ppf
+  match if_scope_is, scope with
+  | Outer, Outer | Where_body, Where_body | Continuation_body, Continuation_body
+    ->
+    Format.fprintf ppf "(%t)" (f Outer)
+  | (Outer | Where_body | Continuation_body), _ -> f scope ppf
 
 let rec expr scope ppf = function
   | Invalid { message } ->

--- a/middle_end/flambda2/simplify/apply_cont_rewrite.ml
+++ b/middle_end/flambda2/simplify/apply_cont_rewrite.ml
@@ -244,14 +244,16 @@ let rewrite_exn_continuation rewrite id exn_cont =
       Exn_continuation.print exn_cont Bound_parameters.print
       rewrite.original_params;
   assert (Flambda_arity.cardinal_unarized exn_cont_arity >= 1);
-  if List.hd rewrite.original_params_usage <> Used
-  then
+  (match List.hd rewrite.original_params_usage with
+  | Used -> ()
+  | Unused | Used_as_invariant ->
     Misc.fatal_errorf
       "The usage of the exn parameter of the continuation rewrite should be \
        [Used]: %a"
-      print rewrite;
+      print rewrite);
   if List.exists
-       (fun x -> x = Used_as_invariant)
+       (fun x ->
+         match x with Used_as_invariant -> true | Used | Unused -> false)
        (rewrite.original_params_usage @ rewrite.extra_params_usage)
   then
     Misc.fatal_errorf

--- a/middle_end/flambda2/simplify/dune
+++ b/middle_end/flambda2/simplify/dune
@@ -34,7 +34,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_algorithms

--- a/middle_end/flambda2/simplify/flow/flow_analysis.ml
+++ b/middle_end/flambda2/simplify/flow/flow_analysis.ml
@@ -60,11 +60,12 @@ let analyze ?(speculative = false) ?print_name ~return_continuation
       let ({ T.Acc.stack; map; extra = _; dummy_toplevel_cont } as t) =
         Flow_acc.extend_args_with_extra_args t
       in
-      assert (stack = []);
+      assert (match stack with [] -> true | _ :: _ -> false);
       assert (
         not
-          (Continuation.name dummy_toplevel_cont
-          = Flow_acc.wrong_dummy_toplevel_cont_name));
+          (String.equal
+             (Continuation.name dummy_toplevel_cont)
+             Flow_acc.wrong_dummy_toplevel_cont_name));
       if Flambda_features.dump_flow ()
       then Format.eprintf "SOURCE:@\n%a@\n@." T.Acc.print t;
       (* dependency graph *)

--- a/middle_end/flambda2/simplify/simplify_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive.ml
@@ -146,7 +146,7 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
       check_arg_kinds prim
         [arg1_ty, arg1_kind; arg2_ty, arg2_kind; arg3_ty, arg3_kind]);
     let original_prim : P.t =
-      if orig_arg1 == arg1 && orig_arg2 == arg2 && orig_arg3 = arg3
+      if orig_arg1 == arg1 && orig_arg2 == arg2 && orig_arg3 == arg3
       then prim
       else Ternary (ternary_prim, arg1, arg2, arg3)
     in

--- a/middle_end/flambda2/simplify_shared/dune
+++ b/middle_end/flambda2/simplify_shared/dune
@@ -25,7 +25,7 @@
    -open
    Flambda2_terms))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_identifiers

--- a/middle_end/flambda2/simplify_shared/exported_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.ml
@@ -83,7 +83,7 @@ let equal_value_slot_info (info1 : value_slot_info) (info2 : value_slot_info) =
   | Dead_value_slot, Dead_value_slot -> true
   | ( Live_value_slot { offset = o1; size = s1; is_scanned = v1 },
       Live_value_slot { offset = o2; size = s2; is_scanned = v2 } ) ->
-    o1 = o2 && s1 = s2 && v1 = v2
+    o1 = o2 && s1 = s2 && Bool.equal v1 v2
   | Dead_value_slot, Live_value_slot _ | Live_value_slot _, Dead_value_slot ->
     false
 

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -190,13 +190,13 @@ module Layout = struct
        then the environment has not started yet (i.e. we have not seen any value
        slots). *)
     | Function_slot _ when offset = 0 ->
-      assert (acc_slots = []);
-      assert (startenv = None);
+      assert (match acc_slots with [] -> true | _ :: _ -> false);
+      assert (Option.is_none startenv);
       (* see comment above *)
       let acc_slots = [0, slot] in
       startenv, acc_slots
     | Function_slot _ ->
-      assert (startenv = None);
+      assert (Option.is_none startenv);
       (* see comment above *)
       let acc_slots =
         (offset, slot) :: (offset - 1, Infix_header) :: acc_slots
@@ -607,7 +607,8 @@ end = struct
            set.allocated_slots
 
   let add_slot_offset state slot offset =
-    assert (slot.pos = Unassigned);
+    assert (
+      match slot.pos with Unassigned -> true | Removed | Assigned _ -> false);
     slot.pos <- Assigned offset;
     List.iter (add_slot_offset_to_set slot) slot.sets;
     state.used_offsets

--- a/middle_end/flambda2/term_basics/dune
+++ b/middle_end/flambda2/term_basics/dune
@@ -25,7 +25,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_algorithms

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -193,10 +193,15 @@ let bytes_like_set kind width =
   | Bytes -> string_or_bigstring_load Bytes width
   | Bigstring -> string_or_bigstring_load Bigstring width
 
-let divmod_bi_check else_branch_size bi =
+let divmod_bi_check else_branch_size (bi : Flambda_kind.Standard_int.t) =
   (* CR gbury: we should allow check Arch.division_crashed_on_overflow, but
      that's likely a dependency we want to avoid ? *)
-  if arch32 || bi <> Flambda_kind.Standard_int.Naked_int32
+  if arch32
+     ||
+     match bi with
+     | Naked_int32 -> false
+     | Naked_int64 | Naked_nativeint | Naked_immediate | Tagged_immediate ->
+       true
   then 2 + else_branch_size
   else 0
 

--- a/middle_end/flambda2/terms/dune
+++ b/middle_end/flambda2/terms/dune
@@ -28,7 +28,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda_backend_utils

--- a/middle_end/flambda2/terms/inlined_attribute.ml
+++ b/middle_end/flambda2/terms/inlined_attribute.ml
@@ -20,7 +20,16 @@ module Use_info = struct
     | Unused_because_of_call_site_decision
     | Unused_because_function_unknown
 
-  let equal t1 t2 = t1 = t2
+  let equal t1 t2 =
+    match t1, t2 with
+    | Expected_to_be_used, Expected_to_be_used
+    | Unused_because_of_call_site_decision, Unused_because_of_call_site_decision
+    | Unused_because_function_unknown, Unused_because_function_unknown ->
+      true
+    | ( ( Expected_to_be_used | Unused_because_of_call_site_decision
+        | Unused_because_function_unknown ),
+        _ ) ->
+      false
 
   let explanation t =
     match t with

--- a/middle_end/flambda2/terms/inlining_history.ml
+++ b/middle_end/flambda2/terms/inlining_history.ml
@@ -164,8 +164,10 @@ module Relative = struct
         (b : Debuginfo.Scoped_location.scopes) =
       match a, b with
       | Cons a, Cons b ->
-        a.item = b.item && a.str = b.str && a.str_fun = b.str_fun
-        && a.name = b.name
+        Debuginfo.Scoped_location.equal_scope_item a.item b.item
+        && String.equal a.str b.str
+        && String.equal a.str_fun b.str_fun
+        && String.equal a.name b.name
       | Empty, _ | _, Empty -> false
     in
     let rec aux ~parent ~child =

--- a/middle_end/flambda2/to_cmm/dune
+++ b/middle_end/flambda2/to_cmm/dune
@@ -30,7 +30,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   ocamloptcomp

--- a/middle_end/flambda2/types/dune
+++ b/middle_end/flambda2/types/dune
@@ -30,7 +30,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries
   ocamlcommon
   flambda2_algorithms

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -2403,7 +2403,8 @@ module Row_like_for_blocks = struct
     }
 
   let is_bottom { known_tags; other_tags; alloc_mode = _ } =
-    Tag.Map.is_empty known_tags && other_tags = Or_bottom.Bottom
+    Tag.Map.is_empty known_tags
+    && match other_tags with Bottom -> true | Ok _ -> false
 
   let all_tags { known_tags; other_tags; alloc_mode = _ } :
       Tag.Set.t Or_unknown.t =

--- a/middle_end/flambda2/ui/dune
+++ b/middle_end/flambda2/ui/dune
@@ -7,5 +7,5 @@
  (flags
   (:standard -principal))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries ocamlcommon flambda_backend_common))

--- a/ocaml/lambda/debuginfo.ml
+++ b/ocaml/lambda/debuginfo.ml
@@ -27,6 +27,19 @@ module Scoped_location = struct
     | Sc_partial_or_eta_wrapper
     | Sc_lazy
 
+  let equal_scope_item si1 si2 =
+    match si1, si2 with
+    | Sc_anonymous_function, Sc_anonymous_function
+    | Sc_value_definition, Sc_value_definition
+    | Sc_module_definition, Sc_module_definition
+    | Sc_class_definition, Sc_class_definition
+    | Sc_method_definition, Sc_method_definition
+    | Sc_partial_or_eta_wrapper, Sc_partial_or_eta_wrapper
+    | Sc_lazy, Sc_lazy -> true
+    | (Sc_anonymous_function | Sc_value_definition | Sc_module_definition
+      | Sc_class_definition | Sc_method_definition | Sc_partial_or_eta_wrapper
+      | Sc_lazy), _ -> false
+
   type scopes =
     | Empty
     | Cons of {item: scope_item; str: string; str_fun: string; name : string; prev: scopes;

--- a/ocaml/lambda/debuginfo.mli
+++ b/ocaml/lambda/debuginfo.mli
@@ -23,6 +23,8 @@ module Scoped_location : sig
     | Sc_partial_or_eta_wrapper
     | Sc_lazy
 
+  val equal_scope_item : scope_item -> scope_item -> bool
+
   type scopes = private
     | Empty
     | Cons of {item: scope_item; str: string; str_fun: string; name : string; prev: scopes;


### PR DESCRIPTION
This moves the `open! Int_replace_polymorphic_compare` into the `dune` files for all of flambda2 (except test directories for the moment).  It then fixes up all remaining uses of polymorphic compare.  These will need reviewing carefully (commit by commit); there was at least one typo caught (use of `=` instead of `==`).  I deleted `Numeric_types.Float` since it seemed like it was unused, and it avoids answering a question about float equality.

I'm also going to check (in the light of https://github.com/ocaml-flambda/flambda-backend/pull/2311) whether warning 4 is being correctly applied across the flambda2 codebase, and whether attributes to disable it on a per-file basis can be removed.