### PR TITLE
Fix assertion in Emit

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -940,7 +940,7 @@ let emit_atomic instr op (size : Cmm.atomic_bitwidth) addr =
 let emit_simd_instr op i =
   (match Simd_selection.register_behavior op with
   | R_to_fst ->
-    assert (arg i 0 = res i 0);
+    assert (Reg.same_loc i.arg.(0) i.res.(0));
     assert (Reg.is_reg i.arg.(0))
   | R_to_RM ->
     assert (Reg.is_reg i.arg.(0))
@@ -949,34 +949,34 @@ let emit_simd_instr op i =
   | R_to_R ->
     assert (Reg.is_reg i.arg.(0) && Reg.is_reg i.res.(0))
   | R_RM_to_fst ->
-    assert (arg i 0 = res i 0);
+    assert (Reg.same_loc i.arg.(0) i.res.(0));
     assert (Reg.is_reg i.arg.(0))
   | R_RM_to_R ->
     assert (Reg.is_reg i.arg.(0));
     assert (Reg.is_reg i.res.(0))
   | R_RM_xmm0_to_fst ->
-    assert (arg i 0 = res i 0);
+    assert (Reg.same_loc i.arg.(0) i.res.(0));
     assert (Reg.is_reg i.arg.(0));
-    assert (i.arg.(2) = phys_xmm0v ())
+    assert (Reg.same_loc i.arg.(2) (phys_xmm0v ()))
   | R_R_to_fst ->
-    assert (arg i 0 = res i 0);
+    assert (Reg.same_loc i.arg.(0) i.res.(0));
     assert (Reg.is_reg i.arg.(0) && Reg.is_reg i.arg.(1))
   | R_RM_rax_rdx_to_rcx ->
     assert (Reg.is_reg i.arg.(0));
-    assert (i.arg.(2) = phys_rax);
-    assert (i.arg.(3) = phys_rdx);
-    assert (i.res.(0) = phys_rcx)
+    assert (Reg.same_loc (i.arg.(2)) phys_rax);
+    assert (Reg.same_loc (i.arg.(3)) phys_rdx);
+    assert (Reg.same_loc i.res.(0) phys_rcx)
   | R_RM_to_rcx ->
     assert (Reg.is_reg i.arg.(0));
-    assert (i.res.(0) = phys_rcx)
+    assert (Reg.same_loc (i.res.(0)) phys_rcx)
   | R_RM_rax_rdx_to_xmm0 ->
     assert (Reg.is_reg i.arg.(0));
-    assert (i.arg.(2) = phys_rax);
-    assert (i.arg.(3) = phys_rdx);
-    assert (i.res.(0) = phys_xmm0v ())
+    assert (Reg.same_loc (i.arg.(2)) phys_rax);
+    assert (Reg.same_loc (i.arg.(3)) phys_rdx);
+    assert (Reg.same_loc (i.res.(0)) (phys_xmm0v ()))
   | R_RM_to_xmm0 ->
     assert (Reg.is_reg i.arg.(0));
-    assert (i.res.(0) = phys_xmm0v ())
+    assert (Reg.same_loc i.res.(0) (phys_xmm0v ()))
   );
   match (op : Simd.operation) with
   | CLMUL (Clmul_64 n) -> I.pclmulqdq (X86_dsl.int n) (arg i 1) (res i 0)


### PR DESCRIPTION
Assertions in `Emit` related to `simd` are too strong. It is sufficient to check for `Reg.same_loc` . Note that register class does not matter at this point after register allcoation and also `Reg.typ` is only used in `Emit.move`.

Checking registers for equality using `=` in `Emit` fails when building with FDO because various fields of `Reg` related to register allocation (`spill_cost` for example) are not initialized when starting compilation from `Emit`. 