### PR TITLE
Add `caml_*_of_string_unboxed` runtime primitives for boxed ints

### DIFF
--- a/ocaml/runtime/ints.c
+++ b/ocaml/runtime/ints.c
@@ -334,9 +334,14 @@ CAMLprim value caml_int32_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Int32_val(arg));
 }
 
+int32_t caml_int32_of_string_unboxed(value s)
+{
+  return (int32_t) parse_intnat(s, 32, INT32_ERRMSG);
+}
+
 CAMLprim value caml_int32_of_string(value s)
 {
-  return caml_copy_int32((int32_t) parse_intnat(s, 32, INT32_ERRMSG));
+  return caml_copy_int32(caml_int32_of_string_unboxed(s));
 }
 
 int32_t caml_int32_bits_of_float_unboxed(double d)
@@ -582,7 +587,7 @@ CAMLprim value caml_int64_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Int64_val(arg));
 }
 
-CAMLprim value caml_int64_of_string(value s)
+int64_t caml_int64_of_string_unboxed(value s)
 {
   const char * p;
   uint64_t res, threshold;
@@ -616,7 +621,12 @@ CAMLprim value caml_int64_of_string(value s)
     }
   }
   if (sign < 0) res = - res;
-  return caml_copy_int64(res);
+  return res;
+}
+
+CAMLprim value caml_int64_of_string(value s)
+{
+  return caml_copy_int64(caml_int64_of_string_unboxed(s));
 }
 
 int64_t caml_int64_bits_of_float_unboxed(double d)
@@ -845,7 +855,12 @@ CAMLprim value caml_nativeint_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Nativeint_val(arg));
 }
 
+intnat caml_nativeint_of_string_unboxed(value s)
+{
+  return parse_intnat(s, 8 * sizeof(value), INTNAT_ERRMSG);
+}
+
 CAMLprim value caml_nativeint_of_string(value s)
 {
-  return caml_copy_nativeint(parse_intnat(s, 8 * sizeof(value), INTNAT_ERRMSG));
+  return caml_copy_nativeint(caml_nativeint_of_string_unboxed(s));
 }

--- a/ocaml/runtime/ints.c
+++ b/ocaml/runtime/ints.c
@@ -334,7 +334,7 @@ CAMLprim value caml_int32_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Int32_val(arg));
 }
 
-int32_t caml_int32_of_string_unboxed(value s)
+CAMLprim int32_t caml_int32_of_string_unboxed(value s)
 {
   return (int32_t) parse_intnat(s, 32, INT32_ERRMSG);
 }
@@ -587,7 +587,7 @@ CAMLprim value caml_int64_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Int64_val(arg));
 }
 
-int64_t caml_int64_of_string_unboxed(value s)
+CAMLprim int64_t caml_int64_of_string_unboxed(value s)
 {
   const char * p;
   uint64_t res, threshold;
@@ -855,7 +855,7 @@ CAMLprim value caml_nativeint_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Nativeint_val(arg));
 }
 
-intnat caml_nativeint_of_string_unboxed(value s)
+CAMLprim intnat caml_nativeint_of_string_unboxed(value s)
 {
   return parse_intnat(s, 8 * sizeof(value), INTNAT_ERRMSG);
 }

--- a/ocaml/runtime4/ints.c
+++ b/ocaml/runtime4/ints.c
@@ -334,9 +334,14 @@ CAMLprim value caml_int32_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Int32_val(arg));
 }
 
+int32_t caml_int32_of_string_unboxed(value s)
+{
+  return (int32_t) parse_intnat(s, 32, INT32_ERRMSG);
+}
+
 CAMLprim value caml_int32_of_string(value s)
 {
-  return caml_copy_int32((int32_t) parse_intnat(s, 32, INT32_ERRMSG));
+  return caml_copy_int32(caml_int32_of_string_unboxed(s));
 }
 
 int32_t caml_int32_bits_of_float_unboxed(double d)
@@ -582,7 +587,7 @@ CAMLprim value caml_int64_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Int64_val(arg));
 }
 
-CAMLprim value caml_int64_of_string(value s)
+int64_t caml_int64_of_string_unboxed(value s)
 {
   const char * p;
   uint64_t res, threshold;
@@ -616,7 +621,12 @@ CAMLprim value caml_int64_of_string(value s)
     }
   }
   if (sign < 0) res = - res;
-  return caml_copy_int64(res);
+  return res;
+}
+
+CAMLprim value caml_int64_of_string(value s)
+{
+  return caml_copy_int64(caml_int64_of_string_unboxed(s));
 }
 
 int64_t caml_int64_bits_of_float_unboxed(double d)
@@ -845,7 +855,12 @@ CAMLprim value caml_nativeint_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Nativeint_val(arg));
 }
 
+intnat caml_nativeint_of_string_unboxed(value s)
+{
+  return parse_intnat(s, 8 * sizeof(value), INTNAT_ERRMSG);
+}
+
 CAMLprim value caml_nativeint_of_string(value s)
 {
-  return caml_copy_nativeint(parse_intnat(s, 8 * sizeof(value), INTNAT_ERRMSG));
+  return caml_copy_nativeint(caml_nativeint_of_string_unboxed(s));
 }

--- a/ocaml/runtime4/ints.c
+++ b/ocaml/runtime4/ints.c
@@ -334,7 +334,7 @@ CAMLprim value caml_int32_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Int32_val(arg));
 }
 
-int32_t caml_int32_of_string_unboxed(value s)
+CAMLprim int32_t caml_int32_of_string_unboxed(value s)
 {
   return (int32_t) parse_intnat(s, 32, INT32_ERRMSG);
 }
@@ -587,7 +587,7 @@ CAMLprim value caml_int64_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Int64_val(arg));
 }
 
-int64_t caml_int64_of_string_unboxed(value s)
+CAMLprim int64_t caml_int64_of_string_unboxed(value s)
 {
   const char * p;
   uint64_t res, threshold;
@@ -855,7 +855,7 @@ CAMLprim value caml_nativeint_format(value fmt, value arg)
   return caml_alloc_sprintf(format_string, Nativeint_val(arg));
 }
 
-intnat caml_nativeint_of_string_unboxed(value s)
+CAMLprim intnat caml_nativeint_of_string_unboxed(value s)
 {
   return parse_intnat(s, 8 * sizeof(value), INTNAT_ERRMSG);
 }

--- a/ocaml/stdlib/int32.ml
+++ b/ocaml/stdlib/int32.ml
@@ -76,7 +76,8 @@ let unsigned_to_int =
 external format : string -> int32 -> string = "caml_int32_format"
 let[@inline available] to_string n = format "%d" n
 
-external of_string : string -> int32 = "caml_int32_of_string"
+external of_string : string -> (int32[@unboxed])
+  = "caml_int32_of_string" "caml_int32_of_string_unboxed"
 
 let[@inline available] of_string_opt s =
   (* TODO: expose a non-raising primitive directly. *)

--- a/ocaml/stdlib/int32.mli
+++ b/ocaml/stdlib/int32.mli
@@ -160,7 +160,8 @@ external to_float : int32 -> float
   [@@unboxed] [@@noalloc]
 (** Convert the given 32-bit integer to a floating-point number. *)
 
-external of_string : string -> int32 = "caml_int32_of_string"
+external of_string : string -> (int32[@unboxed])
+  = "caml_int32_of_string" "caml_int32_of_string_unboxed"
 (** Convert the given string to a 32-bit integer.
    The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the

--- a/ocaml/stdlib/int64.ml
+++ b/ocaml/stdlib/int64.ml
@@ -66,7 +66,8 @@ let unsigned_to_int =
 external format : string -> int64 -> string = "caml_int64_format"
 let[@inline available] to_string n = format "%d" n
 
-external of_string : string -> int64 = "caml_int64_of_string"
+external of_string : string -> (int64[@unboxed])
+  = "caml_int64_of_string" "caml_int64_of_string_unboxed"
 
 let[@inline available] of_string_opt s =
   (* TODO: expose a non-raising primitive directly. *)

--- a/ocaml/stdlib/int64.mli
+++ b/ocaml/stdlib/int64.mli
@@ -180,7 +180,8 @@ external to_nativeint : int64 -> nativeint = "%int64_to_nativeint"
    is taken modulo 2{^32}.  On 64-bit platforms,
    the conversion is exact. *)
 
-external of_string : string -> int64 = "caml_int64_of_string"
+external of_string : string -> (int64[@unboxed])
+  = "caml_int64_of_string" "caml_int64_of_string_unboxed"
 (** Convert the given string to a 64-bit integer.
    The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the

--- a/ocaml/stdlib/nativeint.ml
+++ b/ocaml/stdlib/nativeint.ml
@@ -65,7 +65,8 @@ let unsigned_to_int =
 external format : string -> nativeint -> string = "caml_nativeint_format"
 let[@inline available] to_string n = format "%d" n
 
-external of_string: string -> nativeint = "caml_nativeint_of_string"
+external of_string: string -> (nativeint[@unboxed])
+  = "caml_nativeint_of_string" "caml_nativeint_of_string_unboxed"
 
 let[@inline available] of_string_opt s =
   (* TODO: expose a non-raising primitive directly. *)

--- a/ocaml/stdlib/nativeint.mli
+++ b/ocaml/stdlib/nativeint.mli
@@ -188,7 +188,8 @@ external to_int32 : nativeint -> int32 = "%nativeint_to_int32"
    i.e. the top 32 bits are lost.  On 32-bit platforms,
    the conversion is exact. *)
 
-external of_string : string -> nativeint = "caml_nativeint_of_string"
+external of_string : string -> (nativeint[@unboxed])
+  = "caml_nativeint_of_string" "caml_nativeint_of_string_unboxed"
 (** Convert the given string to a native integer.
    The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the

--- a/ocaml/testsuite/tests/lib-marshal/intext.ml
+++ b/ocaml/testsuite/tests/lib-marshal/intext.ml
@@ -70,7 +70,7 @@ let test_out ?(flags = []) filename =
     (Nativeint.shift_left (Nativeint.of_string "123456789") 32) flags;
   Marshal.to_channel oc
     (Nativeint.shift_left (Nativeint.of_string "-123456789") 32) flags;
-  let i = Int64.of_string "123456789123456" in
+  let i = Sys.opaque_identity (Int64.of_string "123456789123456") in
     Marshal.to_channel oc (i,i) flags;
   close_out oc
 

--- a/ocaml/testsuite/tests/lib-marshal/intext_par.ml
+++ b/ocaml/testsuite/tests/lib-marshal/intext_par.ml
@@ -70,7 +70,8 @@ let test_out filename =
   output_value oc (Nativeint.of_string "-123456");
   output_value oc (Nativeint.shift_left (Nativeint.of_string "123456789") 32);
   output_value oc (Nativeint.shift_left (Nativeint.of_string "-123456789") 32);
-  let i = Int64.of_string "123456789123456" in output_value oc (i,i);
+  let i = Sys.opaque_identity (Int64.of_string "123456789123456") in
+  output_value oc (i,i);
   close_out oc
 
 


### PR DESCRIPTION
Add  `caml_*_of_string_unboxed` runtime primitives for nativeint, int32, and int64. These new primitives return unboxed values and don't cause any allocations in the success case.
