### PR TITLE
Document assumptions about FDO in the backend

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -16,6 +16,10 @@
 
 (* Emission of Intel x86_64 assembly code *)
 
+(* Correctness: carefully consider any use of [Config], [Clflags],
+   [Flambda_backend_flags] and shared variables.
+   For details, see [asmgen.mli]. *)
+
 open Cmm
 open Arch
 open Proc

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -18,6 +18,10 @@
 
 (* Emission of ARM assembly code, 64-bit mode *)
 
+(* Correctness: carefully consider any use of [Config], [Clflags],
+   [Flambda_backend_flags] and shared variables.
+   For details, see [asmgen.mli]. *)
+
 open Misc
 open Cmm
 open Arch

--- a/backend/asmgen.mli
+++ b/backend/asmgen.mli
@@ -39,6 +39,27 @@ val compile_implementation
   -> Lambda.program
   -> unit
 
+(** [compile_implementation_linear] reads Linear IR from [progname] file
+    produced by previous compilation stages (for example,
+    using "ocamlopt -save-ir-after" and "ocamlfdo opt")
+    and continues compilatin from [Emit].
+
+    Correctness: carefully consider any use of [Config], [Clflags],
+    [Flambda_backend_flags] and shared variables during or after [Emit].
+    A mismatch between between their values in different compilation stages
+    might lead to a miscompilation or compilation failures during
+    [compile_implementation_linear]. Mismatches can also be due to
+    marshaling of Linear IR (for example, if physical equality is used).
+
+    In particular, compiler configuration settings and compilation flags used by
+    [ocamlopt] must match the ones used by [ocamlfdo].
+    Currently, [ocamlfdo] uses compiler-libs, so it must be compiled with the same
+    configuration as [ocamlopt] from stages 1 and 2. For example, builds with frame
+    pointers enabled require a compatible [ocamlfdo].
+    There is currently no way to pass compilation flags to [ocamlfdo] so transformations
+    perfomed by [ocamlfdo] must not depend on such compilation flags.  For example, SIMD
+    is disable din [ocamlfdo].
+*)
 val compile_implementation_linear
   : (module Compiler_owee.Unix_intf.S)
   -> string

--- a/backend/asmgen.mli
+++ b/backend/asmgen.mli
@@ -42,7 +42,7 @@ val compile_implementation
 (** [compile_implementation_linear] reads Linear IR from [progname] file
     produced by previous compilation stages (for example,
     using "ocamlopt -save-ir-after" and "ocamlfdo opt")
-    and continues compilatin from [Emit].
+    and continues compilation from [Emit].
 
     Correctness: carefully consider any use of [Config], [Clflags],
     [Flambda_backend_flags] and shared variables during or after [Emit].
@@ -58,7 +58,12 @@ val compile_implementation
     pointers enabled require a compatible [ocamlfdo].
     There is currently no way to pass compilation flags to [ocamlfdo] so transformations
     perfomed by [ocamlfdo] must not depend on such compilation flags.  For example, SIMD
-    is disable din [ocamlfdo].
+    is disabled in [ocamlfdo].
+
+    Note that it is not safe to call functions that access variables whose values depend
+    on previous compilation stages. For example, calling [Reg.create] may return a
+    register that clashes with existing ones, because of the shared stamp counter in [Reg]
+    that is not recorded in Linear IR files.
 *)
 val compile_implementation_linear
   : (module Compiler_owee.Unix_intf.S)


### PR DESCRIPTION
Split-compilation that we use for FDO makes some assumptions that are not easy to see (for example, #2313). This PR proposes a comment to at least document some of them.