### PR TITLE
Prevent Flambda2 unboxing of local values

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1552,6 +1552,11 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
         Warnings.Unboxing_impossible;
       None
   in
+  let unboxing_kind layout mode =
+    match (mode : Lambda.alloc_mode) with
+    | Alloc_heap -> unboxing_kind layout
+    | Alloc_local -> None
+  in
   let params_arity =
     Flambda_arity.from_lambda_list
       (List.map (fun (p : L.lparam) -> p.layout) params)
@@ -1574,11 +1579,11 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
           Flambda_kind.With_subkind.any_value
       in
       let unboxed_return =
-        if attr.unbox_return then unboxing_kind return else None
+        if attr.unbox_return then unboxing_kind return ret_mode else None
       in
       let unboxed_param (param : Lambda.lparam) =
         if param.attributes.unbox_param
-        then unboxing_kind param.layout
+        then unboxing_kind param.layout param.mode
         else None
       in
       let unboxed_params =


### PR DESCRIPTION
The current implementation of unboxing for parameters in Flambda2 will create allocations in the unboxed version, with the hope that these allocations will be simplified away. However, for values with local mode, inserting such allocations is bad, because we don't know the region in which they're going to live.
So until we've found a proper way to handle that, unboxing is disallowed for values with local mode.
Note that an `[@unboxable]` attribute does not prevent the type-checker from inferring a local mode, so we can end up rejecting an `[@unboxable]` attribute even though the code contains no explicit local annotations.