### PR TITLE
Ignore bootstrapping artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ _coverage/
 ocamlc
 ocamlopt
 .ocamldebug
+
+# Artifacts made during bootstrapping
+ocaml/otherlibs/dynlink/byte/dynlink.mli
+ocaml/otherlibs/dynlink/native/dynlink.mli
+ocaml/primitives.new


### PR DESCRIPTION
Bootstrapping produces three files. I would like them ignored. But it would be great if someone knew why these are created and whether ignoring is the right behavior.