### PR TITLE
Tolerate `global` in `transl_mode_annots`

### DIFF
--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -2528,6 +2528,11 @@ type gfoo = GFoo of global_ string * string
 type gfoo = GFoo of global_ string * string
 |}]
 
+type gfoo' = GFoo' : global_ string -> gfoo'
+[%%expect{|
+type gfoo' = GFoo' : global_ string -> gfoo'
+|}]
+
 (* TESTING OF GLOBAL_ *)
 
 (* global arguments must be global when constructing

--- a/ocaml/typing/typemode.ml
+++ b/ocaml/typing/typemode.ml
@@ -27,6 +27,10 @@ let transl_mode_annots modes =
           match acc.linearity with
           | None -> { acc with linearity = Some Linearity.Const.Once }
           | Some _ -> raise (Error (loc, Duplicated_mode `Linearity)))
+        | "global" ->
+          (* CR zqian: global modality might leak to here by ppxes.
+             This is a dirty fix that needs to be fixed ASAP. *)
+          acc
         | s ->
           Misc.fatal_errorf "Unrecognized mode %s at %a - should not parse" s
             Location.print_loc loc

--- a/ocaml/typing/typemode.ml
+++ b/ocaml/typing/typemode.ml
@@ -27,7 +27,7 @@ let transl_mode_annots modes =
           match acc.linearity with
           | None -> { acc with linearity = Some Linearity.Const.Once }
           | Some _ -> raise (Error (loc, Duplicated_mode `Linearity)))
-        | s -> Misc.fatal_errorf "Unrecognized mode %s - should not parse" s
+        | s -> Misc.fatal_errorf "Unrecognized mode %s at %a - should not parse" s Location.print_loc loc
       in
       loop acc rest
   in
@@ -45,8 +45,8 @@ let transl_global_flags gfs =
           match acc with
           | Unrestricted -> Global_flag.Global
           | Global ->
-            Misc.fatal_error "Duplicated global modality - should not parse")
-        | s -> Misc.fatal_errorf "Unrecognized modality %s - should not parse" s
+            Misc.fatal_errorf "Duplicated global modality at %a - should not parse" Location.print_loc loc)
+        | s -> Misc.fatal_errorf "Unrecognized modality %s at %a - should not parse" s Location.print_loc loc
       in
       loop acc rest
   in

--- a/ocaml/typing/typemode.ml
+++ b/ocaml/typing/typemode.ml
@@ -27,7 +27,9 @@ let transl_mode_annots modes =
           match acc.linearity with
           | None -> { acc with linearity = Some Linearity.Const.Once }
           | Some _ -> raise (Error (loc, Duplicated_mode `Linearity)))
-        | s -> Misc.fatal_errorf "Unrecognized mode %s at %a - should not parse" s Location.print_loc loc
+        | s ->
+          Misc.fatal_errorf "Unrecognized mode %s at %a - should not parse" s
+            Location.print_loc loc
       in
       loop acc rest
   in
@@ -45,8 +47,12 @@ let transl_global_flags gfs =
           match acc with
           | Unrestricted -> Global_flag.Global
           | Global ->
-            Misc.fatal_errorf "Duplicated global modality at %a - should not parse" Location.print_loc loc)
-        | s -> Misc.fatal_errorf "Unrecognized modality %s at %a - should not parse" s Location.print_loc loc
+            Misc.fatal_errorf
+              "Duplicated global modality at %a - should not parse"
+              Location.print_loc loc)
+        | s ->
+          Misc.fatal_errorf "Unrecognized modality %s at %a - should not parse"
+            s Location.print_loc loc
       in
       loop acc rest
   in


### PR DESCRIPTION
Our internal tools (PPXes) might leak modalities on both record fields and constructor arguments to the LHS/RHS of arrow types, which is incorrect. This PR is a dirty fix that tolerate that behaviour. 

The commit "ignore global in alloc_mode" should be reverted ASAP. 