### PR TITLE
Make `Sys.opaque_identity` work on different layouts

### DIFF
--- a/ocaml/stdlib/sys.ml.in
+++ b/ocaml/stdlib/sys.ml.in
@@ -159,7 +159,7 @@ let ocaml_release = {
 
 (* Optimization *)
 
-external opaque_identity : 'a -> 'a = "%opaque"
+external[@layout_poly] opaque_identity : ('a : any). 'a -> 'a = "%opaque"
 
 module Immediate64 = struct
   module type Non_immediate = sig

--- a/ocaml/stdlib/sys.mli
+++ b/ocaml/stdlib/sys.mli
@@ -415,7 +415,7 @@ val runtime_warnings_enabled: unit -> bool
 
 (** {1 Optimization} *)
 
-external opaque_identity : 'a -> 'a = "%opaque"
+external[@layout_poly] opaque_identity : ('a : any). 'a -> 'a = "%opaque"
 (** For the purposes of optimization, [opaque_identity] behaves like an
     unknown (and thus possibly side-effecting) function.
 

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly_native.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly_native.ml
@@ -58,3 +58,10 @@ let () =
   Printf.printf "%s\n" (revapply "abcde" (fun x -> x));
   ()
 
+let () =
+  Printf.printf "%s\n" (N.to_string (Sys.opaque_identity #1n));
+  Printf.printf "%s\n" (I32.to_string (Sys.opaque_identity #2l));
+  Printf.printf "%s\n" (I64.to_string (Sys.opaque_identity #3L));
+  Printf.printf "%s\n" (F.to_string (Sys.opaque_identity #4.));
+  Printf.printf "%s\n" (Sys.opaque_identity "abcde");
+  ()

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly_native.reference
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly_native.reference
@@ -23,3 +23,8 @@ abcde
 3
 4.
 abcde
+1
+2
+3
+4.
+abcde


### PR DESCRIPTION
Use the new `[@layout_poly]` attribute on `Sys.opaque_identity`.

Wonder if `Obj.magic` should get the same treatment.