### PR TITLE
`Ast_mapper` and `Ast_iterator` should traverse location inside mode expressions

### DIFF
--- a/ocaml/parsing/ast_iterator.ml
+++ b/ocaml/parsing/ast_iterator.ml
@@ -774,8 +774,6 @@ module CE = struct
     sub.attributes sub pci_attributes
 end
 
-module ME = Jane_syntax.Mode_expr
-
 (* Now, a generic AST mapper, to be extended to cover all kinds and
    cases of the OCaml grammar.  The default behavior of the mapper is
    the identity. *)
@@ -972,8 +970,9 @@ let default_iterator =
     attributes = (fun this l -> List.iter (this.attribute this) l);
     (* Location inside a mode expression needs to be traversed. *)
     modes = (fun this m ->
-      let iter_const sub : ME.Const.t -> _ =
-        fun m -> iter_loc sub (m : ME.Const.t :> _ Location.loc)
+      let open Jane_syntax.Mode_expr in
+      let iter_const sub : Const.t -> _ =
+        fun m -> iter_loc sub (m : Const.t :> _ Location.loc)
       in
       iter_loc_txt this (fun sub -> List.iter (iter_const sub)) m);
     payload =

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -925,26 +925,9 @@ let default_mapper =
     value_description =
       (fun this {pval_name; pval_type; pval_prim; pval_loc;
                  pval_attributes} ->
-        let modes, ptyp_attributes =
-          Jane_syntax.Mode_expr.maybe_of_attrs pval_type.ptyp_attributes
-        in
-        let pval_type = { pval_type with ptyp_attributes } in
-        let pval_type = this.typ this pval_type in
-        let attr =
-          match modes with
-          | None -> None
-          | Some modes ->
-              let modes = this.modes this modes in
-              Jane_syntax.Mode_expr.attr_of modes
-        in
-        let pval_type =
-          match attr with
-          | None -> pval_type
-          | Some attr -> {pval_type with ptyp_attributes = attr :: pval_type.ptyp_attributes}
-        in
         Val.mk
           (map_loc this pval_name)
-          pval_type
+          (this.typ this pval_type)
           ~attrs:(this.attributes this pval_attributes)
           ~loc:(this.location this pval_loc)
           ~prim:pval_prim

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -106,16 +106,13 @@ let map_loc sub {loc; txt} = {loc = sub.location sub loc; txt}
 let map_loc_txt sub f {loc; txt} =
   {loc = sub.location sub loc; txt = f sub txt}
 
-module ME = Jane_syntax.Mode_expr
-
 let map_mode_and_attributes sub attrs =
-  let modes, attrs =
-    Jane_syntax.Mode_expr.maybe_of_attrs attrs
-  in
+  let open Jane_syntax.Mode_expr in
+  let modes, attrs = maybe_of_attrs attrs in
   let mode_attr =
     match modes with
     | Some modes ->
-      Option.to_list (sub.modes sub modes |> ME.attr_of)
+      Option.to_list (sub.modes sub modes |> attr_of)
     | None -> []
   in
   mode_attr @ sub.attributes sub attrs

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -106,17 +106,19 @@ let map_loc sub {loc; txt} = {loc = sub.location sub loc; txt}
 let map_loc_txt sub f {loc; txt} =
   {loc = sub.location sub loc; txt = f sub txt}
 
-let map_mode_expr sub (mode_expr : Jane_syntax.Mode_expr.t)
-  : Jane_syntax.Mode_expr.t =
-  map_loc_txt sub
-    (fun sub modes ->
-       List.map
-         (fun (mode : Jane_syntax.Mode_expr.Const.t) ->
-            let { loc; txt } = (mode :> string loc) in
-            let loc = sub.location sub loc in
-            Jane_syntax.Mode_expr.Const.mk txt loc)
-         modes)
-    mode_expr
+module ME = Jane_syntax.Mode_expr
+
+let map_mode_and_attributes sub attrs =
+  let modes, attrs =
+    Jane_syntax.Mode_expr.maybe_of_attrs attrs
+  in
+  let mode_attr =
+    match modes with
+    | Some modes ->
+      Option.to_list (sub.modes sub modes |> ME.attr_of)
+    | None -> []
+  in
+  mode_attr @ sub.attributes sub attrs
 
 module C = struct
   (* Constants *)
@@ -201,12 +203,12 @@ module T = struct
     let loc = sub.location sub loc in
     match Jane_syntax.Core_type.of_ast typ with
     | Some (jtyp, attrs) -> begin
-        let attrs = sub.attributes sub attrs in
+        let attrs = map_mode_and_attributes sub attrs in
         let jtyp = sub.typ_jane_syntax sub jtyp in
         Jane_syntax.Core_type.core_type_of jtyp ~loc ~attrs
     end
     | None ->
-    let attrs = sub.attributes sub attrs in
+    let attrs = map_mode_and_attributes sub attrs in
     match desc with
     | Ptyp_any -> any ~loc ~attrs ()
     | Ptyp_var s -> var ~loc ~attrs s
@@ -646,7 +648,7 @@ module E = struct
   let map_modes_exp sub : Modes.expression -> Modes.expression = function
     (* CR modes: One day mappers might want to see the modes *)
     | Coerce (modes, exp) ->
-        Coerce (map_mode_expr sub modes, sub.expr sub exp)
+        Coerce (sub.modes sub modes, sub.expr sub exp)
 
   let map_jst sub : Jane_syntax.Expression.t -> Jane_syntax.Expression.t =
     function
@@ -790,11 +792,11 @@ module P = struct
     let loc = sub.location sub loc in
     match Jane_syntax.Pattern.of_ast pat with
     | Some (jpat, attrs) -> begin
-        let attrs = sub.attributes sub attrs in
+        let attrs = map_mode_and_attributes sub attrs in
         Jane_syntax.Pattern.pat_of ~loc ~attrs (sub.pat_jane_syntax sub jpat)
     end
     | None ->
-    let attrs = sub.attributes sub attrs in
+    let attrs = map_mode_and_attributes sub attrs in
     match desc with
     | Ppat_any -> any ~loc ~attrs ()
     | Ppat_var s -> var ~loc ~attrs (map_loc sub s)
@@ -890,8 +892,6 @@ module CE = struct
       (map_loc sub pci_name)
       (f pci_expr)
 end
-
-module ME = Jane_syntax.Mode_expr
 
 (* Now, a generic AST mapper, to be extended to cover all kinds and
    cases of the OCaml grammar.  The default behavior of the mapper is
@@ -1042,7 +1042,7 @@ let default_mapper =
            (this.expr this pvb_expr)
            ?value_constraint:(Option.map map_ct pvb_constraint)
            ~loc:(this.location this pvb_loc)
-           ~attrs:(this.attributes this pvb_attributes)
+           ~attrs:(map_mode_and_attributes this pvb_attributes)
       );
 
 
@@ -1098,12 +1098,7 @@ let default_mapper =
         attr_loc = this.location this a.attr_loc
       }
     );
-    attributes = (fun this l ->
-      List.filter_map (fun attr ->
-        let m, _ = ME.maybe_of_attrs [attr] in
-        match m with
-        | Some m -> this.modes this m |> ME.attr_of
-        | None -> Some (this.attribute this attr)) l);
+    attributes = (fun this l -> List.map (this.attribute this) l);
 
     payload =
       (fun this -> function

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -643,7 +643,6 @@ module E = struct
     | el -> List.map (map_snd (sub.expr sub)) el
 
   let map_modes_exp sub : Modes.expression -> Modes.expression = function
-    (* CR modes: One day mappers might want to see the modes *)
     | Coerce (modes, exp) ->
         Coerce (sub.modes sub modes, sub.expr sub exp)
 

--- a/ocaml/testsuite/tests/parsetree/modes_ast_mapper.ml
+++ b/ocaml/testsuite/tests/parsetree/modes_ast_mapper.ml
@@ -19,10 +19,11 @@ let mapper: Ast_mapper.mapper =
 let test mapper s =
   let p = Lexing.from_string s |> Parse.implementation in
   ignore (mapper.Ast_mapper.structure mapper p);
-  Format.printf "------------------------------"
+  Format.printf "------------------------------\n"
 
 let () =
   test mapper "let f (local_ x) = x";
   test mapper "let unique_ f (local_ x) = x";
   test mapper "let local_ f x: int -> int = x";
+  test mapper "module M : sig val x : string -> string @ foo @@ bar hello end = struct end";
   ()

--- a/ocaml/testsuite/tests/parsetree/modes_ast_mapper.ml
+++ b/ocaml/testsuite/tests/parsetree/modes_ast_mapper.ml
@@ -1,0 +1,28 @@
+(* TEST
+    include ocamlcommon
+*)
+
+let mode_to_string (m : Jane_syntax.Mode_expr.t) =
+  List.map (fun m ->
+    (m : Jane_syntax.Mode_expr.Const.t :> _ Location.loc).txt
+  ) m.txt
+  |> String.concat " "
+let mapper: Ast_mapper.mapper =
+  let open Ast_mapper in
+  { default_mapper with
+  modes = fun sub m ->
+    Format.printf "%s [%a]\n"
+      (mode_to_string m)
+      Location.print_loc m.loc;
+    default_mapper.modes sub m}
+
+let test mapper s =
+  let p = Lexing.from_string s |> Parse.implementation in
+  ignore (mapper.Ast_mapper.structure mapper p);
+  Format.printf "------------------------------"
+
+let () =
+  test mapper "let f (local_ x) = x";
+  test mapper "let unique_ f (local_ x) = x";
+  test mapper "let local_ f x: int -> int = x";
+  ()

--- a/ocaml/testsuite/tests/parsetree/modes_ast_mapper.reference
+++ b/ocaml/testsuite/tests/parsetree/modes_ast_mapper.reference
@@ -1,0 +1,8 @@
+local [File "_none_", line 1, characters 7-13]
+------------------------------local [File "_none_", line 1, characters 15-21]
+unique [File "_none_", line 1, characters 4-11]
+unique [File "_none_", line 1, characters 4-11]
+------------------------------local [File "_none_", line 1, characters 29-30]
+local [File "_none_", line 1, characters 4-10]
+local [File "_none_", line 1, characters 4-10]
+------------------------------

--- a/ocaml/testsuite/tests/parsetree/modes_ast_mapper.reference
+++ b/ocaml/testsuite/tests/parsetree/modes_ast_mapper.reference
@@ -1,8 +1,13 @@
-local [File "_none_", line 1, characters 7-13]
-------------------------------local [File "_none_", line 1, characters 15-21]
+local [File "_none_", line 1]
+------------------------------
+local [File "_none_", line 1]
 unique [File "_none_", line 1, characters 4-11]
 unique [File "_none_", line 1, characters 4-11]
-------------------------------local [File "_none_", line 1, characters 29-30]
+------------------------------
+local [File "_none_", line 1, characters 29-30]
 local [File "_none_", line 1, characters 4-10]
 local [File "_none_", line 1, characters 4-10]
+------------------------------
+bar hello [File "_none_", line 1, characters 49-58]
+foo [File "_none_", line 1]
 ------------------------------

--- a/ocaml/testsuite/tests/parsetree/source_jane_street.ml
+++ b/ocaml/testsuite/tests/parsetree/source_jane_street.ml
@@ -85,6 +85,7 @@ let g () =
   let unique_ once_ f : 'a . 'a -> 'a = fun x -> x in
   let once_ local_ f x y = x + y in
   let local_ unique_ once_ f : int -> int = fun z -> z + z in
+  let local_ f x: int -> int = x in
   (* nroberts: we should reenable this test when we fix
    * pprint_ast to put the (int -> int) annotation back in
    * the correct position. *)

--- a/ocaml/testsuite/tests/typing-modes/modes.ml
+++ b/ocaml/testsuite/tests/typing-modes/modes.ml
@@ -337,8 +337,8 @@ module type S = sig
   val x : string -> string @ local @@ foo bar
 end
 [%%expect{|
-Line 337, characters 38-45:
-337 |   val x : string -> string @ local @@ foo bar
-                                            ^^^^^^^
+Line 2, characters 38-45:
+2 |   val x : string -> string @ local @@ foo bar
+                                          ^^^^^^^
 Error: Modalities on value descriptions are not supported yet.
 |}]


### PR DESCRIPTION
This PR tries to fix two issues:

1. Before this PR, `Ast_mapper` maps over mode expressions as normal attributes all except for ones in `N_ary.function_constraint` which just get ignored (see broken test that triggers this). This PR aims to make this more consistent and adds a `modes` mapper function that applies to all mode expressions. The default mapper will also be responsible for descending into location fields.

2. `Ast_iterator` also ignores modes inside `N_ary.function_constraint` and the default iterator function doesn't descend into location fields. This PR changes this and bring it in line with the new mapper.

Request review from @riaqn 

Extra context: I'm working on modal kind syntax where we want to embed mode expressions in kind annotations. The implementation is similar to how `N_ary_functions` carries mode expressions. That's how I originally ran into the issue with ast_mapper.
