### PR TITLE
Disable stack checks for generated functions

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1864,7 +1864,7 @@ let fundecl fundecl =
   let handle_overflow_and_max_frame_size =
     (* CR mshinwell: this should be conditionalized on a specific
        "stack checks enabled" config option, so we can backport to 4.x *)
-    if not Config.runtime5 then None
+    if not Config.runtime5 || fundecl.fun_no_stack_check then None
     else (
       if !Clflags.runtime_variant = "d" then
         emit_call (Cmm.global_symbol "caml_assert_stack_invariants");

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -48,6 +48,7 @@ type basic_block =
 type codegen_option =
   | Reduce_code_size
   | No_CSE
+  | No_stack_check
 
 let rec of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list =
  fun cmm_options ->
@@ -57,6 +58,7 @@ let rec of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list =
     match hd with
     | No_CSE -> No_CSE :: of_cmm_codegen_option tl
     | Reduce_code_size -> Reduce_code_size :: of_cmm_codegen_option tl
+    | No_stack_check -> No_stack_check :: of_cmm_codegen_option tl
     | Use_linscan_regalloc | Ignore_assert_all Zero_alloc | Assume _ | Check _
       ->
       of_cmm_codegen_option tl)

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -73,6 +73,7 @@ type basic_block =
 type codegen_option =
   | Reduce_code_size
   | No_CSE
+  | No_stack_check
 
 val of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list
 

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -435,7 +435,8 @@ let run cfg_with_layout =
     fun_num_stack_slots;
     fun_frame_required;
     fun_prologue_required;
-    fun_section_name
+    fun_section_name;
+    fun_no_stack_check = List.mem Cfg.No_stack_check cfg.fun_codegen_options
   }
 
 let layout_of_block_list : Cfg.basic_block list -> Cfg_with_layout.layout =

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -384,7 +384,8 @@ end = struct
             None
           | Ignore_assert_all _ | Check _ | Assume _ | Reduce_code_size | No_CSE
           | Use_linscan_regalloc ->
-            None)
+            None
+          | No_stack_check -> None)
         codegen_options
     in
     match a with

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -304,6 +304,7 @@ type codegen_option =
   | Assume of { property: property; strict: bool; never_returns_normally: bool;
                 loc: Location.t }
   | Check of { property: property; strict: bool; loc : Location.t; }
+  | No_stack_check
 
 type fundecl =
   { fun_name: symbol;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -312,6 +312,7 @@ type codegen_option =
   | Assume of { property: property; strict: bool; never_returns_normally: bool;
                 loc: Location.t }
   | Check of { property: property; strict: bool; loc: Location.t }
+  | No_stack_check
 
 type fundecl =
   { fun_name: symbol;

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2494,7 +2494,7 @@ let send_function (arity, result, mode) =
     { fun_name;
       fun_args = List.map (fun (arg, ty) -> VP.create arg, ty) fun_args;
       fun_body = body;
-      fun_codegen_options = [];
+      fun_codegen_options = [No_stack_check];
       fun_dbg;
       fun_poll = Default_poll
     }
@@ -2508,7 +2508,7 @@ let apply_function (arity, result, mode) =
     { fun_name;
       fun_args = List.map (fun (arg, ty) -> VP.create arg, ty) all_args;
       fun_body = body;
-      fun_codegen_options = [];
+      fun_codegen_options = [No_stack_check];
       fun_dbg;
       fun_poll = Default_poll
     }
@@ -2546,7 +2546,7 @@ let tuplify_function arity return =
             :: access_components 0
             @ [Cvar clos],
             dbg () );
-      fun_codegen_options = [];
+      fun_codegen_options = [No_stack_check];
       fun_dbg;
       fun_poll = Default_poll
     }
@@ -2688,7 +2688,7 @@ let final_curry_function nlocal arity result =
       fun_body =
         make_curry_apply result narity (List.tl args_type) [Cvar last_arg]
           last_clos (narity - 1);
-      fun_codegen_options = [];
+      fun_codegen_options = [No_stack_check];
       fun_dbg;
       fun_poll = Default_poll
     }
@@ -2748,7 +2748,7 @@ let intermediate_curry_functions ~nlocal ~arity result =
                 @ value_slot_given_machtype args
                 @ [Cvar clos],
                 dbg () );
-          fun_codegen_options = [];
+          fun_codegen_options = [No_stack_check];
           fun_dbg;
           fun_poll = Default_poll
         }
@@ -2779,7 +2779,7 @@ let intermediate_curry_functions ~nlocal ~arity result =
                   (arg_type :: accumulated_args)
                   (List.map (fun (arg, _) -> Cvar arg) direct_args)
                   clos (num + 1);
-              fun_codegen_options = [];
+              fun_codegen_options = [No_stack_check];
               fun_dbg;
               fun_poll = Default_poll
             }

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -64,6 +64,7 @@ type fundecl =
     fun_frame_required: bool;
     fun_prologue_required: bool;
     fun_section_name: string option;
+    fun_no_stack_check : bool;
   }
 
 (* Invert a test *)

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -66,6 +66,7 @@ type fundecl =
     fun_frame_required: bool;
     fun_prologue_required: bool;
     fun_section_name: string option;
+    fun_no_stack_check : bool;
   }
 
 val traps_to_bytes : int -> int

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -394,6 +394,7 @@ let codegen_option = function
     Printf.sprintf "assert_%s%s"
       (property_to_string property)
       (if strict then "_strict" else "")
+  | No_stack_check -> "no_stack_check"
 
 let print_codegen_options ppf l =
   List.iter (fun c -> fprintf ppf " %s" (codegen_option c)) l

--- a/backend/schedgen.ml
+++ b/backend/schedgen.ml
@@ -390,6 +390,7 @@ method schedule_fundecl f =
       fun_frame_required = f.fun_frame_required;
       fun_prologue_required = f.fun_prologue_required;
       fun_section_name = f.fun_section_name;
+      fun_no_stack_check = f.fun_no_stack_check;
     }
   end else
     f


### PR DESCRIPTION
This pull request disables the stack checks for
"generated" functions (_i.e._ `caml_apply`,
`caml_currify`, `caml_send`, and `caml_tuplify`)
by introducing a "codegen" option disabling
the check for a given function.