### PR TITLE
Move the `Uniqueness` axis into the `Monadic` fragment

### DIFF
--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -2052,6 +2052,7 @@ typing/typemod.cmo : \
     parsing/jane_syntax.cmi \
     typing/includemod_errorprinter.cmi \
     typing/includemod.cmi \
+    typing/includecore.cmi \
     utils/import_info.cmi \
     typing/ident.cmi \
     typing/envaux.cmi \
@@ -2094,6 +2095,7 @@ typing/typemod.cmx : \
     parsing/jane_syntax.cmx \
     typing/includemod_errorprinter.cmx \
     typing/includemod.cmx \
+    typing/includecore.cmx \
     utils/import_info.cmx \
     typing/ident.cmx \
     typing/envaux.cmx \
@@ -2127,15 +2129,15 @@ typing/typemod.cmi : \
     utils/compilation_unit.cmi \
     file_formats/cmi_format.cmi
 typing/typemode.cmo : \
+    utils/warnings.cmi \
     typing/mode.cmi \
-    utils/misc.cmi \
     parsing/location.cmi \
     parsing/jane_syntax_parsing.cmi \
     parsing/jane_syntax.cmi \
     typing/typemode.cmi
 typing/typemode.cmx : \
+    utils/warnings.cmx \
     typing/mode.cmx \
-    utils/misc.cmx \
     parsing/location.cmx \
     parsing/jane_syntax_parsing.cmx \
     parsing/jane_syntax.cmx \
@@ -2294,7 +2296,8 @@ typing/typetexp.cmi : \
     typing/jkind.cmi \
     parsing/jane_asttypes.cmi \
     typing/errortrace.cmi \
-    typing/env.cmi
+    typing/env.cmi \
+    parsing/asttypes.cmi
 typing/uniqueness_analysis.cmo : \
     typing/types.cmi \
     typing/typedtree.cmi \

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1196,7 +1196,10 @@ module Comonadic_with_regionality = struct
       (C.lift SLinearity (Const_min Linearity))
       (S.Positive.disallow_right m)
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy m =
+    let regionality = regionality m |> Regionality.zap_to_legacy in
+    let linearity = linearity m |> Linearity.zap_to_legacy in
+    regionality, linearity
 
   let legacy = of_const Const.legacy
 
@@ -1285,7 +1288,10 @@ module Comonadic_with_locality = struct
       (C.lift SLinearity (Const_min Linearity))
       (S.Positive.disallow_right m)
 
-  let zap_to_legacy = zap_to_floor
+  let zap_to_legacy m =
+    let locality = locality m |> Locality.zap_to_legacy in
+    let linearity = linearity m |> Linearity.zap_to_legacy in
+    locality, linearity
 
   let legacy = of_const Const.legacy
 
@@ -1351,7 +1357,9 @@ module Monadic = struct
       (C.lift SUniqueness (Const_max Uniqueness_op))
       (S.Negative.disallow_right m)
 
-  let zap_to_legacy = zap_to_ceil
+  let zap_to_legacy m =
+    let uniqueness = uniqueness m |> Uniqueness.zap_to_legacy in
+    uniqueness, ()
 
   let legacy = of_const Const.legacy
 

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -666,8 +666,8 @@ module Lattices_mono = struct
       | Max_with ax -> Format.fprintf ppf "max_with_%a" print_axis ax
       | Min_with ax -> Format.fprintf ppf "min_with_%a" print_axis ax
       | Map_comonadic (f0, f1) ->
-        Format.fprintf ppf "map(%a,%a)" print_morph f0 print_morph f1
-      | Map_monadic f0 -> Format.fprintf ppf "map(%a)" print_morph f0
+        Format.fprintf ppf "map_comonadic(%a,%a)" print_morph f0 print_morph f1
+      | Map_monadic f0 -> Format.fprintf ppf "map_monadic(%a)" print_morph f0
       | Unique_to_linear -> Format.fprintf ppf "unique_to_linear"
       | Linear_to_unique -> Format.fprintf ppf "linear_to_unique"
       | Local_to_regional -> Format.fprintf ppf "local_to_regional"
@@ -1312,9 +1312,7 @@ module Comonadic_with_locality = struct
 end
 
 module Monadic = struct
-  module Const = struct
-    include C.Monadic
-  end
+  module Const = C.Monadic
 
   module Obj = struct
     type const = Const.t
@@ -1362,9 +1360,8 @@ module Monadic = struct
     match submode m0 m1 with
     | Ok () -> Ok ()
     | Error { left = uni0, (); right = uni1, () } ->
-      if Uniqueness.Const.le uni0 uni1
-      then assert false
-      else Error (`Uniqueness { left = uni0; right = uni1 })
+      assert (not (Uniqueness.Const.le uni0 uni1));
+      Error (`Uniqueness { left = uni0; right = uni1 })
 
   (* override to report the offending axis *)
   let equate = equate_from_submode submode

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1339,6 +1339,10 @@ module Monadic = struct
   let uniqueness m =
     S.Negative.via_monotone Uniqueness.Obj.obj (Proj (Obj.obj, Uniqueness)) m
 
+  (* The monadic fragment is inverted. Most of the inversion logic is taken care
+     by [Solver_polarized], but some remain, such as the [Min_with] below which
+     is inverted from [Max_with]. *)
+
   let max_with_uniqueness m =
     S.Negative.via_monotone Obj.obj (Min_with Uniqueness)
       (S.Negative.disallow_left m)
@@ -1368,8 +1372,9 @@ module Monadic = struct
     match submode m0 m1 with
     | Ok () -> Ok ()
     | Error { left = uni0, (); right = uni1, () } ->
-      assert (not (Uniqueness.Const.le uni0 uni1));
-      Error (`Uniqueness { left = uni0; right = uni1 })
+      if Uniqueness.Const.le uni0 uni1
+      then assert false
+      else Error (`Uniqueness { left = uni0; right = uni1 })
 
   (* override to report the offending axis *)
   let equate = equate_from_submode submode

--- a/ocaml/typing/solver.ml
+++ b/ocaml/typing/solver.ml
@@ -805,7 +805,10 @@ module Solvers_polarized (C : Lattices_mono) = struct
 
     let newvar = S.newvar
 
-    let submode obj m0 m1 = S.submode obj m1 m0
+    let submode obj m0 m1 =
+      Result.map_error
+        (fun { left; right } -> { left = right; right = left })
+        (S.submode obj m1 m0)
 
     let join = S.meet
 


### PR DESCRIPTION
This PR introduces the object representing the monadic fragment to the mode system, and moves the uniqueness axis into the monadic fragment. 

Currently the monadic fragment contains only the uniqueness axis, which means this PR is not observable externally. However, we will very soon add more axes (`contention`) to the monadic fragment.

Request review from @goldfirere  - I think it's better to review per-commit.