### PR TITLE
Full blown Jane Syntax for mode exprs

### DIFF
--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -1138,8 +1138,7 @@ typing/mode.cmi : \
     typing/mode_intf.cmi
 typing/mode_intf.cmi : \
     typing/solver_intf.cmi \
-    typing/solver.cmi \
-    utils/misc.cmi
+    typing/solver.cmi
 typing/mtype.cmo : \
     typing/types.cmi \
     typing/subst.cmi \
@@ -1991,6 +1990,7 @@ typing/typedtree.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/jkind.cmi \
+    parsing/jane_syntax.cmi \
     parsing/jane_asttypes.cmi \
     typing/ident.cmi \
     typing/env.cmi \
@@ -2006,6 +2006,7 @@ typing/typedtree.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/jkind.cmx \
+    parsing/jane_syntax.cmx \
     parsing/jane_asttypes.cmx \
     typing/ident.cmx \
     typing/env.cmx \
@@ -2021,6 +2022,7 @@ typing/typedtree.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/jkind.cmi \
+    parsing/jane_syntax.cmi \
     parsing/jane_asttypes.cmi \
     typing/ident.cmi \
     typing/env.cmi \
@@ -4176,13 +4178,11 @@ lambda/transl_array_comprehension.cmi : \
     lambda/debuginfo.cmi
 lambda/transl_comprehension_utils.cmo : \
     utils/targetint.cmi \
-    typing/primitive.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
     lambda/transl_comprehension_utils.cmi
 lambda/transl_comprehension_utils.cmx : \
     utils/targetint.cmx \
-    typing/primitive.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
     lambda/transl_comprehension_utils.cmi

--- a/ocaml/boot/menhir/parser.ml
+++ b/ocaml/boot/menhir/parser.ml
@@ -379,7 +379,7 @@ let mkexp_with_modes ?(ghost=false) ~loc modes exp =
   let loc =
     if ghost then ghost_loc loc else make_loc loc
   in
-  Mode.expr_of_coerce ~loc modes exp
+  Jane_syntax.Modes.expr_of ~loc (Coerce (modes, exp))
 
 (* For modes-related attributes, no need to call [register_attr] because they
 result from native syntax which is only parsed at proper places that are

--- a/ocaml/parsing/ast_invariants.ml
+++ b/ocaml/parsing/ast_invariants.ml
@@ -147,6 +147,7 @@ let iterator =
     | Jexp_comprehension _
     | Jexp_immutable_array _
     | Jexp_layout _
+    | Jexp_modes _
       -> ()
   in
   let expr self exp =

--- a/ocaml/parsing/ast_iterator.mli
+++ b/ocaml/parsing/ast_iterator.mli
@@ -46,7 +46,6 @@ type iterator = {
   constructor_declaration: iterator -> constructor_declaration -> unit;
   expr: iterator -> expression -> unit;
   expr_jane_syntax : iterator -> Jane_syntax.Expression.t -> unit;
-  expr_mode_syntax: iterator -> Jane_syntax.Mode_expr.t -> expression -> unit;
   extension: iterator -> extension -> unit;
   extension_constructor: iterator -> extension_constructor -> unit;
   include_declaration: iterator -> include_declaration -> unit;

--- a/ocaml/parsing/depend.ml
+++ b/ocaml/parsing/depend.ml
@@ -332,6 +332,11 @@ and add_expr_jane_syntax bv : Jane_syntax.Expression.t -> _ = function
   | Jexp_layout x -> add_layout_expr bv x
   | Jexp_n_ary_function n_ary -> add_n_ary_function bv n_ary
   | Jexp_tuple x -> add_labeled_tuple_expr bv x
+  | Jexp_modes x -> add_modes_expr bv x
+
+and add_modes_expr bv : Jane_syntax.Modes.expression -> _ =
+  function
+  | Coerce (_modes, exp) -> add_expr bv exp
 
 and add_comprehension_expr bv : Jane_syntax.Comprehensions.expression -> _ =
   function

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -459,8 +459,6 @@ module Mode_expr = struct
 
   let attribute_name = attribute_or_extension_name
 
-  let extension_name = attribute_or_extension_name
-
   let payload_of { txt; _ } =
     match txt with
     | [] -> None
@@ -508,26 +506,36 @@ module Mode_expr = struct
     let loc = { loc with loc_ghost = true } in
     let txt = List.map Const.ghostify txt in
     { loc; txt }
+end
 
-  let coerce_of_expr { pexp_desc; _ } =
+(** Some mode-related constructs *)
+module Modes = struct
+  let feature : Feature.t = Language_extension Mode
+
+  type nonrec expression = Coerce of Mode_expr.t * expression
+
+  let extension_name = Mode_expr.attribute_or_extension_name
+
+  let of_expr { pexp_desc; pexp_attributes; _ } =
     match pexp_desc with
     | Pexp_apply
         ( { pexp_desc = Pexp_extension ({ txt; _ }, payload); pexp_loc; _ },
           [(Nolabel, body)] )
       when txt = extension_name ->
-      let modes = of_payload ~loc:pexp_loc payload in
-      Some (modes, body)
+      let modes = Mode_expr.of_payload ~loc:pexp_loc payload in
+      Some (Coerce (modes, body), pexp_attributes)
     | _ -> None
 
-  let expr_of_coerce ~loc modes body =
-    match payload_of modes with
+  let expr_of ~loc (Coerce (modes, body)) =
+    match Mode_expr.payload_of modes with
     | None -> body
     | Some payload ->
       let ext =
         Ast_helper.Exp.extension ~loc:modes.loc
           (Location.mknoloc extension_name, payload)
       in
-      Ast_helper.Exp.apply ~loc ext [Nolabel, body]
+      Expression.make_entire_jane_syntax ~loc feature (fun () ->
+          Ast_helper.Exp.apply ~loc ext [Nolabel, body])
 end
 
 (** List and array comprehensions *)
@@ -1911,6 +1919,7 @@ module Expression = struct
     | Jexp_layout of Layouts.expression
     | Jexp_n_ary_function of N_ary_functions.expression
     | Jexp_tuple of Labeled_tuples.expression
+    | Jexp_modes of Modes.expression
 
   let of_ast_internal (feat : Feature.t) expr =
     match feat with
@@ -1930,6 +1939,10 @@ module Expression = struct
     | Language_extension Labeled_tuples ->
       let expr, attrs = Labeled_tuples.of_expr expr in
       Some (Jexp_tuple expr, attrs)
+    | Language_extension Mode -> (
+      match Modes.of_expr expr with
+      | Some (expr, attrs) -> Some (Jexp_modes expr, attrs)
+      | None -> None)
     | _ -> None
 
   let of_ast = Expression.make_of_ast ~of_ast_internal
@@ -1942,6 +1955,7 @@ module Expression = struct
       | Jexp_layout x -> Layouts.expr_of ~loc x
       | Jexp_n_ary_function x -> N_ary_functions.expr_of ~loc x
       | Jexp_tuple x -> Labeled_tuples.expr_of ~loc x
+      | Jexp_modes x -> Modes.expr_of ~loc x
     in
     (* Performance hack: save an allocation if [attrs] is empty. *)
     match attrs with

--- a/ocaml/parsing/jane_syntax.mli
+++ b/ocaml/parsing/jane_syntax.mli
@@ -159,18 +159,25 @@ module Mode_expr : sig
       attribute is found. *)
   val of_attrs : Parsetree.attributes -> t * Parsetree.attributes
 
-  (** Decode mode coercion and returns the mode and the body.
-      For example, return [Some (local, expr)] on input [local_ expr].
-      Returns [None] if the given expression is not a mode coercion. *)
-  val coerce_of_expr : Parsetree.expression -> (t * Parsetree.expression) option
-
-  (** Encode a mode coercion like [local_ expr] into an expression *)
-  val expr_of_coerce :
-    loc:Location.t -> t -> Parsetree.expression -> Parsetree.expression
-
   (** In some cases, a single mode expression appears twice in the parsetree;
       one of them needs to be made ghost to make our internal tools happy. *)
   val ghostify : t -> t
+end
+
+(** A subset of the mode-related syntax extensions that is embedded
+    using full-blown Jane Syntax. By "full-blown" Jane Syntax, we
+    mean the [Expression], [Pattern], (etc.) modules below that
+    attempt to create a variant of all possible Jane Street syntax
+    for the syntactic form.
+
+    We avoid full-blown Jane Syntax when it isn't very lightweight to fit the
+    new construct into the (somewhat opinionated) framework. Mode coercions are
+    lightweight to fit into full-blown Jane Syntax.
+*)
+module Modes : sig
+  type expression = Coerce of Mode_expr.t * Parsetree.expression
+
+  val expr_of : loc:Location.t -> expression -> Parsetree.expression
 end
 
 module N_ary_functions : sig
@@ -586,6 +593,7 @@ module Expression : sig
     | Jexp_layout of Layouts.expression
     | Jexp_n_ary_function of N_ary_functions.expression
     | Jexp_tuple of Labeled_tuples.expression
+    | Jexp_modes of Modes.expression
 
   include
     AST

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -154,7 +154,7 @@ let mkexp_with_modes ?(ghost=false) ~loc modes exp =
   let loc =
     if ghost then ghost_loc loc else make_loc loc
   in
-  Mode.expr_of_coerce ~loc modes exp
+  Jane_syntax.Modes.expr_of ~loc (Coerce (modes, exp))
 
 (* For modes-related attributes, no need to call [register_attr] because they
 result from native syntax which is only parsed at proper places that are

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -788,10 +788,6 @@ and sugar_expr ctxt f e =
    expressions that aren't already self-delimiting.
 *)
 and expression ?(jane_syntax_parens = false) ctxt f x =
-  match Jane_syntax.Mode_expr.coerce_of_expr x with
-  | Some (m, body) ->
-    pp f "@[<2>%s %a@]" (modes m) (expression ctxt) body
-  | None ->
   match Jane_syntax.Expression.of_ast x with
   | Some (jexpr, attrs) ->
       jane_syntax_expr ctxt attrs f jexpr ~parens:jane_syntax_parens
@@ -1484,9 +1480,6 @@ and payload ctxt f = function
       pp f " when "; expression ctxt f e
 
 and pp_print_pexp_function ctxt sep f x =
-  (* do not print [@jane.erasable.mode] on expressions *)
-  let _, attrs = maybe_modes_of_attrs x.pexp_attributes in
-  let x = { x with pexp_attributes = attrs } in
   (* We go to some trouble to print nested [Pexp_newtype]/[Lexp_newtype] as
      newtype parameters of the same "fun" (rather than printing several nested
      "fun (type a) -> ..."). This isn't necessary for round-tripping -- it just
@@ -1586,15 +1579,32 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; pvb_constraint = ct; _} =
 (* [in] is not printed *)
 and bindings ctxt f (rf,l) =
   let binding kwd rf f x =
-    let modes, attrs = maybe_modes_of_attrs x.pvb_attributes in
+    let modes_on_binding, attrs =
+      Jane_syntax.Mode_expr.maybe_of_attrs x.pvb_attributes
+    in
     let x =
-      match modes, Jane_syntax.Mode_expr.coerce_of_expr x.pvb_expr with
-      | Some _ , Some (_, sbody) ->
-          {x with pvb_expr = sbody}
+      (* For [let local_ x = e in ...] and [let x @ local = e in ...],
+         the parser puts attributes on both the let-binding and on e.
+
+         The below code is meant to print the modes only in one place,
+         not both. (We print it on the let-binding, not the expression.)
+      *)
+      match modes_on_binding, Jane_syntax.Expression.of_ast x.pvb_expr with
+      | Some modes_on_binding,
+        Some (Jexp_modes (Coerce (modes_on_expr, sbody)), _) ->
+          let mode_names (modes : Jane_syntax.Mode_expr.t) =
+            List.map Location.get_txt (modes.txt :> string loc list)
+          in
+          if
+            List.equal String.equal
+              (mode_names modes_on_binding)
+              (mode_names modes_on_expr)
+          then {x with pvb_expr = sbody}
+          else x
       | _ -> x
     in
     pp f "@[<2>%s %a%s%a@]%a" kwd rec_flag rf
-      (match modes with Some s -> s ^ " " | None -> "")
+      (match modes_on_binding with Some s -> modes s ^ " " | None -> "")
       (binding ctxt) x (item_attributes ctxt) attrs
   in
   match l with
@@ -2006,6 +2016,11 @@ and jane_syntax_expr ctxt attrs f (jexp : Jane_syntax.Expression.t) ~parens =
       if parens then pp f "(%a)" (n_ary_function_expr reset_ctxt) x
       else n_ary_function_expr ctxt f x
   | Jexp_tuple ltexp        -> labeled_tuple_expr ctxt f ltexp
+  | Jexp_modes mexp -> mode_expr ctxt f mexp
+
+and mode_expr ctxt f (mexp : Jane_syntax.Modes.expression) =
+  match mexp with
+  | Coerce (m, body) -> pp f "@[<2>%s %a@]" (modes m) (expression ctxt) body
 
 and comprehension_expr ctxt f (cexp : Jane_syntax.Comprehensions.expression) =
   let punct, comp = match cexp with

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -1592,6 +1592,9 @@ and bindings ctxt f (rf,l) =
       match modes_on_binding, Jane_syntax.Expression.of_ast x.pvb_expr with
       | Some modes_on_binding,
         Some (Jexp_modes (Coerce (modes_on_expr, sbody)), _) ->
+          (* Sanity check: only suppress the printing of one mode expression if
+             the mode expressions are in fact identical.
+          *)
           let mode_names (modes : Jane_syntax.Mode_expr.t) =
             List.map Location.get_txt (modes.txt :> string loc list)
           in

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -380,8 +380,11 @@ and expression_extra i ppf x attrs =
       attributes i ppf attrs;
   | Texp_mode_coerce modes ->
       let modes = (modes :> string Location.loc list Location.loc) in
-      line i ppf "Texp_mode_coerce \"%s\"\n"
-        (String.concat "," (List.map Location.get_txt modes.txt));
+      line i ppf "Texp_mode_coerce %s\n"
+        (String.concat ","
+          (List.map
+            (fun loc -> Printf.sprintf "\"%s\"" loc.txt)
+            modes.txt));
       attributes i ppf attrs;
 
 and alloc_mode: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -378,6 +378,11 @@ and expression_extra i ppf x attrs =
   | Texp_newtype (s, lay) ->
       line i ppf "Texp_newtype %a\n" (typevar_jkind ~print_quote:false) (s, lay);
       attributes i ppf attrs;
+  | Texp_mode_coerce modes ->
+      let modes = (modes :> string Location.loc list Location.loc) in
+      line i ppf "Texp_mode_coerce \"%s\"\n"
+        (String.concat "," (List.map Location.get_txt modes.txt));
+      attributes i ppf attrs;
 
 and alloc_mode: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
   = fun i ppf m -> line i ppf "alloc_mode %a\n" (Mode.Alloc.print ()) m

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -265,6 +265,7 @@ let extra sub = function
       sub.typ sub cty2
   | Texp_newtype _ -> ()
   | Texp_poly cto -> Option.iter (sub.typ sub) cto
+  | Texp_mode_coerce _ -> ()
 
 let function_param sub { fp_loc; fp_kind; fp_newtypes; _ } =
   sub.location sub fp_loc;

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -366,6 +366,7 @@ let extra sub = function
     Texp_coerce (Option.map (sub.typ sub) cty1, sub.typ sub cty2)
   | Texp_newtype _ as d -> d
   | Texp_poly cto -> Texp_poly (Option.map (sub.typ sub) cto)
+  | Texp_mode_coerce modes -> Texp_mode_coerce modes
 
 let function_body sub body =
   match body with

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -5804,9 +5804,9 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_constraint (sarg, sty) ->
-      let sty, alloc_mode = alloc_mode_from_pexp_constraint_typ_attrs sty in
+      let sty, type_mode = alloc_mode_from_pexp_constraint_typ_attrs sty in
       let (ty, exp_extra) =
-        type_constraint env sty alloc_mode
+        type_constraint env sty type_mode
       in
       let ty' = instance ty in
       let error_message_attr_opt =

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -8664,6 +8664,9 @@ and type_mode_expr
       type_expect env expected_mode sbody (mk_expected ty_expected ?explanation)
     in
     {exp with
+     (* CR modes: We should consider not overriding [exp_loc] here -- that would
+        be more consistent to the typing of [Pexp_constraint].
+     *)
      exp_loc = loc;
      exp_extra = (Texp_mode_coerce modes, loc, attributes) :: exp.exp_extra}
 

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -121,6 +121,7 @@ and exp_extra =
   | Texp_coerce of core_type option * core_type
   | Texp_poly of core_type option
   | Texp_newtype of string * Jkind.annotation option
+  | Texp_mode_coerce of Jane_syntax.Mode_expr.t
 
 and expression_desc =
     Texp_ident of

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -209,6 +209,12 @@ and exp_extra =
         (** Used for method bodies. *)
   | Texp_newtype of string * Jkind.annotation option
         (** fun (type t : immediate) ->  *)
+  | Texp_mode_coerce of Jane_syntax.Mode_expr.t
+        (** local_ E *)
+
+(* CR modes: Consider fusing [Texp_mode_coerce] and [Texp_constraint] when
+   the syntax changes.
+*)
 
 (** Jkinds in the typed tree: Compilation of the typed tree to lambda
     sometimes requires jkind information.  Our approach is to

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -438,6 +438,10 @@ let exp_extra sub (extra, loc, attrs) sexp =
         Jane_syntax.Layouts.expr_of ~loc
           (Lexp_newtype(add_loc s, jkind, sexp))
         |> add_jane_syntax_attributes
+    | Texp_mode_coerce modes ->
+        Jane_syntax.Modes.expr_of ~loc
+          (Coerce (modes, sexp))
+        |> add_jane_syntax_attributes
   in
   Exp.mk ~loc ~attrs:!attrs desc
 
@@ -528,7 +532,8 @@ let expression sub exp =
                       (Pcoerce (Option.map (sub.typ sub) ty1, sub.typ sub ty2))
                 | Some (Texp_constraint ty) ->
                     Some (Pconstraint (sub.typ sub ty))
-                | Some (Texp_poly _ | Texp_newtype _) | None -> None
+                | Some (Texp_poly _ | Texp_newtype _ | Texp_mode_coerce _)
+                | None -> None
               in
               let constraint_ =
                 Option.map


### PR DESCRIPTION
Build on Zesen's work in #2331: Use full-blown Jane Syntax for encoding mode coercion expressions rather than another function off to the side.

Usually, full-blown Jane Syntax's costs outweigh its benefits. But, for mode coercions, it's lightweight to add it. So we get to reap the benefit: hooking into the exhaustive match.

We should probably use full-blown Jane Syntax for `stack_` when we add that as a keyword.

The main cost was the time it took to write the PR you're reading. It took about 1.5 hours, where most of that was debugging issues that my initial half-hour attempt introduced. But we have the PR now, so why not merge it.

### Tests
* `source_jane_syntax.ml` shook out bugs in `Ast_mapper` and `Pprintast`, and gives me more confidence we got that right.
* the existing test suite seems sufficient to me.