### PR TITLE
Remove a check for values in `with type` constraints

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -716,3 +716,26 @@ Error: Function arguments and returns must be representable.
          it's the type of a function argument.
 |}]
 
+(***********************************)
+(* Test 11: [any] in package types *)
+
+module type S = sig
+  type t : any
+end
+
+module C : S = struct
+  type t = float
+end
+
+let x = (module C : S with type t = 'a)
+
+(* This should be accepted *)
+[%%expect{|
+module type S = sig type t : any end
+module C : S
+Line 9, characters 16-17:
+9 | let x = (module C : S with type t = 'a)
+                    ^
+Error: The type t in this module cannot be exported.
+       Its type contains local dependencies: C.t
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -733,9 +733,13 @@ let x = (module C : S with type t = 'a)
 [%%expect{|
 module type S = sig type t : any end
 module C : S
-Line 9, characters 16-17:
+Line 9, characters 8-39:
 9 | let x = (module C : S with type t = 'a)
-                    ^
-Error: The type t in this module cannot be exported.
-       Its type contains local dependencies: C.t
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type (module S with type t = C.t)
+       but an expression was expected of type (module S with type t = 'a)
+       The layout of C.t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of C.t must be a sublayout of value, because
+         it's a type declaration in a first-class module.
 |}]

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3272,7 +3272,6 @@ let type_package env m p fl =
   in
   List.iter
     (fun (n, ty) ->
-       (* CR layouts v5: relax value requirement. *)
       try Ctype.unify env ty
             (Ctype.newvar (Jkind.any ~why:Dummy_jkind))
       with Ctype.Unify _ ->

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3274,7 +3274,7 @@ let type_package env m p fl =
     (fun (n, ty) ->
        (* CR layouts v5: relax value requirement. *)
       try Ctype.unify env ty
-            (Ctype.newvar (Jkind.value ~why:Structure_element))
+            (Ctype.newvar (Jkind.any ~why:Dummy_jkind))
       with Ctype.Unify _ ->
         raise (Error(modl.mod_loc, env, Scoping_pack (n,ty))))
     fl';


### PR DESCRIPTION
The first commit adds a failing test, and then the second commit fixes the bug. Except that we then hit the package hack, so this is in a race with #2253. But I'm pretty sure the bug fixed here is independent of the package hack.

Suggested review: @alanechang 