### PR TITLE
Compiler flag to disable checkmach

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -1256,14 +1256,18 @@ module Check_zero_alloc = Analysis (Spec_zero_alloc)
 let unit_info = Unit_info.create ()
 
 let fundecl ppf_dump ~future_funcnames fd =
-  Check_zero_alloc.fundecl fd ~future_funcnames unit_info ppf_dump;
+  if not !Flambda_backend_flags.disable_checkmach
+  then Check_zero_alloc.fundecl fd ~future_funcnames unit_info ppf_dump;
   fd
 
-let reset_unit_info () = Unit_info.reset unit_info
+let reset_unit_info () =
+  if not !Flambda_backend_flags.disable_checkmach then Unit_info.reset unit_info
 
 let record_unit_info ppf_dump =
-  Check_zero_alloc.record_unit unit_info ppf_dump;
-  Compilenv.cache_checks (Compilenv.current_unit_infos ()).ui_checks
+  if not !Flambda_backend_flags.disable_checkmach
+  then (
+    Check_zero_alloc.record_unit unit_info ppf_dump;
+    Compilenv.cache_checks (Compilenv.current_unit_infos ()).ui_checks)
 
 type iter_witnesses = (string -> Witnesses.components -> unit) -> unit
 

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -106,7 +106,9 @@ let mk_dcheckmach f =
 
 let mk_disable_checkmach f =
   "-disable-checkmach", Arg.Unit f,
-  " Disable zero_alloc pass, both summary genration and checking of annotations."
+  " Conservatively assume that all functions may allocate, without checking. \
+    Disables computation of zero_alloc function summaries, \
+    unlike \"-zero-alloc-check none\" which disables checking of zero_alloc annotations)"
 
 let mk_checkmach_details_cutoff f =
   "-checkmach-details-cutoff", Arg.Int f,

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -104,6 +104,10 @@ let mk_zero_alloc_check f =
 let mk_dcheckmach f =
   "-dcheckmach", Arg.Unit f, " (undocumented)"
 
+let mk_disable_checkmach f =
+  "-disable-checkmach", Arg.Unit f,
+  " Disable zero_alloc pass, both summary genration and checking of annotations."
+
 let mk_checkmach_details_cutoff f =
   "-checkmach-details-cutoff", Arg.Int f,
   Printf.sprintf " Do not show more than this number of error locations \
@@ -634,6 +638,7 @@ module type Flambda_backend_options = sig
   val heap_reduction_threshold : int -> unit
   val zero_alloc_check : string -> unit
   val dcheckmach : unit -> unit
+  val disable_checkmach : unit -> unit
   val checkmach_details_cutoff : int -> unit
 
   val function_layout : string -> unit
@@ -747,6 +752,7 @@ struct
     mk_heap_reduction_threshold F.heap_reduction_threshold;
     mk_zero_alloc_check F.zero_alloc_check;
     mk_dcheckmach F.dcheckmach;
+    mk_disable_checkmach F.disable_checkmach;
     mk_checkmach_details_cutoff F.checkmach_details_cutoff;
 
     mk_function_layout F.function_layout;
@@ -908,6 +914,7 @@ module Flambda_backend_options_impl = struct
       Clflags.zero_alloc_check := a
 
   let dcheckmach = set' Flambda_backend_flags.dump_checkmach
+  let disable_checkmach = set' Flambda_backend_flags.disable_checkmach
   let checkmach_details_cutoff n =
     let c : Flambda_backend_flags.checkmach_details_cutoff =
       if n < 0 then Keep_all
@@ -1187,6 +1194,7 @@ module Extra_params = struct
            (Arg.Bad
               (Printf.sprintf "Unexpected value %s for %s" v name)))
     | "dump-checkmach" -> set' Flambda_backend_flags.dump_checkmach
+    | "disable-checkmach" -> set' Flambda_backend_flags.disable_checkmach
     | "checkmach-details-cutoff" ->
       begin match Compenv.check_int ppf name v with
       | Some i ->

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -49,6 +49,7 @@ module type Flambda_backend_options = sig
   val heap_reduction_threshold : int -> unit
   val zero_alloc_check : string -> unit
   val dcheckmach : unit -> unit
+  val disable_checkmach : unit -> unit
   val checkmach_details_cutoff : int -> unit
 
   val function_layout : string -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -33,6 +33,7 @@ let dasm_comments = ref false (* -dasm-comments *)
 let default_heap_reduction_threshold = 500_000_000 / (Sys.word_size / 8)
 let heap_reduction_threshold = ref default_heap_reduction_threshold (* -heap-reduction-threshold *)
 let dump_checkmach = ref false          (* -dcheckmach *)
+let disable_checkmach = ref false       (* -disable-checkmach *)
 
 type checkmach_details_cutoff =
   | Keep_all

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -34,6 +34,7 @@ val dasm_comments : bool ref
 val default_heap_reduction_threshold : int
 val heap_reduction_threshold : int ref
 val dump_checkmach : bool ref
+val disable_checkmach : bool ref
 
 val davail : bool ref
 val dranges : bool ref


### PR DESCRIPTION
Add a compiler flag `-disable-checkmach` that disables ~the pass, i.e., both computation of summaries and checking of annotations will be disabled~ the computation of summaries, and assumes that all functions may allocate. This is not the same as `-zero-alloc-check` compilation flag that only control the checking and cannot turn off the analsyis and summary computation.

The motivation for adding `-disable-checkmach` flag is the change in #2290 that may have pathological cases when the analysis is very slow. The flag is intended as a temporary workaround, not a permanent solution for these situations, until the analysis fixpoint computation can be optimized. The downside is that in the meantime uses will fail the check. 