### PR TITLE
Default function order to source order

### DIFF
--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -53,7 +53,7 @@ module Function_layout = struct
     | Topological -> "topological"
     | Source -> "source"
 
-  let default = Topological
+  let default = Source
 
   let all = [Topological; Source]
 


### PR DESCRIPTION
Change the default sorting of function symbols by debug info instead of topological order. Reverts the default back to what we had prior to #2287. 

~On top of #2290 #2353 #2354 for testing.~ 