### PR TITLE
Fix missing parens around local exp in pprintast

### DIFF
--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -2019,7 +2019,9 @@ and jane_syntax_expr ctxt attrs f (jexp : Jane_syntax.Expression.t) ~parens =
       if parens then pp f "(%a)" (n_ary_function_expr reset_ctxt) x
       else n_ary_function_expr ctxt f x
   | Jexp_tuple ltexp        -> labeled_tuple_expr ctxt f ltexp
-  | Jexp_modes mexp -> mode_expr ctxt f mexp
+  | Jexp_modes mexp ->
+      if parens then pp f "(%a)" (mode_expr ctxt) mexp
+      else mode_expr ctxt f mexp
 
 and mode_expr ctxt f (mexp : Jane_syntax.Modes.expression) =
   match mexp with

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -27,6 +27,8 @@ module Example = struct
       type u = Foo : global_ string * global_ string -> u \
      end"
 
+  let local_exp = parse expression "let x = foo (local_ x) in local_ y"
+
   let longident        = parse longident "No.Longidents.Require.extensions"
   let expression       = parse expression "[x for x = 1 to 10]"
   let pattern          = parse pattern "[:_:]"
@@ -135,6 +137,8 @@ end = struct
 
   let modality_record = test "modality_record" module_expr Example.modality_record
   let modality_cstrarg = test "modality_cstrarg" module_expr Example.modality_cstrarg
+
+  let local_exp = test "local_exp" expression Example.local_exp
 
   let longident = test "longident" longident Example.longident
   let expression = test "expression" expression Example.expression

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -13,6 +13,8 @@ modality_cstrarg:
       | Foo: global_ string * global_ string -> u 
   end
 
+local_exp: let x = foo (local_ x) in local_ y
+
 longident: No.Longidents.Require.extensions
 
 expression: [x for x = 1 to 10]
@@ -81,6 +83,8 @@ modality_cstrarg:
     type u =
       | Foo: global_ string * global_ string -> u 
   end
+
+local_exp: let x = foo (local_ x) in local_ y
 
 longident: No.Longidents.Require.extensions
 


### PR DESCRIPTION
As title. It's subtle enough that I didn't notice it when reviewing. 

Request review from @ncik-roberts 