### PR TITLE
Delay the start of marking with a new GC phase

### DIFF
--- a/ocaml/runtime/array.c
+++ b/ocaml/runtime/array.c
@@ -860,7 +860,8 @@ CAMLprim value caml_array_fill(value array,
       *fp = val;
       if (Is_block(old)) {
         if (Is_young(old)) continue;
-        caml_darken(Caml_state, old, NULL);
+        if (caml_marking_started())
+          caml_darken(Caml_state, old, NULL);
       }
       if (is_val_young_block)
         Ref_table_add(&Caml_state->minor_tables->major_ref, fp);

--- a/ocaml/runtime/caml/major_gc.h
+++ b/ocaml/runtime/caml/major_gc.h
@@ -19,6 +19,7 @@
 #ifdef CAML_INTERNALS
 
 typedef enum {
+  Phase_sweep_main,
   Phase_sweep_and_mark_main,
   Phase_mark_final,
   Phase_sweep_ephe
@@ -27,6 +28,8 @@ extern gc_phase_t caml_gc_phase;
 
 Caml_inline char caml_gc_phase_char(gc_phase_t phase) {
   switch (phase) {
+    case Phase_sweep_main:
+      return 'S';
     case Phase_sweep_and_mark_main:
       return 'M';
     case Phase_mark_final:
@@ -36,6 +39,10 @@ Caml_inline char caml_gc_phase_char(gc_phase_t phase) {
     default:
       return 'U';
   }
+}
+
+Caml_inline int caml_marking_started(void) {
+  return caml_gc_phase != Phase_sweep_main;
 }
 
 intnat caml_opportunistic_major_work_available (void);

--- a/ocaml/runtime/domain.c
+++ b/ocaml/runtime/domain.c
@@ -1784,11 +1784,11 @@ static void handover_finalisers(caml_domain_state* domain_state)
 
   if (f->todo_head != NULL || f->first.size != 0 || f->last.size != 0) {
     /* have some final structures */
-    if (caml_gc_phase != Phase_sweep_and_mark_main) {
+    if (caml_gc_phase != Phase_sweep_main) {
       /* Force a major GC cycle to simplify constraints for
        * handing over finalisers. */
       caml_finish_major_cycle(0);
-      CAMLassert(caml_gc_phase == Phase_sweep_and_mark_main);
+      CAMLassert(caml_gc_phase == Phase_sweep_main);
     }
     caml_add_orphaned_finalisers (f);
     /* Create a dummy final info */

--- a/ocaml/runtime/fiber.c
+++ b/ocaml/runtime/fiber.c
@@ -845,7 +845,8 @@ CAMLprim value caml_continuation_use_noexc (value cont)
 
   /* this forms a barrier between execution and any other domains
      that might be marking this continuation */
-  if (!Is_young(cont) ) caml_darken_cont(cont);
+  if (!Is_young(cont) && caml_marking_started())
+    caml_darken_cont(cont);
 
   /* at this stage the stack is assured to be marked */
   v = Field(cont, 0);

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -137,7 +137,8 @@ Caml_inline void write_barrier(
           then this is in a remembered set already */
        if (Is_young(old_val)) return;
        /* old is a block and in the major heap */
-       caml_darken(Caml_state, old_val, 0);
+       if (caml_marking_started())
+         caml_darken(Caml_state, old_val, 0);
      }
      /* this update is creating a new link from major to minor, remember it */
      if (Is_block_and_young(new_val)) {

--- a/ocaml/runtime/shared_heap.c
+++ b/ocaml/runtime/shared_heap.c
@@ -474,7 +474,10 @@ value* caml_shared_try_alloc(struct caml_heap_state* local, mlsize_t wosize,
     p = large_allocate(local, Bsize_wsize(whsize));
     if (!p) return 0;
   }
-  colour = caml_global_heap_state.MARKED;
+  colour =
+    caml_marking_started()
+    ? caml_global_heap_state.MARKED
+    : caml_global_heap_state.UNMARKED;
   Hd_hp (p) = Make_header_with_reserved(wosize, tag, colour, reserved);
 #ifdef DEBUG
   {

--- a/ocaml/runtime/weak.c
+++ b/ocaml/runtime/weak.c
@@ -59,8 +59,16 @@ CAMLprim value caml_ephe_create (value len)
     caml_invalid_argument ("Weak.create");
   res = caml_alloc_shr (size, Abstract_tag);
 
-  Ephe_link(res) = domain_state->ephe_info->live;
-  domain_state->ephe_info->live = res;
+  /* The new ephemeron needs to be added to:
+       live, if marking has started, to be marked next cycle
+       todo, if marking has not started, to be marked this cycle */
+  if (caml_marking_started()) {
+    Ephe_link(res) = domain_state->ephe_info->live;
+    domain_state->ephe_info->live = res;
+  } else {
+    Ephe_link(res) = domain_state->ephe_info->todo;
+    domain_state->ephe_info->todo = res;
+  }
   for (i = CAML_EPHE_DATA_OFFSET; i < size; i++)
     Field(res, i) = caml_ephe_none;
   /* run memprof callbacks */
@@ -255,7 +263,8 @@ static value ephe_get_field (value e, mlsize_t offset)
   if (elt == caml_ephe_none) {
     res = Val_none;
   } else {
-    caml_darken (Caml_state, elt, 0);
+    if (caml_marking_started())
+      caml_darken (Caml_state, elt, 0);
     res = caml_alloc_small (1, Tag_some);
     Field(res, 0) = elt;
   }
@@ -307,7 +316,8 @@ static void ephe_copy_and_darken(value from, value to)
   mlsize_t to_size = Wosize_val(to);
   while (i < to_size) {
     value field = Field(from, i);
-    caml_darken (domain_state, field, 0);
+    if (caml_marking_started())
+      caml_darken (domain_state, field, 0);
     Store_field(to, i, field);
     ++ i;
   }
@@ -469,7 +479,8 @@ CAMLprim value caml_ephe_blit_key (value es, value ofs,
 CAMLprim value caml_ephe_blit_data (value es, value ed)
 {
   ephe_blit_field (es, CAML_EPHE_DATA_OFFSET, ed, CAML_EPHE_DATA_OFFSET, 1);
-  caml_darken(0, Field(ed, CAML_EPHE_DATA_OFFSET), 0);
+  if (caml_marking_started())
+    caml_darken(0, Field(ed, CAML_EPHE_DATA_OFFSET), 0);
   /* [ed] may be in [Caml_state->ephe_info->live] list. The data value may be
      unmarked. The ephemerons on the live list are not scanned during ephemeron
      marking. Hence, unconditionally darken the data value. */

--- a/ocaml/testsuite/tests/lib-runtime-events/test_instrumented.reference
+++ b/ocaml/testsuite/tests/lib-runtime-events/test_instrumented.reference
@@ -1,1 +1,1 @@
-lost_event_words: 0, total_sizes: 2000004, total_minors: 15
+lost_event_words: 0, total_sizes: 2000004, total_minors: 20


### PR DESCRIPTION
During the new GC phase, marking does not occur. This means that new allocations can be UNMARKED, and caml_modify need not darken the values it sees.

Darkening fewer values means that memory allocated during this phase can be reused more quickly, which reduces heap usage.

For now, this phase continues until sweeping is done. The implementation is currently single-domain only, and the upcoming multi-domain version will not necessarily guarantee that sweeping is completed on all domains before marking begins: the important condition is that marking has not begun until the new phase ends, not that sweeping has ended. So, the new phase is called `Phase_sweep_main`, and the existing phase keeps its name `Phase_sweep_and_mark_main`.

Ephemerons allocated during `Phase_sweep_main` require some special handling: they are added to the `todo` list like ephemerons allocated during the previous cycle, since they are not known to be marked.