### PR TITLE
Zero alloc: don't loose witnesses

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -23,7 +23,7 @@
  * SOFTWARE.                                                                      *
  *                                                                                *
  **********************************************************************************)
-[@@@ocaml.warning "+a-30-40-41-42-32"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 module String = Misc.Stdlib.String
 
@@ -651,8 +651,6 @@ module Unit_info : sig
     Mach.instruction option ->
     unit
 
-  val update : t -> string -> Value.t -> unit
-
   val iter : t -> f:(Func_info.t -> unit) -> unit
 
   val should_keep_witnesses : bool -> bool
@@ -680,11 +678,6 @@ end = struct
     | None ->
       let func_info = Func_info.create name value dbg annotation saved_body in
       String.Tbl.replace t name func_info
-
-  let update t name value =
-    match String.Tbl.find_opt t name with
-    | None -> Misc.fatal_errorf "Cannot find symbol %s" name
-    | Some func_info -> Func_info.update func_info value
 end
 
 (** Check one function. *)

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -1027,7 +1027,7 @@ end = struct
            will be recomputed simultaneously at the end of the compilation
            unit. *)
         if t.unresolved
-        then approx
+        then new_value
         else if Value.lessequal new_value approx
         then approx
         else (
@@ -1044,10 +1044,7 @@ end = struct
       match func_info.saved_body with
       | None -> ()
       | Some b ->
-        let t =
-          create ppf func_info.name String.Set.empty unit_info
-            (Some func_info.value)
-        in
+        let t = create ppf func_info.name String.Set.empty unit_info None in
         let new_value = analyze_body t b in
         if not (Value.lessequal new_value func_info.value)
         then (

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -841,9 +841,14 @@ end = struct
           unresolved (Value.top w)
             "(missing summary: callee compiled without checks)"
         | Some v -> resolved v)
-      | Some callee_info ->
+      | Some callee_info -> (
         (* Callee defined earlier in the same compilation unit. *)
-        resolved callee_info.value
+        match callee_info.saved_body with
+        | None -> resolved callee_info.value
+        | Some _ ->
+          (* callee was unresolved, mark caller as unresolved *)
+          t.unresolved <- true;
+          unresolved callee_info.value "unresolved callee")
 
   let transform_return ~(effect : V.t) dst =
     match effect with

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -843,7 +843,7 @@ end = struct
         match S.get_value_opt callee with
         | None ->
           unresolved (Value.top w)
-            "(missign summary: callee compiled without checks)"
+            "(missing summary: callee compiled without checks)"
         | Some v -> resolved v)
       | Some callee_info ->
         (* Callee defined earlier in the same compilation unit. *)

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -23,7 +23,7 @@
  * SOFTWARE.                                                                      *
  *                                                                                *
  **********************************************************************************)
-[@@@ocaml.warning "+a-30-40-41-42"]
+[@@@ocaml.warning "+a-30-40-41-42-32"]
 
 module String = Misc.Stdlib.String
 
@@ -37,8 +37,6 @@ module Witness = struct
     | Indirect_tailcall
     | Direct_call of { callee : string }
     | Direct_tailcall of { callee : string }
-    | Missing_summary of { callee : string }
-    | Forward_call of { callee : string }
     | Extcall of { callee : string }
     | Arch_specific
     | Probe of
@@ -68,13 +66,10 @@ module Witness = struct
     | Direct_call { callee } -> fprintf ppf "direct call %s" callee
     | Direct_tailcall { callee : string } ->
       fprintf ppf "direct tailcall %s" callee
-    | Missing_summary { callee } -> fprintf ppf "missing summary for %s" callee
-    | Forward_call { callee } ->
-      fprintf ppf "forward call or tailcall (conservatively handled) %s" callee
     | Extcall { callee } -> fprintf ppf "external call to %s" callee
     | Arch_specific -> fprintf ppf "arch specific operation"
     | Probe { name; handler_code_sym } ->
-      fprintf ppf "probe %s handler %s" name handler_code_sym
+      fprintf ppf "probe \"%s\" handler %s" name handler_code_sym
 
   let print ppf { kind; dbg } =
     Format.fprintf ppf "%a %a" print_kind kind Debuginfo.print_compact dbg
@@ -499,7 +494,7 @@ end = struct
               comballoc_msg,
             sub )
         | Indirect_call | Indirect_tailcall | Direct_call _ | Direct_tailcall _
-        | Missing_summary _ | Forward_call _ | Extcall _ ->
+        | Extcall _ ->
           ( Format.dprintf "called function may allocate%s (%a)" component_msg
               Witness.print_kind w.kind,
             [] )
@@ -567,44 +562,19 @@ end = struct
 end
 
 module Func_info = struct
-  (* Fields are mutable: [annotation] changes when a call appears before the
-     declaration. [value] and [unresolved_callers] change to track and update
-     dependencies as the compilation unit is scanned. *)
   type t =
     { name : string;  (** function name *)
-      mutable dbg : Debuginfo.t;  (** debug info associated with the function *)
-      mutable value : Value.t;  (** the result of the check *)
-      mutable annotation : Annotation.t option;
+      dbg : Debuginfo.t;  (** debug info associated with the function *)
+      value : Value.t;  (** the result of the check *)
+      annotation : Annotation.t option
           (** [value] must be lessequal than the expected value
           if there is user-defined annotation on this function. *)
-      mutable unresolved_callers : String.Set.t;  (** direct callers  *)
-      mutable unresolved_callees : Witnesses.t String.Map.t
-          (** direct callees  *)
     }
 
-  let create name =
-    { name;
-      dbg = Debuginfo.none;
-      value = Value.bot;
-      annotation = None;
-      unresolved_callers = String.Set.empty;
-      unresolved_callees = String.Map.empty
-    }
-
-  let is_resolved t = String.Map.is_empty t.unresolved_callees
+  let create name value dbg annotation = { name; dbg; value; annotation }
 
   let print ~witnesses ~msg ppf t =
-    let open Format in
-    let print_names ppf set =
-      pp_print_seq
-        ~pp_sep:(fun ppf () -> pp_print_char ppf ' ')
-        pp_print_string ppf set
-    in
-    fprintf ppf "%s %s %a@,(unresolved callees: %a)@,(unresolved callers: %a)@."
-      msg t.name (Value.print ~witnesses) t.value print_names
-      (t.unresolved_callees |> String.Map.to_seq |> Seq.map (fun (k, _) -> k))
-      print_names
-      (String.Set.to_seq t.unresolved_callers)
+    Format.fprintf ppf "%s %s %a@." msg t.name (Value.print ~witnesses) t.value
 end
 
 module type Spec = sig
@@ -640,26 +610,10 @@ module Unit_info : sig
 
   val find_opt : t -> string -> Func_info.t option
 
-  (** [join_value t name v] name must be in the current compilation unit,
-      and previously recorded.  *)
-  val join_value : t -> string -> Value.t -> unit
-
-  (** [add_value t name v] name must be in the current compilation unit
-      and have not been recorded yet.  *)
-  val add_value : t -> string -> Value.t -> unit
-
-  (** [record_deps t ~caller ~callees] caller and callees must be in the current
-      compilation unit.  *)
-  val record_deps :
-    t -> caller:string -> callees:Witnesses.t String.Map.t -> unit
-
-  (** [cleanup_deps] remove resolved dependencies starting from [name]. *)
-  val cleanup_deps : t -> string -> unit
-
-  val record_annotation :
-    t -> string -> Debuginfo.t -> Annotation.t option -> unit
-
-  val resolve_all : t -> unit
+  (** [recod t name v dbg a] name must be in the current compilation unit,
+      and not previously recorded.  *)
+  val record :
+    t -> string -> Value.t -> Debuginfo.t -> Annotation.t option -> unit
 
   val iter : t -> f:(Func_info.t -> unit) -> unit
 
@@ -672,17 +626,7 @@ end = struct
 
   let reset t = String.Tbl.reset t
 
-  let get_exn t name : Func_info.t = String.Tbl.find t name
-
   let find_opt t name = String.Tbl.find_opt t name
-
-  let get_or_create t name : Func_info.t =
-    match String.Tbl.find_opt t name with
-    | None ->
-      let func_info = Func_info.create name in
-      String.Tbl.replace t name func_info;
-      func_info
-    | Some func_info -> func_info
 
   let should_keep_witnesses keep =
     match !Flambda_backend_flags.checkmach_details_cutoff with
@@ -690,101 +634,14 @@ end = struct
     | No_details -> false
     | At_most _ -> keep
 
-  (* fixpoint backward propogation of function summaries along the recorded
-     dependency edges. *)
-  let rec propagate t (func_info : Func_info.t) =
-    let unresolved_callers = func_info.unresolved_callers in
-    let value = func_info.value in
-    let value =
-      (* conservative use of summaries for unresolved dependencies *)
-      let w =
-        if should_keep_witnesses true
-        then
-          Witnesses.create
-            (Forward_call { callee = func_info.name })
-            Debuginfo.none
-        else Witnesses.empty
-      in
-      let v = V.join value.nor value.exn |> V.replace_witnesses w in
-      { Value.nor = v; exn = v; div = value.div }
-    in
-    String.Set.iter
-      (replace_witnesses_and_propagate t ~value ~callee:func_info.name)
-      unresolved_callers
-
-  and replace_witnesses_and_propagate t ~(value : Value.t) ~callee name =
-    let func_info = get_exn t name in
-    match String.Map.find_opt callee func_info.unresolved_callees with
-    | None ->
-      Misc.fatal_errorf "missing witnesses for unresolved_callee %s of %s"
-        callee name
-    | Some w ->
-      let v = V.replace_witnesses w value.nor in
-      let value = { value with nor = v; exn = v } in
-      join_and_propagate t ~value name
-
-  and join_and_propagate t ~value name =
-    let func_info = get_exn t name in
-    let new_value = Value.join func_info.value value in
-    let old_value = func_info.value in
-    (* propagate witnesses *)
-    func_info.value <- new_value;
-    if not (Value.lessequal new_value old_value) then propagate t func_info
-
   let iter t ~f = String.Tbl.iter (fun _ func_info -> f func_info) t
 
-  let resolve_all t = iter t ~f:(propagate t)
-
-  let add_value t name value =
-    let (_ : Func_info.t) = get_or_create t name in
-    join_and_propagate t name ~value
-
-  let join_value t name value = join_and_propagate t name ~value
-
-  let record_annotation t name dbg annotation =
-    let func_info = get_or_create t name in
-    if Option.is_some func_info.annotation
-    then Misc.fatal_errorf "Duplicate symbol %s" name;
-    func_info.dbg <- dbg;
-    func_info.annotation <- annotation
-
-  let record_deps t ~caller ~callees =
-    let func_info = get_exn t caller in
-    if not (String.Map.is_empty func_info.unresolved_callees)
-    then Misc.fatal_errorf "Unexpected unresolved callees for %s" caller;
-    func_info.unresolved_callees <- callees;
-    String.Map.iter
-      (fun callee _ ->
-        let func_info = get_or_create t callee in
-        func_info.unresolved_callers
-          <- String.Set.add caller func_info.unresolved_callers)
-      callees
-
-  let rec cleanup_deps t name =
-    (* optimization: clean up unresolved *)
-    let func_info = get_exn t name in
-    let unresolved_callees_except_self =
-      String.Map.remove name func_info.unresolved_callees
-    in
-    if String.Map.is_empty unresolved_callees_except_self
-    then (
-      (* remove all resolved deps *)
-      let unresolved_callers = func_info.unresolved_callers in
-      func_info.unresolved_callers <- String.Set.empty;
-      let changed_callers =
-        String.Set.filter
-          (fun caller ->
-            let caller_info : Func_info.t = get_exn t caller in
-            if String.Map.mem name caller_info.unresolved_callees
-            then (
-              caller_info.unresolved_callees
-                <- String.Map.remove name caller_info.unresolved_callees;
-              true)
-            else false)
-          unresolved_callers
-      in
-      (* propagate *)
-      String.Set.iter (cleanup_deps t) changed_callers)
+  let record t name value dbg annotation =
+    match String.Tbl.find_opt t name with
+    | Some _ -> Misc.fatal_errorf "Duplicate symbol %s" name
+    | None ->
+      let func_info = Func_info.create name value dbg annotation in
+      String.Tbl.replace t name func_info
 end
 
 (** Check one function. *)
@@ -803,10 +660,9 @@ end = struct
     { ppf : Format.formatter;
       current_fun_name : string;
       future_funcnames : String.Set.t;
-          (** functions defined later in the same compilation unit  *)
-      mutable unresolved_deps : Witnesses.t String.Map.t;
-          (** must be the current compilation unit.  *)
-      unit_info : Unit_info.t;
+      mutable approx : Value.t option;
+          (** Used for computing fixpoint for self calls. *)
+      unit_info : Unit_info.t;  (** must be the current compilation unit.  *)
       mutable keep_witnesses : bool
     }
 
@@ -814,7 +670,7 @@ end = struct
     { ppf;
       current_fun_name;
       future_funcnames;
-      unresolved_deps = String.Map.empty;
+      approx = None;
       unit_info;
       keep_witnesses = false
     }
@@ -842,7 +698,7 @@ end = struct
     if V.is_not_safe r.div then report_fail t r (msg ^ " div") dbg;
     r
 
-  let report_unit_info ~msg ppf unit_info =
+  let report_unit_info ppf unit_info ~msg =
     if !Flambda_backend_flags.dump_checkmach
     then
       let msg = Printf.sprintf "%s %s:" analysis_name msg in
@@ -855,8 +711,6 @@ end = struct
       Func_info.print ~witnesses:true ppf ~msg func_info
 
   let record_unit unit_info ppf =
-    report_unit_info ppf unit_info ~msg:"before resolve_all";
-    Unit_info.resolve_all unit_info;
     let errors = ref [] in
     let record (func_info : Func_info.t) =
       (match func_info.annotation with
@@ -901,73 +755,56 @@ end = struct
     Profile.record_call ~accumulate:true ("record_unit " ^ analysis_name)
       (fun () -> record_unit unit_info ppf)
 
-  let update_deps t v dep w desc dbg =
-    match dep with
-    | Some callee ->
-      let f old =
-        match old with
-        | None -> Some w
-        | Some old_w -> Some (Witnesses.join w old_w)
-      in
-      t.unresolved_deps <- String.Map.update callee f t.unresolved_deps;
-      report t v ~msg:"unresolved" ~desc dbg
-    | None -> report t v ~msg:"resolved" ~desc dbg
-
   let[@inline always] create_witnesses t kind dbg =
     if t.keep_witnesses then Witnesses.create kind dbg else Witnesses.empty
 
-  (* [find_callee] returns the value associated with the callee and a new
-     dependency to record if there is one. *)
-  let find_callee t callee dbg =
-    match Unit_info.find_opt t.unit_info callee with
-    | None ->
-      if is_future_funcname t callee
-      then (
-        (* The callee is defined later in the file. We have not seen any calls
-           to it yet. *)
-        (* CR-soon gyorsh: Returning Safe is sound because the value of the
-           callee, when it becomes available, will be joined to the final value
-           of the caller (the current function). Analysis result depends on the
-           order of functions in the file. To address it, use more precise
-           function summaries. *)
-        let v = Value.safe in
-        Unit_info.add_value t.unit_info callee v;
-        v, Some callee)
+  (* [find_callee] returns the value associated with the callee. *)
+  let find_callee t callee ~desc dbg w =
+    let return ~msg v =
+      report t v ~msg ~desc dbg;
+      (* Abstract witnesses of a call to the single witness for the callee name.
+         Summary of tailcall self won't be affected because it is not set to Top
+         by [find_callee]. *)
+      Value.replace_witnesses w v
+    in
+    let unresolved v reason =
+      let msg = Printf.sprintf "unresolved %s (%s)" callee reason in
+      return ~msg v
+    in
+    let resolved v = return ~msg:"resolved %s" v in
+    if is_future_funcname t callee
+    then
+      if String.equal callee t.current_fun_name
+      then
+        (* Self call. *)
+        match t.approx with
+        | None ->
+          (* Summary is not computed yet. Conservative. *)
+          let v = Value.safe in
+          t.approx <- Some v;
+          unresolved v "self-call init"
+        | Some approx -> unresolved approx "self-call approx"
       else
+        (* Call is defined later in the current compilation unit. Summary of
+           this callee is not yet computed, conservatively return Top. Won't be
+           able to prove any recursive functions as non-allocating. *)
+        unresolved (Value.top w)
+          "conservative handling of forward or recursive call\nor tailcall"
+    else
+      (* CR gyorsh: unresolved case here is impossible in the conservative
+         analysis because all previous functions have been conservatively
+         resolved.*)
+      match Unit_info.find_opt t.unit_info callee with
+      | None -> (
         (* Callee is not defined in the current compilation unit. *)
-        let v =
-          match S.get_value_opt callee with
-          | None ->
-            let w = create_witnesses t (Missing_summary { callee }) dbg in
-            let v = Value.top w in
-            report t v ~msg:"callee compiled without checks" ~desc:callee
-              Debuginfo.none;
-            v
-          | Some v -> v
-        in
-        v, None
-    | Some callee_info ->
-      (* Callee defined earlier in the same compilation unit, or we have already
-         seen a call to this callee earlier in the same compilation unit
-         (possibly in the same function), but haven't finished analysis of the
-         callee's definition yet. *)
-      (* If callee is not fully resolved, add it to dependencies. *)
-      let dep =
-        if is_future_funcname t callee
-           || not (Func_info.is_resolved callee_info)
-        then Some callee
-        else None
-      in
-      let v =
-        if String.equal t.current_fun_name callee
-        then (
-          (* self-call, conservative *)
-          let v = Value.join callee_info.value Value.safe in
-          Unit_info.add_value t.unit_info callee v;
-          v)
-        else callee_info.value
-      in
-      v, dep
+        match S.get_value_opt callee with
+        | None ->
+          unresolved (Value.top w)
+            "(missign summary: callee compiled without checks)"
+        | Some v -> resolved v)
+      | Some callee_info ->
+        (* Callee defined earlier in the same compilation unit. *)
+        resolved callee_info.value
 
   let transform_return ~(effect : V.t) dst =
     match effect with
@@ -1002,13 +839,7 @@ end = struct
     let effect =
       if Debuginfo.assume_zero_alloc dbg
       then Value.relaxed w
-      else
-        let callee_value, new_dep = find_callee t callee dbg in
-        update_deps t callee_value new_dep w desc dbg;
-        (* Abstract witnesses of a call to the single witness for the callee
-           name. Summary of tailcall self won't be affected because it is set to
-           Safe not Top by [find_callee]. *)
-        Value.replace_witnesses w callee_value
+      else find_callee t callee ~desc dbg w
     in
     transform t ~next ~exn ~effect desc dbg
 
@@ -1137,9 +968,22 @@ end = struct
        To check divergent loops, the initial value of "div" component of all
        Iexit labels of recurisve Icatch handlers is set to "Safe" instead of
        "Bot". *)
-    D.analyze ~exnescape:Value.exn_escape ~init_rc_lbl:Value.diverges ~transfer
-      body
-    |> fst
+    let rec fixpoint () =
+      let new_value =
+        D.analyze ~exnescape:Value.exn_escape ~init_rc_lbl:Value.diverges
+          ~transfer body
+        |> fst
+      in
+      match t.approx with
+      | None -> new_value
+      | Some approx ->
+        if Value.lessequal new_value approx
+        then approx
+        else (
+          t.approx <- Some (Value.join new_value approx);
+          fixpoint ())
+    in
+    fixpoint ()
 
   let fundecl (f : Mach.fundecl) ~future_funcnames unit_info ppf =
     let check () =
@@ -1148,36 +992,25 @@ end = struct
       let a =
         Annotation.find f.fun_codegen_options S.property fun_name f.fun_dbg
       in
-      Unit_info.record_annotation unit_info fun_name f.fun_dbg a;
       let really_check ~keep_witnesses =
         t.keep_witnesses <- Unit_info.should_keep_witnesses keep_witnesses;
         let res = check_instr t f.fun_body in
-        let msg =
-          if String.Map.is_empty t.unresolved_deps
-          then "finished"
-          else "unresolved deps"
-        in
-        report t res ~msg ~desc:"fundecl" f.fun_dbg;
+        report t res ~msg:"finished" ~desc:"fundecl" f.fun_dbg;
         if not t.keep_witnesses
         then (
           let { Witnesses.nor; exn; div } = Value.get_witnesses res in
           assert (Witnesses.is_empty nor);
           assert (Witnesses.is_empty exn);
           assert (Witnesses.is_empty div));
-        report_unit_info ppf unit_info ~msg:"before record deps";
-        Unit_info.record_deps unit_info ~callees:t.unresolved_deps
-          ~caller:fun_name;
-        report_unit_info ppf unit_info ~msg:"after record deps";
-        Unit_info.join_value unit_info fun_name res;
-        report_unit_info ppf unit_info ~msg:"after join value";
-        Unit_info.cleanup_deps unit_info fun_name;
-        report_unit_info ppf unit_info ~msg:"after cleanup_deps"
+        report_unit_info ppf unit_info ~msg:"before record";
+        Unit_info.record unit_info fun_name res f.fun_dbg a;
+        report_unit_info ppf unit_info ~msg:"after record"
       in
       match a with
       | Some a when Annotation.is_assume a ->
         let expected_value = Annotation.expected_value a in
         report t expected_value ~msg:"assumed" ~desc:"fundecl" f.fun_dbg;
-        Unit_info.join_value unit_info fun_name expected_value
+        Unit_info.record unit_info fun_name expected_value f.fun_dbg None
       | None -> really_check ~keep_witnesses:false
       | Some a ->
         let expected_value = Annotation.expected_value a in

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -86,6 +86,8 @@ module Witnesses : sig
 
   val join : t -> t -> t
 
+  val lessequal : t -> t -> bool
+
   val create : Witness.kind -> Debuginfo.t -> t
 
   val print : Format.formatter -> t -> unit
@@ -106,6 +108,8 @@ end = struct
      limit the size of this set. The downside is that it won't get tested as
      much. Only keep witnesses for functions that need checking. *)
   let join = union
+
+  let lessequal = subset
 
   let create kind dbg = singleton (Witness.create dbg kind)
 
@@ -169,7 +173,7 @@ end = struct
     match v1, v2 with
     | Bot, Bot -> true
     | Safe, Safe -> true
-    | Top _, Top _ -> true
+    | Top w1, Top w2 -> Witnesses.lessequal w1 w2
     | Bot, Safe -> true
     | Bot, Top _ -> true
     | Safe, Top _ -> true
@@ -193,11 +197,15 @@ end = struct
     match t with Top w -> w | Bot | Safe -> Witnesses.empty
 
   let diff_witnesses ~expected ~actual =
-    if lessequal actual expected
-    then Witnesses.empty
-    else (
-      assert (expected = Safe);
-      match actual with Bot | Safe -> assert false | Top w -> w)
+    (* If [actual] is Top and [expected] is not Top then return the [actual]
+       witnesses. Otherwise, return empty. *)
+    match actual, expected with
+    | Bot, Bot | Safe, Safe | Bot, Safe -> Witnesses.empty
+    | Bot, Top w | Safe, Top w | Top _, Top w ->
+      assert (Witnesses.is_empty w);
+      Witnesses.empty
+    | Safe, Bot -> Witnesses.empty
+    | Top w, (Bot | Safe) -> w
 
   let is_not_safe = function Top _ -> true | Safe | Bot -> false
 
@@ -321,6 +329,13 @@ module Annotation : sig
 
   val expected_value : t -> Value.t
 
+  (** [valid t value] returns true if and only if the [value] satisfies the annotation,
+      i.e., [value] is less or equal to [expected_value a] when ignoring witnesses. *)
+
+  val valid : t -> Value.t -> bool
+
+  val diff_witnesses : t -> Value.t -> Witnesses.components
+
   val is_assume : t -> bool
 
   val is_strict : t -> bool
@@ -358,6 +373,16 @@ end = struct
   let expected_value t =
     let res = if t.strict then Value.safe else Value.relaxed Witnesses.empty in
     if t.never_returns_normally then { res with nor = V.Bot } else res
+
+  let valid t v =
+    (* Use Value.lessequal but ignore witnesses. *)
+    let expected = expected_value t in
+    let actual = Value.replace_witnesses Witnesses.empty v in
+    Value.lessequal actual expected
+
+  let diff_witnesses t v =
+    let expected = expected_value t in
+    Value.diff_witnesses ~actual:v ~expected
 
   let is_assume t = t.assume
 
@@ -756,10 +781,9 @@ end = struct
       | Some a ->
         Builtin_attributes.mark_property_checked analysis_name
           (Annotation.get_loc a);
-        let expected_value = Annotation.expected_value a in
         if (not (Annotation.is_assume a))
            && S.enabled ()
-           && not (Value.lessequal func_info.value expected_value)
+           && not (Annotation.valid a func_info.value)
         then
           (* CR-soon gyorsh: keeping track of all the witnesses until the end of
              the compilation unit will be expensive. For functions that do not
@@ -770,10 +794,7 @@ end = struct
           (* CR gyorsh: we can add error recovering mode where we sets the
              expected value as the actual value and continue analysis of other
              functions. *)
-          let witnesses =
-            Value.diff_witnesses ~expected:expected_value
-              ~actual:func_info.value
-          in
+          let witnesses = Annotation.diff_witnesses a func_info.value in
           errors
             := { Report.a;
                  fun_name = func_info.name;

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -806,7 +806,10 @@ end = struct
       let msg = Printf.sprintf "unresolved %s (%s)" callee reason in
       return ~msg v
     in
-    let resolved v = return ~msg:"resolved %s" v in
+    let resolved v =
+      let msg = Printf.sprintf "resolved  %s" callee in
+      return ~msg v
+    in
     if is_future_funcname t callee
     then
       if String.equal callee t.current_fun_name
@@ -1044,6 +1047,7 @@ end = struct
         if not (Value.lessequal new_value func_info.value)
         then (
           change := true;
+          report t new_value ~msg:"update" ~desc:"fixpoint" func_info.dbg;
           Func_info.update func_info new_value)
     in
     while !change do

--- a/backend/checkmach.mli
+++ b/backend/checkmach.mli
@@ -53,8 +53,6 @@ module Witness : sig
     | Indirect_tailcall
     | Direct_call of { callee : string }
     | Direct_tailcall of { callee : string }
-    | Missing_summary of { callee : string }
-    | Forward_call of { callee : string }
     | Extcall of { callee : string }
     | Arch_specific
     | Probe of

--- a/tests/backend/checkmach/fail19.output
+++ b/tests/backend/checkmach/fail19.output
@@ -15,7 +15,7 @@ Error: called function may allocate (indirect call)
 
 File "fail19.ml", line 14, characters 15-44:
 Error: expression may allocate
-       (probe test handler camlFail19.probe_handler_test_HIDE_STAMP)
+       (probe "test" handler camlFail19.probe_handler_test_HIDE_STAMP)
 
 File "fail19.ml", line 14, characters 46-54:
 Error: allocation of 24 bytes

--- a/tests/backend/checkmach/fail20.ml
+++ b/tests/backend/checkmach/fail20.ml
@@ -9,3 +9,11 @@ let[@zero_alloc strict] foo x =
   else if x < 0 then
     List.nth (div (x+2)) x
   else nor x
+
+let[@zero_alloc][@inline never][@local never]  foo x =
+  let[@inline never][@local never] bar x y =
+    (Sys.opaque_identity (x + y), x)
+  in
+  fst (bar x (x*x))
+
+let[@zero_alloc] zee x f = foo (Sys.opaque_identity x+1)

--- a/tests/backend/checkmach/fail20.output
+++ b/tests/backend/checkmach/fail20.output
@@ -6,3 +6,9 @@ Error: allocation of 32 bytes on a path to exceptional return (fail20.ml:8,16--2
 
 File "fail20.ml", line 10, characters 13-24:
 Error: called function may allocate on a path to exceptional return (direct call camlFail20.div_HIDE_STAMP)
+
+File "fail20.ml", line 13, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Fail20.foo (camlFail20.foo_HIDE_STAMP)
+
+File "fail20.ml", line 19, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Fail20.zee (camlFail20.zee_HIDE_STAMP)

--- a/tests/backend/checkmach/fail20.output
+++ b/tests/backend/checkmach/fail20.output
@@ -10,5 +10,11 @@ Error: called function may allocate on a path to exceptional return (direct call
 File "fail20.ml", line 13, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail20.foo (camlFail20.foo_HIDE_STAMP)
 
+File "fail20.ml", line 17, characters 6-19:
+Error: called function may allocate (direct call camlFail20.bar_HIDE_STAMP)
+
 File "fail20.ml", line 19, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Fail20.zee (camlFail20.zee_HIDE_STAMP)
+
+File "fail20.ml", line 19, characters 27-56:
+Error: called function may allocate (direct tailcall camlFail20.foo_HIDE_STAMP)


### PR DESCRIPTION
There is a mismatch in handling witnesses: `V.lessequal` ignores them and `V.join` does not.  As a result, witnesses discovered in the last iteration of a fixed point computation might be lost, if there are already other witnesses for the same component.  
The analysis uses `V.lessequal new_value value` to detect fixed points and will not join the `new_value` to the preiously computed value if the only difference is in witnesses. 

This is not a soundness problem in the sense that the check will not miss allocations, but it might not return all allocations as witnesses. We do not guarantee that all witnesses will be reported, but it is a nice property to have. We rely on the witnesses produced by the analysis to visualize allocations and not only to check annotations. Having consistent output also makes testing easier. 

This PR fixes it "properly" by taking witnesses into account in `V.lessequal` and refactoring some other witness related checks to make it clear that we are allowed to ignore witnesses of "expected" values that come from annotations, and not the computed values. The downside of this approach is that the fixpoint can take longer: the height of the abstract domain now depends on the size of the input file in the worst case, instead of being constant height of `3`. I think that the bad case cannot happen in practice because of the order or propagation of witnesses along all the control flow paths within a loop before checking for a fixed point. 

An alternative is to call `join` even when `lessequal` is true. It works too but feels like a hack.

For example, the output of existing test `fail19.ml` changes depending on the order in which functions are emitted in the file: `-function-layout topological` includes `probe` witness and with the `source` layout it doesn't. This happens because the fixpoint for "forward defined" functions discovered a new witness but the value was already `Top`, so the new witness is not recorded. I haven't found a way to reproduce this on main yet.

On top of #2290. 