### PR TITLE
Fix Unbound module Stdlib__Nativeint_u

### DIFF
--- a/ocaml/stdlib/StdlibModules
+++ b/ocaml/stdlib/StdlibModules
@@ -62,10 +62,10 @@ STDLIB_MODULE_BASENAMES = \
   float_u \
   int32 \
   int32_u \
-  int64 \
-  int64_u \
   nativeint \
   nativeint_u \
+  int64 \
+  int64_u \
   lexing \
   parsing \
   set \


### PR DESCRIPTION
Building `make world.opt` in `ocaml/` would fail due to an unbound module Stdlib__Nativeint_u