### PR TITLE
Fix case where local functions optimisation breaks tail calls

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1041,14 +1041,12 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
     maybe_insert_let_cont "staticcatch_result" layout k acc env ccenv
       (fun acc env ccenv k ->
         let pop_region =
-          match r with
-          | Popped_region -> true
-          | Same_region -> false
+          match r with Popped_region -> true | Same_region -> false
         in
         let continuation = Continuation.create () in
         let { Env.body_env; handler_env; extra_params } =
-          Env.add_static_exn_continuation env static_exn
-            ~pop_region continuation
+          Env.add_static_exn_continuation env static_exn ~pop_region
+            continuation
         in
         let recursive : Asttypes.rec_flag =
           if Env.is_static_exn_recursive env static_exn

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
@@ -124,12 +124,12 @@ type add_continuation_result =
 let add_continuation t cont ~push_to_try_stack ~pop_region
     (recursive : Asttypes.rec_flag) =
   let region_stack =
-    if pop_region then
+    if pop_region
+    then
       match t.region_stack with
       | [] -> Misc.fatal_error "Cannot pop region, region stack is empty"
       | _ :: region_stack -> region_stack
-    else
-      t.region_stack
+    else t.region_stack
   in
   let region_stack_in_cont_scope =
     Continuation.Map.add cont region_stack t.region_stack_in_cont_scope
@@ -200,7 +200,7 @@ let add_static_exn_continuation t static_exn ~pop_region cont =
       try_stack_at_handler =
         Continuation.Map.add cont t.try_stack t.try_stack_at_handler;
       static_exn_continuation =
-        Numeric_types.Int.Map.add static_exn cont t.static_exn_continuation;
+        Numeric_types.Int.Map.add static_exn cont t.static_exn_continuation
     }
   in
   let recursive : Asttypes.rec_flag =
@@ -208,8 +208,7 @@ let add_static_exn_continuation t static_exn ~pop_region cont =
     then Recursive
     else Nonrecursive
   in
-  add_continuation t cont
-    ~push_to_try_stack:false ~pop_region recursive
+  add_continuation t cont ~push_to_try_stack:false ~pop_region recursive
 
 let get_static_exn_continuation t static_exn =
   match Numeric_types.Int.Map.find static_exn t.static_exn_continuation with

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
@@ -60,11 +60,12 @@ val add_continuation :
   t ->
   Continuation.t ->
   push_to_try_stack:bool ->
+  pop_region:bool ->
   Asttypes.rec_flag ->
   add_continuation_result
 
 val add_static_exn_continuation :
-  t -> int -> Continuation.t -> add_continuation_result
+  t -> int -> pop_region:bool -> Continuation.t -> add_continuation_result
 
 val get_static_exn_continuation : t -> int -> Continuation.t
 

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -892,7 +892,7 @@ let rec comp_expr stack_info env exp sz cont =
       let nargs = List.length args - 1 in
       comp_args stack_info env args sz
         (comp_primitive stack_info p (sz + nargs - 1) args :: cont)
-  | Lstaticcatch (body, (i, vars) , handler, _) ->
+  | Lstaticcatch (body, (i, vars) , handler, _, _) ->
       let vars = List.map fst vars in
       let nvars = List.length vars in
       let branch1, cont1 = make_branch cont in

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -582,6 +582,10 @@ type lparam = {
 
 type scoped_location = Debuginfo.Scoped_location.t
 
+type pop_region =
+  | Popped_region
+  | Same_region
+
 type lambda =
     Lvar of Ident.t
   | Lmutvar of Ident.t
@@ -598,7 +602,9 @@ type lambda =
   | Lstringswitch of
       lambda * (string * lambda) list * lambda option * scoped_location * layout
   | Lstaticraise of static_label * lambda list
-  | Lstaticcatch of lambda * (static_label * (Ident.t * layout) list) * lambda * layout
+  | Lstaticcatch of
+      lambda * (static_label * (Ident.t * layout) list) * lambda
+      * pop_region * layout
   | Ltrywith of lambda * Ident.t * lambda * layout
 (* Lifthenelse (e, t, f, layout) evaluates t if e evaluates to 0, and evaluates f if
    e evaluates to any other value; layout must be the layout of [t] and [f] *)

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -602,6 +602,18 @@ type lambda =
   | Lstringswitch of
       lambda * (string * lambda) list * lambda option * scoped_location * layout
   | Lstaticraise of static_label * lambda list
+  (* Concerning [Lstaticcatch], the regions that are open in the handler must be
+     a subset of those open at the point of the [Lstaticraise] that jumps to it,
+     as we can't reopen closed regions. All regions that were open at the point of
+     the [Lstaticraise] but not in the handler will be closed just before the [Lstaticraise].
+   
+     However, to be able to express the fact
+     that the [Lstaticraise] might be under a [Lexclave], the [pop_region] flag
+     is used to specify what regions are considered open in the handler. If it
+     is [Same_region], it means that the same regions as those existing at the
+     point of the [Lstaticraise] are considered open in the handler; if it is [Popped_region],
+     it means that we consider the top region at the point of the [Lstaticcatch] to not be
+     considered open inside the handler. *)
   | Lstaticcatch of
       lambda * (static_label * (Ident.t * layout) list) * lambda
       * pop_region * layout

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -630,6 +630,8 @@ type lambda =
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
   | Lregion of lambda * layout
+  (* [Lexclave] closes the newest region opened.
+     Note that [Lexclave] nesting is currently unsupported. *)
   | Lexclave of lambda
 
 and rec_binding = {

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -1115,10 +1115,10 @@ let rec lam ppf = function
   | Lstaticcatch(lbody, (i, vars), lhandler, r, _kind) ->
       let excl =
         match r with
-        | Popped_region -> "exclave"
+        | Popped_region -> " exclave"
         | Same_region -> ""
       in
-      fprintf ppf "@[<2>(catch@ %a@;<1 -1>with (%d%a) %s@ %a)@]"
+      fprintf ppf "@[<2>(catch@ %a@;<1 -1>with (%d%a)%s@ %a)@]"
         lam lbody i
         (fun ppf vars ->
            List.iter

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -1112,8 +1112,13 @@ let rec lam ppf = function
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       fprintf ppf "@[<2>(exit@ %d%a)@]" i lams ls;
-  | Lstaticcatch(lbody, (i, vars), lhandler, _kind) ->
-      fprintf ppf "@[<2>(catch@ %a@;<1 -1>with (%d%a)@ %a)@]"
+  | Lstaticcatch(lbody, (i, vars), lhandler, r, _kind) ->
+      let excl =
+        match r with
+        | Popped_region -> "exclave"
+        | Same_region -> ""
+      in
+      fprintf ppf "@[<2>(catch@ %a@;<1 -1>with (%d%a) %s@ %a)@]"
         lam lbody i
         (fun ppf vars ->
            List.iter
@@ -1121,7 +1126,7 @@ let rec lam ppf = function
              vars
         )
         vars
-        lam lhandler
+        excl lam lhandler
   | Ltrywith(lbody, param, lhandler, _kind) ->
       fprintf ppf "@[<2>(try@ %a@;<1 -1>with %a@ %a)@]"
         lam lbody Ident.print param lam lhandler

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -657,12 +657,12 @@ let rec choice ctx t =
         let l1 = traverse ctx l1 in
         let+ l2 = choice ctx ~tail l2 in
         Ltrywith (l1, id, l2, kind)
-    | Lstaticcatch (l1, ids, l2, kind) ->
+    | Lstaticcatch (l1, ids, l2, r, kind) ->
         (* In [static-catch l1 with ids -> l2],
            the term [l1] is in fact in tail-position *)
         let+ l1 = choice ctx ~tail l1
         and+ l2 = choice ctx ~tail l2 in
-        Lstaticcatch (l1, ids, l2, kind)
+        Lstaticcatch (l1, ids, l2, r, kind)
     | Levent (lam, lev) ->
         let+ lam = choice ctx ~tail lam in
         Levent (lam, lev)

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -745,7 +745,7 @@ let free_methods l =
         fv := Ident.Set.remove id !fv
     | Lletrec(decl, _body) ->
         List.iter (fun { id } -> fv := Ident.Set.remove id !fv) decl
-    | Lstaticcatch(_e1, (_,vars), _e2, _kind) ->
+    | Lstaticcatch(_e1, (_,vars), _e2, _, _kind) ->
         List.iter (fun (id, _) -> fv := Ident.Set.remove id !fv) vars
     | Ltrywith(_e1, exn, _e2, _k) ->
         fv := Ident.Set.remove exn !fv

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1948,7 +1948,7 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
                  return_layout),
        (static_exception_id, val_ids),
        handler,
-      return_layout)
+      Same_region, return_layout)
   in
   let classic =
     match arg, exn_cases with
@@ -1990,7 +1990,9 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
              e.exp_loc None (Lvar val_id) val_cases partial)
   in
   List.fold_left (fun body (static_exception_id, val_ids, handler) ->
-    Lstaticcatch (body, (static_exception_id, val_ids), handler, return_layout)
+    Lstaticcatch
+      (body, (static_exception_id, val_ids),
+       handler, Same_region, return_layout)
   ) classic static_handlers
 
 and transl_letop ~scopes loc env let_ ands param param_sort case case_sort

--- a/ocaml/lambda/value_rec_compiler.ml
+++ b/ocaml/lambda/value_rec_compiler.ml
@@ -160,7 +160,7 @@ let compute_static_size lam =
       in
       compute_and_join_sizes_switch env [cases; fail_case]
     | Lstaticraise _ -> Unreachable
-    | Lstaticcatch (body, _, handler, _)
+    | Lstaticcatch (body, _, handler, _, _)
     | Ltrywith (body, _, handler, _) ->
       compute_and_join_sizes env [body; handler]
     | Lifthenelse (_cond, ifso, ifnot, _) ->
@@ -600,7 +600,7 @@ let rec split_static_function lfun block_var local_idents lam :
     | Reachable _, Some (Reachable _) ->
       Misc.fatal_error "letrec: multiple functions"
     end
-  | Lstaticcatch (body, (nfail, params), handler, layout) ->
+  | Lstaticcatch (body, (nfail, params), handler, r, layout) ->
     let body_res = split_static_function lfun block_var local_idents body in
     let handler_res =
       let local_idents =
@@ -612,9 +612,9 @@ let rec split_static_function lfun block_var local_idents lam :
     begin match body_res, handler_res with
     | Unreachable, Unreachable -> Unreachable
     | Reachable (lfun, body), Unreachable ->
-      Reachable (lfun, Lstaticcatch (body, (nfail, params), handler, layout))
+      Reachable (lfun, Lstaticcatch (body, (nfail, params), handler, r, layout))
     | Unreachable, Reachable (lfun, handler) ->
-      Reachable (lfun, Lstaticcatch (body, (nfail, params), handler, layout))
+      Reachable (lfun, Lstaticcatch (body, (nfail, params), handler, r, layout))
     | Reachable _, Reachable _ ->
       Misc.fatal_error "letrec: multiple functions"
     end

--- a/ocaml/testsuite/tests/typing-local/tailcalls.ml
+++ b/ocaml/testsuite/tests/typing-local/tailcalls.ml
@@ -39,6 +39,77 @@ let foo () =
   let stack = get_backtrace () in
   bar stack
 
+(* Test the local functions optimisation *)
+
+let[@inline never] ignore_local (local_ x) = ()
+
+let rec foo n p a b stack =
+  if n <= 0 then () else
+  let stack' = get_backtrace () in
+  begin match stack with
+  | None -> ()
+  | Some stack -> assert (equal_backtraces stack stack')
+  end;
+  let bar x y =
+    foo (n - 1) p x y (Some stack')
+  in
+  ignore_local (Some a);
+  if p then
+    bar a b
+  else
+    bar b a
+
+let () = foo 10 true 1 2 None
+
+let rec foo2 n p a b stack =
+  if n <= 0 then () else
+  let stack' = get_backtrace () in
+  begin match stack with
+  | None -> ()
+  | Some stack -> assert (equal_backtraces stack stack')
+  end;
+  let bar x y =
+    foo2 (n - 1) p x y (Some stack')
+  in
+  let bar2 p x y =
+    if p then
+      bar y x
+    else
+      bar x y
+  in
+  ignore_local (Some a);
+  if p then
+    bar2 p a b
+  else
+    bar2 p b a
+
+let () = foo2 10 true 1 2 None
+
+let rec foo3 n p a b stack =
+  if n <= 0 then () else
+  let stack' = get_backtrace () in
+  begin match stack with
+  | None -> ()
+  | Some stack -> assert (equal_backtraces stack stack')
+  end;
+  let bar x y =
+    foo3 (n - 1) p x y (Some stack')
+  in
+  let bar2 p x y =
+    ignore_local (Some a);
+    if p then
+      bar y x
+    else
+      bar x y
+  in
+  ignore_local (Some a);
+  if p then
+    bar2 p a b
+  else
+    bar2 p b a
+
+let () = foo3 10 true 1 2 None
+
 external local_stack_offset : unit -> int = "caml_local_stack_offset"
 
 let[@inline never][@specialise never][@local never] allocate () =


### PR DESCRIPTION
The following code will currently stack overflow rather than loop forever:
```ocaml
let[@inline never] ignore_local (local_ x) = ()

let rec foo p a b =
  let bar x y =
    foo p x y
  in
  ignore_local (Some a);
  if p then
    bar a b
  else
    bar b a

let () = foo true 1 2
```
due to the "local functions" optimisation moving the tailcalls inside of the region.

To fix this issue, this PR adds support in lambda for `Lstaticcatch` constructs in the tail of a region, where the handler is executed after the region has closed. This is achieved by adding  a `pop_region` flag to `Lstaticcatch` and updating the cps conversion code to handle it appropriately.

Once this feature is available the fix to the "local functions" optimisation is trivial.