### PR TITLE
Use `Meet_with` for mode crossing

### DIFF
--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -5559,10 +5559,8 @@ let build_submode posi m =
   if posi then build_submode_pos (Alloc.allow_left m)
   else build_submode_neg (Alloc.allow_right m)
 
-(* CR layouts v2.8: use the meet-with-constant morphism when available *)
 (* CR layouts v2.8: merge with Typecore.mode_cross_left when [Value] and
    [Alloc] get unified *)
-(* The approach here works only for 2-element modal axes. *)
 let mode_cross_left env ty mode =
   (* CR layouts v2.8: The old check didn't check for principality, and so
      this one doesn't either. I think it should. But actually test results
@@ -5571,49 +5569,16 @@ let mode_cross_left env ty mode =
      now; will return and figure this out later. *)
   let jkind = type_jkind_purely env ty in
   let upper_bounds = Jkind.get_modal_upper_bounds jkind in
-  let mode = Alloc.disallow_right mode in
-  let mode =
-    if Locality.Const.le upper_bounds.locality Locality.Const.min
-    then Alloc.meet_with_locality Locality.Const.min mode
-    else mode
-  in
-  let mode =
-    if Linearity.Const.le upper_bounds.linearity Linearity.Const.min
-    then Alloc.meet_with_linearity Linearity.Const.min mode
-    else mode
-  in
-  let mode =
-    if Uniqueness.Const.le upper_bounds.uniqueness Uniqueness.Const.min
-    then Alloc.meet_with_uniqueness Uniqueness.Const.min mode
-    else mode
-  in
-  mode
+  Alloc.meet_with upper_bounds mode
 
 (* CR layouts v2.8: merge with Typecore.expect_mode_cross when [Value]
    and [Alloc] get unified *)
-(* The approach here works only for 2-element modal axes. *)
 let mode_cross_right env ty mode =
   (* CR layouts v2.8: This should probably check for principality. See
      similar comment in [mode_cross_left]. *)
   let jkind = type_jkind_purely env ty in
   let upper_bounds = Jkind.get_modal_upper_bounds jkind in
-  let mode = Alloc.disallow_left mode in
-  let mode =
-    if Locality.Const.le upper_bounds.locality Locality.Const.min
-    then Alloc.join_with_locality Locality.Const.max mode
-    else mode
-  in
-  let mode =
-    if Linearity.Const.le upper_bounds.linearity Linearity.Const.min
-    then Alloc.join_with_linearity Linearity.Const.max mode
-    else mode
-  in
-  let mode =
-    if Uniqueness.Const.le upper_bounds.uniqueness Uniqueness.Const.min
-    then Alloc.join_with_uniqueness Uniqueness.Const.max mode
-    else mode
-  in
-  mode
+  Alloc.imply upper_bounds mode
 
 let rec build_subtype env (visited : transient_expr list)
     (loops : (int * type_expr) list) posi level t =

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1259,6 +1259,7 @@ module Comonadic_with_regionality = struct
   end
 
   include Common (Obj)
+  open Obj
 
   type error =
     [ `Regionality of Regionality.error
@@ -1308,6 +1309,11 @@ module Comonadic_with_regionality = struct
       (Meet_with (C.max_with Obj.obj Linearity c))
       (S.Positive.disallow_right m)
 
+  let meet_with c m =
+    Solver.via_monotone obj (Meet_with c) (Solver.disallow_right m)
+
+  let imply c m = Solver.via_monotone obj (Imply c) (Solver.disallow_left m)
+
   let zap_to_legacy m =
     let regionality = regionality m |> Regionality.zap_to_legacy in
     let linearity = linearity m |> Linearity.zap_to_legacy in
@@ -1351,6 +1357,7 @@ module Comonadic_with_locality = struct
   end
 
   include Common (Obj)
+  open Obj
 
   type error =
     [ `Locality of Locality.error
@@ -1405,6 +1412,11 @@ module Comonadic_with_locality = struct
     let linearity = linearity m |> Linearity.zap_to_legacy in
     locality, linearity
 
+  let meet_with c m =
+    Solver.via_monotone obj (Meet_with c) (Solver.disallow_right m)
+
+  let imply c m = Solver.via_monotone obj (Imply c) (Solver.disallow_left m)
+
   let legacy = of_const Const.legacy
 
   (* overriding to report the offending axis *)
@@ -1443,6 +1455,7 @@ module Monadic = struct
   end
 
   include Common (Obj)
+  open Obj
 
   type error = [`Uniqueness of Uniqueness.error]
 
@@ -1472,6 +1485,11 @@ module Monadic = struct
     S.Negative.via_monotone Obj.obj
       (Join_with (C.min_with Obj.obj Uniqueness c))
       (S.Negative.disallow_right m)
+
+  let meet_with c m =
+    Solver.via_monotone obj (Join_with c) (Solver.disallow_right m)
+
+  let imply c m = Solver.via_monotone obj (Subtract c) (Solver.disallow_left m)
 
   let zap_to_legacy m =
     let uniqueness = uniqueness m |> Uniqueness.zap_to_legacy in
@@ -1513,6 +1531,12 @@ module Value = struct
   type r = (disallowed * allowed) t
 
   type lr = (allowed * allowed) t
+
+  type ('a, 'b, 'c) modes =
+    { regionality : 'a;
+      linearity : 'b;
+      uniqueness : 'c
+    }
 
   let min = { comonadic = Comonadic.min; monadic = Monadic.min }
 
@@ -1604,23 +1628,26 @@ module Value = struct
 
   let zap_to_floor { comonadic; monadic } =
     match Monadic.zap_to_floor monadic, Comonadic.zap_to_floor comonadic with
-    | (uniqueness, ()), (locality, linearity) -> locality, linearity, uniqueness
+    | (uniqueness, ()), (regionality, linearity) ->
+      { regionality; linearity; uniqueness }
 
   let zap_to_ceil { comonadic; monadic } =
     match Monadic.zap_to_ceil monadic, Comonadic.zap_to_ceil comonadic with
-    | (uniqueness, ()), (locality, linearity) -> locality, linearity, uniqueness
+    | (uniqueness, ()), (regionality, linearity) ->
+      { regionality; linearity; uniqueness }
 
   let zap_to_legacy { comonadic; monadic } =
     match Monadic.zap_to_legacy monadic, Comonadic.zap_to_legacy comonadic with
-    | (uniqueness, ()), (locality, linearity) -> locality, linearity, uniqueness
+    | (uniqueness, ()), (regionality, linearity) ->
+      { regionality; linearity; uniqueness }
 
   let check_const { comonadic; monadic } =
-    let locality, linearity = Comonadic.check_const comonadic in
+    let regionality, linearity = Comonadic.check_const comonadic in
     let uniqueness = Monadic.check_const monadic in
-    locality, linearity, uniqueness
+    { regionality; linearity; uniqueness }
 
-  let of_const (locality, linearity, uniqueness) =
-    let comonadic = Comonadic.of_const (locality, linearity) in
+  let of_const { regionality; linearity; uniqueness } =
+    let comonadic = Comonadic.of_const (regionality, linearity) in
     let monadic = Monadic.of_const (uniqueness, ()) in
     { comonadic; monadic }
 
@@ -1720,33 +1747,67 @@ module Value = struct
       (Comonadic_to_monadic Comonadic.Obj.obj) m
 
   module Const = struct
-    type t = Regionality.Const.t * Linearity.Const.t * Uniqueness.Const.t
+    type t = (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
 
-    let min = Regionality.Const.min, Linearity.Const.min, Uniqueness.Const.min
+    let split { regionality; linearity; uniqueness } =
+      let monadic = uniqueness, () in
+      let comonadic = regionality, linearity in
+      { comonadic; monadic }
 
-    let max = Regionality.Const.max, Linearity.Const.max, Uniqueness.Const.max
+    let _merge { comonadic; monadic } =
+      let regionality, linearity = comonadic in
+      let uniqueness, () = monadic in
+      { regionality; linearity; uniqueness }
 
-    let le (locality0, linearity0, uniqueness0)
-        (locality1, linearity1, uniqueness1) =
-      Regionality.Const.le locality0 locality1
-      && Uniqueness.Const.le uniqueness0 uniqueness1
-      && Linearity.Const.le linearity0 linearity1
+    let min =
+      { regionality = Regionality.Const.min;
+        linearity = Linearity.Const.min;
+        uniqueness = Uniqueness.Const.min
+      }
+
+    let max =
+      { regionality = Regionality.Const.max;
+        linearity = Linearity.Const.max;
+        uniqueness = Uniqueness.Const.max
+      }
+
+    let le m0 m1 =
+      Regionality.Const.le m0.regionality m1.regionality
+      && Uniqueness.Const.le m0.uniqueness m1.uniqueness
+      && Linearity.Const.le m0.linearity m1.linearity
 
     let print ppf m = print () ppf (of_const m)
 
     let legacy =
-      Regionality.Const.legacy, Linearity.Const.legacy, Uniqueness.Const.legacy
+      { regionality = Regionality.Const.legacy;
+        linearity = Linearity.Const.legacy;
+        uniqueness = Uniqueness.Const.legacy
+      }
 
-    let meet (l0, l1, l2) (r0, r1, r2) =
-      ( Regionality.Const.meet l0 r0,
-        Linearity.Const.meet l1 r1,
-        Uniqueness.Const.meet l2 r2 )
+    let meet m0 m1 =
+      let regionality = Regionality.Const.meet m0.regionality m1.regionality in
+      let linearity = Linearity.Const.meet m0.linearity m1.linearity in
+      let uniqueness = Uniqueness.Const.meet m0.uniqueness m1.uniqueness in
+      { regionality; linearity; uniqueness }
 
-    let join (l0, l1, l2) (r0, r1, r2) =
-      ( Regionality.Const.join l0 r0,
-        Linearity.Const.join l1 r1,
-        Uniqueness.Const.join l2 r2 )
+    let join m0 m1 =
+      let regionality = Regionality.Const.join m0.regionality m1.regionality in
+      let linearity = Linearity.Const.join m0.linearity m1.linearity in
+      let uniqueness = Uniqueness.Const.join m0.uniqueness m1.uniqueness in
+      { regionality; linearity; uniqueness }
   end
+
+  let meet_with c { comonadic; monadic } =
+    let c = Const.split c in
+    let comonadic = Comonadic.meet_with c.comonadic comonadic in
+    let monadic = Monadic.meet_with c.monadic monadic in
+    { monadic; comonadic }
+
+  let imply c { comonadic; monadic } =
+    let c = Const.split c in
+    let comonadic = Comonadic.imply c.comonadic comonadic in
+    let monadic = Monadic.imply c.monadic monadic in
+    { monadic; comonadic }
 
   module List = struct
     type nonrec 'd t = 'd t list
@@ -1776,6 +1837,12 @@ module Alloc = struct
   type r = (disallowed * allowed) t
 
   type lr = (allowed * allowed) t
+
+  type ('a, 'b, 'c) modes =
+    { locality : 'a;
+      linearity : 'b;
+      uniqueness : 'c
+    }
 
   let min = { comonadic = Comonadic.min; monadic = Monadic.min }
 
@@ -1961,19 +2028,13 @@ module Alloc = struct
     S.Positive.via_antitone Comonadic.Obj.obj Monadic_to_comonadic_min
       (Monadic.disallow_left m)
 
+  let of_const { locality; linearity; uniqueness } =
+    let comonadic = Comonadic.of_const (locality, linearity) in
+    let monadic = Monadic.of_const (uniqueness, ()) in
+    { comonadic; monadic }
+
   module Const = struct
-    type ('loc, 'lin, 'uni) modes =
-      { locality : 'loc;
-        linearity : 'lin;
-        uniqueness : 'uni
-      }
-
     type t = (Locality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
-
-    let of_const { locality; linearity; uniqueness } =
-      let comonadic = Comonadic.of_const (locality, linearity) in
-      let monadic = Monadic.of_const (uniqueness, ()) in
-      { comonadic; monadic }
 
     let min =
       let locality = Locality.Const.min in
@@ -2059,7 +2120,17 @@ module Alloc = struct
       merge { comonadic; monadic }
   end
 
-  let of_const = Const.of_const
+  let meet_with c { comonadic; monadic } =
+    let c = Const.split c in
+    let comonadic = Comonadic.meet_with c.comonadic comonadic in
+    let monadic = Monadic.meet_with c.monadic monadic in
+    { monadic; comonadic }
+
+  let imply c { comonadic; monadic } =
+    let c = Const.split c in
+    let comonadic = Comonadic.imply c.comonadic comonadic in
+    let monadic = Monadic.imply c.monadic monadic in
+    { monadic; comonadic }
 
   let zap_to_floor { comonadic; monadic } : Const.t =
     match Monadic.zap_to_floor monadic, Comonadic.zap_to_floor comonadic with
@@ -2102,6 +2173,13 @@ module Alloc = struct
     let monadic = Monadic.disallow_right Monadic.min in
     let comonadic = Comonadic.disallow_right comonadic in
     { comonadic; monadic }
+end
+
+module Const = struct
+  let alloc_as_value ({ locality; linearity; uniqueness } : Alloc.Const.t) :
+      Value.Const.t =
+    let regionality = C.locality_as_regionality locality in
+    { regionality; linearity; uniqueness }
 end
 
 let alloc_as_value m =

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -95,8 +95,6 @@ module type Common = sig
 
   val zap_to_ceil : ('l * allowed) t -> Const.t
 
-  val check_const : ('l * 'r) t -> Const.t option
-
   val of_const : Const.t -> ('l * 'r) t
 end
 
@@ -152,6 +150,8 @@ module type S = sig
     val local : lr
 
     val zap_to_legacy : (allowed * 'r) t -> Const.t
+
+    val check_const : ('l * 'r) t -> Const.t option
   end
 
   module Regionality : sig
@@ -220,29 +220,24 @@ module type S = sig
   (** The most general mode. Used in most type checking,
       including in value bindings in [Env] *)
   module Value : sig
-    module Monadic : sig
-      include Common with type error = [`Uniqueness of Uniqueness.error]
+    module Monadic : Common with type error = [`Uniqueness of Uniqueness.error]
 
-      val check_const : ('l * 'r) t -> Uniqueness.Const.t option
-    end
+    module Comonadic :
+      Common
+        with type error =
+          [ `Regionality of Regionality.error
+          | `Linearity of Linearity.error ]
 
-    module Comonadic : sig
-      include
-        Common
-          with type error =
-            [ `Regionality of Regionality.error
-            | `Linearity of Linearity.error ]
-
-      val check_const :
-        ('l * 'r) t -> Regionality.Const.t option * Linearity.Const.t option
-
-      val linearity : ('l * 'r) t -> ('l * 'r) Linearity.t
-    end
+    type ('a, 'b, 'c) modes =
+      { regionality : 'a;
+        linearity : 'b;
+        uniqueness : 'c
+      }
 
     module Const :
       Lattice
         with type t =
-          Regionality.Const.t * Linearity.Const.t * Uniqueness.Const.t
+          (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
 
     type error =
       [ `Regionality of Regionality.error
@@ -273,9 +268,10 @@ module type S = sig
 
     val check_const :
       ('l * 'r) t ->
-      Regionality.Const.t option
-      * Linearity.Const.t option
-      * Uniqueness.Const.t option
+      ( Regionality.Const.t option,
+        Linearity.Const.t option,
+        Uniqueness.Const.t option )
+      modes
 
     val regionality : ('l * 'r) t -> ('l * 'r) Regionality.t
 
@@ -316,6 +312,10 @@ module type S = sig
     val zap_to_legacy : lr -> Const.t
 
     val comonadic_to_monadic : ('l * 'r) Comonadic.t -> ('r * 'l) Monadic.t
+
+    val meet_with : Const.t -> ('l * 'r) t -> ('l * disallowed) t
+
+    val imply : Const.t -> ('l * 'r) t -> (disallowed * 'r) t
   end
 
   (** The mode on arrow types. Compared to [Value], it contains the [Locality]
@@ -325,10 +325,7 @@ module type S = sig
     module Monadic : sig
       include Common with type error = [`Uniqueness of Uniqueness.error]
 
-      val join_with_uniqueness :
-        Uniqueness.Const.t -> ('l * 'r) t -> (disallowed * 'r) t
-
-      val check_const : ('l * 'r) t -> Uniqueness.Const.t option
+      val imply : Const.t -> ('l * 'r) t -> (disallowed * 'r) t
     end
 
     module Comonadic : sig
@@ -338,27 +335,22 @@ module type S = sig
             [ `Locality of Locality.error
             | `Linearity of Linearity.error ]
 
-      val meet_with_locality :
-        Locality.Const.t -> ('l * 'r) t -> ('l * disallowed) t
-
-      val meet_with_linearity :
-        Linearity.Const.t -> ('l * 'r) t -> ('l * disallowed) t
-
-      val check_const :
-        ('l * 'r) t -> Locality.Const.t option * Linearity.Const.t option
+      val meet_with : Const.t -> ('l * 'r) t -> ('l * disallowed) t
     end
 
-    module Const : sig
-      type ('loc, 'lin, 'uni) modes =
-        { locality : 'loc;
-          linearity : 'lin;
-          uniqueness : 'uni
-        }
+    type ('loc, 'lin, 'uni) modes =
+      { locality : 'loc;
+        linearity : 'lin;
+        uniqueness : 'uni
+      }
 
+    module Const : sig
       include
         Lattice
           with type t =
             (Locality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
+
+      val split : t -> (Monadic.Const.t, Comonadic.Const.t) monadic_comonadic
 
       module Option : sig
         type some = t
@@ -443,6 +435,10 @@ module type S = sig
 
     val zap_to_legacy : lr -> Const.t
 
+    val meet_with : Const.t -> ('l * 'r) t -> ('l * disallowed) t
+
+    val imply : Const.t -> ('l * 'r) t -> (disallowed * 'r) t
+
     (* The following two are about the scenario where we partially apply a
        function [A -> B -> C] to [A] and get back [B -> C]. The mode of the
        three are constrained. *)
@@ -454,6 +450,10 @@ module type S = sig
 
     (** Returns the lower bound needed for [B -> C] in relation to [A -> B -> C] *)
     val partial_apply : (allowed * 'r) t -> l
+  end
+
+  module Const : sig
+    val alloc_as_value : Alloc.Const.t -> Value.Const.t
   end
 
   (** Converts regional to local, identity otherwise *)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -830,6 +830,10 @@ let expect_mode_cross env ty (expected_mode : expected_mode) =
   let upper_bounds = Jkind.get_modal_upper_bounds jkind in
   let upper_bounds = Const.alloc_as_value upper_bounds in
   let mode = Value.imply upper_bounds expected_mode.mode in
+  (* - [strict_local] doesn't need to be updated, because it's only relavant for
+     functions, which don't cross locality.
+     - [mode_tuples] doesn't need to be updated, because [mode] being higher
+     won't violate the invariant. *)
   { expected_mode with mode }
 
 (* Value binding elaboration can insert alloc mode attributes on the forged


### PR DESCRIPTION
This PR uses the `Meet_with` from #2302 to do mode crossing, so now mode crossing supports non-trivial `upper_bounds` of modal kinds.

In that process, some cleaning up of the mode system is required. In particular, to express `alloc_mode_cross_to_max_min`, we need to split the `upper_bound : Alloc.Const.t` into `Monadic.Const.t` and `Comonadic.Const.t`. Previously they are exposed in `check_const` as unlabelled tuples, which is bad. They are now opaque, because the user never needs to look into the axes.