### PR TITLE
[Implicit Source Positions] - Better Error Messages

### DIFF
--- a/ocaml/ocamldoc/odoc_sig.ml
+++ b/ocaml/ocamldoc/odoc_sig.ml
@@ -1850,7 +1850,8 @@ module Analyser =
       | (Parsetree.Pcty_arrow (parse_label, _, pclass_type), Types.Cty_arrow (label, type_expr, class_type)) ->
           (* label = string. In signature, there is no parameter names inside tuples *)
           (* if label = "", no label . Here we have the information to determine if a label is explicit or not. *)
-          (* CR src_pos: Implement Position arguments for classes, and pass a
+          (* XXX jrodri for jrodri: Think more about this... *)
+          (* XCR src_pos: Implement Position arguments for classes, and pass a
              reasonable type to translate the label below *)
           if (Typetexp.transl_label parse_label None) = label then
             (

--- a/ocaml/ocamldoc/odoc_sig.ml
+++ b/ocaml/ocamldoc/odoc_sig.ml
@@ -1847,13 +1847,10 @@ module Analyser =
           in
           ([], Class_structure (inher_l, ele))
 
-      | (Parsetree.Pcty_arrow (parse_label, _, pclass_type), Types.Cty_arrow (label, type_expr, class_type)) ->
+      | (Parsetree.Pcty_arrow (parse_label, type_, pclass_type), Types.Cty_arrow (label, type_expr, class_type)) ->
           (* label = string. In signature, there is no parameter names inside tuples *)
           (* if label = "", no label . Here we have the information to determine if a label is explicit or not. *)
-          (* XXX jrodri for jrodri: Think more about this... *)
-          (* XCR src_pos: Implement Position arguments for classes, and pass a
-             reasonable type to translate the label below *)
-          if (Typetexp.transl_label parse_label None) = label then
+          if (Typetexp.transl_label parse_label (Some type_)) = label then
             (
              let new_param = Simple_name
                  {

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -217,6 +217,8 @@ let error_of_extension ext =
       | _ ->
           Location.errorf ~loc "Invalid syntax for extension '%s'." txt
       end
+  | ({txt = "call_pos"; loc}, _) ->
+      Location.errorf ~loc "call_pos can only exist as the type of a labelled argument"
   | ({txt; loc}, _) ->
       Location.errorf ~loc "Uninterpreted extension '%s'." txt
 

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -218,7 +218,7 @@ let error_of_extension ext =
           Location.errorf ~loc "Invalid syntax for extension '%s'." txt
       end
   | ({txt = "call_pos"; loc}, _) ->
-      Location.errorf ~loc "call_pos can only exist as the type of a labelled argument"
+      Location.errorf ~loc "[%%call_pos] can only exist as the type of a labelled argument"
   | ({txt; loc}, _) ->
       Location.errorf ~loc "Uninterpreted extension '%s'." txt
 

--- a/ocaml/parsing/parsetree.mli
+++ b/ocaml/parsing/parsetree.mli
@@ -338,7 +338,7 @@ and expression_desc =
              {{!expression_desc.Pexp_fun}[Pexp_fun]}.
            - [let f P = E] is represented using
              {{!expression_desc.Pexp_fun}[Pexp_fun]}.
-           - While Position arguments ([lbl:[%src_pos] -> ...]) are parsed as
+           - While Position arguments ([lbl:[%call_pos] -> ...]) are parsed as
              {{!Asttypes.arg_label.Labelled}[Labelled l]}, they are converted to
              {{!Types.arg_label.Position}[Position l]} arguments for type-checking.
          *)

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/commuting.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/commuting.ml
@@ -11,10 +11,10 @@ val pos_b : lexing_position =
   {pos_fname = "b"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
 |}]
 
-let f = fun ~(a:[%src_pos]) ~(b:[%src_pos]) () -> a, b
+let f = fun ~(a:[%call_pos]) ~(b:[%call_pos]) () -> a, b
 [%%expect{|
 val f :
-  a:[%src_pos] -> b:[%src_pos] -> unit -> lexing_position * lexing_position =
+  a:[%call_pos] -> b:[%call_pos] -> unit -> lexing_position * lexing_position =
   <fun>
 |}]
 
@@ -30,18 +30,18 @@ let x = f ~b:pos_b ;;
 let y = x ~a:pos_a ;;
 let z = y () ;;
 [%%expect {|
-val x : a:[%src_pos] -> unit -> lexing_position * lexing_position = <fun>
+val x : a:[%call_pos] -> unit -> lexing_position * lexing_position = <fun>
 val y : unit -> lexing_position * lexing_position = <fun>
 val z : lexing_position * lexing_position =
   ({pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1},
    {pos_fname = "b"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1})
 |}]
 
-let g = fun ~(a:[%src_pos]) ?(c = 0) ~(b:[%src_pos]) () -> a, b, c
+let g = fun ~(a:[%call_pos]) ?(c = 0) ~(b:[%call_pos]) () -> a, b, c
 [%%expect{|
 val g :
-  a:[%src_pos] ->
-  ?c:int -> b:[%src_pos] -> unit -> lexing_position * lexing_position * int =
+  a:[%call_pos] ->
+  ?c:int -> b:[%call_pos] -> unit -> lexing_position * lexing_position * int =
   <fun>
 |}]
 
@@ -52,9 +52,9 @@ let _ = g ~b:pos_b ~a:pos_a () ;;
  {pos_fname = "b"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}, 0)
 |}]
 
-let h = fun ~(a:[%src_pos]) ~(b:int) () -> a, b
+let h = fun ~(a:[%call_pos]) ~(b:int) () -> a, b
 [%%expect{|
-val h : a:[%src_pos] -> b:int -> unit -> lexing_position * int = <fun>
+val h : a:[%call_pos] -> b:int -> unit -> lexing_position * int = <fun>
 |}]
 
 let _ = h ~b:0 ~a:pos_a ();;
@@ -63,9 +63,9 @@ let _ = h ~b:0 ~a:pos_a ();;
 ({pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}, 0)
 |}]
 
-let k = fun ~(a:int) ~(a:[%src_pos])() -> a
+let k = fun ~(a:int) ~(a:[%call_pos])() -> a
 [%%expect{|
-val k : a:int -> a:[%src_pos] -> unit -> lexing_position = <fun>
+val k : a:int -> a:[%call_pos] -> unit -> lexing_position = <fun>
 |}]
 
 let _ = k ~a:Lexing.dummy_pos ~a:0 ();;
@@ -84,26 +84,26 @@ let _ = k ~a:0 ~a:Lexing.dummy_pos ();;
 |}]
 
 (* Labels on source positions can't commute in definitions *)
-let m : a:[%src_pos] -> b:[%src_pos] -> unit -> unit = fun ~(b:[%src_pos]) ~(a:[%src_pos]) () -> ()
+let m : a:[%call_pos] -> b:[%call_pos] -> unit -> unit = fun ~(b:[%call_pos]) ~(a:[%call_pos]) () -> ()
 [%%expect{|
-Line 1, characters 55-99:
-1 | let m : a:[%src_pos] -> b:[%src_pos] -> unit -> unit = fun ~(b:[%src_pos]) ~(a:[%src_pos]) () -> ()
-                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 57-103:
+1 | let m : a:[%call_pos] -> b:[%call_pos] -> unit -> unit = fun ~(b:[%call_pos]) ~(a:[%call_pos]) () -> ()
+                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This function should have type
-         a:[%src_pos] -> b:[%src_pos] -> unit -> unit
-       but its first argument is ~(b:[%src_pos]) instead of ~(a:[%src_pos])
+         a:[%call_pos] -> b:[%call_pos] -> unit -> unit
+       but its first argument is ~(b:[%call_pos]) instead of ~(a:[%call_pos])
 |}]
 
 (* Object system *)
 
-class c ~(a : [%src_pos]) ~(b : [%src_pos]) () =
+class c ~(a : [%call_pos]) ~(b : [%call_pos]) () =
   object 
     method x = a, b
   end
 [%%expect{|
 class c :
-  a:[%src_pos] ->
-  b:[%src_pos] ->
+  a:[%call_pos] ->
+  b:[%call_pos] ->
   unit -> object method x : lexing_position * lexing_position end
 |}]
 
@@ -112,7 +112,7 @@ let x = new c ~b:pos_b ;;
 let y = x ~a:pos_a ;;
 let a, b = (y ())#x ;;
 [%%expect{|
-val x : a:[%src_pos] -> unit -> c = <fun>
+val x : a:[%call_pos] -> unit -> c = <fun>
 val y : unit -> c = <fun>
 val a : lexing_position =
   {pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
@@ -121,34 +121,34 @@ val b : lexing_position =
 |}]
 
 (* Labels on source positions can't commute in class definitions *)
-class m : a:[%src_pos] -> b:[%src_pos] -> unit -> object end =
-  fun ~(b:[%src_pos]) ~(a:[%src_pos]) () -> object end
+class m : a:[%call_pos] -> b:[%call_pos] -> unit -> object end =
+  fun ~(b:[%call_pos]) ~(a:[%call_pos]) () -> object end
 [%%expect{|
-Line 2, characters 6-54:
-2 |   fun ~(b:[%src_pos]) ~(a:[%src_pos]) () -> object end
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The class type b:[%src_pos] -> a:[%src_pos] -> unit -> object  end
+Line 2, characters 6-56:
+2 |   fun ~(b:[%call_pos]) ~(a:[%call_pos]) () -> object end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The class type b:[%call_pos] -> a:[%call_pos] -> unit -> object  end
        is not matched by the class type
-         a:[%src_pos] -> b:[%src_pos] -> unit -> object  end
+         a:[%call_pos] -> b:[%call_pos] -> unit -> object  end
 |}]
 
-(* [%src_pos] is distinct from lexing_position *)
+(* [%call_pos] is distinct from lexing_position *)
 class c :
-  a:lexing_position -> b:[%src_pos] -> unit -> object
+  a:lexing_position -> b:[%call_pos] -> unit -> object
     method x : lexing_position * lexing_position
-  end = fun ~(a : [%src_pos]) ~b () -> object
+  end = fun ~(a : [%call_pos]) ~b () -> object
     method x = a, b
   end
 [%%expect{|
 Lines 4-6, characters 12-5:
-4 | ............~(a : [%src_pos]) ~b () -> object
+4 | ............~(a : [%call_pos]) ~b () -> object
 5 |     method x = a, b
 6 |   end
 Error: The class type
-         a:[%src_pos] -> b:'b -> unit -> object method x : 'a * 'b end
+         a:[%call_pos] -> b:'b -> unit -> object method x : 'a * 'b end
        is not matched by the class type
          a:lexing_position ->
-         b:[%src_pos] ->
+         b:[%call_pos] ->
          unit -> object method x : lexing_position * lexing_position end
 |}]
 

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/expressions.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/expressions.ml
@@ -8,21 +8,21 @@ val x : lexing_position =
   {pos_fname = ""; pos_lnum = 1; pos_bol = 24; pos_cnum = 32}
 |}]
 
-let f = fun ~(src_pos:[%src_pos]) () -> src_pos
+let f = fun ~(call_pos:[%call_pos]) () -> call_pos
 [%%expect{|
-val f : src_pos:[%src_pos] -> unit -> lexing_position = <fun>
+val f : call_pos:[%call_pos] -> unit -> lexing_position = <fun>
 |}]
 
-let _ = f ~src_pos:x () ;;
+let _ = f ~call_pos:x () ;;
 [%%expect{|
 - : lexing_position =
 {pos_fname = ""; pos_lnum = 1; pos_bol = 24; pos_cnum = 32}
 |}]
 
 let _ = "Increment line count"
-let _ = f ~src_pos:[%src_pos] () ;;
+let _ = f ~call_pos:[%src_pos] () ;;
 [%%expect{|
 - : string = "Increment line count"
 - : lexing_position =
-{pos_fname = ""; pos_lnum = 2; pos_bol = 432; pos_cnum = 451}
+{pos_fname = ""; pos_lnum = 2; pos_bol = 438; pos_cnum = 458}
 |}]

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/fn_decl_and_defn.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/fn_decl_and_defn.ml
@@ -2,25 +2,25 @@
    * expect
 *)
 
-type t = src_pos:[%src_pos] -> unit -> unit
+type t = call_pos:[%call_pos] -> unit -> unit
 
 [%%expect {|
-type t = src_pos:[%src_pos] -> unit -> unit
+type t = call_pos:[%call_pos] -> unit -> unit
 |}]
 
-let f : t = fun ~(src_pos:[%src_pos]) () -> ()
+let f : t = fun ~(call_pos:[%call_pos]) () -> ()
 
 [%%expect{|
 val f : t = <fun>
 |}]
 
-let g ~(src_pos:[%src_pos]) () = ()
+let g ~(call_pos:[%call_pos]) () = ()
 
 [%%expect{|
-val g : src_pos:[%src_pos] -> unit -> unit = <fun>
+val g : call_pos:[%call_pos] -> unit -> unit = <fun>
 |}]
 
-let apply (f : t) = f ~src_pos:Lexing.dummy_pos () ;;
+let apply (f : t) = f ~call_pos:Lexing.dummy_pos () ;;
 [%%expect {|
 val apply : t -> unit = <fun>
 |}]
@@ -35,7 +35,7 @@ let _ = apply g ;;
 - : unit = ()
 |}]
 
-let _ = g ~src_pos:Lexing.dummy_pos () ;;
+let _ = g ~call_pos:Lexing.dummy_pos () ;;
 [%%expect{|
 - : unit = ()
 |}]

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/implicit_argument.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/implicit_argument.ml
@@ -2,15 +2,15 @@
    * expect
 *)
 
-let f = fun ~(src_pos:[%src_pos]) () -> src_pos
+let f = fun ~(call_pos:[%call_pos]) () -> call_pos
 [%%expect{|
-val f : src_pos:[%src_pos] -> unit -> lexing_position = <fun>
+val f : call_pos:[%call_pos] -> unit -> lexing_position = <fun>
 |}]
 
 let _ = f ();;
 [%%expect{|
 - : lexing_position =
-{pos_fname = ""; pos_lnum = 1; pos_bol = 151; pos_cnum = 159}
+{pos_fname = ""; pos_lnum = 1; pos_bol = 156; pos_cnum = 164}
 |}]
 
 let j = (f : unit -> lexing_position);;
@@ -18,38 +18,39 @@ let j = (f : unit -> lexing_position);;
 val j : unit -> lexing_position = <fun>
 |}]
 
-let g = fun ~(a:[%src_pos]) ?(c = 0) ~(b:[%src_pos]) () -> a, b
+let g = fun ~(a:[%call_pos]) ?(c = 0) ~(b:[%call_pos]) () -> a, b
 [%%expect{|
 val g :
-  a:[%src_pos] ->
-  ?c:int -> b:[%src_pos] -> unit -> lexing_position * lexing_position = <fun>
+  a:[%call_pos] ->
+  ?c:int -> b:[%call_pos] -> unit -> lexing_position * lexing_position =
+  <fun>
 |}]
 
 let _ = g () ;;
 [%%expect{|
 - : lexing_position * lexing_position =
-({pos_fname = ""; pos_lnum = 1; pos_bol = 549; pos_cnum = 557},
- {pos_fname = ""; pos_lnum = 1; pos_bol = 549; pos_cnum = 557})
+({pos_fname = ""; pos_lnum = 1; pos_bol = 560; pos_cnum = 568},
+ {pos_fname = ""; pos_lnum = 1; pos_bol = 560; pos_cnum = 568})
 |}]
 
-let h ~(a:[%src_pos]) ~(b:[%src_pos]) () : lexing_position * lexing_position
+let h ~(a:[%call_pos]) ~(b:[%call_pos]) () : lexing_position * lexing_position
   = a, b
 [%%expect{|
 val h :
-  a:[%src_pos] -> b:[%src_pos] -> unit -> lexing_position * lexing_position =
+  a:[%call_pos] -> b:[%call_pos] -> unit -> lexing_position * lexing_position =
   <fun>
 |}]
 
 (* Partial application *)
 let x = h ~b:{Lexing.dummy_pos with pos_fname = "b"};;
 [%%expect{|
-val x : a:[%src_pos] -> unit -> lexing_position * lexing_position = <fun>
+val x : a:[%call_pos] -> unit -> lexing_position * lexing_position = <fun>
 |}]
 
 let y = x ();;
 [%%expect{|
 val y : lexing_position * lexing_position =
-  ({pos_fname = ""; pos_lnum = 1; pos_bol = 1119; pos_cnum = 1127},
+  ({pos_fname = ""; pos_lnum = 1; pos_bol = 1135; pos_cnum = 1143},
    {pos_fname = "b"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1})
 |}]
 
@@ -61,22 +62,22 @@ val k : unit -> lexing_position = <fun>
 let _ = j ();;
 [%%expect{|
 - : lexing_position =
-{pos_fname = ""; pos_lnum = 1; pos_bol = 267; pos_cnum = 276}
+{pos_fname = ""; pos_lnum = 1; pos_bol = 272; pos_cnum = 281}
 |}]
 
 let _ = k ();;
 [%%expect{|
 - : lexing_position =
-{pos_fname = ""; pos_lnum = 1; pos_bol = 1327; pos_cnum = 1336}
+{pos_fname = ""; pos_lnum = 1; pos_bol = 1343; pos_cnum = 1352}
 |}]
 
-let m ~(src_pos:[%src_pos]) = ()
+let m ~(call_pos:[%call_pos]) = ()
 [%%expect {|
-Line 1, characters 8-15:
-1 | let m ~(src_pos:[%src_pos]) = ()
-            ^^^^^^^
+Line 1, characters 8-16:
+1 | let m ~(call_pos:[%call_pos]) = ()
+            ^^^^^^^^
 Warning 188 [unerasable-position-argument]: this position argument cannot be erased.
 
-val m : src_pos:[%src_pos] -> unit = <fun>
+val m : call_pos:[%call_pos] -> unit = <fun>
 |}]
 

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
@@ -2,41 +2,41 @@
    * expect
 *)
 
-type t = [%src_pos]
+type t = [%call_pos]
 [%%expect {|
-Line 1, characters 11-18:
-1 | type t = [%src_pos]
-               ^^^^^^^
-Error: Uninterpreted extension 'src_pos'.
+Line 1, characters 11-19:
+1 | type t = [%call_pos]
+               ^^^^^^^^
+Error: Uninterpreted extension 'call_pos'.
 |}]
-(* CR src_pos: Improve this error message to notify that [%src_pos] may only
+(* CR src_pos: Improve this error message to notify that [%call_pos] may only
    be used in arguments *)
 
-type t = unit -> unit -> [%src_pos]
+type t = unit -> unit -> [%call_pos]
 [%%expect {|
-Line 1, characters 27-34:
-1 | type t = unit -> unit -> [%src_pos]
-                               ^^^^^^^
-Error: Uninterpreted extension 'src_pos'.
+Line 1, characters 27-35:
+1 | type t = unit -> unit -> [%call_pos]
+                               ^^^^^^^^
+Error: Uninterpreted extension 'call_pos'.
 |}]
 
-let f ~(src_pos:[%src_pos]) () : [%src_pos] = src_pos
+let f ~(call_pos:[%call_pos]) () : [%call_pos] = call_pos
 
 [%%expect{|
-Line 1, characters 35-42:
-1 | let f ~(src_pos:[%src_pos]) () : [%src_pos] = src_pos
-                                       ^^^^^^^
-Error: Uninterpreted extension 'src_pos'.
+Line 1, characters 37-45:
+1 | let f ~(call_pos:[%call_pos]) () : [%call_pos] = call_pos
+                                         ^^^^^^^^
+Error: Uninterpreted extension 'call_pos'.
 |}]
 
-let apply f = f ~src_pos:Lexing.dummy_pos () ;;
+let apply f = f ~call_pos:Lexing.dummy_pos () ;;
 [%%expect {|
-val apply : (src_pos:Lexing.position -> unit -> 'a) -> 'a = <fun>
+val apply : (call_pos:Lexing.position -> unit -> 'a) -> 'a = <fun>
 |}]
 
-let g = fun ~(src_pos:[%src_pos]) () -> ()
+let g = fun ~(call_pos:[%call_pos]) () -> ()
 [%%expect{|
-val g : src_pos:[%src_pos] -> unit -> unit = <fun>
+val g : call_pos:[%call_pos] -> unit -> unit = <fun>
 |}]
 
 let _ = apply g ;;
@@ -44,42 +44,42 @@ let _ = apply g ;;
 Line 1, characters 14-15:
 1 | let _ = apply g ;;
                   ^
-Error: This expression has type src_pos:[%src_pos] -> unit -> unit
+Error: This expression has type call_pos:[%call_pos] -> unit -> unit
        but an expression was expected of type
-         src_pos:Lexing.position -> (unit -> 'a)
+         call_pos:Lexing.position -> (unit -> 'a)
 |}]
 
-let h ?(src_pos:[%src_pos]) () = ()
+let h ?(call_pos:[%call_pos]) () = ()
 [%%expect{|
-Line 1, characters 16-26:
-1 | let h ?(src_pos:[%src_pos]) () = ()
-                    ^^^^^^^^^^
+Line 1, characters 17-28:
+1 | let h ?(call_pos:[%call_pos]) () = ()
+                     ^^^^^^^^^^^
 Error: A position argument must not be optional.
 |}]
 
-let j (src_pos:[%src_pos]) () = ()
+let j (call_pos:[%call_pos]) () = ()
 [%%expect{|
-Line 1, characters 15-25:
-1 | let j (src_pos:[%src_pos]) () = ()
-                   ^^^^^^^^^^
+Line 1, characters 16-27:
+1 | let j (call_pos:[%call_pos]) () = ()
+                    ^^^^^^^^^^^
 Error: A position argument must not be unlabelled.
 |}]
 
-let k : src_pos:[%src_pos] -> unit -> unit =
-   fun ~src_pos () -> ()
+let k : call_pos:[%call_pos] -> unit -> unit =
+   fun ~call_pos () -> ()
 (* CR src_pos: Improve this error message *)
 [%%expect{|
-Line 2, characters 3-24:
-2 |    fun ~src_pos () -> ()
-       ^^^^^^^^^^^^^^^^^^^^^
-Error: This function should have type src_pos:[%src_pos] -> unit -> unit
-       but its first argument is labeled ~src_pos
-       instead of ~(src_pos:[%src_pos])
+Line 2, characters 3-25:
+2 |    fun ~call_pos () -> ()
+       ^^^^^^^^^^^^^^^^^^^^^^
+Error: This function should have type call_pos:[%call_pos] -> unit -> unit
+       but its first argument is labeled ~call_pos
+       instead of ~(call_pos:[%call_pos])
 |}]
 
-let n = fun ~(src_pos:[%src_pos]) () -> src_pos
+let n = fun ~(call_pos:[%call_pos]) () -> call_pos
 [%%expect{|
-val n : src_pos:[%src_pos] -> unit -> lexing_position = <fun>
+val n : call_pos:[%call_pos] -> unit -> lexing_position = <fun>
 |}]
 
 let _ = n Lexing.dummy_pos ();;
@@ -88,45 +88,45 @@ Line 1, characters 27-29:
 1 | let _ = n Lexing.dummy_pos ();;
                                ^^
 Error: The function applied to this argument has type
-         src_pos:[%src_pos] -> lexing_position
+         call_pos:[%call_pos] -> lexing_position
 This argument cannot be applied without label
 |}]
 
-class this_class_has_an_unerasable_argument ~(pos : [%src_pos]) = object end
+class this_class_has_an_unerasable_argument ~(pos : [%call_pos]) = object end
 
 [%%expect{|
 Line 1, characters 46-49:
-1 | class this_class_has_an_unerasable_argument ~(pos : [%src_pos]) = object end
+1 | class this_class_has_an_unerasable_argument ~(pos : [%call_pos]) = object end
                                                   ^^^
 Warning 188 [unerasable-position-argument]: this position argument cannot be erased.
 
-class this_class_has_an_unerasable_argument : pos:[%src_pos] -> object  end
+class this_class_has_an_unerasable_argument : pos:[%call_pos] -> object  end
 |}]
 
 class c = object 
-  method this_method_has_an_unerasable_argument ~(pos : [%src_pos]) = pos
+  method this_method_has_an_unerasable_argument ~(pos : [%call_pos]) = pos
 end
 [%%expect{|
 Line 2, characters 50-53:
-2 |   method this_method_has_an_unerasable_argument ~(pos : [%src_pos]) = pos
+2 |   method this_method_has_an_unerasable_argument ~(pos : [%call_pos]) = pos
                                                       ^^^
 Warning 188 [unerasable-position-argument]: this position argument cannot be erased.
 
 class c :
   object
     method this_method_has_an_unerasable_argument :
-      pos:[%src_pos] -> lexing_position
+      pos:[%call_pos] -> lexing_position
   end
 |}]
 
-let this_object_has_an_unerasable_argument ~(pos : [%src_pos]) = object end
+let this_object_has_an_unerasable_argument ~(pos : [%call_pos]) = object end
 
 [%%expect{|
 Line 1, characters 45-48:
-1 | let this_object_has_an_unerasable_argument ~(pos : [%src_pos]) = object end
+1 | let this_object_has_an_unerasable_argument ~(pos : [%call_pos]) = object end
                                                  ^^^
 Warning 188 [unerasable-position-argument]: this position argument cannot be erased.
 
-val this_object_has_an_unerasable_argument : pos:[%src_pos] -> <  > = <fun>
+val this_object_has_an_unerasable_argument : pos:[%call_pos] -> <  > = <fun>
 |}]
 

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
@@ -7,17 +7,15 @@ type t = [%call_pos]
 Line 1, characters 11-19:
 1 | type t = [%call_pos]
                ^^^^^^^^
-Error: Uninterpreted extension 'call_pos'.
+Error: call_pos can only exist as the type of a labelled argument
 |}]
-(* CR src_pos: Improve this error message to notify that [%call_pos] may only
-   be used in arguments *)
 
 type t = unit -> unit -> [%call_pos]
 [%%expect {|
 Line 1, characters 27-35:
 1 | type t = unit -> unit -> [%call_pos]
                                ^^^^^^^^
-Error: Uninterpreted extension 'call_pos'.
+Error: call_pos can only exist as the type of a labelled argument
 |}]
 
 let f ~(call_pos:[%call_pos]) () : [%call_pos] = call_pos
@@ -26,7 +24,7 @@ let f ~(call_pos:[%call_pos]) () : [%call_pos] = call_pos
 Line 1, characters 37-45:
 1 | let f ~(call_pos:[%call_pos]) () : [%call_pos] = call_pos
                                          ^^^^^^^^
-Error: Uninterpreted extension 'call_pos'.
+Error: call_pos can only exist as the type of a labelled argument
 |}]
 
 let apply f = f ~call_pos:Lexing.dummy_pos () ;;
@@ -67,7 +65,6 @@ Error: A position argument must not be unlabelled.
 
 let k : call_pos:[%call_pos] -> unit -> unit =
    fun ~call_pos () -> ()
-(* CR src_pos: Improve this error message *)
 [%%expect{|
 Line 2, characters 3-25:
 2 |    fun ~call_pos () -> ()
@@ -75,6 +72,7 @@ Line 2, characters 3-25:
 Error: This function should have type call_pos:[%call_pos] -> unit -> unit
        but its first argument is labeled ~call_pos
        instead of ~(call_pos:[%call_pos])
+Hint: Consider explicitly annotating the label with '[%call_pos]'
 |}]
 
 let n = fun ~(call_pos:[%call_pos]) () -> call_pos

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
@@ -7,7 +7,7 @@ type t = [%call_pos]
 Line 1, characters 11-19:
 1 | type t = [%call_pos]
                ^^^^^^^^
-Error: call_pos can only exist as the type of a labelled argument
+Error: [%call_pos] can only exist as the type of a labelled argument
 |}]
 
 type t = unit -> unit -> [%call_pos]
@@ -15,7 +15,7 @@ type t = unit -> unit -> [%call_pos]
 Line 1, characters 27-35:
 1 | type t = unit -> unit -> [%call_pos]
                                ^^^^^^^^
-Error: call_pos can only exist as the type of a labelled argument
+Error: [%call_pos] can only exist as the type of a labelled argument
 |}]
 
 let f ~(call_pos:[%call_pos]) () : [%call_pos] = call_pos
@@ -24,7 +24,7 @@ let f ~(call_pos:[%call_pos]) () : [%call_pos] = call_pos
 Line 1, characters 37-45:
 1 | let f ~(call_pos:[%call_pos]) () : [%call_pos] = call_pos
                                          ^^^^^^^^
-Error: call_pos can only exist as the type of a labelled argument
+Error: [%call_pos] can only exist as the type of a labelled argument
 |}]
 
 let apply f = f ~call_pos:Lexing.dummy_pos () ;;

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/let_operators.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/let_operators.ml
@@ -2,51 +2,51 @@
    * expect
 *)
 
-let ( let+ ) ~(src_pos : [%src_pos]) a f = f (src_pos, a);;
+let ( let+ ) ~(call_pos : [%call_pos]) a f = f (call_pos, a);;
 [%%expect{|
-val ( let+ ) : src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b =
-  <fun>
+val ( let+ ) :
+  call_pos:[%call_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b = <fun>
 |}]
 
 (* Would be nice to add support for implicit position parameters and (also maybe optional
    arguments) for let operators. *)
 let _ = 
-  let+ (src_pos, a) = 1 in
-  src_pos
+  let+ (call_pos, a) = 1 in
+  call_pos
 
 [%%expect{|
 Line 2, characters 2-6:
-2 |   let+ (src_pos, a) = 1 in
+2 |   let+ (call_pos, a) = 1 in
       ^^^^
 Error: The operator let+ has type
-         src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b
+         call_pos:[%call_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b
        but it was expected to have type 'c -> ('d -> 'e) -> 'f
 |}]
 
-let ( let* ) ?(src_pos = 1) a g = g (src_pos, a);; 
+let ( let* ) ?(call_pos = 1) a g = g (call_pos, a);; 
 
 let _ =
-  let* (src_pos, a) = 1 in
-  src_pos
+  let* (call_pos, a) = 1 in
+  call_pos
 
 [%%expect{|
-val ( let* ) : ?src_pos:int -> 'a -> (int * 'a -> 'b) -> 'b = <fun>
+val ( let* ) : ?call_pos:int -> 'a -> (int * 'a -> 'b) -> 'b = <fun>
 Line 4, characters 2-6:
-4 |   let* (src_pos, a) = 1 in
+4 |   let* (call_pos, a) = 1 in
       ^^^^
 Error: The operator let* has type
-         ?src_pos:int -> 'a -> (int * 'a -> 'b) -> 'b
+         ?call_pos:int -> 'a -> (int * 'a -> 'b) -> 'b
        but it was expected to have type 'c -> ('d -> 'e) -> 'f
 |}]
 
 (* Infix operators work! *)
-let ( >>| ) ~(src_pos : [%src_pos]) x f = f (src_pos, x)
+let ( >>| ) ~(call_pos : [%call_pos]) x f = f (call_pos, x)
 let _ =
-  1 >>| fun (src_pos, a) -> src_pos
+  1 >>| fun (call_pos, a) -> call_pos
 
 [%%expect{|
-val ( >>| ) : src_pos:[%src_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b =
-  <fun>
+val ( >>| ) :
+  call_pos:[%call_pos] -> 'a -> (lexing_position * 'a -> 'b) -> 'b = <fun>
 - : lexing_position =
-{pos_fname = ""; pos_lnum = 3; pos_bol = 1108; pos_cnum = 1110}
+{pos_fname = ""; pos_lnum = 3; pos_bol = 1128; pos_cnum = 1130}
 |}]

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/location_with_directory.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/location_with_directory.ml
@@ -4,5 +4,5 @@
    flags = "-directory app/foo"
 *)
 
-let f = fun ~(src_pos:[%src_pos]) () -> src_pos
+let f = fun ~(call_pos:[%call_pos]) () -> call_pos
 let _ = print_string (f ()).pos_fname;;

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/object_system.ml
@@ -3,28 +3,28 @@
 *)
 
 let object_with_a_method_with_a_positional_parameter = object 
-  method m ~(src_pos : [%src_pos]) () = src_pos
+  method m ~(call_pos : [%call_pos]) () = call_pos
 end
 
 [%%expect{|
 val object_with_a_method_with_a_positional_parameter :
-  < m : src_pos:[%src_pos] -> unit -> lexing_position > = <obj>
+  < m : call_pos:[%call_pos] -> unit -> lexing_position > = <obj>
 |}]
 
 let position = object_with_a_method_with_a_positional_parameter#m ();;
 
 [%%expect{|
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 1; pos_bol = 276; pos_cnum = 291}
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 281; pos_cnum = 296}
 |}]
 
 class class_with_a_method_with_a_positional_parameter = object 
-  method m ~(src_pos : [%src_pos]) () = src_pos
+  method m ~(call_pos : [%call_pos]) () = call_pos
 end
 
 [%%expect{|
 class class_with_a_method_with_a_positional_parameter :
-  object method m : src_pos:[%src_pos] -> unit -> lexing_position end
+  object method m : call_pos:[%call_pos] -> unit -> lexing_position end
 |}]
 
 let o = new class_with_a_method_with_a_positional_parameter;;
@@ -37,52 +37,53 @@ let position = o#m ();;
 
 [%%expect{|
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 1; pos_bol = 866; pos_cnum = 881}
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 876; pos_cnum = 891}
 |}]
 
 let position = (new class_with_a_method_with_a_positional_parameter)#m ();;
 
 [%%expect{|
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 1; pos_bol = 1005; pos_cnum = 1020}
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 1015; pos_cnum = 1030}
 |}]
 
 
-class class_with_positional_parameter ~(src_pos : [%src_pos]) () = object 
-  method src_pos = src_pos
+class class_with_positional_parameter ~(call_pos : [%call_pos]) () = object 
+  method call_pos = call_pos
 end
 
 [%%expect{|
 class class_with_positional_parameter :
-  src_pos:[%src_pos] -> unit -> object method src_pos : lexing_position end
+  call_pos:[%call_pos] ->
+  unit -> object method call_pos : lexing_position end
 |}]
 
 let o = new class_with_positional_parameter ()
-let position = o#src_pos
+let position = o#call_pos
 
 [%%expect{|
 val o : class_with_positional_parameter = <obj>
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 1; pos_bol = 1439; pos_cnum = 1447}
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 1458; pos_cnum = 1466}
 |}]
 
 
 (* Different kinds of shadowed parameters (both a class parameter is shadowed and a
    method parameter is shadowed) *)
 
-class c ~(src_pos : [%src_pos]) () = object(self)
-  method from_class_param = src_pos
+class c ~(call_pos : [%call_pos]) () = object(self)
+  method from_class_param = call_pos
 
-  method m ~(src_pos : [%src_pos]) () = src_pos, self#from_class_param
+  method m ~(call_pos : [%call_pos]) () = call_pos, self#from_class_param
 end
 [%%expect{|
 class c :
-  src_pos:[%src_pos] ->
+  call_pos:[%call_pos] ->
   unit ->
   object
     method from_class_param : lexing_position
     method m :
-      src_pos:[%src_pos] -> unit -> lexing_position * lexing_position
+      call_pos:[%call_pos] -> unit -> lexing_position * lexing_position
   end
 |}]
 
@@ -92,13 +93,13 @@ let from_method_param, from_class_param = c#m()
 [%%expect{|
 val c : c = <obj>
 val from_method_param : lexing_position =
-  {pos_fname = ""; pos_lnum = 2; pos_bol = 2186; pos_cnum = 2228}
+  {pos_fname = ""; pos_lnum = 2; pos_bol = 2216; pos_cnum = 2258}
 val from_class_param : lexing_position =
-  {pos_fname = ""; pos_lnum = 1; pos_bol = 2167; pos_cnum = 2175}
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 2197; pos_cnum = 2205}
 |}]
 
-class parent ~(src_pos : [%src_pos]) () = object
-  method pos = src_pos
+class parent ~(call_pos : [%call_pos]) () = object
+  method pos = call_pos
 end
 
 let o = object 
@@ -108,38 +109,38 @@ let position = o#pos
 
 [%%expect{|
 class parent :
-  src_pos:[%src_pos] -> unit -> object method pos : lexing_position end
+  call_pos:[%call_pos] -> unit -> object method pos : lexing_position end
 val o : parent = <obj>
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 6; pos_bol = 2578; pos_cnum = 2588}
+  {pos_fname = ""; pos_lnum = 6; pos_bol = 2611; pos_cnum = 2621}
 |}]
 
-let o ~(src_pos : [%src_pos]) () = object 
-  inherit parent ~src_pos ()
+let o ~(call_pos : [%call_pos]) () = object 
+  inherit parent ~call_pos ()
 end
 let position = (o ())#pos
 
 [%%expect{|
-val o : src_pos:[%src_pos] -> unit -> parent = <fun>
+val o : call_pos:[%call_pos] -> unit -> parent = <fun>
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 4; pos_bol = 2926; pos_cnum = 2941}
+  {pos_fname = ""; pos_lnum = 4; pos_bol = 2964; pos_cnum = 2979}
 |}]
 
-(* Applying an src_pos argument without a label. *)
-let o ~(src_pos : [%src_pos]) () = object 
-  inherit parent src_pos ()
+(* Applying an call_pos argument without a label. *)
+let o ~(call_pos : [%call_pos]) () = object 
+  inherit parent call_pos ()
 end
 let position = (o ())#pos
 
 [%%expect{|
 Line 2, characters 10-16:
-2 |   inherit parent src_pos ()
+2 |   inherit parent call_pos ()
               ^^^^^^
-Warning 6 [labels-omitted]: label src_pos was omitted in the application of this function.
+Warning 6 [labels-omitted]: label call_pos was omitted in the application of this function.
 
-val o : src_pos:[%src_pos] -> unit -> parent = <fun>
+val o : call_pos:[%call_pos] -> unit -> parent = <fun>
 val position : lexing_position =
-  {pos_fname = ""; pos_lnum = 4; pos_bol = 3249; pos_cnum = 3264}
+  {pos_fname = ""; pos_lnum = 4; pos_bol = 3293; pos_cnum = 3308}
 |}]
 
 
@@ -160,7 +161,7 @@ val position : int = 1
 |}]
 
 (* Partially applying a class *)
-class c ~(a : [%src_pos]) ~(b : [%src_pos]) () =
+class c ~(a : [%call_pos]) ~(b : [%call_pos]) () =
   object 
     method a = a
     method b = b
@@ -168,8 +169,8 @@ class c ~(a : [%src_pos]) ~(b : [%src_pos]) () =
 
 [%%expect{|
 class c :
-  a:[%src_pos] ->
-  b:[%src_pos] ->
+  a:[%call_pos] ->
+  b:[%call_pos] ->
   unit -> object method a : lexing_position method b : lexing_position end
 |}]
 
@@ -179,7 +180,7 @@ let partially_applied_class = new c ~a:pos_a
 [%%expect{|
 val pos_a : lexing_position =
   {pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
-val partially_applied_class : b:[%src_pos] -> unit -> c = <fun>
+val partially_applied_class : b:[%call_pos] -> unit -> c = <fun>
 |}]
 
 let fully_applied_class = partially_applied_class ()
@@ -194,19 +195,19 @@ let a, b = fully_applied_class#a, fully_applied_class#b
 val a : lexing_position =
   {pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
 val b : lexing_position =
-  {pos_fname = ""; pos_lnum = 1; pos_bol = 4459; pos_cnum = 4485}
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 4512; pos_cnum = 4538}
 |}]
 
 class c :
-  x:[%src_pos] -> y:lexing_position -> unit -> object
+  x:[%call_pos] -> y:lexing_position -> unit -> object
     method xy : lexing_position * lexing_position
-  end = fun ~(x : [%src_pos]) ~y () -> object
+  end = fun ~(x : [%call_pos]) ~y () -> object
     method xy = x, y
   end
 
 [%%expect{|
 class c :
-  x:[%src_pos] ->
+  x:[%call_pos] ->
   y:lexing_position ->
   unit -> object method xy : lexing_position * lexing_position end
 |}]
@@ -215,7 +216,7 @@ let x, y = (new c ~y:pos_a ())#xy
 
 [%%expect{|
 val x : lexing_position =
-  {pos_fname = ""; pos_lnum = 1; pos_bol = 5143; pos_cnum = 5154}
+  {pos_fname = ""; pos_lnum = 1; pos_bol = 5199; pos_cnum = 5210}
 val y : lexing_position =
   {pos_fname = "a"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
 |}]

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/recursion.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/recursion.ml
@@ -18,15 +18,15 @@ type t = {
 |}]
 
 (* type-based disambiguation *)
-let rec f ~(src_pos:[%src_pos]) i =
+let rec f ~(call_pos:[%call_pos]) i =
   if i < 0 then 0
-  else f ~src_pos:{ pos_fname = ""
+  else f ~call_pos:{ pos_fname = ""
                   ; pos_lnum = 0
                   ; pos_bol = 0
                   ; pos_cnum = -1 }
           (i - 1)
 [%%expect {|
-val f : src_pos:[%src_pos] -> int -> int = <fun>
+val f : call_pos:[%call_pos] -> int -> int = <fun>
 |}]
 
 let y = { pos_fname = ""
@@ -37,13 +37,13 @@ let y = { pos_fname = ""
 val y : t = {pos_fname = ""; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
 |}]
 
-let rec g ~(src_pos:[%src_pos]) i =
+let rec g ~(call_pos:[%call_pos]) i =
   if i < 0 then 0
-  else g ~src_pos:y (i - 1)
+  else g ~call_pos:y (i - 1)
 [%%expect {|
-Line 3, characters 18-19:
-3 |   else g ~src_pos:y (i - 1)
-                      ^
+Line 3, characters 19-20:
+3 |   else g ~call_pos:y (i - 1)
+                       ^
 Error: This expression has type t but an expression was expected of type
          lexing_position
 |}]

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/shadowing.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/shadowing.ml
@@ -10,12 +10,12 @@ type lexing_position = int
 |}]
 
 (* src_pos works *)
-let f ~(src_pos:[%src_pos]) () = ();;
+let f ~(call_pos:[%call_pos]) () = ();;
 [%%expect{|
-val f : src_pos:[%src_pos] -> unit -> unit = <fun>
+val f : call_pos:[%call_pos] -> unit -> unit = <fun>
 |}]
 
-let _ = f ~src_pos:Lexing.dummy_pos () ;;
+let _ = f ~call_pos:Lexing.dummy_pos () ;;
 [%%expect{|
 - : unit = ()
 |}]
@@ -32,13 +32,13 @@ let _ = h 5;;
 |}]
 
 (* Works with class parameters *)
-class c ~(src_pos : [%src_pos]) () = object end
+class c ~(call_pos : [%call_pos]) () = object end
 
 [%%expect {|
-class c : src_pos:[%src_pos] -> unit -> object  end
+class c : call_pos:[%call_pos] -> unit -> object  end
 |}]
 
-let _ = new c ~src_pos:Lexing.dummy_pos ();;
+let _ = new c ~call_pos:Lexing.dummy_pos ();;
 
 [%%expect{|
 - : c = <obj>
@@ -46,14 +46,14 @@ let _ = new c ~src_pos:Lexing.dummy_pos ();;
 
 (* Works with object method parameters *)
 let o = object
-   method m ~(src_pos : [%src_pos]) () = ()
+   method m ~(call_pos : [%call_pos]) () = ()
 end
 
 [%%expect {|
-val o : < m : src_pos:[%src_pos] -> unit -> unit > = <obj>
+val o : < m : call_pos:[%call_pos] -> unit -> unit > = <obj>
 |}]
 
-let _ = o#m ~src_pos:Lexing.dummy_pos ()
+let _ = o#m ~call_pos:Lexing.dummy_pos ()
 
 [%%expect{|
 - : unit = ()

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/synonyms.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/synonyms.ml
@@ -43,4 +43,3 @@ let _ = x.Lexing.pos_cnum = y.Lexing.pos_cnum && x.pos_cnum = y.pos_cnum && x.Le
 [%%expect{|
 - : bool = true
 |}]
-

--- a/ocaml/testsuite/tests/typing-implicit-source-positions/synonyms.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/synonyms.ml
@@ -15,17 +15,18 @@ val y : lexing_position =
   {pos_fname = ""; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
 |}]
 
-let predef_to_module ~(src_pos:[%src_pos]) () : Lexing.position = src_pos ;;
+let predef_to_module ~(call_pos:[%call_pos]) () : Lexing.position = call_pos ;;
 [%%expect{|
-val predef_to_module : src_pos:[%src_pos] -> unit -> Lexing.position = <fun>
+val predef_to_module : call_pos:[%call_pos] -> unit -> Lexing.position =
+  <fun>
 |}]
 
-let module_to_predef (src_pos:Lexing.position) : lexing_position = src_pos ;;
+let module_to_predef (call_pos:Lexing.position) : lexing_position = call_pos ;;
 [%%expect{|
 val module_to_predef : Lexing.position -> lexing_position = <fun>
 |}]
 
-let x = predef_to_module ~src_pos:Lexing.dummy_pos ();;
+let x = predef_to_module ~call_pos:Lexing.dummy_pos ();;
 [%%expect{|
 val x : Lexing.position =
   {Lexing.pos_fname = ""; pos_lnum = 0; pos_bol = 0; pos_cnum = -1}
@@ -42,3 +43,4 @@ let _ = x.Lexing.pos_cnum = y.Lexing.pos_cnum && x.pos_cnum = y.pos_cnum && x.Le
 [%%expect{|
 - : bool = true
 |}]
+

--- a/ocaml/testsuite/tests/typing-unique/unique.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique.ml
@@ -618,26 +618,26 @@ Line 5, characters 16-17:
 |}]
 
 (* Uniqueness is unbroken by the implicit positional argument. *)
-let f ~(src_pos : [%src_pos]) () =
-  let unique_ x = src_pos in
+let f ~(call_pos : [%call_pos]) () =
+  let unique_ x = call_pos in
   (x, x)
 ;;
 [%%expect{|
-val f : src_pos:[%src_pos] -> unit -> lexing_position * lexing_position =
+val f : call_pos:[%call_pos] -> unit -> lexing_position * lexing_position =
   <fun>
 |}]
 
-let f ~(src_pos : [%src_pos]) () =
-  unique_ (src_pos, src_pos)
+let f ~(call_pos : [%call_pos]) () =
+  unique_ (call_pos, call_pos)
 ;;
 [%%expect{|
-Line 2, characters 20-27:
-2 |   unique_ (src_pos, src_pos)
-                        ^^^^^^^
+Line 2, characters 21-29:
+2 |   unique_ (call_pos, call_pos)
+                         ^^^^^^^^
 Error: This value is used here, but it has already been used as unique:
-Line 2, characters 11-18:
-2 |   unique_ (src_pos, src_pos)
-               ^^^^^^^
+Line 2, characters 11-19:
+2 |   unique_ (call_pos, call_pos)
+               ^^^^^^^^
 
 |}]
 

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -506,7 +506,7 @@ and print_out_type_1 mode ppf =
           pp_print_string ppf l; pp_print_char ppf ':'; print_type ()
       | Position l ->
           pp_print_string ppf l;
-          pp_print_string ppf ":[%src_pos]"
+          pp_print_string ppf ":[%call_pos]"
       | Optional l ->
           pp_print_string ppf ("?" ^ l); pp_print_char ppf ':'; print_type ());
       pp_print_string ppf " ->";
@@ -698,7 +698,7 @@ let rec print_out_class_type ppf =
       let label, print_type = match lab with
         | Nolabel -> "", print_type
         | Labelled l -> l ^ ":", print_type
-        | Position l -> l ^ ":", fun ppf _ -> pp_print_string ppf "[%src_pos]"
+        | Position l -> l ^ ":", fun ppf _ -> pp_print_string ppf "[%call_pos]"
         | Optional l -> "?" ^ l ^ ":", print_type
       in
       fprintf ppf "@[%s%a ->@ %a@]"

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -258,7 +258,7 @@ let rec core_type i ppf x =
   | Ttyp_package { pack_path = s; pack_fields = l } ->
       line i ppf "Ttyp_package %a\n" fmt_path s;
       list i package_with ppf l;
-  | Ttyp_src_pos -> line i ppf "Ttyp_src_pos\n";
+  | Ttyp_call_pos -> line i ppf "Ttyp_call_pos\n";
 
 and labeled_core_type i ppf (l, t) =
   tuple_component_label i ppf l;

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -624,7 +624,7 @@ let typ sub {ctyp_loc; ctyp_desc; ctyp_env; ctyp_attributes; _} =
       List.iter (fun (_, l) -> Option.iter (sub.jkind_annotation sub) l) vars;
       sub.typ sub ct
   | Ttyp_package pack -> sub.package_type sub pack
-  | Ttyp_src_pos -> ()
+  | Ttyp_call_pos -> ()
 
 let class_structure sub {cstr_self; cstr_fields; _} =
   sub.pat sub cstr_self;

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -866,7 +866,7 @@ let typ sub x =
   let ctyp_env = sub.env sub x.ctyp_env in
   let ctyp_desc =
     match x.ctyp_desc with
-    | (Ttyp_var (_,None) | Ttyp_src_pos) as d -> d
+    | (Ttyp_var (_,None) | Ttyp_call_pos) as d -> d
     | Ttyp_var (s, Some jkind) ->
         Ttyp_var (s, Some (sub.jkind_annotation sub jkind))
     | Ttyp_arrow (label, ct1, ct2) ->

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1403,12 +1403,6 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       in
       let (args, cty) =
         let (_, ty_fun0) = Ctype.instance_class [] cl.cl_type in
-        (* XXX jrodri for jrodri: Think more about this later... 
-
-           jrodri: I think this is already impemented/the cr src_pos is fine to delete.
-        *)
-        (* XCR src_pos: Implement Position arguments for classes, and pass a
-           reasonable type to translate the labels below *)
         let sargs = List.map (fun (label, e) -> transl_label label None, e) sargs in
         type_args [] [] cl.cl_type ty_fun0 sargs
       in

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -444,7 +444,7 @@ and class_type_aux env virt self_scope scty =
       let l = transl_label l (Some sty) in
       let cty =
         match l with
-        | Position _ -> ctyp Ttyp_src_pos (Ctype.newconstr Predef.path_lexing_position [])
+        | Position _ -> ctyp Ttyp_call_pos (Ctype.newconstr Predef.path_lexing_position [])
         | Optional _ | Labelled _ | Nolabel ->
           transl_simple_type ~new_var_jkind:Any env ~closed:false Alloc.Const.legacy sty 
       in
@@ -1403,7 +1403,8 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       in
       let (args, cty) =
         let (_, ty_fun0) = Ctype.instance_class [] cl.cl_type in
-        (* CR src_pos: Implement Position arguments for classes, and pass a
+        (* XXX jrodri for jrodri: Think more about this later... *)
+        (* XCR src_pos: Implement Position arguments for classes, and pass a
            reasonable type to translate the labels below *)
         let sargs = List.map (fun (label, e) -> transl_label label None, e) sargs in
         type_args [] [] cl.cl_type ty_fun0 sargs

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1403,7 +1403,10 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       in
       let (args, cty) =
         let (_, ty_fun0) = Ctype.instance_class [] cl.cl_type in
-        (* XXX jrodri for jrodri: Think more about this later... *)
+        (* XXX jrodri for jrodri: Think more about this later... 
+
+           jrodri: I think this is already impemented/the cr src_pos is fine to delete.
+        *)
         (* XCR src_pos: Implement Position arguments for classes, and pass a
            reasonable type to translate the labels below *)
         let sargs = List.map (fun (label, e) -> transl_label label None, e) sargs in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -9875,14 +9875,21 @@ let report_error ~loc env = function
         | Nolabel, _ | _, Nolabel -> true
         | _                       -> false
       in
+      let maybe_positional_argument_hint = 
+        match got, expected with
+        | Labelled _, Position _ ->
+          "\nHint: Consider explicitly annotating the label with '[%call_pos]'"
+        | _ -> ""
+      in
       Location.errorf ~loc
         "@[<v>@[<2>This function should have type@ %a%t@]@,\
-         @[but its first argument is %s@ instead of %s%s@]@]"
+         @[but its first argument is %s@ instead of %s%s@]%s@]"
         Printtyp.type_expr expected_type
         (report_type_expected_explanation_opt explanation)
         (label ~long:true got)
         (if second_long then "being " else "")
         (label ~long:second_long expected)
+        maybe_positional_argument_hint
   | Scoping_let_module(id, ty) ->
       Location.errorf ~loc
         "This `let module' expression has type@ %a@ \

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -7583,7 +7583,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
           (lbl, Arg (arg, Mode.Value.legacy, sort_arg))
       | Position _ ->
           let arg = src_pos (Location.ghostify app_loc) [] env in
-          (* CR src_pos: Confirm that global value mode is correct *)
+          (* XXX jrodri: I think using [Mode.Value.legacy] here is correct, although would
+             like to double check during review as I am not too too familiar with modes. *)
           (lbl, Arg (arg, Mode.Value.legacy, sort_arg))
       | Labelled _ | Nolabel -> assert false)
   | Omitted _ as arg -> (lbl, arg)
@@ -9866,7 +9867,7 @@ let report_error ~loc env = function
       let label ~long l =
         match l with
         | Nolabel -> "unlabeled"
-        | Position l -> sprintf "~(%s:[%%src_pos])" l
+        | Position l -> sprintf "~(%s:[%%call_pos])" l
         | Labelled _ | Optional _ ->
             (if long then "labeled " else "") ^ prefixed_label_name l
       in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -7583,9 +7583,6 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
           (lbl, Arg (arg, Mode.Value.legacy, sort_arg))
       | Position _ ->
           let arg = src_pos (Location.ghostify app_loc) [] env in
-          (* XXX jrodri for goldfirere: I think using [Mode.Value.legacy] here is correct,
-             although would like to double check during review as I am not too too
-             familiar with modes. *)
           (lbl, Arg (arg, Mode.Value.legacy, sort_arg))
       | Labelled _ | Nolabel -> assert false)
   | Omitted _ as arg -> (lbl, arg)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -7583,8 +7583,9 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
           (lbl, Arg (arg, Mode.Value.legacy, sort_arg))
       | Position _ ->
           let arg = src_pos (Location.ghostify app_loc) [] env in
-          (* XXX jrodri: I think using [Mode.Value.legacy] here is correct, although would
-             like to double check during review as I am not too too familiar with modes. *)
+          (* XXX jrodri for goldfirere: I think using [Mode.Value.legacy] here is correct,
+             although would like to double check during review as I am not too too
+             familiar with modes. *)
           (lbl, Arg (arg, Mode.Value.legacy, sort_arg))
       | Labelled _ | Nolabel -> assert false)
   | Omitted _ as arg -> (lbl, arg)

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -599,7 +599,7 @@ and core_type_desc =
   | Ttyp_variant of row_field list * closed_flag * label list option
   | Ttyp_poly of (string * Jkind.annotation option) list * core_type
   | Ttyp_package of package_type
-  | Ttyp_src_pos
+  | Ttyp_call_pos
 
 and package_type = {
   pack_path : Path.t;

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -389,7 +389,7 @@ and expression_desc =
   | Texp_exclave of expression
   | Texp_src_pos
     (* A source position value which has been automatically inferred, either
-       as a result of [%src_pos] occuring in an expression, or omission of a
+       as a result of [%call_pos] occuring in an expression, or omission of a
        Position argument in function application *)
 
 and function_curry =
@@ -827,9 +827,9 @@ and core_type_desc =
   | Ttyp_variant of row_field list * closed_flag * label list option
   | Ttyp_poly of (string * Jkind.annotation option) list * core_type
   | Ttyp_package of package_type
-  | Ttyp_src_pos
-      (** [Ttyp_src_pos] represents the type of the value of a Position
-          argument ([lbl:[%src_pos] -> ...]). *)
+  | Ttyp_call_pos
+      (** [Ttyp_call_pos] represents the type of the value of a Position
+          argument ([lbl:[%call_pos] -> ...]). *)
 
 and package_type = {
   pack_path : Path.t;

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -149,7 +149,7 @@ and arg_label =
   | Nolabel
   | Labelled of string (** [label:T -> ...] *)
   | Optional of string (** [?label:T -> ...] *)
-  | Position of string (** [label:[%src_pos] -> ...] *)
+  | Position of string (** [label:[%call_pos] -> ...] *)
 
 and arrow_desc =
   arg_label * Mode.Alloc.t * Mode.Alloc.t

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -91,7 +91,7 @@ type error =
       {vloc : sort_loc; typ : type_expr; err : Jkind.Violation.t}
   | Bad_jkind_annot of type_expr * Jkind.Violation.t
   | Did_you_mean_unboxed of Longident.t
-  | Invalid_label_for_src_pos of Parsetree.arg_label
+  | Invalid_label_for_call_pos of Parsetree.arg_label
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -641,7 +641,7 @@ let transl_label (label : Parsetree.arg_label)
   | Labelled l, Some { ptyp_desc = Ptyp_extension ({txt="call_pos"; _}, _); _}
       -> Position l
   | _, Some ({ ptyp_desc = Ptyp_extension ({txt="call_pos"; _}, _); _} as arg)
-      -> raise (Error (arg.ptyp_loc, Env.empty, Invalid_label_for_src_pos label))
+      -> raise (Error (arg.ptyp_loc, Env.empty, Invalid_label_for_call_pos label))
   | Labelled l, _ -> Labelled l
   | Optional l, _ -> Optional l
   | Nolabel, _ -> Nolabel
@@ -1569,7 +1569,7 @@ let report_error env ppf = function
   | Did_you_mean_unboxed lid ->
     fprintf ppf "@[%a isn't a class type.@ \
                  Did you mean the unboxed type %a#?@]" longident lid longident lid
-  | Invalid_label_for_src_pos arg_label ->
+  | Invalid_label_for_call_pos arg_label ->
       fprintf ppf "A position argument must not be %s."
         (match arg_label with
         | Nolabel -> "unlabelled"

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -709,10 +709,11 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
           let l = transl_label l (Some arg) in
           let arg_cty =
             if Btype.is_position l then
-              (* XXX jrodri: Hmm, I think that I do not understand the below CR src_pos.
-                 Is it referring to changing the arg_label type to also include the type?
-                 If so, then I think I still don't understand how this would work. *)
-              (* XCR src_pos: Consider bundling argument types into arg_labels, so there
+              (* XXX jrodri for goldfirere: Hmm, I think that I do not understand the
+                 below CR src_pos. Is it referring to changing the arg_label type to also
+                 include the type? If so, then I think I still don't understand how this
+                 would work. *)
+              (* CR src_pos: Consider bundling argument types into arg_labels, so there
                  is no need to create this redundant type *)
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
             else transl_type env ~policy ~row_context arg_mode arg

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -709,12 +709,6 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
           let l = transl_label l (Some arg) in
           let arg_cty =
             if Btype.is_position l then
-              (* XXX jrodri for goldfirere: Hmm, I think that I do not understand the
-                 below CR src_pos. Is it referring to changing the arg_label type to also
-                 include the type? If so, then I think I still don't understand how this
-                 would work. *)
-              (* CR src_pos: Consider bundling argument types into arg_labels, so there
-                 is no need to create this redundant type *)
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
             else transl_type env ~policy ~row_context arg_mode arg
           in

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -638,9 +638,9 @@ let check_arg_type styp =
 let transl_label (label : Parsetree.arg_label)
     (arg_opt : Parsetree.core_type option) =
   match label, arg_opt with
-  | Labelled l, Some { ptyp_desc = Ptyp_extension ({txt="src_pos"; _}, _); _}
+  | Labelled l, Some { ptyp_desc = Ptyp_extension ({txt="call_pos"; _}, _); _}
       -> Position l
-  | _, Some ({ ptyp_desc = Ptyp_extension ({txt="src_pos"; _}, _); _} as arg)
+  | _, Some ({ ptyp_desc = Ptyp_extension ({txt="call_pos"; _}, _); _} as arg)
       -> raise (Error (arg.ptyp_loc, Env.empty, Invalid_label_for_src_pos label))
   | Labelled l, _ -> Labelled l
   | Optional l, _ -> Optional l
@@ -709,9 +709,12 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
           let l = transl_label l (Some arg) in
           let arg_cty =
             if Btype.is_position l then
-              (* CR src_pos: Consider bundling argument types into arg_labels, so there
+              (* XXX jrodri: Hmm, I think that I do not understand the below CR src_pos.
+                 Is it referring to changing the arg_label type to also include the type?
+                 If so, then I think I still don't understand how this would work. *)
+              (* XCR src_pos: Consider bundling argument types into arg_labels, so there
                  is no need to create this redundant type *)
-              ctyp Ttyp_src_pos (newconstr Predef.path_lexing_position [])
+              ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
             else transl_type env ~policy ~row_context arg_mode arg
           in
           let acc_mode =

--- a/ocaml/typing/typetexp.mli
+++ b/ocaml/typing/typetexp.mli
@@ -62,10 +62,10 @@ val valid_tyvar_name : string -> bool
 (** [transl_label lbl ty] produces a Typedtree argument label for an argument
     with label [lbl] and type [ty].
 
-    Position arguments ([lbl:[%src_pos] -> ...]) are parsed as
+    Position arguments ([lbl:[%call_pos] -> ...]) are parsed as
     {{!Parsetree.arg_label.Labelled}[Labelled l]}. This function converts them
     to {{!Types.arg_label.Position}[Position l]} when the type is of the form
-    [[%src_pos]]. *)
+    [[%call_pos]]. *)
 val transl_label :
         Parsetree.arg_label -> Parsetree.core_type option -> Types.arg_label
 
@@ -73,7 +73,7 @@ val transl_label :
     to the argument. [transl_label lbl pat] is equal to:
 
     - [Position l, P] when [lbl] is {{!Parsetree.arg_label.Labelled}[Labelled l]}
-      and [pat] represents [(P : [%src_pos])]
+      and [pat] represents [(P : [%call_pos])]
     - [transl_label lbl None, pat] otherwise.
   *)
 val transl_label_from_pat :

--- a/ocaml/typing/typetexp.mli
+++ b/ocaml/typing/typetexp.mli
@@ -169,7 +169,7 @@ type error =
       {vloc : sort_loc; typ : type_expr; err : Jkind.Violation.t}
   | Bad_jkind_annot of type_expr * Jkind.Violation.t
   | Did_you_mean_unboxed of Longident.t
-  | Invalid_label_for_src_pos of Parsetree.arg_label
+  | Invalid_label_for_call_pos of Parsetree.arg_label
 
 exception Error of Location.t * Env.t * error
 

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -483,15 +483,15 @@ let comprehension sub comp_type comp =
   Jane_syntax.Comprehensions.expr_of (comp_type (comprehension comp))
 
 let label : Types.arg_label -> Parsetree.arg_label = function
-  (* There is no Position label in the Parsetree, since we parse [%src_pos]
+  (* There is no Position label in the Parsetree, since we parse [%call_pos]
      arguments as Labelled. The correctness of this translation depends on
-     also re-inserting the constraint pattern (P : [%src_pos]) to the generated
+     also re-inserting the constraint pattern (P : [%call_pos]) to the generated
      tree. *)
   | Labelled l | Position l -> Labelled l
   | Optional l -> Optional l
   | Nolabel -> Nolabel
 
-let src_pos_extension = Location.mknoloc "src_pos", PStr []
+let call_pos_extension = Location.mknoloc "call_pos_extension", PStr []
 
 let expression sub exp =
   let loc = sub.location sub exp.exp_loc in
@@ -1043,8 +1043,8 @@ let core_type sub ct =
           (Ltyp_poly { bound_vars; inner_type = sub.typ sub ct }) |>
         add_jane_syntax_attributes
     | Ttyp_package pack -> Ptyp_package (sub.package_type sub pack)
-    | Ttyp_src_pos ->
-        Ptyp_extension src_pos_extension
+    | Ttyp_call_pos ->
+        Ptyp_extension call_pos_extension
   in
   Typ.mk ~loc ~attrs:!attrs desc
 


### PR DESCRIPTION
This feature is a catchall feature for lingering changes for the implicit source positions project. This feature contains small changes like:

- Renaming `[%src_pos]` -> `[%call_pos]`
- Addressing a couple of `CR src_pos`'es on better error messages when the implicit source position argument is misused.
- Addressing a CR src_pos that was missed when adding support for the class system a CR src_pos on ocamldoc was missed.
- Deleted an already addressed CR src_pos.

For reviewers
------------------
There are two CR-questions that I left regarding previously existing CR src_pos as I had some questions on them. I left them in the following files:
- ocaml/typing/typetexp.ml:712
- ocaml/typing/typecore.ml:7586

Testing
---------
[X] - Existing CI passes
[X] - Updated tests with the better error messages.