### PR TITLE
Implement `mutable()` logic for record and array

### DIFF
--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -274,9 +274,10 @@ type tpat_alias_identifier = Value.l
 let mkTpat_alias ?id:(mode = dummy_value_mode) (p, ident, name) =
   Tpat_alias (p, ident, name, Uid.internal_not_actually_unique, mode)
 
-type tpat_array_identifier = Asttypes.mutable_flag * Jkind.sort
+type tpat_array_identifier = mutable_flag * Jkind.sort
 
-let mkTpat_array ?id:(mut, arg_sort = (Asttypes.Mutable, Jkind.Sort.value)) l =
+let mkTpat_array
+    ?id:(mut, arg_sort = (Mutable Alloc.Const.legacy, Jkind.Sort.value)) l =
   Tpat_array (mut, arg_sort, l)
 
 type tpat_tuple_identifier = string option list

--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -274,10 +274,11 @@ type tpat_alias_identifier = Value.l
 let mkTpat_alias ?id:(mode = dummy_value_mode) (p, ident, name) =
   Tpat_alias (p, ident, name, Uid.internal_not_actually_unique, mode)
 
-type tpat_array_identifier = mutable_flag * Jkind.sort
+type tpat_array_identifier = mutability * Jkind.sort
 
 let mkTpat_array
-    ?id:(mut, arg_sort = (Mutable Alloc.Const.legacy, Jkind.Sort.value)) l =
+    ?id:(mut, arg_sort =
+        (Mutable Alloc.Comonadic.Const.legacy, Jkind.Sort.value)) l =
   Tpat_array (mut, arg_sort, l)
 
 type tpat_tuple_identifier = string option list

--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -592,6 +592,7 @@ parsing/parse.cmi : \
 parsing/parser.cmo : \
     parsing/syntaxerr.cmi \
     parsing/parsetree.cmi \
+    utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
     utils/language_extension.cmi \
@@ -608,6 +609,7 @@ parsing/parser.cmo : \
 parsing/parser.cmx : \
     parsing/syntaxerr.cmx \
     parsing/parsetree.cmi \
+    utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
     utils/language_extension.cmx \
@@ -1354,6 +1356,7 @@ typing/primitive.cmo : \
     typing/outcometree.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/language_extension.cmi \
     typing/jkind.cmi \
     parsing/attr_helper.cmi \
     typing/primitive.cmi
@@ -1362,6 +1365,7 @@ typing/primitive.cmx : \
     typing/outcometree.cmi \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/language_extension.cmx \
     typing/jkind.cmx \
     parsing/attr_helper.cmx \
     typing/primitive.cmi
@@ -1736,6 +1740,7 @@ typing/typecore.cmo : \
     typing/typedtree.cmi \
     typing/typedecl.cmi \
     typing/subst.cmi \
+    typing/solver.cmi \
     typing/shape.cmi \
     typing/rec_check.cmi \
     typing/printtyp.cmi \
@@ -1777,6 +1782,7 @@ typing/typecore.cmx : \
     typing/typedtree.cmx \
     typing/typedecl.cmx \
     typing/subst.cmx \
+    typing/solver.cmx \
     typing/shape.cmx \
     typing/rec_check.cmx \
     typing/printtyp.cmx \
@@ -1843,6 +1849,7 @@ typing/typedecl.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/language_extension.cmi \
     typing/jkind.cmi \
     parsing/jane_syntax.cmi \
     typing/includecore.cmi \
@@ -1879,6 +1886,7 @@ typing/typedecl.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    utils/language_extension.cmx \
     typing/jkind.cmx \
     parsing/jane_syntax.cmx \
     typing/includecore.cmx \
@@ -2167,7 +2175,6 @@ typing/typeopt.cmo : \
     typing/ctype.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
-    parsing/asttypes.cmi \
     typing/typeopt.cmi
 typing/typeopt.cmx : \
     typing/types.cmx \
@@ -2186,7 +2193,6 @@ typing/typeopt.cmx : \
     typing/ctype.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
-    parsing/asttypes.cmi \
     typing/typeopt.cmi
 typing/typeopt.cmi : \
     typing/types.cmi \
@@ -2332,9 +2338,11 @@ typing/uniqueness_analysis.cmx : \
 typing/uniqueness_analysis.cmi : \
     typing/typedtree.cmi
 typing/untypeast.cmo : \
+    typing/types.cmi \
     typing/typedtree.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
+    typing/mode.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
@@ -2345,9 +2353,11 @@ typing/untypeast.cmo : \
     parsing/ast_helper.cmi \
     typing/untypeast.cmi
 typing/untypeast.cmx : \
+    typing/types.cmx \
     typing/typedtree.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
+    typing/mode.cmx \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -554,9 +554,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
   | Texp_field(arg, id, lbl, float) ->
       let targ = transl_exp ~scopes Jkind.Sort.for_record arg in
       let sem =
-        match lbl.lbl_mut with
-        | Immutable -> Reads_agree
-        | Mutable -> Reads_vary
+        if Types.is_mutable lbl.lbl_mut then Reads_vary else Reads_agree
       in
       let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
       check_record_field_sort id.loc lbl_sort lbl.lbl_repres;
@@ -622,16 +620,14 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       in
       let imm_array = makearray Immutable in
       let lambda_arr_mut : Lambda.mutable_flag =
-        match (amut : Asttypes.mutable_flag) with
-        | Mutable   -> Mutable
-        | Immutable -> Immutable
+        if Types.is_mutable amut then Mutable else Immutable
       in
       begin try
         (* For native code the decision as to which compilation strategy to
            use is made later.  This enables the Flambda passes to lift certain
            kinds of array definitions to symbols. *)
         (* Deactivate constant optimization if array is small enough *)
-        if amut = Asttypes.Mutable &&
+        if Types.is_mutable amut &&
            List.length ll <= use_dup_for_constant_mutable_arrays_bigger_than
         then begin
           raise Not_constant
@@ -640,7 +636,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         if is_local_mode mode then raise Not_constant;
         begin match List.map extract_constant ll with
         | exception Not_constant
-          when kind = Pfloatarray && amut = Asttypes.Mutable ->
+          when kind = Pfloatarray && Types.is_mutable amut ->
             (* We cannot currently lift mutable [Pintarray] arrays safely in
                Flambda because [caml_modify] might be called upon them
                (e.g. from code operating on polymorphic arrays, or functions
@@ -669,9 +665,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                 | Punboxedfloatarray _ | Punboxedintarray _ ->
                   Misc.fatal_error "Use flambda2 for unboxed arrays"
             in
-            match amut with
-            | Mutable   -> duparray_to_mutable const
-            | Immutable -> const
+            if Types.is_mutable amut then duparray_to_mutable const else const
         end
       with Not_constant ->
         makearray lambda_arr_mut
@@ -1663,9 +1657,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                  record_field_kind (layout env lbl.lbl_loc lbl_sort typ)
                in
                let sem =
-                 match mut with
-                 | Immutable -> Reads_agree
-                 | Mutable -> Reads_vary
+                 if Types.is_mutable mut then Reads_vary else Reads_agree
                in
                let access =
                  match repres with
@@ -1691,7 +1683,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     in
     let ll, shape = List.split (Array.to_list lv) in
     let mut : Lambda.mutable_flag =
-      if Array.exists (fun (lbl, _) -> lbl.lbl_mut = Asttypes.Mutable) fields
+      if Array.exists (fun (lbl, _) -> Types.is_mutable lbl.lbl_mut) fields
       then Mutable
       else Immutable in
     let lam =

--- a/ocaml/ocamldoc/odoc_sig.ml
+++ b/ocaml/ocamldoc/odoc_sig.ml
@@ -440,7 +440,7 @@ module Analyser =
       let comment_opt = analyze_alerts comment_opt ld_attributes in
       {
         rf_name = field_name ;
-        rf_mutable = mutable_flag = Mutable ;
+        rf_mutable = Types.is_mutable mutable_flag;
         rf_type = Odoc_env.subst_type env type_expr ;
         rf_text = comment_opt
       }

--- a/ocaml/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/ocaml/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -187,12 +187,12 @@ Error: This pattern matches values of type int
        but a pattern was expected which matches values of type int32
   Hint: Did you mean `0b1000_1101l'?
 |}]
-type t1 = {f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
+type t1 = {mutable f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
 [%%expect{|
-type t1 = { f1 : int32; }
-Line 1, characters 49-55:
-1 | type t1 = {f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
-                                                     ^^^^^^
+type t1 = { mutable f1 : int32; }
+Line 1, characters 57-63:
+1 | type t1 = {mutable f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
+                                                             ^^^^^^
 Error: This expression has type nativeint
        but an expression was expected of type int32
   Hint: Did you mean `1_000l'?

--- a/ocaml/testsuite/tests/typing-modes/mutable.ml
+++ b/ocaml/testsuite/tests/typing-modes/mutable.ml
@@ -3,19 +3,6 @@
    flags = "-extension unique"
 *)
 
-(* Our current approach is to treat "mutable implying global" only in typecore,
-   this simplifies printing, but also means the following duplication cannot be
-   detected. But on the other hand, what would be the error message? A specially
-   tailored message pointing to `mutable` and says "mutable implies global" -
-   that's too much effort for something that will be gone very soon.
-
-   Also note that the legacy syntax [mutable global_ x : string] is not parsable
-   anyway. *)
-type r = {mutable x : string @@ global}
-[%%expect{|
-type r = { mutable global_ x : string; }
-|}]
-
 (* Since [mutable] implies [global] modality, which in turns implies [shared]
    and [many] modalities, the effect of mutable in isolation is not testable
    yet. *)

--- a/ocaml/testsuite/tests/typing-modes/mutable.ml
+++ b/ocaml/testsuite/tests/typing-modes/mutable.ml
@@ -1,0 +1,23 @@
+(* TEST
+   * expect
+   flags = "-extension unique"
+*)
+
+(* Our current approach is to treat "mutable implying global" only in typecore,
+   this simplifies printing, but also means the following duplication cannot be
+   detected. But on the other hand, what would be the error message? A specially
+   tailored message pointing to `mutable` and says "mutable implies global" -
+   that's too much effort for something that will be gone very soon.
+
+   Also note that the legacy syntax [mutable global_ x : string] is not parsable
+   anyway. *)
+type r = {mutable x : string @@ global}
+[%%expect{|
+type r = { mutable global_ x : string; }
+|}]
+
+(* Since [mutable] implies [global] modality, which in turns implies [shared]
+   and [many] modalities, the effect of mutable in isolation is not testable
+   yet. *)
+
+(* CR zqian: add test for mutable when mutable is decoupled from modalities. *)

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -4313,12 +4313,12 @@ let add_method env label priv virt ty sign =
   sign.csig_meths <- meths
 
 type add_instance_variable_failure =
-  | Mutability_mismatch of mutable_flag
+  | Mutability_mismatch of Asttypes.mutable_flag
   | Type_mismatch of Errortrace.unification_error
 
 exception Add_instance_variable_failed of add_instance_variable_failure
 
-let check_mutability mut mut' =
+let check_mutability (mut:Asttypes.mutable_flag) (mut':Asttypes.mutable_flag) =
   match mut, mut' with
   | Mutable, Mutable -> ()
   | Immutable, Immutable -> ()
@@ -5295,10 +5295,10 @@ let match_class_sig_shape ~strict sign1 sign2 =
   in
   let errors =
     Vars.fold
-      (fun lab (mut, vr, _) err ->
+      (fun lab ((mut:Asttypes.mutable_flag), vr, _) err ->
          match Vars.find lab sign1.csig_vars with
          | exception Not_found -> CM_Missing_value lab::err
-         | (mut', vr', _) ->
+         | ((mut':Asttypes.mutable_flag), vr', _) ->
              match mut', mut with
              | Immutable, Mutable -> CM_Non_mutable_value lab::err
              | _, _ ->

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -4313,12 +4313,12 @@ let add_method env label priv virt ty sign =
   sign.csig_meths <- meths
 
 type add_instance_variable_failure =
-  | Mutability_mismatch of Asttypes.mutable_flag
+  | Mutability_mismatch of mutable_flag
   | Type_mismatch of Errortrace.unification_error
 
 exception Add_instance_variable_failed of add_instance_variable_failure
 
-let check_mutability (mut:Asttypes.mutable_flag) (mut':Asttypes.mutable_flag) =
+let check_mutability (mut : mutable_flag) (mut' : mutable_flag) =
   match mut, mut' with
   | Mutable, Mutable -> ()
   | Immutable, Immutable -> ()

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -414,13 +414,13 @@ val add_method : Env.t ->
   label -> private_flag -> virtual_flag -> type_expr -> class_signature -> unit
 
 type add_instance_variable_failure =
-  | Mutability_mismatch of mutable_flag
+  | Mutability_mismatch of Asttypes.mutable_flag
   | Type_mismatch of Errortrace.unification_error
 
 exception Add_instance_variable_failed of add_instance_variable_failure
 
 val add_instance_variable : strict:bool -> Env.t ->
-  label -> mutable_flag -> virtual_flag -> type_expr -> class_signature -> unit
+  label -> Asttypes.mutable_flag -> virtual_flag -> type_expr -> class_signature -> unit
 
 type inherit_class_signature_failure =
   | Self_type_mismatch of Errortrace.unification_error

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -414,13 +414,13 @@ val add_method : Env.t ->
   label -> private_flag -> virtual_flag -> type_expr -> class_signature -> unit
 
 type add_instance_variable_failure =
-  | Mutability_mismatch of Asttypes.mutable_flag
+  | Mutability_mismatch of mutable_flag
   | Type_mismatch of Errortrace.unification_error
 
 exception Add_instance_variable_failed of add_instance_variable_failure
 
 val add_instance_variable : strict:bool -> Env.t ->
-  label -> Asttypes.mutable_flag -> virtual_flag -> type_expr -> class_signature -> unit
+  label -> mutable_flag -> virtual_flag -> type_expr -> class_signature -> unit
 
 type inherit_class_signature_failure =
   | Self_type_mismatch of Errortrace.unification_error

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -123,13 +123,13 @@ let label_usage_complaint priv mut lu
   | Asttypes.Private, _ ->
       if lu.lu_projection then None
       else Some Unused
-  | Asttypes.Public, Asttypes.Immutable -> begin
+  | Asttypes.Public, Types.Immutable -> begin
       match lu.lu_projection, lu.lu_construct with
       | true, _ -> None
       | false, false -> Some Unused
       | false, true -> Some Not_read
     end
-  | Asttypes.Public, Asttypes.Mutable -> begin
+  | Asttypes.Public, Types.Mutable _ -> begin
       match lu.lu_projection, lu.lu_mutation, lu.lu_construct with
       | true, true, _ -> None
       | false, false, false -> Some Unused

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -549,10 +549,10 @@ module Record_diffing = struct
           | Mutable _, Immutable -> Some First
           | Immutable, Mutable _ -> Some Second
           | Mutable m1, Mutable m2 ->
-              if Misc.eq_from_le Mode.Alloc.Const.le m1 m2 then None
+              if Mode.Alloc.Comonadic.Const.eq m1 m2 then None
               else
                 Misc.fatal_errorf "Unexpected mutable(%a) = mutable(%a)"
-                  Mode.Alloc.Const.print m1 Mode.Alloc.Const.print m2
+                  Mode.Alloc.Comonadic.Const.print m1 Mode.Alloc.Comonadic.Const.print m2
         in
         begin match mut with
         | Some mut -> Some (Mutability mut)

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -549,10 +549,12 @@ module Record_diffing = struct
           | Mutable _, Immutable -> Some First
           | Immutable, Mutable _ -> Some Second
           | Mutable m1, Mutable m2 ->
-              if Mode.Alloc.Comonadic.Const.eq m1 m2 then None
-              else
-                Misc.fatal_errorf "Unexpected mutable(%a) = mutable(%a)"
-                  Mode.Alloc.Comonadic.Const.print m1 Mode.Alloc.Comonadic.Const.print m2
+            let open Mode.Alloc.Comonadic.Const in
+            (if not (eq m1 legacy) then
+              Misc.fatal_errorf "Unexpected mutable(%a)" print m1);
+            (if not (eq m2 legacy) then
+              Misc.fatal_errorf "Unexpected mutable(%a)" print m2);
+            None
         in
         begin match mut with
         | Some mut -> Some (Mutability mut)

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1385,6 +1385,8 @@ end
 module Comonadic_with_locality = struct
   module Const = struct
     include C.Comonadic_with_locality
+
+    let eq a b = le a b && le b a
   end
 
   module Obj = struct

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -236,14 +236,10 @@ module type S = sig
         uniqueness : 'c
       }
 
-    module Const : sig
-      include
-        Lattice
-          with type t =
-            (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
-
-      val split : t -> (Monadic.Const.t, Comonadic.Const.t) monadic_comonadic
-    end
+    module Const :
+      Lattice
+        with type t =
+          (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
 
     type error =
       [ `Regionality of Regionality.error
@@ -335,11 +331,18 @@ module type S = sig
     end
 
     module Comonadic : sig
+      module Const : sig
+        include Lattice
+
+        val eq : t -> t -> bool
+      end
+
       include
         Common
           with type error =
             [ `Locality of Locality.error
             | `Linearity of Linearity.error ]
+           and module Const := Const
 
       val meet_with : Const.t -> ('l * 'r) t -> ('l * disallowed) t
     end
@@ -357,6 +360,8 @@ module type S = sig
             (Locality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
 
       val split : t -> (Monadic.Const.t, Comonadic.Const.t) monadic_comonadic
+
+      val merge : (Monadic.Const.t, Comonadic.Const.t) monadic_comonadic -> t
 
       module Option : sig
         type some = t

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -236,10 +236,14 @@ module type S = sig
         uniqueness : 'c
       }
 
-    module Const :
-      Lattice
-        with type t =
-          (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
+    module Const : sig
+      include
+        Lattice
+          with type t =
+            (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
+
+      val split : t -> (Monadic.Const.t, Comonadic.Const.t) monadic_comonadic
+    end
 
     type error =
       [ `Regionality of Regionality.error

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -632,7 +632,12 @@ and print_typargs ppf =
       pp_print_space ppf ()
 and print_out_label ppf (name, mut, arg, gbl) =
   (* See the notes [NON-LEGACY MODES] *)
-  let mut = if mut then "mutable " else "" in
+  let mut =
+    match mut with
+    | Om_immutable -> ""
+    | Om_mutable None -> "mutable "
+    | Om_mutable (Some s) -> "mutable(" ^ s ^ ") "
+  in
   fprintf ppf "@[<2>%s%s%s :@ %a@];"
     mut
     (string_of_gbl_space gbl)

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -441,6 +441,10 @@ let is_initially_labeled_tuple ty =
   | Otyp_tuple ((Some _, _) :: _) -> true
   | _ -> false
 
+let string_of_gbl_space = function
+  | Ogf_global -> "global_ "
+  | Ogf_unrestricted -> ""
+
 let rec print_out_type_0 mode ppf =
   function
   | Otyp_alias {non_gen; aliased; alias } ->
@@ -626,15 +630,14 @@ and print_typargs ppf =
       pp_print_char ppf ')';
       pp_close_box ppf ();
       pp_print_space ppf ()
-and print_out_label ppf (name, mut_or_gbl, arg) =
+and print_out_label ppf (name, mut, arg, gbl) =
   (* See the notes [NON-LEGACY MODES] *)
-  let flag =
-    match mut_or_gbl with
-    | Ogom_mutable -> "mutable "
-    | Ogom_global -> "global_ "
-    | Ogom_immutable -> ""
-  in
-  fprintf ppf "@[<2>%s%s :@ %a@];" flag name print_out_type arg
+  let mut = if mut then "mutable " else "" in
+  fprintf ppf "@[<2>%s%s%s :@ %a@];"
+    mut
+    (string_of_gbl_space gbl)
+    name
+    print_out_type arg
 
 let out_label = ref print_out_label
 

--- a/ocaml/typing/oprint.mli
+++ b/ocaml/typing/oprint.mli
@@ -18,7 +18,7 @@ open Outcometree
 
 val out_ident : (formatter -> out_ident -> unit) ref
 val out_value : (formatter -> out_value -> unit) ref
-val out_label : (formatter -> string * bool * out_type * out_global -> unit) ref
+val out_label : (formatter -> string * out_mutability * out_type * out_global -> unit) ref
 val out_type : (formatter -> out_type -> unit) ref
 val out_type_args : (formatter -> out_type list -> unit) ref
 val out_constr : (formatter -> out_constructor -> unit) ref

--- a/ocaml/typing/oprint.mli
+++ b/ocaml/typing/oprint.mli
@@ -18,7 +18,7 @@ open Outcometree
 
 val out_ident : (formatter -> out_ident -> unit) ref
 val out_value : (formatter -> out_value -> unit) ref
-val out_label : (formatter -> string * out_mutable_or_global * out_type -> unit) ref
+val out_label : (formatter -> string * bool * out_type * out_global -> unit) ref
 val out_type : (formatter -> out_type -> unit) ref
 val out_type_args : (formatter -> out_type list -> unit) ref
 val out_constr : (formatter -> out_constructor -> unit) ref

--- a/ocaml/typing/outcometree.mli
+++ b/ocaml/typing/outcometree.mli
@@ -70,6 +70,10 @@ type out_global =
   | Ogf_global
   | Ogf_unrestricted
 
+type out_mutability =
+  | Om_immutable
+  | Om_mutable of string option
+
 (* should be empty if all the jkind annotations are missing *)
 type out_vars_jkinds = (string * out_jkind option) list
 
@@ -89,7 +93,7 @@ type out_type =
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
   | Otyp_object of { fields: (string * out_type) list; open_row:bool}
-  | Otyp_record of (string * bool * out_type * out_global) list
+  | Otyp_record of (string * out_mutability * out_type * out_global) list
   | Otyp_stuff of string
   | Otyp_sum of out_constructor list
   | Otyp_tuple of (string option * out_type) list

--- a/ocaml/typing/outcometree.mli
+++ b/ocaml/typing/outcometree.mli
@@ -66,11 +66,6 @@ type out_type_param =
     oparam_injectivity : Asttypes.injectivity;
     oparam_jkind : out_jkind option }
 
-type out_mutable_or_global =
-  | Ogom_mutable
-  | Ogom_global
-  | Ogom_immutable
-
 type out_global =
   | Ogf_global
   | Ogf_unrestricted
@@ -94,7 +89,7 @@ type out_type =
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
   | Otyp_object of { fields: (string * out_type) list; open_row:bool}
-  | Otyp_record of (string * out_mutable_or_global * out_type) list
+  | Otyp_record of (string * bool * out_type * out_global) list
   | Otyp_stuff of string
   | Otyp_sum of out_constructor list
   | Otyp_tuple of (string option * out_type) list

--- a/ocaml/typing/parmatch.ml
+++ b/ocaml/typing/parmatch.ml
@@ -541,10 +541,7 @@ let do_set_args ~erase_mutable q r = match q with
     make_pat
       (Tpat_record
          (List.map2 (fun (lid, lbl,_) arg ->
-           if
-             erase_mutable &&
-             (match lbl.lbl_mut with
-             | Mutable -> true | Immutable -> false)
+           if erase_mutable && Types.is_mutable lbl.lbl_mut
            then
              lid, lbl, omega
            else
@@ -2150,7 +2147,7 @@ let inactive ~partial pat =
   | Total -> begin
       let rec loop pat =
         match pat.pat_desc with
-        | Tpat_lazy _ | Tpat_array (Mutable, _, _) ->
+        | Tpat_lazy _ | Tpat_array (Mutable _, _, _) ->
           false
         | Tpat_any | Tpat_var _ | Tpat_variant (_, None, _) ->
             true

--- a/ocaml/typing/patterns.ml
+++ b/ocaml/typing/patterns.ml
@@ -58,7 +58,7 @@ module Simple = struct
     | `Variant of label * pattern option * row_desc ref
     | `Record of
         (Longident.t loc * label_description * pattern) list * closed_flag
-    | `Array of mutable_flag * Jkind.sort * pattern list
+    | `Array of mutability * Jkind.sort * pattern list
     | `Lazy of pattern
   ]
 
@@ -147,7 +147,7 @@ module Head : sig
         { tag: label; has_arg: bool;
           cstr_row: row_desc ref;
           type_row : unit -> row_desc; }
-    | Array of mutable_flag * Jkind.sort * int
+    | Array of mutability * Jkind.sort * int
     | Lazy
 
   type t = desc pattern_data
@@ -174,7 +174,7 @@ end = struct
           type_row : unit -> row_desc; }
           (* the row of the type may evolve if [close_variant] is called,
              hence the (unit -> ...) delay *)
-    | Array of mutable_flag * Jkind.sort * int
+    | Array of mutability * Jkind.sort * int
     | Lazy
 
   type t = desc pattern_data

--- a/ocaml/typing/patterns.mli
+++ b/ocaml/typing/patterns.mli
@@ -46,7 +46,7 @@ module Simple : sig
     | `Variant of label * pattern option * row_desc ref
     | `Record of
         (Longident.t loc * label_description * pattern) list * closed_flag
-    | `Array of mutable_flag * Jkind.sort * pattern list
+    | `Array of mutability * Jkind.sort * pattern list
     | `Lazy of pattern
   ]
   type pattern = view pattern_data
@@ -89,7 +89,7 @@ module Head : sig
           type_row : unit -> row_desc; }
           (* the row of the type may evolve if [close_variant] is called,
              hence the (unit -> ...) delay *)
-    | Array of mutable_flag * Jkind.sort * int
+    | Array of mutability * Jkind.sort * int
     | Lazy
 
   type t = desc pattern_data

--- a/ocaml/typing/printpat.ml
+++ b/ocaml/typing/printpat.ml
@@ -103,10 +103,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
             pretty_lvals filtered_lvs elision_mark
       end
   | Tpat_array (am, _arg_sort, vs) ->
-      let punct = match am with
-        | Mutable   -> '|'
-        | Immutable -> ':'
-      in
+      let punct = if Types.is_mutable am then '|' else ':' in
       fprintf ppf "@[[%c %a %c]@]" punct (pretty_vals " ;") vs punct
   | Tpat_lazy v ->
       fprintf ppf "@[<2>lazy@ %a@]" pretty_arg v

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1580,12 +1580,15 @@ let tree_of_label l =
   let mut, gbl =
     match l.ld_mutable, l.ld_global with
     | Mutable m, _ ->
-        if Alloc.Comonadic.Const.eq m Alloc.Comonadic.Const.legacy then
-          true, Ogf_unrestricted
-        else
-          Misc.fatal_errorf "Unexpected mutable(%a)" Alloc.Comonadic.Const.print m
-    | Immutable, Global -> false, Ogf_global
-    | Immutable, Unrestricted -> false, Ogf_unrestricted
+        let mut =
+          if Alloc.Comonadic.Const.eq m Alloc.Comonadic.Const.legacy then
+            Om_mutable None
+          else
+            Om_mutable (Some "<non-legacy>")
+        in
+        mut, Ogf_unrestricted
+    | Immutable, Global -> Om_immutable, Ogf_global
+    | Immutable, Unrestricted -> Om_immutable, Ogf_unrestricted
   in
   (Ident.name l.ld_id, mut, tree_of_typexp Type l.ld_type, gbl)
 

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1586,10 +1586,10 @@ let tree_of_label l =
     match l.ld_mutable with
     | Immutable -> false
     | Mutable m ->
-        if Misc.eq_from_le Alloc.Const.le m Alloc.Const.legacy then
+        if Alloc.Comonadic.Const.eq m Alloc.Comonadic.Const.legacy then
           true
         else
-          Misc.fatal_errorf "Unexpected mutable(%a)" Alloc.Const.print m
+          Misc.fatal_errorf "Unexpected mutable(%a)" Alloc.Comonadic.Const.print m
   in
   (Ident.name l.ld_id, mut, tree_of_typexp Type l.ld_type, gbl)
 

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1577,19 +1577,15 @@ let param_jkind ty =
   | _ -> None (* this is (C2.2) from Note [When to print jkind annotations] *)
 
 let tree_of_label l =
-  let gbl =
-    match l.ld_global with
-    | Global -> Ogf_global
-    | Unrestricted -> Ogf_unrestricted
-  in
-  let mut =
-    match l.ld_mutable with
-    | Immutable -> false
-    | Mutable m ->
+  let mut, gbl =
+    match l.ld_mutable, l.ld_global with
+    | Mutable m, _ ->
         if Alloc.Comonadic.Const.eq m Alloc.Comonadic.Const.legacy then
-          true
+          true, Ogf_unrestricted
         else
           Misc.fatal_errorf "Unexpected mutable(%a)" Alloc.Comonadic.Const.print m
+    | Immutable, Global -> false, Ogf_global
+    | Immutable, Unrestricted -> false, Ogf_unrestricted
   in
   (Ident.name l.ld_id, mut, tree_of_typexp Type l.ld_type, gbl)
 

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -76,10 +76,20 @@ let fmt_constant f x =
   | Const_unboxed_int64 (i) -> fprintf f "Const_unboxed_int64 %Ld" i
   | Const_unboxed_nativeint (i) -> fprintf f "Const_unboxed_nativeint %nd" i
 
-let fmt_mutable_flag f x =
+let fmt_mutable_flag f (x : Asttypes.mutable_flag) =
   match x with
   | Immutable -> fprintf f "Immutable"
   | Mutable -> fprintf f "Mutable"
+
+let fmt_mutable_mode_flag f (x : Types.mutable_flag) =
+  match x with
+  | Immutable -> fprintf f "Immutable"
+  | Mutable m ->
+    if Misc.eq_from_le Mode.Alloc.Const.le m Mode.Alloc.Const.legacy
+    then fprintf f "Mutable"
+    else
+      Misc.fatal_errorf "Unexpected mutable(%a)"
+        Mode.Alloc.Const.print m
 
 let fmt_virtual_flag f x =
   match x with
@@ -308,7 +318,7 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
       line i ppf "Tpat_record\n";
       list i longident_x_pattern ppf l;
   | Tpat_array (am, arg_sort, l) ->
-      line i ppf "Tpat_array %a\n" fmt_mutable_flag am;
+      line i ppf "Tpat_array %a\n" fmt_mutable_mode_flag am;
       line i ppf "%a\n" Jkind.Sort.format arg_sort;
       list i pattern ppf l;
   | Tpat_lazy p ->
@@ -480,7 +490,7 @@ and expression i ppf x =
       longident i ppf li;
       expression i ppf e2;
   | Texp_array (amut, sort, l, amode) ->
-      line i ppf "Texp_array %a\n" fmt_mutable_flag amut;
+      line i ppf "Texp_array %a\n" fmt_mutable_mode_flag amut;
       line i ppf "%a\n" Jkind.Sort.format sort;
       alloc_mode i ppf amode;
       list i expression ppf l;
@@ -488,7 +498,7 @@ and expression i ppf x =
       line i ppf "Texp_list_comprehension\n";
       comprehension i ppf comp
   | Texp_array_comprehension (amut, sort, comp) ->
-      line i ppf "Texp_array_comprehension %a\n" fmt_mutable_flag amut;
+      line i ppf "Texp_array_comprehension %a\n" fmt_mutable_mode_flag amut;
       line i ppf "%a\n" Jkind.Sort.format sort;
       comprehension i ppf comp
   | Texp_ifthenelse (e1, e2, eo) ->
@@ -1051,7 +1061,7 @@ and label_decl i ppf {ld_id; ld_name = _; ld_mutable; ld_type; ld_loc;
                       ld_attributes} =
   line i ppf "%a\n" fmt_location ld_loc;
   attributes i ppf ld_attributes;
-  line (i+1) ppf "%a\n" fmt_mutable_flag ld_mutable;
+  line (i+1) ppf "%a\n" fmt_mutable_mode_flag ld_mutable;
   line (i+1) ppf "%a" fmt_ident ld_id;
   core_type (i+1) ppf ld_type
 

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -85,11 +85,7 @@ let fmt_mutable_mode_flag f (x : Types.mutability) =
   match x with
   | Immutable -> fprintf f "Immutable"
   | Mutable m ->
-    if Mode.Alloc.Comonadic.Const.eq m Mode.Alloc.Comonadic.Const.legacy
-    then fprintf f "Mutable"
-    else
-      Misc.fatal_errorf "Unexpected mutable(%a)"
-        Mode.Alloc.Comonadic.Const.print m
+    fprintf f "Mutable(%a)" Mode.Alloc.Comonadic.Const.print m
 
 let fmt_virtual_flag f x =
   match x with

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -76,20 +76,20 @@ let fmt_constant f x =
   | Const_unboxed_int64 (i) -> fprintf f "Const_unboxed_int64 %Ld" i
   | Const_unboxed_nativeint (i) -> fprintf f "Const_unboxed_nativeint %nd" i
 
-let fmt_mutable_flag f (x : Asttypes.mutable_flag) =
+let fmt_mutable_flag f x =
   match x with
   | Immutable -> fprintf f "Immutable"
   | Mutable -> fprintf f "Mutable"
 
-let fmt_mutable_mode_flag f (x : Types.mutable_flag) =
+let fmt_mutable_mode_flag f (x : Types.mutability) =
   match x with
   | Immutable -> fprintf f "Immutable"
   | Mutable m ->
-    if Misc.eq_from_le Mode.Alloc.Const.le m Mode.Alloc.Const.legacy
+    if Mode.Alloc.Comonadic.Const.eq m Mode.Alloc.Comonadic.Const.legacy
     then fprintf f "Mutable"
     else
       Misc.fatal_errorf "Unexpected mutable(%a)"
-        Mode.Alloc.Const.print m
+        Mode.Alloc.Comonadic.Const.print m
 
 let fmt_virtual_flag f x =
   match x with

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -103,7 +103,7 @@ type error =
   | Non_collapsable_conjunction of
       Ident.t * Types.class_declaration * Errortrace.unification_error
   | Self_clash of Errortrace.unification_error
-  | Mutability_mismatch of string * mutable_flag
+  | Mutability_mismatch of string * Asttypes.mutable_flag
   | No_overriding of string * string
   | Duplicate of string * string
   | Closing_self_type of class_signature
@@ -541,7 +541,7 @@ type intermediate_class_field =
         attributes : attribute list; }
   | Virtual_val of
       { label : string loc;
-        mut : mutable_flag;
+        mut : Asttypes.mutable_flag;
         id : Ident.t;
         cty : core_type;
         already_declared : bool;
@@ -549,7 +549,7 @@ type intermediate_class_field =
         attributes : attribute list; }
   | Concrete_val of
       { label : string loc;
-        mut : mutable_flag;
+        mut : Asttypes.mutable_flag;
         id : Ident.t;
         override : override_flag;
         definition : expression;
@@ -2294,8 +2294,10 @@ let report_error env ppf = function
            fprintf ppf "but actually has type")
   | Mutability_mismatch (_lab, mut) ->
       let mut1, mut2 =
-        if mut = Immutable then "mutable", "immutable"
-        else "immutable", "mutable" in
+        match mut with
+        | Immutable -> "mutable", "immutable"
+        | Mutable -> "immutable", "mutable"
+      in
       fprintf ppf
         "@[The instance variable is %s;@ it cannot be redefined as %s@]"
         mut1 mut2

--- a/ocaml/typing/typeclass.mli
+++ b/ocaml/typing/typeclass.mli
@@ -121,7 +121,7 @@ type error =
   | Non_collapsable_conjunction of
       Ident.t * Types.class_declaration * Errortrace.unification_error
   | Self_clash of Errortrace.unification_error
-  | Mutability_mismatch of string * mutable_flag
+  | Mutability_mismatch of string * Asttypes.mutable_flag
   | No_overriding of string * string
   | Duplicate of string * string
   | Closing_self_type of class_signature

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -2429,8 +2429,11 @@ and type_pat_aux
        combine the two array pattern constructors. *)
     let ty_elt, arg_sort = solve_Ppat_array ~refine loc env mutability expected_ty in
     let alloc_mode =
-      simple_pat_mode (project_maybe_mutable mutability alloc_mode.mode)
+      match mutability with
+      | Immutable -> alloc_mode.mode
+      | Mutable m0 -> project_mutable m0 alloc_mode.mode |> modality_unbox_left Global
     in
+    let alloc_mode = simple_pat_mode alloc_mode in
     let pl = List.map (fun p -> type_pat ~alloc_mode tps Value p ty_elt) spl in
     rvp {
       pat_desc = Tpat_array (mutability, arg_sort, pl);
@@ -8649,7 +8652,7 @@ and type_generic_array
   =
   let alloc_mode, argument_mode = register_allocation_value_mode expected_mode.mode in
   let type_, argument_mode = match mutability with
-    | Mutable m0 -> Predef.type_array, construct_mutable m0 argument_mode
+    | Mutable m0 -> Predef.type_array, construct_mutable m0 argument_mode |> modality_box_right Global
     | Immutable -> Predef.type_iarray, argument_mode
   in
   let argument_mode = mode_default argument_mode in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -881,9 +881,7 @@ let apply_mode_annots ~loc ~env (m : Alloc.Const.Option.t) mode =
     on the record being accessed, returns the left mode of the projected mutable
     field. *)
 let project_mutable _ (m : (allowed * _) Value.t) =
-  m
-  (* CR zqian: decouple mutable and global. *)
-  |> modality_unbox_left Global
+  m |> Value.disallow_right
 
 let project_maybe_mutable mut m =
   match mut with
@@ -909,8 +907,6 @@ let construct_mutable m0 m =
       which is min, so this call cannot fail."
   );
   m |> Value.disallow_left
-    (* CR zqian: decouple mutable and global *)
-    |> modality_box_right Global
 
 (** Takes [m0] which is the parameter on mutable, and [m] which is a left mode
     on the record being mutated, returns the right mode for the new value of the
@@ -923,8 +919,6 @@ let mutate_mutable m0 (_ : (allowed * _) Value.t) =
   in
   let m0 = Const.alloc_as_value m0 in
   m0 |> Value.of_const |> Value.disallow_left
-    (* CR zqian: decouple mutable and global. *)
-     |> modality_box_right Global
 
 (** Takes a [mutability] and expected mode of the record (adjusted for
     allocation), returns the expected mode for the field. *)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -877,6 +877,62 @@ let apply_mode_annots ~loc ~env (m : Alloc.Const.Option.t) mode =
     | Error (s, e) -> error (s, `Linearity e)
     ) m.linearity
 
+(** Takes [m0] which is the parameter on mutable, and [m] which is a left mode
+    on the record being accessed, returns the left mode of the projected mutable
+    field. *)
+let project_mutable m0 m =
+  let m0 = Const.alloc_as_value m0 in
+  let m0 = Value.Const.split m0 in
+  let comonadic = m.comonadic |> Value.Comonadic.disallow_right in
+  let monadic = Value.Monadic.join
+    [m.monadic;
+     Value.Monadic.of_const m0.monadic]
+  in
+  {monadic; comonadic}
+    (* CR zqian: decouple mutable and global. *)
+    |> modality_unbox_left Global
+
+let project_maybe_mutable mut m =
+  match mut with
+  | Immutable -> Value.disallow_right m
+  | Mutable m0 -> project_mutable m0 m
+
+(** Takes [m0] which is the parameter on mutable, and [m] which is a right mode
+    on the record being constructed, returns the right mode for the mutable
+    field used for construction. *)
+let construct_mutable m0 m =
+  let m0 = Const.alloc_as_value m0 in
+  let m0 = Value.Const.split m0 in
+  (* We require [join m0.comonadic ret <= m],
+    which is equivalent to [m0.comonadic <= m] and
+    [ret <= m] *)
+  (match Value.Comonadic.submode
+          (Value.Comonadic.of_const m0.comonadic)
+          m.comonadic
+  with
+  | Ok () -> ()
+  | Error _ -> Misc.fatal_error
+      "mutable defaults to Comonadic.legacy, \
+      which is min, so this call cannot fail."
+  );
+  m |> Value.disallow_left
+    (* CR zqian: decouple mutable and global *)
+    |> modality_box_right Global
+
+let _construct_maybe_mutable mut m =
+  match mut with
+  | Immutable -> m
+  | Mutable m0 -> construct_mutable m0 m
+
+(** Takes [m0] which is the parameter on mutable, and [m] which is a left mode
+    on the record being mutated, returns the right mode for the new value of the
+    mutable field. *)
+let mutate_mutable m0 (_ : (allowed * _) Value.t) =
+  let m0 = Const.alloc_as_value m0 in
+  m0 |> Value.of_const |> Value.disallow_left
+    (* CR zqian: decouple mutable and global. *)
+     |> modality_box_right Global
+
 (* Typing of patterns *)
 
 (* unification inside type_exp and type_expect *)
@@ -1574,9 +1630,9 @@ let solve_Ppat_record_field ~refine loc env label label_lid record_ty =
   end
 
 let solve_Ppat_array ~refine loc env mutability expected_ty =
-  let type_some_array = match mutability with
-    | Immutable -> Predef.type_iarray
-    | Mutable -> Predef.type_array
+  let type_some_array =
+    if Types.is_mutable mutability then Predef.type_array
+    else Predef.type_iarray
   in
   let jkind, arg_sort = Jkind.of_new_sort_var ~why:Array_element in
   let ty_elt = newgenvar jkind in
@@ -2376,9 +2432,7 @@ and type_pat_aux
        combine the two array pattern constructors. *)
     let ty_elt, arg_sort = solve_Ppat_array ~refine loc env mutability expected_ty in
     let alloc_mode =
-      match mutability with
-      | Mutable -> simple_pat_mode Value.legacy
-      | Immutable -> alloc_mode
+      simple_pat_mode (project_maybe_mutable mutability alloc_mode.mode)
     in
     let pl = List.map (fun p -> type_pat ~alloc_mode tps Value p ty_elt) spl in
     rvp {
@@ -2664,10 +2718,9 @@ and type_pat_aux
       let type_label_pat (label_lid, label, sarg) =
         let ty_arg =
           solve_Ppat_record_field ~refine loc env label label_lid record_ty in
-        let alloc_mode =
-          modality_unbox_left label.lbl_global alloc_mode.mode
-        in
-        let alloc_mode = simple_pat_mode alloc_mode in
+        let mode = project_maybe_mutable label.lbl_mut alloc_mode.mode in
+        let mode = modality_unbox_left label.lbl_global mode in
+        let alloc_mode = simple_pat_mode mode in
         (label_lid, label, type_pat tps Value ~alloc_mode sarg ty_arg)
       in
       let make_record_pat lbl_pat_list =
@@ -2689,7 +2742,7 @@ and type_pat_aux
       let lbl_a_list = List.map type_label_pat lbl_a_list in
       rvp @@ solve_expected (make_record_pat lbl_a_list)
   | Ppat_array spl ->
-      type_pat_array Mutable spl sp.ppat_attributes
+      type_pat_array (Mutable Alloc.Const.legacy) spl sp.ppat_attributes
   | Ppat_or(sp1, sp2) ->
       (* Reset pattern forces for just [tps2] because later we append
          [tps1] and [tps2]'s pattern forces, and we don't want to
@@ -3768,7 +3821,7 @@ let rec is_nonexpansive exp =
           | Tcf_inherit _ -> false
           | Tcf_attribute _ -> true)
         fields &&
-      Vars.fold (fun _ (mut,_,_) b -> decr count; b && mut = Immutable)
+      Vars.fold (fun _ (mut,_,_) b -> decr count; b && mut = Asttypes.Immutable)
         vars true &&
       !count = 0
   | Texp_letmodule (_, _, _, mexp, e)
@@ -5512,9 +5565,18 @@ and type_expect_
         else
           None, expected_mode
       in
-      let lbl_exp_list =
-        List.map (type_label_exp true env argument_mode loc ty_record) lbl_a_list
+      let type_label_exp ((_, label, _) as x) =
+        let argument_mode =
+          match label.lbl_mut with
+          | Immutable -> argument_mode
+          | Mutable m0 ->
+              (* This can't be unboxed record, safe to drop other fields in
+              [argument_mode] *)
+              mode_default (construct_mutable m0 argument_mode.mode)
+        in
+        type_label_exp true env argument_mode loc ty_record x
       in
+      let lbl_exp_list = List.map type_label_exp lbl_a_list in
       with_explanation (fun () ->
         unify_exp_types loc env (instance ty_record) (instance ty_expected));
       (* note: check_duplicates would better be implemented in
@@ -5572,7 +5634,16 @@ and type_expect_
                   unify_exp_types loc env ty_arg1 ty_arg2;
                   with_explanation (fun () ->
                     unify_exp_types loc env (instance ty_expected) ty_res2);
+                  let mode = project_maybe_mutable lbl.lbl_mut mode in
                   let mode = modality_unbox_left lbl.lbl_global mode in
+                  let argument_mode =
+                    match lbl.lbl_mut with
+                    | Immutable -> argument_mode
+                    | Mutable m0 ->
+                      (* can't be unboxed record; safe to drop other fields in
+                         [argument_mode] *)
+                      mode_default (construct_mutable m0 argument_mode.mode)
+                  in
                   let argument_mode =
                     mode_box_modality lbl.lbl_global argument_mode
                   in
@@ -5621,7 +5692,8 @@ and type_expect_
           ty_arg
         end ~post:generalize_structure
       in
-      let mode = modality_unbox_left label.lbl_global rmode in
+      let mode = project_maybe_mutable label.lbl_mut rmode in
+      let mode = modality_unbox_left label.lbl_global mode in
       let boxing : texp_field_boxing =
         match label.lbl_repres with
         | Record_float ->
@@ -5651,11 +5723,15 @@ and type_expect_
         else record.exp_type
       in
       let (label_loc, label, newval) =
-        type_label_exp false env (mode_default rmode) loc
-          ty_record (lid, label, snewval) in
+        match label.lbl_mut with
+        | Mutable m0 ->
+          let mode = mutate_mutable m0 rmode in
+          type_label_exp false env (mode_default mode) loc
+            ty_record (lid, label, snewval)
+        | Immutable ->
+          raise(Error(loc, env, Label_not_mutable lid.txt))
+      in
       unify_exp env record ty_record;
-      if label.lbl_mut = Immutable then
-        raise(Error(loc, env, Label_not_mutable lid.txt));
       rue {
         exp_desc = Texp_setfield(record,
           Locality.disallow_right (regional_to_local (Value.regionality rmode)),
@@ -5671,7 +5747,7 @@ and type_expect_
         ~expected_mode
         ~ty_expected
         ~explanation
-        ~mutability:Mutable
+        ~mutability:(Mutable Alloc.Const.legacy)
         ~attributes:sexp.pexp_attributes
         sargl
   | Pexp_ifthenelse(scond, sifso, sifnot) ->
@@ -7118,7 +7194,7 @@ and type_option_some env expected_mode sarg ty ty0 =
     (type_option arg.exp_type) arg.exp_loc arg.exp_env
 
 (* [expected_mode] is the expected mode of the field. It's already adjusted for
-   allocation but not modality *)
+   allocation and mutation, but not modality *)
 and type_label_exp create env (expected_mode : expected_mode) loc ty_expected
           (lid, label, sarg) =
   (* Here also ty_expected may be at generic_level *)
@@ -8581,18 +8657,19 @@ and type_andops env sarg sands expected_sort expected_ty =
 and type_generic_array
       ~loc
       ~env
-      ~expected_mode
+      ~(expected_mode : expected_mode)
       ~ty_expected
       ~explanation
       ~mutability
       ~attributes
       sargl
   =
-  let alloc_mode, argument_mode = register_allocation expected_mode in
+  let alloc_mode, argument_mode = register_allocation_value_mode expected_mode.mode in
   let type_, argument_mode = match mutability with
-    | Mutable -> Predef.type_array, mode_default Value.legacy
+    | Mutable m0 -> Predef.type_array, construct_mutable m0 argument_mode
     | Immutable -> Predef.type_iarray, argument_mode
   in
+  let argument_mode = mode_default argument_mode in
   let jkind, elt_sort = Jkind.of_new_sort_var ~why:Array_element in
   let ty = newgenvar jkind in
   let to_unify = type_ ty in
@@ -8902,15 +8979,15 @@ and type_comprehension_expr
         comp,
         Predef.list_argument_jkind
     | Cexp_array_comprehension (amut, comp) ->
-        let container_type = match amut with
-          | Mutable   -> Predef.type_array
-          | Immutable -> Predef.type_iarray
+        let container_type, mut = match amut with
+          | Mutable   -> Predef.type_array, Mutable Alloc.Const.legacy
+          | Immutable -> Predef.type_iarray, Immutable
         in
-        Array_comprehension amut,
+        Array_comprehension mut,
         container_type,
         (fun tcomp ->
           Texp_array_comprehension
-            (amut, Jkind.Sort.for_array_comprehension_element, tcomp)),
+            (mut, Jkind.Sort.for_array_comprehension_element, tcomp)),
         comp,
         (* CR layouts v4: When this changes from [value], you will also have to
            update the use of [transl_exp] in transl_array_comprehension.ml. See
@@ -9350,7 +9427,7 @@ let report_type_expected_explanation expl ppf =
       let a_comp_ty =
         match comp_ty with
         | List_comprehension            -> "a list"
-        | Array_comprehension Mutable   -> "an array"
+        | Array_comprehension (Mutable _)   -> "an array"
         | Array_comprehension Immutable -> "an immutable array"
       in
       because ("a for-in iterator in " ^ a_comp_ty ^ " comprehension")

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -487,9 +487,6 @@ let mode_with_position mode position =
 let mode_max_with_position position =
   { mode_max with position }
 
-let mode_box_modality gf expected_mode =
-  mode_default (modality_box_right gf expected_mode.mode)
-
 let mode_global expected_mode =
   let mode = meet_global expected_mode.mode in
   {expected_mode with mode}
@@ -877,16 +874,12 @@ let apply_mode_annots ~loc ~env (m : Alloc.Const.Option.t) mode =
     | Error (s, e) -> error (s, `Linearity e)
     ) m.linearity
 
-(** Takes [m0] which is the parameter on mutable, and [m] which is a left mode
-    on the record being accessed, returns the left mode of the projected mutable
-    field. *)
-let project_mutable _ (m : (allowed * _) Value.t) =
-  m |> Value.disallow_right
-
-let project_maybe_mutable mut m =
-  match mut with
-  | Immutable -> Value.disallow_right m
-  | Mutable m0 -> project_mutable m0 m
+(** Takes the mutability and modalities on a record field, and [m] which is a
+    left mode on the record being accessed, returns the left mode of the
+    projected field. *)
+let project_field mutability modalities (m : (allowed * _) Value.t) =
+  ignore mutability;
+  modality_unbox_left modalities m
 
 (** Takes [m0] which is the parameter on mutable, and [m] which is a right mode
     on the record being constructed, returns the right mode for the mutable
@@ -908,10 +901,9 @@ let construct_mutable m0 m =
   );
   m |> Value.disallow_left
 
-(** Takes [m0] which is the parameter on mutable, and [m] which is a left mode
-    on the record being mutated, returns the right mode for the new value of the
-    mutable field. *)
-let mutate_mutable m0 (_ : (allowed * _) Value.t) =
+(** Takes [m0] which is the parameter on mutable, returns the right mode for the
+    new value of the mutable field. *)
+let mutate_mutable m0 =
   let m0 =
     Alloc.Const.merge
       {comonadic = m0;
@@ -920,15 +912,17 @@ let mutate_mutable m0 (_ : (allowed * _) Value.t) =
   let m0 = Const.alloc_as_value m0 in
   m0 |> Value.of_const |> Value.disallow_left
 
-(** Takes a [mutability] and expected mode of the record (adjusted for
-    allocation), returns the expected mode for the field. *)
-let mode_field mutability (argument_mode : expected_mode) =
-  match mutability with
-  | Immutable -> argument_mode
-  | Mutable m0 ->
-    (* Mutable field, so this can't be unboxed record, safe to drop other fields
-    in [argument_mode] *)
-    mode_default (construct_mutable m0 argument_mode.mode)
+(** Takes the mutability and modalities on the field, and expected mode of the
+    record (adjusted for allocation), returns the expected mode for the field.
+    *)
+let construct_field mutability modalities (argument_mode : expected_mode) =
+  let mode =
+    match mutability with
+    | Immutable -> argument_mode.mode
+    | Mutable m0 -> construct_mutable m0 argument_mode.mode
+  in
+  let mode = modality_box_right modalities mode in
+  mode_default mode
 
 (* Typing of patterns *)
 
@@ -2428,11 +2422,11 @@ and type_pat_aux
        shouldn't be too bad.  We can inline this when we upstream this code and
        combine the two array pattern constructors. *)
     let ty_elt, arg_sort = solve_Ppat_array ~refine loc env mutability expected_ty in
-    let alloc_mode =
-      match mutability with
-      | Immutable -> alloc_mode.mode
-      | Mutable m0 -> project_mutable m0 alloc_mode.mode |> modality_unbox_left Global
+    let modalities : Global_flag.t =
+      (* CR zqian: decouple mutable and global modality *)
+      if Types.is_mutable mutability then Global else Unrestricted
     in
+    let alloc_mode = project_field mutability modalities alloc_mode.mode in
     let alloc_mode = simple_pat_mode alloc_mode in
     let pl = List.map (fun p -> type_pat ~alloc_mode tps Value p ty_elt) spl in
     rvp {
@@ -2675,7 +2669,7 @@ and type_pat_aux
       let args =
         List.map2
           (fun p (ty, gf) ->
-             let alloc_mode = modality_unbox_left gf alloc_mode.mode in
+             let alloc_mode = project_field Immutable gf alloc_mode.mode in
              let alloc_mode = simple_pat_mode alloc_mode in
              type_pat ~alloc_mode tps Value p ty)
           sargs (List.combine ty_args_ty ty_args_gf)
@@ -2718,8 +2712,7 @@ and type_pat_aux
       let type_label_pat (label_lid, label, sarg) =
         let ty_arg =
           solve_Ppat_record_field ~refine loc env label label_lid record_ty in
-        let mode = project_maybe_mutable label.lbl_mut alloc_mode.mode in
-        let mode = modality_unbox_left label.lbl_global mode in
+        let mode = project_field label.lbl_mut label.lbl_global alloc_mode.mode in
         let alloc_mode = simple_pat_mode mode in
         (label_lid, label, type_pat tps Value ~alloc_mode sarg ty_arg)
       in
@@ -5566,7 +5559,7 @@ and type_expect_
           None, expected_mode
       in
       let type_label_exp ((_, label, _) as x) =
-        let argument_mode = mode_field label.lbl_mut argument_mode in
+        let argument_mode = construct_field label.lbl_mut label.lbl_global argument_mode in
         type_label_exp true env argument_mode loc ty_record x
       in
       let lbl_exp_list = List.map type_label_exp lbl_a_list in
@@ -5627,12 +5620,8 @@ and type_expect_
                   unify_exp_types loc env ty_arg1 ty_arg2;
                   with_explanation (fun () ->
                     unify_exp_types loc env (instance ty_expected) ty_res2);
-                  let mode = project_maybe_mutable lbl.lbl_mut mode in
-                  let mode = modality_unbox_left lbl.lbl_global mode in
-                  let argument_mode = mode_field lbl.lbl_mut argument_mode in
-                  let argument_mode =
-                    mode_box_modality lbl.lbl_global argument_mode
-                  in
+                  let mode = project_field lbl.lbl_mut lbl.lbl_global mode in
+                  let argument_mode = construct_field lbl.lbl_mut lbl.lbl_global argument_mode in
                   submode ~loc ~env mode argument_mode;
                   Kept (ty_arg1, lbl.lbl_mut,
                         unique_use ~loc ~env mode argument_mode.mode)
@@ -5678,8 +5667,7 @@ and type_expect_
           ty_arg
         end ~post:generalize_structure
       in
-      let mode = project_maybe_mutable label.lbl_mut rmode in
-      let mode = modality_unbox_left label.lbl_global mode in
+      let mode = project_field label.lbl_mut label.lbl_global rmode in
       let boxing : texp_field_boxing =
         match label.lbl_repres with
         | Record_float ->
@@ -5711,7 +5699,8 @@ and type_expect_
       let (label_loc, label, newval) =
         match label.lbl_mut with
         | Mutable m0 ->
-          let mode = mutate_mutable m0 rmode in
+          let mode = mutate_mutable m0 in
+          let mode = modality_box_right label.lbl_global mode in
           type_label_exp false env (mode_default mode) loc
             ty_record (lid, label, snewval)
         | Immutable ->
@@ -7180,12 +7169,11 @@ and type_option_some env expected_mode sarg ty ty0 =
     (type_option arg.exp_type) arg.exp_loc arg.exp_env
 
 (* [expected_mode] is the expected mode of the field. It's already adjusted for
-   allocation and mutation, but not modality *)
-and type_label_exp create env (expected_mode : expected_mode) loc ty_expected
+   allocation, mutation and modalities. *)
+and type_label_exp create env (arg_mode : expected_mode) loc ty_expected
           (lid, label, sarg) =
   (* Here also ty_expected may be at generic_level *)
   let separate = !Clflags.principal || Env.has_local_constraints env in
-  let arg_mode = mode_box_modality label.lbl_global expected_mode in
   (* #4682: we try two type-checking approaches for [arg] using backtracking:
      - first try: we try with [ty_arg] as expected type;
      - second try; if that fails, we backtrack and try without
@@ -7775,7 +7763,7 @@ and type_construct env (expected_mode : expected_mode) loc lid sarg
   let args =
     List.map2
       (fun e ((ty, gf),t0) ->
-         let argument_mode = mode_box_modality gf argument_mode in
+         let argument_mode = construct_field Immutable gf argument_mode in
          type_argument ~recarg env argument_mode e ty t0)
       sargs (List.combine ty_args ty_args0)
   in
@@ -8650,12 +8638,15 @@ and type_generic_array
       ~attributes
       sargl
   =
-  let alloc_mode, argument_mode = register_allocation_value_mode expected_mode.mode in
-  let type_, argument_mode = match mutability with
-    | Mutable m0 -> Predef.type_array, construct_mutable m0 argument_mode |> modality_box_right Global
-    | Immutable -> Predef.type_iarray, argument_mode
+  let alloc_mode, argument_mode = register_allocation expected_mode in
+  let type_, modalities =
+    (* CR zqian: decouple mutable and global *)
+    if Types.is_mutable mutability then
+      Predef.type_array, Global_flag.Global
+    else
+      Predef.type_iarray, Global_flag.Unrestricted
   in
-  let argument_mode = mode_default argument_mode in
+  let argument_mode = construct_field mutability modalities argument_mode in
   let jkind, elt_sort = Jkind.of_new_sort_var ~why:Array_element in
   let ty = newgenvar jkind in
   let to_unify = type_ ty in

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -22,7 +22,7 @@ open Types
    found in; it's used by [type_forcing_context], which see. *)
 type comprehension_type =
   | List_comprehension
-  | Array_comprehension of mutable_flag
+  | Array_comprehension of mutability
 
 (* This variant is used to print improved error messages, and does not affect
    the behavior of the typechecker itself.

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -362,7 +362,9 @@ let transl_labels ~new_var_jkind env univars closed lbls =
     Builtin_attributes.warning_scope attrs
       (fun () ->
          let gbl =
-            Typemode.transl_global_flags
+           match mut with
+           | Mutable -> Mode.Global_flag.Global
+           | Immutable -> Typemode.transl_global_flags
               (Jane_syntax.Mode_expr.of_attrs arg.ptyp_attributes |> fst)
          in
          let mut : mutability =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -362,10 +362,13 @@ let transl_labels ~new_var_jkind env univars closed lbls =
     Builtin_attributes.warning_scope attrs
       (fun () ->
          let gbl =
-           match mut with
-           | Mutable -> Mode.Global_flag.Global
-           | Immutable -> Typemode.transl_global_flags
+            Typemode.transl_global_flags
               (Jane_syntax.Mode_expr.of_attrs arg.ptyp_attributes |> fst)
+         in
+         let mut : Types.mutable_flag =
+          match mut with
+          | Immutable -> Immutable
+          | Mutable -> Mutable Mode.Alloc.Const.legacy
          in
          let arg = Ast_helper.Typ.force_poly arg in
          let cty = transl_simple_type ~new_var_jkind env ?univars ~closed Mode.Alloc.Const.legacy arg in

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -365,10 +365,10 @@ let transl_labels ~new_var_jkind env univars closed lbls =
             Typemode.transl_global_flags
               (Jane_syntax.Mode_expr.of_attrs arg.ptyp_attributes |> fst)
          in
-         let mut : Types.mutable_flag =
+         let mut : mutability =
           match mut with
           | Immutable -> Immutable
-          | Mutable -> Mutable Mode.Alloc.Const.legacy
+          | Mutable -> Mutable Mode.Alloc.Comonadic.Const.legacy
          in
          let arg = Ast_helper.Typ.force_poly arg in
          let cty = transl_simple_type ~new_var_jkind env ?univars ~closed Mode.Alloc.Const.legacy arg in

--- a/ocaml/typing/typedecl_variance.ml
+++ b/ocaml/typing/typedecl_variance.ml
@@ -256,7 +256,8 @@ let for_constr = function
   | Types.Cstr_tuple l -> List.map (fun (ty,_) -> false, ty) l
   | Types.Cstr_record l ->
       List.map
-        (fun {Types.ld_mutable; ld_type} -> (ld_mutable = Mutable, ld_type))
+        (fun {Types.ld_mutable; ld_type} ->
+          (Types.is_mutable ld_mutable, ld_type))
         l
 
 let compute_variance_gadt env ~check (required, loc as rloc) decl
@@ -353,7 +354,7 @@ let compute_variance_decl env ~check decl (required, _ as rloc) =
       | Type_record (ftl, _) ->
           compute_variance_type env ~check rloc decl
             (mn @ List.map (fun {Types.ld_mutable; ld_type} ->
-                 (ld_mutable = Mutable, ld_type)) ftl)
+                 (Types.is_mutable ld_mutable, ld_type)) ftl)
     in
     if mn = [] || not abstract then
       List.map Variance.strengthen vari

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -99,7 +99,7 @@ and 'k pattern_desc =
         closed_flag ->
       value pattern_desc
   | Tpat_array :
-      mutable_flag * Jkind.sort * value general_pattern list -> value pattern_desc
+      mutability * Jkind.sort * value general_pattern list -> value pattern_desc
   | Tpat_lazy : value general_pattern -> value pattern_desc
   (* computation patterns *)
   | Tpat_value : tpat_value_argument -> computation pattern_desc
@@ -165,9 +165,9 @@ and expression_desc =
       expression * Longident.t loc * label_description * texp_field_boxing
   | Texp_setfield of
       expression * Mode.Locality.l * Longident.t loc * label_description * expression
-  | Texp_array of mutable_flag * Jkind.Sort.t * expression list * Mode.Alloc.r
+  | Texp_array of mutability * Jkind.Sort.t * expression list * Mode.Alloc.r
   | Texp_list_comprehension of comprehension
-  | Texp_array_comprehension of mutable_flag * Jkind.sort * comprehension
+  | Texp_array_comprehension of mutability * Jkind.sort * comprehension
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * Jkind.sort * expression
   | Texp_while of {
@@ -295,7 +295,7 @@ and 'k case =
     }
 
 and record_label_definition =
-  | Kept of Types.type_expr * mutable_flag * unique_use
+  | Kept of Types.type_expr * mutability * unique_use
   | Overridden of Longident.t loc * expression
 
 and binding_op =
@@ -376,7 +376,7 @@ and class_field_desc =
       override_flag * class_expr * string option * (string * Ident.t) list *
         (string * Ident.t) list
     (* Inherited instance variables and concrete methods *)
-  | Tcf_val of string loc * Asttypes.mutable_flag * Ident.t * class_field_kind * bool
+  | Tcf_val of string loc * mutable_flag * Ident.t * class_field_kind * bool
   | Tcf_method of string loc * private_flag * class_field_kind
   | Tcf_constraint of core_type * core_type
   | Tcf_initializer of expression
@@ -674,7 +674,7 @@ and label_declaration =
     {
      ld_id: Ident.t;
      ld_name: string loc;
-     ld_mutable: mutable_flag;
+     ld_mutable: mutability;
      ld_global: Global_flag.t;
      ld_type: core_type;
      ld_loc: Location.t;
@@ -759,7 +759,7 @@ and class_type_field = {
 
 and class_type_field_desc =
   | Tctf_inherit of class_type
-  | Tctf_val of (string * Asttypes.mutable_flag * virtual_flag * core_type)
+  | Tctf_val of (string * mutable_flag * virtual_flag * core_type)
   | Tctf_method of (string * private_flag * virtual_flag * core_type)
   | Tctf_constraint of (core_type * core_type)
   | Tctf_attribute of attribute

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -376,7 +376,7 @@ and class_field_desc =
       override_flag * class_expr * string option * (string * Ident.t) list *
         (string * Ident.t) list
     (* Inherited instance variables and concrete methods *)
-  | Tcf_val of string loc * mutable_flag * Ident.t * class_field_kind * bool
+  | Tcf_val of string loc * Asttypes.mutable_flag * Ident.t * class_field_kind * bool
   | Tcf_method of string loc * private_flag * class_field_kind
   | Tcf_constraint of core_type * core_type
   | Tcf_initializer of expression
@@ -759,7 +759,7 @@ and class_type_field = {
 
 and class_type_field_desc =
   | Tctf_inherit of class_type
-  | Tctf_val of (string * mutable_flag * virtual_flag * core_type)
+  | Tctf_val of (string * Asttypes.mutable_flag * virtual_flag * core_type)
   | Tctf_method of (string * private_flag * virtual_flag * core_type)
   | Tctf_constraint of (core_type * core_type)
   | Tctf_attribute of attribute

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -163,7 +163,7 @@ and 'k pattern_desc =
             Invariant: n > 0
          *)
   | Tpat_array :
-      mutable_flag * Jkind.sort * value general_pattern list -> value pattern_desc
+      Types.mutable_flag * Jkind.sort * value general_pattern list -> value pattern_desc
         (** [| P1; ...; Pn |]    (flag = Mutable)
             [: P1; ...; Pn :]    (flag = Immutable) *)
   | Tpat_lazy : value general_pattern -> value pattern_desc
@@ -354,9 +354,9 @@ and expression_desc =
       expression * Mode.Locality.l * Longident.t loc *
       Types.label_description * expression
     (** [alloc_mode] translates to the [modify_mode] of the record *)
-  | Texp_array of mutable_flag * Jkind.Sort.t * expression list * Mode.Alloc.r
+  | Texp_array of Types.mutable_flag * Jkind.Sort.t * expression list * Mode.Alloc.r
   | Texp_list_comprehension of comprehension
-  | Texp_array_comprehension of mutable_flag * Jkind.sort * comprehension
+  | Texp_array_comprehension of Types.mutable_flag * Jkind.sort * comprehension
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * Jkind.sort * expression
   | Texp_while of {
@@ -520,7 +520,7 @@ and 'k case =
     }
 
 and record_label_definition =
-  | Kept of Types.type_expr * mutable_flag * unique_use
+  | Kept of Types.type_expr * Types.mutable_flag * unique_use
   | Overridden of Longident.t loc * expression
 
 and binding_op =
@@ -604,7 +604,7 @@ and class_field_desc =
       override_flag * class_expr * string option * (string * Ident.t) list *
         (string * Ident.t) list
     (* Inherited instance variables and concrete methods *)
-  | Tcf_val of string loc * mutable_flag * Ident.t * class_field_kind * bool
+  | Tcf_val of string loc * Asttypes.mutable_flag * Ident.t * class_field_kind * bool
   | Tcf_method of string loc * private_flag * class_field_kind
   | Tcf_constraint of core_type * core_type
   | Tcf_initializer of expression
@@ -912,7 +912,7 @@ and label_declaration =
     {
      ld_id: Ident.t;
      ld_name: string loc;
-     ld_mutable: mutable_flag;
+     ld_mutable: Types.mutable_flag;
      ld_global: Mode.Global_flag.t;
      ld_type: core_type;
      ld_loc: Location.t;
@@ -997,7 +997,7 @@ and class_type_field = {
 
 and class_type_field_desc =
   | Tctf_inherit of class_type
-  | Tctf_val of (string * mutable_flag * virtual_flag * core_type)
+  | Tctf_val of (string * Asttypes.mutable_flag * virtual_flag * core_type)
   | Tctf_method of (string * private_flag * virtual_flag * core_type)
   | Tctf_constraint of (core_type * core_type)
   | Tctf_attribute of attribute

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -163,7 +163,7 @@ and 'k pattern_desc =
             Invariant: n > 0
          *)
   | Tpat_array :
-      Types.mutable_flag * Jkind.sort * value general_pattern list -> value pattern_desc
+      Types.mutability * Jkind.sort * value general_pattern list -> value pattern_desc
         (** [| P1; ...; Pn |]    (flag = Mutable)
             [: P1; ...; Pn :]    (flag = Immutable) *)
   | Tpat_lazy : value general_pattern -> value pattern_desc
@@ -354,9 +354,9 @@ and expression_desc =
       expression * Mode.Locality.l * Longident.t loc *
       Types.label_description * expression
     (** [alloc_mode] translates to the [modify_mode] of the record *)
-  | Texp_array of Types.mutable_flag * Jkind.Sort.t * expression list * Mode.Alloc.r
+  | Texp_array of Types.mutability * Jkind.Sort.t * expression list * Mode.Alloc.r
   | Texp_list_comprehension of comprehension
-  | Texp_array_comprehension of Types.mutable_flag * Jkind.sort * comprehension
+  | Texp_array_comprehension of Types.mutability * Jkind.sort * comprehension
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * Jkind.sort * expression
   | Texp_while of {
@@ -520,7 +520,7 @@ and 'k case =
     }
 
 and record_label_definition =
-  | Kept of Types.type_expr * Types.mutable_flag * unique_use
+  | Kept of Types.type_expr * Types.mutability * unique_use
   | Overridden of Longident.t loc * expression
 
 and binding_op =
@@ -604,7 +604,7 @@ and class_field_desc =
       override_flag * class_expr * string option * (string * Ident.t) list *
         (string * Ident.t) list
     (* Inherited instance variables and concrete methods *)
-  | Tcf_val of string loc * Asttypes.mutable_flag * Ident.t * class_field_kind * bool
+  | Tcf_val of string loc * mutable_flag * Ident.t * class_field_kind * bool
   | Tcf_method of string loc * private_flag * class_field_kind
   | Tcf_constraint of core_type * core_type
   | Tcf_initializer of expression
@@ -912,7 +912,7 @@ and label_declaration =
     {
      ld_id: Ident.t;
      ld_name: string loc;
-     ld_mutable: Types.mutable_flag;
+     ld_mutable: Types.mutability;
      ld_global: Mode.Global_flag.t;
      ld_type: core_type;
      ld_loc: Location.t;
@@ -997,7 +997,7 @@ and class_type_field = {
 
 and class_type_field_desc =
   | Tctf_inherit of class_type
-  | Tctf_val of (string * Asttypes.mutable_flag * virtual_flag * core_type)
+  | Tctf_val of (string * mutable_flag * virtual_flag * core_type)
   | Tctf_method of (string * private_flag * virtual_flag * core_type)
   | Tctf_constraint of (core_type * core_type)
   | Tctf_attribute of attribute

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -17,7 +17,6 @@
 
 open Path
 open Types
-open Asttypes
 open Typedtree
 open Lambda
 
@@ -478,9 +477,7 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
           (fun (is_mutable, num_nodes_visited)
                (label:Types.label_declaration) ->
               let is_mutable =
-                match label.ld_mutable with
-                | Mutable -> true
-                | Immutable -> is_mutable
+                Types.is_mutable label.ld_mutable || is_mutable
               in
               let num_nodes_visited = num_nodes_visited + 1 in
               let num_nodes_visited, field =
@@ -548,9 +545,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
           (fun (is_mutable, num_nodes_visited)
                (label:Types.label_declaration) ->
             let is_mutable =
-              match label.ld_mutable with
-              | Mutable -> true
-              | Immutable -> is_mutable
+              Types.is_mutable label.ld_mutable || is_mutable
             in
             let num_nodes_visited = num_nodes_visited + 1 in
             let num_nodes_visited, field =

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -19,6 +19,14 @@ open Asttypes
 
 type jkind = Jkind.t
 
+type mutable_flag =
+  | Immutable
+  | Mutable of Mode.Alloc.Const.t
+
+let is_mutable = function
+  | Immutable -> false
+  | Mutable _ -> true
+
 (* Type expressions for the core language *)
 
 type transient_expr =
@@ -116,7 +124,7 @@ module Vars = Misc.Stdlib.String.Map
 type value_kind =
     Val_reg                             (* Regular value *)
   | Val_prim of Primitive.description   (* Primitive *)
-  | Val_ivar of mutable_flag * string   (* Instance variable (mutable ?) *)
+  | Val_ivar of Asttypes.mutable_flag * string   (* Instance variable (mutable ?) *)
   | Val_self of
       class_signature * self_meths * Ident.t Vars.t * string
                                         (* Self *)
@@ -130,7 +138,7 @@ and self_meths =
 and class_signature =
   { csig_self: type_expr;
     mutable csig_self_row: type_expr;
-    mutable csig_vars: (mutable_flag * virtual_flag * type_expr) Vars.t;
+    mutable csig_vars: (Asttypes.mutable_flag * virtual_flag * type_expr) Vars.t;
     mutable csig_meths: (method_privacy * virtual_flag * type_expr) Meths.t; }
 
 and method_privacy =

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -19,9 +19,9 @@ open Asttypes
 
 type jkind = Jkind.t
 
-type mutable_flag =
+type mutability =
   | Immutable
-  | Mutable of Mode.Alloc.Const.t
+  | Mutable of Mode.Alloc.Comonadic.Const.t
 
 let is_mutable = function
   | Immutable -> false
@@ -124,7 +124,7 @@ module Vars = Misc.Stdlib.String.Map
 type value_kind =
     Val_reg                             (* Regular value *)
   | Val_prim of Primitive.description   (* Primitive *)
-  | Val_ivar of Asttypes.mutable_flag * string   (* Instance variable (mutable ?) *)
+  | Val_ivar of mutable_flag * string   (* Instance variable (mutable ?) *)
   | Val_self of
       class_signature * self_meths * Ident.t Vars.t * string
                                         (* Self *)
@@ -138,7 +138,7 @@ and self_meths =
 and class_signature =
   { csig_self: type_expr;
     mutable csig_self_row: type_expr;
-    mutable csig_vars: (Asttypes.mutable_flag * virtual_flag * type_expr) Vars.t;
+    mutable csig_vars: (mutable_flag * virtual_flag * type_expr) Vars.t;
     mutable csig_meths: (method_privacy * virtual_flag * type_expr) Meths.t; }
 
 and method_privacy =
@@ -290,7 +290,7 @@ and variant_representation =
 and label_declaration =
   {
     ld_id: Ident.t;
-    ld_mutable: mutable_flag;
+    ld_mutable: mutability;
     ld_global: Mode.Global_flag.t;
     ld_type: type_expr;
     ld_jkind : Jkind.t;
@@ -615,7 +615,7 @@ type label_description =
   { lbl_name: string;                   (* Short name *)
     lbl_res: type_expr;                 (* Type of the result *)
     lbl_arg: type_expr;                 (* Type of the argument *)
-    lbl_mut: mutable_flag;              (* Is this a mutable field? *)
+    lbl_mut: mutability;                (* Is this a mutable field? *)
     lbl_global: Mode.Global_flag.t;        (* Is this a global field? *)
     lbl_jkind : Jkind.t;                (* Jkind of the argument *)
     lbl_pos: int;                       (* Position in block *)

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -28,15 +28,15 @@ open Asttypes
 (* CR layouts v2.8: Say more here. *)
 type jkind = Jkind.t
 
-(** The mutable_flag used in typed tree. *)
-type mutable_flag =
+(** Describes a mutable field/element. *)
+type mutability =
   | Immutable
-  | Mutable of Mode.Alloc.Const.t
+  | Mutable of Mode.Alloc.Comonadic.Const.t
   (** The upper bound of the new field value upon mutation. *)
 
 (** Returns [true] is the [mutable_flag] is mutable. Should be called if not
     interested in the payload of [Mutable]. *)
-val is_mutable : mutable_flag -> bool
+val is_mutable : mutability -> bool
 
 (** Type expressions for the core language.
 
@@ -403,7 +403,7 @@ module Vars  : Map.S with type key = string
 type value_kind =
     Val_reg                             (* Regular value *)
   | Val_prim of Primitive.description   (* Primitive *)
-  | Val_ivar of Asttypes.mutable_flag * string   (* Instance variable (mutable ?) *)
+  | Val_ivar of mutable_flag * string   (* Instance variable (mutable ?) *)
   | Val_self of class_signature * self_meths * Ident.t Vars.t * string
                                         (* Self *)
   | Val_anc of class_signature * Ident.t Meths.t * string
@@ -416,7 +416,7 @@ and self_meths =
 and class_signature =
   { csig_self: type_expr;
     mutable csig_self_row: type_expr;
-    mutable csig_vars: (Asttypes.mutable_flag * virtual_flag * type_expr) Vars.t;
+    mutable csig_vars: (mutable_flag * virtual_flag * type_expr) Vars.t;
     mutable csig_meths: (method_privacy * virtual_flag * type_expr) Meths.t; }
 
 and method_privacy =
@@ -578,7 +578,7 @@ and variant_representation =
 and label_declaration =
   {
     ld_id: Ident.t;
-    ld_mutable: mutable_flag;
+    ld_mutable: mutability;
     ld_global: Mode.Global_flag.t;
     ld_type: type_expr;
     ld_jkind : Jkind.t;
@@ -808,7 +808,7 @@ type label_description =
   { lbl_name: string;                   (* Short name *)
     lbl_res: type_expr;                 (* Type of the result *)
     lbl_arg: type_expr;                 (* Type of the argument *)
-    lbl_mut: mutable_flag;              (* Is this a mutable field? *)
+    lbl_mut: mutability;                (* Is this a mutable field? *)
     lbl_global: Mode.Global_flag.t;     (* Is this a global field? *)
     lbl_jkind : Jkind.t;                (* Jkind of the argument *)
     lbl_pos: int;                       (* Position in block *)

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -28,6 +28,16 @@ open Asttypes
 (* CR layouts v2.8: Say more here. *)
 type jkind = Jkind.t
 
+(** The mutable_flag used in typed tree. *)
+type mutable_flag =
+  | Immutable
+  | Mutable of Mode.Alloc.Const.t
+  (** The upper bound of the new field value upon mutation. *)
+
+(** Returns [true] is the [mutable_flag] is mutable. Should be called if not
+    interested in the payload of [Mutable]. *)
+val is_mutable : mutable_flag -> bool
+
 (** Type expressions for the core language.
 
     The [type_desc] variant defines all the possible type expressions one can
@@ -393,7 +403,7 @@ module Vars  : Map.S with type key = string
 type value_kind =
     Val_reg                             (* Regular value *)
   | Val_prim of Primitive.description   (* Primitive *)
-  | Val_ivar of mutable_flag * string   (* Instance variable (mutable ?) *)
+  | Val_ivar of Asttypes.mutable_flag * string   (* Instance variable (mutable ?) *)
   | Val_self of class_signature * self_meths * Ident.t Vars.t * string
                                         (* Self *)
   | Val_anc of class_signature * Ident.t Meths.t * string
@@ -406,7 +416,7 @@ and self_meths =
 and class_signature =
   { csig_self: type_expr;
     mutable csig_self_row: type_expr;
-    mutable csig_vars: (mutable_flag * virtual_flag * type_expr) Vars.t;
+    mutable csig_vars: (Asttypes.mutable_flag * virtual_flag * type_expr) Vars.t;
     mutable csig_meths: (method_privacy * virtual_flag * type_expr) Meths.t; }
 
 and method_privacy =

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -274,15 +274,15 @@ let constructor_declaration sub cd =
     ~info:Docstrings.empty_info
     (map_loc sub cd.cd_name)
 
-let mutable_ (mut : Types.mutable_flag) : Asttypes.mutable_flag =
+let mutable_ (mut : Types.mutability) : mutable_flag =
   match mut with
   | Immutable -> Immutable
   | Mutable m ->
-      if Misc.eq_from_le Mode.Alloc.Const.le m Mode.Alloc.Const.legacy then
+      if Mode.Alloc.Comonadic.Const.eq m Mode.Alloc.Comonadic.Const.legacy then
         Mutable
       else
         Misc.fatal_errorf "unexpected mutable(%a)"
-          Mode.Alloc.Const.print m
+          Mode.Alloc.Comonadic.Const.print m
 
 let label_declaration sub ld =
   let loc = sub.location sub ld.ld_loc in

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -274,11 +274,22 @@ let constructor_declaration sub cd =
     ~info:Docstrings.empty_info
     (map_loc sub cd.cd_name)
 
+let mutable_ (mut : Types.mutable_flag) : Asttypes.mutable_flag =
+  match mut with
+  | Immutable -> Immutable
+  | Mutable m ->
+      if Misc.eq_from_le Mode.Alloc.Const.le m Mode.Alloc.Const.legacy then
+        Mutable
+      else
+        Misc.fatal_errorf "unexpected mutable(%a)"
+          Mode.Alloc.Const.print m
+
 let label_declaration sub ld =
   let loc = sub.location sub ld.ld_loc in
   let attrs = sub.attributes sub ld.ld_attributes in
+  let mut = mutable_ ld.ld_mutable in
   Type.field ~loc ~attrs
-    ~mut:ld.ld_mutable
+    ~mut
     (map_loc sub ld.ld_name)
     (sub.typ sub ld.ld_type)
 
@@ -394,9 +405,8 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
             map_loc sub lid, sub.pat sub pat) list, closed)
     | Tpat_array (am, _, list) -> begin
         let pats = List.map (sub.pat sub) list in
-        match am with
-        | Mutable   -> Ppat_array pats
-        | Immutable ->
+        if Types.is_mutable am then Ppat_array pats
+        else
           Jane_syntax.Immutable_arrays.pat_of
             ~loc
             (Iapat_immutable_array pats)
@@ -623,10 +633,8 @@ let expression sub exp =
     | Texp_array (amut, _, list, _) -> begin
         (* Can be inlined when we get to upstream immutable arrays *)
         let plist = List.map (sub.expr sub) list in
-        match amut with
-        | Mutable ->
-            Pexp_array plist
-        | Immutable ->
+        if Types.is_mutable amut then Pexp_array plist
+        else
             Jane_syntax.Immutable_arrays.expr_of
               ~loc (Iaexp_immutable_array plist)
             |> add_jane_syntax_attributes
@@ -636,6 +644,7 @@ let expression sub exp =
           ~loc sub (fun comp -> Cexp_list_comprehension comp) comp
         |> add_jane_syntax_attributes
     | Texp_array_comprehension (amut, _, comp) ->
+        let amut = mutable_ amut in
         comprehension
           ~loc sub (fun comp -> Cexp_array_comprehension (amut, comp)) comp
         |> add_jane_syntax_attributes

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -1429,5 +1429,3 @@ end
 module type T4 = sig
   type ('a, 'b, 'c, 'd) t
 end
-
-let eq_from_le le a b = le a b && le b a

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -1429,3 +1429,5 @@ end
 module type T4 = sig
   type ('a, 'b, 'c, 'd) t
 end
+
+let eq_from_le le a b = le a b && le b a

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -892,6 +892,3 @@ end
 type filepath = string
 
 type alerts = string Stdlib.String.Map.t
-
-(** Construct an equality function from a less-or-equal function. *)
-val eq_from_le : ('a -> 'a -> bool) -> 'a -> 'a -> bool

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -892,3 +892,6 @@ end
 type filepath = string
 
 type alerts = string Stdlib.String.Map.t
+
+(** Construct an equality function from a less-or-equal function. *)
+val eq_from_le : ('a -> 'a -> bool) -> 'a -> 'a -> bool


### PR DESCRIPTION
This PR implements the logic for `mutable()` logic for record and array, without supporting the syntax `mutable(modes)`.

- The logic of `mutable` in classes are not changed at all, since everything in OO is strictly constrained to legacy anyway.
- Keep the logic that `mutable` implies `global` modality, but this is now implemented in `typecore.ml` only, instead of desugaring. This simplifies printing which is something we will do soon anyway.
- Because `global` modality implies `shared` and `many` modality, which overrides the `mutable()` logic, so this PR has little observable effects. The only two changes are demonstrated by the tests.