### PR TITLE
Stack check as a linear/CFG instruction

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -17,6 +17,7 @@ peephole/**/*.mli
 regalloc/**/*.ml
 regalloc/**/*.mli
 amd64/simd*.ml
+amd64/stack_check.ml
 arm64/simd*.ml
 generic_fns.ml
 generic_fns.mli

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1240,7 +1240,7 @@ let emit_simd_instr op i =
     I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0); I.set E (res8 i 0); I.movzx (res8 i 0) (res i 0)
 
 (* Emit an instruction *)
-let emit_instr ~first fallthrough i =
+let emit_instr ~first ~fallthrough i =
   emit_debug_info_linear i;
   match i.desc with
   | Lend -> ()
@@ -1836,11 +1836,11 @@ let emit_instr ~first fallthrough i =
       sc_max_frame_size_in_bytes = max_frame_size_bytes;
     }
 
-let rec emit_all first fallthrough i =
+let rec emit_all ~first ~fallthrough i =
   match i.desc with
   | Lend -> ()
   | _ ->
-      emit_instr ~first fallthrough i;
+      emit_instr ~first ~fallthrough i;
       emit_all ~first:false (Linear.has_fallthrough i.desc) i.next
 
 let all_functions = ref []
@@ -1900,7 +1900,7 @@ let fundecl fundecl =
   if Config.runtime5 && !Clflags.runtime_variant = "d" then begin
     emit_call (Cmm.global_symbol "caml_assert_stack_invariants");
   end;
-  emit_all true true fundecl.fun_body;
+  emit_all ~first:true ~fallthrough:true fundecl.fun_body;
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
   emit_call_safety_errors ();

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -467,7 +467,7 @@ let emit_call_safety_errors () =
 type stack_realloc = {
   sc_label : Label.t; (* Label of the reallocation code. *)
   sc_return : Label.t; (* Label to return to after reallocation. *)
-  sc_max_frame_size : int; (* Size for reallocation. *)
+  sc_max_frame_size_in_bytes : int; (* Size for reallocation. *)
 }
 
 let stack_realloc = ref (None : stack_realloc option)
@@ -477,19 +477,19 @@ let clear_stack_realloc () =
 
 let emit_stack_realloc () =
   begin match !stack_realloc with
-  | None -> ();
-  | Some { sc_label; sc_return; sc_max_frame_size; } -> begin
-        def_label sc_label;
-        (* Pass the desired frame size on the stack, since all of the
-           argument-passing registers may be in use.
-           Also serves to align the stack properly before the call *)
-        I.push (int (Config.stack_threshold + sc_max_frame_size / 8));
-        cfi_adjust_cfa_offset 8;
-        (* measured in words *)
-        emit_call (Cmm.global_symbol "caml_call_realloc_stack");
-        I.pop r10; (* ignored *)
-        cfi_adjust_cfa_offset (-8);
-        I.jmp (label sc_return)
+  | None -> ()
+  | Some { sc_label; sc_return; sc_max_frame_size_in_bytes; } -> begin
+      def_label sc_label;
+      (* Pass the desired frame size on the stack, since all of the
+         argument-passing registers may be in use.
+         Also serves to align the stack properly before the call *)
+      I.push (int (Config.stack_threshold + sc_max_frame_size_in_bytes / 8));
+      cfi_adjust_cfa_offset 8;
+      (* measured in words *)
+      emit_call (Cmm.global_symbol "caml_call_realloc_stack");
+      I.pop r10; (* ignored *)
+      cfi_adjust_cfa_offset (-8);
+      I.jmp (label sc_return)
     end
   end
 
@@ -1240,7 +1240,7 @@ let emit_simd_instr op i =
     I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0); I.set E (res8 i 0); I.movzx (res8 i 0) (res i 0)
 
 (* Emit an instruction *)
-let emit_instr fallthrough i =
+let emit_instr first fallthrough i =
   emit_debug_info_linear i;
   match i.desc with
   | Lend -> ()
@@ -1820,7 +1820,8 @@ let emit_instr fallthrough i =
           I.pop r11;
           I.jmp r11
     end
-  | Lstackcheck { max_frame_size_bytes; save_registers; } ->
+  | Lstackcheck { max_frame_size_bytes; } ->
+    let save_registers = first in
     let overflow = new_label () and ret = new_label () in
     let threshold_offset = Domainstate.stack_ctx_words * 8 + Stack_check.stack_threshold_size in
     if save_registers then I.push r10;
@@ -1832,15 +1833,15 @@ let emit_instr fallthrough i =
     stack_realloc := Some {
       sc_label = overflow;
       sc_return = ret;
-      sc_max_frame_size = max_frame_size_bytes;
+      sc_max_frame_size_in_bytes = max_frame_size_bytes;
     }
 
-let rec emit_all fallthrough i =
+let rec emit_all first fallthrough i =
   match i.desc with
   | Lend -> ()
   | _ ->
-      emit_instr fallthrough i;
-      emit_all (Linear.has_fallthrough i.desc) i.next
+      emit_instr first fallthrough i;
+      emit_all false (Linear.has_fallthrough i.desc) i.next
 
 let all_functions = ref []
 
@@ -1899,7 +1900,7 @@ let fundecl fundecl =
   if Config.runtime5 && !Clflags.runtime_variant = "d" then begin
     emit_call (Cmm.global_symbol "caml_assert_stack_invariants");
   end;
-  emit_all true fundecl.fun_body;
+  emit_all true true fundecl.fun_body;
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
   emit_call_safety_errors ();

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -89,8 +89,6 @@ let emit_debug_info_linear i =
 
 let fp = Config.with_frame_pointers
 
-let stack_threshold_size = Config.stack_threshold * 8 (* bytes *)
-
 (* Tradeoff between code size and code speed *)
 
 let fastcode_flag = ref true
@@ -104,19 +102,11 @@ let prologue_required = ref false
 
 let frame_required = ref false
 
-let frame_size () =                     (* includes return address *)
-  if !frame_required then begin
-    if num_stack_slots.(2) > 0 then assert_simd_enabled ();
-    let sz =
-      (!stack_offset
-       + 8
-       + 8 * num_stack_slots.(0)
-       + 8 * num_stack_slots.(1)
-       + 16 * num_stack_slots.(2)
-       + (if fp then 8 else 0))
-    in Misc.align sz 16
-  end else
-    !stack_offset + 8
+let frame_size () =
+  Stack_check.frame_size
+    ~stack_offset:!stack_offset
+    ~frame_required:!frame_required
+    ~num_stack_slots
 
 let slot_offset loc cl =
   match loc with
@@ -471,6 +461,36 @@ let emit_call_safety_errors () =
   if align_checks.sc_call > 0 then begin
     def_label align_checks.sc_call;
     emit_call (Cmm.global_symbol "caml_ml_array_align_error")
+  end
+
+(* Stack reallocation *)
+type stack_realloc = {
+  sc_label : Label.t; (* Label of the reallocation code. *)
+  sc_return : Label.t; (* Label to return to after reallocation. *)
+  sc_max_frame_size : int; (* Size for reallocation. *)
+}
+
+let stack_realloc = ref (None : stack_realloc option)
+
+let clear_stack_realloc () =
+  stack_realloc := None
+
+let emit_stack_realloc () =
+  begin match !stack_realloc with
+  | None -> ();
+  | Some { sc_label; sc_return; sc_max_frame_size; } -> begin
+        def_label sc_label;
+        (* Pass the desired frame size on the stack, since all of the
+           argument-passing registers may be in use.
+           Also serves to align the stack properly before the call *)
+        I.push (int (Config.stack_threshold + sc_max_frame_size / 8));
+        cfi_adjust_cfa_offset 8;
+        (* measured in words *)
+        emit_call (Cmm.global_symbol "caml_call_realloc_stack");
+        I.pop r10; (* ignored *)
+        cfi_adjust_cfa_offset (-8);
+        I.jmp (label sc_return)
+    end
   end
 
 (* Record jump tables *)
@@ -1799,7 +1819,21 @@ let emit_instr fallthrough i =
           I.pop (domain_field Domainstate.Domain_exn_handler);
           I.pop r11;
           I.jmp r11
-      end
+    end
+  | Lstackcheck { max_frame_size_bytes; save_registers; } ->
+    let overflow = new_label () and ret = new_label () in
+    let threshold_offset = Domainstate.stack_ctx_words * 8 + Stack_check.stack_threshold_size in
+    if save_registers then I.push r10;
+    I.lea (mem64 NONE (-(max_frame_size_bytes + threshold_offset)) RSP) r10;
+    I.cmp (domain_field Domainstate.Domain_current_stack) r10;
+    if save_registers then I.pop r10;
+    I.jb (label overflow);
+    def_label ret;
+    stack_realloc := Some {
+      sc_label = overflow;
+      sc_return = ret;
+      sc_max_frame_size = max_frame_size_bytes;
+    }
 
 let rec emit_all fallthrough i =
   match i.desc with
@@ -1836,6 +1870,7 @@ let fundecl fundecl =
   call_gc_sites := [];
   local_realloc_sites := [];
   clear_safety_checks ();
+  clear_stack_realloc ();
   for i = 0 to Proc.num_stack_slot_classes - 1 do
     num_stack_slots.(i) <- fundecl.fun_num_stack_slots.(i);
   done;
@@ -1861,53 +1896,14 @@ let fundecl fundecl =
   D.label (label_name (emit_symbol fundecl.fun_name));
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc ();
-  let handle_overflow_and_max_frame_size =
-    (* CR mshinwell: this should be conditionalized on a specific
-       "stack checks enabled" config option, so we can backport to 4.x *)
-    if not Config.runtime5 then None
-    else (
-      if !Clflags.runtime_variant = "d" then
-        emit_call (Cmm.global_symbol "caml_assert_stack_invariants");
-      let { max_frame_size; contains_nontail_calls} =
-        preproc_stack_check
-          ~fun_body:fundecl.fun_body ~frame_size:(frame_size ()) ~trap_size:16
-      in
-      let handle_overflow =
-        if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
-          let overflow = new_label () and ret = new_label () in
-          let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
-          I.lea (mem64 NONE (-(max_frame_size + threshold_offset)) RSP) r10;
-          I.cmp (domain_field Domainstate.Domain_current_stack) r10;
-          I.jb (label overflow);
-          def_label ret;
-          Some (overflow, ret)
-        end else None
-      in
-      match handle_overflow with
-      | None -> None
-      | Some handle_overflow -> Some (handle_overflow, max_frame_size)
-    )
-  in
+  if Config.runtime5 && !Clflags.runtime_variant = "d" then begin
+    emit_call (Cmm.global_symbol "caml_assert_stack_invariants");
+  end;
   emit_all true fundecl.fun_body;
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
   emit_call_safety_errors ();
-  begin match handle_overflow_and_max_frame_size with
-    | None -> ()
-    | Some ((overflow,ret), max_frame_size) -> begin
-        def_label overflow;
-        (* Pass the desired frame size on the stack, since all of the
-           argument-passing registers may be in use.
-           Also serves to align the stack properly before the call *)
-        I.push (int (Config.stack_threshold + max_frame_size / 8));
-        cfi_adjust_cfa_offset 8;
-        (* measured in words *)
-        emit_call (Cmm.global_symbol "caml_call_realloc_stack");
-        I.pop r10; (* ignored *)
-        cfi_adjust_cfa_offset (-8);
-        I.jmp (label ret)
-      end
-  end;
+  emit_stack_realloc ();
   if !frame_required then begin
     let n = frame_size() - 8 - (if fp then 8 else 0) in
     if n <> 0

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1841,7 +1841,7 @@ let rec emit_all ~first ~fallthrough i =
   | Lend -> ()
   | _ ->
       emit_instr ~first ~fallthrough i;
-      emit_all ~first:false (Linear.has_fallthrough i.desc) i.next
+      emit_all ~first:false ~fallthrough:(Linear.has_fallthrough i.desc) i.next
 
 let all_functions = ref []
 

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1240,7 +1240,7 @@ let emit_simd_instr op i =
     I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0); I.set E (res8 i 0); I.movzx (res8 i 0) (res i 0)
 
 (* Emit an instruction *)
-let emit_instr first fallthrough i =
+let emit_instr ~first fallthrough i =
   emit_debug_info_linear i;
   match i.desc with
   | Lend -> ()
@@ -1840,8 +1840,8 @@ let rec emit_all first fallthrough i =
   match i.desc with
   | Lend -> ()
   | _ ->
-      emit_instr first fallthrough i;
-      emit_all false (Linear.has_fallthrough i.desc) i.next
+      emit_instr ~first fallthrough i;
+      emit_all ~first:false (Linear.has_fallthrough i.desc) i.next
 
 let all_functions = ref []
 

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -521,6 +521,8 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        | Name_for_debugger _ | Dls_get)
   | Poptrap | Prologue ->
     if fp then [| rbp |] else [||]
+  | Stack_check _ ->
+    assert false (* the instruction is added after register allocation *)
 
 (* note: keep this function in sync with `destroyed_at_oper` above,
    and `is_destruction_point` below. *)

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -239,7 +239,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
   | Prologue ->
     (* no rewrite *)
     May_still_have_spilled_registers
-  | Op (Intop_imm ((Ipopcnt | Iclz _ | Ictz _ ), _)) ->
+  | Op (Intop_imm ((Ipopcnt | Iclz _ | Ictz _ ), _)) | Stack_check _ ->
     (* should not happen *)
     fatal "unexpected instruction"
   end

--- a/backend/amd64/stack_check.ml
+++ b/backend/amd64/stack_check.ml
@@ -1,4 +1,18 @@
-# 2 "backend/amd64/stack_check.ml"
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
@@ -7,51 +21,46 @@ let stack_threshold_size = Config.stack_threshold * 8 (* bytes *)
 let fp = Config.with_frame_pointers
 
 (* includes return address *)
-let frame_size
-  : stack_offset:int -> frame_required:bool -> num_stack_slots:int array ->  int
-  = fun ~stack_offset ~frame_required ~num_stack_slots ->
-    if frame_required then begin
-      if num_stack_slots.(2) > 0 then Arch.assert_simd_enabled ();
-      let sz =
-        (stack_offset
-        + 8
-        + 8 * num_stack_slots.(0)
-        + 8 * num_stack_slots.(1)
-        + 16 * num_stack_slots.(2)
-        + (if fp then 8 else 0))
-      in
-      Misc.align sz 16
-    end else
+let frame_size :
+    stack_offset:int -> frame_required:bool -> num_stack_slots:int array -> int
+    =
+ fun ~stack_offset ~frame_required ~num_stack_slots ->
+  if frame_required
+  then (
+    if num_stack_slots.(2) > 0 then Arch.assert_simd_enabled ();
+    let sz =
       stack_offset + 8
+      + (8 * num_stack_slots.(0))
+      + (8 * num_stack_slots.(1))
+      + (16 * num_stack_slots.(2))
+      + if fp then 8 else 0
+    in
+    Misc.align sz 16)
+  else stack_offset + 8
 
-let linear
-  : Linear.fundecl -> Linear.fundecl
-  = fun fundecl ->
-   (* CR mshinwell: this should be conditionalized on a specific
-      "stack checks enabled" config option, so we can backport to 4.x *)
-    match Config.runtime5 with
-    | false -> fundecl
-    | true ->
-      let frame_size =
-        frame_size ~stack_offset:0 ~frame_required:fundecl.fun_frame_required ~num_stack_slots:fundecl.fun_num_stack_slots
+let linear : Linear.fundecl -> Linear.fundecl =
+ fun fundecl ->
+  match Config.runtime5 with
+  | false -> fundecl
+  | true ->
+    let frame_size =
+      frame_size ~stack_offset:0 ~frame_required:fundecl.fun_frame_required
+        ~num_stack_slots:fundecl.fun_num_stack_slots
+    in
+    let { Emitaux.max_frame_size; contains_nontail_calls } =
+      Emitaux.preproc_stack_check ~fun_body:fundecl.fun_body ~frame_size
+        ~trap_size:16
+    in
+    let insert_stack_check =
+      contains_nontail_calls || max_frame_size >= stack_threshold_size
+    in
+    if insert_stack_check
+    then
+      let fun_body =
+        Linear.instr_cons
+          (Lstackcheck { max_frame_size_bytes = max_frame_size })
+          [||] [||] ~available_before:fundecl.fun_body.available_before
+          ~available_across:fundecl.fun_body.available_across fundecl.fun_body
       in
-      let { Emitaux.max_frame_size; contains_nontail_calls} =
-        Emitaux.preproc_stack_check
-          ~fun_body:fundecl.fun_body ~frame_size ~trap_size:16
-      in
-      let insert_stack_check =
-        contains_nontail_calls || max_frame_size >= stack_threshold_size
-      in
-      if insert_stack_check then
-        let fun_body =
-          Linear.instr_cons
-            (Lstackcheck { max_frame_size_bytes = max_frame_size; save_registers = false})
-            [||]
-            [||]
-            ~available_before:None
-            ~available_across:None
-            fundecl.fun_body
-        in
-        { fundecl with fun_body; }
-      else
-        fundecl
+      { fundecl with fun_body }
+    else fundecl

--- a/backend/amd64/stack_check.ml
+++ b/backend/amd64/stack_check.ml
@@ -1,0 +1,57 @@
+# 2 "backend/amd64/stack_check.ml"
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+let stack_threshold_size = Config.stack_threshold * 8 (* bytes *)
+
+let fp = Config.with_frame_pointers
+
+(* includes return address *)
+let frame_size
+  : stack_offset:int -> frame_required:bool -> num_stack_slots:int array ->  int
+  = fun ~stack_offset ~frame_required ~num_stack_slots ->
+    if frame_required then begin
+      if num_stack_slots.(2) > 0 then Arch.assert_simd_enabled ();
+      let sz =
+        (stack_offset
+        + 8
+        + 8 * num_stack_slots.(0)
+        + 8 * num_stack_slots.(1)
+        + 16 * num_stack_slots.(2)
+        + (if fp then 8 else 0))
+      in
+      Misc.align sz 16
+    end else
+      stack_offset + 8
+
+let linear
+  : Linear.fundecl -> Linear.fundecl
+  = fun fundecl ->
+   (* CR mshinwell: this should be conditionalized on a specific
+      "stack checks enabled" config option, so we can backport to 4.x *)
+    match Config.runtime5 with
+    | false -> fundecl
+    | true ->
+      let frame_size =
+        frame_size ~stack_offset:0 ~frame_required:fundecl.fun_frame_required ~num_stack_slots:fundecl.fun_num_stack_slots
+      in
+      let { Emitaux.max_frame_size; contains_nontail_calls} =
+        Emitaux.preproc_stack_check
+          ~fun_body:fundecl.fun_body ~frame_size ~trap_size:16
+      in
+      let insert_stack_check =
+        contains_nontail_calls || max_frame_size >= stack_threshold_size
+      in
+      if insert_stack_check then
+        let fun_body =
+          Linear.instr_cons
+            (Lstackcheck { max_frame_size_bytes = max_frame_size; save_registers = false})
+            [||]
+            [||]
+            ~available_before:None
+            ~available_across:None
+            fundecl.fun_body
+        in
+        { fundecl with fun_body; }
+      else
+        fundecl

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -546,6 +546,7 @@ module BR = Branch_relaxation.Make (struct
       | Lambda.Raise_reraise -> 1
       | Lambda.Raise_notrace -> 4
       end
+    | Lstackcheck _ -> assert false (* not supported *)
 
   let relax_poll ~return_label =
     Lop (Ispecific (Ifar_poll { return_label }))
@@ -1088,7 +1089,8 @@ let emit_instr i =
           `	ldr	{emit_reg reg_tmp1}, [sp, #8]\n`;
           `	ldr	{emit_reg reg_trap_ptr}, [sp], 16\n`;
           `	br	{emit_reg reg_tmp1}\n`
-        end
+      end
+    | Lstackcheck _ -> assert false (* not supported *)
 
 (* Emission of an instruction sequence *)
 

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -338,6 +338,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
     [| reg_d7 |]
   | Op _ | Poptrap | Prologue ->
     [||]
+  | Stack_check _ -> assert false (* not supported *)
 
 (* note: keep this function in sync with `destroyed_at_oper` above,
    and `is_destruction_point` below. *)

--- a/backend/arm64/stack_check.ml
+++ b/backend/arm64/stack_check.ml
@@ -1,0 +1,15 @@
+# 2 "backend/arm64/stack_check.ml"
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+let stack_threshold_size = 0
+
+let frame_size
+  : stack_offset:int -> frame_required:bool -> num_stack_slots:int array ->  int
+  = fun ~stack_offset:_ ~frame_required:_ ~num_stack_slots:_ ->
+    Misc.fatal_error "stack checks are not supported on arm64"
+
+let linear
+  : Linear.fundecl -> Linear.fundecl
+  = fun _fundecl ->
+    Misc.fatal_error "stack checks are not supported on arm64"

--- a/backend/arm64/stack_check.ml
+++ b/backend/arm64/stack_check.ml
@@ -1,4 +1,18 @@
-# 2 "backend/arm64/stack_check.ml"
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 

--- a/backend/arm64/stack_check.ml
+++ b/backend/arm64/stack_check.ml
@@ -21,9 +21,12 @@ let stack_threshold_size = 0
 let frame_size
   : stack_offset:int -> frame_required:bool -> num_stack_slots:int array ->  int
   = fun ~stack_offset:_ ~frame_required:_ ~num_stack_slots:_ ->
-    Misc.fatal_error "stack checks are not supported on arm64"
+  Misc.fatal_error "stack checks are not supported on arm64"
 
 let linear
   : Linear.fundecl -> Linear.fundecl
-  = fun _fundecl ->
+  = fun fundecl ->
+  match Config.runtime5 with
+  | false -> fundecl
+  | true ->
     Misc.fatal_error "stack checks are not supported on arm64"

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -385,6 +385,7 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
   ++ Profile.record ~accumulate:true "scheduling" Scheduling.fundecl
   ++ pass_dump_linear_if ppf_dump dump_scheduling "After instruction scheduling"
   ++ Profile.record ~accumulate:true "save_linear" save_linear
+  ++ Stack_check.linear
   ++ Profile.record ~accumulate:true "emit_fundecl" emit_fundecl
 
 let compile_data dl =

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -308,6 +308,8 @@ let dump_basic ppf (basic : basic) =
   | Pushtrap { lbl_handler } -> fprintf ppf "Pushtrap handler=%d" lbl_handler
   | Poptrap -> fprintf ppf "Poptrap"
   | Prologue -> fprintf ppf "Prologue"
+  | Stack_check { max_frame_size_bytes; save_registers = _ } ->
+    fprintf ppf "Stack_checl size=%d" max_frame_size_bytes
 
 let dump_terminator' ?(print_reg = Printmach.reg) ?(res = [||]) ?(args = [||])
     ?(specific_can_raise = fun ppf _ -> Format.fprintf ppf "specific_can_raise")
@@ -523,6 +525,9 @@ let is_pure_basic : basic -> bool = function
        ensured that it wouldn't modify the stack pointer (e.g. there are no used
        local stack slots nor calls). *)
     false
+  | Stack_check _ ->
+    (* May reallocate the stack. *)
+    false
 
 let same_location (r1 : Reg.t) (r2 : Reg.t) =
   Reg.same_loc r1 r2
@@ -551,7 +556,7 @@ let is_noop_move instr =
       | Floatofint | Intoffloat | Opaque | Valueofint | Intofvalue
       | Scalarcast _ | Probe_is_enabled _ | Specific _ | Name_for_debugger _
       | Begin_region | End_region | Dls_get | Poll | Alloc _ )
-  | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
+  | Reloadretaddr | Pushtrap _ | Poptrap | Prologue | Stack_check _ ->
     false
 
 let set_stack_offset (instr : _ instruction) stack_offset =

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -308,8 +308,8 @@ let dump_basic ppf (basic : basic) =
   | Pushtrap { lbl_handler } -> fprintf ppf "Pushtrap handler=%d" lbl_handler
   | Poptrap -> fprintf ppf "Poptrap"
   | Prologue -> fprintf ppf "Prologue"
-  | Stack_check { max_frame_size_bytes; save_registers = _ } ->
-    fprintf ppf "Stack_checl size=%d" max_frame_size_bytes
+  | Stack_check { max_frame_size_bytes } ->
+    fprintf ppf "Stack_check size=%d" max_frame_size_bytes
 
 let dump_terminator' ?(print_reg = Printmach.reg) ?(res = [||]) ?(args = [||])
     ?(specific_can_raise = fun ppf _ -> Format.fprintf ppf "specific_can_raise")

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -51,7 +51,7 @@ let rec find_next_allocation : cell option -> allocation option =
         | Vectorcast _ | Scalarcast _ | Probe_is_enabled _ | Opaque
         | Begin_region | End_region | Specific _ | Name_for_debugger _ | Dls_get
         | Poll )
-    | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
+    | Reloadretaddr | Pushtrap _ | Poptrap | Prologue | Stack_check _ ->
       find_next_allocation (DLL.next cell))
 
 (* [find_compatible_allocations cell ~curr_mode ~curr_size] returns the
@@ -93,7 +93,7 @@ let find_compatible_allocations :
         | Lambda.Alloc_heap ->
           loop allocations (DLL.next cell) ~curr_mode ~curr_size)
       | Op Poll -> return ()
-      | Reloadretaddr | Poptrap | Prologue | Pushtrap _ ->
+      | Reloadretaddr | Poptrap | Prologue | Pushtrap _ | Stack_check _ ->
         (* CR-soon xclerc for xclerc: is it too conservative? (note: only the
            `Pushtrap` case may be too conservative) *)
         { allocations = List.rev allocations; next_cell = Some cell }

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -109,7 +109,7 @@ class cse_generic =
       fun state n cell ->
         let i = DLL.value cell in
         match i.desc with
-        | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> n
+        | Reloadretaddr | Pushtrap _ | Poptrap | Prologue | Stack_check _ -> n
         | Op (Move | Spill | Reload) ->
           (* For moves, we associate the same value number to the result reg as
              to the argument reg. *)

--- a/backend/cfg/cfg_deadcode.ml
+++ b/backend/cfg/cfg_deadcode.ml
@@ -19,7 +19,8 @@ let remove_deadcode (body : Cfg.basic_instruction_list) changed liveness
         match instr.desc with
         | Op _ as op ->
           Cfg.is_pure_basic op && Reg.disjoint_set_array !used_after instr.res
-        | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> false
+        | Reloadretaddr | Pushtrap _ | Poptrap | Prologue | Stack_check _ ->
+          false
       in
       used_after := before;
       changed := !changed || is_deadcode;

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -346,16 +346,9 @@ let check_basic : State.t -> location -> Cfg.basic -> Cfg.basic -> unit =
     State.add_to_explore state expected_lbl_handler result_lbl_handler
   | Poptrap, Poptrap -> ()
   | Prologue, Prologue -> ()
-  | ( Stack_check
-        { max_frame_size_bytes = expected_max_frame_size_bytes;
-          save_registers = expected_save_registers
-        },
-      Stack_check
-        { max_frame_size_bytes = result_max_frame_size_bytes;
-          save_registers = result_save_registers
-        } ) ->
+  | ( Stack_check { max_frame_size_bytes = expected_max_frame_size_bytes },
+      Stack_check { max_frame_size_bytes = result_max_frame_size_bytes } ) ->
     if expected_max_frame_size_bytes <> result_max_frame_size_bytes
-       || expected_save_registers <> result_save_registers
     then different location "stack check"
   | _ -> different location "basic"
  [@@ocaml.warning "-4"]

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -346,6 +346,17 @@ let check_basic : State.t -> location -> Cfg.basic -> Cfg.basic -> unit =
     State.add_to_explore state expected_lbl_handler result_lbl_handler
   | Poptrap, Poptrap -> ()
   | Prologue, Prologue -> ()
+  | ( Stack_check
+        { max_frame_size_bytes = expected_max_frame_size_bytes;
+          save_registers = expected_save_registers
+        },
+      Stack_check
+        { max_frame_size_bytes = result_max_frame_size_bytes;
+          save_registers = result_save_registers
+        } ) ->
+    if expected_max_frame_size_bytes <> result_max_frame_size_bytes
+       || expected_save_registers <> result_save_registers
+    then different location "stack check"
   | _ -> different location "basic"
  [@@ocaml.warning "-4"]
 
@@ -400,6 +411,7 @@ let check_basic_instruction :
     | Pushtrap _ -> false
     | Poptrap -> false
     | Prologue -> false
+    | Stack_check _ -> false
   in
   check_instruction ~check_live ~check_dbg ~check_arg:true idx location expected
     result

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -170,13 +170,7 @@ module S = struct
     | Pushtrap of { lbl_handler : Label.t }
     | Poptrap
     | Prologue
-    | Stack_check of
-        { max_frame_size_bytes : int;
-          save_registers : bool
-        }
-        (** [save_registers] must be set to [true] if the instruction is not
-        guranteed to be the first one in the function. In this case, the
-        registers modified by the instruction will be saved and restored. *)
+    | Stack_check of { max_frame_size_bytes : int }
 
   type 'a with_label_after =
     { op : 'a;

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -170,6 +170,13 @@ module S = struct
     | Pushtrap of { lbl_handler : Label.t }
     | Poptrap
     | Prologue
+    | Stack_check of
+        { max_frame_size_bytes : int;
+          save_registers : bool
+        }
+        (** [save_registers] must be set to [true] if the instruction is not
+        guranteed to be the first one in the function. In this case, the
+        registers modified by the instruction will be saved and restored. *)
 
   type 'a with_label_after =
     { op : 'a;

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -49,7 +49,7 @@ module Transfer :
     Result.ok
     @@
     match instr.desc with
-    | Op _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
+    | Op _ | Reloadretaddr | Pushtrap _ | Poptrap | Prologue | Stack_check _ ->
       if Cfg.is_pure_basic instr.desc && Reg.disjoint_set_array before instr.res
       then
         (* If the operation is without side-effects and the result is unused

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -6,8 +6,7 @@ let from_basic (basic : basic) : Linear.instruction_desc =
   | Reloadretaddr -> Lreloadretaddr
   | Pushtrap { lbl_handler } -> Lpushtrap { lbl_handler }
   | Poptrap -> Lpoptrap
-  | Stack_check { max_frame_size_bytes; save_registers } ->
-    Lstackcheck { max_frame_size_bytes; save_registers }
+  | Stack_check { max_frame_size_bytes } -> Lstackcheck { max_frame_size_bytes }
   | Op op ->
     let op : Mach.operation =
       match op with

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -6,6 +6,8 @@ let from_basic (basic : basic) : Linear.instruction_desc =
   | Reloadretaddr -> Lreloadretaddr
   | Pushtrap { lbl_handler } -> Lpushtrap { lbl_handler }
   | Poptrap -> Lpoptrap
+  | Stack_check { max_frame_size_bytes; save_registers } ->
+    Lstackcheck { max_frame_size_bytes; save_registers }
   | Op op ->
     let op : Mach.operation =
       match op with

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -637,6 +637,9 @@ module Stack_offset_and_exn = struct
         | Poll | Alloc _ )
     | Reloadretaddr | Prologue ->
       stack_offset, traps
+    | Stack_check _ ->
+      Misc.fatal_error
+        "Cfgize.Stack_offset_and_exn.process_basic: unexpected stack check"
 
   (* The argument [stack_offset] has a different meaning from the field
      [stack_offset] of Cfg's basic_blocks and instructions. The argument

--- a/backend/cfg/linear_utils.ml
+++ b/backend/cfg/linear_utils.ml
@@ -38,5 +38,5 @@ let rec defines_label (i : Linear.instruction) =
   | Ladjust_stack_offset _ -> defines_label i.next
   | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Lbranch _ | Lcondbranch _
   | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lpushtrap _ | Lpoptrap | Lraise _
-    ->
+  | Lstackcheck _ ->
     false

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -69,7 +69,8 @@ module Vars = struct
         | Lpoptrap -> t.stack_offset - Proc.trap_frame_size_in_bytes
         | Lend | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _
         | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap
-        | Lraise _ | Ladjust_stack_offset _ ->
+        | Lraise _ | Ladjust_stack_offset _ | Lstackcheck _ ->
+          (* CR xclerc for xclerc: double check `Lstackcheck`. *)
           t.stack_offset
       in
       { stack_offset }

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -67,10 +67,10 @@ module Vars = struct
         | Lop (Istackoffset delta) -> t.stack_offset + delta
         | Lpushtrap _ -> t.stack_offset + Proc.trap_frame_size_in_bytes
         | Lpoptrap -> t.stack_offset - Proc.trap_frame_size_in_bytes
+        | Ladjust_stack_offset { delta_bytes } -> t.stack_offset + delta_bytes
         | Lend | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _
         | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap
-        | Lraise _ | Ladjust_stack_offset _ | Lstackcheck _ ->
-          (* CR xclerc for xclerc: double check `Lstackcheck`. *)
+        | Lraise _ | Lstackcheck _ ->
           t.stack_offset
       in
       { stack_offset }

--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -502,7 +502,6 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
     | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _ | Lbranch _
     | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lpushtrap _
     | Lpoptrap | Ladjust_stack_offset _ | Lraise _ | Lstackcheck _ ->
-      (* CR xclerc for xclerc: double check `Lstackcheck`. *)
       let subrange_state =
         Subrange_state.advance_over_instruction subrange_state insn
       in

--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -501,7 +501,8 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
     | Lend -> first_insn
     | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _ | Lbranch _
     | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lpushtrap _
-    | Lpoptrap | Ladjust_stack_offset _ | Lraise _ ->
+    | Lpoptrap | Ladjust_stack_offset _ | Lraise _ | Lstackcheck _ ->
+      (* CR xclerc for xclerc: double check `Lstackcheck`. *)
       let subrange_state =
         Subrange_state.advance_over_instruction subrange_state insn
       in

--- a/backend/dune
+++ b/backend/dune
@@ -14,7 +14,7 @@
 
 (rule
  (targets arch.ml arch.mli CSE.ml proc.ml regalloc_stack_operands.ml reload.ml scheduling.ml selection.ml
-          simd.ml simd_selection.ml simd_reload.ml simd_proc.ml)
+          simd.ml simd_selection.ml simd_reload.ml simd_proc.ml stack_check.ml)
  (mode    fallback)
  (deps    (glob_files amd64/*.ml)
           (glob_files amd64/*.mli)

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -560,5 +560,8 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
       | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _
       | Lentertrap | Lraise _ ->
         loop i.next fs max_fs nontail_flag
+      | Lstackcheck _ ->
+        (* should not be already present *)
+        assert false
   in
   loop fun_body frame_size frame_size false

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -45,6 +45,7 @@ and instruction_desc =
   | Lpushtrap of { lbl_handler : label; }
   | Lpoptrap
   | Lraise of Lambda.raise_kind
+  | Lstackcheck of { max_frame_size_bytes : int; save_registers : bool; }
 
 let has_fallthrough = function
   | Lreturn | Lbranch _ | Lswitch _ | Lraise _

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -45,7 +45,7 @@ and instruction_desc =
   | Lpushtrap of { lbl_handler : label; }
   | Lpoptrap
   | Lraise of Lambda.raise_kind
-  | Lstackcheck of { max_frame_size_bytes : int; save_registers : bool; }
+  | Lstackcheck of { max_frame_size_bytes : int; }
 
 let has_fallthrough = function
   | Lreturn | Lbranch _ | Lswitch _ | Lraise _

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -45,7 +45,7 @@ and instruction_desc =
   | Lpushtrap of { lbl_handler : label; }
   | Lpoptrap
   | Lraise of Lambda.raise_kind
-  | Lstackcheck of { max_frame_size_bytes : int; save_registers : bool; }
+  | Lstackcheck of { max_frame_size_bytes : int; }
 
 val has_fallthrough :  instruction_desc -> bool
 val end_instr: instruction

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -45,6 +45,7 @@ and instruction_desc =
   | Lpushtrap of { lbl_handler : label; }
   | Lpoptrap
   | Lraise of Lambda.raise_kind
+  | Lstackcheck of { max_frame_size_bytes : int; save_registers : bool; }
 
 val has_fallthrough :  instruction_desc -> bool
 val end_instr: instruction

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -107,6 +107,8 @@ let instr' ?(print_reg = Printmach.reg) ppf i =
       fprintf ppf "pop trap"
   | Lraise k ->
       fprintf ppf "%s %a" (Lambda.raise_kind k) reg i.arg.(0)
+  | Lstackcheck { max_frame_size_bytes; } ->
+      fprintf ppf "stack check (%d bytes)" max_frame_size_bytes
   end;
   if not (Debuginfo.is_none i.dbg) && !Clflags.locations then
     fprintf ppf " %s" (Debuginfo.to_string i.dbg)

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -53,7 +53,7 @@ let precondition : Cfg_with_layout.t -> unit =
       | Dls_get -> ()
       | Poll -> ()
       | Alloc _ -> ())
-    | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> ()
+    | Reloadretaddr | Pushtrap _ | Poptrap | Prologue | Stack_check _ -> ()
   in
   let register_must_not_be_on_stack (id : Instruction.id) (reg : Reg.t) : unit =
     match reg.Reg.loc with

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -142,7 +142,7 @@ let is_move_basic : Cfg.basic -> bool =
     | Dls_get -> false
     | Poll -> false
     | Alloc _ -> false)
-  | Reloadretaddr | Pushtrap _ | Poptrap | Prologue -> false
+  | Reloadretaddr | Pushtrap _ | Poptrap | Prologue | Stack_check _ -> false
 
 let is_move_instruction : Cfg.basic Cfg.instruction -> bool =
  fun instr -> is_move_basic instr.desc

--- a/backend/stack_check.mli
+++ b/backend/stack_check.mli
@@ -1,0 +1,7 @@
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+val stack_threshold_size : int
+
+val frame_size : stack_offset:int -> frame_required:bool -> num_stack_slots:int array ->  int
+
+val linear : Linear.fundecl -> Linear.fundecl

--- a/backend/stack_check.mli
+++ b/backend/stack_check.mli
@@ -1,3 +1,19 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 [@@@ocaml.warning "+a-30-40-41-42"]
 
 val stack_threshold_size : int

--- a/dune
+++ b/dune
@@ -122,6 +122,7 @@
   simd_selection
   simd_reload
   simd_proc
+  stack_check
   reg
   reload
   reloadgen


### PR DESCRIPTION
This pull request gives an explicit representation
to stack checks on the linear and CFG IRs. The
semantics is unaffected. This change is only a
preliminary step to be able to control where
the check is emitted, rather than always emit it
at the top of a function.
