### PR TITLE
probes: add padding after the last semaphore

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -2309,7 +2309,11 @@ let emit_probe_notes0 () =
       D.word (const 0); (* for systemtap probes *)
       D.word (const (Bool.to_int enabled_at_init)); (* for ocaml probes *)
       add_def_symbol label)
-    !probe_semaphores
+    !probe_semaphores;
+  (* ptrace peek/poke to read/write a semaphores accesses 8 bytes,
+     but the size of the semaphore is only 4 bytes.
+     Add padding to avoid illegal accesses when reading the last semaphore. *)
+  D.align ~data:true 8
 
 let emit_probe_notes () =
   match !probes with

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -2310,7 +2310,7 @@ let emit_probe_notes0 () =
       D.word (const (Bool.to_int enabled_at_init)); (* for ocaml probes *)
       add_def_symbol label)
     !probe_semaphores;
-  (* ptrace peek/poke to read/write a semaphores accesses 8 bytes,
+  (* Accessing semaphores with ptrace peek/poke reads/writes 8 bytes,
      but the size of the semaphore is only 4 bytes.
      Add padding to avoid illegal accesses when reading the last semaphore. *)
   D.align ~data:true 8

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -2311,8 +2311,10 @@ let emit_probe_notes0 () =
       add_def_symbol label)
     !probe_semaphores;
   (* Accessing semaphores with ptrace peek/poke reads/writes 8 bytes,
-     but the size of the semaphore is only 4 bytes.
-     Add padding to avoid illegal accesses when reading the last semaphore. *)
+     but the size of a semaphore is only 2 bytes.
+     Add padding to avoid avoid out of bounds accesses
+     when reading the last semaphore for ocaml probes. *)
+  D.word (const 0);
   D.word (const 0);
   D.word (const 0);
   ()

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -2313,7 +2313,9 @@ let emit_probe_notes0 () =
   (* Accessing semaphores with ptrace peek/poke reads/writes 8 bytes,
      but the size of the semaphore is only 4 bytes.
      Add padding to avoid illegal accesses when reading the last semaphore. *)
-  D.align ~data:true 8
+  D.word (const 0);
+  D.word (const 0);
+  ()
 
 let emit_probe_notes () =
   match !probes with


### PR DESCRIPTION
Reading/writing a semaphore using ptrace requires accessing 8 bytes of memory, but a semaphore is only 4 bytes. As a result, accessing the last semaphore can fail (e.g., if it's at the end of a page or a segment).  To avoid it, align the end of the ".probes" section to 8 bytes. 