### PR TITLE
Fix bug (infinite loop) in dominance frontier

### DIFF
--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -320,7 +320,7 @@ let compute_dominance_frontiers (cfg : Cfg.t) (doms : doms) :
     (fun label _idom -> Label.Tbl.replace res label Label.Set.empty)
     doms;
   Label.Tbl.iter
-    (fun label _idom ->
+    (fun label idom ->
       let block = Cfg.get_block_exn cfg label in
       let predecessor_labels = Cfg.predecessor_labels block in
       match predecessor_labels with
@@ -329,10 +329,7 @@ let compute_dominance_frontiers (cfg : Cfg.t) (doms : doms) :
         List.iter predecessor_labels ~f:(fun predecessor_label ->
             let runner = ref predecessor_label in
             let continue = ref true in
-            while
-              (not (Label.equal !runner (Label.Tbl.find doms label)))
-              && !continue
-            do
+            while (not (Label.equal !runner idom)) && !continue do
               let curr =
                 match Label.Tbl.find_opt res !runner with
                 | None -> Label.Set.empty


### PR DESCRIPTION
This pull request fixes a bug in the computation
of the dominance frontier, where the current
code can loop for ever.

Like in https://github.com/ocaml-flambda/flambda-backend/pull/2128, the bug is related to dead code:
when computing the dominance frontier, we
repeatedly move a _runner_ from a block's
predecessor to its immediate dominator until
we reach the dominator of the starting block.

The problem is that the predecessor may in
some very rare cases not be in the same
"component" (See https://github.com/ocaml-flambda/flambda-backend/pull/2128) as the starting block,
which leads to an infinite loop. The fix is to
also stop when we reach a block which is its
own immediate predecessor (_i.e._ a dead block
with no predecessors).
