### PR TITLE
float32 flambda2 operations

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -499,6 +499,8 @@ let mk_compare_floats_untagged dbg a1 a2 =
              runtime/floats.c *)
           add_int (sub_int op1 op2 dbg) (sub_int op3 op4 dbg) dbg))
 
+let mk_compare_float32s_untagged _dbg _a1 _a2 = assert false
+
 let mk_compare_floats dbg a1 a2 =
   bind "float_cmp" a2 (fun a2 ->
       bind "float_cmp" a1 (fun a1 ->
@@ -3701,6 +3703,30 @@ let float_le = binary (Ccmpf CFle)
 let float_gt = binary (Ccmpf CFgt)
 
 let float_ge = binary (Ccmpf CFge)
+
+let float32_abs ~dbg:_ _ = assert false
+
+let float32_neg ~dbg:_ _ = assert false
+
+let float32_add ~dbg:_ _ _ = assert false
+
+let float32_sub ~dbg:_ _ _ = assert false
+
+let float32_mul ~dbg:_ _ _ = assert false
+
+let float32_div ~dbg:_ _ _ = assert false
+
+let float32_eq ~dbg:_ _ _ = assert false
+
+let float32_neq ~dbg:_ _ _ = assert false
+
+let float32_lt ~dbg:_ _ _ = assert false
+
+let float32_le ~dbg:_ _ _ = assert false
+
+let float32_gt ~dbg:_ _ _ = assert false
+
+let float32_ge ~dbg:_ _ _ = assert false
 
 let beginregion ~dbg = Cop (Cbeginregion, [], dbg)
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -127,6 +127,9 @@ val mk_compare_ints_untagged :
 val mk_compare_floats_untagged :
   Debuginfo.t -> expression -> expression -> expression
 
+val mk_compare_float32s_untagged :
+  Debuginfo.t -> expression -> expression -> expression
+
 (** Convert a tagged integer into a raw integer with boolean meaning *)
 val test_bool : Debuginfo.t -> expression -> expression
 
@@ -723,6 +726,8 @@ val uge : dbg:Debuginfo.t -> expression -> expression -> expression
 (** Asbolute value on floats. *)
 val float_abs : dbg:Debuginfo.t -> expression -> expression
 
+val float32_abs : dbg:Debuginfo.t -> expression -> expression
+
 (** Arithmetic negation on floats. *)
 val float_neg : dbg:Debuginfo.t -> expression -> expression
 
@@ -732,10 +737,22 @@ val float_sub : dbg:Debuginfo.t -> expression -> expression -> expression
 
 val float_mul : dbg:Debuginfo.t -> expression -> expression -> expression
 
+val float32_neg : dbg:Debuginfo.t -> expression -> expression
+
+val float32_add : dbg:Debuginfo.t -> expression -> expression -> expression
+
+val float32_sub : dbg:Debuginfo.t -> expression -> expression -> expression
+
+val float32_mul : dbg:Debuginfo.t -> expression -> expression -> expression
+
 (** Float arithmetic operations. *)
 val float_div : dbg:Debuginfo.t -> expression -> expression -> expression
 
 val float_eq : dbg:Debuginfo.t -> expression -> expression -> expression
+
+val float32_div : dbg:Debuginfo.t -> expression -> expression -> expression
+
+val float32_eq : dbg:Debuginfo.t -> expression -> expression -> expression
 
 (** Float arithmetic (dis)equality of cmm expressions. Returns an untagged
     integer (either 0 or 1) to represent the result of the comparison. *)
@@ -747,9 +764,19 @@ val float_le : dbg:Debuginfo.t -> expression -> expression -> expression
 
 val float_gt : dbg:Debuginfo.t -> expression -> expression -> expression
 
+val float32_neq : dbg:Debuginfo.t -> expression -> expression -> expression
+
+val float32_lt : dbg:Debuginfo.t -> expression -> expression -> expression
+
+val float32_le : dbg:Debuginfo.t -> expression -> expression -> expression
+
+val float32_gt : dbg:Debuginfo.t -> expression -> expression -> expression
+
 (** Float arithmetic comparisons on cmm expressions. Returns an untagged integer
     (either 0 or 1) to represent the result of the comparison. *)
 val float_ge : dbg:Debuginfo.t -> expression -> expression -> expression
+
+val float32_ge : dbg:Debuginfo.t -> expression -> expression -> expression
 
 val beginregion : dbg:Debuginfo.t -> expression
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1120,35 +1120,39 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     let dst = K.Standard_int_or_float.Naked_float in
     [box_float mode (Unary (Num_conv { src; dst }, arg)) ~current_region]
   | Pnegfloat (Pfloat64, mode), [[arg]] ->
-    [box_float mode (Unary (Float_arith Neg, unbox_float arg)) ~current_region]
+    [ box_float mode
+        (Unary (Float_arith (Float64, Neg), unbox_float arg))
+        ~current_region ]
   | Pabsfloat (Pfloat64, mode), [[arg]] ->
-    [box_float mode (Unary (Float_arith Abs, unbox_float arg)) ~current_region]
+    [ box_float mode
+        (Unary (Float_arith (Float64, Abs), unbox_float arg))
+        ~current_region ]
   | Paddfloat (Pfloat64, mode), [[arg1]; [arg2]] ->
     [ box_float mode
-        (Binary (Float_arith Add, unbox_float arg1, unbox_float arg2))
+        (Binary (Float_arith (Float64, Add), unbox_float arg1, unbox_float arg2))
         ~current_region ]
   | Psubfloat (Pfloat64, mode), [[arg1]; [arg2]] ->
     [ box_float mode
-        (Binary (Float_arith Sub, unbox_float arg1, unbox_float arg2))
+        (Binary (Float_arith (Float64, Sub), unbox_float arg1, unbox_float arg2))
         ~current_region ]
   | Pmulfloat (Pfloat64, mode), [[arg1]; [arg2]] ->
     [ box_float mode
-        (Binary (Float_arith Mul, unbox_float arg1, unbox_float arg2))
+        (Binary (Float_arith (Float64, Mul), unbox_float arg1, unbox_float arg2))
         ~current_region ]
   | Pdivfloat (Pfloat64, mode), [[arg1]; [arg2]] ->
     [ box_float mode
-        (Binary (Float_arith Div, unbox_float arg1, unbox_float arg2))
+        (Binary (Float_arith (Float64, Div), unbox_float arg1, unbox_float arg2))
         ~current_region ]
   | Pfloatcomp (Pfloat64, comp), [[arg1]; [arg2]] ->
     [ tag_int
         (Binary
-           ( Float_comp (Yielding_bool (convert_float_comparison comp)),
+           ( Float_comp (Float64, Yielding_bool (convert_float_comparison comp)),
              unbox_float arg1,
              unbox_float arg2 )) ]
   | Punboxed_float_comp (Pfloat64, comp), [[arg1]; [arg2]] ->
     [ tag_int
         (Binary
-           ( Float_comp (Yielding_bool (convert_float_comparison comp)),
+           ( Float_comp (Float64, Yielding_bool (convert_float_comparison comp)),
              arg1,
              arg2 )) ]
   | Punbox_float Pfloat64, [[arg]] -> [Unary (Unbox_number Naked_float, arg)]
@@ -1166,19 +1170,53 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     let src = K.Standard_int_or_float.Tagged_immediate in
     let dst = K.Standard_int_or_float.Naked_float32 in
     [box_float32 mode (Unary (Num_conv { src; dst }, arg)) ~current_region]
-  | Pnegfloat (Pfloat32, _), _
-  | Pabsfloat (Pfloat32, _), _
-  | Paddfloat (Pfloat32, _), _
-  | Psubfloat (Pfloat32, _), _
-  | Pmulfloat (Pfloat32, _), _
-  | Pdivfloat (Pfloat32, _), _
-  | Pfloatcomp (Pfloat32, _), _
-  | Punbox_float Pfloat32, _
-  | Pbox_float (Pfloat32, _), _
-  | Pcompare_floats Pfloat32, _
-  | Punboxed_float_comp (Pfloat32, _), _ ->
-    (* CR mslater: (float32) runtime *)
-    assert false
+  | Pnegfloat (Pfloat32, mode), [[arg]] ->
+    [ box_float32 mode
+        (Unary (Float_arith (Float32, Neg), unbox_float32 arg))
+        ~current_region ]
+  | Pabsfloat (Pfloat32, mode), [[arg]] ->
+    [ box_float32 mode
+        (Unary (Float_arith (Float32, Abs), unbox_float32 arg))
+        ~current_region ]
+  | Paddfloat (Pfloat32, mode), [[arg1]; [arg2]] ->
+    [ box_float32 mode
+        (Binary
+           (Float_arith (Float32, Add), unbox_float32 arg1, unbox_float32 arg2))
+        ~current_region ]
+  | Psubfloat (Pfloat32, mode), [[arg1]; [arg2]] ->
+    [ box_float32 mode
+        (Binary
+           (Float_arith (Float32, Sub), unbox_float32 arg1, unbox_float32 arg2))
+        ~current_region ]
+  | Pmulfloat (Pfloat32, mode), [[arg1]; [arg2]] ->
+    [ box_float32 mode
+        (Binary
+           (Float_arith (Float32, Mul), unbox_float32 arg1, unbox_float32 arg2))
+        ~current_region ]
+  | Pdivfloat (Pfloat32, mode), [[arg1]; [arg2]] ->
+    [ box_float32 mode
+        (Binary
+           (Float_arith (Float32, Div), unbox_float32 arg1, unbox_float32 arg2))
+        ~current_region ]
+  | Pfloatcomp (Pfloat32, comp), [[arg1]; [arg2]] ->
+    [ tag_int
+        (Binary
+           ( Float_comp (Float32, Yielding_bool (convert_float_comparison comp)),
+             unbox_float32 arg1,
+             unbox_float32 arg2 )) ]
+  | Punboxed_float_comp (Pfloat32, comp), [[arg1]; [arg2]] ->
+    [ tag_int
+        (Binary
+           ( Float_comp (Float32, Yielding_bool (convert_float_comparison comp)),
+             arg1,
+             arg2 )) ]
+  | Punbox_float Pfloat32, [[arg]] -> [Unary (Unbox_number Naked_float32, arg)]
+  | Pbox_float (Pfloat32, mode), [[arg]] ->
+    [ Unary
+        ( Box_number
+            ( Naked_float32,
+              Alloc_mode.For_allocations.from_lambda mode ~current_region ),
+          arg ) ]
   | Punbox_int bi, [[arg]] ->
     let kind = boxable_number_of_boxed_integer bi in
     [Unary (Unbox_number kind, arg)]
@@ -1818,9 +1856,15 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Pcompare_floats Pfloat64, [[f1]; [f2]] ->
     [ tag_int
         (Binary
-           ( Float_comp (Yielding_int_like_compare_functions ()),
+           ( Float_comp (Float64, Yielding_int_like_compare_functions ()),
              Prim (Unary (Unbox_number Naked_float, f1)),
              Prim (Unary (Unbox_number Naked_float, f2)) )) ]
+  | Pcompare_floats Pfloat32, [[f1]; [f2]] ->
+    [ tag_int
+        (Binary
+           ( Float_comp (Float32, Yielding_int_like_compare_functions ()),
+             Prim (Unary (Unbox_number Naked_float32, f1)),
+             Prim (Unary (Unbox_number Naked_float32, f2)) )) ]
   | Pcompare_bints int_kind, [[i1]; [i2]] ->
     let unboxing_kind = boxable_number_of_boxed_integer int_kind in
     [ tag_int
@@ -1860,18 +1904,17 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
        %a (%a)"
       Printlambda.primitive prim H.print_list_of_simple_or_prim
       (List.flatten args)
-  | ( ( Pfield _ | Pnegint | Pnot | Poffsetint _
-      | Pintoffloat (Pfloat64 | Pfloat32)
-      | Pfloatofint ((Pfloat64 | Pfloat32), _)
+  | ( ( Pfield _ | Pnegint | Pnot | Poffsetint _ | Pintoffloat _
+      | Pfloatofint (_, _)
       | Pfloatoffloat32 _ | Pfloat32offloat _
-      | Pnegfloat (Pfloat64, _)
-      | Pabsfloat (Pfloat64, _)
+      | Pnegfloat (_, _)
+      | Pabsfloat (_, _)
       | Pstringlength | Pbyteslength | Pbintofint _ | Pintofbint _ | Pnegbint _
       | Popaque _ | Pduprecord _ | Parraylength _ | Pduparray _ | Pfloatfield _
       | Pcvtbint _ | Poffsetref _ | Pbswap16 | Pbbswap _ | Pisint _
       | Pint_as_pointer _ | Pbigarraydim _ | Pobj_dup | Pobj_magic _
-      | Punbox_float Pfloat64
-      | Pbox_float (Pfloat64, _)
+      | Punbox_float _
+      | Pbox_float (_, _)
       | Punbox_int _ | Pbox_int _ | Punboxed_product_field _ | Pget_header _
       | Pufloatfield _ | Patomic_load _ | Pmixedfield _ ),
       ([] | _ :: _ :: _ | [([] | _ :: _ :: _)]) ) ->
@@ -1881,12 +1924,12 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
   | ( ( Paddint | Psubint | Pmulint | Pandint | Porint | Pxorint | Plslint
       | Plsrint | Pasrint | Pdivint _ | Pmodint _ | Psetfield _ | Pintcomp _
-      | Paddfloat (Pfloat64, _)
-      | Psubfloat (Pfloat64, _)
-      | Pmulfloat (Pfloat64, _)
-      | Pdivfloat (Pfloat64, _)
-      | Pfloatcomp (Pfloat64, _)
-      | Punboxed_float_comp (Pfloat64, _)
+      | Paddfloat (_, _)
+      | Psubfloat (_, _)
+      | Pmulfloat (_, _)
+      | Pdivfloat (_, _)
+      | Pfloatcomp (_, _)
+      | Punboxed_float_comp (_, _)
       | Pstringrefu | Pbytesrefu | Pstringrefs | Pbytesrefs | Pstring_load_16 _
       | Pstring_load_32 _ | Pstring_load_64 _ | Pstring_load_128 _
       | Pbytes_load_16 _ | Pbytes_load_32 _ | Pbytes_load_64 _

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -350,12 +350,14 @@ type bytes_like_value = Flambda_primitive.bytes_like_value =
   | Bytes
   | Bigstring
 
+type float_bitwidth = Flambda_primitive.float_bitwidth
+
 type infix_binop =
   | Int_arith of binary_int_arith_op (* on tagged immediates *)
   | Int_shift of int_shift_op (* on tagged immediates *)
   | Int_comp of signed_or_unsigned comparison_behaviour (* on tagged imms *)
-  | Float_arith of binary_float_arith_op
-  | Float_comp of unit comparison_behaviour
+  | Float_arith of float_bitwidth * binary_float_arith_op
+  | Float_comp of float_bitwidth * unit comparison_behaviour
 
 type binop =
   | Array_load of array_kind * array_accessor_width * mutability

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -411,8 +411,8 @@ let infix_binop (binop : Fexpr.infix_binop) : Flambda_primitive.binary_primitive
   | Int_arith o -> Int_arith (Tagged_immediate, o)
   | Int_comp c -> Int_comp (Tagged_immediate, c)
   | Int_shift s -> Int_shift (Tagged_immediate, s)
-  | Float_arith o -> Float_arith o
-  | Float_comp c -> Float_comp c
+  | Float_arith (w, o) -> Float_arith (w, o)
+  | Float_comp (w, c) -> Float_comp (w, c)
 
 let block_access_kind (ak : Fexpr.block_access_kind) :
     Flambda_primitive.Block_access_kind.t =

--- a/middle_end/flambda2/parser/flambda_parser.ml
+++ b/middle_end/flambda2/parser/flambda_parser.ml
@@ -4784,7 +4784,7 @@ module Tables = struct
 # 4785 "flambda_parser_in.ml"
         ) = 
 # 431 "flambda_parser.mly"
-                              ( Float_arith o )
+                              ( Float_arith (Float64, o) )
 # 4789 "flambda_parser_in.ml"
          in
         {
@@ -4817,7 +4817,7 @@ module Tables = struct
 # 4818 "flambda_parser_in.ml"
         ) = 
 # 432 "flambda_parser.mly"
-                   ( Float_comp c )
+                   ( Float_comp (Float64, c) )
 # 4822 "flambda_parser_in.ml"
          in
         {

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -428,8 +428,8 @@ infix_binop:
   | o = binary_int_arith_op { Int_arith o }
   | c = int_comp { Int_comp (c Signed) }
   | s = int_shift { Int_shift s }
-  | o = binary_float_arith_op { Float_arith o }
-  | c = float_comp { Float_comp c }
+  | o = binary_float_arith_op { Float_arith (Float64, o) }
+  | c = float_comp { Float_comp (Float64, c) }
 ;
 
 prefix_binop:

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -592,8 +592,8 @@ let binop (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
   | Int_comp (i, c) -> Int_comp (i, c)
   | Int_shift (Tagged_immediate, s) -> Infix (Int_shift s)
   | Int_shift (i, s) -> Int_shift (i, s)
-  | Float_arith o -> Infix (Float_arith o)
-  | Float_comp c -> Infix (Float_comp c)
+  | Float_arith (w, o) -> Infix (Float_arith (w, o))
+  | Float_comp (w, c) -> Infix (Float_comp (w, c))
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
   | Bigarray_get_alignment align -> Bigarray_get_alignment align
   | Bigarray_load _ | Atomic_exchange | Atomic_fetch_and_add ->

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -425,29 +425,44 @@ let int_shift_op ppf (s : int_shift_op) =
   Format.pp_print_string ppf
   @@ match s with Lsl -> "lsl" | Lsr -> "lsr" | Asr -> "asr"
 
-let binary_float_arith_op ppf (o : binary_float_arith_op) =
-  Format.pp_print_string ppf
-  @@ match o with Add -> "+." | Sub -> "-." | Mul -> "*." | Div -> "/."
-
-let float_comp ppf (o : unit comparison_behaviour) =
+let binary_float_arith_op ppf (w : float_bitwidth) (o : binary_float_arith_op) =
   Format.pp_print_string ppf
   @@
-  match o with
-  | Yielding_bool Eq -> "=."
-  | Yielding_bool Neq -> "<>."
-  | Yielding_bool (Lt ()) -> "<."
-  | Yielding_bool (Gt ()) -> ">."
-  | Yielding_bool (Le ()) -> "<=."
-  | Yielding_bool (Ge ()) -> ">=."
-  | Yielding_int_like_compare_functions () -> "?"
+  match w, o with
+  | Float64, Add -> "+."
+  | Float64, Sub -> "-."
+  | Float64, Mul -> "*."
+  | Float64, Div -> "/."
+  | Float32, Add -> "Float32.+."
+  | Float32, Sub -> "Float32.-."
+  | Float32, Mul -> "Float32.*."
+  | Float32, Div -> "Float32./."
+
+let float_comp ppf (w : float_bitwidth) (o : unit comparison_behaviour) =
+  Format.pp_print_string ppf
+  @@
+  match w, o with
+  | Float64, Yielding_bool Eq -> "=."
+  | Float64, Yielding_bool Neq -> "<>."
+  | Float64, Yielding_bool (Lt ()) -> "<."
+  | Float64, Yielding_bool (Gt ()) -> ">."
+  | Float64, Yielding_bool (Le ()) -> "<=."
+  | Float64, Yielding_bool (Ge ()) -> ">=."
+  | Float32, Yielding_bool Eq -> "Float32.=."
+  | Float32, Yielding_bool Neq -> "Float32.<>."
+  | Float32, Yielding_bool (Lt ()) -> "Float32.<."
+  | Float32, Yielding_bool (Gt ()) -> "Float32.>."
+  | Float32, Yielding_bool (Le ()) -> "Float32.<=."
+  | Float32, Yielding_bool (Ge ()) -> "Float32.>=."
+  | (Float64 | Float32), Yielding_int_like_compare_functions () -> "?"
 
 let infix_binop ppf (b : infix_binop) =
   match b with
   | Int_arith o -> binary_int_arith_op ppf o
   | Int_comp c -> int_comp ppf c
   | Int_shift s -> int_shift_op ppf s
-  | Float_arith o -> binary_float_arith_op ppf o
-  | Float_comp c -> float_comp ppf c
+  | Float_arith (w, o) -> binary_float_arith_op ppf w o
+  | Float_comp (w, c) -> float_comp ppf w c
 
 let block_access_kind ppf (access_kind : block_access_kind) =
   let pp_size ppf (size : Int64.t option) =

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -17,12 +17,13 @@
 open! Simplify_import
 module A = Number_adjuncts
 module Float_by_bit_pattern = Numeric_types.Float_by_bit_pattern
+module Float32_by_bit_pattern = Numeric_types.Float32_by_bit_pattern
 
 type 'a binary_arith_outcome_for_one_side_only =
   | Exactly of 'a
   | The_other_side
   | Negation_of_the_other_side
-  | Float_negation_of_the_other_side
+  | Float_negation_of_the_other_side of Flambda_primitive.float_bitwidth
   | Cannot_simplify
   | Invalid
 
@@ -200,8 +201,8 @@ end = struct
                   Unary (Int_arith (standard_int_kind, Neg), other_side)
                 in
                 Some (PR.Set.add (Prim prim) possible_results)
-              | Float_negation_of_the_other_side ->
-                let prim : P.t = Unary (Float_arith Neg, other_side) in
+              | Float_negation_of_the_other_side width ->
+                let prim : P.t = Unary (Float_arith (width, Neg), other_side) in
                 Some (PR.Set.add (Prim prim) possible_results)
               | Cannot_simplify -> None
               | Invalid -> Some possible_results))
@@ -608,32 +609,47 @@ module Binary_int_comp_int64 = Binary_arith_like (Int_ops_for_binary_comp_int64)
 module Binary_int_comp_nativeint =
   Binary_arith_like (Int_ops_for_binary_comp_nativeint)
 
-module Float_ops_for_binary_arith : sig
+module Float_ops_for_binary_arith_gen (Float : sig
+  module F : Numeric_types.Float_by_bit_pattern
+
+  val width : Flambda_primitive.float_bitwidth
+
+  val arg_kind : K.Standard_int_or_float.t
+
+  val result_kind : Flambda_kind.t
+
+  val prover : T.Typing_env.t -> T.t -> F.Set.t T.meet_shortcut
+
+  val unknown : T.t
+
+  val these : F.Set.t -> T.t
+
+  val const : F.t -> Const.t
+end) : sig
   include Binary_arith_like_sig with type op = P.binary_float_arith_op
 end = struct
-  module F = Float_by_bit_pattern
+  module F = Float.F
   module Lhs = F
   module Rhs = F
   module Result = F
 
   type op = P.binary_float_arith_op
 
-  let arg_kind = K.Standard_int_or_float.Naked_float
+  let arg_kind = Float.arg_kind
 
-  let result_kind = K.naked_float
+  let result_kind = Float.result_kind
 
   let ok_to_evaluate denv = DE.propagating_float_consts denv
 
-  let prover_lhs = T.meet_naked_floats
+  let prover_lhs = Float.prover
 
-  let prover_rhs = T.meet_naked_floats
+  let prover_rhs = Float.prover
 
-  let unknown _ = T.any_naked_float
+  let unknown _ = Float.unknown
 
-  let these = T.these_naked_floats
+  let these = Float.these
 
-  let term f =
-    Named.create_simple (Simple.const (Reg_width_const.naked_float f))
+  let term f = Named.create_simple (Simple.const (Float.const f))
 
   module Pair = F.Pair
 
@@ -670,7 +686,7 @@ end = struct
         [@z3 check_float_binary_neutral `Mul 1.0 `Left]
       else if F.equal this_side F.minus_one
       then
-        Float_negation_of_the_other_side
+        Float_negation_of_the_other_side Float.width
         [@z3 check_float_binary_opposite `Mul (-1.0) `Left]
         [@z3 check_float_binary_opposite `Mul (-1.0) `Right]
       else Cannot_simplify
@@ -686,7 +702,7 @@ end = struct
       then The_other_side [@z3 check_float_binary_neutral `Div 1.0 `Right]
       else if F.equal rhs F.minus_one
       then
-        Float_negation_of_the_other_side
+        Float_negation_of_the_other_side Float.width
         [@z3 check_float_binary_opposite `Div (-1.0) `Right]
       else Cannot_simplify
 
@@ -699,7 +715,44 @@ end = struct
     | Div -> Cannot_simplify
 end
 
+module Float_ops_for_binary_arith = Float_ops_for_binary_arith_gen (struct
+  module F = Numeric_types.Float_by_bit_pattern
+
+  let width = Flambda_primitive.Float64
+
+  let arg_kind = K.Standard_int_or_float.Naked_float
+
+  let result_kind = K.naked_float
+
+  let prover = T.meet_naked_floats
+
+  let unknown = T.any_naked_float
+
+  let these = T.these_naked_floats
+
+  let const = Reg_width_const.naked_float
+end)
+
+module Float32_ops_for_binary_arith = Float_ops_for_binary_arith_gen (struct
+  module F = Numeric_types.Float32_by_bit_pattern
+
+  let width = Flambda_primitive.Float32
+
+  let arg_kind = K.Standard_int_or_float.Naked_float32
+
+  let result_kind = K.naked_float32
+
+  let prover = T.meet_naked_float32s
+
+  let unknown = T.any_naked_float32
+
+  let these = T.these_naked_float32s
+
+  let const = Reg_width_const.naked_float32
+end)
+
 module Binary_float_arith = Binary_arith_like (Float_ops_for_binary_arith)
+module Binary_float32_arith = Binary_arith_like (Float32_ops_for_binary_arith)
 
 module Float_ops_for_binary_comp : sig
   include Binary_arith_like_sig with type op = unit P.comparison_behaviour
@@ -791,7 +844,98 @@ end = struct
     | Yielding_int_like_compare_functions () -> Cannot_simplify
 end
 
+module Float32_ops_for_binary_comp : sig
+  include Binary_arith_like_sig with type op = unit P.comparison_behaviour
+end = struct
+  module F = Float32_by_bit_pattern
+  module Lhs = F
+  module Rhs = F
+  module Result = Targetint_31_63
+
+  type op = unit P.comparison_behaviour
+
+  let arg_kind = K.Standard_int_or_float.Naked_float32
+
+  let result_kind = K.naked_immediate
+
+  let ok_to_evaluate denv = DE.propagating_float_consts denv
+
+  let prover_lhs = T.meet_naked_float32s
+
+  let prover_rhs = T.meet_naked_float32s
+
+  let unknown (op : op) =
+    match op with
+    | Yielding_bool _ -> T.these_naked_immediates Targetint_31_63.all_bools
+    | Yielding_int_like_compare_functions () ->
+      T.these_naked_immediates Targetint_31_63.zero_one_and_minus_one
+
+  let these = T.these_naked_immediates
+
+  let term imm : Named.t =
+    Named.create_simple (Simple.const (Reg_width_const.naked_immediate imm))
+
+  module Pair = F.Pair
+
+  let cross_product = F.cross_product
+
+  let op (op : op) n1 n2 =
+    match op with
+    | Yielding_bool op -> (
+      let has_nan = F.is_any_nan n1 || F.is_any_nan n2 in
+      let bool b = Targetint_31_63.bool b in
+      match op with
+      | Eq -> Some (bool (F.IEEE_semantics.equal n1 n2))
+      | Neq -> Some (bool (not (F.IEEE_semantics.equal n1 n2)))
+      | Lt () ->
+        if has_nan
+        then Some (bool false)
+        else Some (bool (F.IEEE_semantics.compare n1 n2 < 0))
+      | Gt () ->
+        if has_nan
+        then Some (bool false)
+        else Some (bool (F.IEEE_semantics.compare n1 n2 > 0))
+      | Le () ->
+        if has_nan
+        then Some (bool false)
+        else Some (bool (F.IEEE_semantics.compare n1 n2 <= 0))
+      | Ge () ->
+        if has_nan
+        then Some (bool false)
+        else Some (bool (F.IEEE_semantics.compare n1 n2 >= 0)))
+    | Yielding_int_like_compare_functions () ->
+      let int i = Targetint_31_63.of_int i in
+      let c = F.IEEE_semantics.compare n1 n2 in
+      if c < 0
+      then Some (int (-1))
+      else if c = 0
+      then Some (int 0)
+      else Some (int 1)
+
+  let result_of_comparison_with_nan (op : unit P.comparison) =
+    match op with
+    | Neq -> Exactly Targetint_31_63.bool_true
+    | Eq | Lt () | Gt () | Le () | Ge () -> Exactly Targetint_31_63.bool_false
+
+  let op_lhs_unknown (op : op) ~rhs : _ binary_arith_outcome_for_one_side_only =
+    match op with
+    | Yielding_bool op ->
+      if F.is_any_nan rhs
+      then result_of_comparison_with_nan op
+      else Cannot_simplify
+    | Yielding_int_like_compare_functions () -> Cannot_simplify
+
+  let op_rhs_unknown (op : op) ~lhs : _ binary_arith_outcome_for_one_side_only =
+    match op with
+    | Yielding_bool op ->
+      if F.is_any_nan lhs
+      then result_of_comparison_with_nan op
+      else Cannot_simplify
+    | Yielding_int_like_compare_functions () -> Cannot_simplify
+end
+
 module Binary_float_comp = Binary_arith_like (Float_ops_for_binary_comp)
+module Binary_float32_comp = Binary_arith_like (Float32_ops_for_binary_comp)
 
 let simplify_phys_equal (op : P.equality_comparison) dacc ~original_term _dbg
     ~arg1:_ ~arg1_ty ~arg2:_ ~arg2_ty ~result_var =
@@ -1053,8 +1197,10 @@ let simplify_binary_primitive0 dacc original_prim (prim : P.binary_primitive)
       | Naked_int32 -> Binary_int_comp_int32.simplify op
       | Naked_int64 -> Binary_int_comp_int64.simplify op
       | Naked_nativeint -> Binary_int_comp_nativeint.simplify op)
-    | Float_arith op -> Binary_float_arith.simplify op
-    | Float_comp op -> Binary_float_comp.simplify op
+    | Float_arith (Float64, op) -> Binary_float_arith.simplify op
+    | Float_comp (Float64, op) -> Binary_float_comp.simplify op
+    | Float_arith (Float32, op) -> Binary_float32_arith.simplify op
+    | Float_comp (Float32, op) -> Binary_float32_comp.simplify op
     | Phys_equal op -> simplify_phys_equal op
     | String_or_bigstring_load (string_like_value, string_accessor_width) ->
       simplify_string_or_bigstring_load string_like_value string_accessor_width

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -752,7 +752,7 @@ end)
 module Binary_float_arith = Binary_arith_like (Float_ops_for_binary_arith)
 module Binary_float32_arith = Binary_arith_like (Float32_ops_for_binary_arith)
 
-module Float_ops_for_binary_comp_gen (Float : sig
+module Float_ops_for_binary_comp_gen (FP : sig
   module F : Numeric_types.Float_by_bit_pattern
 
   val arg_kind : K.Standard_int_or_float.t
@@ -761,22 +761,22 @@ module Float_ops_for_binary_comp_gen (Float : sig
 end) : sig
   include Binary_arith_like_sig with type op = unit P.comparison_behaviour
 end = struct
-  module F = Float.F
+  module F = FP.F
   module Lhs = F
   module Rhs = F
   module Result = Targetint_31_63
 
   type op = unit P.comparison_behaviour
 
-  let arg_kind = Float.arg_kind
+  let arg_kind = FP.arg_kind
 
   let result_kind = K.naked_immediate
 
   let ok_to_evaluate denv = DE.propagating_float_consts denv
 
-  let prover_lhs = Float.prover
+  let prover_lhs = FP.prover
 
-  let prover_rhs = Float.prover
+  let prover_rhs = FP.prover
 
   let unknown (op : op) =
     match op with

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -607,7 +607,7 @@ module Binary_int_comp_int64 = Binary_arith_like (Int_ops_for_binary_comp_int64)
 module Binary_int_comp_nativeint =
   Binary_arith_like (Int_ops_for_binary_comp_nativeint)
 
-module Float_ops_for_binary_arith_gen (Float : sig
+module Float_ops_for_binary_arith_gen (FP : sig
   module F : Numeric_types.Float_by_bit_pattern
 
   val width : Flambda_primitive.float_bitwidth
@@ -626,28 +626,28 @@ module Float_ops_for_binary_arith_gen (Float : sig
 end) : sig
   include Binary_arith_like_sig with type op = P.binary_float_arith_op
 end = struct
-  module F = Float.F
+  module F = FP.F
   module Lhs = F
   module Rhs = F
   module Result = F
 
   type op = P.binary_float_arith_op
 
-  let arg_kind = Float.arg_kind
+  let arg_kind = FP.arg_kind
 
-  let result_kind = Float.result_kind
+  let result_kind = FP.result_kind
 
   let ok_to_evaluate denv = DE.propagating_float_consts denv
 
-  let prover_lhs = Float.prover
+  let prover_lhs = FP.prover
 
-  let prover_rhs = Float.prover
+  let prover_rhs = FP.prover
 
-  let unknown _ = Float.unknown
+  let unknown _ = FP.unknown
 
-  let these = Float.these
+  let these = FP.these
 
-  let term f = Named.create_simple (Simple.const (Float.const f))
+  let term f = Named.create_simple (Simple.const (FP.const f))
 
   module Pair = F.Pair
 
@@ -684,7 +684,7 @@ end = struct
         [@z3 check_float_binary_neutral `Mul 1.0 `Left]
       else if F.equal this_side F.minus_one
       then
-        Float_negation_of_the_other_side Float.width
+        Float_negation_of_the_other_side FP.width
         [@z3 check_float_binary_opposite `Mul (-1.0) `Left]
         [@z3 check_float_binary_opposite `Mul (-1.0) `Right]
       else Cannot_simplify
@@ -700,7 +700,7 @@ end = struct
       then The_other_side [@z3 check_float_binary_neutral `Div 1.0 `Right]
       else if F.equal rhs F.minus_one
       then
-        Float_negation_of_the_other_side Float.width
+        Float_negation_of_the_other_side FP.width
         [@z3 check_float_binary_opposite `Div (-1.0) `Right]
       else Cannot_simplify
 

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -94,11 +94,11 @@ let simplify_comparison ~dbg ~dacc ~cont ~tagged_prim ~float_prim
       ~cmp_prim:tagged_prim
   | Proved (Boxed (_, Naked_float, _)), Proved (Boxed (_, Naked_float, _)) ->
     simplify_comparison_of_boxed_numbers ~dbg dacc cont a b ~kind:Naked_float
-      ~cmp_prim:float_prim
+      ~cmp_prim:(float_prim Flambda_primitive.Float64)
   | Proved (Boxed (_, Naked_float32, _)), Proved (Boxed (_, Naked_float32, _))
     ->
     simplify_comparison_of_boxed_numbers ~dbg dacc cont a b ~kind:Naked_float32
-      ~cmp_prim:float_prim
+      ~cmp_prim:(float_prim Flambda_primitive.Float32)
   | Proved (Boxed (_, Naked_int32, _)), Proved (Boxed (_, Naked_int32, _)) ->
     simplify_comparison_of_boxed_numbers ~dbg dacc cont a b ~kind:Naked_int32
       ~cmp_prim:(boxed_int_prim K.Standard_int.Naked_int32)
@@ -161,37 +161,40 @@ let simplify_returning_extcall ~dbg ~cont ~exn_cont:_ dacc fun_name args
   (* Polymorphic comparisons *)
   | "caml_compare", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~float_prim:(Float_comp (Yielding_int_like_compare_functions ()))
+      ~float_prim:(fun w ->
+        Float_comp (w, Yielding_int_like_compare_functions ()))
       ~tagged_prim:
         (Int_comp (Tagged_immediate, Yielding_int_like_compare_functions Signed))
       ~boxed_int_prim:(fun kind ->
         Int_comp (kind, Yielding_int_like_compare_functions Signed))
   | "caml_equal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~tagged_prim:(Phys_equal Eq) ~float_prim:(Float_comp (Yielding_bool Eq))
+      ~tagged_prim:(Phys_equal Eq)
+      ~float_prim:(fun w -> Float_comp (w, Yielding_bool Eq))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool Eq))
   | "caml_notequal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~tagged_prim:(Phys_equal Neq) ~float_prim:(Float_comp (Yielding_bool Neq))
+      ~tagged_prim:(Phys_equal Neq)
+      ~float_prim:(fun w -> Float_comp (w, Yielding_bool Neq))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool Neq))
   | "caml_lessequal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~float_prim:(Float_comp (Yielding_bool (Le ())))
+      ~float_prim:(fun w -> Float_comp (w, Yielding_bool (Le ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Le Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Le Signed)))
   | "caml_lessthan", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~float_prim:(Float_comp (Yielding_bool (Lt ())))
+      ~float_prim:(fun w -> Float_comp (w, Yielding_bool (Lt ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Lt Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Lt Signed)))
   | "caml_greaterequal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~float_prim:(Float_comp (Yielding_bool (Ge ())))
+      ~float_prim:(fun w -> Float_comp (w, Yielding_bool (Ge ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Ge Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Ge Signed)))
   | "caml_greaterthan", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~float_prim:(Float_comp (Yielding_bool (Gt ())))
+      ~float_prim:(fun w -> Float_comp (w, Yielding_bool (Gt ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Gt Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Gt Signed)))
   | "caml_make_vect", [_; _], [len_ty; init_value_ty] ->

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -161,8 +161,8 @@ let simplify_returning_extcall ~dbg ~cont ~exn_cont:_ dacc fun_name args
   (* Polymorphic comparisons *)
   | "caml_compare", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~float_prim:(fun w ->
-        Float_comp (w, Yielding_int_like_compare_functions ()))
+      ~float_prim:(fun width ->
+        Float_comp (width, Yielding_int_like_compare_functions ()))
       ~tagged_prim:
         (Int_comp (Tagged_immediate, Yielding_int_like_compare_functions Signed))
       ~boxed_int_prim:(fun kind ->
@@ -170,31 +170,31 @@ let simplify_returning_extcall ~dbg ~cont ~exn_cont:_ dacc fun_name args
   | "caml_equal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
       ~tagged_prim:(Phys_equal Eq)
-      ~float_prim:(fun w -> Float_comp (w, Yielding_bool Eq))
+      ~float_prim:(fun width -> Float_comp (width, Yielding_bool Eq))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool Eq))
   | "caml_notequal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
       ~tagged_prim:(Phys_equal Neq)
-      ~float_prim:(fun w -> Float_comp (w, Yielding_bool Neq))
+      ~float_prim:(fun width -> Float_comp (width, Yielding_bool Neq))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool Neq))
   | "caml_lessequal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~float_prim:(fun w -> Float_comp (w, Yielding_bool (Le ())))
+      ~float_prim:(fun width -> Float_comp (width, Yielding_bool (Le ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Le Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Le Signed)))
   | "caml_lessthan", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~float_prim:(fun w -> Float_comp (w, Yielding_bool (Lt ())))
+      ~float_prim:(fun width -> Float_comp (width, Yielding_bool (Lt ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Lt Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Lt Signed)))
   | "caml_greaterequal", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~float_prim:(fun w -> Float_comp (w, Yielding_bool (Ge ())))
+      ~float_prim:(fun width -> Float_comp (width, Yielding_bool (Ge ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Ge Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Ge Signed)))
   | "caml_greaterthan", [a; b], [a_ty; b_ty] ->
     simplify_comparison ~dbg ~dacc ~cont a b a_ty b_ty
-      ~float_prim:(fun w -> Float_comp (w, Yielding_bool (Gt ())))
+      ~float_prim:(fun width -> Float_comp (width, Yielding_bool (Gt ())))
       ~tagged_prim:(Int_comp (Tagged_immediate, Yielding_bool (Gt Signed)))
       ~boxed_int_prim:(fun kind -> Int_comp (kind, Yielding_bool (Gt Signed)))
   | "caml_make_vect", [_; _], [len_ty; init_value_ty] ->

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -467,6 +467,25 @@ let simplify_float_arith_op (op : P.unary_float_arith_op) dacc ~original_term
     SPR.create_unknown dacc ~result_var K.naked_float ~original_term
   | Invalid -> SPR.create_invalid dacc
 
+let simplify_float32_arith_op (op : P.unary_float_arith_op) dacc ~original_term
+    ~arg:_ ~arg_ty ~result_var =
+  let module F = Numeric_types.Float32_by_bit_pattern in
+  let denv = DA.denv dacc in
+  let proof = T.meet_naked_float32s (DE.typing_env denv) arg_ty in
+  match proof with
+  | Known_result fs when DE.propagating_float_consts denv ->
+    assert (not (Float32.Set.is_empty fs));
+    let f =
+      match op with Abs -> F.IEEE_semantics.abs | Neg -> F.IEEE_semantics.neg
+    in
+    let possible_results = F.Set.map f fs in
+    let ty = T.these_naked_float32s possible_results in
+    let dacc = DA.add_variable dacc result_var ty in
+    SPR.create original_term ~try_reify:true dacc
+  | Known_result _ | Need_meet ->
+    SPR.create_unknown dacc ~result_var K.naked_float32 ~original_term
+  | Invalid -> SPR.create_invalid dacc
+
 let simplify_is_boxed_float dacc ~original_term ~arg:_ ~arg_ty ~result_var =
   (* CR mshinwell: see CRs in lambda_to_flambda_primitives.ml
 
@@ -661,7 +680,8 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
       | Naked_int32 -> Unary_int_arith_naked_int32.simplify op
       | Naked_int64 -> Unary_int_arith_naked_int64.simplify op
       | Naked_nativeint -> Unary_int_arith_naked_nativeint.simplify op)
-    | Float_arith op -> simplify_float_arith_op op
+    | Float_arith (Float64, op) -> simplify_float_arith_op op
+    | Float_arith (Float32, op) -> simplify_float32_arith_op op
     | Num_conv { src; dst } -> (
       match src with
       | Tagged_immediate -> Simplify_int_conv_tagged_immediate.simplify ~dst

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -323,9 +323,9 @@ let int_comparison_like_compare_functions (kind : Flambda_kind.Standard_int.t)
   | Naked_nativeint ->
     4
 
-let binary_float_arith_primitive _w _op = 2
+let binary_float_arith_primitive _width _op = 2
 
-let binary_float_comp_primitive _w _op = 2
+let binary_float_comp_primitive _width _op = 2
 
 (* Primitives sizes *)
 
@@ -392,9 +392,10 @@ let binary_prim_size prim =
   | Int_comp (kind, Yielding_bool cmp) -> binary_int_comp_primitive kind cmp
   | Int_comp (kind, Yielding_int_like_compare_functions signedness) ->
     int_comparison_like_compare_functions kind signedness
-  | Float_arith (w, op) -> binary_float_arith_primitive w op
-  | Float_comp (w, Yielding_bool cmp) -> binary_float_comp_primitive w cmp
-  | Float_comp (_w, Yielding_int_like_compare_functions ()) -> 8
+  | Float_arith (width, op) -> binary_float_arith_primitive width op
+  | Float_comp (width, Yielding_bool cmp) ->
+    binary_float_comp_primitive width cmp
+  | Float_comp (_width, Yielding_int_like_compare_functions ()) -> 8
   | Bigarray_get_alignment _ -> 3 (* load data + add index + and *)
   | Atomic_exchange | Atomic_fetch_and_add ->
     does_not_need_caml_c_call_extcall_size

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -323,9 +323,9 @@ let int_comparison_like_compare_functions (kind : Flambda_kind.Standard_int.t)
   | Naked_nativeint ->
     4
 
-let binary_float_arith_primitive _op = 2
+let binary_float_arith_primitive _w _op = 2
 
-let binary_float_comp_primitive _op = 2
+let binary_float_comp_primitive _w _op = 2
 
 (* Primitives sizes *)
 
@@ -392,9 +392,9 @@ let binary_prim_size prim =
   | Int_comp (kind, Yielding_bool cmp) -> binary_int_comp_primitive kind cmp
   | Int_comp (kind, Yielding_int_like_compare_functions signedness) ->
     int_comparison_like_compare_functions kind signedness
-  | Float_arith op -> binary_float_arith_primitive op
-  | Float_comp (Yielding_bool cmp) -> binary_float_comp_primitive cmp
-  | Float_comp (Yielding_int_like_compare_functions ()) -> 8
+  | Float_arith (w, op) -> binary_float_arith_primitive w op
+  | Float_comp (w, Yielding_bool cmp) -> binary_float_comp_primitive w cmp
+  | Float_comp (_w, Yielding_int_like_compare_functions ()) -> 8
   | Bigarray_get_alignment _ -> 3 (* load data + add index + and *)
   | Atomic_exchange | Atomic_fetch_and_add ->
     does_not_need_caml_c_call_extcall_size

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1214,7 +1214,7 @@ let print_unary_primitive ppf p =
       Flambda_kind.Standard_int_or_float.print_lowercase dst
   | Boolean_not -> fprintf ppf "Boolean_not"
   | Reinterpret_int64_as_float -> fprintf ppf "Reinterpret_int64_as_float"
-  | Float_arith (w, o) -> print_unary_float_arith_op ppf w o
+  | Float_arith (width, op) -> print_unary_float_arith_op ppf width op
   | Array_length ak ->
     fprintf ppf "(Array_length %a)" Array_kind_for_length.print ak
   | Bigarray_length { dimension } ->

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -861,6 +861,10 @@ let print_array_accessor_width ppf = function
   | Scalar -> Format.fprintf ppf "scalar"
   | Vec128 -> Format.fprintf ppf "vec128"
 
+type float_bitwidth =
+  | Float32
+  | Float64
+
 type num_dimensions = int
 
 let print_num_dimensions ppf d = Format.fprintf ppf "%d" d
@@ -879,9 +883,13 @@ type unary_float_arith_op =
   | Abs
   | Neg
 
-let print_unary_float_arith_op ppf o =
+let print_unary_float_arith_op ppf w o =
   let fprintf = Format.fprintf in
-  match o with Abs -> fprintf ppf "abs" | Neg -> fprintf ppf "~-"
+  match w, o with
+  | Float64, Abs -> fprintf ppf "abs"
+  | Float64, Neg -> fprintf ppf "~-"
+  | Float32, Abs -> fprintf ppf "Float32.abs"
+  | Float32, Neg -> fprintf ppf "Float32.~-"
 
 type arg_kinds =
   | Variadic of K.t list
@@ -1011,7 +1019,7 @@ type unary_primitive =
         kind : K.t
       }
   | Int_arith of Flambda_kind.Standard_int.t * unary_int_arith_op
-  | Float_arith of unary_float_arith_op
+  | Float_arith of float_bitwidth * unary_float_arith_op
   | Num_conv of
       { src : Flambda_kind.Standard_int_or_float.t;
         dst : Flambda_kind.Standard_int_or_float.t
@@ -1132,7 +1140,9 @@ let compare_unary_primitive p1 p2 =
   | Num_conv { src = src1; dst = dst1 }, Num_conv { src = src2; dst = dst2 } ->
     let c = K.Standard_int_or_float.compare src1 src2 in
     if c <> 0 then c else K.Standard_int_or_float.compare dst1 dst2
-  | Float_arith op1, Float_arith op2 -> Stdlib.compare op1 op2
+  | Float_arith (w1, op1), Float_arith (w2, op2) ->
+    let c = Stdlib.compare w1 w2 in
+    if c <> 0 then c else Stdlib.compare op1 op2
   | Array_length ak1, Array_length ak2 -> Array_kind_for_length.compare ak1 ak2
   | Bigarray_length { dimension = dim1 }, Bigarray_length { dimension = dim2 }
     ->
@@ -1204,7 +1214,7 @@ let print_unary_primitive ppf p =
       Flambda_kind.Standard_int_or_float.print_lowercase dst
   | Boolean_not -> fprintf ppf "Boolean_not"
   | Reinterpret_int64_as_float -> fprintf ppf "Reinterpret_int64_as_float"
-  | Float_arith o -> print_unary_float_arith_op ppf o
+  | Float_arith (w, o) -> print_unary_float_arith_op ppf w o
   | Array_length ak ->
     fprintf ppf "(Array_length %a)" Array_kind_for_length.print ak
   | Bigarray_length { dimension } ->
@@ -1244,7 +1254,8 @@ let arg_kind_of_unary_primitive p =
   | Num_conv { src; dst = _ } -> K.Standard_int_or_float.to_kind src
   | Boolean_not -> K.value
   | Reinterpret_int64_as_float -> K.naked_int64
-  | Float_arith _ -> K.naked_float
+  | Float_arith (Float64, _) -> K.naked_float
+  | Float_arith (Float32, _) -> K.naked_float32
   | Array_length _ | Bigarray_length _ -> K.value
   | Unbox_number _ | Untag_immediate -> K.value
   | Box_number (kind, _) -> K.Boxable_number.unboxed_kind kind
@@ -1272,7 +1283,8 @@ let result_kind_of_unary_primitive p : result_kind =
   | Num_conv { src = _; dst } -> Singleton (K.Standard_int_or_float.to_kind dst)
   | Boolean_not -> Singleton K.value
   | Reinterpret_int64_as_float -> Singleton K.naked_float
-  | Float_arith _ -> Singleton K.naked_float
+  | Float_arith (Float64, _) -> Singleton K.naked_float
+  | Float_arith (Float32, _) -> Singleton K.naked_float32
   | Array_length _ -> Singleton K.value
   | Bigarray_length _ -> Singleton K.naked_immediate
   | Unbox_number kind -> Singleton (K.Boxable_number.unboxed_kind kind)
@@ -1320,7 +1332,7 @@ let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
   | Int_arith (_, (Neg | Swap_byte_endianness))
   | Num_conv _ | Boolean_not | Reinterpret_int64_as_float ->
     No_effects, No_coeffects, Strict
-  | Float_arith (Abs | Neg) ->
+  | Float_arith (_width, (Abs | Neg)) ->
     (* Float operations are not really pure since they actually access the
        globally mutable rounding mode, which can be changed (but only from C
        code). The Flambda_features.float_const_prop tracks whether we are
@@ -1488,13 +1500,17 @@ type binary_float_arith_op =
   | Mul
   | Div
 
-let print_binary_float_arith_op ppf o =
+let print_binary_float_arith_op ppf w o =
   let fprintf = Format.fprintf in
-  match o with
-  | Add -> fprintf ppf "+."
-  | Sub -> fprintf ppf "-."
-  | Mul -> fprintf ppf "*."
-  | Div -> fprintf ppf "/."
+  match w, o with
+  | Float64, Add -> fprintf ppf "+."
+  | Float64, Sub -> fprintf ppf "-."
+  | Float64, Mul -> fprintf ppf "*."
+  | Float64, Div -> fprintf ppf "/."
+  | Float32, Add -> fprintf ppf "Float32.+."
+  | Float32, Sub -> fprintf ppf "Float32.-."
+  | Float32, Mul -> fprintf ppf "Float32.*."
+  | Float32, Div -> fprintf ppf "Float32./."
 
 type binary_primitive =
   | Block_load of Block_access_kind.t * Mutability.t
@@ -1506,8 +1522,8 @@ type binary_primitive =
   | Int_shift of Flambda_kind.Standard_int.t * int_shift_op
   | Int_comp of
       Flambda_kind.Standard_int.t * signed_or_unsigned comparison_behaviour
-  | Float_arith of binary_float_arith_op
-  | Float_comp of unit comparison_behaviour
+  | Float_arith of float_bitwidth * binary_float_arith_op
+  | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
   | Atomic_exchange
   | Atomic_fetch_and_add
@@ -1580,8 +1596,12 @@ let compare_binary_primitive p1 p2 =
   | Int_comp (kind1, comp_behaviour1), Int_comp (kind2, comp_behaviour2) ->
     let c = K.Standard_int.compare kind1 kind2 in
     if c <> 0 then c else Stdlib.compare comp_behaviour1 comp_behaviour2
-  | Float_arith op1, Float_arith op2 -> Stdlib.compare op1 op2
-  | Float_comp comp1, Float_comp comp2 -> Stdlib.compare comp1 comp2
+  | Float_arith (w1, op1), Float_arith (w2, op2) ->
+    let c = Stdlib.compare w1 w2 in
+    if c <> 0 then c else Stdlib.compare op1 op2
+  | Float_comp (w1, comp1), Float_comp (w2, comp2) ->
+    let c = Stdlib.compare w1 w2 in
+    if c <> 0 then c else Stdlib.compare comp1 comp2
   | Bigarray_get_alignment align1, Bigarray_get_alignment align2 ->
     Int.compare align1 align2
   | ( ( Block_load _ | Array_load _ | String_or_bigstring_load _
@@ -1617,8 +1637,8 @@ let print_binary_primitive ppf p =
   | Int_shift (_k, op) -> print_int_shift_op ppf op
   | Int_comp (_, comp_behaviour) ->
     print_comparison_and_behaviour print_signed_or_unsigned ppf comp_behaviour
-  | Float_arith op -> print_binary_float_arith_op ppf op
-  | Float_comp comp_behaviour ->
+  | Float_arith (w, op) -> print_binary_float_arith_op ppf w op
+  | Float_comp (_w, comp_behaviour) ->
     print_comparison_and_behaviour (fun _ppf () -> ()) ppf comp_behaviour;
     fprintf ppf "."
   | Bigarray_get_alignment align ->
@@ -1643,7 +1663,10 @@ let args_kind_of_binary_primitive p =
   | Int_comp (kind, _) ->
     let kind = K.Standard_int.to_kind kind in
     kind, kind
-  | Float_arith _ | Float_comp _ -> K.naked_float, K.naked_float
+  | Float_arith (Float64, _) | Float_comp (Float64, _) ->
+    K.naked_float, K.naked_float
+  | Float_arith (Float32, _) | Float_comp (Float32, _) ->
+    K.naked_float32, K.naked_float32
   | Bigarray_get_alignment _ -> bigstring_kind, K.naked_immediate
   | Atomic_exchange | Atomic_fetch_and_add -> K.value, K.value
 
@@ -1662,7 +1685,8 @@ let result_kind_of_binary_primitive p : result_kind =
   | Bigarray_load (_, kind, _) -> Singleton (Bigarray_kind.element_kind kind)
   | Int_arith (kind, _) | Int_shift (kind, _) ->
     Singleton (K.Standard_int.to_kind kind)
-  | Float_arith _ -> Singleton K.naked_float
+  | Float_arith (Float64, _) -> Singleton K.naked_float
+  | Float_arith (Float32, _) -> Singleton K.naked_float32
   | Phys_equal _ | Int_comp _ | Float_comp _ -> Singleton K.naked_immediate
   | Bigarray_get_alignment _ -> Singleton K.naked_immediate
   | Atomic_exchange | Atomic_fetch_and_add -> Singleton K.value
@@ -1681,7 +1705,7 @@ let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
     No_effects, No_coeffects, Strict
   | Int_shift _ -> No_effects, No_coeffects, Strict
   | Int_comp _ -> No_effects, No_coeffects, Strict
-  | Float_arith (Add | Sub | Mul | Div) ->
+  | Float_arith (_width, (Add | Sub | Mul | Div)) ->
     (* See comments for Unary Float_arith *)
     if Flambda_features.float_const_prop ()
     then No_effects, No_coeffects, Strict

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -883,9 +883,9 @@ type unary_float_arith_op =
   | Abs
   | Neg
 
-let print_unary_float_arith_op ppf w o =
+let print_unary_float_arith_op ppf width op =
   let fprintf = Format.fprintf in
-  match w, o with
+  match width, op with
   | Float64, Abs -> fprintf ppf "abs"
   | Float64, Neg -> fprintf ppf "~-"
   | Float32, Abs -> fprintf ppf "Float32.abs"

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1140,8 +1140,8 @@ let compare_unary_primitive p1 p2 =
   | Num_conv { src = src1; dst = dst1 }, Num_conv { src = src2; dst = dst2 } ->
     let c = K.Standard_int_or_float.compare src1 src2 in
     if c <> 0 then c else K.Standard_int_or_float.compare dst1 dst2
-  | Float_arith (w1, op1), Float_arith (w2, op2) ->
-    let c = Stdlib.compare w1 w2 in
+  | Float_arith (width1, op1), Float_arith (width2, op2) ->
+    let c = Stdlib.compare width1 width2 in
     if c <> 0 then c else Stdlib.compare op1 op2
   | Array_length ak1, Array_length ak2 -> Array_kind_for_length.compare ak1 ak2
   | Bigarray_length { dimension = dim1 }, Bigarray_length { dimension = dim2 }

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1500,9 +1500,9 @@ type binary_float_arith_op =
   | Mul
   | Div
 
-let print_binary_float_arith_op ppf w o =
+let print_binary_float_arith_op ppf width op =
   let fprintf = Format.fprintf in
-  match w, o with
+  match width, op with
   | Float64, Add -> fprintf ppf "+."
   | Float64, Sub -> fprintf ppf "-."
   | Float64, Mul -> fprintf ppf "*."
@@ -1596,11 +1596,11 @@ let compare_binary_primitive p1 p2 =
   | Int_comp (kind1, comp_behaviour1), Int_comp (kind2, comp_behaviour2) ->
     let c = K.Standard_int.compare kind1 kind2 in
     if c <> 0 then c else Stdlib.compare comp_behaviour1 comp_behaviour2
-  | Float_arith (w1, op1), Float_arith (w2, op2) ->
-    let c = Stdlib.compare w1 w2 in
+  | Float_arith (width1, op1), Float_arith (width2, op2) ->
+    let c = Stdlib.compare width1 width2 in
     if c <> 0 then c else Stdlib.compare op1 op2
-  | Float_comp (w1, comp1), Float_comp (w2, comp2) ->
-    let c = Stdlib.compare w1 w2 in
+  | Float_comp (width1, comp1), Float_comp (width2, comp2) ->
+    let c = Stdlib.compare width1 width2 in
     if c <> 0 then c else Stdlib.compare comp1 comp2
   | Bigarray_get_alignment align1, Bigarray_get_alignment align2 ->
     Int.compare align1 align2
@@ -1637,8 +1637,8 @@ let print_binary_primitive ppf p =
   | Int_shift (_k, op) -> print_int_shift_op ppf op
   | Int_comp (_, comp_behaviour) ->
     print_comparison_and_behaviour print_signed_or_unsigned ppf comp_behaviour
-  | Float_arith (w, op) -> print_binary_float_arith_op ppf w op
-  | Float_comp (_w, comp_behaviour) ->
+  | Float_arith (width, op) -> print_binary_float_arith_op ppf width op
+  | Float_comp (_width, comp_behaviour) ->
     print_comparison_and_behaviour (fun _ppf () -> ()) ppf comp_behaviour;
     fprintf ppf "."
   | Bigarray_get_alignment align ->

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -279,6 +279,10 @@ type array_accessor_width =
   | Scalar
   | Vec128
 
+type float_bitwidth =
+  | Float32
+  | Float64
+
 type string_like_value =
   | String
   | Bytes
@@ -361,7 +365,7 @@ type unary_primitive =
         kind : Flambda_kind.t
       }
   | Int_arith of Flambda_kind.Standard_int.t * unary_int_arith_op
-  | Float_arith of unary_float_arith_op
+  | Float_arith of float_bitwidth * unary_float_arith_op
   | Num_conv of
       { src : Flambda_kind.Standard_int_or_float.t;
         dst : Flambda_kind.Standard_int_or_float.t
@@ -460,8 +464,8 @@ type binary_primitive =
   | Int_shift of Flambda_kind.Standard_int.t * int_shift_op
   | Int_comp of
       Flambda_kind.Standard_int.t * signed_or_unsigned comparison_behaviour
-  | Float_arith of binary_float_arith_op
-  | Float_comp of unit comparison_behaviour
+  | Float_arith of float_bitwidth * binary_float_arith_op
+  | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
   | Atomic_exchange
   | Atomic_fetch_and_add

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -792,11 +792,11 @@ let binary_primitive env dbg f x y =
     binary_int_comp_primitive env dbg kind cmp x y
   | Int_comp (kind, Yielding_int_like_compare_functions signed) ->
     binary_int_comp_primitive_yielding_int env dbg kind signed x y
-  | Float_arith (w, op) -> binary_float_arith_primitive env dbg w op x y
-  | Float_comp (w, Yielding_bool cmp) ->
-    binary_float_comp_primitive env dbg w cmp x y
-  | Float_comp (w, Yielding_int_like_compare_functions ()) ->
-    binary_float_comp_primitive_yielding_int env dbg w x y
+  | Float_arith (width, op) -> binary_float_arith_primitive env dbg width op x y
+  | Float_comp (width, Yielding_bool cmp) ->
+    binary_float_comp_primitive env dbg width cmp x y
+  | Float_comp (width, Yielding_int_like_compare_functions ()) ->
+    binary_float_comp_primitive_yielding_int env dbg width x y
   | Bigarray_get_alignment align -> C.bigstring_get_alignment x y align dbg
   | Atomic_exchange -> C.atomic_exchange ~dbg x y
   | Atomic_fetch_and_add -> C.atomic_fetch_and_add ~dbg x y

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -605,8 +605,8 @@ let binary_int_comp_primitive_yielding_int _env dbg _kind
       "Translation of [Int_comp] yielding an integer -1, 0 or 1 in unsigned \
        mode is not yet implemented"
 
-let binary_float_arith_primitive _env dbg w op x y =
-  match (w : P.float_bitwidth), (op : P.binary_float_arith_op) with
+let binary_float_arith_primitive _env dbg width op x y =
+  match (width : P.float_bitwidth), (op : P.binary_float_arith_op) with
   | Float64, Add -> C.float_add ~dbg x y
   | Float64, Sub -> C.float_sub ~dbg x y
   | Float64, Mul -> C.float_mul ~dbg x y
@@ -616,8 +616,8 @@ let binary_float_arith_primitive _env dbg w op x y =
   | Float32, Mul -> C.float32_mul ~dbg x y
   | Float32, Div -> C.float32_div ~dbg x y
 
-let binary_float_comp_primitive _env dbg w op x y =
-  match (w : P.float_bitwidth), (op : unit P.comparison) with
+let binary_float_comp_primitive _env dbg width op x y =
+  match (width : P.float_bitwidth), (op : unit P.comparison) with
   | Float64, Eq -> C.float_eq ~dbg x y
   | Float64, Neq -> C.float_neq ~dbg x y
   | Float64, Lt () -> C.float_lt ~dbg x y
@@ -631,8 +631,8 @@ let binary_float_comp_primitive _env dbg w op x y =
   | Float32, Le () -> C.float32_le ~dbg x y
   | Float32, Ge () -> C.float32_ge ~dbg x y
 
-let binary_float_comp_primitive_yielding_int _env dbg w x y =
-  match (w : P.float_bitwidth) with
+let binary_float_comp_primitive_yielding_int _env dbg width x y =
+  match (width : P.float_bitwidth) with
   | Float64 -> C.mk_compare_floats_untagged dbg x y
   | Float32 -> C.mk_compare_float32s_untagged dbg x y
 


### PR DESCRIPTION
Adds arithmetic operations for `float32` in the middle end; again cuts off at the CMM implementations.
Following PR adds backend support.