### PR TITLE
Unconditionally reserve the top header byte in runtime 4 and runtime 5

### DIFF
--- a/ocaml/configure
+++ b/ocaml/configure
@@ -933,7 +933,6 @@ enable_flambda_invariants
 enable_flambda2
 enable_cmm_invariants
 with_target_bindir
-enable_reserved_header_bits
 enable_stdlib_manpages
 enable_warn_error
 enable_force_safe_string
@@ -1628,9 +1627,6 @@ Optional Features:
                           enable invariants checks in flambda
   --enable-flambda2       enable the Flambda 2 middle end
   --enable-cmm-invariants enable invariants checks in Cmm
-  --enable-reserved-header-bits=BITS
-                          reserve BITS (between 0 and 31) bits in block
-                          headers
   --disable-stdlib-manpages
                           do not build or install the library man pages
   --enable-warn-error     treat C compiler warnings as errors
@@ -3208,7 +3204,7 @@ CSCFLAGS=""
 ostype="Unix"
 SO="so"
 toolchain="cc"
-reserved_header_bits=0
+reserved_header_bits=8
 custom_ops_struct_size=64
 instrumented_runtime=false
 instrumented_runtime_libs=""
@@ -3911,18 +3907,6 @@ fi
 if test ${with_target_bindir+y}
 then :
   withval=$with_target_bindir;
-fi
-
-
-# Check whether --enable-reserved-header-bits was given.
-if test ${enable_reserved_header_bits+y}
-then :
-  enableval=$enable_reserved_header_bits; case $enable_reserved_header_bits in #(
-  [0-9]|[1-2][0-9]|3[0-1]) :
-     reserved_header_bits=$enable_reserved_header_bits ;; #(
-  *) :
-    as_fn_error $? "invalid argument to --enable-reserved-header-bits" "$LINENO" 5 ;;
-esac
 fi
 
 

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -752,6 +752,8 @@ flambda
 cpp_mangling
 frame_pointers
 custom_ops_struct_size
+profinfo_width
+profinfo
 reserved_header_bits
 install_ocamlnat
 install_source_artifacts
@@ -933,6 +935,7 @@ enable_flambda_invariants
 enable_flambda2
 enable_cmm_invariants
 with_target_bindir
+with_profinfo
 enable_stdlib_manpages
 enable_warn_error
 enable_force_safe_string
@@ -1650,6 +1653,10 @@ Optional Packages:
   --with-dune             Path to dune executable (otherwise PATH is searched)
   --with-odoc             build documentation with odoc
   --with-target-bindir    location of binary programs on target system
+  --enable-profinfo-width=8
+                          reserved bits in block headers in runtime 4. 8 bits
+                          are required for mixed block support in runtime 4;
+                          any other value is not sensible.
   --with-afl              use the AFL fuzzer
   --with-flexdll          bootstrap FlexDLL from the given sources
   --without-zstd          disable compression of marshaled data
@@ -3205,6 +3212,8 @@ ostype="Unix"
 SO="so"
 toolchain="cc"
 reserved_header_bits=8
+profinfo=false
+profinfo_width=0
 custom_ops_struct_size=64
 instrumented_runtime=false
 instrumented_runtime_libs=""
@@ -3337,6 +3346,8 @@ OCAML_VERSION_SHORT=5.1
 
 
  # TODO: rename this variable
+
+
 
 
 
@@ -3907,6 +3918,20 @@ fi
 if test ${with_target_bindir+y}
 then :
   withval=$with_target_bindir;
+fi
+
+
+
+# Check whether --with-profinfo was given.
+if test ${with_profinfo+y}
+then :
+  withval=$with_profinfo; case $enable_profinfo_width in #(
+  8) :
+    with_profinfo=true
+      profinfo_width="$enable_profinfo_width" ;; #(
+  *) :
+    as_fn_error $? "invalid argument to --enable-profinfo-width (must be 8)" "$LINENO" 5 ;;
+esac
 fi
 
 
@@ -19622,6 +19647,13 @@ fi
 
 printf "%s\n" "#define HEADER_RESERVED_BITS $reserved_header_bits" >>confdefs.h
 
+printf "%s\n" "#define PROFINFO_WIDTH $profinfo_width" >>confdefs.h
+
+if $profinfo
+then :
+  printf "%s\n" "#define WITH_PROFINFO 1" >>confdefs.h
+
+fi
 printf "%s\n" "#define CUSTOM_OPS_STRUCT_SIZE $custom_ops_struct_size" >>confdefs.h
 
 

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -935,7 +935,6 @@ enable_flambda_invariants
 enable_flambda2
 enable_cmm_invariants
 with_target_bindir
-with_profinfo
 enable_stdlib_manpages
 enable_warn_error
 enable_force_safe_string
@@ -1653,10 +1652,6 @@ Optional Packages:
   --with-dune             Path to dune executable (otherwise PATH is searched)
   --with-odoc             build documentation with odoc
   --with-target-bindir    location of binary programs on target system
-  --enable-profinfo-width=8
-                          reserved bits in block headers in runtime 4. 8 bits
-                          are required for mixed block support in runtime 4;
-                          any other value is not sensible.
   --with-afl              use the AFL fuzzer
   --with-flexdll          bootstrap FlexDLL from the given sources
   --without-zstd          disable compression of marshaled data
@@ -3212,8 +3207,8 @@ ostype="Unix"
 SO="so"
 toolchain="cc"
 reserved_header_bits=8
-profinfo=false
-profinfo_width=0
+profinfo=true
+profinfo_width=8
 custom_ops_struct_size=64
 instrumented_runtime=false
 instrumented_runtime_libs=""
@@ -3918,20 +3913,6 @@ fi
 if test ${with_target_bindir+y}
 then :
   withval=$with_target_bindir;
-fi
-
-
-
-# Check whether --with-profinfo was given.
-if test ${with_profinfo+y}
-then :
-  withval=$with_profinfo; case $enable_profinfo_width in #(
-  8) :
-    with_profinfo=true
-      profinfo_width="$enable_profinfo_width" ;; #(
-  *) :
-    as_fn_error $? "invalid argument to --enable-profinfo-width (must be 8)" "$LINENO" 5 ;;
-esac
 fi
 
 
@@ -19645,6 +19626,8 @@ fi
 
 
 
+# Unconditionally reserve 8 header bits in both runtime 4 and
+# runtime 5, which is required for mixed block support.
 printf "%s\n" "#define HEADER_RESERVED_BITS $reserved_header_bits" >>confdefs.h
 
 printf "%s\n" "#define PROFINFO_WIDTH $profinfo_width" >>confdefs.h
@@ -19654,6 +19637,7 @@ then :
   printf "%s\n" "#define WITH_PROFINFO 1" >>confdefs.h
 
 fi
+
 printf "%s\n" "#define CUSTOM_OPS_STRUCT_SIZE $custom_ops_struct_size" >>confdefs.h
 
 

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -62,8 +62,8 @@ ostype="Unix"
 SO="so"
 toolchain="cc"
 reserved_header_bits=8
-profinfo=false
-profinfo_width=0
+profinfo=true
+profinfo_width=8
 custom_ops_struct_size=64
 instrumented_runtime=false
 instrumented_runtime_libs=""
@@ -466,15 +466,6 @@ AC_ARG_ENABLE([cmm-invariants],
 AC_ARG_WITH([target-bindir],
   [AS_HELP_STRING([--with-target-bindir],
     [location of binary programs on target system])])
-
-AC_ARG_WITH([profinfo],
-  [AS_HELP_STRING([--enable-profinfo-width=8],
-  [reserved bits in block headers in runtime 4. 8 bits are required for mixed block support in runtime 4; any other value is not sensible.])],
-  [AS_CASE([$enable_profinfo_width],
-    [8],
-      [with_profinfo=true
-      profinfo_width="$enable_profinfo_width"],
-    [AC_MSG_ERROR([invalid argument to --enable-profinfo-width (must be 8)])])])
 
 AC_ARG_ENABLE([stdlib-manpages],
   [AS_HELP_STRING([--disable-stdlib-manpages],
@@ -2205,9 +2196,12 @@ AS_IF([test x"$enable_naked_pointers_checker" = "xyes" ],
 ## Check for mmap support for huge pages and contiguous heap
 OCAML_MMAP_SUPPORTS_HUGE_PAGES
 
+# Unconditionally reserve 8 header bits in both runtime 4 and
+# runtime 5, which is required for mixed block support.
 AC_DEFINE_UNQUOTED([HEADER_RESERVED_BITS], [$reserved_header_bits])
 AC_DEFINE_UNQUOTED([PROFINFO_WIDTH], [$profinfo_width])
 AS_IF([$profinfo], [AC_DEFINE([WITH_PROFINFO])])
+
 AC_DEFINE_UNQUOTED([CUSTOM_OPS_STRUCT_SIZE], [$custom_ops_struct_size])
 
 AS_IF([test x"$enable_installing_bytecode_programs" = "xno"],

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -62,6 +62,8 @@ ostype="Unix"
 SO="so"
 toolchain="cc"
 reserved_header_bits=8
+profinfo=false
+profinfo_width=0
 custom_ops_struct_size=64
 instrumented_runtime=false
 instrumented_runtime_libs=""
@@ -205,6 +207,8 @@ AC_SUBST([install_bytecode_programs])
 AC_SUBST([install_source_artifacts])
 AC_SUBST([install_ocamlnat])
 AC_SUBST([reserved_header_bits])
+AC_SUBST([profinfo])
+AC_SUBST([profinfo_width])
 AC_SUBST([custom_ops_struct_size])
 AC_SUBST([frame_pointers])
 AC_SUBST([cpp_mangling])
@@ -462,6 +466,15 @@ AC_ARG_ENABLE([cmm-invariants],
 AC_ARG_WITH([target-bindir],
   [AS_HELP_STRING([--with-target-bindir],
     [location of binary programs on target system])])
+
+AC_ARG_WITH([profinfo],
+  [AS_HELP_STRING([--enable-profinfo-width=8],
+  [reserved bits in block headers in runtime 4. 8 bits are required for mixed block support in runtime 4; any other value is not sensible.])],
+  [AS_CASE([$enable_profinfo_width],
+    [8],
+      [with_profinfo=true
+      profinfo_width="$enable_profinfo_width"],
+    [AC_MSG_ERROR([invalid argument to --enable-profinfo-width (must be 8)])])])
 
 AC_ARG_ENABLE([stdlib-manpages],
   [AS_HELP_STRING([--disable-stdlib-manpages],
@@ -2193,6 +2206,8 @@ AS_IF([test x"$enable_naked_pointers_checker" = "xyes" ],
 OCAML_MMAP_SUPPORTS_HUGE_PAGES
 
 AC_DEFINE_UNQUOTED([HEADER_RESERVED_BITS], [$reserved_header_bits])
+AC_DEFINE_UNQUOTED([PROFINFO_WIDTH], [$profinfo_width])
+AS_IF([$profinfo], [AC_DEFINE([WITH_PROFINFO])])
 AC_DEFINE_UNQUOTED([CUSTOM_OPS_STRUCT_SIZE], [$custom_ops_struct_size])
 
 AS_IF([test x"$enable_installing_bytecode_programs" = "xno"],

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -61,7 +61,7 @@ CSCFLAGS=""
 ostype="Unix"
 SO="so"
 toolchain="cc"
-reserved_header_bits=0
+reserved_header_bits=8
 custom_ops_struct_size=64
 instrumented_runtime=false
 instrumented_runtime_libs=""
@@ -462,14 +462,6 @@ AC_ARG_ENABLE([cmm-invariants],
 AC_ARG_WITH([target-bindir],
   [AS_HELP_STRING([--with-target-bindir],
     [location of binary programs on target system])])
-
-AC_ARG_ENABLE([reserved-header-bits],
-  [AS_HELP_STRING([--enable-reserved-header-bits=BITS],
-    [reserve BITS (between 0 and 31) bits in block headers])],
-  [AS_CASE([$enable_reserved_header_bits],
-    [[[0-9]]|[[1-2]][[0-9]]|3[[0-1]]],
-      [ reserved_header_bits=$enable_reserved_header_bits],
-  [AC_MSG_ERROR([invalid argument to --enable-reserved-header-bits])])])
 
 AC_ARG_ENABLE([stdlib-manpages],
   [AS_HELP_STRING([--disable-stdlib-manpages],

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -106,8 +106,10 @@ For 64-bit architectures:
      +----------+--------+-------+-----+
 bits  63    64-R 63-R  10 9     8 7   0
 
-where 0 <= R <= 31 is HEADER_RESERVED_BITS, set with the
---enable-reserved-header-bits=R argument to configure.
+where 0 <= R <= 31 is HEADER_RESERVED_BITS. R is always
+set to 8 for the flambda-backend compiler in order to support
+mixed blocks. In the upstream compiler, R is set with the
+--enable-reserved-header-bits=R argument.
 
 */
 

--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -104,14 +104,15 @@ For 64-bit architectures:
      +--------+-------+-----+
 bits  63    10 9     8 7   0
 
-For x86-64 with Spacetime profiling:
-  P = PROFINFO_WIDTH (as set by "configure", currently 26 bits, giving a
-    maximum block size of just under 4Gb)
+For 64-bit architectures with mixed block support enabled:
+  P = PROFINFO_WIDTH (as set by "configure", currently 8 bits)
      +----------------+----------------+-------------+
-     | profiling info | wosize         | color | tag |
+     | scannable size | wosize         | color | tag |
      +----------------+----------------+-------------+
 bits  63        (64-P) (63-P)        10 9     8 7   0
 
+Mixed block support uses the PROFINFO_WIDTH functionality
+originally built for Spacetime profiling, hence the odd name.
 */
 
 #define Tag_hd(hd) ((tag_t) ((hd) & 0xFF))

--- a/ocaml/tools/ci/inria/other-configs/script
+++ b/ocaml/tools/ci/inria/other-configs/script
@@ -39,6 +39,6 @@ ${main} -conf --disable-native-compiler \
         -no-native
 ${main} -conf --disable-flat-float-array
 ${main} -conf --enable-flambda
-${main} -conf --enable-frame-pointers -conf --enable-reserved-header-bits=27
+${main} -conf --enable-frame-pointers
 ${main} -with-bootstrap -conf --with-pic
 OCAMLRUNPARAM="c=1" ${main}

--- a/ocaml/utils/config.generated.ml.in
+++ b/ocaml/utils/config.generated.ml.in
@@ -99,7 +99,6 @@ let asm = {@QS@|@AS@|@QS@}
 let asm_cfi_supported = @asm_cfi_supported@
 let with_frame_pointers = @frame_pointers@
 let with_cpp_mangling = @cpp_mangling@
-let reserved_header_bits = @reserved_header_bits@
 let custom_ops_struct_size = @custom_ops_struct_size@
 
 let ext_exe = {@QS@|@exeext@|@QS@}
@@ -119,3 +118,6 @@ let ar_supports_response_files = @ar_supports_response_files@
 
 let naked_pointers = "@naked_pointers@" = "true"
 let runtime5 = "@enable_runtime5@" = "yes"
+
+let reserved_header_bits =
+  if runtime5 then @reserved_header_bits@ else @profinfo_width@

--- a/ocaml/utils/config.mli
+++ b/ocaml/utils/config.mli
@@ -237,9 +237,9 @@ val reserved_header_bits : int
    regardless of whether we're in runtime 4 or runtime 5.
 
    In runtime 5, this corresponds to the HEADER_RESERVED_BITS C preprocessor
-   macro.  In runtime 4, this corresponds to the PROFINFO_WIDTH C preprocessor
-   macro (and is controlled by the --with-profinfo and --enable-profinfo-width
-   configure arguments), and is only set when WITH_PROFINFO is also true.
+   macro. In runtime 4, this corresponds to the PROFINFO_WIDTH C preprocessor
+   macro. Both of these are unconditionally set to a constant by the configure
+   script in order to enable mixed block support.
  *)
 
 val custom_ops_struct_size : int

--- a/ocaml/utils/config.mli
+++ b/ocaml/utils/config.mli
@@ -233,7 +233,14 @@ val with_cmm_invariants : bool
 (** Whether the invariants checks for Cmm are enabled *)
 
 val reserved_header_bits : int
-(** How many bits of a block's header are reserved *)
+(** How many bits of a block's header are reserved. This is correct
+   regardless of whether we're in runtime 4 or runtime 5.
+
+   In runtime 5, this corresponds to the HEADER_RESERVED_BITS C preprocessor
+   macro.  In runtime 4, this corresponds to the PROFINFO_WIDTH C preprocessor
+   macro (and is controlled by the --with-profinfo and --enable-profinfo-width
+   configure arguments), and is only set when WITH_PROFINFO is also true.
+ *)
 
 val custom_ops_struct_size : int
 (** Size in bytes of the custom operations structure. *)


### PR DESCRIPTION
We plan on using the top header byte to encode mixed blocks. This PR:

  * Reserves the header byte in runtime 5
  * Removes the ability to configure reserved bits in runtime 5
  * Restores the ability to independently configure reserved bits (called "profinfo_width") in runtime 4. We don't enable this by default; this is intentional.

This PR can and should be merged prior to #2380.