### PR TITLE
Fix a bug in `rec_check.ml` for arrays of unboxed things

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
@@ -254,3 +254,29 @@ Error: This expression has type ('a : float64)
        But the layout of int32# must be a sublayout of float64, because
          of the definition of arr at line 6, characters 12-16.
 |}]
+
+(*********************)
+(* Test 7: rec check *)
+
+(* See upstream PR #6939 *)
+
+let _ =
+  let[@warning "-10"] rec x = [| x |]; #42.0 in
+  ();;
+[%%expect{|
+Line 2, characters 30-44:
+2 |   let[@warning "-10"] rec x = [| x |]; #42.0 in
+                                  ^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+|}]
+
+let _ =
+  let[@warning "-10"] rec x = [| x |]; #42L in
+  ();;
+
+[%%expect{|
+Line 2, characters 30-43:
+2 |   let[@warning "-10"] rec x = [| x |]; #42L in
+                                  ^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+|}]

--- a/ocaml/typing/rec_check.ml
+++ b/ocaml/typing/rec_check.ml
@@ -527,7 +527,7 @@ let array_mode exp elt_sort = match Typeopt.array_kind exp elt_sort with
     (* non-generic, non-float arrays act as constructors *)
     Guard
   | Lambda.Punboxedfloatarray _ | Lambda.Punboxedintarray _ ->
-    Guard
+    Dereference
 
 (* Expression judgment:
      G |- e : m


### PR DESCRIPTION
Before this PR, this program segfaults in bytecode and hits a middle-end assertion failure on flambda2:
```ocaml
let _ =
  let rec x = [| x |]; #42.0 in
  ();;
```
After this PR, it is correctly rejected by the typechecker.  The issue was introduced for arrays of unboxed types in #2185 and has a one line fix.  I can't imagine anyone would ever hit this in practice, I just noticed it while reading the mixed blocks PR (which also touches this file).

See upstream ocaml/ocaml#6939 for why we reject this - the same is done for normal float arrays.  While the program technically meets the criterea for being a sensible recursive definition, supporting it is hard.  