### PR TITLE
Fix `Mode.zap_to_floor` BUG

### DIFF
--- a/ocaml/lambda/translmode.ml
+++ b/ocaml/lambda/translmode.ml
@@ -24,8 +24,8 @@ let transl_locality_mode_l locality =
 
 let transl_locality_mode_r locality =
   (* r mode are for allocations; [optimise_allocations] should have pushed it
-     to ceil and determined. *)
-  Locality.check_const locality |> Option.get |> transl_locality_mode
+     to ceil and determined; here we push it again just to get the constant. *)
+  Locality.zap_to_ceil locality |> transl_locality_mode
 
 let transl_alloc_mode_l mode =
   (* we only take the locality axis *)

--- a/ocaml/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/ocaml/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -88,14 +88,14 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def>
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
-          value_mode global,many,shared
+          value_mode meet_local,once(0[global,many,global,many]),join_shared(1[shared,shared])
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
           region true
-          alloc_mode global,many,shared
+          alloc_mode map_comonadic(regional_to_global)(6[global,many,global,many]),id(7[shared,shared])
           []
           Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
-          alloc_mode global,many,shared
+          alloc_mode id(2[global,many,global,many]),id(3[shared,shared])
           value
             [
               <case>
@@ -110,11 +110,11 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
               <case>
                 pattern (test_locations.ml[19,572+4]..test_locations.ml[19,572+5])
                   Tpat_var "n"
-                  value_mode global,many,unique
+                  value_mode meet_global,many ∘ map_comonadic(local_to_regional)(2[global,many,global,many]),join_unique(3[shared,shared])
                 expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
                   Texp_apply
                   apply_mode Tail
-                  locality_mode global
+                  locality_mode proj_areality(10[global,many,global,many])
                   expression (test_locations.ml[19,572+21]..test_locations.ml[19,572+22])
                     Texp_ident "Stdlib!.+"
                   [
@@ -123,7 +123,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+20])
                         Texp_apply
                         apply_mode Default
-                        locality_mode global
+                        locality_mode proj_areality(4[global,many,global,many])
                         expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+12])
                           Texp_ident "fib"
                         [
@@ -132,7 +132,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression (test_locations.ml[19,572+13]..test_locations.ml[19,572+20])
                               Texp_apply
                               apply_mode Default
-                              locality_mode global
+                              locality_mode proj_areality(20[global,many,global,many])
                               expression (test_locations.ml[19,572+16]..test_locations.ml[19,572+17])
                                 Texp_ident "Stdlib!.-"
                               [
@@ -151,7 +151,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+34])
                         Texp_apply
                         apply_mode Default
-                        locality_mode global
+                        locality_mode proj_areality(4[global,many,global,many])
                         expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+26])
                           Texp_ident "fib"
                         [
@@ -160,7 +160,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression (test_locations.ml[19,572+27]..test_locations.ml[19,572+34])
                               Texp_apply
                               apply_mode Default
-                              locality_mode global
+                              locality_mode proj_areality(34[global,many,global,many])
                               expression (test_locations.ml[19,572+30]..test_locations.ml[19,572+31])
                                 Texp_ident "Stdlib!.-"
                               [

--- a/ocaml/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/ocaml/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -88,14 +88,14 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def>
         pattern 
           Tpat_var "fib"
-          value_mode global,many,shared
+          value_mode meet_local,once(0[global,many,global,many]),join_shared(1[shared,shared])
         expression 
           Texp_function
           region true
-          alloc_mode global,many,shared
+          alloc_mode map_comonadic(regional_to_global)(6[global,many,global,many]),id(7[shared,shared])
           []
           Tfunction_cases 
-          alloc_mode global,many,shared
+          alloc_mode id(2[global,many,global,many]),id(3[shared,shared])
           value
             [
               <case>
@@ -110,11 +110,11 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
               <case>
                 pattern 
                   Tpat_var "n"
-                  value_mode global,many,unique
+                  value_mode meet_global,many ∘ map_comonadic(local_to_regional)(2[global,many,global,many]),join_unique(3[shared,shared])
                 expression 
                   Texp_apply
                   apply_mode Tail
-                  locality_mode global
+                  locality_mode proj_areality(10[global,many,global,many])
                   expression 
                     Texp_ident "Stdlib!.+"
                   [
@@ -123,7 +123,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression 
                         Texp_apply
                         apply_mode Default
-                        locality_mode global
+                        locality_mode proj_areality(4[global,many,global,many])
                         expression 
                           Texp_ident "fib"
                         [
@@ -132,7 +132,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression 
                               Texp_apply
                               apply_mode Default
-                              locality_mode global
+                              locality_mode proj_areality(20[global,many,global,many])
                               expression 
                                 Texp_ident "Stdlib!.-"
                               [
@@ -151,7 +151,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression 
                         Texp_apply
                         apply_mode Default
-                        locality_mode global
+                        locality_mode proj_areality(4[global,many,global,many])
                         expression 
                           Texp_ident "fib"
                         [
@@ -160,7 +160,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression 
                               Texp_apply
                               apply_mode Default
-                              locality_mode global
+                              locality_mode proj_areality(34[global,many,global,many])
                               expression 
                                 Texp_ident "Stdlib!.-"
                               [

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -83,13 +83,11 @@ module type Common = sig
 
   val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
 
+  val print_raw :
+    ?verbose:bool -> unit -> Format.formatter -> ('l * 'r) t -> unit
+
   val print :
-    ?raw:bool ->
-    ?verbose:bool ->
-    unit ->
-    Format.formatter ->
-    ('l * 'r) t ->
-    unit
+    ?verbose:bool -> unit -> Format.formatter -> (allowed * allowed) t -> unit
 
   val zap_to_floor : (allowed * 'r) t -> Const.t
 
@@ -153,7 +151,7 @@ module type S = sig
 
     val zap_to_legacy : (allowed * 'r) t -> Const.t
 
-    val check_const : ('l * 'r) t -> Const.t option
+    val check_const : (allowed * allowed) t -> Const.t option
   end
 
   module Regionality : sig
@@ -258,22 +256,6 @@ module type S = sig
       (* No new types exposed to avoid too many type names *)
       include Allow_disallow with type (_, _, 'd) sided = 'd t list
     end
-
-    (* some overriding *)
-    val print :
-      ?raw:bool ->
-      ?verbose:bool ->
-      unit ->
-      Format.formatter ->
-      ('l * 'r) t ->
-      unit
-
-    val check_const :
-      ('l * 'r) t ->
-      ( Regionality.Const.t option,
-        Linearity.Const.t option,
-        Uniqueness.Const.t option )
-      modes
 
     val regionality : ('l * 'r) t -> ('l * 'r) Regionality.t
 
@@ -388,16 +370,7 @@ module type S = sig
          and type error := error
          and type 'd t := 'd t
 
-    (* some overriding *)
-    val print :
-      ?raw:bool ->
-      ?verbose:bool ->
-      unit ->
-      Format.formatter ->
-      ('l * 'r) t ->
-      unit
-
-    val check_const : ('l * 'r) t -> Const.Option.t
+    val check_const : (allowed * allowed) t -> Const.Option.t
 
     val locality : ('l * 'r) t -> ('l * 'r) Locality.t
 

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -390,16 +390,16 @@ and expression_extra i ppf x attrs =
       attributes i ppf attrs;
 
 and alloc_mode: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
-  = fun i ppf m -> line i ppf "alloc_mode %a\n" (Mode.Alloc.print ()) m
+  = fun i ppf m -> line i ppf "alloc_mode %a\n" (Mode.Alloc.print_raw ()) m
 
 and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
 
 and locality_mode i ppf m =
   line i ppf "locality_mode %a\n"
-    (Mode.Locality.print ()) m
+    (Mode.Locality.print_raw ()) m
 
 and value_mode i ppf m =
-  line i ppf "value_mode %a\n" (Mode.Value.print ()) m
+  line i ppf "value_mode %a\n" (Mode.Value.print_raw ()) m
 
 and expression_alloc_mode i ppf (expr, am) =
   alloc_mode i ppf am;

--- a/ocaml/typing/solver.ml
+++ b/ocaml/typing/solver.ml
@@ -176,7 +176,7 @@ module Solver_mono (C : Lattices_mono) = struct
   let print_raw :
       type a l r.
       ?verbose:bool -> a C.obj -> Format.formatter -> (a, l * r) mode -> unit =
-   fun ?(verbose = true) (obj : a C.obj) ppf m ->
+   fun ?(verbose = false) (obj : a C.obj) ppf m ->
     let traversed = if verbose then Some VarSet.empty else None in
     match m with
     | Amode a -> C.print obj ppf a
@@ -407,36 +407,32 @@ module Solver_mono (C : Lattices_mono) = struct
       | Ok () -> Ok ()
       | Error e -> Error (C.apply obj f e)
 
-  (** Zap the variable to its lower bound. Returns the [log] of the zapping, in
+  (** Zap [mv] to its lower bound. Returns the [log] of the zapping, in
       case the caller are only interested in the lower bound and wants to
       reverse the zapping.
 
-      As mentioned in [var], [v.lower] is not precise; to get the precise lower
-      bound of [v], we call [submode v v.lower]. This would call [submode u
-      v.lower] for every [u] in [v.vlower], which might fail because for some [u]
-      [u.lower] is more up-to-date than [v.lower]. In that case, we call
-      [submode v u.lower]. We repeat this process until no failure, and we will
-      get the precise lower bound.
+      As mentioned in [var], [mlower mv] is not precise; to get the precise
+      lower bound of [mv], we call [submode mv (mlower mv)]. This will propagate
+      to all its children, which might fail because some children's lower bound
+      [a] is more up-to-date than [mv]. In that case, we call [submode mv a]. We
+      repeat this process until no failure, and we will get the precise lower
+      bound.
 
       The loop is guaranteed to terminate, because for each iteration our
       guessed lower bound is strictly higher; and all lattices are finite.
       *)
-  let zap_to_floor_var_aux (type a) (obj : a C.obj) (v : a var) =
+  let zap_to_floor_morphvar_aux (type a r) (obj : a C.obj)
+      (mv : (a, allowed * r) morphvar) =
     let rec loop lower =
       let log = ref empty_changes in
-      let r = submode_vc ~log:(Some log) obj v lower in
+      let r = submode_mvc ~log:(Some log) obj mv lower in
       match r with
       | Ok () -> !log, lower
       | Error a ->
         undo_changes !log;
         loop (C.join obj a lower)
     in
-    loop v.lower
-
-  let zap_to_floor_morphvar_aux dst (Amorphvar (v, f)) =
-    let src = C.src dst f in
-    let log, lower = zap_to_floor_var_aux src v in
-    log, C.apply dst f lower
+    loop (mlower obj mv)
 
   let eq_morphvar :
       type a l0 r0 l1 r1. (a, l0 * r0) morphvar -> (a, l1 * r1) morphvar -> bool
@@ -633,38 +629,22 @@ module Solver_mono (C : Lattices_mono) = struct
           C.join obj acc (zap_to_floor_morphvar obj mv ~commit:log))
         a mvs
 
-  let check_const : type a l r. a C.obj -> (a, l * r) mode -> a option =
+  let check_const : type a. a C.obj -> (a, allowed * allowed) mode -> a option =
    fun obj m ->
     match m with
     | Amode a -> Some a
     | Amodevar mv ->
       let lower = zap_to_floor_morphvar obj mv ~commit:None in
       if C.le obj (mupper obj mv) lower then Some lower else None
-    | Amodemeet (a, mvs) ->
-      let upper =
-        List.fold_left (fun x mv -> C.meet obj x (mupper obj mv)) a mvs
-      in
-      let lower =
-        List.fold_left
-          (fun x mv -> C.meet obj x (zap_to_floor_morphvar obj mv ~commit:None))
-          a mvs
-      in
-      if C.le obj upper lower then Some upper else None
-    | Amodejoin (a, mvs) ->
-      let upper =
-        List.fold_left (fun x mv -> C.join obj x (mupper obj mv)) a mvs
-      in
-      let lower =
-        List.fold_left
-          (fun x mv -> C.join obj x (zap_to_floor_morphvar obj mv ~commit:None))
-          a mvs
-      in
-      if C.le obj upper lower then Some lower else None
 
   let print :
-      type a l r.
-      ?verbose:bool -> a C.obj -> Format.formatter -> (a, l * r) mode -> unit =
-   fun ?(verbose = true) obj ppf m ->
+      type a.
+      ?verbose:bool ->
+      a C.obj ->
+      Format.formatter ->
+      (a, allowed * allowed) mode ->
+      unit =
+   fun ?(verbose = false) obj ppf m ->
     print_raw obj ~verbose ppf
       (match check_const obj m with None -> m | Some a -> Amode a)
 

--- a/ocaml/typing/solver.ml
+++ b/ocaml/typing/solver.ml
@@ -533,8 +533,7 @@ module Solver_mono (C : Lattices_mono) = struct
                     mus)))
 
   let zap_to_ceil_morphvar obj mv ~log =
-    assert (
-      submode obj (Amode (mupper obj mv)) (Amodevar mv) ~log |> Result.is_ok);
+    assert (submode_cmv obj (mupper obj mv) mv ~log |> Result.is_ok);
     mupper obj mv
 
   let zap_to_ceil : type a l. a C.obj -> (a, l * allowed) mode -> log:_ -> a =

--- a/ocaml/typing/solver_intf.mli
+++ b/ocaml/typing/solver_intf.mli
@@ -271,16 +271,21 @@ module type Solver_polarized = sig
   (** Return the meet of the list of modes. *)
   val meet : 'a obj -> ('a, 'l * allowed) mode list -> ('a, right_only) mode
 
-  (** Checks if a mode has been constrained sufficiently to a constant.
-        Expensive.
+  (** Checks if a mode has been constrained sufficiently to a constant. Because
+      our internal representation is conservative, further constraint is run to
+      decide the bounds. This operation is therefore expensive and requires the
+      mode to be allowed on both sides.
       WARNING: the lattice must be finite for this to terminate.*)
-  val check_const : 'a obj -> ('a, 'l * 'r) mode -> 'a option
+  val check_const : 'a obj -> ('a, allowed * allowed) mode -> 'a option
 
-  (** Print a mode. Calls [check_const] for cleaner printing and thus
-    expensive.
-      WARNING: the lattice must be finite for this to terminate.*)
+  (** Print a mode. Calls [check_const] for cleaner printing; caveats there
+  apply here too. *)
   val print :
-    ?verbose:bool -> 'a obj -> Format.formatter -> ('a, 'l * 'r) mode -> unit
+    ?verbose:bool ->
+    'a obj ->
+    Format.formatter ->
+    ('a, allowed * allowed) mode ->
+    unit
 
   (** Print a mode without calling [check_const]. *)
   val print_raw :


### PR DESCRIPTION
(Based on #2388 , for easier rebasing).

Given `f v`, where `v` is a mode variable and `f` is a morphism, applying `zap_to_floor` will first apply `zap_to_floor` on `v` to get `a`, and then return `f a`.

This is wrong; in particular, if `f` is projection, we would be zapping the whole product to floor instead of just one axis. This wasn't triggering any issue, because for existing axes we want to zap them in the same direction anyway. This is no longer true as we introduce more axes with different legacy direction.

This isn't a soundness issue, as all mode constraints are still met.