### PR TITLE
Extensions universes

### DIFF
--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -504,7 +504,8 @@ let read_one_param ppf position name v =
 
   | "extension" -> Language_extension.enable_of_string_exn v
   | "disable-all-extensions" ->
-    if check_bool ppf name v then Language_extension.set_universe No_extensions
+    if check_bool ppf name v then
+      Language_extension.set_universe_and_enable_all No_extensions
 
   | _ ->
     if !warnings_for_discarded_params &&

--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -504,7 +504,7 @@ let read_one_param ppf position name v =
 
   | "extension" -> Language_extension.enable_of_string_exn v
   | "disable-all-extensions" ->
-    if check_bool ppf name v then Language_extension.disallow_extensions ()
+    if check_bool ppf name v then Language_extension.set_universe No_extensions
 
   | _ ->
     if !warnings_for_discarded_params &&

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -1749,7 +1749,7 @@ module Default = struct
     let _no_verbose_types = clear verbose_types
     let _disable_all_extensions = Language_extension.(fun () -> set_universe No_extensions)
     let _only_erasable_extensions =
-      Language_extension.restrict_to_erasable_extensions
+      Language_extension.(fun () -> set_universe Upstream_compatible)
     let _extension s = Language_extension.(enable_of_string_exn s)
     let _no_extension s = Language_extension.(disable_of_string_exn s)
     let _universe s = Language_extension.(set_universe_of_string_exn s)

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -660,7 +660,7 @@ let mk_no_extension f =
 
 let mk_disable_all_extensions f =
   "-disable-all-extensions", Arg.Unit f,
-  "  Legacy, use [-universe no_extensions].\n\
+  "  Legacy, use [-extension-universe no_extensions].\n\
   \    Disable all extensions, wherever they have been specified; this\n\
   \    flag overrides prior uses of the -extension flag, disables any\n\
   \    extensions that are enabled by default, and causes future uses of\n\
@@ -676,7 +676,7 @@ let mk_only_erasable_extensions f =
     String.concat ", "
   in
 "-only-erasable-extensions", Arg.Unit f,
-  " Legacy, use [-universe upstream_compatible].\n\
+  " Legacy, use [-extension-universe upstream_compatible].\n\
   \    Disable all extensions that cannot be \"erased\" to attributes,\n\
   \    wherever they have been specified; this flag overrides prior\n\
   \    contradictory uses of the -extension flag, raises an error on\n\
@@ -685,20 +685,14 @@ let mk_only_erasable_extensions f =
   \    (Erasable extensions: " ^ erasable_extensions ^ ")"
 ;;
 
-let mk_universe f =
-  let available_universes =
+let mk_extension_universe f =
+  let available_extension_universes =
     Language_extension.Universe.(List.map to_string all)
-  in
-  let descriptions = Language_extension.Universe.(List.map
-    (fun univ -> "      " ^ to_string univ ^ " - " ^ description univ) all)
-    |> String.concat "\n"
 in
-"-universe", Arg.Symbol (available_universes, f),
+"-extension-universe", Arg.Symbol (available_extension_universes, f),
   " Set the extension universe and enable all extensions in it. Each universe\n\
   \    allows a set of extensions, and every successive universe includes \n\
-  \    the previous one. Following universes exist:\n" ^ descriptions
-
-
+  \    the previous one."
 
 let mk_dump_dir f =
   "-dump-dir", Arg.String f,
@@ -885,7 +879,7 @@ module type Common_options = sig
   val _only_erasable_extensions : unit -> unit
   val _extension : string -> unit
   val _no_extension : string -> unit
-  val _universe : string -> unit
+  val _extension_universe : string -> unit
   val _noassert : unit -> unit
   val _nolabels : unit -> unit
   val _nostdlib : unit -> unit
@@ -1160,7 +1154,7 @@ struct
     mk_dtypes F._annot;
     mk_extension F._extension;
     mk_no_extension F._no_extension;
-    mk_universe F._universe;
+    mk_extension_universe F._extension_universe;
     mk_for_pack_byt F._for_pack;
     mk_g_byt F._g;
     mk_no_g F._no_g;
@@ -1281,7 +1275,7 @@ struct
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
     mk_no_extension F._no_extension;
-    mk_universe F._universe;
+    mk_extension_universe F._extension_universe;
     mk_noassert F._noassert;
     mk_noinit F._noinit;
     mk_nolabels F._nolabels;
@@ -1371,7 +1365,7 @@ struct
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
     mk_no_extension F._no_extension;
-    mk_universe F._universe;
+    mk_extension_universe F._extension_universe;
     mk_for_pack_opt F._for_pack;
     mk_g_opt F._g;
     mk_no_g F._no_g;
@@ -1551,7 +1545,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
     mk_no_extension F._no_extension;
-    mk_universe F._universe;
+    mk_extension_universe F._extension_universe;
     mk_no_float_const_prop F._no_float_const_prop;
     mk_noassert F._noassert;
     mk_noinit F._noinit;
@@ -1656,7 +1650,7 @@ struct
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
     mk_no_extension F._no_extension;
-    mk_universe F._universe;
+    mk_extension_universe F._extension_universe;
     mk_noassert F._noassert;
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
@@ -1765,7 +1759,7 @@ module Default = struct
         set_universe_and_enable_all Upstream_compatible)
     let _extension s = Language_extension.(enable_of_string_exn s)
     let _no_extension s = Language_extension.(disable_of_string_exn s)
-    let _universe s =
+    let _extension_universe s =
       Language_extension.(set_universe_and_enable_all_of_string_exn s)
     let _noassert = set noassert
     let _nolabels = set classic

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -694,7 +694,7 @@ let mk_universe f =
     |> String.concat "\n"
 in
 "-universe", Arg.Symbol (available_universes, f),
-  " Set the extension universe and enable all extensions in it. Each universe\
+  " Set the extension universe and enable all extensions in it. Each universe\n\
   \    allows a set of extensions, and every successive universe includes \n\
   \    the previous one. Following universes exist:\n" ^ descriptions
 

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -683,6 +683,13 @@ let mk_only_erasable_extensions f =
   \    (Erasable extensions: " ^ erasable_extensions ^ ")"
 ;;
 
+let mk_universe f =
+  let available_universes = Language_extension.Universe.(List.map to_string all)
+in
+"-universe", Arg.Symbol (available_universes, f),
+  " Universe"
+
+
 let mk_dump_dir f =
   "-dump-dir", Arg.String f,
   "<dir> dump output like -dlambda into <dir>/<target>.dump"
@@ -868,6 +875,7 @@ module type Common_options = sig
   val _only_erasable_extensions : unit -> unit
   val _extension : string -> unit
   val _no_extension : string -> unit
+  val _universe : string -> unit
   val _noassert : unit -> unit
   val _nolabels : unit -> unit
   val _nostdlib : unit -> unit
@@ -1142,6 +1150,7 @@ struct
     mk_dtypes F._annot;
     mk_extension F._extension;
     mk_no_extension F._no_extension;
+    mk_universe F._universe;
     mk_for_pack_byt F._for_pack;
     mk_g_byt F._g;
     mk_no_g F._no_g;
@@ -1262,6 +1271,7 @@ struct
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
     mk_no_extension F._no_extension;
+    mk_universe F._universe;
     mk_noassert F._noassert;
     mk_noinit F._noinit;
     mk_nolabels F._nolabels;
@@ -1351,6 +1361,7 @@ struct
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
     mk_no_extension F._no_extension;
+    mk_universe F._universe;
     mk_for_pack_opt F._for_pack;
     mk_g_opt F._g;
     mk_no_g F._no_g;
@@ -1530,6 +1541,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
     mk_no_extension F._no_extension;
+    mk_universe F._universe;
     mk_no_float_const_prop F._no_float_const_prop;
     mk_noassert F._noassert;
     mk_noinit F._noinit;
@@ -1634,6 +1646,7 @@ struct
     mk_only_erasable_extensions F._only_erasable_extensions;
     mk_extension F._extension;
     mk_no_extension F._no_extension;
+    mk_universe F._universe;
     mk_noassert F._noassert;
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
@@ -1739,6 +1752,7 @@ module Default = struct
       Language_extension.restrict_to_erasable_extensions
     let _extension s = Language_extension.(enable_of_string_exn s)
     let _no_extension s = Language_extension.(disable_of_string_exn s)
+    let _universe s = Language_extension.(set_universe_of_string_exn s)
     let _noassert = set noassert
     let _nolabels = set classic
     let _nostdlib = set no_std_include

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -660,7 +660,7 @@ let mk_no_extension f =
 
 let mk_disable_all_extensions f =
   "-disable-all-extensions", Arg.Unit f,
-  "  Legacy, use [-universe no_extensions].\n
+  "  Legacy, use [-universe no_extensions].\n\
   \    Disable all extensions, wherever they have been specified; this\n\
   \    flag overrides prior uses of the -extension flag, disables any\n\
   \    extensions that are enabled by default, and causes future uses of\n\
@@ -676,7 +676,7 @@ let mk_only_erasable_extensions f =
     String.concat ", "
   in
 "-only-erasable-extensions", Arg.Unit f,
-  " Legacy, use [-universe upstream_compatible].\n
+  " Legacy, use [-universe upstream_compatible].\n\
   \    Disable all extensions that cannot be \"erased\" to attributes,\n\
   \    wherever they have been specified; this flag overrides prior\n\
   \    contradictory uses of the -extension flag, raises an error on\n\
@@ -694,7 +694,7 @@ let mk_universe f =
     |> String.concat "\n"
 in
 "-universe", Arg.Symbol (available_universes, f),
-  " Set the extension universe and enable all extensions in it. Each universe
+  " Set the extension universe and enable all extensions in it. Each universe\
   \    allows a set of extensions, and every successive universe includes \n\
   \    the previous one. Following universes exist:\n" ^ descriptions
 

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -1747,7 +1747,7 @@ module Default = struct
     let _no_strict_sequence = clear strict_sequence
     let _no_unboxed_types = clear unboxed_types
     let _no_verbose_types = clear verbose_types
-    let _disable_all_extensions = Language_extension.disallow_extensions
+    let _disable_all_extensions = Language_extension.(fun () -> set_universe No_extensions)
     let _only_erasable_extensions =
       Language_extension.restrict_to_erasable_extensions
     let _extension s = Language_extension.(enable_of_string_exn s)

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -31,6 +31,7 @@ module type Common_options = sig
   val _only_erasable_extensions : unit -> unit
   val _extension : string -> unit
   val _no_extension : string -> unit
+  val _universe : string -> unit
   val _noassert : unit -> unit
   val _nolabels : unit -> unit
   val _nostdlib : unit -> unit

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -31,7 +31,7 @@ module type Common_options = sig
   val _only_erasable_extensions : unit -> unit
   val _extension : string -> unit
   val _no_extension : string -> unit
-  val _universe : string -> unit
+  val _extension_universe : string -> unit
   val _noassert : unit -> unit
   val _nolabels : unit -> unit
   val _nostdlib : unit -> unit

--- a/ocaml/driver/makedepend.ml
+++ b/ocaml/driver/makedepend.ml
@@ -665,7 +665,7 @@ let run_main argv =
     let program = Filename.basename Sys.argv.(0) in
     Compenv.parse_arguments (ref argv)
       (add_dep_arg (fun f -> Src (f, None))) program;
-    Language_extension.set_universe Alpha;
+    Language_extension.set_universe_and_enable_all Alpha;
     process_dep_args (List.rev !dep_args_rev);
     Compenv.readenv ppf Before_link;
     if !sort_files then sort_files_by_dependencies !files

--- a/ocaml/driver/makedepend.ml
+++ b/ocaml/driver/makedepend.ml
@@ -665,7 +665,8 @@ let run_main argv =
     let program = Filename.basename Sys.argv.(0) in
     Compenv.parse_arguments (ref argv)
       (add_dep_arg (fun f -> Src (f, None))) program;
-    Language_extension.set_universe_and_enable_all Alpha;
+    Language_extension.set_universe_and_enable_all
+      Language_extension.Universe.maximal;
     process_dep_args (List.rev !dep_args_rev);
     Compenv.readenv ppf Before_link;
     if !sort_files then sort_files_by_dependencies !files

--- a/ocaml/driver/makedepend.ml
+++ b/ocaml/driver/makedepend.ml
@@ -665,7 +665,7 @@ let run_main argv =
     let program = Filename.basename Sys.argv.(0) in
     Compenv.parse_arguments (ref argv)
       (add_dep_arg (fun f -> Src (f, None))) program;
-    Language_extension.enable_maximal ();
+    Language_extension.set_universe Alpha;
     process_dep_args (List.rev !dep_args_rev);
     Compenv.readenv ppf Before_link;
     if !sort_files then sort_files_by_dependencies !files

--- a/ocaml/manual/src/cmds/unified-options.etex
+++ b/ocaml/manual/src/cmds/unified-options.etex
@@ -902,9 +902,9 @@ extensions: ones that can be rewritten into attributes while still preserving
 the program's runtime input/output behavior.  Turns off currently-enabled
 non-erasable extensions when specified.  After this flag, specifying a
 non-erasable extension (even to disable it) will fail with an error.  This flag
-cannot be reversed, but it can be strengthened (by "-disable-all-extensions").
+cannot be reversed, but it can be strengthened (by "-universe no_extensions").
 
-\item[(JST) "-disable-all-extensions"]
+\item[(JST) "-universe no_extensions"]
 Disallow all language extensions moving forward, and turn off currently-enabled
 ones.  This makes "-extension" raise errors moving forwards.  This flag cannot
 be reversed.

--- a/ocaml/manual/src/cmds/unified-options.etex
+++ b/ocaml/manual/src/cmds/unified-options.etex
@@ -896,18 +896,20 @@ either with the same or a different language extension; is idempotent.
 Disable the specified \var{language-extension}.  Can be specified more than once,
 either with the same or a different language extension; is idempotent.
 
-\item[(JST) "-only-erasable-extensions"]
-Restricts the "-extension" option to work only with so-called ``erasable''
-extensions: ones that can be rewritten into attributes while still preserving
-the program's runtime input/output behavior.  Turns off currently-enabled
-non-erasable extensions when specified.  After this flag, specifying a
-non-erasable extension (even to disable it) will fail with an error.  This flag
-cannot be reversed, but it can be strengthened (by "-universe no_extensions").
+\item[(JST) "-universe" \var{universe}]
+Set the extension universe and enable all extensions in it. Each universe
+allows a set of extensions, and every successive universe includes
+the previous one. Following universes exist:
 
-\item[(JST) "-universe no_extensions"]
-Disallow all language extensions moving forward, and turn off currently-enabled
-ones.  This makes "-extension" raise errors moving forwards.  This flag cannot
-be reversed.
+\begin{options}
+\item[no_extensions] No extensions.
+\item[upstream_compatible] Extensions compatible with upstream OCaml,
+or erasable extensions.
+\item[stable] All stable extensions.
+\item[beta] All beta extensions.
+\item[Alpha] All alpha extensions.
+\end{options}
+
 
 \end{options}
 %

--- a/ocaml/manual/src/cmds/unified-options.etex
+++ b/ocaml/manual/src/cmds/unified-options.etex
@@ -907,7 +907,7 @@ the previous one. Following universes exist:
 or erasable extensions.
 \item[stable] All stable extensions.
 \item[beta] All beta extensions.
-\item[Alpha] All alpha extensions.
+\item[alpha] All alpha extensions.
 \end{options}
 
 

--- a/ocaml/manual/src/cmds/unified-options.etex
+++ b/ocaml/manual/src/cmds/unified-options.etex
@@ -896,7 +896,7 @@ either with the same or a different language extension; is idempotent.
 Disable the specified \var{language-extension}.  Can be specified more than once,
 either with the same or a different language extension; is idempotent.
 
-\item[(JST) "-universe" \var{universe}]
+\item[(JST) "-extension-universe" \var{universe}]
 Set the extension universe and enable all extensions in it. Each universe
 allows a set of extensions, and every successive universe includes
 the previous one. Following universes exist:

--- a/ocaml/ocamldoc/odoc.ml
+++ b/ocaml/ocamldoc/odoc.ml
@@ -18,7 +18,7 @@
 
 module M = Odoc_messages
 
-let () = Language_extension.set_universe Alpha
+let () = Language_extension.set_universe_and_enable_all Alpha
 
 (* we check if we must load a module given on the command line *)
 let arg_list = Array.to_list Sys.argv

--- a/ocaml/ocamldoc/odoc.ml
+++ b/ocaml/ocamldoc/odoc.ml
@@ -18,7 +18,7 @@
 
 module M = Odoc_messages
 
-let () = Language_extension.enable_maximal ()
+let () = Language_extension.set_universe Alpha
 
 (* we check if we must load a module given on the command line *)
 let arg_list = Array.to_list Sys.argv

--- a/ocaml/ocamldoc/odoc.ml
+++ b/ocaml/ocamldoc/odoc.ml
@@ -18,7 +18,8 @@
 
 module M = Odoc_messages
 
-let () = Language_extension.set_universe_and_enable_all Alpha
+let () = Language_extension.set_universe_and_enable_all
+  Language_extension.Universe.maximal
 
 (* we check if we must load a module given on the command line *)
 let arg_list = Array.to_list Sys.argv

--- a/ocaml/testsuite/tests/ast-invariants/test.ml
+++ b/ocaml/testsuite/tests/ast-invariants/test.ml
@@ -85,5 +85,5 @@ let rec walk dir =
     (Sys.readdir dir)
 
 let () =
-  Language_extension.enable_maximal ();
+  Language_extension.set_universe Alpha;
   walk root

--- a/ocaml/testsuite/tests/ast-invariants/test.ml
+++ b/ocaml/testsuite/tests/ast-invariants/test.ml
@@ -85,5 +85,6 @@ let rec walk dir =
     (Sys.readdir dir)
 
 let () =
-  Language_extension.set_universe_and_enable_all Alpha;
+  Language_extension.set_universe_and_enable_all
+    Language_extension.Universe.maximal;
   walk root

--- a/ocaml/testsuite/tests/ast-invariants/test.ml
+++ b/ocaml/testsuite/tests/ast-invariants/test.ml
@@ -85,5 +85,5 @@ let rec walk dir =
     (Sys.readdir dir)
 
 let () =
-  Language_extension.set_universe Alpha;
+  Language_extension.set_universe_and_enable_all Alpha;
   walk root

--- a/ocaml/testsuite/tests/ast-invariants/test.ml
+++ b/ocaml/testsuite/tests/ast-invariants/test.ml
@@ -82,7 +82,7 @@ let rec walk dir =
            else if Filename.check_suffix fn ".ml" then
              check_file Implem fn
        end)
-    (Sys.readdir dirz
+    (Sys.readdir dir)
 
 let () =
   Language_extension.set_universe_and_enable_all

--- a/ocaml/testsuite/tests/ast-invariants/test.ml
+++ b/ocaml/testsuite/tests/ast-invariants/test.ml
@@ -82,7 +82,7 @@ let rec walk dir =
            else if Filename.check_suffix fn ".ml" then
              check_file Implem fn
        end)
-    (Sys.readdir dir)
+    (Sys.readdir dirz
 
 let () =
   Language_extension.set_universe_and_enable_all

--- a/ocaml/testsuite/tests/language-extensions/language_extensions.ml
+++ b/ocaml/testsuite/tests/language-extensions/language_extensions.ml
@@ -50,11 +50,11 @@ let should_fail name f =
     | exception Arg.Bad msg -> "Failed as expected: " ^ msg)
 ;;
 
-let try_disallowing_extensions name =
+let try_setting_universe univ name =
   should_succeed
     name
-    "disallowing all extensions"
-    (fun () -> Language_extension.set_universe_and_enable_all No_extensions)
+    ("setting universe " ^ Language_extension.Universe.to_string univ)
+    (fun () -> Language_extension.set_universe_and_enable_all univ)
 ;;
 
 type goal = Fail | Succeed
@@ -63,14 +63,15 @@ let with_goal goal ~name ~what test = match goal with
   | Fail    -> should_fail    name      test
   | Succeed -> should_succeed name what test
 
-let when_disallowed goal f_str f =
+let when_universe univ goal f_str f =
   let can_or_can't = match goal with
     | Fail    -> "can't"
     | Succeed -> "can"
   in
   let f_code = "[" ^ f_str ^ "]" in
   with_goal goal
-    ~name:(can_or_can't ^ " call " ^ f_code ^ " when extensions are disallowed")
+    ~name:(can_or_can't ^ " call " ^ f_code ^ " when in universe "
+      ^ Language_extension.Universe.to_string univ)
     ~what:("redundantly calling " ^ f_code)
     (fun () -> f extension)
 ;;
@@ -174,38 +175,38 @@ report ~name:"Enable two layouts, in reverse order"
          then "Succeeded"
          else "Failed");;
 
-(* Test disallowing extensions *)
+(* Test [No_extension] universe. *)
 
-try_disallowing_extensions
-  "can disallow extensions while extensions are enabled";
+try_setting_universe No_extensions
+  "can set [No_extensions] while extensions are enabled";
 
-try_disallowing_extensions
-  "can disallow extensions while extensions are already disallowed";
+try_setting_universe No_extensions
+  "setting [No_extensions] is idempotent";
 
 (* Test that disallowing extensions prevents other functions from working *)
 
-when_disallowed Fail "set ~enabled:true"
+when_universe No_extensions Fail "set ~enabled:true"
   (Language_extension.set ~enabled:true);
 
-when_disallowed Succeed "set ~enabled:false"
+when_universe No_extensions Succeed "set ~enabled:false"
   (Language_extension.set ~enabled:false);
 
-when_disallowed Fail "enable"
+when_universe No_extensions Fail "enable"
   (fun x -> Language_extension.enable x ());
 
-when_disallowed Succeed "disable"
+when_universe No_extensions Succeed "disable"
   Language_extension.disable;
 
-when_disallowed Fail "with_set ~enabled:true"
+when_universe No_extensions Fail "with_set ~enabled:true"
   (Language_extension.with_set ~enabled:true |> lift_with);
 
-when_disallowed Succeed "with_set ~enabled:false"
+when_universe No_extensions Succeed "with_set ~enabled:false"
   (Language_extension.with_set ~enabled:false |> lift_with);
 
-when_disallowed Fail "with_enabled"
+when_universe No_extensions Fail "with_enabled"
   ((fun x -> Language_extension.with_enabled x ()) |> lift_with);
 
-when_disallowed Succeed "with_disabled"
+when_universe No_extensions Succeed "with_disabled"
   (Language_extension.with_disabled |> lift_with);
 
 (* Test explicitly (rather than just via [report]) that [is_enabled] returns
@@ -216,6 +217,38 @@ report
          if Language_extension.is_enabled extension
          then "INCORRECTLY enabled"
          else "correctly disabled");
+
+(* Test [Stable] universe. *)
+
+try_setting_universe Stable
+  "can set [Stable] while extensions are disabled";
+
+(* Test that some extensions work in [Stable] while others don't. *)
+
+when_universe Stable Succeed "Language_extension.(enable Layouts Stable)"
+  (fun _ -> Language_extension.(enable Layouts Stable));
+
+when_universe Stable Fail "Language_extension.(enable Comprehensions) "
+  (fun _ -> Language_extension.(enable Comprehensions ()));
+
+when_universe Stable Fail "Language_extension.(enable Layouts Alpha)"
+  (fun _ -> Language_extension.(enable Layouts Alpha));
+
+(* Test [Beta] universe. *)
+
+try_setting_universe Beta "can set [Beta] from [Stable]";
+
+(* Test that comprehensions is enabled by default in [Beta]: *)
+
+typecheck_with_extension "enabled via [Universe.set]";
+
+when_universe Stable Succeed "Language_extension.(enable Comprehensions) "
+  (fun _ -> Language_extension.(enable Comprehensions ()));
+
+(* Test that [Layouts Alpha] is still disabled. *)
+
+when_universe Stable Fail "Language_extension.(enable Layouts Alpha)"
+  (fun _ -> Language_extension.(enable Layouts Alpha));
 
 (* Test that language extensions round-trip via string *)
 List.iter

--- a/ocaml/testsuite/tests/language-extensions/language_extensions.ml
+++ b/ocaml/testsuite/tests/language-extensions/language_extensions.ml
@@ -54,7 +54,7 @@ let try_disallowing_extensions name =
   should_succeed
     name
     "disallowing all extensions"
-    (fun () -> Language_extension.set_universe No_extensions)
+    (fun () -> Language_extension.set_universe_and_enable_all No_extensions)
 ;;
 
 type goal = Fail | Succeed

--- a/ocaml/testsuite/tests/language-extensions/language_extensions.ml
+++ b/ocaml/testsuite/tests/language-extensions/language_extensions.ml
@@ -54,7 +54,7 @@ let try_disallowing_extensions name =
   should_succeed
     name
     "disallowing all extensions"
-    Language_extension.disallow_extensions
+    (fun () -> Language_extension.set_universe No_extensions)
 ;;
 
 type goal = Fail | Succeed

--- a/ocaml/testsuite/tests/language-extensions/language_extensions.reference
+++ b/ocaml/testsuite/tests/language-extensions/language_extensions.reference
@@ -68,25 +68,25 @@ Succeeded at setting universe no_extensions
 Succeeded at setting universe no_extensions
 
 # can't call [set ~enabled:true] when in universe no_extensions [comprehensions disabled]:
-Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
+Failed as expected: Cannot enable extension comprehensions: incompatible with flag -extension-universe no_extensions
 
 # can call [set ~enabled:false] when in universe no_extensions [comprehensions disabled]:
 Succeeded at redundantly calling [set ~enabled:false]
 
 # can't call [enable] when in universe no_extensions [comprehensions disabled]:
-Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
+Failed as expected: Cannot enable extension comprehensions: incompatible with flag -extension-universe no_extensions
 
 # can call [disable] when in universe no_extensions [comprehensions disabled]:
 Succeeded at redundantly calling [disable]
 
 # can't call [with_set ~enabled:true] when in universe no_extensions [comprehensions disabled]:
-Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
+Failed as expected: Cannot enable extension comprehensions: incompatible with flag -extension-universe no_extensions
 
 # can call [with_set ~enabled:false] when in universe no_extensions [comprehensions disabled]:
 Succeeded at redundantly calling [with_set ~enabled:false]
 
 # can't call [with_enabled] when in universe no_extensions [comprehensions disabled]:
-Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
+Failed as expected: Cannot enable extension comprehensions: incompatible with flag -extension-universe no_extensions
 
 # can call [with_disabled] when in universe no_extensions [comprehensions disabled]:
 Succeeded at redundantly calling [with_disabled]
@@ -101,10 +101,10 @@ Succeeded at setting universe stable
 Succeeded at redundantly calling [Language_extension.(enable Layouts Stable)]
 
 # can't call [Language_extension.(enable Comprehensions) ] when in universe stable [comprehensions disabled]:
-Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe stable
+Failed as expected: Cannot enable extension comprehensions: incompatible with flag -extension-universe stable
 
 # can't call [Language_extension.(enable Layouts Alpha)] when in universe stable [comprehensions disabled]:
-Failed as expected: Cannot enable extension layouts_alpha: incompatible with flag -universe stable
+Failed as expected: Cannot enable extension layouts_alpha: incompatible with flag -extension-universe stable
 
 # can set [Beta] from [Stable] [comprehensions enabled]:
 Succeeded at setting universe beta
@@ -116,5 +116,5 @@ Successfully typechecked "[x for x = 1 to 10]"
 Succeeded at redundantly calling [Language_extension.(enable Comprehensions) ]
 
 # can't call [Language_extension.(enable Layouts Alpha)] when in universe stable [comprehensions enabled]:
-Failed as expected: Cannot enable extension layouts_alpha: incompatible with flag -universe beta
+Failed as expected: Cannot enable extension layouts_alpha: incompatible with flag -extension-universe beta
 

--- a/ocaml/testsuite/tests/language-extensions/language_extensions.reference
+++ b/ocaml/testsuite/tests/language-extensions/language_extensions.reference
@@ -61,36 +61,60 @@ Succeeded
 # Enable two layouts, in reverse order [comprehensions enabled]:
 Succeeded
 
-# can disallow extensions while extensions are enabled [comprehensions disabled]:
-Succeeded at disallowing all extensions
+# can set [No_extensions] while extensions are enabled [comprehensions disabled]:
+Succeeded at setting universe no_extensions
 
-# can disallow extensions while extensions are already disallowed [comprehensions disabled]:
-Succeeded at disallowing all extensions
+# setting [No_extensions] is idempotent [comprehensions disabled]:
+Succeeded at setting universe no_extensions
 
-# can't call [set ~enabled:true] when extensions are disallowed [comprehensions disabled]:
+# can't call [set ~enabled:true] when in universe no_extensions [comprehensions disabled]:
 Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
 
-# can call [set ~enabled:false] when extensions are disallowed [comprehensions disabled]:
+# can call [set ~enabled:false] when in universe no_extensions [comprehensions disabled]:
 Succeeded at redundantly calling [set ~enabled:false]
 
-# can't call [enable] when extensions are disallowed [comprehensions disabled]:
+# can't call [enable] when in universe no_extensions [comprehensions disabled]:
 Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
 
-# can call [disable] when extensions are disallowed [comprehensions disabled]:
+# can call [disable] when in universe no_extensions [comprehensions disabled]:
 Succeeded at redundantly calling [disable]
 
-# can't call [with_set ~enabled:true] when extensions are disallowed [comprehensions disabled]:
+# can't call [with_set ~enabled:true] when in universe no_extensions [comprehensions disabled]:
 Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
 
-# can call [with_set ~enabled:false] when extensions are disallowed [comprehensions disabled]:
+# can call [with_set ~enabled:false] when in universe no_extensions [comprehensions disabled]:
 Succeeded at redundantly calling [with_set ~enabled:false]
 
-# can't call [with_enabled] when extensions are disallowed [comprehensions disabled]:
+# can't call [with_enabled] when in universe no_extensions [comprehensions disabled]:
 Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
 
-# can call [with_disabled] when extensions are disallowed [comprehensions disabled]:
+# can call [with_disabled] when in universe no_extensions [comprehensions disabled]:
 Succeeded at redundantly calling [with_disabled]
 
 # [is_enabled] returns [false] when extensions are disallowed [comprehensions disabled]:
 "comprehensions" is correctly disabled
+
+# can set [Stable] while extensions are disabled [comprehensions disabled]:
+Succeeded at setting universe stable
+
+# can call [Language_extension.(enable Layouts Stable)] when in universe stable [comprehensions disabled]:
+Succeeded at redundantly calling [Language_extension.(enable Layouts Stable)]
+
+# can't call [Language_extension.(enable Comprehensions) ] when in universe stable [comprehensions disabled]:
+Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe stable
+
+# can't call [Language_extension.(enable Layouts Alpha)] when in universe stable [comprehensions disabled]:
+Failed as expected: Cannot enable extension layouts_alpha: incompatible with flag -universe stable
+
+# can set [Beta] from [Stable] [comprehensions enabled]:
+Succeeded at setting universe beta
+
+# "comprehensions" extension enabled via [Universe.set] [comprehensions enabled]:
+Successfully typechecked "[x for x = 1 to 10]"
+
+# can call [Language_extension.(enable Comprehensions) ] when in universe stable [comprehensions enabled]:
+Succeeded at redundantly calling [Language_extension.(enable Comprehensions) ]
+
+# can't call [Language_extension.(enable Layouts Alpha)] when in universe stable [comprehensions enabled]:
+Failed as expected: Cannot enable extension layouts_alpha: incompatible with flag -universe beta
 

--- a/ocaml/testsuite/tests/language-extensions/language_extensions.reference
+++ b/ocaml/testsuite/tests/language-extensions/language_extensions.reference
@@ -68,25 +68,25 @@ Succeeded at disallowing all extensions
 Succeeded at disallowing all extensions
 
 # can't call [set ~enabled:true] when extensions are disallowed [comprehensions disabled]:
-Failed as expected: Cannot enable extension comprehensions: incompatible with flag -disable-all-extensions
+Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
 
 # can call [set ~enabled:false] when extensions are disallowed [comprehensions disabled]:
 Succeeded at redundantly calling [set ~enabled:false]
 
 # can't call [enable] when extensions are disallowed [comprehensions disabled]:
-Failed as expected: Cannot enable extension comprehensions: incompatible with flag -disable-all-extensions
+Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
 
 # can call [disable] when extensions are disallowed [comprehensions disabled]:
 Succeeded at redundantly calling [disable]
 
 # can't call [with_set ~enabled:true] when extensions are disallowed [comprehensions disabled]:
-Failed as expected: Cannot enable extension comprehensions: incompatible with flag -disable-all-extensions
+Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
 
 # can call [with_set ~enabled:false] when extensions are disallowed [comprehensions disabled]:
 Succeeded at redundantly calling [with_set ~enabled:false]
 
 # can't call [with_enabled] when extensions are disallowed [comprehensions disabled]:
-Failed as expected: Cannot enable extension comprehensions: incompatible with flag -disable-all-extensions
+Failed as expected: Cannot enable extension comprehensions: incompatible with flag -universe no_extensions
 
 # can call [with_disabled] when extensions are disallowed [comprehensions disabled]:
 Succeeded at redundantly calling [with_disabled]

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -6,7 +6,7 @@
 (******************************************************************************)
 (* Setup *)
 
-let () = Language_extension.set_universe Alpha;;
+let () = Language_extension.set_universe_and_enable_all Alpha;;
 
 module Example = struct
   open Parsetree
@@ -182,7 +182,7 @@ module _ =
   Print_all
     (struct
       let name = "All extensions enabled"
-      let setup () = Language_extension.set_universe Alpha
+      let setup () = Language_extension.set_universe_and_enable_all Alpha
     end)
     ()
 ;;
@@ -194,7 +194,7 @@ module _ =
   Print_all
     (struct
       let name = "Extensions disallowed"
-      let setup () = Language_extension.set_universe No_extensions
+      let setup () = Language_extension.set_universe_and_enable_all No_extensions
     end)
     ()
 ;;

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -183,7 +183,8 @@ module _ =
   Print_all
     (struct
       let name = "All extensions enabled"
-      let setup () = Language_extension.set_universe_and_enable_all Language_extension.Universe.maximal
+      let setup () = Language_extension.set_universe_and_enable_all
+        Language_extension.Universe.maximal
     end)
     ()
 ;;

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -6,7 +6,7 @@
 (******************************************************************************)
 (* Setup *)
 
-let () = Language_extension.enable_maximal ();;
+let () = Language_extension.set_universe Alpha;;
 
 module Example = struct
   open Parsetree
@@ -182,7 +182,7 @@ module _ =
   Print_all
     (struct
       let name = "All extensions enabled"
-      let setup () = Language_extension.enable_maximal ()
+      let setup () = Language_extension.set_universe Alpha
     end)
     ()
 ;;
@@ -194,7 +194,7 @@ module _ =
   Print_all
     (struct
       let name = "Extensions disallowed"
-      let setup () = Language_extension.disallow_extensions ()
+      let setup () = Language_extension.set_universe No_extensions
     end)
     ()
 ;;

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -6,7 +6,8 @@
 (******************************************************************************)
 (* Setup *)
 
-let () = Language_extension.set_universe_and_enable_all Alpha;;
+let () = Language_extension.set_universe_and_enable_all
+  Language_extension.Universe.maximal;;
 
 module Example = struct
   open Parsetree
@@ -182,7 +183,7 @@ module _ =
   Print_all
     (struct
       let name = "All extensions enabled"
-      let setup () = Language_extension.set_universe_and_enable_all Alpha
+      let setup () = Language_extension.set_universe_and_enable_all Language_extension.Universe.maximal
     end)
     ()
 ;;

--- a/ocaml/testsuite/tests/parsetree/ppx_no_op.ml
+++ b/ocaml/testsuite/tests/parsetree/ppx_no_op.ml
@@ -3,6 +3,7 @@ open Ast_mapper
 (* This PPX rewriter does nothing. *)
 
 let () =
-  Language_extension.set_universe_and_enable_all Alpha;
+  Language_extension.set_universe_and_enable_all
+    Language_extension.Universe.maximal;
   Ast_mapper.register "no-op" (fun _ -> Ast_mapper.default_mapper);
 ;;

--- a/ocaml/testsuite/tests/parsetree/ppx_no_op.ml
+++ b/ocaml/testsuite/tests/parsetree/ppx_no_op.ml
@@ -3,6 +3,6 @@ open Ast_mapper
 (* This PPX rewriter does nothing. *)
 
 let () =
-  Language_extension.set_universe Alpha;
+  Language_extension.set_universe_and_enable_all Alpha;
   Ast_mapper.register "no-op" (fun _ -> Ast_mapper.default_mapper);
 ;;

--- a/ocaml/testsuite/tests/parsetree/ppx_no_op.ml
+++ b/ocaml/testsuite/tests/parsetree/ppx_no_op.ml
@@ -3,6 +3,6 @@ open Ast_mapper
 (* This PPX rewriter does nothing. *)
 
 let () =
-  Language_extension.enable_maximal ();
+  Language_extension.set_universe Alpha;
   Ast_mapper.register "no-op" (fun _ -> Ast_mapper.default_mapper);
 ;;

--- a/ocaml/testsuite/tests/parsetree/test.ml
+++ b/ocaml/testsuite/tests/parsetree/test.ml
@@ -170,7 +170,8 @@ let check_all_ast_attributes_and_extensions_start_with raw_parsetree_str ~prefix
 
 let () =
   process "source.ml";
-  Language_extension.set_universe_and_enable_all Alpha;
+  Language_extension.set_universe_and_enable_all
+    Language_extension.Universe.maximal;
   process "source_jane_street.ml" ~extra_checks:(fun raw_parsetree_str text ->
   (* Additionally check that:
 

--- a/ocaml/testsuite/tests/parsetree/test.ml
+++ b/ocaml/testsuite/tests/parsetree/test.ml
@@ -170,7 +170,7 @@ let check_all_ast_attributes_and_extensions_start_with raw_parsetree_str ~prefix
 
 let () =
   process "source.ml";
-  Language_extension.set_universe Alpha;
+  Language_extension.set_universe_and_enable_all Alpha;
   process "source_jane_street.ml" ~extra_checks:(fun raw_parsetree_str text ->
   (* Additionally check that:
 

--- a/ocaml/testsuite/tests/parsetree/test.ml
+++ b/ocaml/testsuite/tests/parsetree/test.ml
@@ -170,7 +170,7 @@ let check_all_ast_attributes_and_extensions_start_with raw_parsetree_str ~prefix
 
 let () =
   process "source.ml";
-  Language_extension.enable_maximal ();
+  Language_extension.set_universe Alpha;
   process "source_jane_street.ml" ~extra_checks:(fun raw_parsetree_str text ->
   (* Additionally check that:
 

--- a/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.ml
@@ -12,9 +12,9 @@
    ** bytecode
      flags = "-extension layouts_beta"
    ** native
-     flags = "-only-erasable-extensions"
+     flags = "-universe upstream_compatible"
    ** bytecode
-     flags = "-only-erasable-extensions"
+     flags = "-universe upstream_compatible"
    ** setup-ocamlc.byte-build-env
      ocamlc_byte_exit_status = "2"
    *** ocamlc.byte

--- a/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.ml
@@ -12,13 +12,13 @@
    ** bytecode
      flags = "-extension layouts_beta"
    ** native
-     flags = "-universe upstream_compatible"
+     flags = "-extension-universe upstream_compatible"
    ** bytecode
-     flags = "-universe upstream_compatible"
+     flags = "-extension-universe upstream_compatible"
    ** setup-ocamlc.byte-build-env
      ocamlc_byte_exit_status = "2"
    *** ocamlc.byte
-     flags = "-universe no_extensions"
+     flags = "-extension-universe no_extensions"
      compiler_reference = "${test_source_directory}/unboxed_floats_disabled.compilers.reference"
    **** check-ocamlc.byte-output
 *)

--- a/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats.ml
@@ -18,7 +18,7 @@
    ** setup-ocamlc.byte-build-env
      ocamlc_byte_exit_status = "2"
    *** ocamlc.byte
-     flags = "-disable-all-extensions"
+     flags = "-universe no_extensions"
      compiler_reference = "${test_source_directory}/unboxed_floats_disabled.compilers.reference"
    **** check-ocamlc.byte-output
 *)

--- a/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -22,8 +22,8 @@ end;;
 Line 2, characters 2-52:
 2 |   val f_immediate : ('a : immediate). 'a -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Usage of layout immediate/immediate64 in f_immediate can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f_immediate can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -33,8 +33,8 @@ end;;
 Line 2, characters 2-48:
 2 |   val f_immediate : ('a : immediate) -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Usage of layout immediate/immediate64 in f_immediate can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f_immediate can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -44,8 +44,8 @@ end;;
 Line 2, characters 2-25:
 2 |   type ('a : immediate) t
       ^^^^^^^^^^^^^^^^^^^^^^^
-Error: Usage of layout immediate/immediate64 in t can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in t can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -55,8 +55,8 @@ end;;
 Line 2, characters 2-43:
 2 |   type _ g = | MkG : ('a : immediate). 'a g
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Usage of layout immediate/immediate64 in g can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in g can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f (type a : immediate): a -> a = fun x -> x
@@ -64,8 +64,8 @@ let f (type a : immediate): a -> a = fun x -> x
 Line 1, characters 4-5:
 1 | let f (type a : immediate): a -> a = fun x -> x
         ^
-Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f x = (x : (_ : immediate))
@@ -73,8 +73,8 @@ let f x = (x : (_ : immediate))
 Line 1, characters 4-5:
 1 | let f x = (x : (_ : immediate))
         ^
-Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f v: ((_ : immediate)[@error_message "Custom message"]) = v
@@ -82,8 +82,8 @@ let f v: ((_ : immediate)[@error_message "Custom message"]) = v
 Line 1, characters 4-5:
 1 | let f v: ((_ : immediate)[@error_message "Custom message"]) = v
         ^
-Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 (* immediate64 *)
@@ -94,8 +94,8 @@ end;;
 Line 2, characters 2-56:
 2 |   val f_immediate64 : ('a : immediate64). 'a -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Usage of layout immediate/immediate64 in f_immediate64 can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f_immediate64 can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -105,8 +105,8 @@ end;;
 Line 2, characters 2-52:
 2 |   val f_immediate64 : ('a : immediate64) -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Usage of layout immediate/immediate64 in f_immediate64 can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f_immediate64 can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -116,8 +116,8 @@ end;;
 Line 2, characters 2-27:
 2 |   type ('a : immediate64) t
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Usage of layout immediate/immediate64 in t can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in t can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -127,8 +127,8 @@ end;;
 Line 2, characters 2-45:
 2 |   type _ g = | MkG : ('a : immediate64). 'a g
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Usage of layout immediate/immediate64 in g can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in g can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f (type a : immediate64): a -> a = fun x -> x
@@ -136,8 +136,8 @@ let f (type a : immediate64): a -> a = fun x -> x
 Line 1, characters 4-5:
 1 | let f (type a : immediate64): a -> a = fun x -> x
         ^
-Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f x = (x : (_ : immediate64))
@@ -145,8 +145,8 @@ let f x = (x : (_ : immediate64))
 Line 1, characters 4-5:
 1 | let f x = (x : (_ : immediate64))
         ^
-Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
@@ -154,8 +154,8 @@ let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
 Line 1, characters 4-5:
 1 | let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
         ^
-Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 (* CR layouts: This message should change after we fix the package hack.
@@ -173,8 +173,8 @@ module type S = sig type t : immediate64 end
 Line 6, characters 2-49:
 6 |   val f : 'a -> (module S with type t = 'a) -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 (* Annotations here do nothing and should be accepted *)
@@ -197,8 +197,8 @@ end
 Line 3, characters 2-42:
 3 |   val f : ('a id as (_ : immediate)) -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
+Error: Usage of layout immediate/immediate64 in f can't be erased for compatibility with upstream OCaml.
+        This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 (* Other annotations are not effected by this flag *)
@@ -264,7 +264,7 @@ Line 1, characters 30-36:
 1 | external f_1 : int -> bool -> int64# = "foo" "bar";;
                                   ^^^^^^
 Error: [@unboxed] attribute must be added to external declaration
-       argument type with layout bits64. This error is produced
+       argument type with layout bits64 for upstream compatibility. This error is produced
        due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
@@ -274,7 +274,7 @@ Line 1, characters 15-21:
 1 | external f_2 : int32# -> bool -> int = "foo" "bar";;
                    ^^^^^^
 Error: [@unboxed] attribute must be added to external declaration
-       argument type with layout bits32. This error is produced
+       argument type with layout bits32 for upstream compatibility. This error is produced
        due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
@@ -352,7 +352,7 @@ Line 7, characters 15-18:
 7 | external f_1 : M.t -> M.t = "%identity";;
                    ^^^
 Error: [@unboxed] attribute must be added to external declaration
-       argument type with layout float64. This error is produced
+       argument type with layout float64 for upstream compatibility. This error is produced
        due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -1,6 +1,6 @@
 (* TEST
    * expect
-   flags = "-only-erasable-extensions"
+   flags = "-universe upstream_compatible"
 *)
 
 (* Upstream compatible usages of immediate/immediate64 are allowed *)
@@ -23,7 +23,7 @@ Line 2, characters 2-52:
 2 |   val f_immediate : ('a : immediate). 'a -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f_immediate can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -34,7 +34,7 @@ Line 2, characters 2-48:
 2 |   val f_immediate : ('a : immediate) -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f_immediate can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -45,7 +45,7 @@ Line 2, characters 2-25:
 2 |   type ('a : immediate) t
       ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in t can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -56,7 +56,7 @@ Line 2, characters 2-43:
 2 |   type _ g = | MkG : ('a : immediate). 'a g
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in g can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 let f (type a : immediate): a -> a = fun x -> x
@@ -65,7 +65,7 @@ Line 1, characters 4-5:
 1 | let f (type a : immediate): a -> a = fun x -> x
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 let f x = (x : (_ : immediate))
@@ -74,7 +74,7 @@ Line 1, characters 4-5:
 1 | let f x = (x : (_ : immediate))
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 let f v: ((_ : immediate)[@error_message "Custom message"]) = v
@@ -83,7 +83,7 @@ Line 1, characters 4-5:
 1 | let f v: ((_ : immediate)[@error_message "Custom message"]) = v
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 (* immediate64 *)
@@ -95,7 +95,7 @@ Line 2, characters 2-56:
 2 |   val f_immediate64 : ('a : immediate64). 'a -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f_immediate64 can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -106,7 +106,7 @@ Line 2, characters 2-52:
 2 |   val f_immediate64 : ('a : immediate64) -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f_immediate64 can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -117,7 +117,7 @@ Line 2, characters 2-27:
 2 |   type ('a : immediate64) t
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in t can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -128,7 +128,7 @@ Line 2, characters 2-45:
 2 |   type _ g = | MkG : ('a : immediate64). 'a g
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in g can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 let f (type a : immediate64): a -> a = fun x -> x
@@ -137,7 +137,7 @@ Line 1, characters 4-5:
 1 | let f (type a : immediate64): a -> a = fun x -> x
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 let f x = (x : (_ : immediate64))
@@ -146,7 +146,7 @@ Line 1, characters 4-5:
 1 | let f x = (x : (_ : immediate64))
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
@@ -155,11 +155,11 @@ Line 1, characters 4-5:
 1 | let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 (* CR layouts: This message should change after we fix the package hack.
-   But it should still be an error under [-only-erasable-extensions]. *)
+   But it should still be an error under [-universe upstream_compatible]. *)
 module type S = sig
   type t[@@immediate64]
 end
@@ -174,7 +174,7 @@ Line 6, characters 2-49:
 6 |   val f : 'a -> (module S with type t = 'a) -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 (* Annotations here do nothing and should be accepted *)
@@ -198,7 +198,7 @@ Line 3, characters 2-42:
 3 |   val f : ('a id as (_ : immediate)) -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -only-erasable-extensions.
+       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 (* Other annotations are not effected by this flag *)
@@ -265,7 +265,7 @@ Line 1, characters 30-36:
                                   ^^^^^^
 Error: [@unboxed] attribute must be added to external declaration
        argument type with layout bits64. This error is produced
-       due to the use of -only-erasable-extensions.
+       due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 external f_2 : int32# -> bool -> int = "foo" "bar";;
@@ -275,7 +275,7 @@ Line 1, characters 15-21:
                    ^^^^^^
 Error: [@unboxed] attribute must be added to external declaration
        argument type with layout bits32. This error is produced
-       due to the use of -only-erasable-extensions.
+       due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 external f_3 : (float#[@unboxed]) -> bool -> string  = "foo" "bar";;
@@ -353,7 +353,7 @@ Line 7, characters 15-18:
                    ^^^
 Error: [@unboxed] attribute must be added to external declaration
        argument type with layout float64. This error is produced
-       due to the use of -only-erasable-extensions.
+       due to the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 external f_2 : M.t -> M.t = "%identity" [@@unboxed];;
@@ -365,7 +365,7 @@ Error: External declaration here is not upstream compatible.
        The only types with non-value layouts allowed are float#,
        int32#, int64#, and nativeint#. Unknown type with layout
        float64 encountered. This error is produced due to
-       the use of -only-erasable-extensions.
+       the use of -universe (no_extensions|upstream_compatible).
 |}];;
 
 module M2 : sig

--- a/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -1,6 +1,6 @@
 (* TEST
    * expect
-   flags = "-universe upstream_compatible"
+   flags = "-extension-universe upstream_compatible"
 *)
 
 (* Upstream compatible usages of immediate/immediate64 are allowed *)
@@ -23,7 +23,7 @@ Line 2, characters 2-52:
 2 |   val f_immediate : ('a : immediate). 'a -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f_immediate can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -34,7 +34,7 @@ Line 2, characters 2-48:
 2 |   val f_immediate : ('a : immediate) -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f_immediate can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -45,7 +45,7 @@ Line 2, characters 2-25:
 2 |   type ('a : immediate) t
       ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in t can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -56,7 +56,7 @@ Line 2, characters 2-43:
 2 |   type _ g = | MkG : ('a : immediate). 'a g
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in g can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f (type a : immediate): a -> a = fun x -> x
@@ -65,7 +65,7 @@ Line 1, characters 4-5:
 1 | let f (type a : immediate): a -> a = fun x -> x
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f x = (x : (_ : immediate))
@@ -74,7 +74,7 @@ Line 1, characters 4-5:
 1 | let f x = (x : (_ : immediate))
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f v: ((_ : immediate)[@error_message "Custom message"]) = v
@@ -83,7 +83,7 @@ Line 1, characters 4-5:
 1 | let f v: ((_ : immediate)[@error_message "Custom message"]) = v
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 (* immediate64 *)
@@ -95,7 +95,7 @@ Line 2, characters 2-56:
 2 |   val f_immediate64 : ('a : immediate64). 'a -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f_immediate64 can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -106,7 +106,7 @@ Line 2, characters 2-52:
 2 |   val f_immediate64 : ('a : immediate64) -> 'a -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f_immediate64 can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -117,7 +117,7 @@ Line 2, characters 2-27:
 2 |   type ('a : immediate64) t
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in t can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module type S = sig
@@ -128,7 +128,7 @@ Line 2, characters 2-45:
 2 |   type _ g = | MkG : ('a : immediate64). 'a g
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in g can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f (type a : immediate64): a -> a = fun x -> x
@@ -137,7 +137,7 @@ Line 1, characters 4-5:
 1 | let f (type a : immediate64): a -> a = fun x -> x
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f x = (x : (_ : immediate64))
@@ -146,7 +146,7 @@ Line 1, characters 4-5:
 1 | let f x = (x : (_ : immediate64))
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
@@ -155,11 +155,11 @@ Line 1, characters 4-5:
 1 | let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
         ^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 (* CR layouts: This message should change after we fix the package hack.
-   But it should still be an error under [-universe upstream_compatible]. *)
+   But it should still be an error under [-extension-universe upstream_compatible]. *)
 module type S = sig
   type t[@@immediate64]
 end
@@ -174,7 +174,7 @@ Line 6, characters 2-49:
 6 |   val f : 'a -> (module S with type t = 'a) -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 (* Annotations here do nothing and should be accepted *)
@@ -198,7 +198,7 @@ Line 3, characters 2-42:
 3 |   val f : ('a id as (_ : immediate)) -> 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Usage of layout immediate/immediate64 in f can't be erased.
-       This error is produced due to the use of -universe (no_extensions|upstream_compatible).
+       This error is produced due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 (* Other annotations are not effected by this flag *)
@@ -265,7 +265,7 @@ Line 1, characters 30-36:
                                   ^^^^^^
 Error: [@unboxed] attribute must be added to external declaration
        argument type with layout bits64. This error is produced
-       due to the use of -universe (no_extensions|upstream_compatible).
+       due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 external f_2 : int32# -> bool -> int = "foo" "bar";;
@@ -275,7 +275,7 @@ Line 1, characters 15-21:
                    ^^^^^^
 Error: [@unboxed] attribute must be added to external declaration
        argument type with layout bits32. This error is produced
-       due to the use of -universe (no_extensions|upstream_compatible).
+       due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 external f_3 : (float#[@unboxed]) -> bool -> string  = "foo" "bar";;
@@ -353,7 +353,7 @@ Line 7, characters 15-18:
                    ^^^
 Error: [@unboxed] attribute must be added to external declaration
        argument type with layout float64. This error is produced
-       due to the use of -universe (no_extensions|upstream_compatible).
+       due to the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 external f_2 : M.t -> M.t = "%identity" [@@unboxed];;
@@ -365,7 +365,7 @@ Error: External declaration here is not upstream compatible.
        The only types with non-value layouts allowed are float#,
        int32#, int64#, and nativeint#. Unknown type with layout
        float64 encountered. This error is produced due to
-       the use of -universe (no_extensions|upstream_compatible).
+       the use of -extension-universe (no_extensions|upstream_compatible).
 |}];;
 
 module M2 : sig

--- a/ocaml/testsuite/tests/typing-layouts/immediates.ml
+++ b/ocaml/testsuite/tests/typing-layouts/immediates.ml
@@ -14,7 +14,7 @@
    ** setup-ocamlc.byte-build-env
      ocamlc_byte_exit_status = "2"
    *** ocamlc.byte
-     flags = "-universe no_extensions"
+     flags = "-extension-universe no_extensions"
      compiler_reference = "${test_source_directory}/immediates_disabled.compilers.reference"
    **** check-ocamlc.byte-output
 

--- a/ocaml/testsuite/tests/typing-layouts/immediates.ml
+++ b/ocaml/testsuite/tests/typing-layouts/immediates.ml
@@ -14,7 +14,7 @@
    ** setup-ocamlc.byte-build-env
      ocamlc_byte_exit_status = "2"
    *** ocamlc.byte
-     flags = "-disable-all-extensions"
+     flags = "-universe no_extensions"
      compiler_reference = "${test_source_directory}/immediates_disabled.compilers.reference"
    **** check-ocamlc.byte-output
 

--- a/ocaml/testsuite/tests/typing-modules/include_functor_disabled_1.ml
+++ b/ocaml/testsuite/tests/typing-modules/include_functor_disabled_1.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-disable-all-extensions"
+   flags = "-universe no_extensions"
    ocamlc_byte_exit_status = "2"
    * setup-ocamlc.byte-build-env
    ** ocamlc.byte

--- a/ocaml/testsuite/tests/typing-modules/include_functor_disabled_1.ml
+++ b/ocaml/testsuite/tests/typing-modules/include_functor_disabled_1.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-universe no_extensions"
+   flags = "-extension-universe no_extensions"
    ocamlc_byte_exit_status = "2"
    * setup-ocamlc.byte-build-env
    ** ocamlc.byte

--- a/ocaml/testsuite/tests/typing-modules/include_functor_disabled_2.ml
+++ b/ocaml/testsuite/tests/typing-modules/include_functor_disabled_2.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-disable-all-extensions"
+   flags = "-universe no_extensions"
    ocamlc_byte_exit_status = "2"
    * setup-ocamlc.byte-build-env
    ** ocamlc.byte

--- a/ocaml/testsuite/tests/typing-modules/include_functor_disabled_2.ml
+++ b/ocaml/testsuite/tests/typing-modules/include_functor_disabled_2.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-universe no_extensions"
+   flags = "-extension-universe no_extensions"
    ocamlc_byte_exit_status = "2"
    * setup-ocamlc.byte-build-env
    ** ocamlc.byte

--- a/ocaml/testsuite/tests/typing-modules/include_functor_disabled_3.ml
+++ b/ocaml/testsuite/tests/typing-modules/include_functor_disabled_3.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-disable-all-extensions"
+   flags = "-universe no_extensions"
    ocamlc_byte_exit_status = "2"
    * setup-ocamlc.byte-build-env
    ** ocamlc.byte

--- a/ocaml/testsuite/tests/typing-modules/include_functor_disabled_3.ml
+++ b/ocaml/testsuite/tests/typing-modules/include_functor_disabled_3.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-universe no_extensions"
+   flags = "-extension-universe no_extensions"
    ocamlc_byte_exit_status = "2"
    * setup-ocamlc.byte-build-env
    ** ocamlc.byte

--- a/ocaml/testsuite/tests/typing-simd/test_disabled.ml
+++ b/ocaml/testsuite/tests/typing-simd/test_disabled.ml
@@ -1,4 +1,5 @@
 (* TEST
+   flags = "-no-extension simd"
    * expect
 *)
 

--- a/ocaml/testsuite/tests/typing-simd/test_enabled.ml
+++ b/ocaml/testsuite/tests/typing-simd/test_enabled.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension simd"
    * expect
 *)
 
@@ -32,4 +31,3 @@ type t = float64x2;;
 [%%expect{|
 type t = float64x2
 |}];;
-

--- a/ocaml/testsuite/tests/typing-small-numbers/test_disabled.ml
+++ b/ocaml/testsuite/tests/typing-small-numbers/test_disabled.ml
@@ -8,5 +8,5 @@ Line 1, characters 9-16:
 1 | type t = float32;;
              ^^^^^^^
 Error: Unbound type constructor float32
-Hint: Did you mean float or float#?
+Hint: Did you mean float, float# or float32x4?
 |}];;

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2293,7 +2293,7 @@ let () =
     in
     Some (Location.errorf ~loc
       "@[Usage of layout immediate/immediate64%a can't be erased.@;\
-      This error is produced due to the use of -only-erasable-extensions.@]"
+      This error is produced due to the use of -universe (no_extensions|upstream_compatible).@]"
       format_id id)
   | _ -> None)
 

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2293,7 +2293,8 @@ let () =
     in
     Some (Location.errorf ~loc
       "@[Usage of layout immediate/immediate64%a can't be erased.@;\
-      This error is produced due to the use of -universe (no_extensions|upstream_compatible).@]"
+      This error is produced due to the use of -extension-universe (\
+      no_extensions|upstream_compatible).@]"
       format_id id)
   | _ -> None)
 

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2292,9 +2292,9 @@ let () =
       | None -> ()
     in
     Some (Location.errorf ~loc
-      "@[Usage of layout immediate/immediate64%a can't be erased.@;\
-      This error is produced due to the use of -extension-universe (\
-      no_extensions|upstream_compatible).@]"
+      "@[Usage of layout immediate/immediate64%a can't be erased \
+      for compatibility with upstream OCaml.@; This error is produced due to \
+      the use of -extension-universe (no_extensions|upstream_compatible).@]"
       format_id id)
   | _ -> None)
 

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -3219,7 +3219,7 @@ let report_error ppf = function
     fprintf ppf
       "@[[%@unboxed] attribute must be added to external declaration@ \
           argument type with layout %a. This error is produced@ \
-          due to the use of -only-erasable-extensions.@]"
+          due to the use of -universe (no_extensions|upstream_compatible).@]"
       Jkind.Sort.format_const sort
   | Non_value_sort_not_upstream_compatible sort ->
     fprintf ppf
@@ -3227,7 +3227,7 @@ let report_error ppf = function
          The only types with non-value layouts allowed are float#,@ \
          int32#, int64#, and nativeint#. Unknown type with layout@ \
          %a encountered. This error is produced due to@ \
-         the use of -only-erasable-extensions.@]"
+         the use of -universe (no_extensions|upstream_compatible).@]"
       Jkind.Sort.format_const sort
 
 let () =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -3218,9 +3218,9 @@ let report_error ppf = function
   | Missing_unboxed_attribute_on_non_value_sort sort ->
     fprintf ppf
       "@[[%@unboxed] attribute must be added to external declaration@ \
-          argument type with layout %a. This error is produced@ \
-          due to the use of -extension-universe (no_extensions|\
-          upstream_compatible).@]"
+          argument type with layout %a for upstream compatibility. \
+          This error is produced@ due to the use of -extension-universe \
+          (no_extensions|upstream_compatible).@]"
       Jkind.Sort.format_const sort
   | Non_value_sort_not_upstream_compatible sort ->
     fprintf ppf

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -3219,7 +3219,8 @@ let report_error ppf = function
     fprintf ppf
       "@[[%@unboxed] attribute must be added to external declaration@ \
           argument type with layout %a. This error is produced@ \
-          due to the use of -universe (no_extensions|upstream_compatible).@]"
+          due to the use of -extension-universe (no_extensions|\
+          upstream_compatible).@]"
       Jkind.Sort.format_const sort
   | Non_value_sort_not_upstream_compatible sort ->
     fprintf ppf
@@ -3227,7 +3228,8 @@ let report_error ppf = function
          The only types with non-value layouts allowed are float#,@ \
          int32#, int64#, and nativeint#. Unknown type with layout@ \
          %a encountered. This error is produced due to@ \
-         the use of -universe (no_extensions|upstream_compatible).@]"
+         the use of -extension-universe (no_extensions|\
+         upstream_compatible).@]"
       Jkind.Sort.format_const sort
 
 let () =

--- a/ocaml/utils/language_extension.ml
+++ b/ocaml/utils/language_extension.ml
@@ -338,10 +338,6 @@ let enable_all_in_universe () =
   in
   extensions := List.filter_map maximal_in_universe Exist.all
 
-let restrict_to_erasable_extensions () =
-  let changed = Universe.set Upstream_compatible in
-  if changed then extensions := List.filter Universe.is_allowed !extensions
-
 let erasable_extensions_only () =
   Universe.is No_extensions || Universe.is Upstream_compatible
 

--- a/ocaml/utils/language_extension.ml
+++ b/ocaml/utils/language_extension.ml
@@ -336,10 +336,6 @@ let enable_all_in_universe () =
 let erasable_extensions_only () =
   Universe.is No_extensions || Universe.is Upstream_compatible
 
-let set_universe u =
-  Universe.set u;
-  extensions := List.filter Universe.is_allowed !extensions
-
 let set_universe_and_enable_all u =
   Universe.set u;
   enable_all_in_universe ()

--- a/ocaml/utils/language_extension.ml
+++ b/ocaml/utils/language_extension.ml
@@ -152,6 +152,8 @@ module Universe : sig
 
   val all : t list
 
+  val maximal : t
+
   val to_string : t -> string
 
   val of_string : string -> t option
@@ -170,6 +172,8 @@ end = struct
   (* If you add a constructor, you should also add it to [all]. *)
 
   let all = [No_extensions; Upstream_compatible; Stable; Beta; Alpha]
+
+  let maximal = Alpha
 
   let to_string = function
     | No_extensions -> "no_extensions"

--- a/ocaml/utils/language_extension.ml
+++ b/ocaml/utils/language_extension.ml
@@ -196,9 +196,9 @@ end = struct
     in
     compare (rank t1) (rank t2)
 
-  (* For now, the default universe is set to [Alpha] but only a limited set
-     of extensions is enabled. After the migration to extension universes,
-     the default will be [No_extensions]. *)
+  (* For now, the default universe is set to [Alpha] but only a limited set of
+     extensions is enabled. After the migration to extension universes, the
+     default will be [No_extensions]. *)
   let universe = ref Alpha
 
   let compiler_options = function

--- a/ocaml/utils/language_extension.ml
+++ b/ocaml/utils/language_extension.ml
@@ -154,6 +154,8 @@ module Universe : sig
 
   val to_string : t -> string
 
+  val description : t -> string
+
   val of_string : string -> t option
 
   val set : t -> unit
@@ -176,6 +178,14 @@ end = struct
     | Stable -> "stable"
     | Beta -> "beta"
     | Alpha -> "alpha"
+
+  let description = function
+    | No_extensions -> "no extensions"
+    | Upstream_compatible ->
+      "extensions compatible with upstream OCaml, or erasable extensions"
+    | Stable -> "all stable extensions"
+    | Beta -> "all beta extensions"
+    | Alpha -> "all alpha extensions"
 
   let of_string = function
     | "no_extensions" -> Some No_extensions
@@ -333,11 +343,15 @@ let erasable_extensions_only () =
 
 let set_universe u =
   Universe.set u;
+  extensions := List.filter Universe.is_allowed !extensions
+
+let set_universe_and_enable_all u =
+  Universe.set u;
   enable_all_in_universe ()
 
-let set_universe_of_string_exn univ_name =
+let set_universe_and_enable_all_of_string_exn univ_name =
   match Universe.of_string univ_name with
-  | Some u -> set_universe u
+  | Some u -> set_universe_and_enable_all u
   | None ->
     raise (Arg.Bad (Printf.sprintf "Universe %s is not known" univ_name))
 

--- a/ocaml/utils/language_extension.ml
+++ b/ocaml/utils/language_extension.ml
@@ -156,7 +156,7 @@ module Universe : sig
 
   val of_string : string -> t option
 
-  val set : t -> bool
+  val set : t -> unit
 
   val is : t -> bool
 end = struct
@@ -226,17 +226,7 @@ end = struct
         (compiler_options !universe)
         ()
 
-  (* returns whether or not a change was actually made *)
-  let set new_universe =
-    let cmp = compare new_universe !universe in
-    if cmp > 0
-    then
-      fail "Cannot specify %s: incompatible with %s"
-        (compiler_options new_universe)
-        (compiler_options !universe)
-        ();
-    universe := new_universe;
-    cmp <> 0
+  let set new_universe = universe := new_universe
 
   let is u = compare u !universe = 0
 end
@@ -342,8 +332,8 @@ let erasable_extensions_only () =
   Universe.is No_extensions || Universe.is Upstream_compatible
 
 let set_universe u =
-  let changed = Universe.set u in
-  if changed then enable_all_in_universe ()
+  Universe.set u;
+  enable_all_in_universe ()
 
 let set_universe_of_string_exn univ_name =
   match Universe.of_string univ_name with

--- a/ocaml/utils/language_extension.mli
+++ b/ocaml/utils/language_extension.mli
@@ -49,18 +49,22 @@ with type 'a extn := 'a t
 (** Equality on language extensions *)
 val equal : 'a t -> 'b t -> bool
 
-(** The type of langauge extension universes. *)
+(** The type of language extension universes. Each universe allows a set of
+    extensions, and every successive universe includes the previous one. *)
 module Universe : sig
   type t =
     | No_extensions
     | Upstream_compatible
-    | Stable
-    | Beta
-    | Alpha
+        (** Upstream compatible extensions, also known as "erasable". *)
+    | Stable  (** Extensions of [Stable] maturity. *)
+    | Beta  (** Extensions of [Beta] maturity. *)
+    | Alpha  (** All extensions. Default. *)
 
   val all : t list
 
   val to_string : t -> string
+
+  val description : t -> string
 
   val of_string : string -> t option
 end
@@ -121,9 +125,15 @@ val with_disabled : 'a t -> (unit -> unit) -> unit
     [Upstream_compatible]. *)
 val erasable_extensions_only : unit -> bool
 
+(** Set the extension universe, disabling disallowed extensions. *)
 val set_universe : Universe.t -> unit
 
-val set_universe_of_string_exn : string -> unit
+(** Set the extension universe and enable all allowed extensions. *)
+val set_universe_and_enable_all : Universe.t -> unit
+
+(** Parse a command-line string and call [set_universe_and_enable_all].
+    Raises if the argument is invalid. *)
+val set_universe_and_enable_all_of_string_exn : string -> unit
 
 (**/**)
 

--- a/ocaml/utils/language_extension.mli
+++ b/ocaml/utils/language_extension.mli
@@ -50,7 +50,9 @@ with type 'a extn := 'a t
 val equal : 'a t -> 'b t -> bool
 
 (** The type of language extension universes. Each universe allows a set of
-    extensions, and every successive universe includes the previous one. *)
+    extensions, and every successive universe includes the previous one.
+
+    Each variant corresponds to the [-extension-universe <variant>] CLI flag. *)
 module Universe : sig
   type t =
     | No_extensions
@@ -58,13 +60,12 @@ module Universe : sig
         (** Upstream compatible extensions, also known as "erasable". *)
     | Stable  (** Extensions of [Stable] maturity. *)
     | Beta  (** Extensions of [Beta] maturity. *)
-    | Alpha  (** All extensions. Default. *)
+    | Alpha  (** All extensions. This is the universe enabled by default
+        for the time being. *)
 
   val all : t list
 
   val to_string : t -> string
-
-  val description : t -> string
 
   val of_string : string -> t option
 end

--- a/ocaml/utils/language_extension.mli
+++ b/ocaml/utils/language_extension.mli
@@ -49,6 +49,22 @@ with type 'a extn := 'a t
 (** Equality on language extensions *)
 val equal : 'a t -> 'b t -> bool
 
+(** The type of langauge extension universes. *)
+module Universe : sig
+  type t =
+    | No_extensions
+    | Upstream_compatible
+    | Stable
+    | Beta
+    | Alpha
+
+  val all : t list
+
+  val to_string : t -> string
+
+  val of_string : string -> t option
+end
+
 (** Disable all extensions *)
 val disable_all : unit -> unit
 
@@ -131,6 +147,10 @@ val disallow_extensions : unit -> unit
 (** Check if the allowable extensions are restricted to only those that are
     "erasable". This is true when [restrict_to_erasable_extensions] was called. *)
 val erasable_extensions_only : unit -> bool
+
+val set_universe : Universe.t -> unit
+
+val set_universe_of_string_exn : string -> unit
 
 (**/**)
 

--- a/ocaml/utils/language_extension.mli
+++ b/ocaml/utils/language_extension.mli
@@ -66,6 +66,9 @@ module Universe : sig
 
   val all : t list
 
+  (** Equal to [Alpha]. *)
+  val maximal : t
+
   val to_string : t -> string
 
   val of_string : string -> t option

--- a/ocaml/utils/language_extension.mli
+++ b/ocaml/utils/language_extension.mli
@@ -107,32 +107,18 @@ val is_enabled : 'a t -> bool
 val is_at_least : 'a t -> 'a -> bool
 
 (** Tooling support: Temporarily enable and disable language extensions; these
-    operations are idempotent.  Calls to [set], [enable], [disable], and
-    [disallow_extensions] inside the body of the function argument will also
-    be rolled back when the function finishes, but this behavior may change;
-    nest multiple [with_*] functions instead.  *)
+    operations are idempotent.  Calls to [set], [enable], [disable] inside the body
+    of the function argument will also be rolled back when the function finishes,
+    but this behavior may change; nest multiple [with_*] functions instead.  *)
 val with_set : unit t -> enabled:bool -> (unit -> unit) -> unit
 
 val with_enabled : 'a t -> 'a -> (unit -> unit) -> unit
 
 val with_disabled : 'a t -> (unit -> unit) -> unit
 
-(** Permanently restrict the allowable extensions to those that are
-    "erasable", i.e. those that can be harmlessly translated to attributes and
-    compiled with the upstream compiler.  Used for [-only-erasable-extensions]
-    to ensure that some code is guaranteed to be compatible with upstream
-    OCaml after rewriting to attributes.  When called, disables any
-    currently-enabled non-erasable extensions, including any that are on by
-    default.  Causes any future uses of [set ~enabled:true], [enable], and
-    their [with_] variants to raise if used with a non-erasable extension.
-    The [is_enabled] function will still work on any extensions, it will just
-    always return [false] on non-erasable ones.  Will raise if called after
-    [disallow_extensions]; the ratchet of extension restriction only goes one
-    way. *)
-val restrict_to_erasable_extensions : unit -> unit
-
 (** Check if the allowable extensions are restricted to only those that are
-    "erasable". This is true when [restrict_to_erasable_extensions] was called. *)
+    "erasable". This is true when the universe is set to [No_extensions] or
+    [Upstream_compatible]. *)
 val erasable_extensions_only : unit -> bool
 
 val set_universe : Universe.t -> unit

--- a/ocaml/utils/language_extension.mli
+++ b/ocaml/utils/language_extension.mli
@@ -68,10 +68,6 @@ end
 (** Disable all extensions *)
 val disable_all : unit -> unit
 
-(** Maximally enable all extensions (that is, set to [Alpha] for [maturity]
-    extensions. *)
-val enable_maximal : unit -> unit
-
 (** Check if a language extension is "erasable", i.e. whether it can be
     harmlessly translated to attributes and compiled with the upstream
     compiler. *)
@@ -134,15 +130,6 @@ val with_disabled : 'a t -> (unit -> unit) -> unit
     [disallow_extensions]; the ratchet of extension restriction only goes one
     way. *)
 val restrict_to_erasable_extensions : unit -> unit
-
-(** Permanently ban all extensions; used for [-disable-all-extensions] to ensure
-    that some code is 100% extension-free.  When called, disables any
-    currently-enabled extensions, including the defaults.  Causes any future
-    uses of [set ~enabled:true], [enable], and their [with_] variants to raise;
-    also causes any future uses of [restrict_to_erasable_extensions] to raise.
-    The [is_enabled] function will still work, it will just always return
-    [false].*)
-val disallow_extensions : unit -> unit
 
 (** Check if the allowable extensions are restricted to only those that are
     "erasable". This is true when [restrict_to_erasable_extensions] was called. *)

--- a/ocaml/utils/language_extension.mli
+++ b/ocaml/utils/language_extension.mli
@@ -127,9 +127,6 @@ val with_disabled : 'a t -> (unit -> unit) -> unit
     [Upstream_compatible]. *)
 val erasable_extensions_only : unit -> bool
 
-(** Set the extension universe, disabling disallowed extensions. *)
-val set_universe : Universe.t -> unit
-
 (** Set the extension universe and enable all allowed extensions. *)
 val set_universe_and_enable_all : Universe.t -> unit
 

--- a/ocaml/utils/language_extension.mli
+++ b/ocaml/utils/language_extension.mli
@@ -60,7 +60,8 @@ module Universe : sig
         (** Upstream compatible extensions, also known as "erasable". *)
     | Stable  (** Extensions of [Stable] maturity. *)
     | Beta  (** Extensions of [Beta] maturity. *)
-    | Alpha  (** All extensions. This is the universe enabled by default
+    | Alpha
+        (** All extensions. This is the universe enabled by default
         for the time being. *)
 
   val all : t list


### PR DESCRIPTION
This PR implements extension universes and adds the `-extension-universe` flag. It also changes old uses of `-disable-all-extensions` and `-only-erasable-extensions` to the new flag.