### PR TITLE
make mode system scale better with more axes

### DIFF
--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1228,8 +1228,6 @@ module Regionality = struct
   let global = of_const Const.Global
 
   let legacy = of_const Const.legacy
-
-  let zap_to_legacy = zap_to_floor
 end
 
 module Linearity = struct
@@ -1353,11 +1351,6 @@ module Comonadic_with_regionality = struct
 
   let imply c m = Solver.via_monotone obj (Imply c) (Solver.disallow_left m)
 
-  let zap_to_legacy m =
-    let regionality = regionality m |> Regionality.zap_to_legacy in
-    let linearity = linearity m |> Linearity.zap_to_legacy in
-    regionality, linearity
-
   let legacy = of_const Const.legacy
 
   (* overriding to report the offending axis *)
@@ -1374,12 +1367,6 @@ module Comonadic_with_regionality = struct
 
   (* override to report the offending axis *)
   let equate = equate_from_submode submode
-
-  (** overriding to check per-axis *)
-  let check_const m =
-    let regionality = Regionality.check_const (regionality m) in
-    let linearity = Linearity.check_const (linearity m) in
-    regionality, linearity
 end
 
 module Comonadic_with_locality = struct
@@ -1551,7 +1538,7 @@ module Monadic = struct
   (** overriding to check per-axis *)
   let check_const m =
     let uniqueness = Uniqueness.check_const (uniqueness m) in
-    uniqueness
+    uniqueness, ()
 end
 
 type ('mo, 'como) monadic_comonadic =
@@ -1576,6 +1563,16 @@ module Value = struct
       linearity : 'b;
       uniqueness : 'c
     }
+
+  let split { regionality; linearity; uniqueness } =
+    let monadic = uniqueness, () in
+    let comonadic = regionality, linearity in
+    { comonadic; monadic }
+
+  let merge { comonadic; monadic } =
+    let regionality, linearity = comonadic in
+    let uniqueness, () = monadic in
+    { regionality; linearity; uniqueness }
 
   let min = { comonadic = Comonadic.min; monadic = Monadic.min }
 
@@ -1665,29 +1662,10 @@ module Value = struct
       (Monadic.print ?raw ?verbose ())
       monadic
 
-  let zap_to_floor { comonadic; monadic } =
-    match Monadic.zap_to_floor monadic, Comonadic.zap_to_floor comonadic with
-    | (uniqueness, ()), (regionality, linearity) ->
-      { regionality; linearity; uniqueness }
-
-  let zap_to_ceil { comonadic; monadic } =
-    match Monadic.zap_to_ceil monadic, Comonadic.zap_to_ceil comonadic with
-    | (uniqueness, ()), (regionality, linearity) ->
-      { regionality; linearity; uniqueness }
-
-  let zap_to_legacy { comonadic; monadic } =
-    match Monadic.zap_to_legacy monadic, Comonadic.zap_to_legacy comonadic with
-    | (uniqueness, ()), (regionality, linearity) ->
-      { regionality; linearity; uniqueness }
-
-  let check_const { comonadic; monadic } =
-    let regionality, linearity = Comonadic.check_const comonadic in
-    let uniqueness = Monadic.check_const monadic in
-    { regionality; linearity; uniqueness }
-
-  let of_const { regionality; linearity; uniqueness } =
-    let comonadic = Comonadic.of_const (regionality, linearity) in
-    let monadic = Monadic.of_const (uniqueness, ()) in
+  let of_const c =
+    let { monadic; comonadic } = split c in
+    let comonadic = Comonadic.of_const comonadic in
+    let monadic = Monadic.of_const monadic in
     { comonadic; monadic }
 
   let legacy =
@@ -1788,62 +1766,46 @@ module Value = struct
   module Const = struct
     type t = (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
 
-    let split { regionality; linearity; uniqueness } =
-      let monadic = uniqueness, () in
-      let comonadic = regionality, linearity in
-      { comonadic; monadic }
+    module Monadic = Monadic.Const
+    module Comonadic = Comonadic.Const
 
-    let _merge { comonadic; monadic } =
-      let regionality, linearity = comonadic in
-      let uniqueness, () = monadic in
-      { regionality; linearity; uniqueness }
+    let min = merge { comonadic = Comonadic.min; monadic = Monadic.min }
 
-    let min =
-      { regionality = Regionality.Const.min;
-        linearity = Linearity.Const.min;
-        uniqueness = Uniqueness.Const.min
-      }
-
-    let max =
-      { regionality = Regionality.Const.max;
-        linearity = Linearity.Const.max;
-        uniqueness = Uniqueness.Const.max
-      }
+    let max = merge { comonadic = Comonadic.max; monadic = Monadic.max }
 
     let le m0 m1 =
-      Regionality.Const.le m0.regionality m1.regionality
-      && Uniqueness.Const.le m0.uniqueness m1.uniqueness
-      && Linearity.Const.le m0.linearity m1.linearity
+      let m0 = split m0 in
+      let m1 = split m1 in
+      Comonadic.le m0.comonadic m1.comonadic && Monadic.le m0.monadic m1.monadic
 
     let print ppf m = print () ppf (of_const m)
 
     let legacy =
-      { regionality = Regionality.Const.legacy;
-        linearity = Linearity.Const.legacy;
-        uniqueness = Uniqueness.Const.legacy
-      }
+      merge { comonadic = Comonadic.legacy; monadic = Monadic.legacy }
 
     let meet m0 m1 =
-      let regionality = Regionality.Const.meet m0.regionality m1.regionality in
-      let linearity = Linearity.Const.meet m0.linearity m1.linearity in
-      let uniqueness = Uniqueness.Const.meet m0.uniqueness m1.uniqueness in
-      { regionality; linearity; uniqueness }
+      let m0 = split m0 in
+      let m1 = split m1 in
+      let monadic = Monadic.meet m0.monadic m1.monadic in
+      let comonadic = Comonadic.meet m0.comonadic m1.comonadic in
+      merge { monadic; comonadic }
 
     let join m0 m1 =
-      let regionality = Regionality.Const.join m0.regionality m1.regionality in
-      let linearity = Linearity.Const.join m0.linearity m1.linearity in
-      let uniqueness = Uniqueness.Const.join m0.uniqueness m1.uniqueness in
-      { regionality; linearity; uniqueness }
+      let m0 = split m0 in
+      let m1 = split m1 in
+      let monadic = Monadic.join m0.monadic m1.monadic in
+      let comonadic = Comonadic.join m0.comonadic m1.comonadic in
+      merge { monadic; comonadic }
   end
 
   let meet_with c { comonadic; monadic } =
-    let c = Const.split c in
+    let c = split c in
     let comonadic = Comonadic.meet_with c.comonadic comonadic in
     let monadic = Monadic.meet_with c.monadic monadic in
     { monadic; comonadic }
 
   let imply c { comonadic; monadic } =
-    let c = Const.split c in
+    let c = split c in
     let comonadic = Comonadic.imply c.comonadic comonadic in
     let monadic = Monadic.imply c.monadic monadic in
     { monadic; comonadic }
@@ -1882,6 +1844,16 @@ module Alloc = struct
       linearity : 'b;
       uniqueness : 'c
     }
+
+  let split { locality; linearity; uniqueness } =
+    let monadic = uniqueness, () in
+    let comonadic = locality, linearity in
+    { comonadic; monadic }
+
+  let merge { comonadic; monadic } =
+    let locality, linearity = comonadic in
+    let uniqueness, () = monadic in
+    { locality; linearity; uniqueness }
 
   let min = { comonadic = Comonadic.min; monadic = Monadic.min }
 
@@ -2075,42 +2047,36 @@ module Alloc = struct
   module Const = struct
     type t = (Locality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
 
-    let min =
-      let locality = Locality.Const.min in
-      let linearity = Linearity.Const.min in
-      let uniqueness = Uniqueness.Const.min in
-      { locality; linearity; uniqueness }
+    module Monadic = Monadic.Const
+    module Comonadic = Comonadic.Const
 
-    let max =
-      let locality = Locality.Const.max in
-      let linearity = Linearity.Const.max in
-      let uniqueness = Uniqueness.Const.max in
-      { locality; linearity; uniqueness }
+    let min = merge { comonadic = Comonadic.min; monadic = Monadic.min }
+
+    let max = merge { comonadic = Comonadic.max; monadic = Monadic.max }
 
     let le m0 m1 =
-      Locality.Const.le m0.locality m1.locality
-      && Uniqueness.Const.le m0.uniqueness m1.uniqueness
-      && Linearity.Const.le m0.linearity m1.linearity
+      let m0 = split m0 in
+      let m1 = split m1 in
+      Comonadic.le m0.comonadic m1.comonadic && Monadic.le m0.monadic m1.monadic
 
     let print ppf m = print () ppf (of_const m)
 
     let legacy =
-      let locality = Locality.Const.legacy in
-      let linearity = Linearity.Const.legacy in
-      let uniqueness = Uniqueness.Const.legacy in
-      { locality; linearity; uniqueness }
+      merge { comonadic = Comonadic.legacy; monadic = Monadic.legacy }
 
     let meet m0 m1 =
-      let locality = Locality.Const.meet m0.locality m1.locality in
-      let linearity = Linearity.Const.meet m0.linearity m1.linearity in
-      let uniqueness = Uniqueness.Const.meet m0.uniqueness m1.uniqueness in
-      { locality; linearity; uniqueness }
+      let m0 = split m0 in
+      let m1 = split m1 in
+      let monadic = Monadic.meet m0.monadic m1.monadic in
+      let comonadic = Comonadic.meet m0.comonadic m1.comonadic in
+      merge { monadic; comonadic }
 
     let join m0 m1 =
-      let locality = Locality.Const.join m0.locality m1.locality in
-      let linearity = Linearity.Const.join m0.linearity m1.linearity in
-      let uniqueness = Uniqueness.Const.join m0.uniqueness m1.uniqueness in
-      { locality; linearity; uniqueness }
+      let m0 = split m0 in
+      let m1 = split m1 in
+      let monadic = Monadic.join m0.monadic m1.monadic in
+      let comonadic = Comonadic.join m0.comonadic m1.comonadic in
+      merge { monadic; comonadic }
 
     module Option = struct
       type some = t
@@ -2132,64 +2098,51 @@ module Alloc = struct
         { locality; uniqueness; linearity }
     end
 
-    let split { locality; linearity; uniqueness } =
-      let monadic = uniqueness, () in
-      let comonadic = locality, linearity in
-      { comonadic; monadic }
-
-    let merge { comonadic; monadic } =
-      let locality, linearity = comonadic in
-      let uniqueness, () = monadic in
-      { locality; linearity; uniqueness }
-
     (** See [Alloc.close_over] for explanation. *)
     let close_over m =
       let { monadic; comonadic } = split m in
       let comonadic =
-        Comonadic.Const.join comonadic
-          (C.monadic_to_comonadic_min Comonadic.Obj.obj monadic)
+        Comonadic.join comonadic
+          (C.monadic_to_comonadic_min C.Comonadic_with_locality monadic)
       in
-      let monadic = Monadic.Const.min in
+      let monadic = Monadic.min in
       merge { comonadic; monadic }
 
     (** See [Alloc.partial_apply] for explanation. *)
     let partial_apply m =
       let { comonadic; _ } = split m in
-      let monadic = Monadic.Const.min in
+      let monadic = Monadic.min in
       merge { comonadic; monadic }
+
+    let split = split
   end
 
   let meet_with c { comonadic; monadic } =
-    let c = Const.split c in
+    let c = split c in
     let comonadic = Comonadic.meet_with c.comonadic comonadic in
     let monadic = Monadic.meet_with c.monadic monadic in
     { monadic; comonadic }
 
   let imply c { comonadic; monadic } =
-    let c = Const.split c in
+    let c = split c in
     let comonadic = Comonadic.imply c.comonadic comonadic in
     let monadic = Monadic.imply c.monadic monadic in
     { monadic; comonadic }
 
-  let zap_to_floor { comonadic; monadic } : Const.t =
-    match Monadic.zap_to_floor monadic, Comonadic.zap_to_floor comonadic with
-    | (uniqueness, ()), (locality, linearity) ->
-      { locality; linearity; uniqueness }
+  let zap_to_ceil { comonadic; monadic } =
+    let monadic = Monadic.zap_to_ceil monadic in
+    let comonadic = Comonadic.zap_to_ceil comonadic in
+    merge { monadic; comonadic }
 
-  let zap_to_ceil { comonadic; monadic } : Const.t =
-    match Monadic.zap_to_ceil monadic, Comonadic.zap_to_ceil comonadic with
-    | (uniqueness, ()), (locality, linearity) ->
-      { locality; linearity; uniqueness }
+  let zap_to_legacy { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy monadic in
+    let comonadic = Comonadic.zap_to_legacy comonadic in
+    merge { monadic; comonadic }
 
-  let zap_to_legacy { comonadic; monadic } : Const.t =
-    match Monadic.zap_to_legacy monadic, Comonadic.zap_to_legacy comonadic with
-    | (uniqueness, ()), (locality, linearity) ->
-      { locality; linearity; uniqueness }
-
-  let check_const { comonadic; monadic } : Const.Option.t =
-    let locality, linearity = Comonadic.check_const comonadic in
-    let uniqueness = Monadic.check_const monadic in
-    { locality; linearity; uniqueness }
+  let check_const { comonadic; monadic } =
+    let comonadic = Comonadic.check_const comonadic in
+    let monadic = Monadic.check_const monadic in
+    merge { monadic; comonadic }
 
   (** This is about partially applying [A -> B -> C] to [A] and getting [B ->
     C]. [comonadic] and [monadic] constutute the mode of [A], and we need to

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -91,10 +91,6 @@ module type Common = sig
     ('l * 'r) t ->
     unit
 
-  val zap_to_floor : (allowed * 'r) t -> Const.t
-
-  val zap_to_ceil : ('l * allowed) t -> Const.t
-
   val of_const : Const.t -> ('l * 'r) t
 end
 
@@ -151,9 +147,9 @@ module type S = sig
 
     val local : lr
 
-    val zap_to_legacy : (allowed * 'r) t -> Const.t
-
     val check_const : ('l * 'r) t -> Const.t option
+
+    val zap_to_floor : (allowed * 'r) t -> Const.t
   end
 
   module Regionality : sig
@@ -175,8 +171,6 @@ module type S = sig
     val regional : lr
 
     val local : lr
-
-    val zap_to_legacy : (allowed * 'r) t -> Const.t
   end
 
   module Linearity : sig
@@ -195,8 +189,6 @@ module type S = sig
     val many : lr
 
     val once : lr
-
-    val zap_to_legacy : (allowed * 'r) t -> Const.t
   end
 
   module Uniqueness : sig
@@ -215,8 +207,6 @@ module type S = sig
     val shared : lr
 
     val unique : lr
-
-    val zap_to_legacy : ('l * allowed) t -> Const.t
   end
 
   (** The most general mode. Used in most type checking,
@@ -268,13 +258,6 @@ module type S = sig
       ('l * 'r) t ->
       unit
 
-    val check_const :
-      ('l * 'r) t ->
-      ( Regionality.Const.t option,
-        Linearity.Const.t option,
-        Uniqueness.Const.t option )
-      modes
-
     val regionality : ('l * 'r) t -> ('l * 'r) Regionality.t
 
     val uniqueness : ('l * 'r) t -> ('l * 'r) Uniqueness.t
@@ -310,8 +293,6 @@ module type S = sig
 
     val join_with_uniqueness :
       Uniqueness.Const.t -> ('l * 'r) t -> (disallowed * 'r) t
-
-    val zap_to_legacy : lr -> Const.t
 
     val comonadic_to_monadic : ('l * 'r) Comonadic.t -> ('r * 'l) Monadic.t
 
@@ -436,6 +417,8 @@ module type S = sig
       Uniqueness.Const.t -> ('l * 'r) t -> (disallowed * 'r) t
 
     val zap_to_legacy : lr -> Const.t
+
+    val zap_to_ceil : ('l * allowed) t -> Const.t
 
     val meet_with : Const.t -> ('l * 'r) t -> ('l * disallowed) t
 

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -346,8 +346,9 @@ type expected_mode =
 
     strictly_local : bool;
     (** Indicates that the expression was directly annotated with [local], which
-    should force any allocations to be on the stack. If [true] the [mode] field
-    must be greater than [local]. *)
+    should force any allocations to be on the stack. No invariant between this
+    field and [mode]: this field being [true] while [mode] being [global] is
+    sensible, but not very useful as it will fail all expressions. *)
 
     tuple_modes : Value.r list;
     (** For t in tuple_modes, t <= regional_to_global mode *)
@@ -415,8 +416,6 @@ let meet_regional mode =
 let meet_global mode =
   Value.meet [mode; (Value.max_with_regionality Regionality.global)]
 
-let meet_unique mode =
-  Value.meet [mode; (Value.max_with_uniqueness Uniqueness.unique)]
 
 let meet_many mode =
   Value.meet [mode; (Value.max_with_linearity Linearity.many)]
@@ -493,10 +492,6 @@ let mode_global expected_mode =
   let mode = meet_global expected_mode.mode in
   {expected_mode with mode}
 
-let mode_local expected_mode =
-  { expected_mode with
-    mode = Value.join_with_regionality Regionality.Const.Local expected_mode.mode }
-
 let mode_exclave expected_mode =
   let mode =
     Value.join_with_regionality Regionality.Const.Local expected_mode.mode
@@ -506,17 +501,13 @@ let mode_exclave expected_mode =
   }
 
 let mode_strictly_local expected_mode =
-  { (mode_local expected_mode)
+  { expected_mode
     with strictly_local = true
   }
 
-let mode_unique expected_mode =
-  let mode = meet_unique expected_mode.mode in
-  { expected_mode with mode }
-
-let mode_once expected_mode =
-  { expected_mode with
-    mode = Value.join_with_linearity Linearity.Const.Once expected_mode.mode}
+let mode_coerce mode expected_mode =
+  let mode = Value.meet [expected_mode.mode; mode] in
+  { expected_mode with mode; tuple_modes = [] }
 
 let mode_tailcall_function mode =
   { (mode_default mode) with
@@ -851,21 +842,14 @@ let apply_mode_annots ~loc ~env (m : Alloc.Const.Option.t) mode =
   let error axis =
     raise (Error(loc, env, Param_mode_mismatch axis))
   in
-  Option.iter (fun locality ->
-    match Locality.equate (Locality.of_const locality) (Alloc.locality mode) with
-    | Ok () -> ()
-    | Error (s, e) -> error (s, `Locality e)
-    ) m.locality;
-  Option.iter (fun uniqueness ->
-    match Uniqueness.equate (Uniqueness.of_const uniqueness) (Alloc.uniqueness mode) with
-    | Ok () -> ()
-    | Error (s, e) -> error (s, `Uniqueness e)
-    ) m.uniqueness;
-  Option.iter (fun linearity ->
-    match Linearity.equate (Linearity.of_const linearity) (Alloc.linearity mode) with
-    | Ok () -> ()
-    | Error (s, e) -> error (s, `Linearity e)
-    ) m.linearity
+  let min = Alloc.Const.Option.value ~default:Alloc.Const.min m in
+  let max = Alloc.Const.Option.value ~default:Alloc.Const.max m in
+  (match Alloc.submode (Alloc.of_const min) mode with
+  | Ok () -> ()
+  | Error e -> error (Left_le_right, e));
+  (match Alloc.submode mode (Alloc.of_const max) with
+  | Ok () -> ()
+  | Error e -> error (Right_le_left, e))
 
 (* Typing of patterns *)
 
@@ -8598,38 +8582,14 @@ and type_mode_expr
   : Jane_syntax.Modes.expression -> _ = function
   | Coerce (m, sbody) ->
     let modes = Typemode.transl_mode_annots m in
-    (* CR zqian: All axes should be handled in one go. We can't do that yet
-       because [mode_strictly_local] is special. *)
-    let expected_mode =
-      match modes.uniqueness with
-      | Some Unique ->
-          let expected_mode = mode_unique expected_mode in
-          expect_mode_cross env ty_expected expected_mode
-      | Some m ->
-          Misc.fatal_errorf "The mode %a should not interpret" Uniqueness.Const.print m
-      | None -> expected_mode
-    in
-    let expected_mode =
-      match modes.linearity with
-      | Some Once ->
-          let expected_mode = expect_mode_cross env ty_expected expected_mode in
-          submode ~loc ~env ~reason:Other
-            (Value.min_with_linearity Linearity.once) expected_mode;
-          mode_once expected_mode
-      | Some m ->
-          Misc.fatal_errorf "The mode %a should not interpret" Linearity.Const.print m
-      | None -> expected_mode
-    in
+    let min = Alloc.Const.Option.value ~default:Alloc.Const.min modes |> Const.alloc_as_value in
+    let max = Alloc.Const.Option.value ~default:Alloc.Const.max modes |> Const.alloc_as_value in
+    submode ~loc ~env ~reason:Other (Value.of_const min) expected_mode;
+    let expected_mode = mode_coerce (Value.of_const max) expected_mode in
     let expected_mode =
       match modes.locality with
-      | Some Local ->
-          let expected_mode = expect_mode_cross env ty_expected expected_mode in
-          submode ~loc ~env ~reason:Other
-            (Value.min_with_regionality Regionality.local) expected_mode;
-          mode_strictly_local expected_mode
-      | Some m ->
-          Misc.fatal_errorf "The mode %a should not interpret" Locality.Const.print m
-      | None -> expected_mode
+      | Some Local -> mode_strictly_local expected_mode
+      | _ -> expected_mode
     in
     let exp =
       type_expect env expected_mode sbody (mk_expected ty_expected ?explanation)


### PR DESCRIPTION
The PR contains two commits, both to reduce the code needed in the future when we introduce more axes. 

- The first commit utilises the `merge` and `split` for constant mode operations, so they no longer mention specific axes.
- The second commit changes two places in `typecore.ml`, so they no longer need to mention specific axes.