### PR TITLE
Refactor arrow modes printing

### DIFF
--- a/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
+++ b/ocaml/testsuite/tests/typing-implicit-source-positions/invalid_usages.ml
@@ -44,7 +44,7 @@ Line 1, characters 14-15:
                   ^
 Error: This expression has type call_pos:[%call_pos] -> unit -> unit
        but an expression was expected of type
-         call_pos:Lexing.position -> (unit -> 'a)
+         call_pos:Lexing.position -> unit -> 'a
 |}]
 
 let h ?(call_pos:[%call_pos]) () = ()

--- a/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
@@ -573,3 +573,13 @@ Line 2, characters 71-72:
                                                                            ^
 
 |}]
+
+(* CR layouts: this should succeed. *)
+let foo : (string -> string) -> (string -> string) @ unique
+  = fun f -> f
+[%%expect{|
+Line 2, characters 13-14:
+2 |   = fun f -> f
+                 ^
+Error: Found a shared value where a unique value was expected
+|}]

--- a/ocaml/testsuite/tests/typing-modes/modes.ml
+++ b/ocaml/testsuite/tests/typing-modes/modes.ml
@@ -161,18 +161,18 @@ Error: Found a shared value where a unique value was expected
 (* arrow types *)
 type r = local_ string @ unique once -> unique_ string @ local once
 [%%expect{|
-type r = local_ unique_ once_ string -> local_ unique_ once_ string
+type r = local_ once_ unique_ string -> local_ once_ unique_ string
 |}]
 
 type r = local_ string * y:string @ unique once -> local_ string * w:string @ once
 [%%expect{|
-type r = local_ unique_ once_ string * string -> local_ once_ string * string
+type r = local_ once_ unique_ string * string -> local_ once_ string * string
 |}]
 
 type r = x:local_ string * y:string @ unique once -> local_ string * w:string @ once
 [%%expect{|
 type r =
-    x:local_ unique_ once_ string * string -> local_ once_ string * string
+    x:local_ once_ unique_ string * string -> local_ once_ string * string
 |}]
 
 
@@ -250,12 +250,12 @@ type r = { global_ x : string; }
 
 let foo ?(local_ x @ unique once = 42) () = ()
 [%%expect{|
-val foo : ?x:local_ unique_ once_ int -> unit -> unit = <fun>
+val foo : ?x:local_ once_ unique_ int -> unit -> unit = <fun>
 |}]
 
 let foo ?(local_ x : _ @@ unique once = 42) () = ()
 [%%expect{|
-val foo : ?x:local_ unique_ once_ int -> unit -> unit = <fun>
+val foo : ?x:local_ once_ unique_ int -> unit -> unit = <fun>
 |}]
 
 let foo ?(local_ x : 'a. 'a -> 'a @@ unique once) = ()
@@ -268,12 +268,12 @@ Error: Optional parameters cannot be polymorphic
 
 let foo ?x:(local_ (x,y) @ unique once = (42, 42)) () = ()
 [%%expect{|
-val foo : ?x:local_ unique_ once_ int * int -> unit -> unit = <fun>
+val foo : ?x:local_ once_ unique_ int * int -> unit -> unit = <fun>
 |}]
 
 let foo ?x:(local_ (x,y) : _ @@ unique once = (42, 42)) () = ()
 [%%expect{|
-val foo : ?x:local_ unique_ once_ int * int -> unit -> unit = <fun>
+val foo : ?x:local_ once_ unique_ int * int -> unit -> unit = <fun>
 |}]
 
 let foo ?x:(local_ (x,y) : 'a.'a->'a @@ unique once) () = ()

--- a/ocaml/testsuite/tests/typing-unique/unique_typedecl.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique_typedecl.ml
@@ -37,9 +37,9 @@ Lines 3-4, characters 0-68:
 4 | = 'a -> unique_ 'b -> unique_ once_ ('c -> unique_ once_ ('d -> 'e))
 Error: The type constraints are not consistent.
        Type 'a -> unique_ 'b -> 'c -> 'd -> 'e is not compatible with type
-         'a -> unique_ 'b -> unique_ once_ ('c -> unique_ once_ ('d -> 'e))
+         'a -> unique_ 'b -> once_ unique_ ('c -> once_ unique_ ('d -> 'e))
        Type unique_ 'b -> 'c -> 'd -> 'e is not compatible with type
-         unique_ 'b -> unique_ once_ ('c -> unique_ once_ ('d -> 'e))
+         unique_ 'b -> once_ unique_ ('c -> once_ unique_ ('d -> 'e))
 |}]
 
 type distinct_sarg = unit constraint unique_ int -> int = int -> int

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -1588,6 +1588,17 @@ let with_locality locality m =
   Alloc.submode_exn (Alloc.meet_with (Comonadic Areality) Locality.Const.min m) m';
   m'
 
+let curry_mode alloc arg : Alloc.Const.t =
+  let acc =
+    Alloc.Const.join
+      (Alloc.Const.close_over arg)
+      (Alloc.Const.partial_apply alloc)
+  in
+  (* Arrow types cross uniqueness axis. Therefore, when user writes an
+  A -> B -> C (to be used as constraint on something), we should make
+  (B -> C) shared. A proper way to do this is via modal kinds. *)
+  {acc with uniqueness=Uniqueness.Const.Shared}
+
 let rec instance_prim_locals locals mvar macc finalret ty =
   match locals, get_desc ty with
   | l :: locals, Tarrow ((lbl,marg,mret),arg,ret,commu) ->

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -211,6 +211,7 @@ val prim_mode :
 val instance_prim:
         Primitive.description -> type_expr ->
         type_expr * Mode.Locality.lr option * Jkind.Sort.t option
+val curry_mode : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
 
 val apply:
         ?use_current_level:bool ->

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -211,6 +211,10 @@ val prim_mode :
 val instance_prim:
         Primitive.description -> type_expr ->
         type_expr * Mode.Locality.lr option * Jkind.Sort.t option
+
+(** Given (a @ m1 -> b -> c) @ m0, where [m0] and [m1] are modes expressed by
+    user-syntax, [curry_mode m0 m1] gives the mode we implicitly interpret b->c
+    to have. *)
 val curry_mode : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
 
 val apply:

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -2108,6 +2108,13 @@ module Alloc = struct
         { locality; uniqueness; linearity }
     end
 
+    let diff m0 m1 =
+      let diff le a0 a1 = if le a0 a1 && le a1 a0 then None else Some a0 in
+      let locality = diff Locality.Const.le m0.locality m1.locality in
+      let linearity = diff Linearity.Const.le m0.linearity m1.linearity in
+      let uniqueness = diff Uniqueness.Const.le m0.uniqueness m1.uniqueness in
+      { locality; linearity; uniqueness }
+
     (** See [Alloc.close_over] for explanation. *)
     let close_over m =
       let { monadic; comonadic } = split m in

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -358,6 +358,10 @@ module type S = sig
         val value : t -> default:some -> some
       end
 
+      (** [diff a b] returns [None] for axes where [a] and [b] match, and [Some
+      a0] for axes where [a] is [a0] and [b] isn't. *)
+      val diff : t -> t -> Option.t
+
       (** Similar to [Alloc.close_over] but for constants *)
       val close_over : t -> t
 

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -338,14 +338,17 @@ let pr_var_jkinds =
   disallowed in parsing of this file, but non-legacy modes might still pop
   up. For example, the current file might cite values from other files that
   mention non-legacy modes *)
-let print_out_legacy_axis f ppf = function
-  | None -> ()
-  | Some m -> Format.fprintf ppf "%a_ " f m
+let print_out_mode ppf = function
+  | Omd_local -> fprintf ppf "local_"
+  | Omd_unique -> fprintf ppf "unique_"
+  | Omd_once -> fprintf ppf "once_"
 
-let print_out_modes ppf (m : Mode.Alloc.Const.Option.t) =
-  print_out_legacy_axis Mode.Locality.Const.print ppf m.locality;
-  print_out_legacy_axis Mode.Linearity.Const.print ppf m.linearity;
-  print_out_legacy_axis Mode.Uniqueness.Const.print ppf m.uniqueness
+let print_out_mode_space ppf m =
+  print_out_mode ppf m;
+  pp_print_space ppf ()
+
+let print_out_modes ppf l =
+  pp_print_list print_out_mode_space ppf l
 
 (* Labeled tuples with the first element labeled sometimes require parens. *)
 let is_initially_labeled_tuple ty =
@@ -377,12 +380,16 @@ let rec print_out_type_0 ppf =
    - Or, there is at least one mode to print.
  *)
 and print_out_type_mode ~arg mode ppf ty =
-  let mode = Format.asprintf "%a" print_out_modes mode in
+  let has_modes =
+    match mode with
+    | [] -> false
+    | _ -> true
+  in
   let parens =
     is_initially_labeled_tuple ty
-    && (arg || String.length mode > 0)
+    && (arg || has_modes)
   in
-  pp_print_string ppf mode;
+  print_out_modes ppf mode;
   if parens then
     pp_print_char ppf '(';
   print_out_type_2 ppf ty;

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -332,108 +332,20 @@ let pr_var_jkind ppf (v, l) = match l with
 let pr_var_jkinds =
   print_list pr_var_jkind (fun ppf -> fprintf ppf "@ ")
 
-let join_locality lm1 lm2 =
-  match lm1, lm2 with
-  | Olm_local, _ -> Olm_local
-  | _, Olm_local -> Olm_local
-  | Olm_unknown, _ -> Olm_unknown
-  | _, Olm_unknown -> Olm_unknown
-  | Olm_global, Olm_global -> Olm_global
+(* NON-LEGACY MODES
+  Here, we are printing mode annotations even if the mode extension is
+  disabled. Mode extension being disabled means mode annotations are
+  disallowed in parsing of this file, but non-legacy modes might still pop
+  up. For example, the current file might cite values from other files that
+  mention non-legacy modes *)
+let print_out_legacy_axis f ppf = function
+  | None -> ()
+  | Some m -> Format.fprintf ppf "%a_ " f m
 
-let join_uniqueness u1 u2 =
-  match u1, u2 with
-  | Oum_shared, _ -> Oum_shared
-  | _, Oum_shared -> Oum_shared
-  | Oum_unknown, _ -> Oum_unknown
-  | _, Oum_unknown -> Oum_unknown
-  | Oum_unique, Oum_unique -> Oum_unique
-
-let join_linearity l1 l2 =
-  match l1, l2 with
-  | Olinm_once, _
-  | _, Olinm_once -> Olinm_once
-  | Olinm_unknown, _
-  | _, Olinm_unknown -> Olinm_unknown
-  | Olinm_many, Olinm_many -> Olinm_many
-
-let uniqueness_to_linearity = function
-  | Oum_unique -> Olinm_once
-  | Oum_shared -> Olinm_many
-  | Oum_unknown -> Olinm_unknown
-
-let join_modes m1 m2 =
-  { oam_locality = join_locality m1.oam_locality m2.oam_locality;
-    oam_uniqueness = join_uniqueness m1.oam_uniqueness m2.oam_uniqueness;
-    oam_linearity = join_linearity m1.oam_linearity m2.oam_linearity }
-
-let default_mode =
-  { oam_locality = Olm_global;
-    oam_uniqueness = Oum_shared;
-    oam_linearity = Olinm_many; }
-
-let close_over arg_mode =
-  let oam_locality = arg_mode.oam_locality in
-  let oam_uniqueness = Oum_shared in
-  let oam_linearity =
-    join_linearity
-      arg_mode.oam_linearity
-      (uniqueness_to_linearity arg_mode.oam_uniqueness)
-  in
-  { oam_locality;
-    oam_uniqueness;
-    oam_linearity }
-
-let partial_apply alloc_mode =
-  let oam_locality = alloc_mode.oam_locality in
-  let oam_uniqueness = Oum_shared in
-  let oam_linearity = alloc_mode.oam_linearity in
-  { oam_locality; oam_uniqueness; oam_linearity }
-
-(* Following functions are used to check if the return mode can omitted in the
-   case of currying *)
-let locality_agree expected real =
-  match expected, real with
-  (* If expected and real matches, can omit *)
-  | Olm_local, Olm_local | Olm_global, Olm_global -> true
-  (* If the real mode is unknown, we'd rather not put extra parentheses, because
-     we wouldn't put "unknown" around the parentheses either, which would make
-     the printing even less precise *)
-  | _, Olm_unknown -> true
-  (* In all other cases (the real mode is known), we will print the mode to be
-     safe*)
-  | _, _ -> false
-
-let uniqueness_agree expected real =
-  match expected, real with
-  | Oum_unique, Oum_unique | Oum_shared, Oum_shared -> true
-  | _, Oum_unknown -> true
-  | _, _ -> false
-
-let linearity_agree expected real =
-  match expected, real with
-  | Olinm_many, Olinm_many | Olinm_once, Olinm_once -> true
-  | _, Olinm_unknown -> true
-  | _, _ -> false
-
-let mode_agree expected real =
-  locality_agree expected.oam_locality real.oam_locality &&
-  uniqueness_agree expected.oam_uniqueness real.oam_uniqueness &&
-  linearity_agree expected.oam_linearity real.oam_linearity
-
-let is_local mode =
-  match mode.oam_locality with
-  | Olm_local -> true
-  | _ -> false
-
-let is_unique mode =
-  match mode.oam_uniqueness with
-  | Oum_unique -> true
-  | _ -> false
-
-let is_once mode =
-  match mode.oam_linearity with
-  | Olinm_once -> true
-  | _ -> false
+let print_out_modes ppf (m : Mode.Alloc.Const.Option.t) =
+  print_out_legacy_axis Mode.Locality.Const.print ppf m.locality;
+  print_out_legacy_axis Mode.Linearity.Const.print ppf m.linearity;
+  print_out_legacy_axis Mode.Uniqueness.Const.print ppf m.uniqueness
 
 (* Labeled tuples with the first element labeled sometimes require parens. *)
 let is_initially_labeled_tuple ty =
@@ -445,55 +357,39 @@ let string_of_gbl_space = function
   | Ogf_global -> "global_ "
   | Ogf_unrestricted -> ""
 
-let rec print_out_type_0 mode ppf =
+let rec print_out_type_0 ppf =
   function
   | Otyp_alias {non_gen; aliased; alias } ->
     fprintf ppf "@[%a@ as %a@]"
-      (print_out_type_0 mode) aliased
+      print_out_type_0 aliased
       (ty_var ~non_gen) alias
   | Otyp_poly ([], ty) ->
-      print_out_type_0 mode ppf ty  (* no "." if there are no vars *)
+      print_out_type_0 ppf ty  (* no "." if there are no vars *)
   | Otyp_poly (sl, ty) ->
       fprintf ppf "@[<hov 2>%a.@ %a@]"
         pr_var_jkinds sl
-        (print_out_type_0 mode) ty
+        print_out_type_0 ty
   | ty ->
-      print_out_type_1 mode ppf ty
+      print_out_type_1 ppf ty
 
 (* We must parenthesize a labeled tuple with the first element labeled when:
    - It is an argument to a function ([~arg])
    - Or, there is at least one mode to print.
  *)
 and print_out_type_mode ~arg mode ppf ty =
-  let is_local = is_local mode in
-  let is_unique = is_unique mode in
-  let is_once = is_once mode in
+  let mode = Format.asprintf "%a" print_out_modes mode in
   let parens =
     is_initially_labeled_tuple ty
-    && (arg || is_local || is_unique || is_once)
+    && (arg || String.length mode > 0)
   in
-  (* NON-LEGACY MODES
-     Here, we are printing mode annotations even if the mode extension is
-     disabled. Mode extension being disabled means mode annotations are
-     disallowed in parsing of this file, but non-legacy modes might still pop
-     up. For example, the current file might cite values from other files that
-     mention non-legacy modes *)
-  if is_local then begin
-    pp_print_string ppf "local_";
-    pp_print_space ppf () end;
-  if is_unique then begin
-    pp_print_string ppf "unique_";
-    pp_print_space ppf () end;
-  if is_once then begin
-    pp_print_string ppf "once_";
-    pp_print_space ppf () end;
+  pp_print_string ppf mode;
   if parens then
     pp_print_char ppf '(';
-  print_out_type_2 mode ppf ty;
+  print_out_type_2 ppf ty;
   if parens then
     pp_print_char ppf ')'
 
-and print_out_type_1 mode ppf =
+and print_out_type_1 ppf =
   function
   | Otyp_arrow (lab, am, ty1, rm, ty2) ->
       pp_open_box ppf 0;
@@ -509,34 +405,38 @@ and print_out_type_1 mode ppf =
           pp_print_string ppf ("?" ^ l); pp_print_char ppf ':'; print_type ());
       pp_print_string ppf " ->";
       pp_print_space ppf ();
-      let mode =
-        join_modes
-          (partial_apply mode)
-          (close_over am)
-      in
-      print_out_ret mode rm ppf ty2;
+      print_out_ret rm ppf ty2;
       pp_close_box ppf ()
-  | ty -> print_out_type_mode ~arg:false mode ppf ty
+  | ty -> print_out_type_2 ppf ty
 
 and print_out_arg am ppf ty =
   print_out_type_mode ~arg:true am ppf ty
 
-and print_out_ret mode rm ppf =
+and print_out_ret rm ppf =
   function
-  (* the 'mode' argument only has meaning if we are talking about closure *)
   | Otyp_arrow _ as ty ->
-    if mode_agree mode rm
-      then print_out_type_1 rm ppf ty
-      else print_out_type_mode ~arg:false rm ppf ty
-  | ty -> print_out_type_mode ~arg:false rm ppf ty
+    begin match rm with
+    | Orm_not_arrow _ -> assert false
+    | Orm_no_parens ->
+      print_out_type_1 ppf ty
+    | Orm_parens rm ->
+      print_out_modes ppf rm;
+      pp_print_char ppf '(';
+      print_out_type_1 ppf ty;
+      pp_print_char ppf ')'
+    end
+  | ty ->
+    match rm with
+    | Orm_not_arrow rm -> print_out_type_mode ~arg:false rm ppf ty
+    | _ -> assert false
 
-and print_out_type_2 mode ppf =
+and print_out_type_2 ppf =
   function
   | Otyp_tuple tyl ->
       fprintf
         ppf "@[<0>%a@]" (print_labeled_typlist print_simple_out_type " *") tyl
-  | ty -> print_out_type_3 mode ppf ty
-and print_out_type_3 mode ppf =
+  | ty -> print_out_type_3 ppf ty
+and print_out_type_3 ppf =
   function
     Otyp_class (id, tyl) ->
       fprintf ppf "@[%a#%a@]" print_typargs tyl print_ident id
@@ -571,7 +471,7 @@ and print_out_type_3 mode ppf =
   | Otyp_alias _ | Otyp_poly _ | Otyp_arrow _ | Otyp_tuple _ as ty ->
       pp_open_box ppf 1;
       pp_print_char ppf '(';
-      print_out_type_0 mode ppf ty;
+      print_out_type_0 ppf ty;
       pp_print_char ppf ')';
       pp_close_box ppf ()
   | Otyp_abstract | Otyp_open
@@ -589,15 +489,15 @@ and print_out_type_3 mode ppf =
       fprintf ppf ")@]"
   | Otyp_attribute (t, attr) ->
       fprintf ppf "@[<1>(%a [@@%s])@]"
-        (print_out_type_0 mode) t attr.oattr_name
+        print_out_type_0 t attr.oattr_name
   | Otyp_jkind_annot (t, lay) ->
     fprintf ppf "@[<1>(%a@ :@ %a)@]"
-      (print_out_type_0 mode) t
+      print_out_type_0 t
       print_out_jkind lay
 and print_out_type ppf typ =
-  print_out_type_0 default_mode ppf typ
+  print_out_type_0 ppf typ
 and print_simple_out_type ppf typ =
-  print_out_type_3 default_mode ppf typ
+  print_out_type_3 ppf typ
 and print_record_decl ppf lbls =
   fprintf ppf "{%a@;<1 -2>}"
     (print_list_init print_out_label (fun ppf -> fprintf ppf "@ ")) lbls
@@ -690,7 +590,7 @@ let rec print_out_class_type ppf =
       in
       fprintf ppf "@[%a%a@]" pr_tyl tyl print_ident id
   | Octy_arrow (lab, ty, cty) ->
-      let print_type = print_out_type_2 default_mode in
+      let print_type = print_out_type_2 in
       let label, print_type = match lab with
         | Nolabel -> "", print_type
         | Labelled l -> l ^ ":", print_type

--- a/ocaml/typing/outcometree.mli
+++ b/ocaml/typing/outcometree.mli
@@ -84,11 +84,24 @@ type arg_label =
   | Optional of string
   | Position of string
 
+type out_arg_mode = Mode.Alloc.Const.Option.t
+
+type out_ret_mode =
+  | Orm_not_arrow of Mode.Alloc.Const.Option.t
+  (** The ret type is not arrow, with modes annotating. *)
+  | Orm_no_parens
+  (** The ret type is arrow, and no need to print parens around the arrow *)
+  | Orm_parens of Mode.Alloc.Const.Option.t
+  (** The ret type is arrow, and need to print parens around the arrow, with
+      modes annotating. *)
+
 type out_type =
   | Otyp_abstract
   | Otyp_open
   | Otyp_alias of {non_gen:bool; aliased:out_type; alias:string}
-  | Otyp_arrow of arg_label * out_alloc_mode * out_type * out_alloc_mode * out_type
+  | Otyp_arrow of arg_label * out_arg_mode * out_type * out_ret_mode * out_type
+  (* INVARIANT: the [out_ret_mode] is [Orm_not_arrow] unless the RHS [out_type]
+    is [Otyp_arrow] *)
   | Otyp_class of out_ident * out_type list
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
@@ -115,26 +128,6 @@ and out_constructor = {
 and out_variant =
   | Ovar_fields of (string * bool * out_type list) list
   | Ovar_typ of out_type
-
-and out_locality =
-  | Olm_local
-  | Olm_global
-  | Olm_unknown
-
-and out_uniqueness =
-  | Oum_unique
-  | Oum_shared
-  | Oum_unknown
-
-and out_linearity =
-  | Olinm_many
-  | Olinm_once
-  | Olinm_unknown
-
-and out_alloc_mode =
-  { oam_locality : out_locality;
-    oam_uniqueness : out_uniqueness;
-    oam_linearity : out_linearity }
 
 type out_class_type =
   | Octy_constr of out_ident * out_type list

--- a/ocaml/typing/outcometree.mli
+++ b/ocaml/typing/outcometree.mli
@@ -84,14 +84,19 @@ type arg_label =
   | Optional of string
   | Position of string
 
-type out_arg_mode = Mode.Alloc.Const.Option.t
+type out_mode =
+  | Omd_local
+  | Omd_unique
+  | Omd_once
+
+type out_arg_mode = out_mode list
 
 type out_ret_mode =
-  | Orm_not_arrow of Mode.Alloc.Const.Option.t
+  | Orm_not_arrow of out_mode list
   (** The ret type is not arrow, with modes annotating. *)
   | Orm_no_parens
   (** The ret type is arrow, and no need to print parens around the arrow *)
-  | Orm_parens of Mode.Alloc.Const.Option.t
+  | Orm_parens of out_mode list
   (** The ret type is arrow, and need to print parens around the arrow, with
       modes annotating. *)
 

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1314,7 +1314,7 @@ let rec tree_of_typexp mode alloc_mode ty =
             tree_of_typexp mode arg_mode ty1
         in
         let acc_mode = curry_mode alloc_mode arg_mode in
-        let (rm, t2) = tree_of_ret_typ_unsafe mode acc_mode (mret, ty2) in
+        let (rm, t2) = tree_of_ret_typ_mutating mode acc_mode (mret, ty2) in
         Btype.backtrack snap;
         Otyp_arrow (lab, tree_of_modes arg_mode, t1, rm, t2)
     | Ttuple labeled_tyl ->
@@ -1453,7 +1453,7 @@ and tree_of_typ_gf (ty, gf) =
 
     NB: This function might mutate states; the caller is responsible for
     reverting them. *)
-and tree_of_ret_typ_unsafe mode acc_mode (m, ty) =
+and tree_of_ret_typ_mutating mode acc_mode (m, ty) =
   match get_desc ty with
   | Tarrow _ -> begin
       (* We first try to equate [m] with the [acc_mode]; if that succeeds, we

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -676,17 +676,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
             else transl_type env ~policy ~row_context arg_mode arg
           in
-          let {locality; linearity; _} : Alloc.Const.t =
-            Alloc.Const.join
-              (Alloc.Const.close_over arg_mode)
-              (Alloc.Const.partial_apply acc_mode)
-          in
-          (* Arrow types cross uniqueness axis. Therefore, when user writes an
-          A -> B -> C (to be used as constraint on something), we should make
-          (B -> C) shared. A proper way to do this is via modal kinds. *)
-          let acc_mode : Alloc.Const.t
-            = {locality; linearity; uniqueness=Uniqueness.Const.Shared}
-          in
+          let acc_mode = curry_mode acc_mode arg_mode in
           let ret_mode =
             match rest with
             | [] -> ret_mode


### PR DESCRIPTION
This PR refactors the logic around modes in `printtyp.ml` and `oprint.ml`, in particular the part about currying.

Currently, `oprint.ml` has its own copy of handling currying, legacy modes and such, which duplicates code elsewhere. 

Instead, we should make `printtyp.ml` worry about these (using the existing code from `mode.ml` and `ctype.ml`), and `outcometree.mli` should reflect the final printing, and `oprint.ml` should verbatim print the given outcometree