### PR TITLE
Unconditionally reserve the top header byte in runtime 4

### DIFF
--- a/ocaml/configure
+++ b/ocaml/configure
@@ -935,7 +935,6 @@ enable_flambda_invariants
 enable_flambda2
 enable_cmm_invariants
 with_target_bindir
-with_profinfo
 enable_stdlib_manpages
 enable_warn_error
 enable_force_safe_string
@@ -1653,10 +1652,6 @@ Optional Packages:
   --with-dune             Path to dune executable (otherwise PATH is searched)
   --with-odoc             build documentation with odoc
   --with-target-bindir    location of binary programs on target system
-  --enable-profinfo-width=8
-                          reserved bits in block headers in runtime 4. 8 bits
-                          are required for mixed block support in runtime 4;
-                          any other value is not sensible.
   --with-afl              use the AFL fuzzer
   --with-flexdll          bootstrap FlexDLL from the given sources
   --without-zstd          disable compression of marshaled data
@@ -3212,8 +3207,8 @@ ostype="Unix"
 SO="so"
 toolchain="cc"
 reserved_header_bits=8
-profinfo=false
-profinfo_width=0
+profinfo=true
+profinfo_width=8
 custom_ops_struct_size=64
 instrumented_runtime=false
 instrumented_runtime_libs=""
@@ -3918,20 +3913,6 @@ fi
 if test ${with_target_bindir+y}
 then :
   withval=$with_target_bindir;
-fi
-
-
-
-# Check whether --with-profinfo was given.
-if test ${with_profinfo+y}
-then :
-  withval=$with_profinfo; case $enable_profinfo_width in #(
-  8) :
-    with_profinfo=true
-      profinfo_width="$enable_profinfo_width" ;; #(
-  *) :
-    as_fn_error $? "invalid argument to --enable-profinfo-width (must be 8)" "$LINENO" 5 ;;
-esac
 fi
 
 
@@ -19645,6 +19626,8 @@ fi
 
 
 
+# Unconditionally reserve 8 header bits in both runtime 4 and
+# runtime 5, which is required for mixed block support.
 printf "%s\n" "#define HEADER_RESERVED_BITS $reserved_header_bits" >>confdefs.h
 
 printf "%s\n" "#define PROFINFO_WIDTH $profinfo_width" >>confdefs.h
@@ -19654,6 +19637,7 @@ then :
   printf "%s\n" "#define WITH_PROFINFO 1" >>confdefs.h
 
 fi
+
 printf "%s\n" "#define CUSTOM_OPS_STRUCT_SIZE $custom_ops_struct_size" >>confdefs.h
 
 

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -62,8 +62,8 @@ ostype="Unix"
 SO="so"
 toolchain="cc"
 reserved_header_bits=8
-profinfo=false
-profinfo_width=0
+profinfo=true
+profinfo_width=8
 custom_ops_struct_size=64
 instrumented_runtime=false
 instrumented_runtime_libs=""
@@ -466,15 +466,6 @@ AC_ARG_ENABLE([cmm-invariants],
 AC_ARG_WITH([target-bindir],
   [AS_HELP_STRING([--with-target-bindir],
     [location of binary programs on target system])])
-
-AC_ARG_WITH([profinfo],
-  [AS_HELP_STRING([--enable-profinfo-width=8],
-  [reserved bits in block headers in runtime 4. 8 bits are required for mixed block support in runtime 4; any other value is not sensible.])],
-  [AS_CASE([$enable_profinfo_width],
-    [8],
-      [with_profinfo=true
-      profinfo_width="$enable_profinfo_width"],
-    [AC_MSG_ERROR([invalid argument to --enable-profinfo-width (must be 8)])])])
 
 AC_ARG_ENABLE([stdlib-manpages],
   [AS_HELP_STRING([--disable-stdlib-manpages],
@@ -2205,9 +2196,12 @@ AS_IF([test x"$enable_naked_pointers_checker" = "xyes" ],
 ## Check for mmap support for huge pages and contiguous heap
 OCAML_MMAP_SUPPORTS_HUGE_PAGES
 
+# Unconditionally reserve 8 header bits in both runtime 4 and
+# runtime 5, which is required for mixed block support.
 AC_DEFINE_UNQUOTED([HEADER_RESERVED_BITS], [$reserved_header_bits])
 AC_DEFINE_UNQUOTED([PROFINFO_WIDTH], [$profinfo_width])
 AS_IF([$profinfo], [AC_DEFINE([WITH_PROFINFO])])
+
 AC_DEFINE_UNQUOTED([CUSTOM_OPS_STRUCT_SIZE], [$custom_ops_struct_size])
 
 AS_IF([test x"$enable_installing_bytecode_programs" = "xno"],


### PR DESCRIPTION
Builds on #2389 to also unconditionally reserve the top header byte in runtime 4. This is a prerequisite for the rollout of mixed blocks.

A priori, you'd expect this change to be a no-op for existing code on 64 bit platforms. The top header byte, if not reserved, is interpreted as part of the size of the block. And you'd need to create a comically big value to require stealing bits from the top byte. Napkin math to support this claim: with the top header byte reserved, there are 46 remaining bits used to encode the size. To require more than 46 size bits, you'd need to create a value that's 2^46 words = 512 TiB large.

Internal testing supports this claim.