### PR TITLE
Fix labeled tuple pattern location in parser

### DIFF
--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -3549,9 +3549,10 @@ pattern_no_exn:
       { let loc = $loc(label) in
         Some label, mkpatvar ~loc label }
   | TILDE LPAREN label = LIDENT COLON cty = core_type RPAREN
-      { let loc = $loc(label) in
-        let pat = mkpatvar ~loc label in
-        Some label, mkpat_opt_constraint ~loc pat (Some cty) }
+      { let lbl_loc = $loc(label) in
+        let pat_loc = $startpos($2), $endpos in
+        let pat = mkpatvar ~loc:lbl_loc label in
+        Some label, mkpat_opt_constraint ~loc:pat_loc pat (Some cty) }
 
 labeled_tuple_pat_element_list(self):
   | labeled_tuple_pat_element_list(self) COMMA labeled_tuple_pat_element(self)


### PR DESCRIPTION
Labeled tuple patterns can be puns and have type annotations, as in:
```ocaml
let f (~(x:int), ~(y:int)) = x + y
```
However, there is a small bug in the parser for patterns like this: the location on the subpatterns for each tuple element (e.g., `(x:int)`) should include the type annotation but do not.  This fixes that.  Note that labeled tuple expressions can also look like this, but the parser there was already correct.

Existing tests pass.  I haven't added a new test.  I found this because of a ppxlib invariant check that ensures locations are properly nested.  We could and maybe should add a similar test to the compiler.  But the ppxlib code is 700 lines of objects, so I think it's reasonable to leave that for the future.