### PR TITLE
Take into account witnesses when computing [lessequal] on values

### DIFF
--- a/ocaml/lambda/assume_info.ml
+++ b/ocaml/lambda/assume_info.ml
@@ -34,6 +34,7 @@ module Witnesses = struct
   type t = unit
 
   let join _ _ = ()
+  let lessequal _ _ = true
   let meet _ _ = ()
   let print _ _ = ()
   let empty = ()

--- a/ocaml/lambda/assume_info.mli
+++ b/ocaml/lambda/assume_info.mli
@@ -15,6 +15,7 @@ module Witnesses : sig
 
   val join : t -> t -> t
   val meet : t -> t -> t
+  val lessequal : t -> t -> bool
   val print : Format.formatter -> t -> unit
   val compare : t -> t -> int
 end

--- a/ocaml/utils/zero_alloc_utils.ml
+++ b/ocaml/utils/zero_alloc_utils.ml
@@ -5,6 +5,8 @@ module type WS = sig
 
   val meet : t -> t -> t
 
+  val lessequal : t -> t -> bool
+
   val print : Format.formatter -> t -> unit
 
   val compare : t -> t -> int
@@ -39,7 +41,7 @@ module Make (Witnesses : WS) = struct
       match v1, v2 with
       | Bot, Bot -> true
       | Safe, Safe -> true
-      | Top _, Top _ -> true
+      | Top w1, Top w2 -> Witnesses.lessequal w1 w2
       | Bot, Safe -> true
       | Bot, Top _ -> true
       | Safe, Top _ -> true

--- a/ocaml/utils/zero_alloc_utils.mli
+++ b/ocaml/utils/zero_alloc_utils.mli
@@ -10,6 +10,8 @@ module type WS = sig
 
   val meet : t -> t -> t
 
+  val lessequal : t -> t -> bool
+
   val print : Format.formatter -> t -> unit
 
   val compare : t -> t -> int


### PR DESCRIPTION
otherwise we lose witnesses sometimes. 

Take 3 of #2353.  
(I messed up something when merging on the chain of PRs and this PR closed on me, can't reopen it as it's base branch is gone.)
