### PR TITLE
Improve error message around `any` in functions

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi.ml
@@ -23,7 +23,7 @@ Error: Function arguments and returns must be representable.
        The layout of Any_missing_cmi_lib2.t is any, because
          the .cmi file for Any_missing_cmi_lib2.t is missing.
        But the layout of Any_missing_cmi_lib2.t must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
        No .cmi file found containing Any_missing_cmi_lib2.t.
        Hint: Adding "any_missing_cmi_lib2" to your dependencies might help.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete.ml
@@ -105,7 +105,7 @@ Error: This pattern matches values of type t_any
        The layout of t_any is any, because
          of the definition of t_any at line 1, characters 0-16.
        But the layout of t_any must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
 |}]
 
 (* Function_result *)
@@ -120,7 +120,7 @@ Error: This expression has type t_any but an expression was expected of type
        The layout of t_any is any, because
          of the definition of t_any at line 1, characters 0-16.
        But the layout of t_any must be representable, because
-         it's the type of a function result.
+         we must know concretely how to return a function result.
 |}]
 
 (* Structure_item_expression *)

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
@@ -27,7 +27,7 @@ Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
          the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -42,7 +42,7 @@ Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
          the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -57,7 +57,7 @@ Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
          the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -72,7 +72,7 @@ Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
          the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be representable, because
-         it's the type of a function result.
+         we must know concretely how to return a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -89,7 +89,7 @@ Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
          the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -106,7 +106,7 @@ Error: Function arguments and returns must be representable.
        The layout of Function_a.t is any, because
          the .cmi file for Function_a.t is missing.
        But the layout of Function_a.t must be representable, because
-         it's the type of a function result.
+         we must know concretely how to return a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -259,7 +259,7 @@ Error: This definition has type 'b -> 'b which is less general than
        The layout of 'a is any, because
          of the annotation on the universal variable 'a.
        But the layout of 'a must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
 |}]
 (* CR layouts v2.9: This error message is not great. Check later if layout history
    is able to improve it. *)
@@ -399,7 +399,7 @@ Error: This pattern matches values of type a
        The layout of a is any, because
          of the annotation on the abstract type declaration for a.
        But the layout of a must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
 |}]
 
 (****************************************)
@@ -433,7 +433,7 @@ Error: Function arguments and returns must be representable.
        The layout of a is any, because
          of the annotation on the abstract type declaration for a.
        But the layout of a must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
 |}]
 
 (**************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -363,7 +363,7 @@ Error: This expression has type t_any but an expression was expected of type
        The layout of t_any is any, because
          of the definition of t_any at line 5, characters 0-18.
        But the layout of t_any must be representable, because
-         it's the type of a function result.
+         we must know concretely how to return a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -377,7 +377,7 @@ Error: This pattern matches values of type t_any
        The layout of t_any is any, because
          of the definition of t_any at line 5, characters 0-18.
        But the layout of t_any must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
 |}];;
 
 (*****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -104,7 +104,7 @@ Error: This expression has type t_any but an expression was expected of type
        The layout of t_any is any, because
          of the definition of t_any at line 1, characters 0-18.
        But the layout of t_any must be representable, because
-         it's the type of a function result.
+         we must know concretely how to return a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -118,7 +118,7 @@ Error: This pattern matches values of type t_any
        The layout of t_any is any, because
          of the definition of t_any at line 1, characters 0-18.
        But the layout of t_any must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
 |}];;
 
 (*****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -706,7 +706,7 @@ Error: Function arguments and returns must be representable.
        The layout of X.t is any, because
          of the definition of t at line 2, characters 2-14.
        But the layout of X.t must be representable, because
-         it's the type of a function argument.
+         we must know concretely how to pass a function argument.
 |}]
 
 (***********************************)

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1219,8 +1219,10 @@ end = struct
     | Record_assignment ->
       fprintf ppf "it's the record type used in an assignment"
     | Let_binding -> fprintf ppf "it's the type of a variable bound by a `let`"
-    | Function_argument -> fprintf ppf "it's the type of a function argument"
-    | Function_result -> fprintf ppf "it's the type of a function result"
+    | Function_argument ->
+      fprintf ppf "we must know concretely how to pass a function argument"
+    | Function_result ->
+      fprintf ppf "we must know concretely how to return a function result"
     | Structure_item_expression ->
       fprintf ppf "it's the type of an expression in a structure"
     | External_argument ->


### PR DESCRIPTION
As title.

Inspired by feedback from a colleague.