### PR TITLE
Fix and test vector load/store for arrays of unboxed ints

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -142,17 +142,24 @@ let array_length ~dbg arr (kind : P.Array_kind.t) =
        though the contents are of word width. *)
     C.unboxed_int64_or_nativeint_array_length arr dbg
 
-let array_load_128 ~dbg arr index element_width_log2 =
+let array_load_128 ~dbg ~element_width_log2 ~skip_custom_ops arr index =
   C.unaligned_load_128 arr
-    (C.lsl_int (C.untag_int index dbg)
-       (Cconst_int (element_width_log2, dbg))
+    ((C.add_int
+        (Cconst_int ((if skip_custom_ops then Arch.size_addr else 0), dbg))
+        (C.lsl_int (C.untag_int index dbg)
+           (Cconst_int (element_width_log2, dbg))
+           dbg))
        dbg)
     dbg
 
-let array_set_128 ~dbg arr index new_value element_width_log2 =
+let array_set_128 ~dbg ~element_width_log2 ~skip_custom_ops arr index new_value
+    =
   C.unaligned_set_128 arr
-    (C.lsl_int (C.untag_int index dbg)
-       (Cconst_int (element_width_log2, dbg))
+    ((C.add_int
+        (Cconst_int ((if skip_custom_ops then Arch.size_addr else 0), dbg))
+        (C.lsl_int (C.untag_int index dbg)
+           (Cconst_int (element_width_log2, dbg))
+           dbg))
        dbg)
     new_value dbg
 
@@ -165,9 +172,12 @@ let array_load ~dbg (kind : P.Array_kind.t)
   | Values, Scalar -> C.addr_array_ref arr index dbg
   | Naked_floats, Scalar -> C.unboxed_float_array_ref arr index dbg
   | Naked_int32s, Scalar -> C.unboxed_int32_array_ref arr index dbg
-  | (Immediates | Naked_int64s | Naked_nativeints | Naked_floats), Vec128 ->
-    array_load_128 ~dbg arr index 3
-  | Naked_int32s, Vec128 -> array_load_128 ~dbg arr index 2
+  | (Immediates | Naked_floats), Vec128 ->
+    array_load_128 ~dbg ~element_width_log2:3 ~skip_custom_ops:false arr index
+  | (Naked_int64s | Naked_nativeints), Vec128 ->
+    array_load_128 ~dbg ~element_width_log2:3 ~skip_custom_ops:true arr index
+  | Naked_int32s, Vec128 ->
+    array_load_128 ~dbg ~element_width_log2:2 ~skip_custom_ops:true arr index
   | Values, Vec128 ->
     Misc.fatal_error "Attempted to load a SIMD vector from a value array."
 
@@ -188,9 +198,15 @@ let array_set ~dbg (kind : P.Array_set_kind.t)
       C.unboxed_int32_array_set arr ~index ~new_value dbg
     | (Naked_int64s | Naked_nativeints), Scalar ->
       C.unboxed_int64_or_nativeint_array_set arr ~index ~new_value dbg
-    | (Immediates | Naked_int64s | Naked_nativeints | Naked_floats), Vec128 ->
-      array_set_128 ~dbg arr index new_value 3
-    | Naked_int32s, Vec128 -> array_set_128 ~dbg arr index new_value 2
+    | (Immediates | Naked_floats), Vec128 ->
+      array_set_128 ~dbg ~element_width_log2:3 ~skip_custom_ops:false arr index
+        new_value
+    | (Naked_int64s | Naked_nativeints), Vec128 ->
+      array_set_128 ~dbg ~element_width_log2:3 ~skip_custom_ops:true arr index
+        new_value
+    | Naked_int32s, Vec128 ->
+      array_set_128 ~dbg ~element_width_log2:2 ~skip_custom_ops:true arr index
+        new_value
     | Values _, Vec128 ->
       Misc.fatal_error "Attempted to store a SIMD vector to a value array."
   in

--- a/tests/simd/arrays.ml
+++ b/tests/simd/arrays.ml
@@ -9,6 +9,10 @@ external int64x2_of_int64s : int64 -> int64 -> int64x2 = "" "vec128_of_int64s" [
 external int64x2_low_int64 : int64x2 -> int64 = "" "vec128_low_int64" [@@noalloc] [@@unboxed]
 external int64x2_high_int64 : int64x2 -> int64 = "" "vec128_high_int64" [@@noalloc] [@@unboxed]
 
+external int32x4_of_int64s : int64 -> int64 -> int32x4 = "" "vec128_of_int64s" [@@noalloc] [@@unboxed]
+external int32x4_low_int64 : int32x4 -> int64 = "" "vec128_low_int64" [@@noalloc] [@@unboxed]
+external int32x4_high_int64 : int32x4 -> int64 = "" "vec128_high_int64" [@@noalloc] [@@unboxed]
+
 external float64x2_low_int64 : float64x2 -> int64 = "" "vec128_low_int64" [@@noalloc] [@@unboxed]
 external float64x2_high_int64 : float64x2 -> int64 = "" "vec128_high_int64" [@@noalloc] [@@unboxed]
 
@@ -284,13 +288,11 @@ module Float_arrays = struct
   external floatarray_set_float64x2 : floatarray -> int -> float64x2 -> unit = "%caml_floatarray_set128"
   external floatarray_set_float64x2_unsafe : floatarray -> int -> float64x2 -> unit = "%caml_floatarray_set128u"
 
-  (* CR mslater: unboxed array tests waiting on PR#2238
   external unboxed_float_array_get_float64x2 : float# array -> int -> float64x2 = "%caml_unboxed_float_array_get128"
   external unboxed_float_array_get_float64x2_unsafe : float# array -> int -> float64x2 = "%caml_unboxed_float_array_get128u"
 
   external unboxed_float_array_set_float64x2 : float# array -> int -> float64x2 -> unit = "%caml_unboxed_float_array_set128"
   external unboxed_float_array_set_float64x2_unsafe : float# array -> int -> float64x2 -> unit = "%caml_unboxed_float_array_set128u"
-  *)
 
   let float_array () = [| 0.0; 1.0; 2.0; 3.0 |]
   let float_iarray () = [: 0.0; 1.0; 2.0; 3.0 :]
@@ -301,6 +303,8 @@ module Float_arrays = struct
     Array.Floatarray.set a 2 2.0;
     Array.Floatarray.set a 3 3.0;
     a
+  ;;
+  let unboxed_float_array () = [| #0.0; #1.0; #2.0; #3.0 |]
 
   let () =
     let float_array = float_array () in
@@ -467,6 +471,71 @@ module Float_arrays = struct
     fail a 1;
     fail a (-1)
   ;;
+
+  let () =
+    let unboxed_float_array = unboxed_float_array () in
+    let _01 = f64x2 0.0 1.0 in
+    let _12 = f64x2 1.0 2.0 in
+    let get = unboxed_float_array_get_float64x2 unboxed_float_array 0 in
+    eq (float64x2_low_int64 _01) (float64x2_high_int64 _01)
+       (float64x2_low_int64 get) (float64x2_high_int64 get);
+    let get = unboxed_float_array_get_float64x2 unboxed_float_array 1 in
+    eq (float64x2_low_int64 _12) (float64x2_high_int64 _12)
+       (float64x2_low_int64 get) (float64x2_high_int64 get);
+
+    let _45 = f64x2 4.0 5.0 in
+    let _67 = f64x2 6.0 7.0 in
+    unboxed_float_array_set_float64x2 unboxed_float_array 0 _45;
+    let get = unboxed_float_array_get_float64x2 unboxed_float_array 0 in
+    eq (float64x2_low_int64 _45) (float64x2_high_int64 _45)
+       (float64x2_low_int64 get) (float64x2_high_int64 get);
+    unboxed_float_array_set_float64x2 unboxed_float_array 1 _67;
+    let get = unboxed_float_array_get_float64x2 unboxed_float_array 1 in
+    eq (float64x2_low_int64 _67) (float64x2_high_int64 _67)
+       (float64x2_low_int64 get) (float64x2_high_int64 get)
+  ;;
+
+  let () =
+    let unboxed_float_array = unboxed_float_array () in
+    let _01 = f64x2 0.0 1.0 in
+    let _12 = f64x2 1.0 2.0 in
+    let get = unboxed_float_array_get_float64x2_unsafe unboxed_float_array 0 in
+    eq (float64x2_low_int64 _01) (float64x2_high_int64 _01)
+       (float64x2_low_int64 get) (float64x2_high_int64 get);
+    let get = unboxed_float_array_get_float64x2_unsafe unboxed_float_array 1 in
+    eq (float64x2_low_int64 _12) (float64x2_high_int64 _12)
+       (float64x2_low_int64 get) (float64x2_high_int64 get);
+
+    let _45 = f64x2 4.0 5.0 in
+    let _67 = f64x2 6.0 7.0 in
+    unboxed_float_array_set_float64x2_unsafe unboxed_float_array 0 _45;
+    let get = unboxed_float_array_get_float64x2_unsafe unboxed_float_array 0 in
+    eq (float64x2_low_int64 _45) (float64x2_high_int64 _45)
+       (float64x2_low_int64 get) (float64x2_high_int64 get);
+    unboxed_float_array_set_float64x2_unsafe unboxed_float_array 1 _67;
+    let get = unboxed_float_array_get_float64x2_unsafe unboxed_float_array 1 in
+    eq (float64x2_low_int64 _67) (float64x2_high_int64 _67)
+       (float64x2_low_int64 get) (float64x2_high_int64 get)
+  ;;
+
+  let () =
+    let a = unboxed_float_array () in
+    let _0 = f64x2 0.0 0.0 in
+    let fail a i =
+      try
+        let _ = unboxed_float_array_get_float64x2 a i in
+        let _ = unboxed_float_array_set_float64x2 a i _0 in
+        Printf.printf "Did not fail on index %d\n" i
+      with | Invalid_argument s when s = "index out of bounds" -> ()
+    in
+    fail a (-1);
+    fail a 3;
+    fail a 4;
+    fail [||] 0;
+    fail [|#0.0|] 0;
+    fail [|#0.0|] 1;
+    fail [|#0.0|] (-1)
+  ;;
 end
 
 module Int_arrays = struct
@@ -480,7 +549,6 @@ module Int_arrays = struct
   external int_array_set_int64x2 : int array -> int -> int64x2 -> unit = "%caml_int_array_set128"
   external int_array_set_int64x2_unsafe : int array -> int -> int64x2 -> unit = "%caml_int_array_set128u"
 
-  (* CR mslater: unboxed array tests waiting on PR#2238
   external unboxed_int64_array_get_int64x2 : int64# array -> int -> int64x2 = "%caml_unboxed_int64_array_get128"
   external unboxed_int64_array_get_int64x2_unsafe : int64# array -> int -> int64x2 = "%caml_unboxed_int64_array_get128u"
 
@@ -498,12 +566,15 @@ module Int_arrays = struct
 
   external unboxed_int32_array_set_int32x4 : int32# array -> int -> int32x4 -> unit = "%caml_unboxed_int32_array_set128"
   external unboxed_int32_array_set_int32x4_unsafe : int32# array -> int -> int32x4 -> unit = "%caml_unboxed_int32_array_set128u"
-  *)
 
   let i64x2 x y = int64x2_of_int64s x y
+  let i32x4 x y z w = int32x4_of_int64s Int64.(logor (shift_left (of_int32 y) 32) (of_int32 x)) Int64.(logor (shift_left (of_int32 w) 32) (of_int32 z))
   let tag i = Int64.(add (shift_left i 1) 1L)
   let int_array () = [| 0; 1; 2; 3 |]
   let int_iarray () = [: 0; 1; 2; 3 :]
+  let unboxed_int64_array () = [| #0L; #1L; #2L; #3L |]
+  let unboxed_nativeint_array () = [| #0n; #1n; #2n; #3n |]
+  let unboxed_int32_array () = [| #0l; #1l; #2l; #3l; #4l; #5l; #6l; #7l |]
 
   let () =
     let int_array = int_array () in
@@ -601,5 +672,210 @@ module Int_arrays = struct
     fail [: 0 :] 0;
     fail [: 0 :] 1;
     fail [: 0 :] (-1)
+  ;;
+
+  let () =
+    let unboxed_int64_array = unboxed_int64_array () in
+    let _01 = i64x2 0L 1L in
+    let _12 = i64x2 1L 2L in
+    let get = unboxed_int64_array_get_int64x2 unboxed_int64_array 0 in
+    eq (int64x2_low_int64 _01) (int64x2_high_int64 _01)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+    let get = unboxed_int64_array_get_int64x2 unboxed_int64_array 1 in
+    eq (int64x2_low_int64 _12) (int64x2_high_int64 _12)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+
+    let _45 = i64x2 4L 5L in
+    let _67 = i64x2 6L 7L in
+    unboxed_int64_array_set_int64x2 unboxed_int64_array 0 _45;
+    let get = unboxed_int64_array_get_int64x2 unboxed_int64_array 0 in
+    eq (int64x2_low_int64 _45) (int64x2_high_int64 _45)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+    unboxed_int64_array_set_int64x2 unboxed_int64_array 1 _67;
+    let get = unboxed_int64_array_get_int64x2 unboxed_int64_array 1 in
+    eq (int64x2_low_int64 _67) (int64x2_high_int64 _67)
+       (int64x2_low_int64 get) (int64x2_high_int64 get)
+  ;;
+
+  let () =
+    let unboxed_int64_array = unboxed_int64_array () in
+    let _01 = i64x2 0L 1L in
+    let _12 = i64x2 1L 2L in
+    let get = unboxed_int64_array_get_int64x2_unsafe unboxed_int64_array 0 in
+    eq (int64x2_low_int64 _01) (int64x2_high_int64 _01)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+    let get = unboxed_int64_array_get_int64x2_unsafe unboxed_int64_array 1 in
+    eq (int64x2_low_int64 _12) (int64x2_high_int64 _12)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+
+    let _45 = i64x2 4L 5L in
+    let _67 = i64x2 6L 7L in
+    unboxed_int64_array_set_int64x2_unsafe unboxed_int64_array 0 _45;
+    let get = unboxed_int64_array_get_int64x2_unsafe unboxed_int64_array 0 in
+    eq (int64x2_low_int64 _45) (int64x2_high_int64 _45)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+    unboxed_int64_array_set_int64x2_unsafe unboxed_int64_array 1 _67;
+    let get = unboxed_int64_array_get_int64x2_unsafe unboxed_int64_array 1 in
+    eq (int64x2_low_int64 _67) (int64x2_high_int64 _67)
+       (int64x2_low_int64 get) (int64x2_high_int64 get)
+  ;;
+
+  let () =
+    let a = unboxed_int64_array () in
+    let _0 = i64x2 0L 0L in
+    let fail a i =
+      try
+        let _ = unboxed_int64_array_get_int64x2 a i in
+        let _ = unboxed_int64_array_set_int64x2 a i _0 in
+        Printf.printf "Did not fail on index %d\n" i
+      with | Invalid_argument s when s = "index out of bounds" -> ()
+    in
+    fail a (-1);
+    fail a 3;
+    fail a 4;
+    fail [||] 0;
+    fail [|#0L|] 0;
+    fail [|#0L|] 1;
+    fail [|#0L|] (-1)
+  ;;
+
+  let () =
+    let unboxed_nativeint_array = unboxed_nativeint_array () in
+    let _01 = i64x2 0L 1L in
+    let _12 = i64x2 1L 2L in
+    let get = unboxed_nativeint_array_get_int64x2 unboxed_nativeint_array 0 in
+    eq (int64x2_low_int64 _01) (int64x2_high_int64 _01)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+    let get = unboxed_nativeint_array_get_int64x2 unboxed_nativeint_array 1 in
+    eq (int64x2_low_int64 _12) (int64x2_high_int64 _12)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+
+    let _45 = i64x2 4L 5L in
+    let _67 = i64x2 6L 7L in
+    unboxed_nativeint_array_set_int64x2 unboxed_nativeint_array 0 _45;
+    let get = unboxed_nativeint_array_get_int64x2 unboxed_nativeint_array 0 in
+    eq (int64x2_low_int64 _45) (int64x2_high_int64 _45)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+    unboxed_nativeint_array_set_int64x2 unboxed_nativeint_array 1 _67;
+    let get = unboxed_nativeint_array_get_int64x2 unboxed_nativeint_array 1 in
+    eq (int64x2_low_int64 _67) (int64x2_high_int64 _67)
+       (int64x2_low_int64 get) (int64x2_high_int64 get)
+  ;;
+
+  let () =
+    let unboxed_nativeint_array = unboxed_nativeint_array () in
+    let _01 = i64x2 0L 1L in
+    let _12 = i64x2 1L 2L in
+    let get = unboxed_nativeint_array_get_int64x2_unsafe unboxed_nativeint_array 0 in
+    eq (int64x2_low_int64 _01) (int64x2_high_int64 _01)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+    let get = unboxed_nativeint_array_get_int64x2_unsafe unboxed_nativeint_array 1 in
+    eq (int64x2_low_int64 _12) (int64x2_high_int64 _12)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+
+    let _45 = i64x2 4L 5L in
+    let _67 = i64x2 6L 7L in
+    unboxed_nativeint_array_set_int64x2_unsafe unboxed_nativeint_array 0 _45;
+    let get = unboxed_nativeint_array_get_int64x2_unsafe unboxed_nativeint_array 0 in
+    eq (int64x2_low_int64 _45) (int64x2_high_int64 _45)
+       (int64x2_low_int64 get) (int64x2_high_int64 get);
+    unboxed_nativeint_array_set_int64x2_unsafe unboxed_nativeint_array 1 _67;
+    let get = unboxed_nativeint_array_get_int64x2_unsafe unboxed_nativeint_array 1 in
+    eq (int64x2_low_int64 _67) (int64x2_high_int64 _67)
+       (int64x2_low_int64 get) (int64x2_high_int64 get)
+  ;;
+
+  let () =
+    let a = unboxed_nativeint_array () in
+    let _0 = i64x2 0L 0L in
+    let fail a i =
+      try
+        let _ = unboxed_nativeint_array_get_int64x2 a i in
+        let _ = unboxed_nativeint_array_set_int64x2 a i _0 in
+        Printf.printf "Did not fail on index %d\n" i
+      with | Invalid_argument s when s = "index out of bounds" -> ()
+    in
+    fail a (-1);
+    fail a 3;
+    fail a 4;
+    fail [||] 0;
+    fail [|#0n|] 0;
+    fail [|#0n|] 1;
+    fail [|#0n|] (-1)
+  ;;
+
+  let () =
+    let unboxed_int32_array = unboxed_int32_array () in
+    let _0123 = i32x4 0l 1l 2l 3l in
+    let _2345 = i32x4 2l 3l 4l 5l in
+    let get = unboxed_int32_array_get_int32x4 unboxed_int32_array 0 in
+    eq (int32x4_low_int64 _0123) (int32x4_high_int64 _0123)
+       (int32x4_low_int64 get) (int32x4_high_int64 get);
+    let get = unboxed_int32_array_get_int32x4 unboxed_int32_array 2 in
+    eq (int32x4_low_int64 _2345) (int32x4_high_int64 _2345)
+       (int32x4_low_int64 get) (int32x4_high_int64 get);
+
+    let _4567 = i32x4 4l 5l 6l 7l in
+    let _6789 = i32x4 6l 7l 8l 9l in
+    unboxed_int32_array_set_int32x4 unboxed_int32_array 0 _4567;
+    let get = unboxed_int32_array_get_int32x4 unboxed_int32_array 0 in
+    eq (int32x4_low_int64 _4567) (int32x4_high_int64 _4567)
+       (int32x4_low_int64 get) (int32x4_high_int64 get);
+    unboxed_int32_array_set_int32x4 unboxed_int32_array 1 _6789;
+    let get = unboxed_int32_array_get_int32x4 unboxed_int32_array 1 in
+    eq (int32x4_low_int64 _6789) (int32x4_high_int64 _6789)
+       (int32x4_low_int64 get) (int32x4_high_int64 get)
+  ;;
+
+  let () =
+    let unboxed_int32_array = unboxed_int32_array () in
+    let _0123 = i32x4 0l 1l 2l 3l in
+    let _2345 = i32x4 2l 3l 4l 5l in
+    let get = unboxed_int32_array_get_int32x4_unsafe unboxed_int32_array 0 in
+    eq (int32x4_low_int64 _0123) (int32x4_high_int64 _0123)
+       (int32x4_low_int64 get) (int32x4_high_int64 get);
+    let get = unboxed_int32_array_get_int32x4_unsafe unboxed_int32_array 2 in
+    eq (int32x4_low_int64 _2345) (int32x4_high_int64 _2345)
+       (int32x4_low_int64 get) (int32x4_high_int64 get);
+
+    let _4567 = i32x4 4l 5l 6l 7l in
+    let _6789 = i32x4 6l 7l 8l 9l in
+    unboxed_int32_array_set_int32x4_unsafe unboxed_int32_array 0 _4567;
+    let get = unboxed_int32_array_get_int32x4_unsafe unboxed_int32_array 0 in
+    eq (int32x4_low_int64 _4567) (int32x4_high_int64 _4567)
+       (int32x4_low_int64 get) (int32x4_high_int64 get);
+    unboxed_int32_array_set_int32x4_unsafe unboxed_int32_array 1 _6789;
+    let get = unboxed_int32_array_get_int32x4_unsafe unboxed_int32_array 1 in
+    eq (int32x4_low_int64 _6789) (int32x4_high_int64 _6789)
+       (int32x4_low_int64 get) (int32x4_high_int64 get)
+  ;;
+
+  let () =
+    let a = unboxed_int32_array () in
+    let _0 = i32x4 0l 0l 0l 0l in
+    let fail a i =
+      try
+        let _ = unboxed_int32_array_get_int32x4 a i in
+        let _ = unboxed_int32_array_set_int32x4 a i _0 in
+        Printf.printf "Did not fail on index %d\n" i
+      with | Invalid_argument s when s = "index out of bounds" -> ()
+    in
+    fail a (-1);
+    fail a 5;
+    fail a 6;
+    fail [||] 0;
+    fail [|#0l|] 0;
+    fail [|#0l|] 1;
+    fail [|#0l|] 2;
+    fail [|#0l|] 3;
+    fail [|#0l;#1l|] 0;
+    fail [|#0l;#1l|] 1;
+    fail [|#0l;#1l|] 2;
+    fail [|#0l;#1l|] 3;
+    fail [|#0l;#1l;#2l|] 0;
+    fail [|#0l;#1l;#2l|] 1;
+    fail [|#0l;#1l;#2l|] 2;
+    fail [|#0l;#1l;#2l|] 3;
+    fail [|#0l|] (-1)
   ;;
 end


### PR DESCRIPTION
The array load/store functions for `int32# array`/`int64# array`/`nativeint# array` need to skip the custom_ops pointer - see tests.