### PR TITLE
Re-export stable extension modules from `Stable`.

### DIFF
--- a/ocaml/otherlibs/stable/stable.ml
+++ b/ocaml/otherlibs/stable/stable.ml
@@ -1,0 +1,3 @@
+module Float_u = Stdlib__Float_u
+module Iarray = Stdlib__Iarray
+module IarrayLabels = Stdlib__IarrayLabels

--- a/ocaml/otherlibs/stable/stable.mli
+++ b/ocaml/otherlibs/stable/stable.mli
@@ -1,0 +1,3 @@
+module Float_u = Stdlib__Float_u
+module Iarray = Stdlib__Iarray
+module IarrayLabels = Stdlib__IarrayLabels

--- a/ocaml/testsuite/tests/lib-extensions/stable_exports.ml
+++ b/ocaml/testsuite/tests/lib-extensions/stable_exports.ml
@@ -1,0 +1,27 @@
+(* TEST
+flags = "-extension-universe stable"
+include stable
+* bytecode
+* native
+*)
+
+open Stable
+
+(* Test that [Float_u] is exported. *)
+
+let () =
+  let pi = Float_u.of_float 3.14 in
+  assert (Float_u.to_float pi = 3.14)
+;;
+
+(* Test that [Iarray] is exported. *)
+let () =
+  let arr = Iarray.init 4 (fun x -> x) in
+  assert (Iarray.get arr 2 = 2)
+;;
+
+(* Test that [IarrayLabels] is exported. *)
+let () =
+  let arr = IarrayLabels.init 4 ~f:(fun x -> x) in
+  assert (IarrayLabels.get arr 2 = 2)
+;;


### PR DESCRIPTION
Title. We can't yet fully move them to `otherlibs` since accessing them from `Stable` requires changes to the build rules.