### PR TITLE
Move int<->float casts into scalar cast instruction

### DIFF
--- a/backend/CSEgen.ml
+++ b/backend/CSEgen.ml
@@ -74,7 +74,7 @@ method class_of_operation op =
   | Icompf _
   | Icsel _
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf | Iscalarcast _
-  | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue | Ivectorcast _ -> Op_pure
+  | Ivalueofint | Iintofvalue | Ivectorcast _ -> Op_pure
   | Ispecific _ -> Op_other
   | Iname_for_debugger _ -> Op_other
   | Iprobe_is_enabled _ -> Op_other

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -46,7 +46,7 @@ method! class_of_operation op =
   | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Icompf _
   | Icsel _
-  | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue | Ivectorcast _ | Iscalarcast _
+  | Ivalueofint | Iintofvalue | Ivectorcast _ | Iscalarcast _
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _ | Iconst_vec128 _
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _ | Iextcall _
   | Istackoffset _ | Iload _ | Istore _ | Ialloc _
@@ -88,7 +88,7 @@ class cfg_cse = object
   | Move | Spill | Reload | Negf | Absf | Addf | Subf | Mulf | Divf
   | Compf _
   | Csel _
-  | Floatofint | Intoffloat | Valueofint | Intofvalue | Vectorcast _ | Scalarcast _
+  | Valueofint | Intofvalue | Vectorcast _ | Scalarcast _
   | Const_int _ | Const_float _ | Const_symbol _ | Const_vec128 _
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1483,12 +1483,12 @@ let emit_instr fallthrough i =
       I.andpd (mem64_rip VEC128 (emit_symbol "caml_absf_mask")) (res i 0)
   | Lop(Iaddf | Isubf | Imulf | Idivf as floatop) ->
       instr_for_floatop floatop (arg i 1) (res i 0)
-  | Lop(Ifloatofint) ->
-      I.cvtsi2sd  (arg i 0)  (res i 0)
-  | Lop(Iintoffloat) ->
-      I.cvttsd2si (arg i 0) (res i 0)
   | Lop(Iintofvalue | Ivalueofint | Ivectorcast Bits128) ->
       move i.arg.(0) i.res.(0)
+  | Lop(Iscalarcast Float_of_int) ->
+      I.cvtsi2sd  (arg i 0)  (res i 0)
+  | Lop(Iscalarcast Float_to_int) ->
+      I.cvttsd2si (arg i 0) (res i 0)
   | Lop(Iscalarcast (V128_of_scalar Float64x2 | V128_to_scalar Float64x2)) ->
       I.movsd (arg i 0) (res i 0)
   | Lop(Iscalarcast (V128_to_scalar Int64x2 | V128_of_scalar Int64x2)) ->

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -452,7 +452,6 @@ let destroyed_at_oper = function
   | Iop(Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
        | Icompf _
        | Icsel _
-       | Ifloatofint | Iintoffloat
        | Ivalueofint | Iintofvalue
        | Ivectorcast _ | Iscalarcast _
        | Iconst_int _ | Iconst_float _ | Iconst_symbol _ | Iconst_vec128 _
@@ -506,7 +505,6 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        | Negf | Absf | Addf | Subf | Mulf | Divf
        | Compf _
        | Csel _
-       | Floatofint | Intoffloat
        | Valueofint | Intofvalue
        | Vectorcast _
        | Scalarcast _
@@ -584,7 +582,7 @@ let safe_register_pressure = function
     Iextcall _ -> if win64 then if fp then 7 else 8 else 0
   | Ialloc _ | Ipoll _ | Imove | Ispill | Ireload
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
-  | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue | Ivectorcast _
+  | Ivalueofint | Iintofvalue | Ivectorcast _
   | Icompf _ | Iscalarcast _
   | Icsel _
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _ | Iconst_vec128 _
@@ -639,7 +637,7 @@ let max_register_pressure =
             _, _)
   | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Icsel _
-  | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue | Ivectorcast _ | Iscalarcast _
+  | Ivalueofint | Iintofvalue | Ivectorcast _ | Iscalarcast _
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _ | Iconst_vec128 _
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Istackoffset _ | Iload _
@@ -735,7 +733,6 @@ let operation_supported = function
   | Cclz _ | Cctz _
   | Ccmpi _ | Caddv | Cadda | Ccmpa _
   | Cnegf | Cabsf | Caddf | Csubf | Cmulf | Cdivf
-  | Cfloatofint | Cintoffloat
   | Cvalueofint | Cintofvalue
   | Ccmpf _
   | Craise _

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -190,7 +190,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
   | Op (Scalarcast (V128_to_scalar (Int16x8 | Int8x16))) ->
     (* CR mslater: (SIMD) replace once we have unboxed int16/int8 *)
     May_still_have_spilled_registers
-  | Op (Floatofint | Intoffloat | Vectorcast _) ->
+  | Op (Scalarcast (Float_of_int | Float_to_int) | Vectorcast _) ->
     may_use_stack_operand_for_only_argument map instr ~has_result:true
   | Op (Const_symbol _) ->
     if !Clflags.pic_code || !Clflags.dlcode || Arch.win64 then

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -127,9 +127,6 @@ method! reload_operation op arg res =
       then (let r = self#makereg res.(0) in (arg, [|r|]))
       else (arg, res)
   | Ispecific(Isimd op) -> Simd_reload.reload_operation self#makereg op arg res
-  | Ifloatofint | Iintoffloat ->
-      (* Result must be in register, but argument can be on stack *)
-      (arg, (if stackp res.(0) then [| self#makereg res.(0) |] else res))
   | Iconst_int n ->
       if n <= 0x7FFFFFFFn && n >= -0x80000000n
       then (arg, res)
@@ -161,6 +158,9 @@ method! reload_operation op arg res =
         done;
         arg'.(len - 1) <- r;
         (arg', [|r|])
+  | Iscalarcast (Float_of_int | Float_to_int) ->
+    (* Result must be in register, but argument can be on stack *)
+    (arg, (if stackp res.(0) then [| self#makereg res.(0) |] else res))
   | Iscalarcast (V128_to_scalar (Float64x2) | V128_of_scalar (Float64x2)) ->
     (* These are just moves; either the argument or result may be on the stack. *)
     begin match stackp arg.(0), stackp res.(0) with

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -168,7 +168,7 @@ let pseudoregs_for_operation op arg res =
   | Ispecific (Isextend32|Izextend32|Ilea _|Istore_int (_, _, _)
               |Ipause|Ilfence|Isfence|Imfence
               |Ioffset_loc (_, _)|Ifloatsqrtf _|Irdtsc|Iprefetch _)
-  | Imove|Ispill|Ireload|Ifloatofint|Iintoffloat|Ivalueofint|Iintofvalue
+  | Imove|Ispill|Ireload|Ivalueofint|Iintofvalue
   | Ivectorcast _ | Iscalarcast _
   | Iconst_int _|Iconst_float _|Iconst_vec128 _
   | Iconst_symbol _|Icall_ind|Icall_imm _|Itailcall_ind|Itailcall_imm _

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -500,7 +500,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Iintop (Imulh _)) -> 1
     | Lop (Iintop _) -> 1
     | Lop (Iintop_imm _) -> 1
-    | Lop (Ifloatofint | Iintoffloat | Iabsf | Inegf | Ispecific Isqrtf) -> 1
+    | Lop (Iabsf | Inegf | Ispecific Isqrtf) -> 1
     | Lop (Ivalueofint | Iintofvalue) -> 1
     | Lop (Ivectorcast _) -> 1
     | Lop (Iscalarcast _) -> 1
@@ -695,6 +695,10 @@ let emit_instr i =
     | Lop(Iintop_atomic _) ->
       (* Never generated; builtins are not yet translated to atomics *)
       assert false
+    | Lop(Iscalarcast Float_to_int) ->
+        `	fcvtzs {emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
+    | Lop(Iscalarcast Float_of_int) ->
+        `	scvtf	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
     | Lop(Ivectorcast _ | Iscalarcast _) ->
       (* Never generated; SIMD instructions are not yet translated *)
       assert false
@@ -882,10 +886,8 @@ let emit_instr i =
     | Lop(Iintop_imm(op, n)) ->
         let instr = name_for_int_operation op in
         `	{emit_string instr}     {emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, #{emit_int n}\n`
-    | Lop(Ifloatofint | Iintoffloat | Iabsf | Inegf | Ispecific Isqrtf as op) ->
+    | Lop(Iabsf | Inegf | Ispecific Isqrtf as op) ->
         let instr = (match op with
-                     | Ifloatofint      -> "scvtf"
-                     | Iintoffloat      -> "fcvtzs"
                      | Iabsf            -> "fabs"
                      | Inegf            -> "fneg"
                      | Ispecific Isqrtf -> "fsqrt"

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -310,7 +310,7 @@ let destroyed_at_oper = function
     else destroyed_at_c_noalloc_call
   | Iop(Ialloc _) | Iop(Ipoll _) ->
       [| reg_x8 |]
-  | Iop( Iintoffloat | Ifloatofint
+  | Iop( Iscalarcast (Float_to_int | Float_of_int)
        | Iload{memory_chunk=Single; _} | Istore(Single, _, _)) ->
       [| reg_d7 |]            (* d7 / s7 destroyed *)
   | _ -> [||]
@@ -333,7 +333,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   | Op Poll -> destroyed_at_alloc_or_poll
   | Op (Alloc _) ->
     destroyed_at_alloc_or_poll
-  | Op( Intoffloat | Floatofint
+  | Op( Scalarcast (Float_to_int | Float_of_int)
       | Load {memory_chunk = Single; _ } | Store(Single, _, _)) ->
     [| reg_d7 |]
   | Op _ | Poptrap | Prologue ->
@@ -387,7 +387,7 @@ let safe_register_pressure = function
 let max_register_pressure = function
   | Iextcall _ -> [| 7; 8 |]  (* 7 integer callee-saves, 8 FP callee-saves *)
   | Ialloc _ | Ipoll _ -> [| 22; 32 |]
-  | Iintoffloat | Ifloatofint
+  | Iscalarcast (Float_to_int | Float_of_int)
   | Iload{memory_chunk=Single; _} | Istore(Single, _, _) -> [| 23; 31 |]
   | _ -> [| 23; 32 |]
 
@@ -429,7 +429,7 @@ let init () = ()
 let operation_supported = function
   | Cclz _ | Cctz _ | Cpopcnt
   | Cprefetch _ | Catomic _
-  | Cvectorcast _ | Cscalarcast _
+  | Cvectorcast _ | Cscalarcast (V128_of_scalar _ | V128_to_scalar _)
     -> false   (* Not implemented *)
   | Cbswap _
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
@@ -437,7 +437,8 @@ let operation_supported = function
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
   | Ccmpi _ | Caddv | Cadda | Ccmpa _
   | Cnegf | Cabsf | Caddf | Csubf | Cmulf | Cdivf
-  | Cfloatofint | Cintoffloat | Cintofvalue | Cvalueofint
+  | Cintofvalue | Cvalueofint
+  | Cscalarcast (Float_of_int | Float_to_int)
   | Ccmpf _
   | Ccsel _
   | Craise _

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -278,11 +278,11 @@ let dump_op ppf = function
   | Divf -> Format.fprintf ppf "divf"
   | Compf _ -> Format.fprintf ppf "compf"
   | Csel _ -> Format.fprintf ppf "csel"
-  | Floatofint -> Format.fprintf ppf "floattoint"
-  | Intoffloat -> Format.fprintf ppf "intoffloat"
   | Valueofint -> Format.fprintf ppf "valueofint"
   | Intofvalue -> Format.fprintf ppf "intofvalue"
   | Vectorcast Bits128 -> Format.fprintf ppf "vec128->vec128"
+  | Scalarcast Float_of_int -> Format.fprintf ppf "int->float"
+  | Scalarcast Float_to_int -> Format.fprintf ppf "float->int"
   | Scalarcast (V128_to_scalar ty) ->
     Format.fprintf ppf "%s->scalar" (Primitive.vec128_name ty)
   | Scalarcast (V128_of_scalar ty) ->
@@ -486,8 +486,6 @@ let is_pure_operation : operation -> bool = function
   | Divf -> true
   | Compf _ -> true
   | Csel _ -> true
-  | Floatofint -> true
-  | Intoffloat -> true
   | Vectorcast _ -> true
   | Scalarcast _ -> true
   (* Conservative to ensure valueofint/intofvalue are not eliminated before
@@ -548,9 +546,9 @@ let is_noop_move instr =
       ( Const_int _ | Const_float _ | Const_symbol _ | Const_vec128 _
       | Stackoffset _ | Load _ | Store _ | Intop _ | Intop_imm _
       | Intop_atomic _ | Negf | Absf | Addf | Subf | Mulf | Divf | Compf _
-      | Floatofint | Intoffloat | Opaque | Valueofint | Intofvalue
-      | Scalarcast _ | Probe_is_enabled _ | Specific _ | Name_for_debugger _
-      | Begin_region | End_region | Dls_get | Poll | Alloc _ )
+      | Opaque | Valueofint | Intofvalue | Scalarcast _ | Probe_is_enabled _
+      | Specific _ | Name_for_debugger _ | Begin_region | End_region | Dls_get
+      | Poll | Alloc _ )
   | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
     false
 

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -47,10 +47,9 @@ let rec find_next_allocation : cell option -> allocation option =
         ( Move | Spill | Reload | Const_int _ | Const_float _ | Const_symbol _
         | Const_vec128 _ | Stackoffset _ | Load _ | Store _ | Intop _
         | Intop_imm _ | Intop_atomic _ | Negf | Absf | Addf | Subf | Mulf | Divf
-        | Compf _ | Csel _ | Floatofint | Intoffloat | Valueofint | Intofvalue
-        | Vectorcast _ | Scalarcast _ | Probe_is_enabled _ | Opaque
-        | Begin_region | End_region | Specific _ | Name_for_debugger _ | Dls_get
-        | Poll )
+        | Compf _ | Csel _ | Valueofint | Intofvalue | Vectorcast _
+        | Scalarcast _ | Probe_is_enabled _ | Opaque | Begin_region | End_region
+        | Specific _ | Name_for_debugger _ | Dls_get | Poll )
     | Reloadretaddr | Pushtrap _ | Poptrap | Prologue ->
       find_next_allocation (DLL.next cell))
 
@@ -99,9 +98,9 @@ let find_compatible_allocations :
         { allocations = List.rev allocations; next_cell = Some cell }
       | Op
           ( Move | Spill | Reload | Negf | Absf | Addf | Subf | Mulf | Divf
-          | Floatofint | Intoffloat | Valueofint | Intofvalue | Vectorcast _
-          | Opaque | Const_int _ | Const_float _ | Const_vec128 _
-          | Const_symbol _ | Stackoffset _ | Load _
+          | Valueofint | Intofvalue | Vectorcast _ | Opaque | Const_int _
+          | Const_float _ | Const_vec128 _ | Const_symbol _ | Stackoffset _
+          | Load _
           | Store (_, _, _)
           | Compf _ | Csel _ | Specific _ | Name_for_debugger _
           | Probe_is_enabled _ | Scalarcast _ | Dls_get

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -85,8 +85,7 @@ class cse_generic =
       | Intop_imm (_, _) -> Op_pure
       | Intop_atomic _ -> Op_store true
       | Compf _ | Csel _ | Negf | Absf | Addf | Subf | Mulf | Divf
-      | Scalarcast _ | Floatofint | Intoffloat | Valueofint | Intofvalue
-      | Vectorcast _ ->
+      | Scalarcast _ | Valueofint | Intofvalue | Vectorcast _ ->
         Op_pure
       | Specific _ -> Op_other
       | Name_for_debugger _ -> Op_other

--- a/backend/cfg/cfg_equivalence.ml
+++ b/backend/cfg/cfg_equivalence.ml
@@ -248,8 +248,6 @@ let check_operation : location -> Cfg.operation -> Cfg.operation -> unit =
   | Compf left_comp, Compf right_comp
     when Cmm.equal_float_comparison left_comp right_comp ->
     ()
-  | Floatofint, Floatofint -> ()
-  | Intoffloat, Intoffloat -> ()
   | Valueofint, Valueofint -> ()
   | Intofvalue, Intofvalue -> ()
   | ( Probe_is_enabled { name = expected_name },

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -81,8 +81,6 @@ module S = struct
     | Divf
     | Compf of Mach.float_comparison (* CR gyorsh: can merge with float_test? *)
     | Csel of Mach.test
-    | Floatofint
-    | Intoffloat
     | Valueofint
     | Intofvalue
     | Vectorcast of Cmm.vector_cast

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -36,8 +36,6 @@ let from_basic (basic : basic) : Linear.instruction_desc =
       | Divf -> Idivf
       | Compf c -> Icompf c
       | Csel c -> Icsel c
-      | Floatofint -> Ifloatofint
-      | Intoffloat -> Iintoffloat
       | Valueofint -> Ivalueofint
       | Intofvalue -> Iintofvalue
       | Vectorcast cast -> Ivectorcast cast

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -178,8 +178,6 @@ let basic_or_terminator_of_operation :
   | Isubf -> Basic (Op Subf)
   | Imulf -> Basic (Op Mulf)
   | Idivf -> Basic (Op Divf)
-  | Ifloatofint -> Basic (Op Floatofint)
-  | Iintoffloat -> Basic (Op Intoffloat)
   | Ivalueofint -> Basic (Op Valueofint)
   | Iintofvalue -> Basic (Op Intofvalue)
   | Ivectorcast cast -> Basic (Op (Vectorcast cast))
@@ -631,10 +629,9 @@ module Stack_offset_and_exn = struct
         ( Move | Spill | Reload | Const_int _ | Const_float _ | Const_symbol _
         | Const_vec128 _ | Load _ | Store _ | Intop _ | Intop_imm _
         | Intop_atomic _ | Negf | Absf | Addf | Subf | Mulf | Divf | Compf _
-        | Floatofint | Intoffloat | Valueofint | Csel _ | Intofvalue
-        | Scalarcast _ | Vectorcast _ | Probe_is_enabled _ | Opaque
-        | Begin_region | End_region | Specific _ | Name_for_debugger _ | Dls_get
-        | Poll | Alloc _ )
+        | Valueofint | Csel _ | Intofvalue | Scalarcast _ | Vectorcast _
+        | Probe_is_enabled _ | Opaque | Begin_region | End_region | Specific _
+        | Name_for_debugger _ | Dls_get | Poll | Alloc _ )
     | Reloadretaddr | Prologue ->
       stack_offset, traps
 

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -857,7 +857,7 @@ end = struct
     match op with
     | Imove | Ispill | Ireload | Iconst_int _ | Iconst_float _ | Iconst_symbol _
     | Iconst_vec128 _ | Iload _ | Icompf _ | Inegf | Iabsf | Iaddf | Isubf
-    | Imulf | Idivf | Ifloatofint | Iintoffloat | Ivectorcast _ | Iscalarcast _
+    | Imulf | Idivf | Ivectorcast _ | Iscalarcast _
     | Iintop_imm
         ( ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
           | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ ),

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -193,6 +193,8 @@ type vector_cast =
   | Bits128
 
 type scalar_cast =
+  | Float_to_int
+  | Float_of_int
   | V128_to_scalar of Primitive.vec128_type
   | V128_of_scalar of Primitive.vec128_type
 
@@ -229,7 +231,6 @@ type operation =
   | Ccmpa of integer_comparison
   | Cnegf | Cabsf
   | Caddf | Csubf | Cmulf | Cdivf
-  | Cfloatofint | Cintoffloat
   | Cvalueofint | Cintofvalue
   | Cvectorcast of vector_cast
   | Cscalarcast of scalar_cast

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -174,6 +174,8 @@ type vector_cast =
   | Bits128
 
 type scalar_cast =
+  | Float_to_int
+  | Float_of_int
   | V128_to_scalar of Primitive.vec128_type
   | V128_of_scalar of Primitive.vec128_type
 
@@ -215,7 +217,6 @@ type operation =
   | Ccmpa of integer_comparison
   | Cnegf | Cabsf
   | Caddf | Csubf | Cmulf | Cdivf
-  | Cfloatofint | Cintoffloat
   | Cvalueofint | Cintofvalue
   | Cvectorcast of vector_cast
   | Cscalarcast of scalar_cast

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3351,9 +3351,9 @@ let unary op ~dbg x = Cop (op, [x], dbg)
 
 let binary op ~dbg x y = Cop (op, [x; y], dbg)
 
-let int_of_float = unary Cintoffloat
+let int_of_float = unary (Cscalarcast Float_to_int)
 
-let float_of_int = unary Cfloatofint
+let float_of_int = unary (Cscalarcast Float_of_int)
 
 let lsl_int_caml_raw ~dbg arg1 arg2 =
   incr_int (lsl_int (decr_int arg1 dbg) arg2 dbg) dbg

--- a/backend/comballoc.ml
+++ b/backend/comballoc.ml
@@ -84,8 +84,8 @@ let rec combine i allocstate =
           let newnext, s' = combine i.next allocstate in
           (instr_cons_debug i.desc i.arg i.res i.dbg newnext, s')
     end
-  | Iop((Imove|Ispill|Ireload|Inegf|Iabsf|Iaddf|Isubf|Imulf|Idivf|Ifloatofint|
-         Iintoffloat|Ivalueofint|Iintofvalue|Ivectorcast _|Iopaque|Iconst_int _|
+  | Iop((Imove|Ispill|Ireload|Inegf|Iabsf|Iaddf|Isubf|Imulf|Idivf|
+         Ivalueofint|Iintofvalue|Ivectorcast _|Iopaque|Iconst_int _|
          Iconst_float _|Iconst_vec128 _|Iconst_symbol _|Istackoffset _|Iload _|
          Istore (_, _, _)|Icompf _|Icsel _ |Ispecific _|Iname_for_debugger _|
          Iprobe_is_enabled _|Iscalarcast _|Idls_get))

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -225,10 +225,10 @@ let rec available_regs (instr : M.instruction) ~all_regs_that_might_be_named
            | Iconst_int _ | Iconst_float _ | Iconst_vec128 _ | Iconst_symbol _
            | Iextcall _ | Istackoffset _ | Iload _ | Istore _ | Iintop _
            | Iintop_imm _ | Iintop_atomic _ | Icompf _ | Inegf | Iabsf | Iaddf
-           | Isubf | Imulf | Idivf | Icsel _ | Ifloatofint | Iintoffloat
-           | Ivalueofint | Iintofvalue | Iopaque | Ispecific _ | Iscalarcast _
-           | Ivectorcast _ | Iprobe_is_enabled _ | Ibeginregion | Iendregion
-           | Idls_get ) as op) ->
+           | Isubf | Imulf | Idivf | Icsel _ | Ivalueofint | Iintofvalue
+           | Iopaque | Ispecific _ | Iscalarcast _ | Ivectorcast _
+           | Iprobe_is_enabled _ | Ibeginregion | Iendregion | Idls_get ) as op)
+        ->
         (* We split the calculation of registers that become unavailable after a
            call into two parts. First: anything that the target marks as
            destroyed by the operation, combined with any registers that will be
@@ -288,10 +288,10 @@ let rec available_regs (instr : M.instruction) ~all_regs_that_might_be_named
           | Iconst_vec128 _ | Iconst_symbol _ | Itailcall_ind | Itailcall_imm _
           | Iextcall _ | Istackoffset _ | Iload _ | Istore _ | Iintop _
           | Iintop_imm _ | Iintop_atomic _ | Icompf _ | Inegf | Iabsf | Iaddf
-          | Isubf | Imulf | Idivf | Icsel _ | Ifloatofint | Iintoffloat
-          | Ivalueofint | Iintofvalue | Iopaque | Ispecific _ | Iscalarcast _
-          | Ivectorcast _ | Iname_for_debugger _ | Iprobe_is_enabled _
-          | Ibeginregion | Idls_get ->
+          | Isubf | Imulf | Idivf | Icsel _ | Ivalueofint | Iintofvalue
+          | Iopaque | Ispecific _ | Iscalarcast _ | Ivectorcast _
+          | Iname_for_debugger _ | Iprobe_is_enabled _ | Ibeginregion | Idls_get
+            ->
             RD.Set.empty
         in
         let made_unavailable =

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -87,7 +87,6 @@ type operation =
   | Icompf of float_comparison
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Icsel of test
-  | Ifloatofint | Iintoffloat
   | Ivalueofint | Iintofvalue
   | Ivectorcast of Cmm.vector_cast
   | Iscalarcast of Cmm.scalar_cast
@@ -195,7 +194,7 @@ let rec instr_iter f i =
             | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
             | Icompf _
             | Icsel _ | Iscalarcast _
-            | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue | Ivectorcast _
+            | Ivalueofint | Iintofvalue | Ivectorcast _
             | Ispecific _ | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _
             | Iopaque
             | Ibeginregion | Iendregion | Ipoll _ | Idls_get) ->
@@ -219,7 +218,7 @@ let operation_is_pure = function
   | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Icompf _
   | Icsel _
-  | Ifloatofint | Iintoffloat | Ivectorcast _ | Iscalarcast _
+  | Ivectorcast _ | Iscalarcast _
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _ | Iconst_vec128 _
   | Iload _ -> true
   | Iname_for_debugger _ -> false
@@ -238,7 +237,7 @@ let operation_can_raise op =
   | Imove | Ispill | Ireload | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Icompf _
   | Icsel _ | Iscalarcast _
-  | Ifloatofint | Iintoffloat | Ivalueofint | Iintofvalue | Ivectorcast _
+  | Ivalueofint | Iintofvalue | Ivectorcast _
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _ | Iconst_vec128 _
   | Istackoffset _ | Istore _  | Iload _ | Iname_for_debugger _
   | Itailcall_imm _ | Itailcall_ind

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -81,7 +81,6 @@ type operation =
   | Icompf of float_comparison
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Icsel of test
-  | Ifloatofint | Iintoffloat
   | Ivalueofint | Iintofvalue
   | Ivectorcast of Cmm.vector_cast
   | Iscalarcast of Cmm.scalar_cast

--- a/backend/polling.ml
+++ b/backend/polling.ml
@@ -244,7 +244,7 @@ let find_poll_alloc_or_calls instr =
       | Iop(Imove | Ispill | Ireload | Iconst_int _ | Iconst_float _ | Iconst_vec128 _ |
             Iconst_symbol _ | Iextcall { alloc = false } | Istackoffset _ |
             Iload _ | Istore _ | Iintop _ | Iintop_imm _ | Iintop_atomic _ |
-            Ifloatofint | Iintoffloat | Inegf | Iabsf | Iaddf | Isubf |
+            Inegf | Iabsf | Iaddf | Isubf |
             Imulf | Idivf | Iopaque | Ispecific _ | Ibeginregion | Iendregion |
             Icsel _ | Icompf _ | Iname_for_debugger _ | Iprobe _ | Iscalarcast _ |
             Iprobe_is_enabled _ | Ivalueofint | Iintofvalue | Ivectorcast _ | Idls_get)-> None

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -220,12 +220,12 @@ let operation d = function
   | Cdivf -> "/f"
   | Ccsel ret_typ ->
     to_string "csel %a" machtype ret_typ
-  | Cfloatofint -> "floatofint"
-  | Cintoffloat -> "intoffloat"
   | Cvalueofint -> "valueofint"
   | Cintofvalue -> "intofvalue"
   | Cvectorcast Bits128 ->
     Printf.sprintf "vec128->vec128"
+  | Cscalarcast Float_to_int -> "float->int"
+  | Cscalarcast Float_of_int -> "int->float"
   | Cscalarcast (V128_to_scalar ty) ->
     Printf.sprintf "%s->scalar" (Primitive.vec128_name ty)
   | Cscalarcast (V128_of_scalar ty) ->

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -221,13 +221,13 @@ let operation' ?(print_reg = reg) op arg ppf res =
     let len = Array.length arg in
     fprintf ppf "csel %a ? %a : %a"
       (test tst) arg reg arg.(len-2) reg arg.(len-1)
-  | Ifloatofint -> fprintf ppf "floatofint %a" reg arg.(0)
-  | Iintoffloat -> fprintf ppf "intoffloat %a" reg arg.(0)
   | Ivalueofint -> fprintf ppf "valueofint %a" reg arg.(0)
   | Iintofvalue -> fprintf ppf "intofvalue %a" reg arg.(0)
   | Ivectorcast Bits128 ->
     fprintf ppf "vec128->vec128 %a"
-      reg arg.(0)
+    reg arg.(0)
+  | Iscalarcast Float_of_int -> fprintf ppf "int->float %a" reg arg.(0)
+  | Iscalarcast Float_to_int -> fprintf ppf "float->int %a" reg arg.(0)
   | Iscalarcast (V128_of_scalar ty) ->
     fprintf ppf "scalar->%s %a"
       (Primitive.vec128_name ty) reg arg.(0)

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -32,8 +32,6 @@ let precondition : Cfg_with_layout.t -> unit =
       | Divf -> ()
       | Compf _ -> ()
       | Csel _ -> ()
-      | Floatofint -> ()
-      | Intoffloat -> ()
       | Valueofint -> ()
       | Intofvalue -> ()
       | Vectorcast _ -> ()

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -129,8 +129,6 @@ let is_move_basic : Cfg.basic -> bool =
     | Divf -> false
     | Compf _ -> false
     | Csel _ -> false
-    | Floatofint -> false
-    | Intoffloat -> false
     | Valueofint -> false
     | Intofvalue -> false
     | Probe_is_enabled _ -> false

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -172,11 +172,11 @@ let oper_result_type = function
   | Cadda -> typ_addr
   | Cnegf | Cabsf | Caddf | Csubf | Cmulf | Cdivf -> typ_float
   | Ccsel ty -> ty
-  | Cfloatofint -> typ_float
-  | Cintoffloat -> typ_int
   | Cvalueofint -> typ_val
   | Cintofvalue -> typ_int
   | Cvectorcast Bits128 -> typ_vec128
+  | Cscalarcast Float_of_int -> typ_float
+  | Cscalarcast Float_to_int -> typ_int
   | Cscalarcast (V128_of_scalar _) -> typ_vec128
   | Cscalarcast (V128_to_scalar (Float64x2 | Float32x4)) -> typ_float
   | Cscalarcast (V128_to_scalar (Int8x16 | Int16x8 | Int32x4 | Int64x2)) -> typ_int
@@ -485,7 +485,7 @@ method is_simple_expr = function
       | Cclz _ | Cctz _ | Cpopcnt
       | Cbswap _
       | Ccsel _
-      | Cabsf | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat
+      | Cabsf | Caddf | Csubf | Cmulf | Cdivf
       | Cvectorcast _ | Cscalarcast _
       | Cvalueofint | Cintofvalue
       | Ctuple_field _
@@ -543,7 +543,7 @@ method effects_of exp =
       | Ccsel _
       | Cclz _ | Cctz _ | Cpopcnt
       | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf | Cabsf
-      | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat
+      | Caddf | Csubf | Cmulf | Cdivf
       | Cvectorcast _ | Cscalarcast _
       | Cvalueofint | Cintofvalue | Ccmpf _ ->
         EC.none
@@ -668,8 +668,6 @@ method select_operation op args _dbg =
   | (Csubf, _) -> (Isubf, args)
   | (Cmulf, _) -> (Imulf, args)
   | (Cdivf, _) -> (Idivf, args)
-  | (Cfloatofint, _) -> (Ifloatofint, args)
-  | (Cintoffloat, _) -> (Iintoffloat, args)
   | (Cvalueofint, _) -> (Ivalueofint, args)
   | (Cintofvalue, _) -> (Iintofvalue, args)
   | (Cvectorcast cast, _) -> (Ivectorcast cast, args)

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -369,8 +369,8 @@ unaryop:
     LOAD chunk                  { Cload {memory_chunk=$2;
                                          mutability=Asttypes.Mutable;
                                          is_atomic=false} }
-  | FLOATOFINT                  { Cfloatofint }
-  | INTOFFLOAT                  { Cintoffloat }
+  | FLOATOFINT                  { Cscalarcast Float_of_int }
+  | INTOFFLOAT                  { Cscalarcast Float_to_int }
   | VALUEOFINT                  { Cvalueofint }
   | INTOFVALUE                  { Cintofvalue }
   | RAISE                       { Craise $1 }


### PR DESCRIPTION
Preparation for #2391 - moves `floatofint` and `intoffloat` instructions into `scalar_cast`. This will reduce code duplication when adding float32 casts.