### PR TITLE
Fix let pun locations

### DIFF
--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -121,8 +121,8 @@ let ghloc ~loc d = { txt = d; loc = ghost_loc loc }
 let ghstr ~loc d = Str.mk ~loc:(ghost_loc loc) d
 let ghsig ~loc d = Sig.mk ~loc:(ghost_loc loc) d
 
-let ghpatvar ~loc name =
-  ghpat ~loc (Ppat_var (mkrhs name loc))
+let ghexpvar ~loc name =
+  ghexp ~loc (Pexp_ident (mkrhs (Lident name) loc))
 
 let mkinfix arg1 op arg2 =
   Pexp_apply(op, [Nolabel, arg1; Nolabel, arg2])
@@ -3168,7 +3168,7 @@ let_binding_body:
       { let p,e,c,attrs = $1 in (p,e,c,false), attrs }
 /* BEGIN AVOID */
   | val_ident %prec below_HASH
-      { (ghpatvar ~loc:$loc $1, mkexpvar ~loc:$loc $1, None, true), [] }
+      { (mkpatvar ~loc:$loc $1, ghexpvar ~loc:$loc $1, None, true), [] }
   (* The production that allows puns is marked so that [make list-parse-errors]
      does not attempt to exploit it. That would be problematic because it
      would then generate bindings such as [let x], which are rejected by the
@@ -3210,7 +3210,7 @@ letop_binding_body:
       { (pat, exp) }
   | val_ident
       (* Let-punning *)
-      { (mkpatvar ~loc:$loc $1, mkexpvar ~loc:$loc $1) }
+      { (mkpatvar ~loc:$loc $1, ghexpvar ~loc:$loc $1) }
   (* CR zqian: support mode annotation on letop. *)
   | pat = simple_pattern COLON typ = core_type EQUAL exp = seq_expr
       { let loc = ($startpos(pat), $endpos(typ)) in

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -121,6 +121,9 @@ let ghloc ~loc d = { txt = d; loc = ghost_loc loc }
 let ghstr ~loc d = Str.mk ~loc:(ghost_loc loc) d
 let ghsig ~loc d = Sig.mk ~loc:(ghost_loc loc) d
 
+let ghpatvar ~loc name =
+  ghpat ~loc (Ppat_var (mkrhs name loc))
+
 let mkinfix arg1 op arg2 =
   Pexp_apply(op, [Nolabel, arg1; Nolabel, arg2])
 
@@ -3165,7 +3168,7 @@ let_binding_body:
       { let p,e,c,attrs = $1 in (p,e,c,false), attrs }
 /* BEGIN AVOID */
   | val_ident %prec below_HASH
-      { (mkpatvar ~loc:$loc $1, mkexpvar ~loc:$loc $1, None, true), [] }
+      { (ghpatvar ~loc:$loc $1, mkexpvar ~loc:$loc $1, None, true), [] }
   (* The production that allows puns is marked so that [make list-parse-errors]
      does not attempt to exploit it. That would be problematic because it
      would then generate bindings such as [let x], which are rejected by the


### PR DESCRIPTION
This PR fixes an issue with locations in let puns.  The pun:
```ocaml
let%bind x in ...
```
desugars into
```ocaml
let%bind x = x in ...
```
The problem is that neither the pattern nor the expression are given a ghost location. This breaks `ppxlib`'s invariant checks, which mandate that sibling ast notes may not have overlapping (non-ghost) locations.

So, to support let punning, we must make one of the ghost.

Which one?  I made the pattern's location ghost, for two reasons:
* The reason ppxlib wants one of these two locations to be ghost is so that merlin knows what is at the location - a pattern or an expression.  What might someone do on this punned variable in merlin?  Autocompleting seems reasonable, and that's a thing you do on expressions.  Destructing seems less reasonable, and that's a thing you do on patterns. So we should want the "real" thing to be the expression, for merlin.
* For other things that can be punned (like record field patterns and expressions) the thing on the left in the expanded version is given a ghost location.  Though there the thing on the left is a label and here it is a pattern, so this doesn't feel like much of a reason.

I'm not sure what kind of test should be added to the compiler for this, if any, but I did test locally that ppxlib no longer gets angry about a punned let binding in a situation where it did before.
