### PR TITLE
Catch and handle Bottom equations in the typing environment

### DIFF
--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -106,7 +106,9 @@ type t =
        list *)
     current_level : One_level.t;
     next_binding_time : Binding_time.t;
-    min_binding_time : Binding_time.t (* Earlier variables have mode In_types *)
+    min_binding_time : Binding_time.t;
+        (* Earlier variables have mode In_types *)
+    has_bottom : bool
   }
 
 and serializable =
@@ -122,6 +124,10 @@ let is_empty t =
   && (match t.prev_levels with [] -> true | _ :: _ -> false)
   && Symbol.Set.is_empty t.defined_symbols
 
+let make_bottom t = { t with has_bottom = true }
+
+let has_bottom t = t.has_bottom
+
 let aliases t =
   Cached_level.aliases (One_level.just_after_level t.current_level)
 
@@ -130,9 +136,12 @@ let [@ocamlformat "disable"] print ppf
       ({ resolver = _; binding_time_resolver = _;get_imported_names = _;
          prev_levels; current_level; next_binding_time = _;
          defined_symbols; code_age_relation; min_binding_time;
+         has_bottom;
        } as t) =
   if is_empty t then
     Format.pp_print_string ppf "Empty"
+  else if has_bottom then
+    Format.pp_print_string ppf "Bottom"
   else
     let levels =
       current_level :: prev_levels
@@ -371,7 +380,8 @@ let create ~resolver ~get_imported_names =
     next_binding_time = Binding_time.earliest_var;
     defined_symbols = Symbol.Set.empty;
     code_age_relation = Code_age_relation.empty;
-    min_binding_time = Binding_time.earliest_var
+    min_binding_time = Binding_time.earliest_var;
+    has_bottom = false
   }
 
 let increment_scope t =
@@ -486,9 +496,9 @@ let find_with_binding_time_and_mode' t name kind =
              (see [Cached_level.clean_for_export]) *)
           type_and_binding_time))
   | found ->
-    let ty, _ = found in
+    let ty, binding_time_and_mode = found in
     check_optional_kind_matches name ty kind;
-    found
+    if t.has_bottom then MTC.bottom_like ty, binding_time_and_mode else found
 
 (* This version doesn't check min_binding_time. This ensures that no allocation
    occurs when we're not interested in the name mode. *)
@@ -922,7 +932,8 @@ and add_env_extension_with_extra_variables t
     ~variable:(fun var kind t ->
       add_variable_definition t var kind Name_mode.in_types)
     ~equation:(fun name ty t ->
-      add_equation ~raise_on_bottom:true t name ty ~meet_type)
+      try add_equation ~raise_on_bottom:true t name ty ~meet_type
+      with Bottom_equation -> make_bottom t)
     env_extension t
 
 let add_env_extension_from_level t level ~meet_type : t =
@@ -933,7 +944,9 @@ let add_env_extension_from_level t level ~meet_type : t =
   in
   let t =
     Name.Map.fold
-      (fun name ty t -> add_equation ~raise_on_bottom:true t name ty ~meet_type)
+      (fun name ty t ->
+        try add_equation ~raise_on_bottom:true t name ty ~meet_type
+        with Bottom_equation -> make_bottom t)
       (TEL.equations level) t
   in
   Variable.Map.fold
@@ -942,19 +955,29 @@ let add_env_extension_from_level t level ~meet_type : t =
     t
 
 let add_equation_strict t name ty ~meet_type : _ Or_bottom.t =
-  try Ok (add_equation ~raise_on_bottom:true t name ty ~meet_type)
-  with Bottom_equation -> Bottom
+  if t.has_bottom
+  then Bottom
+  else
+    try Ok (add_equation ~raise_on_bottom:true t name ty ~meet_type)
+    with Bottom_equation -> Bottom
 
 let add_env_extension_strict t env_extension ~meet_type : _ Or_bottom.t =
-  try Ok (add_env_extension ~raise_on_bottom:true t env_extension ~meet_type)
-  with Bottom_equation -> Bottom
+  if t.has_bottom
+  then Bottom
+  else
+    try Ok (add_env_extension ~raise_on_bottom:true t env_extension ~meet_type)
+    with Bottom_equation -> Bottom
 
 let add_env_extension_maybe_bottom t env_extension ~meet_type =
   add_env_extension ~raise_on_bottom:false t env_extension ~meet_type
 
-let add_equation = add_equation ~raise_on_bottom:true
+let add_equation t name ty ~meet_type =
+  try add_equation ~raise_on_bottom:true t name ty ~meet_type
+  with Bottom_equation -> make_bottom t
 
-let add_env_extension = add_env_extension ~raise_on_bottom:true
+let add_env_extension t env_extension ~meet_type =
+  try add_env_extension ~raise_on_bottom:true t env_extension ~meet_type
+  with Bottom_equation -> make_bottom t
 
 let add_definitions_of_params t ~params =
   List.fold_left

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -115,6 +115,8 @@ val create :
   get_imported_names:(unit -> Name.Set.t) ->
   t
 
+val has_bottom : t -> bool
+
 val closure_env : t -> t
 
 val resolver : t -> Compilation_unit.t -> Serializable.t option

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -115,7 +115,7 @@ val create :
   get_imported_names:(unit -> Name.Set.t) ->
   t
 
-val has_bottom : t -> bool
+val is_bottom : t -> bool
 
 val closure_env : t -> t
 

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -1246,7 +1246,7 @@ and meet_function_type (env : TE.t)
       ~right_a:code_id2 ~meet_b:meet ~left_b:rec_info1 ~right_b:rec_info2
 
 and meet_type env t1 t2 : _ Or_bottom.t =
-  if TE.has_bottom env
+  if TE.is_bottom env
   then Bottom
   else
     match meet env t1 t2 with
@@ -1916,7 +1916,7 @@ and join_env_extension env (ext1 : TEE.t) (ext2 : TEE.t) : TEE.t =
 
 (* Exposed to the outside world with Or_bottom type *)
 let meet env ty1 ty2 : _ Or_bottom.t =
-  if TE.has_bottom env
+  if TE.is_bottom env
   then Bottom
   else
     let scope = TE.current_scope env in
@@ -1932,7 +1932,7 @@ let meet env ty1 ty2 : _ Or_bottom.t =
         Ok (res_ty, env_extension)
 
 let meet_shape env t ~shape ~result_var ~result_kind : _ Or_bottom.t =
-  if TE.has_bottom env
+  if TE.is_bottom env
   then Bottom
   else
     let result = Bound_name.create_var result_var in
@@ -1942,7 +1942,7 @@ let meet_shape env t ~shape ~result_var ~result_kind : _ Or_bottom.t =
     | Ok (_, env_extension) -> Ok env_extension
 
 let meet_env_extension env ext1 ext2 : _ Or_bottom.t =
-  if TE.has_bottom env
+  if TE.is_bottom env
   then Bottom
   else
     let scope = TE.current_scope env in

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -1246,9 +1246,12 @@ and meet_function_type (env : TE.t)
       ~right_a:code_id2 ~meet_b:meet ~left_b:rec_info1 ~right_b:rec_info2
 
 and meet_type env t1 t2 : _ Or_bottom.t =
-  match meet env t1 t2 with
-  | Ok (res, env) -> Ok (extract_value res t1 t2, env)
-  | Bottom -> Bottom
+  if TE.has_bottom env
+  then Bottom
+  else
+    match meet env t1 t2 with
+    | Ok (res, env) -> Ok (extract_value res t1 t2, env)
+    | Bottom -> Bottom
 
 and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
   if not (K.equal (TG.kind t1) (TG.kind t2))
@@ -1913,37 +1916,46 @@ and join_env_extension env (ext1 : TEE.t) (ext2 : TEE.t) : TEE.t =
 
 (* Exposed to the outside world with Or_bottom type *)
 let meet env ty1 ty2 : _ Or_bottom.t =
-  let scope = TE.current_scope env in
-  let scoped_env = TE.increment_scope env in
-  match meet scoped_env ty1 ty2 with
-  | Bottom -> Bottom
-  | Ok (r, scoped_env) ->
-    let res_ty = extract_value r ty1 ty2 in
-    if TG.is_obviously_bottom res_ty
-    then Bottom
-    else
-      let env_extension = TE.cut_as_extension scoped_env ~cut_after:scope in
-      Ok (res_ty, env_extension)
+  if TE.has_bottom env
+  then Bottom
+  else
+    let scope = TE.current_scope env in
+    let scoped_env = TE.increment_scope env in
+    match meet scoped_env ty1 ty2 with
+    | Bottom -> Bottom
+    | Ok (r, scoped_env) ->
+      let res_ty = extract_value r ty1 ty2 in
+      if TG.is_obviously_bottom res_ty
+      then Bottom
+      else
+        let env_extension = TE.cut_as_extension scoped_env ~cut_after:scope in
+        Ok (res_ty, env_extension)
 
 let meet_shape env t ~shape ~result_var ~result_kind : _ Or_bottom.t =
-  let result = Bound_name.create_var result_var in
-  let env = TE.add_definition env result result_kind in
-  match meet env t shape with
-  | Bottom -> Bottom
-  | Ok (_, env_extension) -> Ok env_extension
+  if TE.has_bottom env
+  then Bottom
+  else
+    let result = Bound_name.create_var result_var in
+    let env = TE.add_definition env result result_kind in
+    match meet env t shape with
+    | Bottom -> Bottom
+    | Ok (_, env_extension) -> Ok env_extension
 
 let meet_env_extension env ext1 ext2 : _ Or_bottom.t =
-  let scope = TE.current_scope env in
-  let scoped_env = TE.increment_scope env in
-  match
-    TE.add_env_extension_strict scoped_env ext1 ~meet_type:(New meet_type)
-  with
-  | Bottom -> Bottom
-  | Ok scoped_env -> (
+  if TE.has_bottom env
+  then Bottom
+  else
+    let scope = TE.current_scope env in
+    let scoped_env = TE.increment_scope env in
     match
-      TE.add_env_extension_strict scoped_env ext2 ~meet_type:(New meet_type)
+      TE.add_env_extension_strict scoped_env ext1 ~meet_type:(New meet_type)
     with
     | Bottom -> Bottom
-    | Ok scoped_env ->
-      let env_extension = TE.cut_as_extension scoped_env ~cut_after:scope in
-      Ok env_extension)
+    | Ok scoped_env -> (
+      match
+        TE.add_env_extension_strict scoped_env ext2 ~meet_type:(New meet_type)
+      with
+      | Bottom -> Bottom
+      | Ok scoped_env ->
+        let env_extension = TE.cut_as_extension scoped_env ~cut_after:scope in
+        Ok env_extension)

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -130,7 +130,7 @@ let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
     else Unknown
 
 let rec meet env (t1 : TG.t) (t2 : TG.t) : (TG.t * TEE.t) Or_bottom.t =
-  if TE.has_bottom (Meet_env.env env)
+  if TE.is_bottom (Meet_env.env env)
   then Bottom
   else
     let t, env_extension = meet0 env t1 t2 in
@@ -1015,7 +1015,7 @@ and meet_env_extension0 env (ext1 : TEE.t) (ext2 : TEE.t) extra_extensions :
     meet_env_extension0 env ext new_ext extra_extensions
 
 and meet_env_extension (env : Meet_env.t) t1 t2 : TEE.t Or_bottom.t =
-  if TE.has_bottom (Meet_env.env env)
+  if TE.is_bottom (Meet_env.env env)
   then Bottom
   else try Ok (meet_env_extension0 env t1 t2 []) with Bottom_meet -> Bottom
 
@@ -1682,7 +1682,7 @@ and join_env_extension env (ext1 : TEE.t) (ext2 : TEE.t) : TEE.t =
   TEE.from_map equations
 
 let meet_shape env t ~shape ~result_var ~result_kind : _ Or_bottom.t =
-  if TE.has_bottom env
+  if TE.is_bottom env
   then Bottom
   else
     let result = Bound_name.create_var result_var in

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -130,8 +130,11 @@ let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
     else Unknown
 
 let rec meet env (t1 : TG.t) (t2 : TG.t) : (TG.t * TEE.t) Or_bottom.t =
-  let t, env_extension = meet0 env t1 t2 in
-  if TG.is_obviously_bottom t then Bottom else Ok (t, env_extension)
+  if TE.has_bottom (Meet_env.env env)
+  then Bottom
+  else
+    let t, env_extension = meet0 env t1 t2 in
+    if TG.is_obviously_bottom t then Bottom else Ok (t, env_extension)
 
 and meet0 env (t1 : TG.t) (t2 : TG.t) : TG.t * TEE.t =
   if not (K.equal (TG.kind t1) (TG.kind t2))
@@ -1012,7 +1015,9 @@ and meet_env_extension0 env (ext1 : TEE.t) (ext2 : TEE.t) extra_extensions :
     meet_env_extension0 env ext new_ext extra_extensions
 
 and meet_env_extension (env : Meet_env.t) t1 t2 : TEE.t Or_bottom.t =
-  try Ok (meet_env_extension0 env t1 t2 []) with Bottom_meet -> Bottom
+  if TE.has_bottom (Meet_env.env env)
+  then Bottom
+  else try Ok (meet_env_extension0 env t1 t2 []) with Bottom_meet -> Bottom
 
 and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
   if not (K.equal (TG.kind t1) (TG.kind t2))
@@ -1677,7 +1682,10 @@ and join_env_extension env (ext1 : TEE.t) (ext2 : TEE.t) : TEE.t =
   TEE.from_map equations
 
 let meet_shape env t ~shape ~result_var ~result_kind : _ Or_bottom.t =
-  let result = Bound_name.create_var result_var in
-  let env = TE.add_definition env result result_kind in
-  let<+ _meet_ty, env_extension = meet (Meet_env.create env) t shape in
-  env_extension
+  if TE.has_bottom env
+  then Bottom
+  else
+    let result = Bound_name.create_var result_var in
+    let env = TE.add_definition env result result_kind in
+    let<+ _meet_ty, env_extension = meet (Meet_env.create env) t shape in
+    env_extension


### PR DESCRIPTION
The exception `Bottom_equation` is raised when an inconsistency is discovered in a typing environment and there is no `Or_bottom` wrapper to handle it properly.
This can happen for legitimate reasons (the typing env is not always in a fully-reduced state, and in theory even adding unrelated equations could cause us to perform a bit of reduction and discover Bottom). However, currently (with the advanced meet) we let it crash the compiler, in order to get a better sense of what cases can trigger this. This PR is one attempt to properly catch the exception and handle it.

My first attempts changed the type of all functions that could throw the exception to return `Or_bottom.t` instead. It proved very painful to do: a lot of places in `Simplify` rely on such functions, and not all of them can do something obviously correct in the case where `Bottom` is returned.
So this proposal hides everything in the typing environment: an additional `has_bottom` flag tracks whether we have introduced a bottom equation, and every operation that can return a Bottom value (`meet`, `find`, ...) will immediately return `Bottom` if the environment has this flag set.

The next step is to start exposing this flag in the `Flambda2_types` interface in some way, to allow `Simplify` to make clear when it is expecting its environment to be non-bottom. I'll work on that on the same branch for now and update this PR when it's done, unless we decide to merge this first (in which case I'll make a follow-up PR).