### PR TITLE
Fix incorrect use of AC_ARG_ENABLE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,22 +48,22 @@ AC_ARG_ENABLE([middle-end],
 AC_ARG_ENABLE([runtime5],
   [AS_HELP_STRING([--enable-runtime5],
     [Use the OCaml 5 runtime])],
-  [runtime5_arg=--enable-runtime5],
-  [runtime5_arg=])
+  [],
+  [enable_runtime5=no])
 
 AC_ARG_ENABLE([coverage],
   [AS_HELP_STRING([--enable-coverage],
     [Run compiler tests instrumented to output coverage data using bisect_ppx
      (WARNING: Cannot build an installable compiler with this flag enabled.
      Mainly intended for use in CI.)])],
-  [coverage=yes],
-  [coverage=no])
+  [],
+  [enable_coverage=no])
 
 AC_ARG_ENABLE([legacy-library-layout],
   [AS_HELP_STRING([--enable-legacy-library-layout],
     [Install libraries unix, str, dynlink and bigarray in the toplevel
      ocaml library directory (Same as upstream OCaml < 5.0)])],
-  [legacy_layout=yes],
+  [],
   [legacy_layout=no])
 
 AC_ARG_ENABLE([dev],
@@ -71,14 +71,21 @@ AC_ARG_ENABLE([dev],
     [Use the dev build profile for dune when building the 2nd stage.
      Can speed up the compile time by a lot. (WARNING: do not use for
      production compiler deployments)])],
-  [main_build_profile=dev],
-  [main_build_profile=main])
+  [],
+  [enable_dev=no])
 
 AC_SUBST([prefix])
 AC_SUBST([middle_end])
 AC_SUBST([dune])
+
+coverage="$enable_coverage"
 AC_SUBST([coverage])
+
+legacy_layout="$legacy_layout"
 AC_SUBST([legacy_layout])
+
+main_build_profile=main
+AS_IF([test x"$enable_dev" = xyes], [main_build_profile=dev])
 AC_SUBST([main_build_profile])
 
 # Don't error on options that this configure script doesn't understand but
@@ -86,7 +93,7 @@ AC_SUBST([main_build_profile])
 AC_DISABLE_OPTION_CHECKING
 
 AX_SUBDIRS_CONFIGURE([ocaml],
-  [$middle_end_arg,$runtime5_arg,-C,--disable-ocamldoc,--disable-stdlib-manpages,--enable-ocamltest,--without-zstd],
+  [$middle_end_arg,--enable-runtime5=$enable_runtime5,-C,--disable-ocamldoc,--disable-stdlib-manpages,--enable-ocamltest,--without-zstd],
   [],
   [],
   [])

--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_ARG_ENABLE([legacy-library-layout],
     [Install libraries unix, str, dynlink and bigarray in the toplevel
      ocaml library directory (Same as upstream OCaml < 5.0)])],
   [],
-  [legacy_layout=no])
+  [enable_legacy_layout=no])
 
 AC_ARG_ENABLE([dev],
   [AS_HELP_STRING([--enable-dev],
@@ -81,7 +81,7 @@ AC_SUBST([dune])
 coverage="$enable_coverage"
 AC_SUBST([coverage])
 
-legacy_layout="$legacy_layout"
+legacy_layout="$enable_legacy_layout"
 AC_SUBST([legacy_layout])
 
 main_build_profile=main

--- a/ocaml/Makefile.config.in
+++ b/ocaml/Makefile.config.in
@@ -245,11 +245,7 @@ POLL_INSERTION=@poll_insertion@
 DUNE=@dune@
 
 # Selection of OCaml 4.x or 5.x runtime
-ifeq "@enable_runtime5@" "yes"
-  RUNTIME_SUFFIX=
-else
-  RUNTIME_SUFFIX=4
-endif
+RUNTIME_SUFFIX=@runtime_suffix@
 RUNTIME_DIR=runtime$(RUNTIME_SUFFIX)
 
 # Deprecated variables

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -861,6 +861,7 @@ VERSION
 default_build_target
 native_compiler
 CONFIGURE_ARGS
+runtime_suffix
 enable_runtime5
 target_alias
 host_alias
@@ -3241,8 +3242,15 @@ then :
   enableval=$enable_runtime5;
 fi
 
+if test x"$enable_runtime5" = xyes
+then :
+  runtime_suffix=
+else $as_nop
+  runtime_suffix=4
+fi
 
 ## Output variables
+
 
 
 

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -93,10 +93,14 @@ AC_CONFIG_AUX_DIR([build-aux])
 AC_ARG_ENABLE([runtime5],
   [AS_HELP_STRING([--enable-runtime5],
     [Use the OCaml 5 runtime])])
+AS_IF([test x"$enable_runtime5" = xyes],
+      [runtime_suffix=],
+      [runtime_suffix=4])
 
 ## Output variables
 
 AC_SUBST([enable_runtime5])
+AC_SUBST([runtime_suffix])
 AC_SUBST([CONFIGURE_ARGS])
 AC_SUBST([native_compiler])
 AC_SUBST([default_build_target])


### PR DESCRIPTION
The two last arguments to `AC_ARG_ENABLE` are not 'if enabled' and 'if disabled', they are 'if specified' and 'if unspecified'. Getting this wrong in `configure.ac` means that currently `--enable-runtime5` and `--disable-runtime5` do the same thing, enabling runtime5.

This patch fixes these uses, so that `--enable-foo` and `--disable-foo` become opposites.