### PR TITLE
Zero alloc: fix bug interaction between "opt" and top-level "all"

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -57,9 +57,7 @@ let rec of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list =
     match hd with
     | No_CSE -> No_CSE :: of_cmm_codegen_option tl
     | Reduce_code_size -> Reduce_code_size :: of_cmm_codegen_option tl
-    | Use_linscan_regalloc | Assume _ | Check _
-      ->
-      of_cmm_codegen_option tl)
+    | Use_linscan_regalloc | Assume _ | Check _ -> of_cmm_codegen_option tl)
 
 type t =
   { blocks : basic_block Label.Tbl.t;

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -57,7 +57,7 @@ let rec of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list =
     match hd with
     | No_CSE -> No_CSE :: of_cmm_codegen_option tl
     | Reduce_code_size -> Reduce_code_size :: of_cmm_codegen_option tl
-    | Use_linscan_regalloc | Ignore_assert_all Zero_alloc | Assume _ | Check _
+    | Use_linscan_regalloc | Assume _ | Check _
       ->
       of_cmm_codegen_option tl)
 

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -313,16 +313,7 @@ end = struct
         codegen_options
     in
     match a with
-    | [] ->
-      if !Clflags.zero_alloc_check_assert_all && not !ignore_assert_all
-      then
-        Some
-          { strict = false;
-            assume = false;
-            never_returns_normally = false;
-            loc = Debuginfo.to_location dbg
-          }
-      else None
+    | [] -> None
     | [p] -> Some p
     | _ :: _ ->
       Misc.fatal_errorf "Unexpected duplicate annotation %a for %s"

--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -294,7 +294,6 @@ end = struct
   let is_strict t = t.strict
 
   let find codegen_options spec fun_name dbg =
-    let ignore_assert_all = ref false in
     let a =
       List.filter_map
         (fun (c : Cmm.codegen_option) ->
@@ -304,10 +303,7 @@ end = struct
           | Assume { property; strict; never_returns_normally; loc }
             when property = spec ->
             Some { strict; assume = true; never_returns_normally; loc }
-          | Ignore_assert_all property when property = spec ->
-            ignore_assert_all := true;
-            None
-          | Ignore_assert_all _ | Check _ | Assume _ | Reduce_code_size | No_CSE
+          | Check _ | Assume _ | Reduce_code_size | No_CSE
           | Use_linscan_regalloc ->
             None)
         codegen_options

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -301,7 +301,6 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
-  | Ignore_assert_all of property
   | Assume of { property: property; strict: bool; never_returns_normally: bool;
                 loc: Location.t }
   | Check of { property: property; strict: bool; loc : Location.t; }

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -309,7 +309,6 @@ type codegen_option =
   | Reduce_code_size
   | No_CSE
   | Use_linscan_regalloc
-  | Ignore_assert_all of property
   | Assume of { property: property; strict: bool; never_returns_normally: bool;
                 loc: Location.t }
   | Check of { property: property; strict: bool; loc: Location.t }

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3601,24 +3601,6 @@ let cmm_arith_size (e : Cmm.expression) =
   | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ | Ctrywith _ ->
     None
 
-let transl_property : Lambda.property -> Cmm.property = function
-  | Zero_alloc -> Zero_alloc
-
-let transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list = function
-  | Default_check -> []
-  | Ignore_assert_all p -> [Ignore_assert_all (transl_property p)]
-  | Assume { property; strict; never_returns_normally; loc } ->
-    [ Assume
-        { property = transl_property property;
-          strict;
-          never_returns_normally;
-          loc
-        } ]
-  | Check { property; strict; loc; opt } ->
-    if Lambda.is_check_enabled ~opt property
-    then [Check { property = transl_property property; strict; loc }]
-    else []
-
 let kind_of_layout (layout : Lambda.layout) =
   match layout with
   | Pvalue (Pboxedfloatval Pfloat64) -> Boxed_float

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -851,8 +851,6 @@ val gc_root_table : Cmm.symbol list -> phrase
    should be assumed to be potentially large. *)
 val cmm_arith_size : expression -> int option
 
-val transl_attrib : Lambda.check_attribute -> Cmm.codegen_option list
-
 (* CR lmaurer: Return [Linkage_name.t] instead *)
 val make_symbol : ?compilation_unit:Compilation_unit.t -> string -> string
 

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -383,8 +383,6 @@ let codegen_option = function
   | Reduce_code_size -> "reduce_code_size"
   | No_CSE -> "no_cse"
   | Use_linscan_regalloc -> "linscan"
-  | Ignore_assert_all property ->
-    Printf.sprintf "ignore %s" (property_to_string property)
   | Assume { property; strict; never_returns_normally = _; loc = _ } ->
     Printf.sprintf "assume_%s%s%s"
       (property_to_string property)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1827,7 +1827,8 @@ let make_unboxed_function_wrapper acc function_slot params params_arity
       ~stub:true ~inline:Inline_attribute.Default_inline
       ~poll_attribute:
         (Poll_attribute.from_lambda (Function_decl.poll_attribute decl))
-      ~check:(Check_attribute.from_lambda (Function_decl.check_attribute decl))
+      ~check:(Check_attribute.from_lambda (Function_decl.check_attribute decl)
+                (Debuginfo.Scoped_location.to_location (Function_decl.loc decl)))
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~is_opaque:false ~recursive ~newer_version_of:None ~cost_metrics
       ~inlining_arguments:(Inlining_arguments.create ~round:0)
@@ -2191,7 +2192,8 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
       ~stub ~inline
       ~poll_attribute:
         (Poll_attribute.from_lambda (Function_decl.poll_attribute decl))
-      ~check:(Check_attribute.from_lambda (Function_decl.check_attribute decl))
+      ~check:(Check_attribute.from_lambda (Function_decl.check_attribute decl)
+                 (Debuginfo.Scoped_location.to_location (Function_decl.loc decl)))
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~is_opaque:(Function_decl.is_opaque decl)
       ~recursive ~newer_version_of:None ~cost_metrics
@@ -2318,6 +2320,7 @@ let close_functions acc external_env ~current_region function_declarations =
         in
         let check =
           Check_attribute.from_lambda (Function_decl.check_attribute decl)
+          (Debuginfo.Scoped_location.to_location (Function_decl.loc decl))
         in
         let cost_metrics = Cost_metrics.zero in
         let dbg = Debuginfo.from_location (Function_decl.loc decl) in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1827,8 +1827,10 @@ let make_unboxed_function_wrapper acc function_slot params params_arity
       ~stub:true ~inline:Inline_attribute.Default_inline
       ~poll_attribute:
         (Poll_attribute.from_lambda (Function_decl.poll_attribute decl))
-      ~check:(Check_attribute.from_lambda (Function_decl.check_attribute decl)
-                (Debuginfo.Scoped_location.to_location (Function_decl.loc decl)))
+      ~check:
+        (Check_attribute.from_lambda
+           (Function_decl.check_attribute decl)
+           (Debuginfo.Scoped_location.to_location (Function_decl.loc decl)))
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~is_opaque:false ~recursive ~newer_version_of:None ~cost_metrics
       ~inlining_arguments:(Inlining_arguments.create ~round:0)
@@ -2192,8 +2194,10 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
       ~stub ~inline
       ~poll_attribute:
         (Poll_attribute.from_lambda (Function_decl.poll_attribute decl))
-      ~check:(Check_attribute.from_lambda (Function_decl.check_attribute decl)
-                 (Debuginfo.Scoped_location.to_location (Function_decl.loc decl)))
+      ~check:
+        (Check_attribute.from_lambda
+           (Function_decl.check_attribute decl)
+           (Debuginfo.Scoped_location.to_location (Function_decl.loc decl)))
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~is_opaque:(Function_decl.is_opaque decl)
       ~recursive ~newer_version_of:None ~cost_metrics
@@ -2319,8 +2323,9 @@ let close_functions acc external_env ~current_region function_declarations =
           Poll_attribute.from_lambda (Function_decl.poll_attribute decl)
         in
         let check =
-          Check_attribute.from_lambda (Function_decl.check_attribute decl)
-          (Debuginfo.Scoped_location.to_location (Function_decl.loc decl))
+          Check_attribute.from_lambda
+            (Function_decl.check_attribute decl)
+            (Debuginfo.Scoped_location.to_location (Function_decl.loc decl))
         in
         let cost_metrics = Cost_metrics.zero in
         let dbg = Debuginfo.from_location (Function_decl.loc decl) in

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -510,7 +510,6 @@ let simplify_function context ~outer_dacc function_slot code_id
     let never_delete =
       match Code_metadata.check code_metadata with
       | Default_check -> !Clflags.zero_alloc_check_assert_all
-      | Ignore_assert_all Zero_alloc -> false
       | Assume { property = Zero_alloc; _ } -> false
       | Check { property = Zero_alloc; _ } -> true
     in

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -49,7 +49,8 @@ let from_lambda : Lambda.check_attribute -> Location.t -> t =
  fun a loc ->
   match a with
   | Default_check ->
-    if !Clflags.zero_alloc_check_assert_all
+    if !Clflags.zero_alloc_check_assert_all &&
+       Lambda.is_check_enabled ~opt:false Zero_alloc
     then Check { property = Zero_alloc; strict = false; loc }
     else Default_check
   | Ignore_assert_all Zero_alloc -> Default_check

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -48,9 +48,14 @@ let print ppf t =
     Format.fprintf ppf "@[assert_%a%s@]" Property.print property
       (if strict then "_strict" else "")
 
-let from_lambda : Lambda.check_attribute -> t = function
-  | Default_check -> Default_check
-  | Ignore_assert_all p -> Ignore_assert_all (Property.from_lambda p)
+let from_lambda : Lambda.check_attribute -> Location.t -> t =
+ fun a loc ->
+  match a with
+  | Default_check ->
+    if !Clflags.zero_alloc_check_assert_all
+    then Check { property = Zero_alloc; strict = false; loc }
+    else Default_check
+  | Ignore_assert_all Zero_alloc -> Default_check
   | Assume { property; strict; never_returns_normally; loc } ->
     Assume
       { property = Property.from_lambda property;

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -22,7 +22,6 @@ end
 
 type t =
   | Default_check
-  | Ignore_assert_all of Property.t
   | Assume of
       { property : Property.t;
         strict : bool;
@@ -38,8 +37,6 @@ type t =
 let print ppf t =
   match t with
   | Default_check -> ()
-  | Ignore_assert_all property ->
-    Format.fprintf ppf "@[ignore %a@]" Property.print property
   | Assume { property; strict; never_returns_normally; loc = _ } ->
     Format.fprintf ppf "@[assume_%a%s%s@]" Property.print property
       (if strict then "_strict" else "")
@@ -71,7 +68,6 @@ let from_lambda : Lambda.check_attribute -> Location.t -> t =
 let equal x y =
   match x, y with
   | Default_check, Default_check -> true
-  | Ignore_assert_all p1, Ignore_assert_all p2 -> Property.equal p1 p2
   | ( Check { property = p1; strict = s1; loc = loc1 },
       Check { property = p2; strict = s2; loc = loc2 } ) ->
     Property.equal p1 p2 && Bool.equal s1 s2 && Location.compare loc1 loc2 = 0
@@ -82,8 +78,8 @@ let equal x y =
     ) ->
     Property.equal p1 p2 && Bool.equal s1 s2 && Bool.equal n1 n2
     && Location.compare loc1 loc2 = 0
-  | (Default_check | Ignore_assert_all _ | Check _ | Assume _), _ -> false
+  | (Default_check | Check _ | Assume _), _ -> false
 
 let is_default : t -> bool = function
   | Default_check -> true
-  | Ignore_assert_all _ | Check _ | Assume _ -> false
+  | Check _ | Assume _ -> false

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -49,8 +49,8 @@ let from_lambda : Lambda.check_attribute -> Location.t -> t =
  fun a loc ->
   match a with
   | Default_check ->
-    if !Clflags.zero_alloc_check_assert_all &&
-       Lambda.is_check_enabled ~opt:false Zero_alloc
+    if !Clflags.zero_alloc_check_assert_all
+       && Lambda.is_check_enabled ~opt:false Zero_alloc
     then Check { property = Zero_alloc; strict = false; loc }
     else Default_check
   | Ignore_assert_all Zero_alloc -> Default_check

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -35,4 +35,5 @@ val equal : t -> t -> bool
 
 val is_default : t -> bool
 
-val from_lambda : Lambda.check_attribute -> t
+val from_lambda : Lambda.check_attribute -> Location.t -> t
+

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -35,4 +35,3 @@ val equal : t -> t -> bool
 val is_default : t -> bool
 
 val from_lambda : Lambda.check_attribute -> Location.t -> t
-

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -16,7 +16,6 @@ end
 
 type t =
   | Default_check
-  | Ignore_assert_all of Property.t
   | Assume of
       { property : Property.t;
         strict : bool;

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -124,10 +124,7 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
   let res, entry_sym = R.raw_symbol res ~global:Global entry_name in
   let entry =
     let fun_codegen =
-      let fun_codegen =
-        [ Cmm.Reduce_code_size;
-          Cmm.Use_linscan_regalloc ]
-      in
+      let fun_codegen = [Cmm.Reduce_code_size; Cmm.Use_linscan_regalloc] in
       if Flambda_features.backend_cse_at_toplevel ()
       then fun_codegen
       else Cmm.No_CSE :: fun_codegen

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -126,8 +126,7 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
     let fun_codegen =
       let fun_codegen =
         [ Cmm.Reduce_code_size;
-          Cmm.Use_linscan_regalloc;
-          Cmm.Ignore_assert_all Cmm.Zero_alloc ]
+          Cmm.Use_linscan_regalloc ]
       in
       if Flambda_features.backend_cse_at_toplevel ()
       then fun_codegen

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -327,7 +327,6 @@ let transl_property : Check_attribute.Property.t -> Cmm.property = function
 let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list =
   function
   | Default_check -> []
-  | Ignore_assert_all p -> [Ignore_assert_all (transl_property p)]
   | Assume { property; strict; never_returns_normally; loc } ->
     [ Assume
         { property = transl_property property;

--- a/tests/backend/checkmach/dune
+++ b/tests/backend/checkmach/dune
@@ -9,3 +9,11 @@
 (rule
  (alias  runtest)
  (action (copy fail25.ml fail26.ml)))
+
+(rule
+ (alias  runtest)
+ (action (copy test_all_opt.ml test_all_opt2.ml)))
+
+(rule
+ (alias  runtest)
+ (action (copy test_all_opt.ml test_all_opt3.ml)))

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -793,3 +793,60 @@
  (enabled_if (= %{context_name} "main"))
  (deps fail26.output fail26.output.corrected)
  (action (diff fail26.output fail26.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_all_opt.output.corrected)
+ (deps (:ml test_all_opt.ml) filter.sh)
+ (action
+   (with-outputs-to test_all_opt.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_all_opt.output test_all_opt.output.corrected)
+ (action (diff test_all_opt.output test_all_opt.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_all_opt2.output.corrected)
+ (deps (:ml test_all_opt2.ml) filter.sh)
+ (action
+   (with-outputs-to test_all_opt2.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check all -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_all_opt2.output test_all_opt2.output.corrected)
+ (action (diff test_all_opt2.output test_all_opt2.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_all_opt3.output.corrected)
+ (deps (:ml test_all_opt3.ml) filter.sh)
+ (action
+   (with-outputs-to test_all_opt3.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check opt -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_all_opt3.output test_all_opt3.output.corrected)
+ (action (diff test_all_opt3.output test_all_opt3.output.corrected)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -130,4 +130,13 @@ let () =
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_flags:"-zero-alloc-check default -disable-checkmach -function-layout source"
     ~extra_dep:None ~exit_code:2 "fail26";
+  print_test_expected_output ~cutoff:default_cutoff
+    ~extra_flags:"-zero-alloc-check default"
+    ~extra_dep:None ~exit_code:2 "test_all_opt";
+  print_test_expected_output ~cutoff:default_cutoff
+    ~extra_flags:"-zero-alloc-check all"
+    ~extra_dep:None ~exit_code:2 "test_all_opt2";
+  print_test_expected_output ~cutoff:default_cutoff
+    ~extra_flags:"-zero-alloc-check opt"
+    ~extra_dep:None ~exit_code:2 "test_all_opt3";
   ()

--- a/tests/backend/checkmach/test_all_opt.ml
+++ b/tests/backend/checkmach/test_all_opt.ml
@@ -7,13 +7,3 @@ let[@zero_alloc opt] foo x = (x,x)
 let[@zero_alloc] bar x = [x;x]
 
 let baz x = [|x;x+1|]
-(* CR-soon gyorsh:
-   The check fails on [baz] with -check-zero-alloc default/all/opt.
-   This shows that the current interpretation of [@@@zero_alloc all] on functions
-   that do not have an explicit "zero_alloc" attribute
-   is to require "zero all" with both "opt" and "default" flags.
-   This behavior behavior exposes an implementation detail that does not matter in
-   practice because "opt" flag is only intended for testing, and the behavior
-   with "default" and "all" flags is indistinguishable.
-   Fix it in the next commit.
-*)

--- a/tests/backend/checkmach/test_all_opt.ml
+++ b/tests/backend/checkmach/test_all_opt.ml
@@ -1,0 +1,19 @@
+[@@@zero_alloc all]
+
+(* check fails with -check-zero-alloc opt/all, passes with -check-zero-alloc default *)
+let[@zero_alloc opt] foo x = (x,x)
+
+(* check fails with -check-zero-alloc default/all, passes with "-check-zero-alloc opt" *)
+let[@zero_alloc] bar x = [x;x]
+
+let baz x = [|x;x+1|]
+(* CR-soon gyorsh:
+   The check fails on [baz] with -check-zero-alloc default/all/opt.
+   This shows that the current interpretation of [@@@zero_alloc all] on functions
+   that do not have an explicit "zero_alloc" attribute
+   is to require "zero all" with both "opt" and "default" flags.
+   This behavior behavior exposes an implementation detail that does not matter in
+   practice because "opt" flag is only intended for testing, and the behavior
+   with "default" and "all" flags is indistinguishable.
+   Fix it in the next commit.
+*)

--- a/tests/backend/checkmach/test_all_opt.output
+++ b/tests/backend/checkmach/test_all_opt.output
@@ -1,0 +1,14 @@
+File "test_all_opt.ml", line 7, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_all_opt.bar (camlTest_all_opt.bar_HIDE_STAMP)
+
+File "test_all_opt.ml", line 7, characters 25-30:
+Error: allocation of 24 bytes
+
+File "test_all_opt.ml", line 7, characters 28-30:
+Error: allocation of 24 bytes
+
+File "test_all_opt.ml", line 9, characters 8-21:
+Error: Annotation check for zero_alloc failed on function Test_all_opt.baz (camlTest_all_opt.baz_HIDE_STAMP)
+
+File "test_all_opt.ml", line 9, characters 12-21:
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/test_all_opt2.output
+++ b/tests/backend/checkmach/test_all_opt2.output
@@ -1,0 +1,20 @@
+File "test_all_opt2.ml", line 4, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_all_opt2.foo (camlTest_all_opt2.foo_HIDE_STAMP)
+
+File "test_all_opt2.ml", line 4, characters 29-34:
+Error: allocation of 24 bytes
+
+File "test_all_opt2.ml", line 7, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_all_opt2.bar (camlTest_all_opt2.bar_HIDE_STAMP)
+
+File "test_all_opt2.ml", line 7, characters 25-30:
+Error: allocation of 24 bytes
+
+File "test_all_opt2.ml", line 7, characters 28-30:
+Error: allocation of 24 bytes
+
+File "test_all_opt2.ml", line 9, characters 8-21:
+Error: Annotation check for zero_alloc failed on function Test_all_opt2.baz (camlTest_all_opt2.baz_HIDE_STAMP)
+
+File "test_all_opt2.ml", line 9, characters 12-21:
+Error: allocation of 24 bytes

--- a/tests/backend/checkmach/test_all_opt3.output
+++ b/tests/backend/checkmach/test_all_opt3.output
@@ -3,9 +3,3 @@ Error: Annotation check for zero_alloc failed on function Test_all_opt3.foo (cam
 
 File "test_all_opt3.ml", line 4, characters 29-34:
 Error: allocation of 24 bytes
-
-File "test_all_opt3.ml", line 9, characters 8-21:
-Error: Annotation check for zero_alloc failed on function Test_all_opt3.baz (camlTest_all_opt3.baz_HIDE_STAMP)
-
-File "test_all_opt3.ml", line 9, characters 12-21:
-Error: allocation of 24 bytes

--- a/tests/backend/checkmach/test_all_opt3.output
+++ b/tests/backend/checkmach/test_all_opt3.output
@@ -1,0 +1,11 @@
+File "test_all_opt3.ml", line 4, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_all_opt3.foo (camlTest_all_opt3.foo_HIDE_STAMP)
+
+File "test_all_opt3.ml", line 4, characters 29-34:
+Error: allocation of 24 bytes
+
+File "test_all_opt3.ml", line 9, characters 8-21:
+Error: Annotation check for zero_alloc failed on function Test_all_opt3.baz (camlTest_all_opt3.baz_HIDE_STAMP)
+
+File "test_all_opt3.ml", line 9, characters 12-21:
+Error: allocation of 24 bytes


### PR DESCRIPTION
The following example fails the check:
```
[@@@zero_alloc all]
let[@zero_alloc opt] foo x = (x,x)
```
but it is expected to pass the check by default (and fail with `-check-zero-alloc all` compiler flag). 

This PR fixes the bug and adds a test to show the expected behavior. 

The bug is that `Clflags.zero_alloc_check_assert_all` is checked too late.  The cause of the bug is that "opt" annotations are removed by the middle-end (`from_lambda` transformation) if `Lambda.is_check_enabled ~opt` is false, but then in the backend, if `Clflags.zero_alloc_check_assert_all` is true, we add "assert zero_alloc"  annotations on the same function, because it doesn't have "ignore" or "assume". The fix is to check the two flags in one place in the middle-end during `from_lambda` conversion.  The reason that we don't check it all in the backend is the interaction with the dead code elimination in flambda: it's better to remove unnecessary "asserts" earlier. We can probably move this check even earlier after #2400 is merged, but that would be a separate PR for refactoring only.

As a result of the fix, we can eliminate the now-unused `Ignore_all` constructor from the middle-end and `Cmm`.

~On top of #2416.~  Best review commit-by-commit.