### PR TITLE
`NO_PROFINFO` to 0

### DIFF
--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -125,8 +125,7 @@ originally built for Spacetime profiling, hence the odd name.
 #ifdef WITH_PROFINFO
 #define PROFINFO_SHIFT (Gen_profinfo_shift(PROFINFO_WIDTH))
 #define PROFINFO_MASK (Gen_profinfo_mask(PROFINFO_WIDTH))
-/* Use NO_PROFINFO to debug problems with profinfo macros */
-#define NO_PROFINFO 0xff
+#define NO_PROFINFO 0
 #define Hd_no_profinfo(hd) ((hd) & ~(PROFINFO_MASK << PROFINFO_SHIFT))
 #define Wosize_hd(hd) ((mlsize_t) ((Hd_no_profinfo(hd)) >> 10))
 #define Profinfo_hd(hd) (Gen_profinfo_hd(PROFINFO_WIDTH, hd))


### PR DESCRIPTION
Make `NO_PROFINFO` always set bits to 0, even if you're using a runtime 4 that has `WITH_PROFINFO` enabled. Before the top byte was always 0xff.

cc @mshinwell in case this should go in the tag. (I think it should.)