### PR TITLE
Use more instructive type (`label` vs `int`) in `amd64/emit.mlp`

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -676,7 +676,7 @@ let output_epilogue f =
 
 (* Floating-point constants *)
 
-let float_constants = ref ([] : (int64 * int) list)
+let float_constants = ref ([] : (int64 * label) list)
 
 let add_float_constant cst =
   try
@@ -692,7 +692,7 @@ let emit_float_constant f lbl =
 
 (* Vector constants *)
 
-let vec128_constants = ref ([] : (Cmm.vec128_bits * int) list)
+let vec128_constants = ref ([] : (Cmm.vec128_bits * label) list)
 
 let add_vec128_constant bits =
   try


### PR DESCRIPTION
This pull request simply replaces an `int` type
with a `label` type, to make clearer what an
association list is storing.