### PR TITLE
Shorter sequence for stack checks

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1196,6 +1196,19 @@ let emit_simd_instr op i =
   | SSE42 (Cmpistrz n) ->
     I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0); I.set E (res8 i 0); I.movzx (res8 i 0) (res i 0)
 
+(* CR xclerc for xclerc: consider for a proper type (possibly when rebasing
+   over the branch moving checks down) *)
+let handle_overflow = ref (None : (label * label * int) option)
+
+let emit_stack_check () =
+    begin match !handle_overflow with
+    | None -> ()
+    | Some (overflow, ret, _max_frame_size) ->
+      I.cmp (domain_field Domainstate.Domain_current_stack_bound) rsp;
+      I.jb (label overflow);
+      def_label ret;
+    end
+
 (* Emit an instruction *)
 let emit_instr fallthrough i =
   emit_debug_info_linear i;
@@ -1215,7 +1228,8 @@ let emit_instr fallthrough i =
         I.sub (int n) rsp;
         cfi_adjust_cfa_offset n;
       end;
-    end
+    end;
+    emit_stack_check ()
   | Lop(Imove | Ispill | Ireload) ->
       move i.arg.(0) i.res.(0)
   | Lop(Iconst_int n) ->
@@ -1838,40 +1852,28 @@ let fundecl fundecl =
   D.label (label_name (emit_symbol fundecl.fun_name));
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc ();
-  let handle_overflow_and_max_frame_size =
-    (* CR mshinwell: this should be conditionalized on a specific
-       "stack checks enabled" config option, so we can backport to 4.x *)
-    if not Config.runtime5 then None
-    else (
-      if !Clflags.runtime_variant = "d" then
-        emit_call (Cmm.global_symbol "caml_assert_stack_invariants");
-      let { max_frame_size; contains_nontail_calls} =
-        preproc_stack_check
-          ~fun_body:fundecl.fun_body ~frame_size:(frame_size ()) ~trap_size:16
-      in
-      let handle_overflow =
-        if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
-          let overflow = new_label () and ret = new_label () in
-          let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
-          I.lea (mem64 NONE (-(max_frame_size + threshold_offset)) RSP) r10;
-          I.cmp (domain_field Domainstate.Domain_current_stack) r10;
-          I.jb (label overflow);
-          def_label ret;
-          Some (overflow, ret)
-        end else None
-      in
-      match handle_overflow with
-      | None -> None
-      | Some handle_overflow -> Some (handle_overflow, max_frame_size)
-    )
-  in
+  handle_overflow := None;
+  (* CR mshinwell: this should be conditionalized on a specific
+     "stack checks enabled" config option, so we can backport to 4.x *)
+  if Config.runtime5 then (
+    if !Clflags.runtime_variant = "d" then
+      emit_call (Cmm.global_symbol "caml_assert_stack_invariants");
+    let { max_frame_size; contains_nontail_calls} =
+      preproc_stack_check
+        ~fun_body:fundecl.fun_body ~frame_size:(frame_size ()) ~trap_size:16
+    in
+    if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
+      let overflow = new_label () and ret = new_label () in
+      handle_overflow := Some (overflow, ret, max_frame_size)
+    end);
+  if not !prologue_required then assert (!handle_overflow = None);
   emit_all true fundecl.fun_body;
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
   emit_call_safety_errors ();
-  begin match handle_overflow_and_max_frame_size with
+  begin match !handle_overflow with
     | None -> ()
-    | Some ((overflow,ret), max_frame_size) -> begin
+    | Some (overflow, ret, max_frame_size) -> begin
         def_label overflow;
         (* Pass the desired frame size on the stack, since all of the
            argument-passing registers may be in use.

--- a/ocaml/otherlibs/systhreads/st_stubs.c
+++ b/ocaml/otherlibs/systhreads/st_stubs.c
@@ -92,6 +92,7 @@ struct caml_thread_struct {
   struct caml_thread_struct * prev;
   int domain_id;      /* The id of the domain to which this thread belongs */
   struct stack_info* current_stack;      /* saved Caml_state->current_stack */
+  struct stack_info* current_stack_bound;      /* saved Caml_state->current_stack_bound */
   struct c_stack_link* c_stack;          /* saved Caml_state->c_stack */
   /* Note: we do not save Caml_state->stack_cache, because it can
      safely be shared between all threads on the same domain. */
@@ -249,6 +250,7 @@ static void save_runtime_state(void)
   caml_thread_t th = Active_thread;
   CAMLassert(th != NULL);
   th->current_stack = Caml_state->current_stack;
+  th->current_stack_bound = Caml_state->current_stack_bound;
   th->c_stack = Caml_state->c_stack;
   th->gc_regs = Caml_state->gc_regs;
   th->gc_regs_buckets = Caml_state->gc_regs_buckets;
@@ -277,6 +279,7 @@ static void restore_runtime_state(caml_thread_t th)
   CAMLassert(th != NULL);
   Active_thread = th;
   Caml_state->current_stack = th->current_stack;
+  Caml_state->current_stack_bound = th->current_stack_bound;
   Caml_state->c_stack = th->c_stack;
   Caml_state->gc_regs = th->gc_regs;
   Caml_state->gc_regs_buckets = th->gc_regs_buckets;
@@ -374,6 +377,7 @@ static caml_thread_t caml_thread_new_info(void)
     caml_stat_free(th);
     return NULL;
   }
+  th->current_stack_bound = th->current_stack + Stack_threshold_offset;
   th->c_stack = NULL;
   th->local_roots = NULL;
   th->local_arenas = NULL;

--- a/ocaml/runtime/amd64.S
+++ b/ocaml/runtime/amd64.S
@@ -994,7 +994,7 @@ CFI_STARTPROC
     /* Load new stack pointer and set parent */
         movq    Stack_handler(%rax), %r11
         movq    %rcx, Handler_parent(%r11)
-        movq    %rax, Caml_state(current_stack)
+        movq    %rax, Caml_state(current_stack) /* CR xclerc for xclerc: also current_stack_bound */
         movq    Stack_sp(%rax), %r11
     /* Create an exception handler on the target stack
        after 16byte DWARF & gc_regs block (which is unused here) */
@@ -1027,7 +1027,7 @@ LBL(frame_runstack):
     /* restore parent stack and exn_handler into Caml_state */
         movq    Handler_parent(%r11), %r10
         movq    Stack_exception(%r10), %r11
-        movq    %r10, Caml_state(current_stack)
+        movq    %r10, Caml_state(current_stack) /* CR xclerc for xclerc: also current_stack_bound */
         movq    %r11, Caml_state(exn_handler)
     /* free old stack by switching directly to c_stack; is a no-alloc call */
         movq    Stack_sp(%r10), %r13 /* saved across C call */

--- a/ocaml/runtime/caml/domain_state.tbl
+++ b/ocaml/runtime/caml/domain_state.tbl
@@ -34,6 +34,10 @@ DOMAIN_STATE(value*, young_trigger)
 DOMAIN_STATE(struct stack_info*, current_stack)
 /* Current stack */
 
+DOMAIN_STATE(struct stack_info*, current_stack_bound)
+/* Current stack bound (equal to current_stack + Stack_threshold_offset,
+   maintained independently to simplify stack checks) */
+
 DOMAIN_STATE(void*, exn_handler)
 /* Pointer into the current stack */
 

--- a/ocaml/runtime/caml/fiber.h
+++ b/ocaml/runtime/caml/fiber.h
@@ -93,6 +93,8 @@ CAML_STATIC_ASSERT(sizeof(struct stack_info) ==
  * +------------------------+ <--- Caml_state->current_stack
  */
 
+#define Stack_threshold_offset ((Stack_threshold_words + Stack_ctx_words) * sizeof(value))
+
 /* Some ABI reserve space at the bottom of every C stack frame. */
 
 #if defined(TARGET_amd64) && (defined(_WIN32) || defined(__CYGWIN__))

--- a/ocaml/runtime/domain.c
+++ b/ocaml/runtime/domain.c
@@ -655,6 +655,7 @@ static void domain_create(uintnat initial_minor_heap_wsize) {
 
   domain_state->current_stack =
       caml_alloc_main_stack(stack_wsize);
+  domain_state->current_stack_bound = domain_state->current_stack + Stack_threshold_offset;
   if(domain_state->current_stack == NULL) {
     goto alloc_main_stack_failure;
   }

--- a/ocaml/runtime/fiber.c
+++ b/ocaml/runtime/fiber.c
@@ -785,6 +785,7 @@ int caml_try_realloc_stack(asize_t required_space)
 
   caml_free_stack(old_stack);
   Caml_state->current_stack = new_stack;
+  Caml_state->current_stack_bound = Caml_state->current_stack + Stack_threshold_offset;
   return 1;
 }
 

--- a/ocaml/runtime/interp.c
+++ b/ocaml/runtime/interp.c
@@ -621,6 +621,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         CAMLassert(parent_stack != NULL);
 
         domain_state->current_stack = parent_stack;
+        domain_state->current_stack_bound = domain_state->current_stack + Stack_threshold_offset;
         sp = domain_state->current_stack->sp;
         caml_free_stack(old_stack);
 
@@ -1024,6 +1025,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
           value hexn = Stack_handle_exception(old_stack);
           old_stack->sp = sp;
           domain_state->current_stack = parent_stack;
+          domain_state->current_stack_bound = domain_state->current_stack + Stack_threshold_offset;
           sp = domain_state->current_stack->sp;
           caml_free_stack(old_stack);
 
@@ -1051,6 +1053,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
 /* Stack checks */
 
     check_stacks:
+      /* CR xclerc for xclerc: the way stack checks are implemented here
+         means that maintaining `current_stack_bound` is ~useless. */
       if (sp < Stack_threshold_ptr(domain_state->current_stack)) {
         domain_state->current_stack->sp = sp;
         if (!caml_try_realloc_stack(Stack_threshold / sizeof(value))) {
@@ -1341,6 +1345,7 @@ do_resume: {
 
       domain_state->current_stack->sp = sp;
       domain_state->current_stack = Ptr_val(accu);
+      domain_state->current_stack_bound = domain_state->current_stack + Stack_threshold_offset;
       sp = domain_state->current_stack->sp;
 
       domain_state->trap_sp_off = Long_val(sp[0]);
@@ -1384,6 +1389,7 @@ do_resume: {
 
       old_stack->sp = sp;
       domain_state->current_stack = parent_stack;
+      domain_state->current_stack_bound = domain_state->current_stack + Stack_threshold_offset;
       sp = parent_stack->sp;
       Stack_parent(old_stack) = NULL;
       Field(cont, 0) = Val_ptr(old_stack);
@@ -1425,6 +1431,7 @@ do_resume: {
 
       self->sp = sp;
       domain_state->current_stack = parent;
+      domain_state->current_stack_bound = domain_state->current_stack + Stack_threshold_offset;
       sp = parent->sp;
 
       CAMLassert(Stack_parent(cont_tail) == NULL);


### PR DESCRIPTION
This pull request tweaks the instruction sequence
emitted to make it shorter, and also avoid the
consumption of a register (the later does not
matter here, but may simplify another pull request).

The original sequence was:

```
          I.lea (mem64 NONE (-(max_frame_size + threshold_offset)) RSP) r10;
          I.cmp (domain_field Domainstate.Domain_current_stack) r10;
          I.jb (label overflow);
```

and is now:

```
      I.cmp (domain_field Domainstate.Domain_current_stack_bound) rsp;
      I.jb (label overflow);
```

which is possible because the new sequence is
emitted after `rsp` is updated, and because a
newly-introduced domain field (namely
`current_stack_bound`) contains the value that
was computed by the old sequence.

(original suggestion by @stedolan, errors are mine)