### PR TITLE
Fix mode locks for classes and modules

### DIFF
--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -369,7 +369,7 @@ let name_expression ~loc ~attrs sort exp =
       str_loc = loc;
       str_env = exp.exp_env; }
   in
-  let final_env = Env.add_value id vd exp.exp_env in
+  let final_env = Env.add_value ~mode:Mode.Value.legacy id vd exp.exp_env in
   let str =
     { str_items = [item];
       str_type = sg;

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1404,7 +1404,7 @@ let build_substs update_env ?(freshen_bound_variables = false) s =
           let rebind id id' new_env =
             match find_in_old id with
             | exception Not_found -> new_env
-            | vd -> Env.add_value_lazy id' vd new_env
+            | vd -> Env.add_value_lazy ~mode:Mode.Value.max id' vd new_env
           in
           let update_free id new_env =
             match find_in_old id with
@@ -1451,7 +1451,7 @@ let subst update_env ?freshen_bound_variables s =
 let rename idmap lam =
   let update_env oldid vd env =
     let newid = Ident.Map.find oldid idmap in
-    Env.add_value_lazy newid vd env
+    Env.add_value_lazy ~mode:Mode.Value.max newid vd env
   in
   let s = Ident.Map.map (fun new_id -> Lvar new_id) idmap in
   subst update_env s lam

--- a/ocaml/testsuite/tests/typing-modes/class.ml
+++ b/ocaml/testsuite/tests/typing-modes/class.ml
@@ -105,9 +105,11 @@ Error: This value escapes its region.
 let u =
     let obj = new cla in
     portable_use obj#m
-(* CR zqian: this should fail. *)
 [%%expect{|
-val u : unit = ()
+Line 3, characters 17-22:
+3 |     portable_use obj#m
+                     ^^^^^
+Error: This value is nonportable but expected to be portable.
 |}]
 
 (* for methods, arguments can be of any modes *)
@@ -135,9 +137,11 @@ Error: This value is nonportable but expected to be portable.
 let u =
     let foo () = new cla in
     portable_use foo
-(* CR zqian: this should fail. *)
 [%%expect{|
-val u : unit = ()
+Line 3, characters 17-20:
+3 |     portable_use foo
+                     ^^^
+Error: This value is nonportable but expected to be portable.
 |}]
 
 module type SC = sig
@@ -162,7 +166,9 @@ val u : unit = ()
 let u =
     let obj = new cla in
     portable_use obj
-(* CR zqian: this should fail. *)
 [%%expect{|
-val u : unit = ()
+Line 3, characters 17-20:
+3 |     portable_use obj
+                     ^^^
+Error: This value is nonportable but expected to be portable.
 |}]

--- a/ocaml/toplevel/topdirs.ml
+++ b/ocaml/toplevel/topdirs.ml
@@ -430,7 +430,7 @@ let reg_show_prim name to_sig doc =
 let () =
   reg_show_prim "show_val"
     (fun env loc id lid ->
-       let _path, desc, _, _ = Env.lookup_value ~loc lid env in
+       let _path, desc, _ = Env.lookup_value ~loc lid env in
        [ Sig_value (id, desc, Exported) ]
     )
     "Print the signature of the corresponding value."
@@ -573,7 +573,7 @@ let secretly_the_same_path env path1 path2 =
 let () =
   reg_show_prim "show_module"
     (fun env loc id lid ->
-       let path, md = Env.lookup_module ~loc lid env in
+       let path, md, _, _ = Env.lookup_module ~loc lid env in
        let id = match path with
          | Pident id -> id
          | _ -> id
@@ -624,7 +624,7 @@ let () =
 let () =
   reg_show_prim "show_class"
     (fun env loc id lid ->
-       let _path, desc_class = Env.lookup_class ~loc lid env in
+       let _path, desc_class, _, _ = Env.lookup_class ~loc lid env in
        let _path, desc_cltype = Env.lookup_cltype ~loc lid env in
        let _path, typedcl = Env.lookup_type ~loc lid env in
        [

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -325,13 +325,18 @@ type shared_context =
   | Probe
   | Lazy
 
-type value_lock =
+type lock =
   | Escape_lock of escaping_context
   | Share_lock of shared_context
   | Closure_lock of closure_context option * Mode.Value.Comonadic.r
   | Region_lock
   | Exclave_lock
   | Unboxed_lock (* to prevent capture of terms with non-value types *)
+
+type lock_item =
+  | Value
+  | Module
+  | Class
 
 module IdTbl =
   struct
@@ -374,7 +379,7 @@ module IdTbl =
         }
 
       | Lock of {
-          mode: 'lock;
+          lock: 'lock;
           next: ('lock, 'a, 'b) t;
         }
 
@@ -407,8 +412,8 @@ module IdTbl =
       | _ ->
           assert false
 
-    let add_lock mode next =
-      { current = Ident.empty; layer = Lock {mode; next} }
+    let add_lock lock next =
+      { current = Ident.empty; layer = Lock {lock; next} }
 
     let map f next =
       {
@@ -416,21 +421,24 @@ module IdTbl =
         layer = Map {f; next}
       }
 
-    let rec find_same id tbl =
+    let rec find_same_without_locks id tbl =
       try Ident.find_same id tbl.current
       with Not_found as exn ->
         begin match tbl.layer with
-        | Open {next; _} -> find_same id next
-        | Map {f; next} -> f (find_same id next)
-        | Lock {mode=_; next} -> find_same id next
+        | Open {next; _} -> find_same_without_locks id next
+        | Map {f; next} -> f (find_same_without_locks id next)
+        | Lock {lock=_; next} -> find_same_without_locks id next
         | Nothing -> raise exn
         end
 
-    let rec find_name_and_locks wrap ~mark name tbl macc =
+    let find_same id (tbl : (empty, _, _) t) =
+      find_same_without_locks id tbl
+
+    let rec find_name_and_locks wrap ~mark name tbl macc : _ Result.t =
       try
         let (id, desc) = Ident.find_name name tbl.current in
-        Pident id, macc, desc
-      with Not_found as exn ->
+        Ok (Pident id, macc, desc)
+      with Not_found ->
         begin match tbl.layer with
         | Open {using; root; next; components} ->
             begin try
@@ -438,33 +446,38 @@ module IdTbl =
               let res = Pdot (root, name), macc, descr in
               if mark then begin match using with
               | None -> ()
-              | Some f -> begin
-                  match find_name_and_locks wrap ~mark:false name next macc with
-                  | exception Not_found -> f name None
-                  | _, _, descr' -> f name (Some (descr', descr))
+              | Some f -> begin match
+                  (find_name_and_locks wrap ~mark:false name next macc : _ Result.t)
+                  with
+                  | Error _ -> f name None
+                  | Ok (_, _, descr') -> f name (Some (descr', descr))
                 end
               end;
-              res
+              Ok res
             with Not_found ->
               find_name_and_locks wrap ~mark name next macc
             end
         | Map {f; next} ->
-            let (p, macc, desc) =
-              find_name_and_locks wrap ~mark name next macc in
-            p, macc, f desc
-        | Lock {mode; next} ->
-            find_name_and_locks wrap ~mark name next (mode :: macc)
+            find_name_and_locks wrap ~mark name next macc
+            |> Result.map (fun (p, macc, desc) -> p, macc, f desc)
+        | Lock {lock; next} ->
+            find_name_and_locks wrap ~mark name next (lock :: macc)
         | Nothing ->
-            raise exn
+            Error macc
         end
 
-    let find_name_and_modes wrap ~mark name tbl =
+    let find_name_and_locks wrap ~mark name tbl =
       find_name_and_locks wrap ~mark name tbl []
 
+    (** Find item by name whose accesses are not affected by locks, and thus
+        shouldn't encounter any locks. *)
     let find_name wrap ~mark name tbl =
-      let (id, ([] : empty list), desc) =
-        find_name_and_modes wrap ~mark name tbl in
-      id, desc
+      match (find_name_and_locks wrap ~mark name tbl
+        : (_ * empty list * _, empty list) Result.t) with
+      | Ok (id, [], desc) -> id, desc
+      | Ok (_, _ :: _, _) -> .
+      | Error [] -> raise Not_found
+      | Error (_ :: _) -> .
 
     let rec find_all wrap name tbl =
       List.map
@@ -482,7 +495,7 @@ module IdTbl =
       | Map {f; next} ->
           List.map (fun (p, desc) -> (p, f desc))
             (find_all wrap name next)
-      | Lock {mode=_;next} ->
+      | Lock {lock=_;next} ->
           find_all wrap name next
 
     let rec find_all_idents name tbl () =
@@ -499,7 +512,7 @@ module IdTbl =
             else
               find_all_idents name next ()
         | Map {next; _ } -> find_all_idents name next ()
-        | Lock {mode=_;next} ->
+        | Lock {lock=_;next} ->
             find_all_idents name next ()
       in
       Seq.append current next ()
@@ -524,7 +537,7 @@ module IdTbl =
           |> fold_name wrap
                (fun name (path, desc) -> f name (path, g desc))
                next
-      | Lock {mode=_; next} ->
+      | Lock {lock=_; next} ->
           fold_name wrap f next acc
 
     let rec local_keys tbl acc =
@@ -547,7 +560,7 @@ module IdTbl =
           iter wrap f next
       | Map {f=g; next} ->
           iter wrap (fun id (path, desc) -> f id (path, g desc)) next
-      | Lock {mode=_; next} ->
+      | Lock {lock=_; next} ->
           iter wrap f next
       | Nothing -> ()
 
@@ -555,7 +568,7 @@ module IdTbl =
       let keys2 = local_keys tbl2 [] in
       List.filter
         (fun id ->
-           try ignore (find_same id tbl1); false
+           try ignore (find_same_without_locks id tbl1); false
            with Not_found -> true)
         keys2
 
@@ -570,13 +583,13 @@ type type_descriptions = type_descr_kind
 let in_signature_flag = 0x01
 
 type t = {
-  values: (value_lock, value_entry, value_data) IdTbl.t;
+  values: (lock, value_entry, value_data) IdTbl.t;
   constrs: constructor_data TycompTbl.t;
   labels: label_data TycompTbl.t;
   types: (empty, type_data, type_data) IdTbl.t;
-  modules: (empty, module_entry, module_data) IdTbl.t;
+  modules: (lock, module_entry, module_data) IdTbl.t;
   modtypes: (empty, modtype_data, modtype_data) IdTbl.t;
-  classes: (empty, class_data, class_data) IdTbl.t;
+  classes: (lock, class_data, class_data) IdTbl.t;
   cltypes: (empty, cltype_data, cltype_data) IdTbl.t;
   functor_args: unit Ident.tbl;
   summary: summary;
@@ -683,6 +696,10 @@ and cltype_data =
   { cltda_declaration : class_type_declaration;
     cltda_shape : Shape.t }
 
+let mda_mode = Mode.Value.legacy |> Mode.Value.disallow_right
+
+let clda_mode = Mode.Value.legacy |> Mode.Value.disallow_right
+
 let empty_structure =
   Structure_comps {
     comp_values = NameMap.empty;
@@ -718,10 +735,11 @@ type lookup_error =
   | Generative_used_as_applicative of Longident.t
   | Illegal_reference_to_recursive_module
   | Cannot_scrape_alias of Longident.t * Path.t
-  | Local_value_escaping of Longident.t * escaping_context
-  | Once_value_used_in of Longident.t * shared_context
-  | Value_used_in_closure of Longident.t * Mode.Value.Comonadic.error * closure_context option
-  | Local_value_used_in_exclave of Longident.t
+  | Local_value_escaping of lock_item * Longident.t * escaping_context
+  | Once_value_used_in of lock_item * Longident.t * shared_context
+  | Value_used_in_closure of lock_item * Longident.t *
+      Mode.Value.Comonadic.error * closure_context option
+  | Local_value_used_in_exclave of lock_item * Longident.t
   | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
 
 type error =
@@ -735,6 +753,16 @@ let error err = raise (Error err)
 
 let lookup_error loc env err =
   error (Lookup_error(loc, env, err))
+
+type actual_mode = {
+  mode : Mode.Value.l;
+  context : shared_context option
+}
+
+let mode_default mode = {
+  mode;
+  context = None
+}
 
 let same_constr = ref (fun _ _ _ -> assert false)
 
@@ -831,14 +859,14 @@ let check_functor_application =
   (* to be filled by Includemod *)
   ref ((fun ~errors:_ ~loc:_
          ~lid_whole_app:_  ~f0_path:_ ~args:_
-         ~arg_path:_ ~arg_mty:_ ~param_mty:_
+         ~arg_path:_ ~arg_mty:_ ~arg_mode:_ ~param_mty:_
          _env
          -> assert false) :
          errors:bool -> loc:Location.t ->
        lid_whole_app:Longident.t ->
-       f0_path:Path.t -> args:(Path.t * Types.module_type) list ->
-       arg_path:Path.t -> arg_mty:module_type -> param_mty:module_type ->
-       t -> unit)
+       f0_path:Path.t -> args:(Path.t * Types.module_type * Mode.Value.l) list ->
+       arg_path:Path.t -> arg_mty:module_type -> arg_mode:Mode.Value.l ->
+       param_mty:module_type -> t -> unit)
 
 let scrape_alias =
   (* to be filled with Mtype.scrape_alias *)
@@ -895,18 +923,20 @@ let set_unit_name = Current_unit_name.set
 let get_unit_name = Current_unit_name.get
 
 let find_same_module id tbl =
-  match IdTbl.find_same id tbl with
+  match IdTbl.find_same_without_locks id tbl with
   | x -> x
   | exception Not_found
     when Ident.is_global id && not (Current_unit_name.is_ident id) ->
       Mod_persistent
 
 let find_name_module ~mark name tbl =
-  match IdTbl.find_name wrap_module ~mark name tbl with
-  | x -> x
-  | exception Not_found when not (Current_unit_name.is name) ->
+  match IdTbl.find_name_and_locks wrap_module ~mark name tbl with
+  | Ok x -> x
+  | Error locks when not (Current_unit_name.is name) ->
       let path = Pident(Ident.create_persistent name) in
-      path, Mod_persistent
+      path, locks, Mod_persistent
+  | _ ->
+    raise Not_found
 
 let add_persistent_structure id env =
   if not (Ident.is_global id) then invalid_arg "Env.add_persistent_structure";
@@ -917,9 +947,9 @@ let add_persistent_structure id env =
          non-persistent module already in the environment.
          (See PR#9345) *)
       match
-        IdTbl.find_name wrap_module ~mark:false (Ident.name id) env.modules
+        IdTbl.find_name_and_locks wrap_module ~mark:false (Ident.name id) env.modules
       with
-      | exception Not_found | _, Mod_persistent -> false
+      | Error _ | Ok (_, _, Mod_persistent) -> false
       | _ -> true
     in
     let summary =
@@ -1079,12 +1109,12 @@ let modtype_of_functor_appl fcomp p1 p2 =
 let check_functor_appl
     ~errors ~loc ~lid_whole_app ~f0_path ~args
     ~f_comp
-    ~arg_path ~arg_mty ~param_mty
+    ~arg_path ~arg_mty ~arg_mode ~param_mty
     env =
   if not (Hashtbl.mem f_comp.fcomp_cache arg_path) then
     !check_functor_application
       ~errors ~loc ~lid_whole_app ~f0_path ~args
-      ~arg_path ~arg_mty ~param_mty
+      ~arg_path ~arg_mty ~arg_mode ~param_mty
       env
 
 let modname_of_ident id = Ident.name id |> Compilation_unit.Name.of_string
@@ -1154,7 +1184,7 @@ let find_module_lazy ~alias path env =
 let find_value_full path env =
   match path with
   | Pident id -> begin
-      match IdTbl.find_same id env.values with
+      match IdTbl.find_same_without_locks id env.values with
       | Val_bound data -> data
       | Val_unbound _ -> raise Not_found
     end
@@ -1239,7 +1269,7 @@ let find_modtype path env =
 
 let find_class_full path env =
   match path with
-  | Pident id -> IdTbl.find_same id env.classes
+  | Pident id -> IdTbl.find_same_without_locks id env.classes
   | Pdot(p, s) ->
       let sc = find_structure_components p env in
       NameMap.find s sc.comp_classes
@@ -1344,12 +1374,12 @@ let find_shape env (ns : Shape.Sig_component_kind.t) id =
   | Extension_constructor ->
       (TycompTbl.find_same id env.constrs).cda_shape
   | Value ->
-      begin match IdTbl.find_same id env.values with
+      begin match IdTbl.find_same_without_locks id env.values with
       | Val_bound x -> x.vda_shape
       | Val_unbound _ -> raise Not_found
       end
   | Module ->
-      begin match IdTbl.find_same id env.modules with
+      begin match IdTbl.find_same_without_locks id env.modules with
       | Mod_local { mda_shape; _ } -> mda_shape
       | Mod_persistent -> Shape.for_persistent_unit (Ident.name id)
       | Mod_unbound _ ->
@@ -1365,7 +1395,7 @@ let find_shape env (ns : Shape.Sig_component_kind.t) id =
   | Module_type ->
       (IdTbl.find_same id env.modtypes).mtda_shape
   | Class ->
-      (IdTbl.find_same id env.classes).clda_shape
+      (IdTbl.find_same_without_locks id env.classes).clda_shape
   | Class_type ->
       (IdTbl.find_same id env.cltypes).cltda_shape
 
@@ -1961,7 +1991,7 @@ and check_value_name name loc =
         error (Illegal_value_name(loc, name))
     done
 
-and store_value ?check mode id addr decl shape env =
+and store_value ?check ~mode id addr decl shape env =
   let open Subst.Lazy in
   check_value_name (Ident.name id) decl.val_loc;
   Builtin_attributes.mark_alerts_used decl.val_attributes;
@@ -1971,14 +2001,13 @@ and store_value ?check mode id addr decl shape env =
   let vda =
     { vda_description = decl;
       vda_address = addr;
-      vda_mode = Mode.Value.disallow_right mode;
+      vda_mode = mode;
       vda_shape = shape }
   in
   { env with
     values = IdTbl.add id (Val_bound vda) env.values;
     summary =
-      Env_value(env.summary, id, Subst.Lazy.force_value_description decl,
-        Mode.Value.disallow_right mode) }
+      Env_value(env.summary, id, Subst.Lazy.force_value_description decl, mode) }
 
 and store_constructor ~check type_decl type_id cstr_id cstr env =
   Builtin_attributes.warning_scope cstr.cstr_attributes (fun () ->
@@ -2238,10 +2267,11 @@ let add_functor_arg id env =
    functor_args = Ident.add id () env.functor_args;
    summary = Env_functor_arg (env.summary, id)}
 
-let add_value_lazy ?check ?shape ?(mode=Mode.Value.allow_right Mode.Value.legacy)  id desc env =
+let add_value_lazy ?check ?shape ~mode id desc env =
   let addr = value_declaration_address env id desc in
   let shape = shape_or_leaf desc.Subst.Lazy.val_uid shape in
-  store_value ?check mode id addr desc shape env
+  let mode = Mode.Value.disallow_right mode in
+  store_value ?check ~mode id addr desc shape env
 
 let add_type ~check ?shape id info env =
   let shape = shape_or_leaf info.type_uid shape in
@@ -2307,12 +2337,13 @@ let add_local_type path info env =
 
 (* Insertion of bindings by name *)
 
-let enter_value ?check name desc env =
+let enter_value ?check ~mode name desc env =
   let id = Ident.create_local name in
   let desc = Subst.Lazy.of_value_description desc in
   let addr = value_declaration_address env id desc in
+  let mode = Mode.Value.disallow_right mode in
   let env =
-    store_value ?check Mode.Value.legacy id addr desc (Shape.leaf desc.val_uid)
+    store_value ?check ~mode id addr desc (Shape.leaf desc.val_uid)
       env
   in
   (id, env)
@@ -2353,29 +2384,33 @@ let enter_cltype ~scope name desc env =
 let enter_module ~scope ?arg s presence mty env =
   enter_module_declaration ~scope ?arg s presence (md mty) env
 
+let add_lock lock env =
+  { env with
+    values = IdTbl.add_lock lock env.values;
+    modules = IdTbl.add_lock lock env.modules;
+    classes = IdTbl.add_lock lock env.classes;
+  }
+
 let add_escape_lock escaping_context env =
   let lock = Escape_lock escaping_context in
-  { env with values = IdTbl.add_lock lock env.values }
+  add_lock lock env
 
 let add_share_lock shared_context env =
   let lock = Share_lock shared_context in
-  { env with values = IdTbl.add_lock lock env.values }
+  add_lock lock env
 
 let add_closure_lock ?closure_context comonadic env =
   let lock = Closure_lock
     (closure_context,
      Mode.Value.Comonadic.disallow_left comonadic)
   in
-  { env with values = IdTbl.add_lock lock env.values }
+  add_lock lock env
 
-let add_region_lock env =
-  { env with values = IdTbl.add_lock Region_lock env.values }
+let add_region_lock env = add_lock Region_lock env
 
-let add_exclave_lock env =
-  { env with values = IdTbl.add_lock Exclave_lock env.values }
+let add_exclave_lock env = add_lock Exclave_lock env
 
-let add_unboxed_lock env =
-  { env with values = IdTbl.add_lock Unboxed_lock env.values }
+let add_unboxed_lock env = add_lock Unboxed_lock env
 
 (* Insertion of all components of a signature *)
 
@@ -2387,7 +2422,8 @@ let proj_shape map mod_shape item =
       Shape.Map.add map item shape, Some shape
 
 module Add_signature(T : Types.Wrapped)(M : sig
-  val add_value: ?shape:Shape.t -> Ident.t -> T.value_description -> t -> t
+  val add_value: ?shape:Shape.t -> mode:(Mode.allowed * 'r0) Mode.Value.t -> Ident.t ->
+    T.value_description  -> t -> t
   val add_module_declaration: ?arg:bool -> ?shape:Shape.t -> check:bool
     -> Ident.t -> module_presence -> T.module_declaration -> t -> t
   val add_modtype: ?shape:Shape.t -> Ident.t -> T.modtype_declaration -> t -> t
@@ -2398,7 +2434,7 @@ end) = struct
     match comp with
     | Sig_value(id, decl, _) ->
         let map, shape = proj_shape map mod_shape (Shape.Item.value id) in
-        map, M.add_value ?shape id decl env
+        map, M.add_value ?shape ~mode:Mode.Value.legacy id decl env
     | Sig_type(id, decl, _, _) ->
         let map, shape = proj_shape map mod_shape (Shape.Item.type_ id) in
         map, add_type ~check:false ?shape id decl env
@@ -2428,8 +2464,8 @@ end
 
 let add_signature =
   let module M = Add_signature(Types)(struct
-    let add_value ?shape id vd =
-      add_value_lazy ?shape id (Subst.Lazy.of_value_description vd)
+    let add_value ?shape ~mode id vd =
+      add_value_lazy ?shape ~mode id (Subst.Lazy.of_value_description vd)
     let add_module_declaration = add_module_declaration
     let add_modtype = add_modtype
   end)
@@ -2438,7 +2474,7 @@ let add_signature =
 
 let add_signature_lazy =
   let module M = Add_signature(Subst.Lazy)(struct
-    let add_value = add_value_lazy ?check:None ?mode:None
+    let add_value ?shape ~mode = add_value_lazy ?check:None ?shape ~mode
     let add_module_declaration =
       add_module_declaration_lazy ~update_summary:true
     let add_modtype = add_modtype_lazy ~update_summary:true
@@ -2462,8 +2498,8 @@ let enter_signature_and_shape ~scope ~parent_shape mod_shape sg env =
   enter_signature_and_shape ~scope ~parent_shape (Some mod_shape) sg env
 
 let add_value_lazy = add_value_lazy ?shape:None
-let add_value ?check ?mode id vd =
-  add_value_lazy ?check ?mode id (Subst.Lazy.of_value_description vd)
+let add_value ?check ~mode id vd =
+  add_value_lazy ?check ~mode id (Subst.Lazy.of_value_description vd)
 let add_class = add_class ?shape:None
 let add_cltype = add_cltype ?shape:None
 let add_modtype_lazy = add_modtype_lazy ?shape:None
@@ -2909,7 +2945,7 @@ type _ load =
   | Don't_load : unit load
 
 let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
-  let path, data =
+  let path, locks, data =
     match find_name_module ~mark:use s env.modules with
     | res -> res
     | exception Not_found ->
@@ -2919,8 +2955,8 @@ let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
   | Mod_local mda -> begin
       use_module ~use ~loc path mda;
       match load with
-      | Load -> path, (mda : a)
-      | Don't_load -> path, (() : a)
+      | Load -> path, locks, (mda : a)
+      | Don't_load -> path, locks, (() : a)
     end
   | Mod_unbound reason ->
       report_module_unbound ~errors ~loc env reason
@@ -2929,48 +2965,56 @@ let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
       match load with
       | Don't_load ->
           check_pers_mod ~allow_hidden:false ~loc name;
-          path, (() : a)
+          path, locks, (() : a)
       | Load -> begin
           match find_pers_mod ~allow_hidden:false name with
           | mda ->
               use_module ~use ~loc path mda;
-              path, (mda : a)
+              path, locks, (mda : a)
           | exception Not_found ->
               may_lookup_error errors loc env (Unbound_module (Lident s))
         end
     end
 
-let escape_mode ~errors ~env ~loc id vmode escaping_context =
-  match
+let escape_mode ~errors ~env ~loc ~item ~lid vmode escaping_context =
+  begin match
   Mode.Regionality.submode
-    (Mode.Value.proj (Comonadic Areality) vmode)
+    (Mode.Value.proj (Comonadic Areality) vmode.mode)
     (Mode.Regionality.global)
   with
   | Ok () -> ()
   | Error _ ->
       may_lookup_error errors loc env
-        (Local_value_escaping (id, escaping_context))
+        (Local_value_escaping (item, lid, escaping_context))
+  end;
+  vmode
 
-let share_mode ~errors ~env ~loc id vmode shared_context =
+let share_mode ~errors ~env ~loc ~item ~lid vmode shared_context =
   match
     Mode.Linearity.submode
-      (Mode.Value.proj (Comonadic Linearity) vmode)
+      (Mode.Value.proj (Comonadic Linearity) vmode.mode)
       Mode.Linearity.many
   with
   | Error _ ->
       may_lookup_error errors loc env
-        (Once_value_used_in (id, shared_context))
-  | Ok () -> Mode.Value.join [Mode.Value.min_with (Monadic Uniqueness) Mode.Uniqueness.shared; vmode]
+        (Once_value_used_in (item, lid, shared_context))
+  | Ok () ->
+    let mode =
+      Mode.Value.join [
+        Mode.Value.min_with (Monadic Uniqueness) Mode.Uniqueness.shared;
+        vmode.mode]
+    in
+    {mode; context = Some shared_context}
 
-let closure_mode ~errors ~env ~loc id {Mode.monadic; comonadic}
-  closure_context comonadic0 : Mode.Value.l =
+let closure_mode ~errors ~env ~loc ~item ~lid
+  ({mode = {Mode.monadic; comonadic}; _} as vmode) closure_context comonadic0 =
   begin
     match
       Mode.Value.Comonadic.submode comonadic comonadic0
     with
     | Error e ->
         may_lookup_error errors loc env
-          (Value_used_in_closure (id, e, closure_context))
+          (Value_used_in_closure (item, lid, e, closure_context))
     | Ok () -> ()
   end;
   let monadic =
@@ -2978,52 +3022,69 @@ let closure_mode ~errors ~env ~loc id {Mode.monadic; comonadic}
       [ monadic;
         Mode.Value.comonadic_to_monadic comonadic0 ]
   in
-  {monadic; comonadic}
+  {vmode with mode = {monadic; comonadic}}
 
-let exclave_mode ~errors ~env ~loc id vmode =
+let exclave_mode ~errors ~env ~loc ~item ~lid vmode =
   match
   Mode.Regionality.submode
-    (Mode.Value.proj (Comonadic Areality) vmode)
+    (Mode.Value.proj (Comonadic Areality) vmode.mode)
     Mode.Regionality.regional
 with
-| Ok () -> vmode |> Mode.value_to_alloc_r2l |> Mode.alloc_as_value
+| Ok () ->
+  let mode = vmode.mode |> Mode.value_to_alloc_r2l |> Mode.alloc_as_value in
+  {vmode with mode}
 | Error _ ->
     may_lookup_error errors loc env
-      (Local_value_used_in_exclave id)
+      (Local_value_used_in_exclave (item, lid))
 
-let lock_mode ~errors ~loc env id vda locks =
-  let vmode = vda.vda_mode in
+let region_mode vmode =
+  let mode =
+    vmode.mode |> Mode.value_to_alloc_r2l |> Mode.alloc_to_value_l2r
+  in
+  {vmode with mode}
+
+let unboxed_type ~errors ~env ~loc ~lid ty =
+  match ty with
+  | None -> ()
+  | Some ty ->
+    match !constrain_type_jkind env ty Jkind.(value ~why:Captured_in_object) with
+    | Ok () -> ()
+    | Result.Error err ->
+      may_lookup_error errors loc env (Non_value_used_in_object (lid, ty, err))
+
+(** Takes the [mode] and [ty] of a value at definition site, walks through the
+    list of locks and constrains [mode] and [ty]. Return the access mode of the
+    value allowed by the locks.
+
+    [ty] is optional as the function works on modules and classes as well, for
+    which [ty] should be [None]. *)
+let walk_locks ~errors ~loc ~env ~item ~lid mode ty locks =
+  let vmode = { mode; context = None } in
   List.fold_left
-    (fun (vmode, must_lock, reason) lock ->
+    (fun vmode lock ->
       match lock with
-      | Region_lock -> (vmode |> Mode.value_to_alloc_r2l |> Mode.alloc_to_value_l2r, must_lock, reason)
+      | Region_lock -> region_mode vmode
       | Escape_lock escaping_context ->
-          escape_mode ~errors ~env ~loc id vmode escaping_context;
-          (vmode, must_lock, reason)
+          escape_mode ~errors ~env ~loc ~item ~lid vmode escaping_context
       | Share_lock shared_context ->
-          let vmode = share_mode ~errors ~env ~loc id vmode shared_context in
-          vmode, must_lock, Some shared_context
+          share_mode ~errors ~env ~loc ~item ~lid vmode shared_context
       | Closure_lock (closure_context, comonadic) ->
-          let vmode =
-            closure_mode ~errors ~env ~loc id vmode closure_context comonadic
-          in
-          vmode, must_lock, reason
+          closure_mode ~errors ~env ~loc ~item ~lid vmode closure_context comonadic
       | Exclave_lock ->
-          let vmode = exclave_mode ~errors ~env ~loc id vmode in
-          vmode, must_lock, reason
+          exclave_mode ~errors ~env ~loc ~item ~lid vmode
       | Unboxed_lock ->
-          vmode, true, reason
-    ) (vmode, false, None) locks
+          unboxed_type ~errors ~env ~loc ~lid ty;
+          vmode
+    ) vmode locks
 
 let lookup_ident_value ~errors ~use ~loc name env =
-  match IdTbl.find_name_and_modes wrap_value ~mark:use name env.values with
-  | (path, locks, Val_bound vda) ->
-      let mode, must_box, reasons = lock_mode ~errors ~loc env (Lident name) vda locks in
+  match IdTbl.find_name_and_locks wrap_value ~mark:use name env.values with
+  | Ok (path, locks, Val_bound vda) ->
       use_value ~use ~loc path vda;
-      path, vda.vda_description, mode, must_box, reasons
-  | (_, _, Val_unbound reason) ->
+      path, locks, vda
+  | Ok (_, _, Val_unbound reason) ->
       report_value_unbound ~errors ~loc env reason (Lident name)
-  | exception Not_found ->
+  | Error _ ->
       may_lookup_error errors loc env (Unbound_value (Lident name, No_hint))
 
 let lookup_ident_type ~errors ~use ~loc s env =
@@ -3043,11 +3104,11 @@ let lookup_ident_modtype ~errors ~use ~loc s env =
       may_lookup_error errors loc env (Unbound_modtype (Lident s))
 
 let lookup_ident_class ~errors ~use ~loc s env =
-  match IdTbl.find_name wrap_identity ~mark:use s env.classes with
-  | (path, clda) ->
+  match IdTbl.find_name_and_locks wrap_identity ~mark:use s env.classes with
+  | Ok (path, locks, clda) ->
       use_class ~use ~loc path clda;
-      path, clda.clda_declaration
-  | exception Not_found ->
+      path, locks, clda.clda_declaration
+  | Error _ ->
       may_lookup_error errors loc env (Unbound_class (Lident s))
 
 let lookup_ident_cltype ~errors ~use ~loc s env =
@@ -3088,21 +3149,21 @@ let lookup_all_ident_constructors ~errors ~use ~loc usage s env =
 let rec lookup_module_components ~errors ~use ~loc lid env =
   match lid with
   | Lident s ->
-      let path, data = lookup_ident_module Load ~errors ~use ~loc s env in
-      path, data.mda_components
+      let path, locks, data = lookup_ident_module Load ~errors ~use ~loc s env in
+      path, locks, data.mda_components
   | Ldot(l, s) ->
-      let path, data = lookup_dot_module ~errors ~use ~loc l s env in
-      path, data.mda_components
+      let path, locks, data = lookup_dot_module ~errors ~use ~loc l s env in
+      path, locks, data.mda_components
   | Lapply _ as lid ->
       let f_path, f_comp, arg = lookup_apply ~errors ~use ~loc lid env in
       let comps =
         !components_of_functor_appl' ~loc ~f_path ~f_comp ~arg env in
-      Papply (f_path, arg), comps
+      Papply (f_path, arg), [], comps
 
 and lookup_structure_components ~errors ~use ~loc lid env =
-  let path, comps = lookup_module_components ~errors ~use ~loc lid env in
+  let path, locks, comps = lookup_module_components ~errors ~use ~loc lid env in
   match get_components_res comps with
-  | Ok (Structure_comps comps) -> path, comps
+  | Ok (Structure_comps comps) -> path, locks, comps
   | Ok (Functor_comps _) ->
       may_lookup_error errors loc env (Functor_used_as_structure lid)
   | Error No_components_abstract ->
@@ -3130,40 +3191,43 @@ and lookup_all_args ~errors ~use ~loc lid0 env =
     | Lident _ | Ldot _ as f_lid ->
         (f_lid, args)
     | Lapply (f_lid, arg_lid) ->
-        let arg_path, arg_md = lookup_module ~errors ~use ~loc arg_lid env in
-        loop_lid_arg ((f_lid,arg_path,arg_md.md_type)::args) f_lid
+        let arg_path, arg_md, arg_vmode =
+          lookup_module ~errors ~use ~lock:false ~loc arg_lid env
+        in
+        loop_lid_arg ((f_lid,arg_path,arg_md.md_type,arg_vmode)::args) f_lid
   in
   loop_lid_arg [] lid0
 
 and lookup_apply ~errors ~use ~loc lid0 env =
   let f0_lid, args0 = lookup_all_args ~errors ~use ~loc lid0 env in
-  let args_for_errors = List.map (fun (_,p,mty) -> (p,mty)) args0 in
-  let f0_path, f0_comp =
+  let args_for_errors = List.map (fun (_,p,mty,vmode) -> (p,mty,vmode.mode)) args0 in
+  let f0_path, _, f0_comp =
     lookup_module_components ~errors ~use ~loc f0_lid env
   in
-  let check_one_apply ~errors ~loc ~f_lid ~f_comp ~arg_path ~arg_mty env =
+  let check_one_apply ~errors ~loc ~f_lid ~f_comp ~arg_path ~arg_mty ~arg_mode
+    env =
     let f_comp, param_mty =
       get_functor_components ~errors ~loc f_lid env f_comp
     in
     check_functor_appl
       ~errors ~loc ~lid_whole_app:lid0
       ~f0_path ~args:args_for_errors ~f_comp
-      ~arg_path ~arg_mty ~param_mty
+      ~arg_path ~arg_mty ~arg_mode:arg_mode.mode ~param_mty
       env;
     arg_path, f_comp
   in
   let rec check_apply ~path:f_path ~comp:f_comp = function
     | [] -> invalid_arg "Env.lookup_apply: empty argument list"
-    | [ f_lid, arg_path, arg_mty ] ->
+    | [ f_lid, arg_path, arg_mty, arg_mode ] ->
         let arg_path, comps =
           check_one_apply ~errors ~loc ~f_lid ~f_comp
-            ~arg_path ~arg_mty env
+            ~arg_path ~arg_mty ~arg_mode env
         in
         f_path, comps, arg_path
-    | (f_lid, arg_path, arg_mty) :: args ->
+    | (f_lid, arg_path, arg_mty, arg_mode) :: args ->
         let arg_path, f_comp =
           check_one_apply ~errors ~loc ~f_lid ~f_comp
-            ~arg_path ~arg_mty env
+            ~arg_path ~arg_mty ~arg_mode env
         in
         let comp =
           !components_of_functor_appl' ~loc ~f_path ~f_comp ~arg:arg_path env
@@ -3173,45 +3237,54 @@ and lookup_apply ~errors ~use ~loc lid0 env =
   in
   check_apply ~path:f0_path ~comp:f0_comp args0
 
-and lookup_module ~errors ~use ~loc lid env =
-  match lid with
-  | Lident s ->
-      let path, data = lookup_ident_module Load ~errors ~use ~loc s env in
-      let md = Subst.Lazy.force_module_decl data.mda_declaration in
-      path, md
-  | Ldot(l, s) ->
-      let path, data = lookup_dot_module ~errors ~use ~loc l s env in
-      let md = Subst.Lazy.force_module_decl data.mda_declaration in
-      path, md
-  | Lapply _ as lid ->
-      let path_f, comp_f, path_arg = lookup_apply ~errors ~use ~loc lid env in
-      let md = md (modtype_of_functor_appl comp_f path_f path_arg) in
-      Papply(path_f, path_arg), md
+and lookup_module ~errors ~use ~lock ~loc lid env =
+  let path, locks, md =
+    match lid with
+    | Lident s ->
+        let path, locks, data = lookup_ident_module Load ~errors ~use ~loc s env in
+        let md = Subst.Lazy.force_module_decl data.mda_declaration in
+        path, locks, md
+    | Ldot(l, s) ->
+        let path, locks, data = lookup_dot_module ~errors ~use ~loc l s env in
+        let md = Subst.Lazy.force_module_decl data.mda_declaration in
+        path, locks, md
+    | Lapply _ as lid ->
+        let path_f, comp_f, path_arg = lookup_apply ~errors ~use ~loc lid env in
+        let md = md (modtype_of_functor_appl comp_f path_f path_arg) in
+        Papply(path_f, path_arg), [], md
+  in
+  let vmode =
+    if lock then
+      walk_locks ~errors ~loc ~env ~item:Module ~lid mda_mode None locks
+    else
+      mode_default mda_mode
+  in
+  path, md, vmode
 
 and lookup_dot_module ~errors ~use ~loc l s env =
-  let p, comps = lookup_structure_components ~errors ~use ~loc l env in
+  let p, locks, comps = lookup_structure_components ~errors ~use ~loc l env in
   match NameMap.find s comps.comp_modules with
   | mda ->
       let path = Pdot(p, s) in
       use_module ~use ~loc path mda;
-      (path, mda)
+      (path, locks, mda)
   | exception Not_found ->
       may_lookup_error errors loc env (Unbound_module (Ldot(l, s)))
 
 let lookup_dot_value ~errors ~use ~loc l s env =
-  let (path, comps) =
+  let (path, locks, comps) =
     lookup_structure_components ~errors ~use ~loc l env
   in
   match NameMap.find s comps.comp_values with
   | vda ->
       let path = Pdot(path, s) in
       use_value ~use ~loc path vda;
-      (path, vda.vda_description)
+      (path, locks, vda)
   | exception Not_found ->
       may_lookup_error errors loc env (Unbound_value (Ldot(l, s), No_hint))
 
 let lookup_dot_type ~errors ~use ~loc l s env =
-  let (p, comps) = lookup_structure_components ~errors ~use ~loc l env in
+  let (p, _, comps) = lookup_structure_components ~errors ~use ~loc l env in
   match NameMap.find s comps.comp_types with
   | tda ->
       let path = Pdot(p, s) in
@@ -3221,7 +3294,7 @@ let lookup_dot_type ~errors ~use ~loc l s env =
       may_lookup_error errors loc env (Unbound_type (Ldot(l, s)))
 
 let lookup_dot_modtype ~errors ~use ~loc l s env =
-  let (p, comps) = lookup_structure_components ~errors ~use ~loc l env in
+  let (p, _, comps) = lookup_structure_components ~errors ~use ~loc l env in
   match NameMap.find s comps.comp_modtypes with
   | mta ->
       let path = Pdot(p, s) in
@@ -3231,17 +3304,17 @@ let lookup_dot_modtype ~errors ~use ~loc l s env =
       may_lookup_error errors loc env (Unbound_modtype (Ldot(l, s)))
 
 let lookup_dot_class ~errors ~use ~loc l s env =
-  let (p, comps) = lookup_structure_components ~errors ~use ~loc l env in
+  let (p, locks, comps) = lookup_structure_components ~errors ~use ~loc l env in
   match NameMap.find s comps.comp_classes with
   | clda ->
       let path = Pdot(p, s) in
       use_class ~use ~loc path clda;
-      (path, clda.clda_declaration)
+      (path, locks, clda.clda_declaration)
   | exception Not_found ->
       may_lookup_error errors loc env (Unbound_class (Ldot(l, s)))
 
 let lookup_dot_cltype ~errors ~use ~loc l s env =
-  let (p, comps) = lookup_structure_components ~errors ~use ~loc l env in
+  let (p, _, comps) = lookup_structure_components ~errors ~use ~loc l env in
   match NameMap.find s comps.comp_cltypes with
   | cltda ->
       let path = Pdot(p, s) in
@@ -3251,7 +3324,7 @@ let lookup_dot_cltype ~errors ~use ~loc l s env =
       may_lookup_error errors loc env (Unbound_cltype (Ldot(l, s)))
 
 let lookup_all_dot_labels ~errors ~use ~loc usage l s env =
-  let (_, comps) = lookup_structure_components ~errors ~use ~loc l env in
+  let (_, _, comps) = lookup_structure_components ~errors ~use ~loc l env in
   match NameMap.find s comps.comp_labels with
   | [] | exception Not_found ->
       may_lookup_error errors loc env (Unbound_label (Ldot(l, s)))
@@ -3269,7 +3342,7 @@ let lookup_all_dot_constructors ~errors ~use ~loc usage l s env =
       lookup_all_ident_constructors
         ~errors ~use ~loc usage s (Lazy.force initial)
   | _ ->
-      let (_, comps) = lookup_structure_components ~errors ~use ~loc l env in
+      let (_, _, comps) = lookup_structure_components ~errors ~use ~loc l env in
       match NameMap.find s comps.comp_constrs with
       | [] | exception Not_found ->
           may_lookup_error errors loc env (Unbound_constructor (Ldot(l, s)))
@@ -3282,26 +3355,54 @@ let lookup_all_dot_constructors ~errors ~use ~loc usage l s env =
 
 (* General forms of the lookup functions *)
 
-let lookup_module_path ~errors ~use ~loc ~load lid env : Path.t =
-  match lid with
-  | Lident s ->
-      if !Clflags.transparent_modules && not load then
-        fst (lookup_ident_module Don't_load ~errors ~use ~loc s env)
-      else
-        fst (lookup_ident_module Load ~errors ~use ~loc s env)
-  | Ldot(l, s) -> fst (lookup_dot_module ~errors ~use ~loc l s env)
-  | Lapply _ as lid ->
-      let path_f, _comp_f, path_arg = lookup_apply ~errors ~use ~loc lid env in
-      Papply(path_f, path_arg)
+let lookup_module_path ~errors ~use ~lock ~loc ~load lid env : Path.t * _ =
+  let path, locks =
+    match lid with
+    | Lident s ->
+        if !Clflags.transparent_modules && not load then
+          let path, locks, _ =
+            lookup_ident_module Don't_load ~errors ~use ~loc s env
+          in
+          path, locks
+        else
+          let path, locks, _ =
+            lookup_ident_module Load ~errors ~use ~loc s env
+          in
+          path, locks
+    | Ldot(l, s) ->
+        let path, locks, _ = lookup_dot_module ~errors ~use ~loc l s env in
+        path, locks
+    | Lapply _ as lid ->
+        let path_f, _comp_f, path_arg = lookup_apply ~errors ~use ~loc lid env in
+        Papply(path_f, path_arg), []
+  in
+  let vmode =
+    if lock then
+      walk_locks ~errors ~loc ~env ~item:Module ~lid mda_mode None locks
+    else
+      mode_default mda_mode
+  in
+  path, vmode
 
 let lookup_value_lazy ~errors ~use ~loc lid env =
   match lid with
   | Lident s -> lookup_ident_value ~errors ~use ~loc s env
-  | Ldot(l, s) ->
-    let path, desc = lookup_dot_value ~errors ~use ~loc l s env in
-    let mode = Mode.Value.disallow_right Mode.Value.legacy in
-    path, desc, mode, false, None
+  | Ldot(l, s) -> lookup_dot_value ~errors ~use ~loc l s env
   | Lapply _ -> assert false
+
+let lookup_value ~errors ~use ~loc lid env =
+  check_value_name (Longident.last lid) loc;
+  let path, locks, vda =
+    lookup_value_lazy ~errors ~use ~loc lid env
+  in
+  let vd = Subst.Lazy.force_value_description vda.vda_description in
+  let vmode =
+    if use then
+      walk_locks ~errors ~loc ~env ~item:Value ~lid vda.vda_mode (Some vd.val_type) locks
+    else
+      mode_default vda.vda_mode
+  in
+  path, vd, vmode
 
 let lookup_type_full ~errors ~use ~loc lid env =
   match lid with
@@ -3324,10 +3425,19 @@ let lookup_modtype ~errors ~use ~loc lid env =
   path, Subst.Lazy.force_modtype_decl mt
 
 let lookup_class ~errors ~use ~loc lid env =
-  match lid with
-  | Lident s -> lookup_ident_class ~errors ~use ~loc s env
-  | Ldot(l, s) -> lookup_dot_class ~errors ~use ~loc l s env
-  | Lapply _ -> assert false
+  let path, locks, cld =
+    match lid with
+    | Lident s -> lookup_ident_class ~errors ~use ~loc s env
+    | Ldot(l, s) -> lookup_dot_class ~errors ~use ~loc l s env
+    | Lapply _ -> assert false
+  in
+  let vmode =
+    if use then
+      walk_locks ~errors ~loc ~env ~item:Class ~lid clda_mode None locks
+    else
+      mode_default clda_mode
+  in
+  path, cld, vmode
 
 let lookup_cltype ~errors ~use ~loc lid env =
   match lid with
@@ -3387,14 +3497,15 @@ let lookup_all_constructors_from_type ~use ~loc usage ty_path env =
 
 let find_module_by_name lid env =
   let loc = Location.(in_file !input_name) in
-  lookup_module ~errors:false ~use:false ~loc lid env
+  let path, desc, _ =
+    lookup_module ~errors:false ~use:false ~lock:false ~loc lid env
+  in
+  path, desc
 
 let find_value_by_name lid env =
   let loc = Location.(in_file !input_name) in
-  let path, desc, _, _, _ =
-    lookup_value_lazy ~errors:false ~use:false ~loc lid env
-  in
-  path, Subst.Lazy.force_value_description desc
+  let path, desc, _ = lookup_value ~errors:false ~use:false ~loc lid env in
+  path, desc
 
 let find_type_by_name lid env =
   let loc = Location.(in_file !input_name) in
@@ -3406,7 +3517,8 @@ let find_modtype_by_name lid env =
 
 let find_class_by_name lid env =
   let loc = Location.(in_file !input_name) in
-  lookup_class ~errors:false ~use:false ~loc lid env
+  let path, desc, _ = lookup_class ~errors:false ~use:false ~loc lid env in
+  path, desc
 
 let find_cltype_by_name lid env =
   let loc = Location.(in_file !input_name) in
@@ -3439,27 +3551,16 @@ let find_cltype_index id env = find_index_tbl id env.cltypes
 
 (* Ordinary lookup functions *)
 
-let lookup_module_path ?(use=true) ~loc ~load lid env =
-  lookup_module_path ~errors:true ~use ~loc ~load lid env
+let lookup_module_path ?(use=true) ?(lock=use) ~loc ~load lid env =
+  let path, vmode = lookup_module_path ~errors:true ~use ~lock ~loc ~load lid env in
+  path, vmode.mode, vmode.context
 
-let lookup_module ?(use=true) ~loc lid env =
-  lookup_module ~errors:true ~use ~loc lid env
+let lookup_module ?(use=true) ?(lock=use) ~loc lid env =
+  let path, md, vmode = lookup_module ~errors:true ~use ~lock ~loc lid env in
+  path, md, vmode.mode, vmode.context
 
 let lookup_value ?(use=true) ~loc lid env =
-  check_value_name (Longident.last lid) loc;
-  let path, desc, mode, must_box, reasons =
-    lookup_value_lazy ~errors:true ~use ~loc lid env
-  in
-  let vd = Subst.Lazy.force_value_description desc in
-  if must_box then begin
-    match !constrain_type_jkind env vd.val_type
-            (Jkind.(value ~why:Captured_in_object))
-    with
-    | Ok () -> ()
-    | Result.Error err ->
-      lookup_error loc env (Non_value_used_in_object (lid, vd.val_type, err))
-  end;
-  path, vd, mode, reasons
+  lookup_value ~errors:true ~use ~loc lid env
 
 let lookup_type ?(use=true) ~loc lid env =
   lookup_type ~errors:true ~use ~loc lid env
@@ -3471,7 +3572,8 @@ let lookup_modtype_path ?(use=true) ~loc lid env =
   fst (lookup_modtype_lazy ~errors:true ~use ~loc lid env)
 
 let lookup_class ?(use=true) ~loc lid env =
-  lookup_class ~errors:true ~use ~loc lid env
+  let path, cld, vmode = lookup_class ~errors:true ~use ~loc lid env in
+  path, cld, vmode.mode, vmode.context
 
 let lookup_cltype ?(use=true) ~loc lid env =
   lookup_cltype ~errors:true ~use ~loc lid env
@@ -3501,8 +3603,8 @@ let lookup_all_labels_from_type ?(use=true) ~loc usage ty_path env =
   lookup_all_labels_from_type ~use ~loc usage ty_path env
 
 let lookup_instance_variable ?(use=true) ~loc name env =
-  match IdTbl.find_name_and_modes wrap_value ~mark:use name env.values with
-  | (path, _, Val_bound vda) -> begin
+  match IdTbl.find_name_and_locks wrap_value ~mark:use name env.values with
+  | Ok (path, _, Val_bound vda) -> begin
       let desc = vda.vda_description in
       match desc.val_kind with
       | Val_ivar(mut, cl_num) ->
@@ -3511,23 +3613,23 @@ let lookup_instance_variable ?(use=true) ~loc name env =
       | _ ->
           lookup_error loc env (Not_an_instance_variable name)
     end
-  | (_, _, Val_unbound Val_unbound_instance_variable) ->
+  | Ok (_, _, Val_unbound Val_unbound_instance_variable) ->
       lookup_error loc env (Masked_instance_variable (Lident name))
-  | (_, _, Val_unbound Val_unbound_self) ->
+  | Ok (_, _, Val_unbound Val_unbound_self) ->
       lookup_error loc env (Not_an_instance_variable name)
-  | (_, _, Val_unbound Val_unbound_ancestor) ->
+  | Ok (_, _, Val_unbound Val_unbound_ancestor) ->
       lookup_error loc env (Not_an_instance_variable name)
-  | (_, _, Val_unbound Val_unbound_ghost_recursive _) ->
+  | Ok (_, _, Val_unbound Val_unbound_ghost_recursive _) ->
       lookup_error loc env (Unbound_instance_variable name)
-  | exception Not_found ->
+  | Error _ ->
       lookup_error loc env (Unbound_instance_variable name)
 
 (* Checking if a name is bound *)
 
 let bound_module name env =
-  match IdTbl.find_name wrap_module ~mark:false name env.modules with
-  | _ -> true
-  | exception Not_found ->
+  match IdTbl.find_name_and_locks wrap_module ~mark:false name env.modules with
+  | Ok _ -> true
+  | Error _ ->
       if Current_unit_name.is name then false
       else begin
         match
@@ -3539,9 +3641,9 @@ let bound_module name env =
       end
 
 let bound wrap proj name env =
-  match IdTbl.find_name_and_modes wrap ~mark:false name (proj env) with
-  | _ -> true
-  | exception Not_found -> false
+  match IdTbl.find_name_and_locks wrap ~mark:false name (proj env) with
+  | Ok _ -> true
+  | Error _ -> false
 
 let bound_value name env =
   bound wrap_value (fun env -> env.values) name env
@@ -3567,7 +3669,7 @@ let find_all wrap proj1 proj2 f lid env acc =
         (fun name (p, data) acc -> f name p data acc)
         (proj1 env) acc
   | Some l ->
-      let p, desc =
+      let p, _locks, desc =
         lookup_module_components
           ~errors:false ~use:false ~loc:Location.none l env
       in
@@ -3587,7 +3689,7 @@ let find_all_simple_list proj1 proj2 f lid env acc =
         (fun data acc -> f data acc)
         (proj1 env) acc
   | Some l ->
-      let (_p, desc) =
+      let (_p, _locks, desc) =
         lookup_module_components
           ~errors:false ~use:false ~loc:Location.none l env
       in
@@ -3627,7 +3729,7 @@ let fold_modules f lid env acc =
         env.modules
         acc
   | Some l ->
-      let p, desc =
+      let p, _locks, desc =
         lookup_module_components
           ~errors:false ~use:false ~loc:Location.none l env
       in
@@ -3819,7 +3921,7 @@ let string_of_escaping_context : escaping_context -> string =
   | Module -> "a module"
   | Lazy -> "a lazy expression"
 
-let string_of_shared_context =
+let string_of_shared_context : shared_context -> string =
   function
   | For_loop -> "a for loop"
   | While_loop -> "a while loop"
@@ -3830,6 +3932,51 @@ let string_of_shared_context =
   | Module -> "a module"
   | Probe -> "a probe"
   | Lazy -> "a lazy expression"
+
+let sharedness_hint ppf : shared_context -> _ = function
+  | For_loop ->
+    Format.fprintf ppf
+        "@[Hint: This identifier cannot be used uniquely,@ \
+          because it was defined outside of the for-loop.@]"
+  | While_loop ->
+    Format.fprintf ppf
+        "@[Hint: This identifier cannot be used uniquely,@ \
+          because it was defined outside of the while-loop.@]"
+  | Comprehension ->
+    Format.fprintf ppf
+        "@[Hint: This identifier cannot be used uniquely,@ \
+          because it was defined outside of the comprehension.@]"
+  | Letop ->
+    Format.fprintf ppf
+        "@[Hint: This identifier cannot be used uniquely,@ \
+          because it was defined outside of the let-op.@]"
+  | Class ->
+    Format.fprintf ppf
+        "@[Hint: This identifier cannot be used uniquely,@ \
+          because it is defined in a class.@]"
+  | Closure ->
+    Format.fprintf ppf
+        "@[Hint: This identifier was defined outside of the current closure.@ \
+          Either this closure has to be once, or the identifier can be used only@ \
+          as shared.@]"
+  | Module ->
+    Format.fprintf ppf
+        "@[Hint: This identifier cannot be used uniquely,@ \
+          because it is defined in a module.@]"
+  | Probe ->
+    Format.fprintf ppf
+        "@[Hint: This identifier cannot be used uniquely,@ \
+          because it is defined outside of the probe.@]"
+  | Lazy ->
+    Format.fprintf ppf
+        "@[Hint: This identifier cannot be used uniquely,@ \
+          because it is defined outside of the lazy expression.@]"
+
+let print_lock_item ppf (item, lid) =
+  match item with
+  | Module -> fprintf ppf "Modules are"
+  | Class -> fprintf ppf "Classes are"
+  | Value -> fprintf ppf "The value %a is" !print_longident lid
 
 let report_lookup_error _loc env ppf = function
   | Unbound_value(lid, hint) -> begin
@@ -3934,17 +4081,19 @@ let report_lookup_error _loc env ppf = function
       fprintf ppf
         "The module %a is an alias for module %a, which %s"
         !print_longident lid !print_path p cause
-  | Local_value_escaping (lid, context) ->
+  | Local_value_escaping (item, lid, context) ->
       fprintf ppf
-        "@[The value %a is local, so cannot be used \
+        "@[%a local, so cannot be used \
           inside %s.@]"
-        !print_longident lid (string_of_escaping_context context);
-  | Once_value_used_in (lid, context) ->
+        print_lock_item (item, lid)
+        (string_of_escaping_context context);
+  | Once_value_used_in (item, lid, context) ->
       fprintf ppf
-        "@[The value %a is once, so cannot be used \
+        "@[%a once, so cannot be used \
             inside %s@]"
-        !print_longident lid (string_of_shared_context context)
-  | Value_used_in_closure (lid, error, context) ->
+        print_lock_item (item, lid)
+        (string_of_shared_context context)
+  | Value_used_in_closure (item, lid, error, context) ->
       let e0, e1 =
         match error with
         | Error (Areality, _) -> "local", "might escape"
@@ -3952,19 +4101,20 @@ let report_lookup_error _loc env ppf = function
         | Error (Portability, _) -> "nonportable", "is portable"
       in
       fprintf ppf
-      "@[The value %a is %s, so cannot be used \
+      "@[%a %s, so cannot be used \
             inside a closure that %s.@]"
-      !print_longident lid e0 e1;
+      print_lock_item (item, lid)
+      e0 e1;
       begin match error, context with
       | Error (Areality, _), Some Tailcall_argument ->
          fprintf ppf "@.@[Hint: The closure might escape because it \
                           is an argument to a tail call@]"
       | _ -> ()
       end
-  | Local_value_used_in_exclave lid ->
-      fprintf ppf "@[The value %a is local, so it cannot be used \
+  | Local_value_used_in_exclave (item, lid) ->
+      fprintf ppf "@[%a local, so it cannot be used \
                   inside an exclave_@]"
-        !print_longident lid
+        print_lock_item (item, lid)
   | Non_value_used_in_object (lid, typ, err) ->
       fprintf ppf "@[%a must have a type of layout value because it is \
                    captured by an object.@ %a@]"

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -16,7 +16,6 @@
 (* Environment handling *)
 
 open Types
-open Mode
 open Misc
 
 type value_unbound_reason =
@@ -194,6 +193,12 @@ type shared_context =
   | Probe
   | Lazy
 
+(** Items whose accesses are affected by locks *)
+type lock_item =
+  | Value
+  | Module
+  | Class
+
 type lookup_error =
   | Unbound_value of Longident.t * unbound_value_hint
   | Unbound_type of Longident.t
@@ -215,10 +220,10 @@ type lookup_error =
   | Generative_used_as_applicative of Longident.t
   | Illegal_reference_to_recursive_module
   | Cannot_scrape_alias of Longident.t * Path.t
-  | Local_value_escaping of Longident.t * escaping_context
-  | Once_value_used_in of Longident.t * shared_context
-  | Value_used_in_closure of Longident.t * Mode.Value.Comonadic.error * closure_context option
-  | Local_value_used_in_exclave of Longident.t
+  | Local_value_escaping of lock_item * Longident.t * escaping_context
+  | Once_value_used_in of lock_item * Longident.t * shared_context
+  | Value_used_in_closure of lock_item * Longident.t * Mode.Value.Comonadic.error * closure_context option
+  | Local_value_used_in_exclave of lock_item * Longident.t
   | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
 
 val lookup_error: Location.t -> t -> lookup_error -> 'a
@@ -235,34 +240,34 @@ val lookup_error: Location.t -> t -> lookup_error -> 'a
    [lookup_foo ~use:true] exactly one time -- otherwise warnings may be
    emitted the wrong number of times. *)
 
-(** The returned shared_context looks strange, but useful for error printing
-    when the returned uniqueness mode is too high because of some linearity_lock
-    during lookup, and fail to satisfy expected_mode in the caller.
+type actual_mode = {
+  mode : Mode.Value.l;
+  context : shared_context option
+  (** Explains why [mode] is high. *)
+}
 
-    TODO: A better approach is passing down the expected mode to this function
-    as argument, so that sub-moding error is triggered at the place where error
-    hints are immediately available. *)
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
-  Path.t * value_description * Mode.Value.l * shared_context option
+  Path.t * value_description * actual_mode
 val lookup_type:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * type_declaration
 val lookup_module:
-  ?use:bool -> loc:Location.t -> Longident.t -> t ->
-  Path.t * module_declaration
+  ?use:bool -> ?lock:bool -> loc:Location.t -> Longident.t -> t ->
+  Path.t * module_declaration * Mode.Value.l * shared_context option
 val lookup_modtype:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * modtype_declaration
 val lookup_class:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
-  Path.t * class_declaration
+  Path.t * class_declaration * Mode.Value.l * shared_context option
 val lookup_cltype:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * class_type_declaration
 
 val lookup_module_path:
-  ?use:bool -> loc:Location.t -> load:bool -> Longident.t -> t -> Path.t
+  ?use:bool -> ?lock:bool -> loc:Location.t -> load:bool -> Longident.t -> t ->
+    Path.t * Mode.Value.l * shared_context option
 val lookup_modtype_path:
   ?use:bool -> loc:Location.t -> Longident.t -> t -> Path.t
 
@@ -339,10 +344,10 @@ val make_copy_of_types: t -> (t -> t)
 (* Insertion by identifier *)
 
 val add_value_lazy:
-    ?check:(string -> Warnings.t) -> ?mode:((allowed * 'r) Mode.Value.t) ->
+    ?check:(string -> Warnings.t) -> mode:(Mode.allowed * 'r) Mode.Value.t ->
     Ident.t -> Subst.Lazy.value_description -> t -> t
 val add_value:
-    ?check:(string -> Warnings.t) -> ?mode:((allowed * 'r) Mode.Value.t) ->
+    ?check:(string -> Warnings.t) -> mode:(Mode.allowed * 'r) Mode.Value.t ->
     Ident.t -> Types.value_description -> t -> t
 val add_type:
     check:bool -> ?shape:Shape.t -> Ident.t -> type_declaration -> t -> t
@@ -404,7 +409,7 @@ val remove_last_open: Path.t -> t -> t option
 (* Insertion by name *)
 
 val enter_value:
-    ?check:(string -> Warnings.t) ->
+    ?check:(string -> Warnings.t) -> mode:(Mode.allowed * 'r) Mode.Value.t ->
     string -> value_description -> t -> Ident.t * t
 val enter_type: scope:int -> string -> type_declaration -> t -> Ident.t * t
 val enter_extension:
@@ -446,7 +451,7 @@ val add_escape_lock : escaping_context -> t -> t
     relaxed to `shared` *)
 val add_share_lock : shared_context -> t -> t
 val add_closure_lock : ?closure_context:closure_context
-  -> ('l_ * allowed) Mode.Value.Comonadic.t -> t -> t
+  -> ('l * Mode.allowed) Mode.Value.Comonadic.t -> t -> t
 val add_region_lock : t -> t
 val add_exclave_lock : t -> t
 val add_unboxed_lock : t -> t
@@ -544,8 +549,8 @@ val set_type_used_callback:
 val check_functor_application:
   (errors:bool -> loc:Location.t ->
    lid_whole_app:Longident.t ->
-   f0_path:Path.t -> args:(Path.t * Types.module_type) list ->
-   arg_path:Path.t -> arg_mty:Types.module_type ->
+   f0_path:Path.t -> args:(Path.t * Types.module_type * Mode.Value.l) list ->
+   arg_path:Path.t -> arg_mty:Types.module_type -> arg_mode:Mode.Value.l ->
    param_mty:Types.module_type ->
    t -> unit) ref
 (* Forward declaration to break mutual recursion with Typemod. *)
@@ -610,3 +615,5 @@ type address_head =
   | AHlocal of Ident.t
 
 val address_head : address -> address_head
+
+val sharedness_hint : Format.formatter -> shared_context -> unit

--- a/ocaml/typing/includemod.ml
+++ b/ocaml/typing/includemod.ml
@@ -1037,12 +1037,13 @@ let check_modtype_inclusion ~loc env mty1 path1 mty2 =
 
 let check_functor_application_in_path
     ~errors ~loc ~lid_whole_app ~f0_path ~args
-    ~arg_path ~arg_mty ~param_mty env =
+    ~arg_path ~arg_mty ~arg_mode ~param_mty env =
+  Mode.Value.submode_exn arg_mode Mode.Value.legacy;
   match check_modtype_inclusion_raw ~loc env arg_mty arg_path param_mty with
   | Ok _ -> ()
   | Error _errs ->
       if errors then
-        let prepare_arg (arg_path, arg_mty) =
+        let prepare_arg (arg_path, arg_mty, _arg_mode) =
           let aliasable = can_alias env arg_path in
           let smd = Mtype.strengthen ~aliasable arg_mty arg_path in
           (Error.Named arg_path, smd)

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -494,7 +494,7 @@ let enter_ancestor_met ~loc name ~sign ~meths ~cl_num ~ty ~attrs met_env =
       Types.val_loc = loc;
       val_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) }
   in
-  Env.enter_value ~check name desc met_env
+  Env.enter_value ~check ~mode:Mode.Value.legacy name desc met_env
 
 let add_self_met loc id sign self_var_kind vars cl_num
       as_var ty attrs met_env =
@@ -510,7 +510,7 @@ let add_self_met loc id sign self_var_kind vars cl_num
       Types.val_loc = loc;
       val_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) }
   in
-  Env.add_value ~check id desc met_env
+  Env.add_value ~check ~mode:Mode.Value.legacy id desc met_env
 
 let add_instance_var_met loc label id sign cl_num attrs met_env =
   let mut, ty =
@@ -526,7 +526,7 @@ let add_instance_var_met loc label id sign cl_num attrs met_env =
       val_zero_alloc = Builtin_attributes.Default_zero_alloc;
       val_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) }
   in
-  Env.add_value id desc met_env
+  Env.add_value ~mode:Mode.Value.legacy id desc met_env
 
 let add_instance_vars_met loc vars sign cl_num met_env =
   List.fold_left
@@ -1024,6 +1024,11 @@ and class_structure cl_num virt self_scope final val_env met_env loc
      - cannot refer to local or once variables in the
      environment
      - access to unique variables will be relaxed to shared *)
+  (* CR zqian: We should add [Env.add_sync_lock] which restricts
+  syncness/contention to legacy, but that lock would be a no-op. However, we
+  should be future-proof for potential axes who legacy is set otherwise. The
+  best is to call [Env.add_legacy_lock] (which can be defined by
+  [Env.add_closure_lock]) that covers all axes. *)
   let val_env = Env.add_escape_lock Class (Env.add_unboxed_lock val_env) in
   let val_env = Env.add_share_lock Class val_env in
   let met_env = Env.add_escape_lock Class (Env.add_unboxed_lock met_env) in
@@ -1128,7 +1133,10 @@ and class_expr cl_num val_env met_env virt self_scope scl =
 and class_expr_aux cl_num val_env met_env virt self_scope scl =
   match scl.pcl_desc with
   | Pcl_constr (lid, styl) ->
-      let (path, decl) = Env.lookup_class ~loc:scl.pcl_loc lid.txt val_env in
+      let (path, decl, mode, _) =
+        Env.lookup_class ~loc:scl.pcl_loc lid.txt val_env
+      in
+      Mode.Value.submode_exn mode Mode.Value.legacy;
       if Path.same decl.cty_path unbound_class then
         raise(Error(scl.pcl_loc, val_env, Unbound_class_2 lid.txt));
       let tyl = List.map
@@ -1466,7 +1474,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
              let id' = Ident.create_local (Ident.name id) in
              ((id', expr)
               :: vals,
-              Env.add_value id' desc met_env))
+              Env.add_value ~mode:Mode.Value.legacy id' desc met_env))
           (let_bound_idents_with_modes_sorts_and_checks defs)
           ([], met_env)
       in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -2903,7 +2903,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
            else Warnings.Unused_var_strict s in
          let id' = Ident.rename pv_id in
          let val_env =
-          Env.add_value pv_id
+          Env.add_value ~mode:Mode.Value.legacy pv_id
             { val_type = pv_type
             ; val_kind = Val_reg
             ; val_attributes = pv_attributes
@@ -2914,7 +2914,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             val_env
          in
          let met_env =
-          Env.add_value id' ~check
+          Env.add_value ~mode:Mode.Value.legacy id' ~check
             { val_type = pv_type
             ; val_kind = Val_ivar (Immutable, cl_num)
             ; val_attributes = pv_attributes
@@ -5180,7 +5180,7 @@ and type_expect_
         jexp
   | None -> match desc with
   | Pexp_ident lid ->
-      let path, mode, shared_context, desc, kind = type_ident env ~recarg lid in
+      let path, {Env.mode; context}, desc, kind = type_ident env ~recarg lid in
       let exp_desc =
         match desc.val_kind with
         | Val_ivar (_, cl_num) ->
@@ -5208,7 +5208,7 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
       in
-      submode ~loc ~env ?shared_context mode expected_mode;
+      submode ~loc ~env ?shared_context:context mode expected_mode;
       exp
   | Pexp_constant(Pconst_string (str, _, _) as cst) -> (
       let cst = constant_or_raise env loc cst in
@@ -5960,6 +5960,7 @@ and type_expect_
         exp_extra = (exp_extra, loc, sexp.pexp_attributes) :: arg.exp_extra;
       }
   | Pexp_send (e, {txt=met}) ->
+      submode ~loc ~env Mode.Value.legacy expected_mode;
       let pm = position_and_mode env expected_mode sexp in
       let (obj,meth,typ) =
         with_local_level_if_principal
@@ -5991,7 +5992,11 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_new cl ->
-      let (cl_path, cl_decl) = Env.lookup_class ~loc:cl.loc cl.txt env in
+      submode ~loc ~env Value.legacy expected_mode;
+      let (cl_path, cl_decl, cl_mode, _) =
+        Env.lookup_class ~loc:cl.loc cl.txt env
+      in
+      Value.submode_exn cl_mode Value.legacy;
       let pm = position_and_mode env expected_mode sexp in
       begin match cl_decl.cty_new with
           None ->
@@ -6573,11 +6578,12 @@ and type_constraint_expect
   ret, ty, exp_extra
 
 and type_ident env ?(recarg=Rejected) lid =
-  let (path, desc, mode, reason) = Env.lookup_value ~loc:lid.loc lid.txt env in
+  let path, desc, actual_mode = Env.lookup_value ~loc:lid.loc lid.txt env in
   (* Mode crossing here is needed only because of the strange behaviour of
   [type_let] - it checks the LHS before RHS. Had it checks the RHS before LHS,
   identifiers would be mode crossed when being added to the environment. *)
-  let mode = mode_cross_left env desc.val_type mode in
+  let mode = mode_cross_left env desc.val_type actual_mode.mode in
+  let actual_mode = {actual_mode with mode} in
   let is_recarg =
     match get_desc desc.val_type with
     | Tconstr(p, _, _) -> Path.is_constructor_typath p
@@ -6609,13 +6615,13 @@ and type_ident env ?(recarg=Rejected) lid =
        ty, Id_prim (Option.map Locality.disallow_right mode, sort)
     | _ ->
        instance desc.val_type, Id_value in
-  path, mode, reason, { desc with val_type }, kind
+  path, actual_mode, { desc with val_type }, kind
 
 and type_binding_op_ident env s =
   let loc = s.loc in
   let lid = Location.mkloc (Longident.Lident s.txt) loc in
-  let path, mode, _reason, desc, kind = type_ident env lid in
-  submode ~env ~loc:lid.loc ~reason:Other mode mode_legacy;
+  let path, {Env.mode; context}, desc, kind = type_ident env lid in
+  submode ~env ~loc:lid.loc ~reason:Other ?shared_context:context mode mode_legacy;
   let path =
     match desc.val_kind with
     | Val_ivar _ ->
@@ -9342,7 +9348,7 @@ let type_expression env jkind sexp =
       Pexp_ident lid ->
         let loc = sexp.pexp_loc in
         (* Special case for keeping type variables when looking-up a variable *)
-        let (_path, desc, _mode, _reasons) =
+        let (_path, desc, _actual_mode) =
           Env.lookup_value ~use:false ~loc lid.txt env
         in
         {exp with exp_type = desc.val_type}
@@ -9555,50 +9561,6 @@ let escaping_hint (failure_reason : Value.error) submode_reason
   | Other -> []
   end
 
-let sharedness_hint _fail_reason submode_reason context =
-  (match context with
-  | None -> []
-  | Some Env.For_loop ->
-    [Location.msg
-        "@[Hint: This identifier cannot be used uniquely,@ \
-          because it was defined outside of the for-loop.@]"]
-  | Some Env.While_loop ->
-    [Location.msg
-        "@[Hint: This identifier cannot be used uniquely,@ \
-          because it was defined outside of the while-loop.@]"]
-  | Some Env.Comprehension ->
-    [Location.msg
-        "@[Hint: This identifier cannot be used uniquely,@ \
-          because it was defined outside of the comprehension.@]"]
-  | Some Env.Letop ->
-    [Location.msg
-        "@[Hint: This identifier cannot be used uniquely,@ \
-          because it was defined outside of the let-op.@]"]
-  | Some Env.Class ->
-    [Location.msg
-        "@[Hint: This identifier cannot be used uniquely,@ \
-          because it is defined in a class.@]"]
-  | Some Env.Closure ->
-    [Location.msg
-        "@[Hint: This identifier was defined outside of the current closure.@ \
-          Either this closure has to be once, or the identifier can be used only@ \
-          as shared.@]"]
-  | Some Env.Module ->
-    [Location.msg
-        "@[Hint: This identifier cannot be used uniquely,@ \
-          because it is defined in a module.@]"]
-  | Some Env.Probe ->
-    [Location.msg
-        "@[Hint: This identifier cannot be used uniquely,@ \
-          because it is defined outside of the probe.@]"]
-  | Some Env.Lazy ->
-    [Location.msg
-        "@[Hint: This identifier cannot be used uniquely,@ \
-          because it is defined outside of the lazy expression.@]"]
-  )
-  @
-  match submode_reason with
-  | Application _ | Other -> []
 
 let contention_hint _fail_reason _submode_reason context =
   match context with
@@ -10172,7 +10134,11 @@ let report_error ~loc env = function
       let sub =
         match fail_reason with
         | Error (Comonadic Linearity, _) | Error (Monadic Uniqueness, _) ->
-          sharedness_hint fail_reason submode_reason shared_context
+            shared_context
+          |> Option.map
+              (fun context -> Location.mknoloc
+                (fun ppf -> Env.sharedness_hint ppf context))
+          |> Option.to_list
         | Error (Comonadic Areality, _) ->
           escaping_hint fail_reason submode_reason closure_context
         | Error (Monadic Contention, _ ) ->

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2945,7 +2945,7 @@ let transl_value_decl env loc valdecl =
       }
   in
   let (id, newenv) =
-    Env.enter_value valdecl.pval_name.txt v env
+    Env.enter_value ~mode:Mode.Value.legacy valdecl.pval_name.txt v env
       ~check:(fun s -> Warnings.Unused_value_declaration s)
   in
   Ctype.check_and_update_generalized_ty_jkind ~name:id ~loc ty;

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -194,7 +194,9 @@ let extract_sig_functor_open funct_body env loc mty sig_acc =
 (* Compute the environment after opening a module *)
 
 let type_open_ ?used_slot ?toplevel ovf env loc lid =
-  let path = Env.lookup_module_path ~load:true ~loc:lid.loc lid.txt env in
+  let path, _, _ =
+    Env.lookup_module_path ~lock:false ~load:true ~loc:lid.loc lid.txt env
+  in
   match Env.open_signature ~loc ?used_slot ?toplevel ovf path env with
   | Ok env -> path, env
   | Error _ ->
@@ -924,7 +926,7 @@ let rec approx_modtype env smty =
       in
       Mty_ident path
   | Pmty_alias lid ->
-      let path =
+      let path, _, _ =
         Env.lookup_module_path ~use:false ~load:false
           ~loc:smty.pmty_loc lid.txt env
       in
@@ -977,7 +979,7 @@ let rec approx_modtype env smty =
 and approx_modtype_jane_syntax env = function
   | Jane_syntax.Module_type.Jmty_strengthen { mty = smty; mod_id } ->
     let mty = approx_modtype env smty in
-    let path =
+    let path, _, _ =
       (* CR-someday: potentially improve error message for strengthening with
          a mutually recursive module. *)
       Env.lookup_module_path ~use:false ~load:false
@@ -1037,7 +1039,7 @@ and approx_sig env ssg =
           Sig_module(id, pres, md, Trec_not, Exported) :: approx_sig newenv srem
       | Psig_modsubst pms ->
           let scope = Ctype.create_scope () in
-          let _, md =
+          let _, md, _, _ =
             Env.lookup_module ~use:false ~loc:pms.pms_manifest.loc
                pms.pms_manifest.txt env
           in
@@ -1445,7 +1447,8 @@ let transl_modtype_longident loc env lid =
   Env.lookup_modtype_path ~loc lid env
 
 let transl_module_alias loc env lid =
-  Env.lookup_module_path ~load:false ~loc lid env
+  let path, _, _ = Env.lookup_module_path ~lock:false ~load:false ~loc lid env in
+  path
 
 let mkmty desc typ env loc attrs =
   let mty = {
@@ -1542,7 +1545,7 @@ and transl_modtype_aux env smty =
 and transl_modtype_jane_syntax_aux ~loc env = function
   | Jane_syntax.Module_type.Jmty_strengthen { mty ; mod_id } ->
       let tmty = transl_modtype_aux env mty in
-      let path, md =
+      let path, md, _, _ =
         Env.lookup_module ~use:false ~loc:mod_id.loc mod_id.txt env
       in
       let aliasable = not (Env.is_functor_arg path env) in
@@ -1566,10 +1569,10 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
     | Pwith_type (l,decl) ->l , With_type decl
     | Pwith_typesubst (l,decl) ->l , With_typesubst decl
     | Pwith_module (l,l') ->
-        let path, md = Env.lookup_module ~loc l'.txt env in
+        let path, md, _, _ = Env.lookup_module ~lock:false ~loc l'.txt env in
         l , With_module {lid=l';path;md; remove_aliases}
     | Pwith_modsubst (l,l') ->
-        let path, md' = Env.lookup_module ~loc l'.txt env in
+        let path, md', _, _ = Env.lookup_module ~lock:false ~loc l'.txt env in
         l , With_modsubst (l',path,md')
     | Pwith_modtype (l,smty) ->
         let mty = transl_modtype env smty in
@@ -1754,8 +1757,8 @@ and transl_signature env (sg : Parsetree.signature) =
         sig_item, tsg, newenv
     | Psig_modsubst pms ->
         let scope = Ctype.create_scope () in
-        let path, md =
-          Env.lookup_module ~loc:pms.pms_manifest.loc
+        let path, md, _, _ =
+          Env.lookup_module ~loc:pms.pms_manifest.loc ~lock:false
             pms.pms_manifest.txt env
         in
         let aliasable = not (Env.is_functor_arg path env) in
@@ -2387,9 +2390,10 @@ let rec type_module ?(alias=false) sttn funct_body anchor env smod =
 and type_module_aux ~alias sttn funct_body anchor env smod =
   match smod.pmod_desc with
     Pmod_ident lid ->
-      let path =
+      let path, mode, _ =
         Env.lookup_module_path ~load:(not alias) ~loc:smod.pmod_loc lid.txt env
       in
+      Mode.Value.submode_exn mode Mode.Value.legacy;
       let md = { mod_desc = Tmod_ident (path, lid);
                  mod_type = Mty_alias path;
                  mod_env = env;
@@ -3210,7 +3214,9 @@ let type_module_type_of env smod =
   let tmty =
     match smod.pmod_desc with
     | Pmod_ident lid -> (* turn off strengthening in this case *)
-        let path, md = Env.lookup_module ~loc:smod.pmod_loc lid.txt env in
+        let path, md, _, _ =
+          Env.lookup_module ~lock:false ~loc:smod.pmod_loc lid.txt env
+        in
           { mod_desc = Tmod_ident (path, lid);
             mod_type = md.md_type;
             mod_env = env;


### PR DESCRIPTION
This PR is based on #2398, because we need the syncness/contention axes for testing (the uniqueness/linearity legacy setting cannot test this). It is however orthogonal to #2398 and can be reviewed standalone. After approval, this PR should **not** be merged until #2398 is merged.

This PR fixes the following things:
- Accessing modules/classes inside a closure_lock/shared_lock/escaping_lock should trigger locks too.
- `new cla` should always be `legacy`, where `cla` is a class.
- `obj # meth` should always be `legacy`, where `obj` is an object, and `meth` is a method.

In addition, it does the following clean up:
- `unboxed_lock` is enforced during `walk_locks`, instead of generating a boolean `must_lock`.
- `Env.add_value` takes mandatory `mode` instead of optional - it's dangerous to just assume value is `legacy` when unspecified.