### PR TITLE
Add missing location in wrapper functions

### DIFF
--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -817,7 +817,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
             ap_func = Lvar inner_id;
             ap_args = args;
             ap_result_layout = return;
-            ap_loc = Loc_unknown;
+            ap_loc = loc;
             ap_region_close = Rc_normal;
             ap_mode = alloc_heap;
             ap_tailcall = Default_tailcall;

--- a/ocaml/testsuite/tests/backtrace/backtrace_or_exception.ml
+++ b/ocaml/testsuite/tests/backtrace/backtrace_or_exception.ml
@@ -1,6 +1,10 @@
 (* TEST
    flags = "-g"
    ocamlrunparam += ",b=1"
+   * bytecode
+     reference = "${test_source_directory}/backtrace_or_exception.reference"
+   * native
+     reference = "${test_source_directory}/backtrace_or_exception.opt.reference"
 *)
 
 exception Exn

--- a/ocaml/testsuite/tests/backtrace/backtrace_or_exception.opt.reference
+++ b/ocaml/testsuite/tests/backtrace/backtrace_or_exception.opt.reference
@@ -6,6 +6,7 @@ exception Backtrace_or_exception.Exn
 Raised at Backtrace_or_exception.without_reraise in file "backtrace_or_exception.ml", line 23, characters 4-13
 Called from Backtrace_or_exception.run in file "backtrace_or_exception.ml", line 43, characters 6-10
 Re-raised at Backtrace_or_exception.return_exn in file "backtrace_or_exception.ml", line 14, characters 4-13
+Called from Backtrace_or_exception.return_exn in file "backtrace_or_exception.ml" (inlined), line 12, characters 15-101
 Called from Backtrace_or_exception.with_reraise in file "backtrace_or_exception.ml", line 27, characters 8-44
 Re-raised at Backtrace_or_exception.with_reraise in file "backtrace_or_exception.ml", line 30, characters 4-13
 Called from Backtrace_or_exception.run in file "backtrace_or_exception.ml", line 43, characters 6-10

--- a/tests/backend/checkmach/t1.output
+++ b/tests/backend/checkmach/t1.output
@@ -1,8 +1,8 @@
 File "t1.ml", line 6, characters 7-17:
 Error: Annotation check for zero_alloc failed on function T1.Params.test12 (camlT1.test12_HIDE_STAMP)
 
-File "_none_", line 1:
-Error: called function may allocate (indirect tailcall)
-
 File "t1.ml", line 6, characters 31-45:
 Error: allocation of 24 bytes
+
+File "t1.ml", lines 6-7, characters 26-12:
+Error: called function may allocate (indirect tailcall)


### PR DESCRIPTION
Currently, compiler-generated wrapper function does not have debug info on the call to the original function. This makes sense because the call does not exist in source code and so doesn't have a source location. Unfortunately, this call can be mentioned in zero_alloc error messages. Showing `_none_` as the source file is not very helpful.  

This PRs proposes to use the location of the original function  definition. 