### PR TITLE
Install META files

### DIFF
--- a/dune
+++ b/dune
@@ -446,6 +446,7 @@
 
 (install
  (files
+  (ocaml/compilerlibs/META as compiler-libs/META)
   (external/owee/libcompiler_owee_stubs.a
    as
    compiler-libs/libcompiler_owee_stubs.a)

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -503,6 +503,8 @@
     (dynlink.cmi as dynlink/dynlink.cmi)
 
     .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Misc.cmx
+
+    (META as dynlink/META)
   )
   (section lib)
   (package ocaml))

--- a/ocaml/otherlibs/runtime_events/dune
+++ b/ocaml/otherlibs/runtime_events/dune
@@ -42,6 +42,7 @@
     (.runtime_events.objs/byte/runtime_events.cmt as runtime_events/runtime_events.cmt)
     (.runtime_events.objs/byte/runtime_events.cmti as runtime_events/runtime_events.cmti)
     (runtime_events_consumer.h as runtime_events_consumer.h)
+    (META as runtime_events/META)
   )
   (section lib)
   (package ocaml))

--- a/ocaml/otherlibs/str/dune
+++ b/ocaml/otherlibs/str/dune
@@ -41,6 +41,7 @@
     (.str.objs/byte/str.cmi as str/str.cmi)
     (.str.objs/byte/str.cmt as str/str.cmt)
     (.str.objs/byte/str.cmti as str/str.cmti)
+    (META as str/META)
   )
   (section lib)
   (package ocaml))

--- a/ocaml/otherlibs/systhreads/dune
+++ b/ocaml/otherlibs/systhreads/dune
@@ -32,6 +32,7 @@
   (byte/.threads.objs/byte/event.cmi as threads/event.cmi)
   (byte/.threads.objs/byte/event.cmti as threads/event.cmti)
   (byte/.threads.objs/byte/thread.cmi as threads/thread.cmi)
-  (byte/.threads.objs/byte/thread.cmti as threads/thread.cmti))
+  (byte/.threads.objs/byte/thread.cmti as threads/thread.cmti)
+  (META as threads/META))
  (section lib)
  (package ocaml))

--- a/ocaml/otherlibs/systhreads4/dune
+++ b/ocaml/otherlibs/systhreads4/dune
@@ -39,6 +39,8 @@
     (byte/.threads.objs/byte/event.cmti as threads/event.cmti)
     (byte/.threads.objs/byte/thread.cmi as threads/thread.cmi)
     (byte/.threads.objs/byte/thread.cmti as threads/thread.cmti)
+
+    (META as threads/META)
   )
   (section lib)
   (package ocaml))

--- a/ocaml/otherlibs/unix/dune
+++ b/ocaml/otherlibs/unix/dune
@@ -158,6 +158,7 @@
     (dllunix_stubs.so as stublibs/dllunix_stubs.so)
     (socketaddr.h as caml/socketaddr.h)
     (unixsupport.h as caml/unixsupport.h)
+    (META as unix/META)
   )
   (section lib)
   (package ocaml))

--- a/ocaml/stdlib/dune
+++ b/ocaml/stdlib/dune
@@ -514,6 +514,7 @@
   .stdlib.objs/native/stdlib__In_channel.cmx
   .stdlib.objs/native/stdlib__Out_channel.cmx
   .stdlib.objs/native/stdlib__Iarray.cmx
-  .stdlib.objs/native/stdlib__IarrayLabels.cmx)
+  .stdlib.objs/native/stdlib__IarrayLabels.cmx
+  (META as stdlib/META))
  (section lib)
  (package ocaml_runtime_stdlib))


### PR DESCRIPTION
This installs `META` files as required by `ocamlfind` for use with https://github.com/chambart/opam-repository-js/tree/with-extensions/

```
% find ocaml -name META                   
ocaml/compilerlibs/META
ocaml/otherlibs/runtime_events/META
ocaml/otherlibs/systhreads4/META
ocaml/otherlibs/unix/META
ocaml/otherlibs/str/META
ocaml/otherlibs/systhreads/META
ocaml/otherlibs/dynlink/META
ocaml/stdlib/META
% find _install -name META
_install/lib/ocaml/compiler-libs/META
_install/lib/ocaml/unix/META
_install/lib/ocaml/threads/META
_install/lib/ocaml/stdlib/META
_install/lib/ocaml/str/META
_install/lib/ocaml/dynlink/META
```

(The `runtime_events` library doesn't seem to be being installed at present, but that is a separate issue.)