### PR TITLE
Enable SIMD tests only on amd64 architecture

### DIFF
--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -50,7 +50,8 @@
 (rule
  (alias runtest)
  (enabled_if
-  (= %{context_name} "main"))
+  (and (= %{context_name} "main")
+       (= %{architecture} amd64)))
  (action
   (progn
    (diff empty.expected basic.out)


### PR DESCRIPTION
In particular to allow tests to pass on arm64.  Extracted from #1691 .