### PR TITLE
Force pthread option on macOS

### DIFF
--- a/ocaml/configure
+++ b/ocaml/configure
@@ -18529,6 +18529,8 @@ case $host in #(
     PTHREAD_LIBS="-l:libpthread.a -lgcc_eh" ;; #(
   *-pc-windows) :
     PTHREAD_LIBS="-l:libpthread.lib" ;; #(
+  *-apple-darwin*) :
+    PTHREAD_LIBS="-pthread" ;; #(
   *) :
 
 

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -2116,6 +2116,8 @@ AS_CASE([$host],
     [PTHREAD_LIBS="-l:libpthread.a -lgcc_eh"],
   [*-pc-windows],
     [PTHREAD_LIBS="-l:libpthread.lib"],
+  [*-apple-darwin*],
+    [PTHREAD_LIBS="-pthread"],
   [AX_PTHREAD(
     [common_cflags="$common_cflags $PTHREAD_CFLAGS"
     saved_CFLAGS="$CFLAGS"


### PR DESCRIPTION
The autoconf detection of the correct flags to use pthreads on macOS is broken, and produces warnings from the linker about duplicate libraries (because e.g. `-pthread -lpthread` is specified).  The easiest option by some way seems to be forcing the correct option to use, which this PR does.  Tested on the systhreads tests.