### PR TITLE
Disable two tests on arm64

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
                 "*.mlp": "ocaml",
                 "smmintrin.h": "c",
                 "tmmintrin.h": "c",
-                "pmmintrin.h": "c"
+                "pmmintrin.h": "c",
+                "*.tbl": "c"
         }
 }

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/probe.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/probe.ml
@@ -1,5 +1,6 @@
 (* TEST
  setup-ocamlopt.opt-build-env;
+ arch_amd64;
  flags = "-extension layouts_alpha";
  compiler_reference2 = "${test_source_directory}/probe.reference";
  ocamlopt_opt_exit_status = "2";

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/probe.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/probe.reference
@@ -1,11 +1,11 @@
-File "probe.ml", line 12, characters 6-7:
-12 |   let f () = x in
+File "probe.ml", line 13, characters 6-7:
+13 |   let f () = x in
            ^
 Warning 26 [unused-var]: unused variable f.
 
-File "probe.ml", lines 11-14, characters 20-2:
-11 | ....................[%probe "a" (
-12 |   let f () = x in
-13 |   ()
-14 | )]
+File "probe.ml", lines 12-15, characters 20-2:
+12 | ....................[%probe "a" (
+13 |   let f () = x in
+14 |   ()
+15 | )]
 Error: Variables in probe handlers must have jkind value, but x in this handler does not.

--- a/testsuite/tests/unboxed-primitive-args/test.ml
+++ b/testsuite/tests/unboxed-primitive-args/test.ml
@@ -1,6 +1,7 @@
 (* TEST
  readonly_files = "common.mli common.ml test_common.c test_common.h";
  flambda2;
+ arch_amd64;
  setup-ocamlopt.opt-build-env;
  test_file = "${test_source_directory}/gen_test.ml";
  ocaml_script_as_argument = "true";


### PR DESCRIPTION
One relies on SIMD and the other on probes, neither of which are currently supported on arm64.  Based on #2447.