### PR TITLE
Mode system exposes bounds (with warnings)

### DIFF
--- a/ocaml/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/ocaml/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -88,14 +88,14 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def>
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
-          value_mode meet_local,once(0[global,many,global,many]),join_shared(1[shared,shared])
+          value_mode global,many,shared
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
           region true
-          alloc_mode map_comonadic(regional_to_global)(6[global,many,global,many]),id(7[shared,shared])
+          alloc_mode global,many,shared
           []
           Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
-          alloc_mode id(2[global,many,global,many]),id(3[shared,shared])
+          alloc_mode global,many,shared
           value
             [
               <case>
@@ -110,11 +110,11 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
               <case>
                 pattern (test_locations.ml[19,572+4]..test_locations.ml[19,572+5])
                   Tpat_var "n"
-                  value_mode meet_global,many ∘ map_comonadic(local_to_regional)(2[global,many,global,many]),join_unique(3[shared,shared])
+                  value_mode global,many,unique
                 expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
                   Texp_apply
                   apply_mode Tail
-                  locality_mode proj_areality(10[global,many,global,many])
+                  locality_mode global
                   expression (test_locations.ml[19,572+21]..test_locations.ml[19,572+22])
                     Texp_ident "Stdlib!.+"
                   [
@@ -123,7 +123,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+20])
                         Texp_apply
                         apply_mode Default
-                        locality_mode proj_areality(4[global,many,global,many])
+                        locality_mode global
                         expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+12])
                           Texp_ident "fib"
                         [
@@ -132,7 +132,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression (test_locations.ml[19,572+13]..test_locations.ml[19,572+20])
                               Texp_apply
                               apply_mode Default
-                              locality_mode proj_areality(20[global,many,global,many])
+                              locality_mode global
                               expression (test_locations.ml[19,572+16]..test_locations.ml[19,572+17])
                                 Texp_ident "Stdlib!.-"
                               [
@@ -151,7 +151,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+34])
                         Texp_apply
                         apply_mode Default
-                        locality_mode proj_areality(4[global,many,global,many])
+                        locality_mode global
                         expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+26])
                           Texp_ident "fib"
                         [
@@ -160,7 +160,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression (test_locations.ml[19,572+27]..test_locations.ml[19,572+34])
                               Texp_apply
                               apply_mode Default
-                              locality_mode proj_areality(34[global,many,global,many])
+                              locality_mode global
                               expression (test_locations.ml[19,572+30]..test_locations.ml[19,572+31])
                                 Texp_ident "Stdlib!.-"
                               [

--- a/ocaml/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/ocaml/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -88,14 +88,14 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def>
         pattern 
           Tpat_var "fib"
-          value_mode meet_local,once(0[global,many,global,many]),join_shared(1[shared,shared])
+          value_mode global,many,shared
         expression 
           Texp_function
           region true
-          alloc_mode map_comonadic(regional_to_global)(6[global,many,global,many]),id(7[shared,shared])
+          alloc_mode global,many,shared
           []
           Tfunction_cases 
-          alloc_mode id(2[global,many,global,many]),id(3[shared,shared])
+          alloc_mode global,many,shared
           value
             [
               <case>
@@ -110,11 +110,11 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
               <case>
                 pattern 
                   Tpat_var "n"
-                  value_mode meet_global,many ∘ map_comonadic(local_to_regional)(2[global,many,global,many]),join_unique(3[shared,shared])
+                  value_mode global,many,unique
                 expression 
                   Texp_apply
                   apply_mode Tail
-                  locality_mode proj_areality(10[global,many,global,many])
+                  locality_mode global
                   expression 
                     Texp_ident "Stdlib!.+"
                   [
@@ -123,7 +123,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression 
                         Texp_apply
                         apply_mode Default
-                        locality_mode proj_areality(4[global,many,global,many])
+                        locality_mode global
                         expression 
                           Texp_ident "fib"
                         [
@@ -132,7 +132,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression 
                               Texp_apply
                               apply_mode Default
-                              locality_mode proj_areality(20[global,many,global,many])
+                              locality_mode global
                               expression 
                                 Texp_ident "Stdlib!.-"
                               [
@@ -151,7 +151,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression 
                         Texp_apply
                         apply_mode Default
-                        locality_mode proj_areality(4[global,many,global,many])
+                        locality_mode global
                         expression 
                           Texp_ident "fib"
                         [
@@ -160,7 +160,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression 
                               Texp_apply
                               apply_mode Default
-                              locality_mode proj_areality(34[global,many,global,many])
+                              locality_mode global
                               expression 
                                 Texp_ident "Stdlib!.-"
                               [

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1201,11 +1201,13 @@ module Common (Obj : Obj) = struct
 
   let of_const : type l r. const -> (l * r) t = fun a -> Solver.of_const obj a
 
-  let get_floor m = Solver.get_floor obj m
+  module Guts = struct
+    let get_floor m = Solver.get_floor obj m
 
-  let get_ceil m = Solver.get_ceil obj m
+    let get_ceil m = Solver.get_ceil obj m
 
-  let get_conservative_floor m = Solver.get_conservative_floor obj m
+    let get_conservative_floor m = Solver.get_conservative_floor obj m
+  end
 end
 [@@inline]
 
@@ -1231,8 +1233,8 @@ module Locality = struct
   let zap_to_legacy = zap_to_floor
 
   let check_const m =
-    let floor = get_floor m in
-    let ceil = get_ceil m in
+    let floor = Guts.get_floor m in
+    let ceil = Guts.get_ceil m in
     if Const.le ceil floor then Some ceil else None
 end
 

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1575,7 +1575,7 @@ module Value = struct
       Comonadic.le m0.comonadic m1.comonadic && Monadic.le m0.monadic m1.monadic
 
     let print ppf m =
-      let {monadic; comonadic} = split m in
+      let { monadic; comonadic } = split m in
       Format.fprintf ppf "%a,%a" Comonadic.print comonadic Monadic.print monadic
 
     let legacy =
@@ -2054,7 +2054,7 @@ module Alloc = struct
       Comonadic.le m0.comonadic m1.comonadic && Monadic.le m0.monadic m1.monadic
 
     let print ppf m =
-      let {monadic; comonadic} = split m in
+      let { monadic; comonadic } = split m in
       Format.fprintf ppf "%a,%a" Comonadic.print comonadic Monadic.print monadic
 
     let legacy =

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1207,6 +1207,8 @@ module Common (Obj : Obj) = struct
     let get_ceil m = Solver.get_ceil obj m
 
     let get_conservative_floor m = Solver.get_conservative_floor obj m
+
+    let get_conservative_ceil m = Solver.get_conservative_ceil obj m
   end
 end
 [@@inline]
@@ -1232,10 +1234,17 @@ module Locality = struct
 
   let zap_to_legacy = zap_to_floor
 
-  let check_const m =
-    let floor = Guts.get_floor m in
-    let ceil = Guts.get_ceil m in
-    if Const.le ceil floor then Some ceil else None
+  module Guts = struct
+    let check_const m =
+      let floor = Guts.get_floor m in
+      let ceil = Guts.get_ceil m in
+      if Const.le ceil floor then Some ceil else None
+
+    let check_const_conservative m =
+      let floor = Guts.get_conservative_floor m in
+      let ceil = Guts.get_conservative_ceil m in
+      if Const.le ceil floor then Some ceil else None
+  end
 end
 
 module Regionality = struct

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1195,15 +1195,17 @@ module Common (Obj : Obj) = struct
 
   let print ?verbose () ppf m = Solver.print ?verbose obj ppf m
 
-  let print_raw ?verbose () ppf m = Solver.print_raw ?verbose obj ppf m
-
   let zap_to_ceil m = with_log (Solver.zap_to_ceil obj m)
 
   let zap_to_floor m = with_log (Solver.zap_to_floor obj m)
 
   let of_const : type l r. const -> (l * r) t = fun a -> Solver.of_const obj a
 
-  let check_const m = Solver.check_const obj m
+  let get_floor m = Solver.get_floor obj m
+
+  let get_ceil m = Solver.get_ceil obj m
+
+  let get_conservative_floor m = Solver.get_conservative_floor obj m
 end
 [@@inline]
 
@@ -1227,6 +1229,11 @@ module Locality = struct
   let legacy = of_const Const.legacy
 
   let zap_to_legacy = zap_to_floor
+
+  let check_const m =
+    let floor = get_floor m in
+    let ceil = get_ceil m in
+    if Const.le ceil floor then Some ceil else None
 end
 
 module Regionality = struct
@@ -1430,12 +1437,6 @@ module Comonadic_with_locality = struct
 
   (* override to report the offending axis *)
   let equate a b = try_with_log (equate_from_submode submode_log a b)
-
-  (** overriding to check per-axis *)
-  let check_const m =
-    let locality = Locality.check_const (proj Areality m) in
-    let linearity = Linearity.check_const (proj Linearity m) in
-    locality, linearity
 end
 
 module Monadic = struct
@@ -1502,11 +1503,6 @@ module Monadic = struct
 
   (* override to report the offending axis *)
   let equate a b = try_with_log (equate_from_submode submode_log a b)
-
-  (** overriding to check per-axis *)
-  let check_const m =
-    let uniqueness = Uniqueness.check_const (proj Uniqueness m) in
-    uniqueness, ()
 end
 
 type ('mo, 'como) monadic_comonadic =
@@ -1550,13 +1546,6 @@ module Value = struct
     let uniqueness, () = monadic in
     { regionality; linearity; uniqueness }
 
-  let print_raw ?verbose () ppf { monadic; comonadic } =
-    Format.fprintf ppf "%a,%a"
-      (Comonadic.print_raw ?verbose ())
-      comonadic
-      (Monadic.print_raw ?verbose ())
-      monadic
-
   let print ?verbose () ppf { monadic; comonadic } =
     Format.fprintf ppf "%a,%a"
       (Comonadic.print ?verbose ())
@@ -1585,7 +1574,9 @@ module Value = struct
       let m1 = split m1 in
       Comonadic.le m0.comonadic m1.comonadic && Monadic.le m0.monadic m1.monadic
 
-    let print ppf m = print_raw () ppf (of_const m)
+    let print ppf m =
+      let {monadic; comonadic} = split m in
+      Format.fprintf ppf "%a,%a" Comonadic.print comonadic Monadic.print monadic
 
     let legacy =
       merge { comonadic = Comonadic.legacy; monadic = Monadic.legacy }
@@ -1919,13 +1910,6 @@ module Alloc = struct
   let equate_exn m0 m1 =
     match equate m0 m1 with Ok () -> () | Error _ -> invalid_arg "equate_exn"
 
-  let print_raw ?verbose () ppf { monadic; comonadic } =
-    Format.fprintf ppf "%a,%a"
-      (Comonadic.print_raw ?verbose ())
-      comonadic
-      (Monadic.print_raw ?verbose ())
-      monadic
-
   let print ?verbose () ppf { monadic; comonadic } =
     Format.fprintf ppf "%a,%a"
       (Comonadic.print ?verbose ())
@@ -2069,7 +2053,9 @@ module Alloc = struct
       let m1 = split m1 in
       Comonadic.le m0.comonadic m1.comonadic && Monadic.le m0.monadic m1.monadic
 
-    let print ppf m = print_raw () ppf (of_const m)
+    let print ppf m =
+      let {monadic; comonadic} = split m in
+      Format.fprintf ppf "%a,%a" Comonadic.print comonadic Monadic.print monadic
 
     let legacy =
       merge { comonadic = Comonadic.legacy; monadic = Monadic.legacy }
@@ -2156,11 +2142,6 @@ module Alloc = struct
   let zap_to_legacy { comonadic; monadic } =
     let monadic = Monadic.zap_to_legacy monadic in
     let comonadic = Comonadic.zap_to_legacy comonadic in
-    merge { monadic; comonadic }
-
-  let check_const { comonadic; monadic } =
-    let comonadic = Comonadic.check_const comonadic in
-    let monadic = Monadic.check_const monadic in
     merge { monadic; comonadic }
 
   (** This is about partially applying [A -> B -> C] to [A] and getting [B ->

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -83,11 +83,7 @@ module type Common = sig
 
   val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
 
-  val print_raw :
-    ?verbose:bool -> unit -> Format.formatter -> ('l * 'r) t -> unit
-
-  val print :
-    ?verbose:bool -> unit -> Format.formatter -> (allowed * allowed) t -> unit
+  val print : ?verbose:bool -> unit -> Format.formatter -> ('l * 'r) t -> unit
 
   val of_const : Const.t -> ('l * 'r) t
 end
@@ -147,6 +143,21 @@ module type S = sig
 
     val zap_to_ceil : ('l * allowed) t -> Const.t
 
+    (* The functions to obtain the bounds are dangerous; see notes on functions
+       of same names in [solver_intf.mli] for cautions.
+
+       In addition, they are dangerous (even the non-conservative ones), because
+       the caller might obtain the floor/ceil of multiple mode variables and use
+       them in conjunction, without realizing that those bounds might have
+       constraints between them that prevent the bounds to hold in conjunction.
+
+       Therefore, those functions should be avoided. Currently they are used
+       only by merlin. *)
+    val get_conservative_floor : (l * 'r) t -> Const.t
+
+    val get_ceil : ('l * allowed) t -> Const.t
+
+    (** Returns [Some c] if the given mode has been constrained to constant [c]. *)
     val check_const : (allowed * allowed) t -> Const.t option
   end
 
@@ -388,8 +399,6 @@ module type S = sig
         with module Const := Const
          and type error := error
          and type 'd t := 'd t
-
-    val check_const : (allowed * allowed) t -> Const.Option.t
 
     val proj : ('m, 'a, 'l * 'r) axis -> ('l * 'r) t -> 'm
 

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -143,19 +143,22 @@ module type S = sig
 
     val zap_to_ceil : ('l * allowed) t -> Const.t
 
-    (* The functions to obtain the bounds are dangerous; see notes on functions
-       of same names in [solver_intf.mli] for cautions.
+    module Guts : sig
+      (* The functions to obtain bounds are dangerous; see notes on functions of
+         same names in [solver_intf.mli] for cautions.
 
-       In addition, they are dangerous (even the non-conservative ones), because
-       the caller might obtain the floor/ceil of multiple mode variables and use
-       them in conjunction, without realizing that those bounds might have
-       constraints between them that prevent the bounds to hold in conjunction.
+         In addition, they are dangerous (even the non-conservative ones),
+         because the caller might obtain the floor/ceil of multiple mode
+         variables and use them in conjunction, without realizing that those
+         bounds might have constraints between them that prevent the bounds to
+         hold in conjunction.
 
-       Therefore, those functions should be avoided. Currently they are used
-       only by merlin. *)
-    val get_conservative_floor : (l * 'r) t -> Const.t
+         Therefore, those functions should be avoided. Currently they are used
+         only by merlin. *)
+      val get_conservative_floor : (l * 'r) t -> Const.t
 
-    val get_ceil : ('l * allowed) t -> Const.t
+      val get_ceil : ('l * allowed) t -> Const.t
+    end
 
     (** Returns [Some c] if the given mode has been constrained to constant [c]. *)
     val check_const : (allowed * allowed) t -> Const.t option

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -144,24 +144,20 @@ module type S = sig
     val zap_to_ceil : ('l * allowed) t -> Const.t
 
     module Guts : sig
-      (* The functions to obtain bounds are dangerous; see notes on functions of
-         same names in [solver_intf.mli] for cautions.
+      (** This module exposes some functions that allow callers to inspect modes
+      directly, which could be useful for error printing and dev tools (such as
+      merlin). Any usage of this in type checking should be pondered. *)
 
-         In addition, they are dangerous (even the non-conservative ones),
-         because the caller might obtain the floor/ceil of multiple mode
-         variables and use them in conjunction, without realizing that those
-         bounds might have constraints between them that prevent the bounds to
-         hold in conjunction.
+      (** Returns [Some c] if the given mode has been constrained to constant
+          [c]. see notes on [get_floor] in [solver_intf.mli] for cautions. *)
+      val check_const : (allowed * allowed) t -> Const.t option
 
-         Therefore, those functions should be avoided. Currently they are used
-         only by merlin. *)
-      val get_conservative_floor : (l * 'r) t -> Const.t
-
-      val get_ceil : ('l * allowed) t -> Const.t
+      (** Similar to [check_const] but doesn't run the further constraining
+          needed for precise bounds. As a result, it is inexpensive and returns
+          a conservative result. I.e., it might return [None] for
+          fully-constrained modes. *)
+      val check_const_conservative : (l * 'r) t -> Const.t option
     end
-
-    (** Returns [Some c] if the given mode has been constrained to constant [c]. *)
-    val check_const : (allowed * allowed) t -> Const.t option
   end
 
   module Regionality : sig

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -404,16 +404,16 @@ and expression_extra i ppf x attrs =
       attributes i ppf attrs;
 
 and alloc_mode: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
-  = fun i ppf m -> line i ppf "alloc_mode %a\n" (Mode.Alloc.print_raw ()) m
+  = fun i ppf m -> line i ppf "alloc_mode %a\n" (Mode.Alloc.print ()) m
 
 and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
 
 and locality_mode i ppf m =
   line i ppf "locality_mode %a\n"
-    (Mode.Locality.print_raw ()) m
+    (Mode.Locality.print ()) m
 
 and value_mode i ppf m =
-  line i ppf "value_mode %a\n" (Mode.Value.print_raw ()) m
+  line i ppf "value_mode %a\n" (Mode.Value.print ()) m
 
 and expression_alloc_mode i ppf (expr, am) =
   alloc_mode i ppf am;

--- a/ocaml/typing/solver_intf.mli
+++ b/ocaml/typing/solver_intf.mli
@@ -271,24 +271,28 @@ module type Solver_polarized = sig
   (** Return the meet of the list of modes. *)
   val meet : 'a obj -> ('a, 'l * allowed) mode list -> ('a, right_only) mode
 
-  (** Checks if a mode has been constrained sufficiently to a constant. Because
-      our internal representation is conservative, further constraint is run to
-      decide the bounds. This operation is therefore expensive and requires the
-      mode to be allowed on both sides.
-      WARNING: the lattice must be finite for this to terminate.*)
-  val check_const : 'a obj -> ('a, allowed * allowed) mode -> 'a option
+  (** Returns the lower bound of the mode. Because of our conservative internal
+      representation, further constraining is needed for precise bound.
+      This operation is therefore expensive and requires the mode to be allowed
+      on the left.
+      WARNING: the lattice must be finite for this to terminate. *)
+  val get_floor : 'a obj -> ('a, allowed * 'r) mode -> 'a
 
-  (** Print a mode. Calls [check_const] for cleaner printing; caveats there
-  apply here too. *)
+  (** Returns the upper bound of the mode. Notes for [get_floor] applies. *)
+  val get_ceil : 'a obj -> ('a, 'l * allowed) mode -> 'a
+
+  (** Similar to [get_floor] but does not run the further constraining needed
+      for a precise bound. As a result, the returned bound is conservative;
+      i.e., it might be lower than the real floor. *)
+  val get_conservative_floor : 'a obj -> ('a, 'l * 'r) mode -> 'a
+
+  (** Similar to [get_ceil] but does not run the further constraining needed
+      for a precise bound. As a result, the returned bound is conservative;
+      i.e., it might be higher than the real ceil. *)
+  val get_conservative_ceil : 'a obj -> ('a, 'l * 'r) mode -> 'a
+
+  (** Printing a mode for debugging. *)
   val print :
-    ?verbose:bool ->
-    'a obj ->
-    Format.formatter ->
-    ('a, allowed * allowed) mode ->
-    unit
-
-  (** Print a mode without calling [check_const]. *)
-  val print_raw :
     ?verbose:bool -> 'a obj -> Format.formatter -> ('a, 'l * 'r) mode -> unit
 
   (** Apply a monotone morphism whose source and target modes are of the

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -9488,7 +9488,7 @@ let escaping_hint (failure_reason : Value.error) submode_reason
         match get_desc ty with
         | Tarrow ((_, _, res_mode), _, res_ty, _) ->
           begin match
-            Locality.check_const (Alloc.proj (Comonadic Areality) res_mode)
+            Locality.Guts.check_const (Alloc.proj (Comonadic Areality) res_mode)
           with
           | Some Global ->
             Some (n+1, true)

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2467,7 +2467,7 @@ let make_native_repr env core_type ty ~global_repr ~is_layout_poly ~why =
       Same_as_ocaml_repr sort
 
 let prim_const_mode m =
-  match Mode.Locality.check_const m with
+  match Mode.Locality.Guts.check_const m with
   | Some Global -> Prim_global
   | Some Local -> Prim_local
   | None -> assert false


### PR DESCRIPTION
This PR makes the mode system expose functions to query modes' bounds. Note that due to our biased implementation, the recorded ceil is precise and cheap to get. However, the new interface pretends that it has the similar issue as the floor, for the following reasons:
- First, the caller doesn't need to know the bias.
- Second, we use the same `Solver_polarized` interface when we dualize the solver;as a result, ceil and floor needs to be dual.

Additionally, I also slightly improved the raw mode printer, so if the mode has been constrained to constant even by conservative bounds, it will just print the constant. The non-raw printer (that checks for precise bounds) is removed as we barely need it.