### PR TITLE
Fix Idls_get case in arm64 emitter

### DIFF
--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -956,11 +956,10 @@ let emit_instr i =
     | Lop (Iprobe _ | Iprobe_is_enabled _) ->
       fatal_error ("Probes not supported.")
     | Lop(Idls_get) ->
-      (* BACKPORT BEGIN *)
-      fatal_error ("Idls_get not supported.")
-      (*let offset = Domainstate.(idx_of_field Domain_dls_root) * 8 in
-      `	ldr	{emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, {emit_int offset}]\n`*)
-      (* BACKPORT END *)
+      if Config.runtime5 then
+        let offset = Domainstate.(idx_of_field Domain_dls_root) * 8 in
+        `	ldr	{emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, {emit_int offset}]\n`
+      else Misc.fatal_error "Dls is not supported in runtime4."
     | Lop (Icsel tst) ->
       let len = Array.length i.arg in
       let ifso = i.arg.(len - 2) in


### PR DESCRIPTION
A small fix which removes the last of the `BACKPORT` markers from the backend and middle end (i.e. the flambda-backend copies of such, not the ones under `ocaml/`).