### PR TITLE
Fixes and re-enables a test

### DIFF
--- a/ocaml/testsuite/tests/hidden_includes/missing_cmi_layout.ocamlc.reference
+++ b/ocaml/testsuite/tests/hidden_includes/missing_cmi_layout.ocamlc.reference
@@ -1,0 +1,10 @@
+File "libc/c2.ml", line 1, characters 12-15:
+1 | let x = B.f B.x
+                ^^^
+Error: Function arguments and returns must be representable.
+       The layout of A.t is any, because
+         the .cmi file for A.t is missing.
+       But the layout of A.t must be representable, because
+         we must know concretely how to pass a function argument.
+       No .cmi file found containing A.t.
+       Hint: Adding "a" to your dependencies might help.

--- a/ocaml/testsuite/tests/hidden_includes/test.ml
+++ b/ocaml/testsuite/tests/hidden_includes/test.ml
@@ -1,6 +1,4 @@
 (* TEST
- reason = "broken due to layout error";
- skip;
 (* This tests the -H flag.
 
    The basic structure is that libc depends on libb, which depends on liba.  We
@@ -37,11 +35,16 @@ flags = "-I liba -I libb -nocwd";
 module = "libb/b.ml";
 ocamlc.byte;
 {
-  (* Test hiding A completely *)
+  (* Test hiding A completely. You can't do much with types from it because
+     their layouts are unknown. *)
   flags = "-I libb -nocwd";
   module = "libc/c2.ml";
   setup-ocamlc.byte-build-env;
+  ocamlc_byte_exit_status = "2";
   ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/missing_cmi_layout.ocamlc.reference";
+  check-ocamlc.byte-output;
 }
 {
   (* Test hiding A completely, but using it *)


### PR DESCRIPTION
@stedolan pointed out that the `-H` tests, backported from upstream, were in fact silently not running because they used the new ocamltest stanzas and were just ignored.  Oops!

In #2444 he moved us to the new test stanza format, so the test can now run.  But it wasn't passing.

The failing test tried to apply a function to an argument whose layout we couldn't deduce because of a missing cmi.  It's entirely expected this test should pass upstream (where you can apply a function to an argument whose type you know nothing about) but not in our compiler (where you need to know the layout).  So, I've just accepted the new output from that case and re-enabled the test.

Reviewer: @stedolan or @goldfirere 
