### PR TITLE
Zero alloc: more precise handling of assume annotations on inlined calls

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -833,10 +833,11 @@ end = struct
   let transform_call t ~next ~exn callee w ~desc dbg =
     report t next ~msg:"transform_call next" ~desc dbg;
     report t exn ~msg:"transform_call exn" ~desc dbg;
+    let v = find_callee t callee ~desc dbg w in
     let effect =
       match Metadata.assume_value dbg ~can_raise:true w with
-      | Some v -> v
-      | None -> find_callee t callee ~desc dbg w
+      | Some v' -> Value.meet v v'
+      | None -> v
     in
     transform t ~next ~exn ~effect desc dbg
 

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -831,3 +831,22 @@
  (enabled_if (= %{context_name} "main"))
  (deps test_all_opt3.output test_all_opt3.output.corrected)
  (action (diff test_all_opt3.output test_all_opt3.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_assume_inlining.output.corrected)
+ (deps (:ml test_assume_inlining.ml) filter.sh)
+ (action
+   (with-outputs-to test_assume_inlining.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_inlining.output test_assume_inlining.output.corrected)
+ (action (diff test_assume_inlining.output test_assume_inlining.output.corrected)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -138,4 +138,6 @@ let () =
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_flags:"-zero-alloc-check opt"
     ~extra_dep:None ~exit_code:2 "test_all_opt3";
+  print_test_expected_output ~cutoff:default_cutoff
+    ~extra_dep:None ~exit_code:2 "test_assume_inlining";
   ()

--- a/tests/backend/checkmach/test_assume_fail.ml
+++ b/tests/backend/checkmach/test_assume_fail.ml
@@ -58,7 +58,7 @@ let[@zero_alloc strict] test61 x = test60 x
 (* allocations on the path to a call labeled [@zero_alloc assume never_returns_normally]
    do not count for the normal check, but do count for the strict check *)
 
-let[@inline never] test62 x = [x;x]
+let[@inline never] test62 x = if List.length x > 0 then [x;x] else failwith (string_of_int (List.length x))
 
 let[@zero_alloc] test63 x =
   let p = [x;x+1] in

--- a/tests/backend/checkmach/test_assume_inlining.ml
+++ b/tests/backend/checkmach/test_assume_inlining.ml
@@ -1,0 +1,111 @@
+exception Exn of int
+
+(* don't inline bar : passes *)
+module A1 = struct
+  let[@inline never] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline never] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline never] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end
+
+(* inline bar : fails *)
+
+module A2 = struct
+  let[@inline never] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline always] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end
+
+
+(* inline bar and assume f is strict: passes *)
+
+module A3 = struct
+  let[@inline never][@zero_alloc assume strict] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline never] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end
+
+(* inline bar and assume f is strict and f is inlined: passes *)
+
+module A4 = struct
+  let[@inline always][@zero_alloc assume strict] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline never] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end
+
+
+(* inline bar and assume g never returns normally: passes *)
+
+module A5 = struct
+  let[@inline never] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline never][@zero_alloc assume never_returns_normally] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end
+
+
+(* inline bar and assume g never returns normally and inline g: passes *)
+
+module A6 = struct
+  let[@inline never] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline always][@zero_alloc assume never_returns_normally] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end

--- a/tests/backend/checkmach/test_assume_inlining.output
+++ b/tests/backend/checkmach/test_assume_inlining.output
@@ -1,0 +1,5 @@
+File "test_assume_inlining.ml", line 34, characters 7-17:
+Error: Annotation check for zero_alloc failed on function Test_assume_inlining.A2.foo (camlTest_assume_inlining.foo_HIDE_STAMP)
+
+File "test_assume_inlining.ml", line 35, characters 4-9:
+Error: called function may allocate (direct call camlTest_assume_inlining.f_HIDE_STAMP) (test_assume_inlining.ml:35,4--9;test_assume_inlining.ml:30,6--9)


### PR DESCRIPTION
The result of zero_alloc check sometimes depends on inlining decisions, even when inlining does not eliminate any allocations. This PR adds an example of some cases that fail:

1) When a function annotated with "assume" is inlined into another function that is also annotated with "assume", the callee's annotation is dropped. The result of the check may differ depending on inlining if the callee's annotation has `strict` or `never_returns_normally`, but the caller doesn't have these keywords, .
2) When a function annotated with "assume" contains a `try-with` and the analysis cannot prove that the exception handler always raises, then the check fails when the function is inlined and passes when the function is not inlined.

This PR fixes the first issue. Note that only direct calls are handled more precisely. Maybe we should consider doing it for allocations too. 

The second issue is harder to fix, but after fixing the first issue, it can be worked around as shown in the new test (or by annotating with `strict assume` on the caller). 