### PR TITLE
Enable Domain module fully on runtime5

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4106,3 +4106,5 @@ let allocate_unboxed_nativeint_array =
 
 (* Drop internal optional arguments from exported interface *)
 let block_header x y = block_header x y
+
+let dls_get ~dbg = Cop (Cdls_get, [], dbg)

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1067,3 +1067,5 @@ val setfield_unboxed_int32 : ternary_primitive
 val setfield_unboxed_float32 : ternary_primitive
 
 val setfield_unboxed_int64_or_nativeint : ternary_primitive
+
+val dls_get : dbg:Debuginfo.t -> expression

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2247,7 +2247,7 @@ end = struct
       let w = create_witnesses t (Extcall { callee = func }) dbg in
       transform_top t ~next ~exn w ("external call to " ^ func) dbg
     | Ispecific s -> transform_specific t s ~next ~exn dbg
-    | Idls_get -> Misc.fatal_error "Idls_get not supported"
+    | Idls_get -> next
 
   module D = Dataflow.Backward ((Value : Dataflow.DOMAIN))
 
@@ -2574,7 +2574,7 @@ end = struct
           in
           transform t ~effect ~next ~exn:Value.bot "heap allocation" dbg
         | Specific s -> transform_specific t s ~next ~exn:Value.bot dbg
-        | Dls_get -> Misc.fatal_error "Idls_get not supported"
+        | Dls_get -> next
 
       let basic next (i : Cfg.basic Cfg.instruction) t : (domain, error) result
           =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -702,9 +702,10 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Punboxed_product_field _ | Pget_header _ ->
     false
   | Patomic_exchange | Patomic_cas | Patomic_fetch_add | Patomic_load _ -> false
-  | Prunstack | Pperform | Presume | Preperform | Pdls_get ->
+  | Prunstack | Pperform | Presume | Preperform ->
     Misc.fatal_errorf "Primitive %a is not yet supported by Flambda 2"
       Printlambda.primitive prim
+  | Pdls_get -> false
 
 type non_tail_continuation =
   Acc.t ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1887,6 +1887,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     [Ternary (Atomic_compare_and_set, atomic, old_value, new_value)]
   | Patomic_fetch_add, [[atomic]; [i]] ->
     [Binary (Atomic_fetch_and_add, atomic, i)]
+  | Pdls_get, _ -> [Nullary Dls_get]
   | ( ( Pmodint Unsafe
       | Pdivbint { is_safe = Unsafe; size = _; mode = _ }
       | Pmodbint { is_safe = Unsafe; size = _; mode = _ }
@@ -2000,7 +2001,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     Misc.fatal_errorf
       "[%a] should have been handled by [Closure_conversion.close_primitive]"
       Printlambda.primitive prim
-  | (Prunstack | Pperform | Presume | Preperform | Pdls_get), _ ->
+  | (Prunstack | Pperform | Presume | Preperform), _ ->
     Misc.fatal_errorf "Primitive %a is not yet supported by Flambda 2"
       Printlambda.primitive prim
 

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -516,7 +516,8 @@ let nullop _env (op : Flambda_primitive.nullary_primitive) : Fexpr.nullop =
   match op with
   | Begin_region -> Begin_region
   | Begin_try_region -> Begin_try_region
-  | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Enter_inlined_apply _ ->
+  | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Enter_inlined_apply _
+  | Dls_get ->
     Misc.fatal_errorf "TODO: Nullary primitive: %a" Flambda_primitive.print
       (Flambda_primitive.Nullary op)
 

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -49,3 +49,8 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     let ty = T.this_tagged_immediate Targetint_31_63.zero in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc
+  | Dls_get ->
+    let named = Named.create_prim original_prim dbg in
+    let ty = T.any_value in
+    let dacc = DA.add_variable dacc result_var ty in
+    Simplify_primitive_result.create named ~try_reify:false dacc

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -341,6 +341,7 @@ let nullary_prim_size prim =
   | Begin_region -> 1
   | Begin_try_region -> 1
   | Enter_inlined_apply _ -> 0
+  | Dls_get -> 1
 
 let unary_prim_size prim =
   match (prim : Flambda_primitive.unary_primitive) with

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -937,10 +937,11 @@ type nullary_primitive =
   | Begin_region
   | Begin_try_region
   | Enter_inlined_apply of { dbg : Inlined_debuginfo.t }
+  | Dls_get
 
 let nullary_primitive_eligible_for_cse = function
   | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Begin_region
-  | Begin_try_region | Enter_inlined_apply _ ->
+  | Begin_try_region | Enter_inlined_apply _ | Dls_get ->
     false
 
 let compare_nullary_primitive p1 p2 =
@@ -953,28 +954,34 @@ let compare_nullary_primitive p1 p2 =
   | Begin_try_region, Begin_try_region -> 0
   | Enter_inlined_apply { dbg = dbg1 }, Enter_inlined_apply { dbg = dbg2 } ->
     Inlined_debuginfo.compare dbg1 dbg2
+  | Dls_get, Dls_get -> 0
   | ( Invalid _,
       ( Optimised_out _ | Probe_is_enabled _ | Begin_region | Begin_try_region
-      | Enter_inlined_apply _ ) ) ->
+      | Enter_inlined_apply _ | Dls_get ) ) ->
     -1
   | ( Optimised_out _,
       ( Probe_is_enabled _ | Begin_region | Begin_try_region
-      | Enter_inlined_apply _ ) ) ->
+      | Enter_inlined_apply _ | Dls_get ) ) ->
     -1
   | Optimised_out _, Invalid _ -> 1
-  | Probe_is_enabled _, (Begin_region | Begin_try_region | Enter_inlined_apply _)
-    ->
+  | ( Probe_is_enabled _,
+      (Begin_region | Begin_try_region | Enter_inlined_apply _ | Dls_get) ) ->
     -1
   | Probe_is_enabled _, (Invalid _ | Optimised_out _) -> 1
-  | Begin_region, (Begin_try_region | Enter_inlined_apply _) -> -1
+  | Begin_region, (Begin_try_region | Enter_inlined_apply _ | Dls_get) -> -1
   | Begin_region, (Invalid _ | Optimised_out _ | Probe_is_enabled _) -> 1
-  | Begin_try_region, Enter_inlined_apply _ -> -1
+  | Begin_try_region, (Enter_inlined_apply _ | Dls_get) -> -1
   | ( Begin_try_region,
       (Invalid _ | Optimised_out _ | Probe_is_enabled _ | Begin_region) ) ->
     1
   | ( Enter_inlined_apply _,
       ( Invalid _ | Optimised_out _ | Probe_is_enabled _ | Begin_region
       | Begin_try_region ) ) ->
+    1
+  | Enter_inlined_apply _, Dls_get -> -1
+  | ( Dls_get,
+      ( Invalid _ | Optimised_out _ | Probe_is_enabled _ | Begin_region
+      | Begin_try_region | Enter_inlined_apply _ ) ) ->
     1
 
 let equal_nullary_primitive p1 p2 = compare_nullary_primitive p1 p2 = 0
@@ -994,6 +1001,7 @@ let print_nullary_primitive ppf p =
   | Enter_inlined_apply { dbg } ->
     Format.fprintf ppf "@[<hov 1>(Enter_inlined_apply@ %a)@]"
       Inlined_debuginfo.print dbg
+  | Dls_get -> Format.pp_print_string ppf "Dls_get"
 
 let result_kind_of_nullary_primitive p : result_kind =
   match p with
@@ -1003,6 +1011,7 @@ let result_kind_of_nullary_primitive p : result_kind =
   | Begin_region -> Singleton K.region
   | Begin_try_region -> Singleton K.region
   | Enter_inlined_apply _ -> Unit
+  | Dls_get -> Singleton K.value
 
 let coeffects_of_mode : Alloc_mode.For_allocations.t -> Coeffects.t = function
   | Local _ -> Coeffects.Has_coeffects
@@ -1025,11 +1034,12 @@ let effects_and_coeffects_of_nullary_primitive p : Effects_and_coeffects.t =
     (* This doesn't really have effects, but without effects, these primitives
        get deleted during lambda_to_flambda. *)
     Arbitrary_effects, Has_coeffects, Strict
+  | Dls_get -> No_effects, Has_coeffects, Strict
 
 let nullary_classify_for_printing p =
   match p with
   | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Begin_region
-  | Begin_try_region | Enter_inlined_apply _ ->
+  | Begin_try_region | Enter_inlined_apply _ | Dls_get ->
     Neither
 
 type unary_primitive =
@@ -2187,7 +2197,7 @@ let free_names t =
   match t with
   | Nullary
       ( Invalid _ | Optimised_out _ | Probe_is_enabled _ | Begin_region
-      | Begin_try_region | Enter_inlined_apply _ ) ->
+      | Begin_try_region | Enter_inlined_apply _ | Dls_get ) ->
     Name_occurrences.empty
   | Unary (prim, x0) ->
     Name_occurrences.union
@@ -2214,7 +2224,7 @@ let apply_renaming t renaming =
   match t with
   | Nullary
       ( Invalid _ | Optimised_out _ | Probe_is_enabled _ | Begin_region
-      | Begin_try_region | Enter_inlined_apply _ ) ->
+      | Begin_try_region | Enter_inlined_apply _ | Dls_get ) ->
     t
   | Unary (prim, x0) ->
     let prim' = apply_renaming_unary_primitive prim renaming in
@@ -2244,7 +2254,7 @@ let ids_for_export t =
   match t with
   | Nullary
       ( Invalid _ | Optimised_out _ | Probe_is_enabled _ | Begin_region
-      | Begin_try_region | Enter_inlined_apply _ ) ->
+      | Begin_try_region | Enter_inlined_apply _ | Dls_get ) ->
     Ids_for_export.empty
   | Unary (prim, x0) ->
     Ids_for_export.union

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -325,6 +325,7 @@ type nullary_primitive =
   | Enter_inlined_apply of { dbg : Inlined_debuginfo.t }
       (** Used in classic mode to denote the start of an inlined function body.
           This is then used in to_cmm to correctly add inlined debuginfo. *)
+  | Dls_get  (** Obtain the domain-local state block. *)
 
 (** Untagged binary integer arithmetic operations.
 

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -664,6 +664,7 @@ let nullary_primitive _env res dbg prim =
       "The primitive [Enter_inlined_apply] should not be translated by \
        [to_cmm_primitive] but should instead be handled in [to_cmm_expr] to \
        correctly adjust the inlined debuginfo in the env."
+  | Dls_get -> None, res, C.dls_get ~dbg
 
 let unary_primitive env res dbg f arg =
   match (f : P.unary_primitive) with

--- a/ocaml/asmcomp/amd64/emit.mlp
+++ b/ocaml/asmcomp/amd64/emit.mlp
@@ -932,7 +932,7 @@ let emit_instr env fallthrough i =
     I.movzx (res8 i 0) (res i 0)
   | Lop (Idls_get) ->
     if Config.runtime5
-    then  I.mov (domain_field Domainstate.Domain_dls_root) (res i 0)
+    then I.mov (domain_field Domainstate.Domain_dls_root) (res i 0)
     else Misc.fatal_error "Idls_get not implemented in runtime4."
   | Lreloadretaddr ->
       ()

--- a/ocaml/middle_end/semantics_of_primitives.ml
+++ b/ocaml/middle_end/semantics_of_primitives.ml
@@ -160,7 +160,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Pget_header _ -> No_effects, No_coeffects
   | Pdls_get ->
       (* only read *)
-      No_effects, No_coeffects
+      No_effects, Has_coeffects
 
 type return_type =
   | Float

--- a/ocaml/runtime4/domain.c
+++ b/ocaml/runtime4/domain.c
@@ -197,3 +197,13 @@ CAMLprim value caml_domain_spawn(void)
 {
   caml_failwith("Domains not supported on runtime4");
 }
+
+CAMLprim value caml_ml_domain_id(void)
+{
+  caml_failwith("Domains not supported on runtime4");
+}
+
+CAMLprim value caml_domain_dls_set(void)
+{
+  caml_failwith("Domains not supported on runtime4");
+}

--- a/ocaml/runtime4/domain.c
+++ b/ocaml/runtime4/domain.c
@@ -207,3 +207,8 @@ CAMLprim value caml_domain_dls_set(void)
 {
   caml_failwith("Domains not supported on runtime4");
 }
+
+CAMLprim value caml_domain_dls_get(void)
+{
+  caml_failwith("Domains not supported on runtime4");
+}

--- a/ocaml/runtime4/domain.c
+++ b/ocaml/runtime4/domain.c
@@ -175,3 +175,25 @@ CAMLprim value caml_ml_condition_broadcast(value wrapper)
 
   return (*caml_hook_condition_broadcast)(wrapper);
 }
+
+/* Dummy implementations to enable [Stdlib.Domain] to link. */
+
+CAMLprim value caml_recommended_domain_count(void)
+{
+  caml_failwith("Domains not supported on runtime4");
+}
+
+CAMLprim value caml_ml_domain_cpu_relax(void)
+{
+  caml_failwith("Domains not supported on runtime4");
+}
+
+CAMLprim value caml_init_domain_self(void)
+{
+  caml_failwith("Domains not supported on runtime4");
+}
+
+CAMLprim value caml_domain_spawn(void)
+{
+  caml_failwith("Domains not supported on runtime4");
+}

--- a/ocaml/stdlib/domain.ml
+++ b/ocaml/stdlib/domain.ml
@@ -21,302 +21,374 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
-(* CR ocaml 5 domains: domain-local-storage assumes single-domain,
-   i.e. calling split will never be necessary.
-   For multi-domain support we'll need the upstream 5.x implementation.
-*)
+module Runtime_4 = struct
+  module DLS = struct
 
-module DLS = struct
+    let unique_value = Obj.repr (ref 0)
+    let state = ref (Array.make 8 unique_value)
 
-  let unique_value = Obj.repr (ref 0)
-  let state = ref (Array.make 8 unique_value)
+    type 'a key = int * (unit -> 'a)
 
-  type 'a key = int * (unit -> 'a)
+    let key_counter = ref 0
 
-  let key_counter = ref 0
+    let new_key ?split_from_parent:_ init_orphan =
+      let idx = !key_counter in
+      key_counter := idx + 1;
+      (idx, init_orphan)
 
-  let new_key ?split_from_parent:_ init_orphan =
-    let idx = !key_counter in
-    key_counter := idx + 1;
-    (idx, init_orphan)
+    (* If necessary, grow the current domain's local state array such that [idx]
+    * is a valid index in the array. *)
+    let maybe_grow idx =
+      let st = !state in
+      let sz = Array.length st in
+      if idx < sz then st
+      else begin
+        let rec compute_new_size s =
+          if idx < s then s else compute_new_size (2 * s)
+        in
+        let new_sz = compute_new_size sz in
+        let new_st = Array.make new_sz unique_value in
+        Array.blit st 0 new_st 0 sz;
+        state := new_st;
+        new_st
+      end
 
-  (* If necessary, grow the current domain's local state array such that [idx]
-   * is a valid index in the array. *)
-  let maybe_grow idx =
-    let st = !state in
-    let sz = Array.length st in
-    if idx < sz then st
-    else begin
-      let rec compute_new_size s =
-        if idx < s then s else compute_new_size (2 * s)
-      in
-      let new_sz = compute_new_size sz in
-      let new_st = Array.make new_sz unique_value in
-      Array.blit st 0 new_st 0 sz;
-      state := new_st;
-      new_st
-    end
+    let set (idx, _init) x =
+      let st = maybe_grow idx in
+      (* [Sys.opaque_identity] ensures that flambda does not look at the type of
+      * [x], which may be a [float] and conclude that the [st] is a float array.
+      * We do not want OCaml's float array optimisation kicking in here. *)
+      st.(idx) <- Obj.repr (Sys.opaque_identity x)
 
-  let set (idx, _init) x =
-    let st = maybe_grow idx in
-    (* [Sys.opaque_identity] ensures that flambda does not look at the type of
-     * [x], which may be a [float] and conclude that the [st] is a float array.
-     * We do not want OCaml's float array optimisation kicking in here. *)
-    st.(idx) <- Obj.repr (Sys.opaque_identity x)
-
-  let get (idx, init) =
-    let st = maybe_grow idx in
-    let v = st.(idx) in
-    if v == unique_value then
-      let v' = Obj.repr (init ()) in
-      st.(idx) <- (Sys.opaque_identity v');
-      Obj.magic v'
-    else Obj.magic v
-end
-
-(******** Callbacks **********)
-
-(* first spawn, domain startup and at exit functionality *)
-let first_domain_spawned = Atomic.make false
-
-let first_spawn_function = ref (fun () -> ())
-
-let before_first_spawn f =
-  if Atomic.get first_domain_spawned then
-    raise (Invalid_argument "first domain already spawned")
-  else begin
-    let old_f = !first_spawn_function in
-    let new_f () = old_f (); f () in
-    first_spawn_function := new_f
+    let get (idx, init) =
+      let st = maybe_grow idx in
+      let v = st.(idx) in
+      if v == unique_value then
+        let v' = Obj.repr (init ()) in
+        st.(idx) <- (Sys.opaque_identity v');
+        Obj.magic v'
+      else Obj.magic v
   end
 
-let at_exit_key = DLS.new_key (fun () -> (fun () -> ()))
+  (******** Callbacks **********)
 
-let at_exit f =
-  let old_exit : unit -> unit = DLS.get at_exit_key in
-  let new_exit () =
-    (* The domain termination callbacks ([at_exit]) are run in
-       last-in-first-out (LIFO) order in order to be symmetric with the domain
-       creation callbacks ([at_each_spawn]) which run in first-in-fisrt-out
-       (FIFO) order. *)
-    f (); old_exit ()
-  in
-  DLS.set at_exit_key new_exit
+  (* first spawn, domain startup and at exit functionality *)
+  let first_domain_spawned = Atomic.make false
 
-let do_at_exit () =
-  let f : unit -> unit = DLS.get at_exit_key in
-  f ()
+  let first_spawn_function = ref (fun () -> ())
+
+  let before_first_spawn f =
+    if Atomic.get first_domain_spawned then
+      raise (Invalid_argument "first domain already spawned")
+    else begin
+      let old_f = !first_spawn_function in
+      let new_f () = old_f (); f () in
+      first_spawn_function := new_f
+    end
+
+  let at_exit_key = DLS.new_key (fun () -> (fun () -> ()))
+
+  let at_exit f =
+    let old_exit : unit -> unit = DLS.get at_exit_key in
+    let new_exit () =
+      (* The domain termination callbacks ([at_exit]) are run in
+        last-in-first-out (LIFO) order in order to be symmetric with the domain
+        creation callbacks ([at_each_spawn]) which run in first-in-fisrt-out
+        (FIFO) order. *)
+      f (); old_exit ()
+    in
+    DLS.set at_exit_key new_exit
+
+  let do_at_exit () =
+    let f : unit -> unit = DLS.get at_exit_key in
+    f ()
+
+  (* Unimplemented functions *)
+  let not_implemented () =
+    failwith "Multi-domain functionality not supported in runtime4"
+  type !'a t
+  type id = int
+  let spawn _ = not_implemented ()
+  let join _ = not_implemented ()
+  let get_id _ = not_implemented ()
+  let self () = not_implemented ()
+  let cpu_relax () = not_implemented ()
+  let is_main_domain () = not_implemented ()
+  let recommended_domain_count () = not_implemented ()
+end
+
+module Runtime_5 = struct
+  module Raw = struct
+    (* Low-level primitives provided by the runtime *)
+    type t = private int
+    external spawn : (unit -> unit) -> Mutex.t -> t
+      = "caml_domain_spawn"
+    external self : unit -> t
+      = "caml_ml_domain_id"
+    external cpu_relax : unit -> unit
+      = "caml_ml_domain_cpu_relax"
+    external get_recommended_domain_count: unit -> int
+      = "caml_recommended_domain_count" [@@noalloc]
+  end
+
+  let cpu_relax () = Raw.cpu_relax ()
+
+  type id = Raw.t
+
+  type 'a state =
+  | Running
+  | Finished of ('a, exn) result
+
+  type 'a t = {
+    domain : Raw.t;
+    term_mutex: Mutex.t;
+    term_condition: Condition.t;
+    term_state: 'a state ref (* protected by [term_mutex] *)
+  }
+
+  module DLS = struct
+
+    type dls_state = Obj.t array
+
+    let unique_value = Obj.repr (ref 0)
+
+    external get_dls_state : unit -> dls_state = "%dls_get"
+
+    external set_dls_state : dls_state -> unit =
+      "caml_domain_dls_set" [@@noalloc]
+
+    let create_dls () =
+      let st = Array.make 8 unique_value in
+      set_dls_state st
+
+    let _ = create_dls ()
+
+    type 'a key = int * (unit -> 'a)
+
+    let key_counter = Atomic.make 0
+
+    type key_initializer =
+      KI: 'a key * ('a -> 'a) -> key_initializer
+
+    let parent_keys = Atomic.make ([] : key_initializer list)
+
+    let rec add_parent_key ki =
+      let l = Atomic.get parent_keys in
+      if not (Atomic.compare_and_set parent_keys l (ki :: l))
+      then add_parent_key ki
+
+    let new_key ?split_from_parent init_orphan =
+      let idx = Atomic.fetch_and_add key_counter 1 in
+      let k = (idx, init_orphan) in
+      begin match split_from_parent with
+      | None -> ()
+      | Some split -> add_parent_key (KI(k, split))
+      end;
+      k
+
+    (* If necessary, grow the current domain's local state array such that [idx]
+    * is a valid index in the array. *)
+    let maybe_grow idx =
+      let st = get_dls_state () in
+      let sz = Array.length st in
+      if idx < sz then st
+      else begin
+        let rec compute_new_size s =
+          if idx < s then s else compute_new_size (2 * s)
+        in
+        let new_sz = compute_new_size sz in
+        let new_st = Array.make new_sz unique_value in
+        Array.blit st 0 new_st 0 sz;
+        set_dls_state new_st;
+        new_st
+      end
+
+    let set (idx, _init) x =
+      let st = maybe_grow idx in
+      (* [Sys.opaque_identity] ensures that flambda does not look at the type of
+      * [x], which may be a [float] and conclude that the [st] is a float array.
+      * We do not want OCaml's float array optimisation kicking in here. *)
+      st.(idx) <- Obj.repr (Sys.opaque_identity x)
+
+    let get (idx, init) =
+      let st = maybe_grow idx in
+      let v = st.(idx) in
+      if v == unique_value then
+        let v' = Obj.repr (init ()) in
+        st.(idx) <- (Sys.opaque_identity v');
+        Obj.magic v'
+      else Obj.magic v
+
+    let get_initial_keys () : (int * Obj.t) list =
+      List.map
+        (fun (KI ((idx, _) as k, split)) ->
+            (idx, Obj.repr (split (get k))))
+        (Atomic.get parent_keys)
+
+    let set_initial_keys (l: (int * Obj.t) list) =
+      List.iter
+        (fun (idx, v) ->
+          let st = maybe_grow idx in st.(idx) <- v)
+        l
+
+  end
+
+  (******** Identity **********)
+
+  let get_id { domain; _ } = domain
+
+  let self () = Raw.self ()
+
+  let is_main_domain () = (self () :> int) = 0
+
+  (******** Callbacks **********)
+
+  (* first spawn, domain startup and at exit functionality *)
+  let first_domain_spawned = Atomic.make false
+
+  let first_spawn_function = ref (fun () -> ())
+
+  let before_first_spawn f =
+    if Atomic.get first_domain_spawned then
+      raise (Invalid_argument "first domain already spawned")
+    else begin
+      let old_f = !first_spawn_function in
+      let new_f () = old_f (); f () in
+      first_spawn_function := new_f
+    end
+
+  let at_exit_key = DLS.new_key (fun () -> (fun () -> ()))
+
+  let at_exit f =
+    let old_exit : unit -> unit = DLS.get at_exit_key in
+    let new_exit () =
+      (* The domain termination callbacks ([at_exit]) are run in
+        last-in-first-out (LIFO) order in order to be symmetric with the domain
+        creation callbacks ([at_each_spawn]) which run in first-in-fisrt-out
+        (FIFO) order. *)
+      f (); old_exit ()
+    in
+    DLS.set at_exit_key new_exit
+
+  let do_at_exit () =
+    let f : unit -> unit = DLS.get at_exit_key in
+    f ()
+
+  (******* Creation and Termination ********)
+
+  let do_before_first_spawn () =
+    if not (Atomic.get first_domain_spawned) then begin
+      Atomic.set first_domain_spawned true;
+      !first_spawn_function();
+      (* Release the old function *)
+      first_spawn_function := (fun () -> ())
+    end
+
+  let spawn f =
+    do_before_first_spawn ();
+    let pk = DLS.get_initial_keys () in
+
+    (* The [term_mutex] and [term_condition] are used to
+      synchronize with the joining domains *)
+    let term_mutex = Mutex.create () in
+    let term_condition = Condition.create () in
+    let term_state = ref Running in
+
+    let body () =
+      let result =
+        match
+          DLS.create_dls ();
+          DLS.set_initial_keys pk;
+          let res = f () in
+          res
+        with
+        | x -> Ok x
+        | exception ex -> Error ex
+      in
+
+      let result' =
+        (* Run the [at_exit] callbacks when the domain computation either
+          terminates normally or exceptionally. *)
+        match do_at_exit () with
+        | () -> result
+        | exception ex ->
+            begin match result with
+            | Ok _ ->
+                (* If the domain computation terminated normally, but the
+                  [at_exit] callbacks raised an exception, then return the
+                  exception. *)
+                Error ex
+            | Error _ ->
+                (* If both the domain computation and the [at_exit] callbacks
+                  raised exceptions, then ignore the exception from the
+                  [at_exit] callbacks and return the original exception. *)
+                result
+            end
+      in
+
+      (* Synchronize with joining domains *)
+      Mutex.lock term_mutex;
+      match !term_state with
+      | Running ->
+          term_state := Finished result';
+          Condition.broadcast term_condition;
+      | Finished _ ->
+          failwith "internal error: Am I already finished?"
+      (* [term_mutex] is unlocked in the runtime after the cleanup functions on
+        the C side are finished. *)
+    in
+    { domain = Raw.spawn body term_mutex;
+      term_mutex;
+      term_condition;
+      term_state }
+
+  let join { term_mutex; term_condition; term_state; _ } =
+    Mutex.lock term_mutex;
+    let rec loop () =
+      match !term_state with
+      | Running ->
+          Condition.wait term_condition term_mutex;
+          loop ()
+      | Finished res ->
+          Mutex.unlock term_mutex;
+          res
+    in
+    match loop () with
+    | Ok x -> x
+    | Error ex -> raise ex
+
+  let recommended_domain_count = Raw.get_recommended_domain_count
+end
+
+module type S = sig
+  type !'a t
+  val spawn : (unit -> 'a) -> 'a t
+  val join : 'a t -> 'a
+  type id = private int
+  val get_id : 'a t -> id
+  val self : unit -> id
+  val cpu_relax : unit -> unit
+  val is_main_domain : unit -> bool
+  val recommended_domain_count : unit -> int
+  val before_first_spawn : (unit -> unit) -> unit
+  val at_exit : (unit -> unit) -> unit
+  val do_at_exit : unit -> unit
+
+  module DLS : sig
+    type 'a key
+    val new_key : ?split_from_parent:('a -> 'a) -> (unit -> 'a) -> 'a key
+    val get : 'a key -> 'a
+    val set : 'a key -> 'a -> unit
+  end
+end
+
+let runtime_4_impl = (module Runtime_4 : S)
+let runtime_5_impl = (module Runtime_5 : S)
+
+external runtime5 : unit -> bool = "%runtime5"
+
+let impl = if runtime5 () then runtime_5_impl else runtime_4_impl
+
+include (val impl : S)
 
 let _ = Stdlib.do_domain_local_at_exit := do_at_exit
-
-(* CR ocaml 5 domains: use this code
-
-module Raw = struct
-  (* Low-level primitives provided by the runtime *)
-  type t = private int
-  external spawn : (unit -> unit) -> Mutex.t -> t
-    = "caml_domain_spawn"
-  external self : unit -> t
-    = "caml_ml_domain_id"
-  external cpu_relax : unit -> unit
-    = "caml_ml_domain_cpu_relax"
-  external get_recommended_domain_count: unit -> int
-    = "caml_recommended_domain_count" [@@noalloc]
-end
-
-let cpu_relax () = Raw.cpu_relax ()
-
-type id = Raw.t
-
-type 'a state =
-| Running
-| Finished of ('a, exn) result
-
-type 'a t = {
-  domain : Raw.t;
-  term_mutex: Mutex.t;
-  term_condition: Condition.t;
-  term_state: 'a state ref (* protected by [term_mutex] *)
-}
-
-module DLS = struct
-
-  type dls_state = Obj.t array
-
-  let unique_value = Obj.repr (ref 0)
-
-  external get_dls_state : unit -> dls_state = "%dls_get"
-
-  external set_dls_state : dls_state -> unit =
-    "caml_domain_dls_set" [@@noalloc]
-
-  let create_dls () =
-    let st = Array.make 8 unique_value in
-    set_dls_state st
-
-  let _ = create_dls ()
-
-  type 'a key = int * (unit -> 'a)
-
-  let key_counter = Atomic.make 0
-
-  type key_initializer =
-    KI: 'a key * ('a -> 'a) -> key_initializer
-
-  let parent_keys = Atomic.make ([] : key_initializer list)
-
-  let rec add_parent_key ki =
-    let l = Atomic.get parent_keys in
-    if not (Atomic.compare_and_set parent_keys l (ki :: l))
-    then add_parent_key ki
-
-  let new_key ?split_from_parent init_orphan =
-    let idx = Atomic.fetch_and_add key_counter 1 in
-    let k = (idx, init_orphan) in
-    begin match split_from_parent with
-    | None -> ()
-    | Some split -> add_parent_key (KI(k, split))
-    end;
-    k
-
-  (* If necessary, grow the current domain's local state array such that [idx]
-   * is a valid index in the array. *)
-  let maybe_grow idx =
-    let st = get_dls_state () in
-    let sz = Array.length st in
-    if idx < sz then st
-    else begin
-      let rec compute_new_size s =
-        if idx < s then s else compute_new_size (2 * s)
-      in
-      let new_sz = compute_new_size sz in
-      let new_st = Array.make new_sz unique_value in
-      Array.blit st 0 new_st 0 sz;
-      set_dls_state new_st;
-      new_st
-    end
-
-  let set (idx, _init) x =
-    let st = maybe_grow idx in
-    (* [Sys.opaque_identity] ensures that flambda does not look at the type of
-     * [x], which may be a [float] and conclude that the [st] is a float array.
-     * We do not want OCaml's float array optimisation kicking in here. *)
-    st.(idx) <- Obj.repr (Sys.opaque_identity x)
-
-  let get (idx, init) =
-    let st = maybe_grow idx in
-    let v = st.(idx) in
-    if v == unique_value then
-      let v' = Obj.repr (init ()) in
-      st.(idx) <- (Sys.opaque_identity v');
-      Obj.magic v'
-    else Obj.magic v
-
-  let get_initial_keys () : (int * Obj.t) list =
-    List.map
-      (fun (KI ((idx, _) as k, split)) ->
-           (idx, Obj.repr (split (get k))))
-      (Atomic.get parent_keys)
-
-  let set_initial_keys (l: (int * Obj.t) list) =
-    List.iter
-      (fun (idx, v) ->
-        let st = maybe_grow idx in st.(idx) <- v)
-      l
-
-end
-
-(******** Identity **********)
-
-let get_id { domain; _ } = domain
-
-let self () = Raw.self ()
-
-let is_main_domain () = (self () :> int) = 0
-
-(******* Creation and Termination ********)
-
-let do_before_first_spawn () =
-  if not (Atomic.get first_domain_spawned) then begin
-    Atomic.set first_domain_spawned true;
-    !first_spawn_function();
-    (* Release the old function *)
-    first_spawn_function := (fun () -> ())
-  end
-
-let spawn f =
-  do_before_first_spawn ();
-  let pk = DLS.get_initial_keys () in
-
-  (* The [term_mutex] and [term_condition] are used to
-     synchronize with the joining domains *)
-  let term_mutex = Mutex.create () in
-  let term_condition = Condition.create () in
-  let term_state = ref Running in
-
-  let body () =
-    let result =
-      match
-        DLS.create_dls ();
-        DLS.set_initial_keys pk;
-        let res = f () in
-        res
-      with
-      | x -> Ok x
-      | exception ex -> Error ex
-    in
-
-    let result' =
-      (* Run the [at_exit] callbacks when the domain computation either
-         terminates normally or exceptionally. *)
-      match do_at_exit () with
-      | () -> result
-      | exception ex ->
-          begin match result with
-          | Ok _ ->
-              (* If the domain computation terminated normally, but the
-                 [at_exit] callbacks raised an exception, then return the
-                 exception. *)
-              Error ex
-          | Error _ ->
-              (* If both the domain computation and the [at_exit] callbacks
-                 raised exceptions, then ignore the exception from the
-                 [at_exit] callbacks and return the original exception. *)
-              result
-          end
-    in
-
-    (* Synchronize with joining domains *)
-    Mutex.lock term_mutex;
-    match !term_state with
-    | Running ->
-        term_state := Finished result';
-        Condition.broadcast term_condition;
-    | Finished _ ->
-        failwith "internal error: Am I already finished?"
-    (* [term_mutex] is unlocked in the runtime after the cleanup functions on
-       the C side are finished. *)
-  in
-  { domain = Raw.spawn body term_mutex;
-    term_mutex;
-    term_condition;
-    term_state }
-
-let join { term_mutex; term_condition; term_state; _ } =
-  Mutex.lock term_mutex;
-  let rec loop () =
-    match !term_state with
-    | Running ->
-        Condition.wait term_condition term_mutex;
-        loop ()
-    | Finished res ->
-        Mutex.unlock term_mutex;
-        res
-  in
-  match loop () with
-  | Ok x -> x
-  | Error ex -> raise ex
-
-let recommended_domain_count = Raw.get_recommended_domain_count
-
-*)

--- a/ocaml/stdlib/domain.mli
+++ b/ocaml/stdlib/domain.mli
@@ -17,8 +17,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* CR ocaml 5 domains: domains not supported on 4.x
-
 [@@@alert unstable
     "The Domain interface may change in incompatible ways in the future."
 ]
@@ -66,7 +64,6 @@ val recommended_domain_count : unit -> int
     simultaneously (including domains already running).
 
     The value returned is at least [1]. *)
-*)
 
 val before_first_spawn : (unit -> unit) -> unit
 (** [before_first_spawn f] registers [f] to be called before the first domain


### PR DESCRIPTION
This enables the `Domain` module fully on runtime5.  One consequence of this is that the domain-local state (`Domain.DLS` ) module changes under runtime5 to the upstream runtime5 implementation, rather than what we are using for runtime4.

Not yet ready for review, will mark as draft for now.  (The diff must be viewed in a whitespace-insensitive mode, though.)

Based on #2205 to avoid conflicts