### PR TITLE
Fix typo in `check_const_conservative`

### DIFF
--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -156,7 +156,7 @@ module type S = sig
           needed for precise bounds. As a result, it is inexpensive and returns
           a conservative result. I.e., it might return [None] for
           fully-constrained modes. *)
-      val check_const_conservative : (l * 'r) t -> Const.t option
+      val check_const_conservative : ('l * 'r) t -> Const.t option
     end
   end
 


### PR DESCRIPTION
This fixes a typo in the mode system interface that make it unusable. 

@goldfirere 