### PR TITLE
Improve SIMD constant error messages

### DIFF
--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -200,6 +200,8 @@ let rec const_int_args n args name =
   match n, args with
   | 0, [] -> []
   | n, Cconst_int (i, _) :: args -> i :: const_int_args (n - 1) args name
+  | n, Cconst_natint (i, _) :: args ->
+    Nativeint.to_int i :: const_int_args (n - 1) args name
   | _ -> Misc.fatal_errorf "Invalid int constant arguments for %s" name
 
 (* Assumes unboxed int64: no tag, comes as Cconst_int when representable by

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -17,6 +17,13 @@ open Cmm
 open Cmm_helpers
 open Arch
 
+type error = Bad_immediate of string
+
+exception Error of error
+
+let bad_immediate fmt =
+  Format.kasprintf (fun msg -> raise (Error (Bad_immediate msg))) fmt
+
 let four_args name args =
   match args with
   | [arg1; arg2; arg3; arg4] -> arg1, arg2, arg3, arg4
@@ -193,16 +200,14 @@ let rec const_float_args n args name =
   match n, args with
   | 0, [] -> []
   | n, Cconst_float (f, _) :: args -> f :: const_float_args (n - 1) args name
-  | _ -> Misc.fatal_errorf "Invalid float constant arguments for %s" name
+  | _ -> bad_immediate "Did not find constant float arguments for %s" name
 
 (* Assumes untagged int or unboxed int32, always representable by int63 *)
 let rec const_int_args n args name =
   match n, args with
   | 0, [] -> []
   | n, Cconst_int (i, _) :: args -> i :: const_int_args (n - 1) args name
-  | n, Cconst_natint (i, _) :: args ->
-    Nativeint.to_int i :: const_int_args (n - 1) args name
-  | _ -> Misc.fatal_errorf "Invalid int constant arguments for %s" name
+  | _ -> bad_immediate "Did not find constant int arguments for %s" name
 
 (* Assumes unboxed int64: no tag, comes as Cconst_int when representable by
    int63, otherwise we get Cconst_natint *)
@@ -213,23 +218,23 @@ let rec const_int64_args n args name =
     Int64.of_int i :: const_int64_args (n - 1) args name
   | n, Cconst_natint (i, _) :: args ->
     Int64.of_nativeint i :: const_int64_args (n - 1) args name
-  | _ -> Misc.fatal_errorf "Invalid int64 constant arguments for %s" name
+  | _ -> bad_immediate "Did not find constant int64 arguments for %s" name
 
 let int64_of_int8 i =
   (* CR mslater: (SIMD) replace once we have unboxed int8 *)
   if i < 0 || i > 0xff
-  then Misc.fatal_errorf "Int8 constant must be in [0x0,0xff]: %016x" i;
+  then bad_immediate "Int8 constant not in range [0x0,0xff]: %016x" i;
   Int64.of_int i
 
 let int64_of_int16 i =
   (* CR mslater: (SIMD) replace once we have unboxed int16 *)
   if i < 0 || i > 0xffff
-  then Misc.fatal_errorf "Int16 constant must be in [0x0,0xffff]: %016x" i;
+  then bad_immediate "Int16 constant not in range [0x0,0xffff]: %016x" i;
   Int64.of_int i
 
 let int64_of_int32 i =
   if i < Int32.to_int Int32.min_int || i > Int32.to_int Int32.max_int
-  then Misc.fatal_errorf "Constant was not an int32: %016x" i;
+  then bad_immediate "Int32 constant not in range [0x0,0xffffffff]: %016x" i;
   Int64.of_int i |> Int64.logand 0xffffffffL
 
 let int64_of_float32 f =
@@ -751,3 +756,11 @@ let extcall ~dbg ~returns ~alloc ~is_c_builtin ~effects ~coeffects ~ty_args name
     | Some op -> op
     | None -> default
   else default
+
+let report_error ppf = function
+  | Bad_immediate msg -> Format.pp_print_string ppf msg
+
+let () =
+  Location.register_error_of_exn (function
+    | Error err -> Some (Location.error_of_printer_file report_error err)
+    | _ -> None)

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -223,18 +223,18 @@ let rec const_int64_args n args name =
 let int64_of_int8 i =
   (* CR mslater: (SIMD) replace once we have unboxed int8 *)
   if i < 0 || i > 0xff
-  then bad_immediate "Int8 constant not in range [0x0,0xff]: %016x" i;
+  then bad_immediate "Int8 constant not in range [0x0,0xff]: 0x%016x" i;
   Int64.of_int i
 
 let int64_of_int16 i =
   (* CR mslater: (SIMD) replace once we have unboxed int16 *)
   if i < 0 || i > 0xffff
-  then bad_immediate "Int16 constant not in range [0x0,0xffff]: %016x" i;
+  then bad_immediate "Int16 constant not in range [0x0,0xffff]: 0x%016x" i;
   Int64.of_int i
 
 let int64_of_int32 i =
   if i < Int32.to_int Int32.min_int || i > Int32.to_int Int32.max_int
-  then bad_immediate "Int32 constant not in range [0x0,0xffffffff]: %016x" i;
+  then bad_immediate "Int32 constant not in range [0x0,0xffffffff]: 0x%016x" i;
   Int64.of_int i |> Int64.logand 0xffffffffL
 
 let int64_of_float32 f =

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -50,8 +50,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (and (= %{context_name} "main")
-       (= %{architecture} amd64)))
+  (and
+   (= %{context_name} "main")
+   (= %{architecture} amd64)))
  (action
   (progn
    (diff empty.expected basic.out)

--- a/tests/simd/errors/dune
+++ b/tests/simd/errors/dune
@@ -1,0 +1,339 @@
+; Error message tests
+
+(rule
+ (alias runtest)
+ (enabled_if
+  (= %{context_name} "main"))
+ (deps f32c1.expected f32c1.corrected)
+ (action
+  (progn
+   (diff f32c1.expected f32c1.corrected)
+   (diff f32c4.expected f32c4.corrected)
+   (diff f64c1.expected f64c1.corrected)
+   (diff f64c2.expected f64c2.corrected)
+   (diff i8c1.expected i8c1.corrected)
+   (diff i8c16.expected i8c16.corrected)
+   (diff i8_range.expected i8_range.corrected)
+   (diff i16c1.expected i16c1.corrected)
+   (diff i16c8.expected i16c8.corrected)
+   (diff i16_range.expected i16_range.corrected)
+   (diff i32c1.expected i32c1.corrected)
+   (diff i32c4.expected i32c4.corrected)
+   (diff i32_range.expected i32_range.corrected)
+   (diff i64c1.expected i64c1.corrected)
+   (diff i64c2.expected i64c2.corrected))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets f32c1.corrected)
+ (deps
+  (:ml f32c1.ml))
+ (action
+  (with-outputs-to
+   f32c1.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets f32c4.corrected)
+ (deps
+  (:ml f32c4.ml))
+ (action
+  (with-outputs-to
+   f32c4.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i32c1.corrected)
+ (deps
+  (:ml i32c1.ml))
+ (action
+  (with-outputs-to
+   i32c1.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i32c4.corrected)
+ (deps
+  (:ml i32c4.ml))
+ (action
+  (with-outputs-to
+   i32c4.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i32_range.corrected)
+ (deps
+  (:ml i32_range.ml))
+ (action
+  (with-outputs-to
+   i32_range.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets f64c1.corrected)
+ (deps
+  (:ml f64c1.ml))
+ (action
+  (with-outputs-to
+   f64c1.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets f64c2.corrected)
+ (deps
+  (:ml f64c2.ml))
+ (action
+  (with-outputs-to
+   f64c2.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i16c1.corrected)
+ (deps
+  (:ml i16c1.ml))
+ (action
+  (with-outputs-to
+   i16c1.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i16c8.corrected)
+ (deps
+  (:ml i16c8.ml))
+ (action
+  (with-outputs-to
+   i16c8.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i16_range.corrected)
+ (deps
+  (:ml i16_range.ml))
+ (action
+  (with-outputs-to
+   i16_range.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i8c1.corrected)
+ (deps
+  (:ml i8c1.ml))
+ (action
+  (with-outputs-to
+   i8c1.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i8c16.corrected)
+ (deps
+  (:ml i8c16.ml))
+ (action
+  (with-outputs-to
+   i8c16.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i8_range.corrected)
+ (deps
+  (:ml i8_range.ml))
+ (action
+  (with-outputs-to
+   i8_range.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i64c1.corrected)
+ (deps
+  (:ml i64c1.ml))
+ (action
+  (with-outputs-to
+   i64c1.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))
+
+(rule
+ (enabled_if
+  (= %{context_name} "main"))
+ (targets i64c2.corrected)
+ (deps
+  (:ml i64c2.ml))
+ (action
+  (with-outputs-to
+   i64c2.corrected
+   (with-accepted-exit-codes
+    2
+    (run
+     %{bin:ocamlopt.opt}
+     %{ml}
+     -extension
+     simd
+     -color
+     never
+     -error-style
+     short)))))

--- a/tests/simd/errors/f32c1.expected
+++ b/tests/simd/errors/f32c1.expected
@@ -1,0 +1,2 @@
+File "f32c1.ml", line 1:
+Error: Did not find constant float arguments for caml_float32x4_const1

--- a/tests/simd/errors/f32c1.ml
+++ b/tests/simd/errors/f32c1.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = float32x4
+
+external const1 : float -> t = "" "caml_float32x4_const1"
+        [@@noalloc] [@@unboxed] [@@builtin]
+
+let _ = const1 (Sys.opaque_identity 1.0)

--- a/tests/simd/errors/f32c4.expected
+++ b/tests/simd/errors/f32c4.expected
@@ -1,0 +1,2 @@
+File "f32c4.ml", line 1:
+Error: Did not find constant float arguments for caml_float32x4_const4

--- a/tests/simd/errors/f32c4.ml
+++ b/tests/simd/errors/f32c4.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = float32x4
+
+external const4 : float -> float -> float -> float -> t = "" "caml_float32x4_const4"
+        [@@noalloc] [@@unboxed] [@@builtin]
+
+let _ = const4 0.0 0.0 (Sys.opaque_identity 1.0) 0.0

--- a/tests/simd/errors/f64c1.expected
+++ b/tests/simd/errors/f64c1.expected
@@ -1,0 +1,2 @@
+File "f64c1.ml", line 1:
+Error: Did not find constant float arguments for caml_float64x2_const1

--- a/tests/simd/errors/f64c1.ml
+++ b/tests/simd/errors/f64c1.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = float64x2
+
+external const1 : float -> t = "" "caml_float64x2_const1"
+        [@@noalloc] [@@unboxed] [@@builtin]
+
+let _ = const1 (Sys.opaque_identity 1.0)

--- a/tests/simd/errors/f64c2.expected
+++ b/tests/simd/errors/f64c2.expected
@@ -1,0 +1,2 @@
+File "f64c2.ml", line 1:
+Error: Did not find constant float arguments for caml_float64x2_const2

--- a/tests/simd/errors/f64c2.ml
+++ b/tests/simd/errors/f64c2.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = float64x2
+
+external const2 : float -> float -> t = "" "caml_float64x2_const2"
+        [@@noalloc] [@@unboxed] [@@builtin]
+
+let _ = const2 0.0 (Sys.opaque_identity 1.0)

--- a/tests/simd/errors/i16_range.expected
+++ b/tests/simd/errors/i16_range.expected
@@ -1,0 +1,2 @@
+File "i16_range.ml", line 1:
+Error: Int16 constant not in range [0x0,0xffff]: 0x0000000000010000

--- a/tests/simd/errors/i16_range.ml
+++ b/tests/simd/errors/i16_range.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int16x8
+
+external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int16x8_const1"
+        [@@noalloc] [@@builtin]
+
+let _ = const1 0x10000

--- a/tests/simd/errors/i16c1.expected
+++ b/tests/simd/errors/i16c1.expected
@@ -1,0 +1,2 @@
+File "i16c1.ml", line 1:
+Error: Did not find constant int arguments for caml_int16x8_const1

--- a/tests/simd/errors/i16c1.ml
+++ b/tests/simd/errors/i16c1.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int16x8
+
+external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int16x8_const1"
+        [@@noalloc] [@@builtin]
+
+let _ = const1 (Sys.opaque_identity 1)

--- a/tests/simd/errors/i16c8.expected
+++ b/tests/simd/errors/i16c8.expected
@@ -1,0 +1,2 @@
+File "i16c8.ml", line 1:
+Error: Did not find constant int arguments for caml_int16x8_const8

--- a/tests/simd/errors/i16c8.ml
+++ b/tests/simd/errors/i16c8.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int16x8
+
+external const8 : (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (t[@unboxed]) = "" "caml_int16x8_const8"
+        [@@noalloc] [@@builtin]
+
+let _ = const8 0 0 0 0 0 0 0 (Sys.opaque_identity 1)

--- a/tests/simd/errors/i32_range.expected
+++ b/tests/simd/errors/i32_range.expected
@@ -1,0 +1,2 @@
+File "i32_range.ml", line 1:
+Error: Int32 constant not in range [0x0,0xffffffff]: 0x0000000100000000

--- a/tests/simd/errors/i32_range.ml
+++ b/tests/simd/errors/i32_range.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int32x4
+
+external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int32x4_const1"
+        [@@noalloc] [@@builtin]
+
+let _ = const1 0x100000000

--- a/tests/simd/errors/i32c1.expected
+++ b/tests/simd/errors/i32c1.expected
@@ -1,0 +1,2 @@
+File "i32c1.ml", line 1:
+Error: Did not find constant int arguments for caml_int32x4_const1

--- a/tests/simd/errors/i32c1.ml
+++ b/tests/simd/errors/i32c1.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int32x4
+
+external const1 : int32 -> t = "" "caml_int32x4_const1"
+        [@@noalloc] [@@unboxed] [@@builtin]
+
+let _ = const1 (Sys.opaque_identity 1l)

--- a/tests/simd/errors/i32c4.expected
+++ b/tests/simd/errors/i32c4.expected
@@ -1,0 +1,2 @@
+File "i32c4.ml", line 1:
+Error: Did not find constant int arguments for caml_int32x4_const4

--- a/tests/simd/errors/i32c4.ml
+++ b/tests/simd/errors/i32c4.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int32x4
+
+external const4 : int32 -> int32 -> int32 -> int32 -> t = "" "caml_int32x4_const4"
+        [@@noalloc] [@@unboxed] [@@builtin]
+
+let _ = const4 0l 0l (Sys.opaque_identity 1l) 0l

--- a/tests/simd/errors/i64c1.expected
+++ b/tests/simd/errors/i64c1.expected
@@ -1,0 +1,2 @@
+File "i64c1.ml", line 1:
+Error: Did not find constant int64 arguments for caml_int64x2_const1

--- a/tests/simd/errors/i64c1.ml
+++ b/tests/simd/errors/i64c1.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int64x2
+
+external const1 : int64 -> t = "" "caml_int64x2_const1"
+        [@@noalloc] [@@unboxed] [@@builtin]
+
+let _ = const1 (Sys.opaque_identity 1L)

--- a/tests/simd/errors/i64c2.expected
+++ b/tests/simd/errors/i64c2.expected
@@ -1,0 +1,2 @@
+File "i64c2.ml", line 1:
+Error: Did not find constant int64 arguments for caml_int64x2_const2

--- a/tests/simd/errors/i64c2.ml
+++ b/tests/simd/errors/i64c2.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int64x2
+
+external const2 : int64 -> int64 -> t = "" "caml_int64x2_const2"
+        [@@noalloc] [@@unboxed] [@@builtin]
+
+let _ = const2 0L (Sys.opaque_identity 1L)

--- a/tests/simd/errors/i8_range.expected
+++ b/tests/simd/errors/i8_range.expected
@@ -1,0 +1,2 @@
+File "i8_range.ml", line 1:
+Error: Int8 constant not in range [0x0,0xff]: 0x0000000000000100

--- a/tests/simd/errors/i8_range.ml
+++ b/tests/simd/errors/i8_range.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int8x16
+
+external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int8x16_const1"
+        [@@noalloc] [@@builtin]
+
+let _ = const1 0x100

--- a/tests/simd/errors/i8c1.expected
+++ b/tests/simd/errors/i8c1.expected
@@ -1,0 +1,2 @@
+File "i8c1.ml", line 1:
+Error: Did not find constant int arguments for caml_int8x16_const1

--- a/tests/simd/errors/i8c1.ml
+++ b/tests/simd/errors/i8c1.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int8x16
+
+external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int8x16_const1"
+        [@@noalloc] [@@builtin]
+
+let _ = const1 (Sys.opaque_identity 1)

--- a/tests/simd/errors/i8c16.expected
+++ b/tests/simd/errors/i8c16.expected
@@ -1,0 +1,2 @@
+File "i8c16.ml", line 1:
+Error: Did not find constant int arguments for caml_int8x16_const16

--- a/tests/simd/errors/i8c16.ml
+++ b/tests/simd/errors/i8c16.ml
@@ -1,0 +1,8 @@
+open Stdlib
+
+type t = int8x16
+
+external const16 : (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (int[@untagged]) -> (t[@unboxed]) = "" "caml_int8x16_const16"
+        [@@noalloc] [@@builtin]
+
+let _ = const16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 (Sys.opaque_identity 1)


### PR DESCRIPTION
Passing a non-constant argument to any of the SIMD constant constructor externals now raises a proper error instead of `Misc.fatal_errorf`.

