### PR TITLE
`[@zero_alloc]` in signatures (part 2 of 3)

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -272,12 +272,8 @@ end = struct
 
   let get_loc t = t.loc
 
-  let expected_value t =
-    let res = if t.strict then Value.safe else Value.relaxed Witnesses.empty in
-    let res =
-      if t.never_returns_normally then { res with nor = V.Bot } else res
-    in
-    res
+  let expected_value { strict; never_returns_normally; _ } =
+    Value.of_annotation ~strict ~never_returns_normally
 
   let valid t v =
     (* Use Value.lessequal but ignore witnesses. *)

--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -393,6 +393,16 @@ let mk_value_binding ~vb_pat ~vb_expr ~vb_attributes =
     vb_sort = Jkind.Sort.value;
   }
 
+let mk_value_description ~val_type ~val_kind ~val_attributes =
+  {
+    val_type;
+    val_kind;
+    val_loc = Location.none;
+    val_attributes;
+    val_uid = Uid.internal_not_actually_unique;
+    val_zero_alloc = Default_check;
+  }
+
 let mkTtyp_any = Ttyp_var (None, None)
 let mkTtyp_var s = Ttyp_var (Some s, None)
 

--- a/chamelon/compat.mli
+++ b/chamelon/compat.mli
@@ -170,5 +170,11 @@ val mk_value_binding :
   vb_attributes:attributes ->
   value_binding
 
+val mk_value_description :
+  val_type:type_expr ->
+  val_kind:value_kind ->
+  val_attributes:attributes ->
+  value_description
+
 val print_path : Path.t -> string
 val replace_id_in_path : Path.t -> Ident.t -> Path.t

--- a/chamelon/compat.upstream.ml
+++ b/chamelon/compat.upstream.ml
@@ -252,6 +252,15 @@ let mk_constructor_description cstr_name =
 let mk_value_binding ~vb_pat ~vb_expr ~vb_attributes =
   { vb_pat; vb_expr; vb_attributes; vb_loc = Location.none }
 
+let mk_value_description ~val_type ~val_kind ~val_attributes =
+  {
+    val_type;
+    val_kind;
+    val_loc = Location.none;
+    val_attributes;
+    val_uid = Uid.internal_not_actually_unique;
+  }
+
 let mkTtyp_any = Ttyp_any
 let mkTtyp_var s = Ttyp_var s
 

--- a/chamelon/minimizer/dummy.ml
+++ b/chamelon/minimizer/dummy.ml
@@ -70,13 +70,8 @@ let dummy_core_typet : Parsetree.core_type =
   }
 
 let dummy_value_description =
-  {
-    val_type = dummy_type_expr;
-    val_kind = Val_reg;
-    val_loc = Location.none;
-    val_attributes = [];
-    val_uid = Uid.internal_not_actually_unique;
-  }
+  mk_value_description ~val_type:dummy_type_expr ~val_kind:Val_reg
+    ~val_attributes:[]
 
 let exp_desc_to_exp ed =
   {

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -54,14 +54,14 @@ let from_lambda : Lambda.check_attribute -> Location.t -> t =
     then Check { property = Zero_alloc; strict = false; loc }
     else Default_check
   | Ignore_assert_all Zero_alloc -> Default_check
-  | Assume { property; strict; never_returns_normally; loc } ->
+  | Assume { property; strict; never_returns_normally; loc; arity = _ } ->
     Assume
       { property = Property.from_lambda property;
         strict;
         never_returns_normally;
         loc
       }
-  | Check { property; strict; opt; loc } ->
+  | Check { property; strict; opt; loc; arity = _ } ->
     if Builtin_attributes.is_check_enabled ~opt property
     then Check { property = Property.from_lambda property; strict; loc }
     else Default_check

--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -344,6 +344,7 @@ let name_expression ~loc ~attrs sort exp =
       val_kind = Val_reg;
       val_loc = loc;
       val_attributes = attrs;
+      val_zero_alloc = Default_check;
       val_uid = Uid.internal_not_actually_unique; }
   in
   let sg = [Sig_value(id, vd, Exported)] in

--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -972,6 +972,7 @@ typing/includeclass.cmi : \
     typing/env.cmi \
     typing/ctype.cmi
 typing/includecore.cmo : \
+    utils/zero_alloc_utils.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/printtyp.cmi \
@@ -990,6 +991,7 @@ typing/includecore.cmo : \
     parsing/asttypes.cmi \
     typing/includecore.cmi
 typing/includecore.cmx : \
+    utils/zero_alloc_utils.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
     typing/printtyp.cmx \
@@ -1948,6 +1950,7 @@ typing/typedecl.cmi : \
     typing/ident.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
+    parsing/builtin_attributes.cmi \
     parsing/asttypes.cmi
 typing/typedecl_properties.cmo : \
     typing/types.cmi \
@@ -2254,6 +2257,7 @@ typing/types.cmo : \
     typing/jkind.cmi \
     typing/ident.cmi \
     utils/config.cmi \
+    parsing/builtin_attributes.cmi \
     parsing/asttypes.cmi \
     typing/types.cmi
 typing/types.cmx : \
@@ -2269,6 +2273,7 @@ typing/types.cmx : \
     typing/jkind.cmx \
     typing/ident.cmx \
     utils/config.cmx \
+    parsing/builtin_attributes.cmx \
     parsing/asttypes.cmi \
     typing/types.cmi
 typing/types.cmi : \
@@ -2281,6 +2286,7 @@ typing/types.cmi : \
     parsing/location.cmi \
     typing/jkind.cmi \
     typing/ident.cmi \
+    parsing/builtin_attributes.cmi \
     parsing/asttypes.cmi
 typing/typetexp.cmo : \
     typing/types.cmi \

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -639,12 +639,14 @@ type check_attribute = Builtin_attributes.check_attribute =
   | Check of { property: property;
                strict: bool;
                opt: bool;
+               arity: int;
                loc: Location.t;
              }
   | Assume of { property: property;
                 strict: bool;
-                loc: Location.t;
                 never_returns_normally: bool;
+                arity: int;
+                loc: Location.t;
               }
 
 type loop_attribute =

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -512,12 +512,14 @@ type check_attribute = Builtin_attributes.check_attribute =
                   exceptional returns or divering loops are ignored).
                   This definition may not be applicable to new properties. *)
                opt: bool;
+               arity: int;
                loc: Location.t;
              }
   | Assume of { property: property;
                 strict: bool;
-                loc: Location.t;
                 never_returns_normally: bool;
+                arity: int;
+                loc: Location.t;
               }
 
 type loop_attribute =

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -903,9 +903,12 @@ let parse_property_attribute ~is_arity_allowed ~default_arity attr property =
         ]
         payload
 
-let get_property_attribute ~is_arity_allowed ~default_arity l p =
+let get_property_attribute ~in_signature ~default_arity l p =
   let attr = find_attribute (is_property_attribute p) l in
-  let res = parse_property_attribute ~is_arity_allowed ~default_arity attr p in
+  let res =
+    parse_property_attribute ~is_arity_allowed:in_signature ~default_arity attr
+      p
+  in
   (match attr, res with
    | None, Default_check -> ()
    | _, Default_check -> ()
@@ -913,10 +916,10 @@ let get_property_attribute ~is_arity_allowed ~default_arity l p =
    | Some _, Ignore_assert_all _ -> ()
    | Some _, Assume _ -> ()
    | Some attr, Check { opt; _ } ->
-     if is_check_enabled ~opt p && !Clflags.native_code then
-       (* The warning for unchecked functions will not trigger if the check is requested
-          through the [@@@zero_alloc all] top-level annotation rather than through the
-          function annotation [@zero_alloc]. *)
+     if not in_signature && is_check_enabled ~opt p && !Clflags.native_code then
+       (* The warning for unchecked functions will not trigger if the check is
+          requested through the [@@@zero_alloc all] top-level annotation rather
+          than through the function annotation [@zero_alloc]. *)
        register_property attr.attr_name);
    res
 

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -251,17 +251,21 @@ type check_attribute =
                   exceptional returns or diverging loops are ignored).
                   This definition may not be applicable to new properties. *)
                opt: bool;
+               arity: int;
                loc: Location.t;
              }
   | Assume of { property: property;
                 strict: bool;
-                loc: Location.t;
                 never_returns_normally: bool;
+                arity: int;
+                loc: Location.t;
               }
 
 val is_check_enabled : opt:bool -> property -> bool
 
-val get_property_attribute : Parsetree.attributes -> property -> check_attribute
+val get_property_attribute :
+  is_arity_allowed:bool -> default_arity:int -> Parsetree.attributes ->
+  property -> check_attribute
 
 val assume_zero_alloc :
   is_check_allowed:bool -> check_attribute -> Zero_alloc_utils.Assume_info.t

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -263,8 +263,11 @@ type check_attribute =
 
 val is_check_enabled : opt:bool -> property -> bool
 
+(* Gets a zero_alloc attribute.  [~in_signature] controls both whether the
+   "arity n" field is allowed, and whether we track this attribute for
+   warning 199. *)
 val get_property_attribute :
-  is_arity_allowed:bool -> default_arity:int -> Parsetree.attributes ->
+  in_signature:bool -> default_arity:int -> Parsetree.attributes ->
   property -> check_attribute
 
 val assume_zero_alloc :

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -511,8 +511,8 @@ Error: Signature mismatch:
  *        The former provides a weaker "zero_alloc" guarantee than the latter.
  * |}] *)
 
-(**********************************************************)
-(* Test 4: requires function types, does not do expansion *)
+(*************************************************************************)
+(* Test 4: Requires valid arity, inferred or provided, without expansion *)
 
 module type S_non_func_int = sig
   val[@zero_alloc] x : int
@@ -524,7 +524,7 @@ Line 2, characters 2-26:
 Error: In signatures, zero_alloc is only supported on function declarations.
        Found no arrows in this declaration's type.
        Hint: You can write "[@zero_alloc arity n]" to specify the arity
-       of an alias.
+       of an alias (for n > 0).
 |}]
 
 module type S_non_func_alias = sig
@@ -538,7 +538,7 @@ Line 3, characters 2-24:
 Error: In signatures, zero_alloc is only supported on function declarations.
        Found no arrows in this declaration's type.
        Hint: You can write "[@zero_alloc arity n]" to specify the arity
-       of an alias.
+       of an alias (for n > 0).
 |}]
 
 module type S_func_alias = sig
@@ -553,7 +553,41 @@ Line 4, characters 2-24:
 Error: In signatures, zero_alloc is only supported on function declarations.
        Found no arrows in this declaration's type.
        Hint: You can write "[@zero_alloc arity n]" to specify the arity
-       of an alias.
+       of an alias (for n > 0).
+|}]
+
+module type S_func_alias = sig
+  type t = int -> int
+  val[@zero_alloc arity 0] x : t
+end
+[%%expect{|
+Line 3, characters 2-32:
+3 |   val[@zero_alloc arity 0] x : t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In signatures, zero_alloc is only supported on function declarations.
+       Found no arrows in this declaration's type.
+       Hint: You can write "[@zero_alloc arity n]" to specify the arity
+       of an alias (for n > 0).
+|}]
+
+module type S_arity_0 = sig
+  val[@zero_alloc arity 0] f : int -> int
+end
+[%%expect{|
+Line 2, characters 2-41:
+2 |   val[@zero_alloc arity 0] f : int -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid zero_alloc attribute: arity must be greater than 0.
+|}]
+
+module type S_arity_negative = sig
+  val[@zero_alloc arity (-1)] f : int -> int
+end
+[%%expect{|
+Line 2, characters 2-44:
+2 |   val[@zero_alloc arity (-1)] f : int -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid zero_alloc attribute: arity must be greater than 0.
 |}]
 
 (********************************************)
@@ -613,7 +647,7 @@ Line 2, characters 2-33:
 Error: In signatures, zero_alloc is only supported on function declarations.
        Found no arrows in this declaration's type.
        Hint: You can write "[@zero_alloc arity n]" to specify the arity
-       of an alias.
+       of an alias (for n > 0).
 |}]
 
 module type S_alias_explicit_arity_2 = sig

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -468,7 +468,8 @@ Line 2, characters 2-26:
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In signatures, zero_alloc is only supported on function declarations.
        Found no arrows in this declaration's type.
-       Hint: You can add "(arity n)" to specify the arity of an alias.
+       Hint: You can write "[@zero_alloc arity n]" to specify the arity
+       of an alias.
 |}]
 
 module type S4_2 = sig
@@ -481,7 +482,8 @@ Line 3, characters 2-24:
       ^^^^^^^^^^^^^^^^^^^^^^
 Error: In signatures, zero_alloc is only supported on function declarations.
        Found no arrows in this declaration's type.
-       Hint: You can add "(arity n)" to specify the arity of an alias.
+       Hint: You can write "[@zero_alloc arity n]" to specify the arity
+       of an alias.
 |}]
 
 module type S4_3 = sig
@@ -495,7 +497,8 @@ Line 4, characters 2-24:
       ^^^^^^^^^^^^^^^^^^^^^^
 Error: In signatures, zero_alloc is only supported on function declarations.
        Found no arrows in this declaration's type.
-       Hint: You can add "(arity n)" to specify the arity of an alias.
+       Hint: You can write "[@zero_alloc arity n]" to specify the arity
+       of an alias.
 |}]
 
 (********************************************)
@@ -531,11 +534,11 @@ Lines 17-19, characters 21-3:
 19 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : int -> int -> int [@@zero_alloc (arity 1)] end
+         sig val f : int -> int -> int [@@zero_alloc arity 1] end
        is not included in
          S5_1
        Values do not match:
-         val f : int -> int -> int [@@zero_alloc (arity 1)]
+         val f : int -> int -> int [@@zero_alloc arity 1]
        is not included in
          val f : int -> int -> int [@@zero_alloc]
        zero_alloc arity mismatch:
@@ -553,18 +556,19 @@ Line 2, characters 2-34:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In signatures, zero_alloc is only supported on function declarations.
        Found no arrows in this declaration's type.
-       Hint: You can add "(arity n)" to specify the arity of an alias.
+       Hint: You can write "[@zero_alloc arity n]" to specify the arity
+       of an alias.
 |}]
 
 module type S5_3 = sig
-  val[@zero_alloc (arity 2)] f : t5_two_args
+  val[@zero_alloc arity 2] f : t5_two_args
 end
 
 module M5_4 : S5_3 = struct
   let[@zero_alloc] f x y = x + y
 end
 [%%expect{|
-module type S5_3 = sig val f : t5_two_args [@@zero_alloc (arity 2)] end
+module type S5_3 = sig val f : t5_two_args [@@zero_alloc arity 2] end
 module M5_4 : S5_3
 |}]
 
@@ -578,13 +582,13 @@ Lines 1-3, characters 21-3:
 3 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : int -> int -> int [@@zero_alloc (arity 1)] end
+         sig val f : int -> int -> int [@@zero_alloc arity 1] end
        is not included in
          S5_3
        Values do not match:
-         val f : int -> int -> int [@@zero_alloc (arity 1)]
+         val f : int -> int -> int [@@zero_alloc arity 1]
        is not included in
-         val f : t5_two_args [@@zero_alloc (arity 2)]
+         val f : t5_two_args [@@zero_alloc arity 2]
        zero_alloc arity mismatch:
        When using "zero_alloc" in a signature, the syntactic arity of
        the implementation must match the function type in the interface.
@@ -592,14 +596,14 @@ Error: Signature mismatch:
 |}]
 
 module type S5_4 = sig
-  val[@zero_alloc (arity 1)] f : t5_two_args
+  val[@zero_alloc arity 1] f : t5_two_args
 end
 
 module M5_6 : S5_4 = struct
   let[@zero_alloc] f x y = x + y
 end
 [%%expect{|
-module type S5_4 = sig val f : t5_two_args [@@zero_alloc (arity 1)] end
+module type S5_4 = sig val f : t5_two_args [@@zero_alloc arity 1] end
 Lines 5-7, characters 21-3:
 5 | .....................struct
 6 |   let[@zero_alloc] f x y = x + y
@@ -612,7 +616,7 @@ Error: Signature mismatch:
        Values do not match:
          val f : int -> int -> int [@@zero_alloc]
        is not included in
-         val f : t5_two_args [@@zero_alloc (arity 1)]
+         val f : t5_two_args [@@zero_alloc arity 1]
        zero_alloc arity mismatch:
        When using "zero_alloc" in a signature, the syntactic arity of
        the implementation must match the function type in the interface.
@@ -680,7 +684,7 @@ Error: Signature mismatch:
 (* Test 7: A practicalish example of a non-obvious zero_alloc arity *)
 
 module type S7 = sig
-  val[@zero_alloc (arity 2)] f : int -> int -> int -> int*int
+  val[@zero_alloc arity 2] f : int -> int -> int -> int*int
 end
 
 (* The expected behavior from the backend analysis for the two funtions below
@@ -698,7 +702,7 @@ end
 
 [%%expect{|
 module type S7 =
-  sig val f : int -> int -> int -> int * int [@@zero_alloc (arity 2)] end
+  sig val f : int -> int -> int -> int * int [@@zero_alloc arity 2] end
 module M7_1 : S7
 Lines 13-16, characters 19-3:
 13 | ...................struct
@@ -713,7 +717,7 @@ Error: Signature mismatch:
        Values do not match:
          val f : int -> int -> int -> int * int [@@zero_alloc]
        is not included in
-         val f : int -> int -> int -> int * int [@@zero_alloc (arity 2)]
+         val f : int -> int -> int -> int * int [@@zero_alloc arity 2]
        zero_alloc arity mismatch:
        When using "zero_alloc" in a signature, the syntactic arity of
        the implementation must match the function type in the interface.
@@ -721,55 +725,55 @@ Error: Signature mismatch:
 |}]
 
 (*************************************)
-(* Test 8: Parsing "(arity n)" works *)
+(* Test 8: Parsing "arity n" works *)
 
 
 module type S8_1 = sig
-  val[@zero_alloc (arity 42)] f : int -> int
+  val[@zero_alloc arity 42] f : int -> int
 end
 
 module type S8_2 = sig
-  val[@zero_alloc (arity 42) opt] f : int -> int
+  val[@zero_alloc arity 42 opt] f : int -> int
 end
 
 module type S8_3 = sig
-  val[@zero_alloc opt (arity 42)] f : int -> int
+  val[@zero_alloc opt arity 42] f : int -> int
 end
 
 module type S8_4 = sig
-  val[@zero_alloc (arity 42) opt strict] f : int -> int
+  val[@zero_alloc arity 42 opt strict] f : int -> int
 end
 
 module type S8_5 = sig
-  val[@zero_alloc opt (arity 42) strict] f : int -> int
+  val[@zero_alloc opt arity 42 strict] f : int -> int
 end
 
 module type S8_6 = sig
-  val[@zero_alloc opt strict (arity 42)] f : int -> int
+  val[@zero_alloc opt strict arity 42] f : int -> int
 end
 
 [%%expect{|
-module type S8_1 = sig val f : int -> int [@@zero_alloc (arity 42)] end
-module type S8_2 = sig val f : int -> int [@@zero_alloc opt (arity 42)] end
-module type S8_3 = sig val f : int -> int [@@zero_alloc opt (arity 42)] end
+module type S8_1 = sig val f : int -> int [@@zero_alloc arity 42] end
+module type S8_2 = sig val f : int -> int [@@zero_alloc opt arity 42] end
+module type S8_3 = sig val f : int -> int [@@zero_alloc opt arity 42] end
 module type S8_4 =
-  sig val f : int -> int [@@zero_alloc strict opt (arity 42)] end
+  sig val f : int -> int [@@zero_alloc strict opt arity 42] end
 module type S8_5 =
-  sig val f : int -> int [@@zero_alloc strict opt (arity 42)] end
+  sig val f : int -> int [@@zero_alloc strict opt arity 42] end
 module type S8_6 =
-  sig val f : int -> int [@@zero_alloc strict opt (arity 42)] end
+  sig val f : int -> int [@@zero_alloc strict opt arity 42] end
 |}]
 
-(****************************************************)
-(* Test 9: (arity n) in structures gives warning 47 *)
+(**************************************************)
+(* Test 9: arity n in structures gives warning 47 *)
 
 module M9_1 = struct
-  let[@zero_alloc (arity 2)] f x y = x + y
+  let[@zero_alloc arity 2] f x y = x + y
 end
 
 [%%expect{|
 Line 2, characters 7-17:
-2 |   let[@zero_alloc (arity 2)] f x y = x + y
+2 |   let[@zero_alloc arity 2] f x y = x + y
            ^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 The "arity" field is only supported on "zero_alloc" in signatures
@@ -778,11 +782,11 @@ module M9_1 : sig val f : int -> int -> int [@@zero_alloc] end
 |}]
 
 module M9_2 = struct
-  let[@zero_alloc (arity 2)] f = fun x y -> x + y
+  let[@zero_alloc arity 2] f = fun x y -> x + y
 end
 [%%expect{|
 Line 2, characters 7-17:
-2 |   let[@zero_alloc (arity 2)] f = fun x y -> x + y
+2 |   let[@zero_alloc arity 2] f = fun x y -> x + y
            ^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 The "arity" field is only supported on "zero_alloc" in signatures
@@ -791,11 +795,11 @@ module M9_2 : sig val f : int -> int -> int [@@zero_alloc] end
 |}]
 
 module M9_3 = struct
-  let f = fun[@zero_alloc (arity 2)]  x y -> x + y
+  let f = fun[@zero_alloc arity 2]  x y -> x + y
 end
 [%%expect{|
 Line 2, characters 15-25:
-2 |   let f = fun[@zero_alloc (arity 2)]  x y -> x + y
+2 |   let f = fun[@zero_alloc arity 2]  x y -> x + y
                    ^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 The "arity" field is only supported on "zero_alloc" in signatures
@@ -806,13 +810,13 @@ module M9_3 : sig val f : int -> int -> int [@@zero_alloc] end
 module M9_4 = struct
   let f x =
     if x = 42 then
-      fun[@zero_alloc (arity 1)] y -> y
+      fun[@zero_alloc arity 1] y -> y
     else
       fun y -> y + 1
 end
 [%%expect{|
 Line 4, characters 11-21:
-4 |       fun[@zero_alloc (arity 1)] y -> y
+4 |       fun[@zero_alloc arity 1] y -> y
                ^^^^^^^^^^
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 The "arity" field is only supported on "zero_alloc" in signatures

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -16,24 +16,34 @@ module type S_payloads_base = sig
   val[@zero_alloc] f : int -> int
 end
 
-module type S_payloads_opt = sig
-  val[@zero_alloc opt] f : int -> int
-end
-
 module type S_payloads_strict = sig
   val[@zero_alloc strict] f : int -> int
 end
+
+[%%expect{|
+module type S_payloads_base = sig val f : int -> int [@@zero_alloc] end
+module type S_payloads_strict =
+  sig val f : int -> int [@@zero_alloc strict] end
+|}]
+
+module type S_payloads_opt = sig
+  val[@zero_alloc opt] f : int -> int
+end
+[%%expect{|
+Line 2, characters 2-37:
+2 |   val[@zero_alloc opt] f : int -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "zero_alloc opt" is not supported in signatures.
+|}]
 
 module type S_payloads_strict_opt = sig
   val[@zero_alloc strict opt] f : int -> int
 end
 [%%expect{|
-module type S_payloads_base = sig val f : int -> int [@@zero_alloc] end
-module type S_payloads_opt = sig val f : int -> int [@@zero_alloc opt] end
-module type S_payloads_strict =
-  sig val f : int -> int [@@zero_alloc strict] end
-module type S_payloads_strict_opt =
-  sig val f : int -> int [@@zero_alloc strict opt] end
+Line 2, characters 2-44:
+2 |   val[@zero_alloc strict opt] f : int -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: "zero_alloc opt" is not supported in signatures.
 |}]
 
 module type S_payloads_assume = sig
@@ -96,53 +106,54 @@ module M_assume_strict : S_good_inc_base
 module M_assume_strict_nrn : S_good_inc_base
 |}]
 
-module type S_good_inc_opt = sig
-  val[@zero_alloc opt] f : 'a -> 'a
-end
-
-module M_base : S_good_inc_opt = struct
-  let[@zero_alloc] f x = x
-end
-
-module M_opt : S_good_inc_opt = struct
-  let[@zero_alloc opt] f x = x
-end
-
-module M_assume : S_good_inc_opt = struct
-  let[@zero_alloc assume] f x = x
-end
-
-module M_assume_nrn : S_good_inc_opt = struct
-  let[@zero_alloc assume never_returns_normally] f x = x
-end
-
-module M_strict : S_good_inc_opt = struct
-  let[@zero_alloc strict] f x = x
-end
-
-module M_strict_opt : S_good_inc_opt = struct
-  let[@zero_alloc strict opt] f x = x
-end
-
-module M_assume_strict : S_good_inc_opt = struct
-  let[@zero_alloc assume strict] f x = x
-end
-
-module M_assume_strict_nrn : S_good_inc_opt = struct
-  let[@zero_alloc assume strict never_returns_normally] f x = x
-end
-
-[%%expect{|
-module type S_good_inc_opt = sig val f : 'a -> 'a [@@zero_alloc opt] end
-module M_base : S_good_inc_opt
-module M_opt : S_good_inc_opt
-module M_assume : S_good_inc_opt
-module M_assume_nrn : S_good_inc_opt
-module M_strict : S_good_inc_opt
-module M_strict_opt : S_good_inc_opt
-module M_assume_strict : S_good_inc_opt
-module M_assume_strict_nrn : S_good_inc_opt
-|}]
+(* CR ccasinghino: The below should work once we allow opt in signatures. *)
+(* module type S_good_inc_opt = sig
+ *   val[@zero_alloc opt] f : 'a -> 'a
+ * end
+ *
+ * module M_base : S_good_inc_opt = struct
+ *   let[@zero_alloc] f x = x
+ * end
+ *
+ * module M_opt : S_good_inc_opt = struct
+ *   let[@zero_alloc opt] f x = x
+ * end
+ *
+ * module M_assume : S_good_inc_opt = struct
+ *   let[@zero_alloc assume] f x = x
+ * end
+ *
+ * module M_assume_nrn : S_good_inc_opt = struct
+ *   let[@zero_alloc assume never_returns_normally] f x = x
+ * end
+ *
+ * module M_strict : S_good_inc_opt = struct
+ *   let[@zero_alloc strict] f x = x
+ * end
+ *
+ * module M_strict_opt : S_good_inc_opt = struct
+ *   let[@zero_alloc strict opt] f x = x
+ * end
+ *
+ * module M_assume_strict : S_good_inc_opt = struct
+ *   let[@zero_alloc assume strict] f x = x
+ * end
+ *
+ * module M_assume_strict_nrn : S_good_inc_opt = struct
+ *   let[@zero_alloc assume strict never_returns_normally] f x = x
+ * end
+ *
+ * [%%expect{|
+ * module type S_good_inc_opt = sig val f : 'a -> 'a [@@zero_alloc opt] end
+ * module M_base : S_good_inc_opt
+ * module M_opt : S_good_inc_opt
+ * module M_assume : S_good_inc_opt
+ * module M_assume_nrn : S_good_inc_opt
+ * module M_strict : S_good_inc_opt
+ * module M_strict_opt : S_good_inc_opt
+ * module M_assume_strict : S_good_inc_opt
+ * module M_assume_strict_nrn : S_good_inc_opt
+ * |}] *)
 
 module type S_good_inc_strict = sig
   val[@zero_alloc strict] f : 'a -> 'a
@@ -168,34 +179,36 @@ module M_assume_strict : S_good_inc_strict
 module M_assume_strict_nrn : S_good_inc_strict
 |}]
 
-module type S_good_inc_strict_opt = sig
-  val[@zero_alloc strict opt] f : 'a -> 'a
-end
+(* CR ccasinghino: The below should work once we allow opt in signatures. *)
+(* module type S_good_inc_strict_opt = sig
+ *   val[@zero_alloc strict opt] f : 'a -> 'a
+ * end
+ *
+ * module M_strict : S_good_inc_strict_opt = struct
+ *   let[@zero_alloc strict] f x = x
+ * end
+ *
+ * module M_strict_opt : S_good_inc_strict_opt = struct
+ *   let[@zero_alloc strict opt] f x = x
+ * end
+ *
+ * module M_assume_strict : S_good_inc_strict_opt = struct
+ *   let[@zero_alloc assume strict] f x = x
+ * end
+ *
+ * module M_assume_strict_nrn : S_good_inc_strict_opt = struct
+ *   let[@zero_alloc assume strict never_returns_normally] f x = x
+ * end
+ *
+ * [%%expect{|
+ * module type S_good_inc_strict_opt =
+ *   sig val f : 'a -> 'a [@@zero_alloc strict opt] end
+ * module M_strict : S_good_inc_strict_opt
+ * module M_strict_opt : S_good_inc_strict_opt
+ * module M_assume_strict : S_good_inc_strict_opt
+ * module M_assume_strict_nrn : S_good_inc_strict_opt
+ * |}] *)
 
-module M_strict : S_good_inc_strict_opt = struct
-  let[@zero_alloc strict] f x = x
-end
-
-module M_strict_opt : S_good_inc_strict_opt = struct
-  let[@zero_alloc strict opt] f x = x
-end
-
-module M_assume_strict : S_good_inc_strict_opt = struct
-  let[@zero_alloc assume strict] f x = x
-end
-
-module M_assume_strict_nrn : S_good_inc_strict_opt = struct
-  let[@zero_alloc assume strict never_returns_normally] f x = x
-end
-
-[%%expect{|
-module type S_good_inc_strict_opt =
-  sig val f : 'a -> 'a [@@zero_alloc strict opt] end
-module M_strict : S_good_inc_strict_opt
-module M_strict_opt : S_good_inc_strict_opt
-module M_assume_strict : S_good_inc_strict_opt
-module M_assume_strict_nrn : S_good_inc_strict_opt
-|}]
 
 (*********************************)
 (* Test 3: disallowed inclusions *)
@@ -248,32 +261,33 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
-module type S_bad_inc_opt = sig
-  val[@zero_alloc opt] f : 'a -> 'a
-end
-
-module M_absent : S_bad_inc_opt = struct
-  let f x = x
-end
-
-[%%expect{|
-module type S_bad_inc_opt = sig val f : 'a -> 'a [@@zero_alloc opt] end
-Lines 5-7, characters 34-3:
-5 | ..................................struct
-6 |   let f x = x
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val f : 'a -> 'a end
-       is not included in
-         S_bad_inc_opt
-       Values do not match:
-         val f : 'a -> 'a
-       is not included in
-         val f : 'a -> 'a [@@zero_alloc opt]
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
-|}]
+(* CR ccasinghino: The below should work once we allow opt in signatures. *)
+(* module type S_bad_inc_opt = sig
+ *   val[@zero_alloc opt] f : 'a -> 'a
+ * end
+ *
+ * module M_absent : S_bad_inc_opt = struct
+ *   let f x = x
+ * end
+ *
+ * [%%expect{|
+ * module type S_bad_inc_opt = sig val f : 'a -> 'a [@@zero_alloc opt] end
+ * Lines 5-7, characters 34-3:
+ * 5 | ..................................struct
+ * 6 |   let f x = x
+ * 7 | end
+ * Error: Signature mismatch:
+ *        Modules do not match:
+ *          sig val f : 'a -> 'a end
+ *        is not included in
+ *          S_bad_inc_opt
+ *        Values do not match:
+ *          val f : 'a -> 'a
+ *        is not included in
+ *          val f : 'a -> 'a [@@zero_alloc opt]
+ *        The former provides a weaker "zero_alloc" guarantee than the latter.
+ *        Hint: Add a "zero_alloc" attribute to the implementation.
+ * |}] *)
 
 module type S_bad_inc_strict = sig
   val[@zero_alloc strict] f : 'a -> 'a
@@ -406,95 +420,96 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
-module type S_strict_opt = sig
-  val[@zero_alloc strict opt] f : 'a -> 'a
-end
-
-module M_absent : S_strict_opt = struct
-  let f x = x
-end
-
-[%%expect{|
-module type S_strict_opt = sig val f : 'a -> 'a [@@zero_alloc strict opt] end
-Lines 5-7, characters 33-3:
-5 | .................................struct
-6 |   let f x = x
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val f : 'a -> 'a end
-       is not included in
-         S_strict_opt
-       Values do not match:
-         val f : 'a -> 'a
-       is not included in
-         val f : 'a -> 'a [@@zero_alloc strict opt]
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
-|}]
-
-module M_assume : S_strict_opt = struct
-  let[@zero_alloc assume] f x = x
-end
-
-[%%expect{|
-Lines 1-3, characters 33-3:
-1 | .................................struct
-2 |   let[@zero_alloc assume] f x = x
-3 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val f : 'a -> 'a [@@zero_alloc] end
-       is not included in
-         S_strict_opt
-       Values do not match:
-         val f : 'a -> 'a [@@zero_alloc]
-       is not included in
-         val f : 'a -> 'a [@@zero_alloc strict opt]
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-|}]
-
-module M_opt : S_strict_opt = struct
-  let[@zero_alloc opt] f x = x
-end
-
-[%%expect{|
-Lines 1-3, characters 30-3:
-1 | ..............................struct
-2 |   let[@zero_alloc opt] f x = x
-3 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val f : 'a -> 'a [@@zero_alloc opt] end
-       is not included in
-         S_strict_opt
-       Values do not match:
-         val f : 'a -> 'a [@@zero_alloc opt]
-       is not included in
-         val f : 'a -> 'a [@@zero_alloc strict opt]
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-|}]
-
-module M_assume_nrn : S_strict_opt = struct
-  let[@zero_alloc assume never_returns_normally] f x = x
-end
-
-[%%expect{|
-Lines 1-3, characters 37-3:
-1 | .....................................struct
-2 |   let[@zero_alloc assume never_returns_normally] f x = x
-3 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val f : 'a -> 'a [@@zero_alloc] end
-       is not included in
-         S_strict_opt
-       Values do not match:
-         val f : 'a -> 'a [@@zero_alloc]
-       is not included in
-         val f : 'a -> 'a [@@zero_alloc strict opt]
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-|}]
+(* CR ccasinghino: The below should work once we allow opt in signatures. *)
+(* module type S_strict_opt = sig
+ *   val[@zero_alloc strict opt] f : 'a -> 'a
+ * end
+ *
+ * module M_absent : S_strict_opt = struct
+ *   let f x = x
+ * end
+ *
+ * [%%expect{|
+ * module type S_strict_opt = sig val f : 'a -> 'a [@@zero_alloc strict opt] end
+ * Lines 5-7, characters 33-3:
+ * 5 | .................................struct
+ * 6 |   let f x = x
+ * 7 | end
+ * Error: Signature mismatch:
+ *        Modules do not match:
+ *          sig val f : 'a -> 'a end
+ *        is not included in
+ *          S_strict_opt
+ *        Values do not match:
+ *          val f : 'a -> 'a
+ *        is not included in
+ *          val f : 'a -> 'a [@@zero_alloc strict opt]
+ *        The former provides a weaker "zero_alloc" guarantee than the latter.
+ *        Hint: Add a "zero_alloc" attribute to the implementation.
+ * |}]
+ *
+ * module M_assume : S_strict_opt = struct
+ *   let[@zero_alloc assume] f x = x
+ * end
+ *
+ * [%%expect{|
+ * Lines 1-3, characters 33-3:
+ * 1 | .................................struct
+ * 2 |   let[@zero_alloc assume] f x = x
+ * 3 | end
+ * Error: Signature mismatch:
+ *        Modules do not match:
+ *          sig val f : 'a -> 'a [@@zero_alloc] end
+ *        is not included in
+ *          S_strict_opt
+ *        Values do not match:
+ *          val f : 'a -> 'a [@@zero_alloc]
+ *        is not included in
+ *          val f : 'a -> 'a [@@zero_alloc strict opt]
+ *        The former provides a weaker "zero_alloc" guarantee than the latter.
+ * |}]
+ *
+ * module M_opt : S_strict_opt = struct
+ *   let[@zero_alloc opt] f x = x
+ * end
+ *
+ * [%%expect{|
+ * Lines 1-3, characters 30-3:
+ * 1 | ..............................struct
+ * 2 |   let[@zero_alloc opt] f x = x
+ * 3 | end
+ * Error: Signature mismatch:
+ *        Modules do not match:
+ *          sig val f : 'a -> 'a [@@zero_alloc opt] end
+ *        is not included in
+ *          S_strict_opt
+ *        Values do not match:
+ *          val f : 'a -> 'a [@@zero_alloc opt]
+ *        is not included in
+ *          val f : 'a -> 'a [@@zero_alloc strict opt]
+ *        The former provides a weaker "zero_alloc" guarantee than the latter.
+ * |}]
+ *
+ * module M_assume_nrn : S_strict_opt = struct
+ *   let[@zero_alloc assume never_returns_normally] f x = x
+ * end
+ *
+ * [%%expect{|
+ * Lines 1-3, characters 37-3:
+ * 1 | .....................................struct
+ * 2 |   let[@zero_alloc assume never_returns_normally] f x = x
+ * 3 | end
+ * Error: Signature mismatch:
+ *        Modules do not match:
+ *          sig val f : 'a -> 'a [@@zero_alloc] end
+ *        is not included in
+ *          S_strict_opt
+ *        Values do not match:
+ *          val f : 'a -> 'a [@@zero_alloc]
+ *        is not included in
+ *          val f : 'a -> 'a [@@zero_alloc strict opt]
+ *        The former provides a weaker "zero_alloc" guarantee than the latter.
+ * |}] *)
 
 (**********************************************************)
 (* Test 4: requires function types, does not do expansion *)
@@ -770,43 +785,26 @@ Error: Signature mismatch:
 (*************************************)
 (* Test 8: Parsing "arity n" works *)
 
-
+(* CR ccasinghino: when we have support for opt, add tests for all the
+   combinations here. *)
 module type S_arity_42 = sig
   val[@zero_alloc arity 42] f : int -> int
 end
 
-module type S_arity_42_opt = sig
-  val[@zero_alloc arity 42 opt] f : int -> int
+module type S_arity_42_strict = sig
+  val[@zero_alloc arity 42 strict] f : int -> int
 end
 
-module type S_opt_arity_42 = sig
-  val[@zero_alloc opt arity 42] f : int -> int
-end
-
-module type S_arity_42_opt_strict = sig
-  val[@zero_alloc arity 42 opt strict] f : int -> int
-end
-
-module type S_opt_arity_42_strict = sig
-  val[@zero_alloc opt arity 42 strict] f : int -> int
-end
-
-module type S_opt_strict_arity_42 = sig
-  val[@zero_alloc opt strict arity 42] f : int -> int
+module type S_strict_arity_42 = sig
+  val[@zero_alloc strict arity 42] f : int -> int
 end
 
 [%%expect{|
 module type S_arity_42 = sig val f : int -> int [@@zero_alloc arity 42] end
-module type S_arity_42_opt =
-  sig val f : int -> int [@@zero_alloc opt arity 42] end
-module type S_opt_arity_42 =
-  sig val f : int -> int [@@zero_alloc opt arity 42] end
-module type S_arity_42_opt_strict =
-  sig val f : int -> int [@@zero_alloc strict opt arity 42] end
-module type S_opt_arity_42_strict =
-  sig val f : int -> int [@@zero_alloc strict opt arity 42] end
-module type S_opt_strict_arity_42 =
-  sig val f : int -> int [@@zero_alloc strict opt arity 42] end
+module type S_arity_42_strict =
+  sig val f : int -> int [@@zero_alloc strict arity 42] end
+module type S_strict_arity_42 =
+  sig val f : int -> int [@@zero_alloc strict arity 42] end
 |}]
 
 (**************************************************)

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -1,0 +1,821 @@
+(* TEST
+   * expect
+*)
+
+(* This tests the typing behavior of `[@zero_alloc]` annotation in signatures.
+
+   These tests are just about what is allowed and not allowed by the
+   typechecker.  The implementation of the actual `[@zero_alloc]` backend checks
+   (including how the annotations in signatures affect those checks) are tested
+   in the `tests/backend/checkmach` directory at the root of the project.
+*)
+
+(*******************************************)
+(* Test 1: Allowed and disallowed payloads *)
+module type S1_1 = sig
+  val[@zero_alloc] f : int -> int
+end
+
+module type S1_2 = sig
+  val[@zero_alloc opt] f : int -> int
+end
+
+module type S1_3 = sig
+  val[@zero_alloc strict] f : int -> int
+end
+
+module type S1_4 = sig
+  val[@zero_alloc strict opt] f : int -> int
+end
+[%%expect{|
+module type S1_1 = sig val f : int -> int [@@zero_alloc] end
+module type S1_2 = sig val f : int -> int [@@zero_alloc opt] end
+module type S1_3 = sig val f : int -> int [@@zero_alloc strict] end
+module type S1_4 = sig val f : int -> int [@@zero_alloc strict opt] end
+|}]
+
+module type S1_5 = sig
+  val[@zero_alloc assume] f : int -> int
+end
+[%%expect{|
+Line 2, characters 2-40:
+2 |   val[@zero_alloc assume] f : int -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: zero_alloc "assume" attributes are not supported in signatures
+|}]
+
+module type S1_6 = sig
+  val[@zero_alloc ignore] f : int -> int
+end
+[%%expect{|
+Line 2, characters 2-40:
+2 |   val[@zero_alloc ignore] f : int -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: zero_alloc "ignore" attributes are not supported in signatures
+|}]
+
+(******************************)
+(* Test 2: allowed inclusions *)
+module type S2_1 = sig
+  val[@zero_alloc] f : 'a -> 'a
+end
+
+module M2_1 : S2_1 = struct
+  let[@zero_alloc] f x = x
+end
+
+module M2_2 : S2_1 = struct
+  let[@zero_alloc assume] f x = x
+end
+
+module M2_3 : S2_1 = struct
+  let[@zero_alloc assume never_returns_normally] f x = x
+end
+
+module M2_4 : S2_1 = struct
+  let[@zero_alloc strict] f x = x
+end
+
+module M2_5 : S2_1 = struct
+  let[@zero_alloc assume strict] f x = x
+end
+
+module M2_6 : S2_1 = struct
+  let[@zero_alloc assume strict never_returns_normally] f x = x
+end
+
+[%%expect{|
+module type S2_1 = sig val f : 'a -> 'a [@@zero_alloc] end
+module M2_1 : S2_1
+module M2_2 : S2_1
+module M2_3 : S2_1
+module M2_4 : S2_1
+module M2_5 : S2_1
+module M2_6 : S2_1
+|}]
+
+module type S2_2 = sig
+  val[@zero_alloc opt] f : 'a -> 'a
+end
+
+module M2_7 : S2_2 = struct
+  let[@zero_alloc] f x = x
+end
+
+module M2_8 : S2_2 = struct
+  let[@zero_alloc opt] f x = x
+end
+
+module M2_9 : S2_2 = struct
+  let[@zero_alloc assume] f x = x
+end
+
+module M2_10 : S2_2 = struct
+  let[@zero_alloc assume never_returns_normally] f x = x
+end
+
+module M2_11 : S2_2 = struct
+  let[@zero_alloc strict] f x = x
+end
+
+module M2_12 : S2_2 = struct
+  let[@zero_alloc strict opt] f x = x
+end
+
+module M2_13 : S2_2 = struct
+  let[@zero_alloc assume strict] f x = x
+end
+
+module M2_14 : S2_2 = struct
+  let[@zero_alloc assume strict never_returns_normally] f x = x
+end
+
+[%%expect{|
+module type S2_2 = sig val f : 'a -> 'a [@@zero_alloc opt] end
+module M2_7 : S2_2
+module M2_8 : S2_2
+module M2_9 : S2_2
+module M2_10 : S2_2
+module M2_11 : S2_2
+module M2_12 : S2_2
+module M2_13 : S2_2
+module M2_14 : S2_2
+|}]
+
+module type S2_3 = sig
+  val[@zero_alloc strict] f : 'a -> 'a
+end
+
+module M2_15 : S2_3 = struct
+  let[@zero_alloc strict] f x = x
+end
+
+module M2_16 : S2_3 = struct
+  let[@zero_alloc assume strict] f x = x
+end
+
+module M2_17 : S2_3 = struct
+  let[@zero_alloc assume strict never_returns_normally] f x = x
+end
+
+[%%expect{|
+module type S2_3 = sig val f : 'a -> 'a [@@zero_alloc strict] end
+module M2_15 : S2_3
+module M2_16 : S2_3
+module M2_17 : S2_3
+|}]
+
+module type S2_4 = sig
+  val[@zero_alloc strict opt] f : 'a -> 'a
+end
+
+module M2_18 : S2_4 = struct
+  let[@zero_alloc strict] f x = x
+end
+
+module M2_19 : S2_4 = struct
+  let[@zero_alloc strict opt] f x = x
+end
+
+module M2_20 : S2_4 = struct
+  let[@zero_alloc assume strict] f x = x
+end
+
+module M2_21 : S2_4 = struct
+  let[@zero_alloc assume strict never_returns_normally] f x = x
+end
+
+[%%expect{|
+module type S2_4 = sig val f : 'a -> 'a [@@zero_alloc strict opt] end
+module M2_18 : S2_4
+module M2_19 : S2_4
+module M2_20 : S2_4
+module M2_21 : S2_4
+|}]
+
+(*********************************)
+(* Test 3: disallowed inclusions *)
+
+module type S3_1 = sig
+  val[@zero_alloc] f : 'a -> 'a
+end
+
+module M3_1 : S3_1 = struct
+  let f x = x
+end
+
+[%%expect{|
+module type S3_1 = sig val f : 'a -> 'a [@@zero_alloc] end
+Lines 5-7, characters 21-3:
+5 | .....................struct
+6 |   let f x = x
+7 | end
+Error: Signature mismatch:
+       Modules do not match: sig val f : 'a -> 'a end is not included in S3_1
+       Values do not match:
+         val f : 'a -> 'a
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module M3_2 : S3_1 = struct
+  let[@zero_alloc opt] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 21-3:
+1 | .....................struct
+2 |   let[@zero_alloc opt] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc opt] end
+       is not included in
+         S3_1
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc opt]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module type S3_2 = sig
+  val[@zero_alloc opt] f : 'a -> 'a
+end
+
+module M3_3 : S3_2 = struct
+  let f x = x
+end
+
+[%%expect{|
+module type S3_2 = sig val f : 'a -> 'a [@@zero_alloc opt] end
+Lines 5-7, characters 21-3:
+5 | .....................struct
+6 |   let f x = x
+7 | end
+Error: Signature mismatch:
+       Modules do not match: sig val f : 'a -> 'a end is not included in S3_2
+       Values do not match:
+         val f : 'a -> 'a
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc opt]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module type S3_3 = sig
+  val[@zero_alloc strict] f : 'a -> 'a
+end
+
+module M3_4 : S3_3= struct
+  let f x = x
+end
+
+[%%expect{|
+module type S3_3 = sig val f : 'a -> 'a [@@zero_alloc strict] end
+Lines 5-7, characters 20-3:
+5 | ....................struct
+6 |   let f x = x
+7 | end
+Error: Signature mismatch:
+       Modules do not match: sig val f : 'a -> 'a end is not included in S3_3
+       Values do not match:
+         val f : 'a -> 'a
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module M3_5 : S3_3 = struct
+  let[@zero_alloc assume] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 21-3:
+1 | .....................struct
+2 |   let[@zero_alloc assume] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc] end
+       is not included in
+         S3_3
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module M3_6 : S3_3 = struct
+  let[@zero_alloc opt] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 21-3:
+1 | .....................struct
+2 |   let[@zero_alloc opt] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc opt] end
+       is not included in
+         S3_3
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc opt]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module M3_7 : S3_3 = struct
+  let[@zero_alloc strict opt] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 21-3:
+1 | .....................struct
+2 |   let[@zero_alloc strict opt] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc strict opt] end
+       is not included in
+         S3_3
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc strict opt]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module M3_8 : S3_3 = struct
+  let[@zero_alloc assume never_returns_normally] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 21-3:
+1 | .....................struct
+2 |   let[@zero_alloc assume never_returns_normally] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc] end
+       is not included in
+         S3_3
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module type S3_4 = sig
+  val[@zero_alloc strict opt] f : 'a -> 'a
+end
+
+module M3_9 : S3_4 = struct
+  let f x = x
+end
+
+[%%expect{|
+module type S3_4 = sig val f : 'a -> 'a [@@zero_alloc strict opt] end
+Lines 5-7, characters 21-3:
+5 | .....................struct
+6 |   let f x = x
+7 | end
+Error: Signature mismatch:
+       Modules do not match: sig val f : 'a -> 'a end is not included in S3_4
+       Values do not match:
+         val f : 'a -> 'a
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict opt]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module M3_10 : S3_4 = struct
+  let[@zero_alloc assume] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 22-3:
+1 | ......................struct
+2 |   let[@zero_alloc assume] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc] end
+       is not included in
+         S3_4
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict opt]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module M3_11 : S3_4 = struct
+  let[@zero_alloc opt] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 22-3:
+1 | ......................struct
+2 |   let[@zero_alloc opt] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc opt] end
+       is not included in
+         S3_4
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc opt]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict opt]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+module M3_12 : S3_4 = struct
+  let[@zero_alloc assume never_returns_normally] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 22-3:
+1 | ......................struct
+2 |   let[@zero_alloc assume never_returns_normally] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc] end
+       is not included in
+         S3_4
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict opt]
+       The former provides a weaker "zero_alloc" guarantee than the latter
+|}]
+
+(**********************************************************)
+(* Test 4: requires function types, does not do expansion *)
+
+module type S4_1 = sig
+  val[@zero_alloc] x : int
+end
+[%%expect{|
+Line 2, characters 2-26:
+2 |   val[@zero_alloc] x : int
+      ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In signatures, zero_alloc is only supported on function declarations.
+       Found no arrows in this declaration's type.
+       Hint: You can add "(arity n)" to specify the arity of an alias.
+|}]
+
+module type S4_2 = sig
+  type t = string
+  val[@zero_alloc] x : t
+end
+[%%expect{|
+Line 3, characters 2-24:
+3 |   val[@zero_alloc] x : t
+      ^^^^^^^^^^^^^^^^^^^^^^
+Error: In signatures, zero_alloc is only supported on function declarations.
+       Found no arrows in this declaration's type.
+       Hint: You can add "(arity n)" to specify the arity of an alias.
+|}]
+
+module type S4_3 = sig
+  type t = int -> int
+  type s = t
+  val[@zero_alloc] x : s
+end
+[%%expect{|
+Line 4, characters 2-24:
+4 |   val[@zero_alloc] x : s
+      ^^^^^^^^^^^^^^^^^^^^^^
+Error: In signatures, zero_alloc is only supported on function declarations.
+       Found no arrows in this declaration's type.
+       Hint: You can add "(arity n)" to specify the arity of an alias.
+|}]
+
+(********************************************)
+(* Test 5: impl arity must match intf arity *)
+
+type t5_two_args = int -> int -> int
+
+module type S5_1 = sig
+  val[@zero_alloc] f : int -> int -> int
+end
+
+module M5_1 : S5_1 = struct
+  let[@zero_alloc] f x y = x + y
+end
+
+module M5_2 : S5_1 = struct
+  let[@zero_alloc] f x =
+    function 0 -> x + x
+           | n -> x + n
+end
+
+module M5_3 : S5_1 = struct
+  let[@zero_alloc] f x = fun y -> x + y
+end
+[%%expect{|
+type t5_two_args = int -> int -> int
+module type S5_1 = sig val f : int -> int -> int [@@zero_alloc] end
+module M5_1 : S5_1
+module M5_2 : S5_1
+Lines 17-19, characters 21-3:
+17 | .....................struct
+18 |   let[@zero_alloc] f x = fun y -> x + y
+19 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : int -> int -> int [@@zero_alloc (arity 1)] end
+       is not included in
+         S5_1
+       Values do not match:
+         val f : int -> int -> int [@@zero_alloc (arity 1)]
+       is not included in
+         val f : int -> int -> int [@@zero_alloc]
+       zero_alloc arity mismatch:
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
+       Here the former is 1 and the latter is 2.
+|}]
+
+module type S5_2 = sig
+  val[@zero_alloc] f : t5_two_args
+end
+[%%expect{|
+Line 2, characters 2-34:
+2 |   val[@zero_alloc] f : t5_two_args
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In signatures, zero_alloc is only supported on function declarations.
+       Found no arrows in this declaration's type.
+       Hint: You can add "(arity n)" to specify the arity of an alias.
+|}]
+
+module type S5_3 = sig
+  val[@zero_alloc (arity 2)] f : t5_two_args
+end
+
+module M5_4 : S5_3 = struct
+  let[@zero_alloc] f x y = x + y
+end
+[%%expect{|
+module type S5_3 = sig val f : t5_two_args [@@zero_alloc (arity 2)] end
+module M5_4 : S5_3
+|}]
+
+module M5_5 : S5_3 = struct
+  let[@zero_alloc] f x = fun y -> x + y
+end
+[%%expect{|
+Lines 1-3, characters 21-3:
+1 | .....................struct
+2 |   let[@zero_alloc] f x = fun y -> x + y
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : int -> int -> int [@@zero_alloc (arity 1)] end
+       is not included in
+         S5_3
+       Values do not match:
+         val f : int -> int -> int [@@zero_alloc (arity 1)]
+       is not included in
+         val f : t5_two_args [@@zero_alloc (arity 2)]
+       zero_alloc arity mismatch:
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
+       Here the former is 1 and the latter is 2.
+|}]
+
+module type S5_4 = sig
+  val[@zero_alloc (arity 1)] f : t5_two_args
+end
+
+module M5_6 : S5_4 = struct
+  let[@zero_alloc] f x y = x + y
+end
+[%%expect{|
+module type S5_4 = sig val f : t5_two_args [@@zero_alloc (arity 1)] end
+Lines 5-7, characters 21-3:
+5 | .....................struct
+6 |   let[@zero_alloc] f x y = x + y
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : int -> int -> int [@@zero_alloc] end
+       is not included in
+         S5_4
+       Values do not match:
+         val f : int -> int -> int [@@zero_alloc]
+       is not included in
+         val f : t5_two_args [@@zero_alloc (arity 1)]
+       zero_alloc arity mismatch:
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
+       Here the former is 2 and the latter is 1.
+|}]
+
+module M5_7 : S5_4 = struct
+  let[@zero_alloc] f x = fun y -> x + y
+end
+[%%expect{|
+module M5_7 : S5_4
+|}]
+
+(******************************************************************)
+(* Test 6: we don't update the arity as a result of substitutions *)
+
+module type S6_1 = sig
+  type t
+  val[@zero_alloc] f : int -> t
+end
+
+module M6_1 : S6_1 = struct
+  type t = int
+  let[@zero_alloc] f x = x
+end
+
+module type S6_2 = S6_1 with type t = int -> int
+
+module M6_2 : S6_2  = struct
+  type t = int -> int
+  let[@zero_alloc] f x = fun y -> x + y
+end
+
+module M6_3 : S6_2  = struct
+  type t = int -> int
+  let[@zero_alloc] f x y = x + y
+end
+[%%expect{|
+module type S6_1 = sig type t val f : int -> t [@@zero_alloc] end
+module M6_1 : S6_1
+module type S6_2 =
+  sig type t = int -> int val f : int -> t [@@zero_alloc] end
+module M6_2 : S6_2
+Lines 18-21, characters 22-3:
+18 | ......................struct
+19 |   type t = int -> int
+20 |   let[@zero_alloc] f x y = x + y
+21 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = int -> int val f : int -> int -> int [@@zero_alloc] end
+       is not included in
+         S6_2
+       Values do not match:
+         val f : int -> int -> int [@@zero_alloc]
+       is not included in
+         val f : int -> t [@@zero_alloc]
+       zero_alloc arity mismatch:
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
+       Here the former is 2 and the latter is 1.
+|}]
+
+(********************************************************************)
+(* Test 7: A practicalish example of a non-obvious zero_alloc arity *)
+
+module type S7 = sig
+  val[@zero_alloc (arity 2)] f : int -> int -> int -> int*int
+end
+
+(* The expected behavior from the backend analysis for the two funtions below
+   is checked in [tests/backend/checkmach/test_arity.ml] *)
+
+module M7_1 : S7 = struct
+  let[@zero_alloc] f x y =
+    if x = y+1 then fun z -> (z,z) else fun z -> (z,0)
+end
+
+module M7_2 : S7 = struct
+  let[@zero_alloc] f x y z =
+    if x = y+1 then (z,z) else (z,0)
+end
+
+[%%expect{|
+module type S7 =
+  sig val f : int -> int -> int -> int * int [@@zero_alloc (arity 2)] end
+module M7_1 : S7
+Lines 13-16, characters 19-3:
+13 | ...................struct
+14 |   let[@zero_alloc] f x y z =
+15 |     if x = y+1 then (z,z) else (z,0)
+16 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : int -> int -> int -> int * int [@@zero_alloc] end
+       is not included in
+         S7
+       Values do not match:
+         val f : int -> int -> int -> int * int [@@zero_alloc]
+       is not included in
+         val f : int -> int -> int -> int * int [@@zero_alloc (arity 2)]
+       zero_alloc arity mismatch:
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
+       Here the former is 3 and the latter is 2.
+|}]
+
+(*************************************)
+(* Test 8: Parsing "(arity n)" works *)
+
+
+module type S8_1 = sig
+  val[@zero_alloc (arity 42)] f : int -> int
+end
+
+module type S8_2 = sig
+  val[@zero_alloc (arity 42) opt] f : int -> int
+end
+
+module type S8_3 = sig
+  val[@zero_alloc opt (arity 42)] f : int -> int
+end
+
+module type S8_4 = sig
+  val[@zero_alloc (arity 42) opt strict] f : int -> int
+end
+
+module type S8_5 = sig
+  val[@zero_alloc opt (arity 42) strict] f : int -> int
+end
+
+module type S8_6 = sig
+  val[@zero_alloc opt strict (arity 42)] f : int -> int
+end
+
+[%%expect{|
+module type S8_1 = sig val f : int -> int [@@zero_alloc (arity 42)] end
+module type S8_2 = sig val f : int -> int [@@zero_alloc opt (arity 42)] end
+module type S8_3 = sig val f : int -> int [@@zero_alloc opt (arity 42)] end
+module type S8_4 =
+  sig val f : int -> int [@@zero_alloc strict opt (arity 42)] end
+module type S8_5 =
+  sig val f : int -> int [@@zero_alloc strict opt (arity 42)] end
+module type S8_6 =
+  sig val f : int -> int [@@zero_alloc strict opt (arity 42)] end
+|}]
+
+(****************************************************)
+(* Test 9: (arity n) in structures gives warning 47 *)
+
+module M9_1 = struct
+  let[@zero_alloc (arity 2)] f x y = x + y
+end
+
+[%%expect{|
+Line 2, characters 7-17:
+2 |   let[@zero_alloc (arity 2)] f x y = x + y
+           ^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+The "arity" field is only supported on "zero_alloc" in signatures
+
+module M9_1 : sig val f : int -> int -> int [@@zero_alloc] end
+|}]
+
+module M9_2 = struct
+  let[@zero_alloc (arity 2)] f = fun x y -> x + y
+end
+[%%expect{|
+Line 2, characters 7-17:
+2 |   let[@zero_alloc (arity 2)] f = fun x y -> x + y
+           ^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+The "arity" field is only supported on "zero_alloc" in signatures
+
+module M9_2 : sig val f : int -> int -> int [@@zero_alloc] end
+|}]
+
+module M9_3 = struct
+  let f = fun[@zero_alloc (arity 2)]  x y -> x + y
+end
+[%%expect{|
+Line 2, characters 15-25:
+2 |   let f = fun[@zero_alloc (arity 2)]  x y -> x + y
+                   ^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+The "arity" field is only supported on "zero_alloc" in signatures
+
+module M9_3 : sig val f : int -> int -> int [@@zero_alloc] end
+|}]
+
+module M9_4 = struct
+  let f x =
+    if x = 42 then
+      fun[@zero_alloc (arity 1)] y -> y
+    else
+      fun y -> y + 1
+end
+[%%expect{|
+Line 4, characters 11-21:
+4 |       fun[@zero_alloc (arity 1)] y -> y
+               ^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+The "arity" field is only supported on "zero_alloc" in signatures
+
+module M9_4 : sig val f : int -> int -> int end
+|}]

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -237,7 +237,7 @@ Error: Signature mismatch:
        is not included in
          val f : 'a -> 'a [@@zero_alloc]
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
 |}]
 
 module M_opt : S_bad_inc_base = struct
@@ -251,14 +251,15 @@ Lines 1-3, characters 32-3:
 3 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : 'a -> 'a [@@zero_alloc opt] end
+         sig val f : 'a -> 'a end
        is not included in
          S_bad_inc_base
        Values do not match:
-         val f : 'a -> 'a [@@zero_alloc opt]
+         val f : 'a -> 'a
        is not included in
          val f : 'a -> 'a [@@zero_alloc]
        The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
 |}]
 
 (* CR ccasinghino: The below should work once we allow opt in signatures. *)
@@ -313,7 +314,7 @@ Error: Signature mismatch:
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
 |}]
 
 module M_base : S_bad_inc_strict = struct
@@ -368,14 +369,15 @@ Lines 1-3, characters 34-3:
 3 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : 'a -> 'a [@@zero_alloc opt] end
+         sig val f : 'a -> 'a end
        is not included in
          S_bad_inc_strict
        Values do not match:
-         val f : 'a -> 'a [@@zero_alloc opt]
+         val f : 'a -> 'a
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
        The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
 |}]
 
 module M_strict_opt : S_bad_inc_strict = struct
@@ -389,14 +391,15 @@ Lines 1-3, characters 41-3:
 3 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : 'a -> 'a [@@zero_alloc strict opt] end
+         sig val f : 'a -> 'a end
        is not included in
          S_bad_inc_strict
        Values do not match:
-         val f : 'a -> 'a [@@zero_alloc strict opt]
+         val f : 'a -> 'a
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
        The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
 |}]
 
 module M_assume_nrn : S_bad_inc_strict = struct
@@ -939,7 +942,7 @@ Error: Signature mismatch:
        is not included in
          val f : int -> int [@@zero_alloc]
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
 |}]
 
 module M_strict_for_mto = struct

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -302,6 +302,26 @@ Error: Signature mismatch:
        Hint: Add a "zero_alloc" attribute to the implementation.
 |}]
 
+module M_base : S_bad_inc_strict = struct
+  let[@zero_alloc] f x = x
+end
+[%%expect{|
+Lines 1-3, characters 35-3:
+1 | ...................................struct
+2 |   let[@zero_alloc] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc] end
+       is not included in
+         S_bad_inc_strict
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict]
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+|}]
+
 module M_assume : S_bad_inc_strict = struct
   let[@zero_alloc assume] f x = x
 end

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -1,5 +1,5 @@
 (* TEST
-   * expect
+   expect;
 *)
 
 (* This tests the typing behavior of `[@zero_alloc]` annotation in signatures.

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -12,29 +12,31 @@
 
 (*******************************************)
 (* Test 1: Allowed and disallowed payloads *)
-module type S1_1 = sig
+module type S_payloads_base = sig
   val[@zero_alloc] f : int -> int
 end
 
-module type S1_2 = sig
+module type S_payloads_opt = sig
   val[@zero_alloc opt] f : int -> int
 end
 
-module type S1_3 = sig
+module type S_payloads_strict = sig
   val[@zero_alloc strict] f : int -> int
 end
 
-module type S1_4 = sig
+module type S_payloads_strict_opt = sig
   val[@zero_alloc strict opt] f : int -> int
 end
 [%%expect{|
-module type S1_1 = sig val f : int -> int [@@zero_alloc] end
-module type S1_2 = sig val f : int -> int [@@zero_alloc opt] end
-module type S1_3 = sig val f : int -> int [@@zero_alloc strict] end
-module type S1_4 = sig val f : int -> int [@@zero_alloc strict opt] end
+module type S_payloads_base = sig val f : int -> int [@@zero_alloc] end
+module type S_payloads_opt = sig val f : int -> int [@@zero_alloc opt] end
+module type S_payloads_strict =
+  sig val f : int -> int [@@zero_alloc strict] end
+module type S_payloads_strict_opt =
+  sig val f : int -> int [@@zero_alloc strict opt] end
 |}]
 
-module type S1_5 = sig
+module type S_payloads_assume = sig
   val[@zero_alloc assume] f : int -> int
 end
 [%%expect{|
@@ -44,7 +46,7 @@ Line 2, characters 2-40:
 Error: zero_alloc "assume" attributes are not supported in signatures
 |}]
 
-module type S1_6 = sig
+module type S_payloads_ignore = sig
   val[@zero_alloc ignore] f : int -> int
 end
 [%%expect{|
@@ -56,162 +58,167 @@ Error: zero_alloc "ignore" attributes are not supported in signatures
 
 (******************************)
 (* Test 2: allowed inclusions *)
-module type S2_1 = sig
+module type S_good_inc_base = sig
   val[@zero_alloc] f : 'a -> 'a
 end
 
-module M2_1 : S2_1 = struct
+module M_base : S_good_inc_base = struct
   let[@zero_alloc] f x = x
 end
 
-module M2_2 : S2_1 = struct
+module M_assume : S_good_inc_base = struct
   let[@zero_alloc assume] f x = x
 end
 
-module M2_3 : S2_1 = struct
+module M_assume_nrn : S_good_inc_base = struct
   let[@zero_alloc assume never_returns_normally] f x = x
 end
 
-module M2_4 : S2_1 = struct
+module M_stict : S_good_inc_base = struct
   let[@zero_alloc strict] f x = x
 end
 
-module M2_5 : S2_1 = struct
+module M_assume_strict : S_good_inc_base = struct
   let[@zero_alloc assume strict] f x = x
 end
 
-module M2_6 : S2_1 = struct
+module M_assume_strict_nrn : S_good_inc_base = struct
   let[@zero_alloc assume strict never_returns_normally] f x = x
 end
 
 [%%expect{|
-module type S2_1 = sig val f : 'a -> 'a [@@zero_alloc] end
-module M2_1 : S2_1
-module M2_2 : S2_1
-module M2_3 : S2_1
-module M2_4 : S2_1
-module M2_5 : S2_1
-module M2_6 : S2_1
+module type S_good_inc_base = sig val f : 'a -> 'a [@@zero_alloc] end
+module M_base : S_good_inc_base
+module M_assume : S_good_inc_base
+module M_assume_nrn : S_good_inc_base
+module M_stict : S_good_inc_base
+module M_assume_strict : S_good_inc_base
+module M_assume_strict_nrn : S_good_inc_base
 |}]
 
-module type S2_2 = sig
+module type S_good_inc_opt = sig
   val[@zero_alloc opt] f : 'a -> 'a
 end
 
-module M2_7 : S2_2 = struct
+module M_base : S_good_inc_opt = struct
   let[@zero_alloc] f x = x
 end
 
-module M2_8 : S2_2 = struct
+module M_opt : S_good_inc_opt = struct
   let[@zero_alloc opt] f x = x
 end
 
-module M2_9 : S2_2 = struct
+module M_assume : S_good_inc_opt = struct
   let[@zero_alloc assume] f x = x
 end
 
-module M2_10 : S2_2 = struct
+module M_assume_nrn : S_good_inc_opt = struct
   let[@zero_alloc assume never_returns_normally] f x = x
 end
 
-module M2_11 : S2_2 = struct
+module M_strict : S_good_inc_opt = struct
   let[@zero_alloc strict] f x = x
 end
 
-module M2_12 : S2_2 = struct
+module M_strict_opt : S_good_inc_opt = struct
   let[@zero_alloc strict opt] f x = x
 end
 
-module M2_13 : S2_2 = struct
+module M_assume_strict : S_good_inc_opt = struct
   let[@zero_alloc assume strict] f x = x
 end
 
-module M2_14 : S2_2 = struct
+module M_assume_strict_nrn : S_good_inc_opt = struct
   let[@zero_alloc assume strict never_returns_normally] f x = x
 end
 
 [%%expect{|
-module type S2_2 = sig val f : 'a -> 'a [@@zero_alloc opt] end
-module M2_7 : S2_2
-module M2_8 : S2_2
-module M2_9 : S2_2
-module M2_10 : S2_2
-module M2_11 : S2_2
-module M2_12 : S2_2
-module M2_13 : S2_2
-module M2_14 : S2_2
+module type S_good_inc_opt = sig val f : 'a -> 'a [@@zero_alloc opt] end
+module M_base : S_good_inc_opt
+module M_opt : S_good_inc_opt
+module M_assume : S_good_inc_opt
+module M_assume_nrn : S_good_inc_opt
+module M_strict : S_good_inc_opt
+module M_strict_opt : S_good_inc_opt
+module M_assume_strict : S_good_inc_opt
+module M_assume_strict_nrn : S_good_inc_opt
 |}]
 
-module type S2_3 = sig
+module type S_good_inc_strict = sig
   val[@zero_alloc strict] f : 'a -> 'a
 end
 
-module M2_15 : S2_3 = struct
+module M_strict : S_good_inc_strict = struct
   let[@zero_alloc strict] f x = x
 end
 
-module M2_16 : S2_3 = struct
+module M_assume_strict : S_good_inc_strict = struct
   let[@zero_alloc assume strict] f x = x
 end
 
-module M2_17 : S2_3 = struct
+module M_assume_strict_nrn : S_good_inc_strict = struct
   let[@zero_alloc assume strict never_returns_normally] f x = x
 end
 
 [%%expect{|
-module type S2_3 = sig val f : 'a -> 'a [@@zero_alloc strict] end
-module M2_15 : S2_3
-module M2_16 : S2_3
-module M2_17 : S2_3
+module type S_good_inc_strict =
+  sig val f : 'a -> 'a [@@zero_alloc strict] end
+module M_strict : S_good_inc_strict
+module M_assume_strict : S_good_inc_strict
+module M_assume_strict_nrn : S_good_inc_strict
 |}]
 
-module type S2_4 = sig
+module type S_good_inc_strict_opt = sig
   val[@zero_alloc strict opt] f : 'a -> 'a
 end
 
-module M2_18 : S2_4 = struct
+module M_strict : S_good_inc_strict_opt = struct
   let[@zero_alloc strict] f x = x
 end
 
-module M2_19 : S2_4 = struct
+module M_strict_opt : S_good_inc_strict_opt = struct
   let[@zero_alloc strict opt] f x = x
 end
 
-module M2_20 : S2_4 = struct
+module M_assume_strict : S_good_inc_strict_opt = struct
   let[@zero_alloc assume strict] f x = x
 end
 
-module M2_21 : S2_4 = struct
+module M_assume_strict_nrn : S_good_inc_strict_opt = struct
   let[@zero_alloc assume strict never_returns_normally] f x = x
 end
 
 [%%expect{|
-module type S2_4 = sig val f : 'a -> 'a [@@zero_alloc strict opt] end
-module M2_18 : S2_4
-module M2_19 : S2_4
-module M2_20 : S2_4
-module M2_21 : S2_4
+module type S_good_inc_strict_opt =
+  sig val f : 'a -> 'a [@@zero_alloc strict opt] end
+module M_strict : S_good_inc_strict_opt
+module M_strict_opt : S_good_inc_strict_opt
+module M_assume_strict : S_good_inc_strict_opt
+module M_assume_strict_nrn : S_good_inc_strict_opt
 |}]
 
 (*********************************)
 (* Test 3: disallowed inclusions *)
 
-module type S3_1 = sig
+module type S_bad_inc_base = sig
   val[@zero_alloc] f : 'a -> 'a
 end
 
-module M3_1 : S3_1 = struct
+module M_absent : S_bad_inc_base = struct
   let f x = x
 end
 
 [%%expect{|
-module type S3_1 = sig val f : 'a -> 'a [@@zero_alloc] end
-Lines 5-7, characters 21-3:
-5 | .....................struct
+module type S_bad_inc_base = sig val f : 'a -> 'a [@@zero_alloc] end
+Lines 5-7, characters 35-3:
+5 | ...................................struct
 6 |   let f x = x
 7 | end
 Error: Signature mismatch:
-       Modules do not match: sig val f : 'a -> 'a end is not included in S3_1
+       Modules do not match:
+         sig val f : 'a -> 'a end
+       is not included in
+         S_bad_inc_base
        Values do not match:
          val f : 'a -> 'a
        is not included in
@@ -219,20 +226,20 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module M3_2 : S3_1 = struct
+module M_opt : S_bad_inc_base = struct
   let[@zero_alloc opt] f x = x
 end
 
 [%%expect{|
-Lines 1-3, characters 21-3:
-1 | .....................struct
+Lines 1-3, characters 32-3:
+1 | ................................struct
 2 |   let[@zero_alloc opt] f x = x
 3 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a [@@zero_alloc opt] end
        is not included in
-         S3_1
+         S_bad_inc_base
        Values do not match:
          val f : 'a -> 'a [@@zero_alloc opt]
        is not included in
@@ -240,22 +247,25 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module type S3_2 = sig
+module type S_bad_inc_opt = sig
   val[@zero_alloc opt] f : 'a -> 'a
 end
 
-module M3_3 : S3_2 = struct
+module M_absent : S_bad_inc_opt = struct
   let f x = x
 end
 
 [%%expect{|
-module type S3_2 = sig val f : 'a -> 'a [@@zero_alloc opt] end
-Lines 5-7, characters 21-3:
-5 | .....................struct
+module type S_bad_inc_opt = sig val f : 'a -> 'a [@@zero_alloc opt] end
+Lines 5-7, characters 34-3:
+5 | ..................................struct
 6 |   let f x = x
 7 | end
 Error: Signature mismatch:
-       Modules do not match: sig val f : 'a -> 'a end is not included in S3_2
+       Modules do not match:
+         sig val f : 'a -> 'a end
+       is not included in
+         S_bad_inc_opt
        Values do not match:
          val f : 'a -> 'a
        is not included in
@@ -263,22 +273,25 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module type S3_3 = sig
+module type S_bad_inc_strict = sig
   val[@zero_alloc strict] f : 'a -> 'a
 end
 
-module M3_4 : S3_3= struct
+module M_absent : S_bad_inc_strict = struct
   let f x = x
 end
 
 [%%expect{|
-module type S3_3 = sig val f : 'a -> 'a [@@zero_alloc strict] end
-Lines 5-7, characters 20-3:
-5 | ....................struct
+module type S_bad_inc_strict = sig val f : 'a -> 'a [@@zero_alloc strict] end
+Lines 5-7, characters 37-3:
+5 | .....................................struct
 6 |   let f x = x
 7 | end
 Error: Signature mismatch:
-       Modules do not match: sig val f : 'a -> 'a end is not included in S3_3
+       Modules do not match:
+         sig val f : 'a -> 'a end
+       is not included in
+         S_bad_inc_strict
        Values do not match:
          val f : 'a -> 'a
        is not included in
@@ -286,20 +299,20 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module M3_5 : S3_3 = struct
+module M_assume : S_bad_inc_strict = struct
   let[@zero_alloc assume] f x = x
 end
 
 [%%expect{|
-Lines 1-3, characters 21-3:
-1 | .....................struct
+Lines 1-3, characters 37-3:
+1 | .....................................struct
 2 |   let[@zero_alloc assume] f x = x
 3 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a [@@zero_alloc] end
        is not included in
-         S3_3
+         S_bad_inc_strict
        Values do not match:
          val f : 'a -> 'a [@@zero_alloc]
        is not included in
@@ -307,20 +320,20 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module M3_6 : S3_3 = struct
+module M_opt : S_bad_inc_strict = struct
   let[@zero_alloc opt] f x = x
 end
 
 [%%expect{|
-Lines 1-3, characters 21-3:
-1 | .....................struct
+Lines 1-3, characters 34-3:
+1 | ..................................struct
 2 |   let[@zero_alloc opt] f x = x
 3 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a [@@zero_alloc opt] end
        is not included in
-         S3_3
+         S_bad_inc_strict
        Values do not match:
          val f : 'a -> 'a [@@zero_alloc opt]
        is not included in
@@ -328,20 +341,20 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module M3_7 : S3_3 = struct
+module M_strict_opt : S_bad_inc_strict = struct
   let[@zero_alloc strict opt] f x = x
 end
 
 [%%expect{|
-Lines 1-3, characters 21-3:
-1 | .....................struct
+Lines 1-3, characters 41-3:
+1 | .........................................struct
 2 |   let[@zero_alloc strict opt] f x = x
 3 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a [@@zero_alloc strict opt] end
        is not included in
-         S3_3
+         S_bad_inc_strict
        Values do not match:
          val f : 'a -> 'a [@@zero_alloc strict opt]
        is not included in
@@ -349,20 +362,20 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module M3_8 : S3_3 = struct
+module M_assume_nrn : S_bad_inc_strict = struct
   let[@zero_alloc assume never_returns_normally] f x = x
 end
 
 [%%expect{|
-Lines 1-3, characters 21-3:
-1 | .....................struct
+Lines 1-3, characters 41-3:
+1 | .........................................struct
 2 |   let[@zero_alloc assume never_returns_normally] f x = x
 3 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a [@@zero_alloc] end
        is not included in
-         S3_3
+         S_bad_inc_strict
        Values do not match:
          val f : 'a -> 'a [@@zero_alloc]
        is not included in
@@ -370,22 +383,25 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module type S3_4 = sig
+module type S_strict_opt = sig
   val[@zero_alloc strict opt] f : 'a -> 'a
 end
 
-module M3_9 : S3_4 = struct
+module M_absent : S_strict_opt = struct
   let f x = x
 end
 
 [%%expect{|
-module type S3_4 = sig val f : 'a -> 'a [@@zero_alloc strict opt] end
-Lines 5-7, characters 21-3:
-5 | .....................struct
+module type S_strict_opt = sig val f : 'a -> 'a [@@zero_alloc strict opt] end
+Lines 5-7, characters 33-3:
+5 | .................................struct
 6 |   let f x = x
 7 | end
 Error: Signature mismatch:
-       Modules do not match: sig val f : 'a -> 'a end is not included in S3_4
+       Modules do not match:
+         sig val f : 'a -> 'a end
+       is not included in
+         S_strict_opt
        Values do not match:
          val f : 'a -> 'a
        is not included in
@@ -393,20 +409,20 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module M3_10 : S3_4 = struct
+module M_assume : S_strict_opt = struct
   let[@zero_alloc assume] f x = x
 end
 
 [%%expect{|
-Lines 1-3, characters 22-3:
-1 | ......................struct
+Lines 1-3, characters 33-3:
+1 | .................................struct
 2 |   let[@zero_alloc assume] f x = x
 3 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a [@@zero_alloc] end
        is not included in
-         S3_4
+         S_strict_opt
        Values do not match:
          val f : 'a -> 'a [@@zero_alloc]
        is not included in
@@ -414,20 +430,20 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module M3_11 : S3_4 = struct
+module M_opt : S_strict_opt = struct
   let[@zero_alloc opt] f x = x
 end
 
 [%%expect{|
-Lines 1-3, characters 22-3:
-1 | ......................struct
+Lines 1-3, characters 30-3:
+1 | ..............................struct
 2 |   let[@zero_alloc opt] f x = x
 3 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a [@@zero_alloc opt] end
        is not included in
-         S3_4
+         S_strict_opt
        Values do not match:
          val f : 'a -> 'a [@@zero_alloc opt]
        is not included in
@@ -435,20 +451,20 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter
 |}]
 
-module M3_12 : S3_4 = struct
+module M_assume_nrn : S_strict_opt = struct
   let[@zero_alloc assume never_returns_normally] f x = x
 end
 
 [%%expect{|
-Lines 1-3, characters 22-3:
-1 | ......................struct
+Lines 1-3, characters 37-3:
+1 | .....................................struct
 2 |   let[@zero_alloc assume never_returns_normally] f x = x
 3 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a [@@zero_alloc] end
        is not included in
-         S3_4
+         S_strict_opt
        Values do not match:
          val f : 'a -> 'a [@@zero_alloc]
        is not included in
@@ -459,7 +475,7 @@ Error: Signature mismatch:
 (**********************************************************)
 (* Test 4: requires function types, does not do expansion *)
 
-module type S4_1 = sig
+module type S_non_func_int = sig
   val[@zero_alloc] x : int
 end
 [%%expect{|
@@ -472,7 +488,7 @@ Error: In signatures, zero_alloc is only supported on function declarations.
        of an alias.
 |}]
 
-module type S4_2 = sig
+module type S_non_func_alias = sig
   type t = string
   val[@zero_alloc] x : t
 end
@@ -486,7 +502,7 @@ Error: In signatures, zero_alloc is only supported on function declarations.
        of an alias.
 |}]
 
-module type S4_3 = sig
+module type S_func_alias = sig
   type t = int -> int
   type s = t
   val[@zero_alloc] x : s
@@ -504,39 +520,40 @@ Error: In signatures, zero_alloc is only supported on function declarations.
 (********************************************)
 (* Test 5: impl arity must match intf arity *)
 
-type t5_two_args = int -> int -> int
+type t_two_args = int -> int -> int
 
-module type S5_1 = sig
+module type S_arity_int_int = sig
   val[@zero_alloc] f : int -> int -> int
 end
 
-module M5_1 : S5_1 = struct
+module M_int_int_params : S_arity_int_int = struct
   let[@zero_alloc] f x y = x + y
 end
 
-module M5_2 : S5_1 = struct
+module M_int_param_int_case : S_arity_int_int = struct
   let[@zero_alloc] f x =
     function 0 -> x + x
            | n -> x + n
 end
 
-module M5_3 : S5_1 = struct
+module M_nested_functions : S_arity_int_int = struct
   let[@zero_alloc] f x = fun y -> x + y
 end
 [%%expect{|
-type t5_two_args = int -> int -> int
-module type S5_1 = sig val f : int -> int -> int [@@zero_alloc] end
-module M5_1 : S5_1
-module M5_2 : S5_1
-Lines 17-19, characters 21-3:
-17 | .....................struct
+type t_two_args = int -> int -> int
+module type S_arity_int_int =
+  sig val f : int -> int -> int [@@zero_alloc] end
+module M_int_int_params : S_arity_int_int
+module M_int_param_int_case : S_arity_int_int
+Lines 17-19, characters 46-3:
+17 | ..............................................struct
 18 |   let[@zero_alloc] f x = fun y -> x + y
 19 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : int -> int -> int [@@zero_alloc arity 1] end
        is not included in
-         S5_1
+         S_arity_int_int
        Values do not match:
          val f : int -> int -> int [@@zero_alloc arity 1]
        is not included in
@@ -547,121 +564,123 @@ Error: Signature mismatch:
        Here the former is 1 and the latter is 2.
 |}]
 
-module type S5_2 = sig
-  val[@zero_alloc] f : t5_two_args
+module type S_alias_no_arity = sig
+  val[@zero_alloc] f : t_two_args
 end
 [%%expect{|
-Line 2, characters 2-34:
-2 |   val[@zero_alloc] f : t5_two_args
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 2-33:
+2 |   val[@zero_alloc] f : t_two_args
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In signatures, zero_alloc is only supported on function declarations.
        Found no arrows in this declaration's type.
        Hint: You can write "[@zero_alloc arity n]" to specify the arity
        of an alias.
 |}]
 
-module type S5_3 = sig
-  val[@zero_alloc arity 2] f : t5_two_args
+module type S_alias_explicit_arity_2 = sig
+  val[@zero_alloc arity 2] f : t_two_args
 end
 
-module M5_4 : S5_3 = struct
+module M_good_explicit_arity_2 : S_alias_explicit_arity_2 = struct
   let[@zero_alloc] f x y = x + y
 end
 [%%expect{|
-module type S5_3 = sig val f : t5_two_args [@@zero_alloc arity 2] end
-module M5_4 : S5_3
+module type S_alias_explicit_arity_2 =
+  sig val f : t_two_args [@@zero_alloc arity 2] end
+module M_good_explicit_arity_2 : S_alias_explicit_arity_2
 |}]
 
-module M5_5 : S5_3 = struct
+module M_bad_explicit_arity_2 : S_alias_explicit_arity_2 = struct
   let[@zero_alloc] f x = fun y -> x + y
 end
 [%%expect{|
-Lines 1-3, characters 21-3:
-1 | .....................struct
+Lines 1-3, characters 59-3:
+1 | ...........................................................struct
 2 |   let[@zero_alloc] f x = fun y -> x + y
 3 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : int -> int -> int [@@zero_alloc arity 1] end
        is not included in
-         S5_3
+         S_alias_explicit_arity_2
        Values do not match:
          val f : int -> int -> int [@@zero_alloc arity 1]
        is not included in
-         val f : t5_two_args [@@zero_alloc arity 2]
+         val f : t_two_args [@@zero_alloc arity 2]
        zero_alloc arity mismatch:
        When using "zero_alloc" in a signature, the syntactic arity of
        the implementation must match the function type in the interface.
        Here the former is 1 and the latter is 2.
 |}]
 
-module type S5_4 = sig
-  val[@zero_alloc arity 1] f : t5_two_args
+module type S_alias_explicit_arity_1 = sig
+  val[@zero_alloc arity 1] f : t_two_args
 end
 
-module M5_6 : S5_4 = struct
+module M_bad_explicit_arity_1 : S_alias_explicit_arity_1 = struct
   let[@zero_alloc] f x y = x + y
 end
 [%%expect{|
-module type S5_4 = sig val f : t5_two_args [@@zero_alloc arity 1] end
-Lines 5-7, characters 21-3:
-5 | .....................struct
+module type S_alias_explicit_arity_1 =
+  sig val f : t_two_args [@@zero_alloc arity 1] end
+Lines 5-7, characters 59-3:
+5 | ...........................................................struct
 6 |   let[@zero_alloc] f x y = x + y
 7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : int -> int -> int [@@zero_alloc] end
        is not included in
-         S5_4
+         S_alias_explicit_arity_1
        Values do not match:
          val f : int -> int -> int [@@zero_alloc]
        is not included in
-         val f : t5_two_args [@@zero_alloc arity 1]
+         val f : t_two_args [@@zero_alloc arity 1]
        zero_alloc arity mismatch:
        When using "zero_alloc" in a signature, the syntactic arity of
        the implementation must match the function type in the interface.
        Here the former is 2 and the latter is 1.
 |}]
 
-module M5_7 : S5_4 = struct
+module M_good_explicit_arity_1 : S_alias_explicit_arity_1 = struct
   let[@zero_alloc] f x = fun y -> x + y
 end
 [%%expect{|
-module M5_7 : S5_4
+module M_good_explicit_arity_1 : S_alias_explicit_arity_1
 |}]
 
 (******************************************************************)
 (* Test 6: we don't update the arity as a result of substitutions *)
 
-module type S6_1 = sig
+module type S_abstract = sig
   type t
   val[@zero_alloc] f : int -> t
 end
 
-module M6_1 : S6_1 = struct
+module M_abstract : S_abstract = struct
   type t = int
   let[@zero_alloc] f x = x
 end
 
-module type S6_2 = S6_1 with type t = int -> int
+module type S_subst = S_abstract with type t = int -> int
 
-module M6_2 : S6_2  = struct
+module M_subst_good : S_subst  = struct
   type t = int -> int
   let[@zero_alloc] f x = fun y -> x + y
 end
 
-module M6_3 : S6_2  = struct
+module M_subst_bad : S_subst  = struct
   type t = int -> int
   let[@zero_alloc] f x y = x + y
 end
 [%%expect{|
-module type S6_1 = sig type t val f : int -> t [@@zero_alloc] end
-module M6_1 : S6_1
-module type S6_2 =
+module type S_abstract = sig type t val f : int -> t [@@zero_alloc] end
+module M_abstract : S_abstract
+module type S_subst =
   sig type t = int -> int val f : int -> t [@@zero_alloc] end
-module M6_2 : S6_2
-Lines 18-21, characters 22-3:
-18 | ......................struct
+module M_subst_good : S_subst
+Lines 18-21, characters 32-3:
+18 | ................................struct
 19 |   type t = int -> int
 20 |   let[@zero_alloc] f x y = x + y
 21 | end
@@ -669,7 +688,7 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t = int -> int val f : int -> int -> int [@@zero_alloc] end
        is not included in
-         S6_2
+         S_subst
        Values do not match:
          val f : int -> int -> int [@@zero_alloc]
        is not included in
@@ -683,29 +702,29 @@ Error: Signature mismatch:
 (********************************************************************)
 (* Test 7: A practicalish example of a non-obvious zero_alloc arity *)
 
-module type S7 = sig
+module type S_fun_in_fun = sig
   val[@zero_alloc arity 2] f : int -> int -> int -> int*int
 end
 
 (* The expected behavior from the backend analysis for the two funtions below
    is checked in [tests/backend/checkmach/test_arity.ml] *)
 
-module M7_1 : S7 = struct
+module M_fun_in_fun_good : S_fun_in_fun = struct
   let[@zero_alloc] f x y =
     if x = y+1 then fun z -> (z,z) else fun z -> (z,0)
 end
 
-module M7_2 : S7 = struct
+module M_fun_in_fun_bad : S_fun_in_fun = struct
   let[@zero_alloc] f x y z =
     if x = y+1 then (z,z) else (z,0)
 end
 
 [%%expect{|
-module type S7 =
+module type S_fun_in_fun =
   sig val f : int -> int -> int -> int * int [@@zero_alloc arity 2] end
-module M7_1 : S7
-Lines 13-16, characters 19-3:
-13 | ...................struct
+module M_fun_in_fun_good : S_fun_in_fun
+Lines 13-16, characters 41-3:
+13 | .........................................struct
 14 |   let[@zero_alloc] f x y z =
 15 |     if x = y+1 then (z,z) else (z,0)
 16 | end
@@ -713,7 +732,7 @@ Error: Signature mismatch:
        Modules do not match:
          sig val f : int -> int -> int -> int * int [@@zero_alloc] end
        is not included in
-         S7
+         S_fun_in_fun
        Values do not match:
          val f : int -> int -> int -> int * int [@@zero_alloc]
        is not included in
@@ -728,46 +747,48 @@ Error: Signature mismatch:
 (* Test 8: Parsing "arity n" works *)
 
 
-module type S8_1 = sig
+module type S_arity_42 = sig
   val[@zero_alloc arity 42] f : int -> int
 end
 
-module type S8_2 = sig
+module type S_arity_42_opt = sig
   val[@zero_alloc arity 42 opt] f : int -> int
 end
 
-module type S8_3 = sig
+module type S_opt_arity_42 = sig
   val[@zero_alloc opt arity 42] f : int -> int
 end
 
-module type S8_4 = sig
+module type S_arity_42_opt_strict = sig
   val[@zero_alloc arity 42 opt strict] f : int -> int
 end
 
-module type S8_5 = sig
+module type S_opt_arity_42_strict = sig
   val[@zero_alloc opt arity 42 strict] f : int -> int
 end
 
-module type S8_6 = sig
+module type S_opt_strict_arity_42 = sig
   val[@zero_alloc opt strict arity 42] f : int -> int
 end
 
 [%%expect{|
-module type S8_1 = sig val f : int -> int [@@zero_alloc arity 42] end
-module type S8_2 = sig val f : int -> int [@@zero_alloc opt arity 42] end
-module type S8_3 = sig val f : int -> int [@@zero_alloc opt arity 42] end
-module type S8_4 =
+module type S_arity_42 = sig val f : int -> int [@@zero_alloc arity 42] end
+module type S_arity_42_opt =
+  sig val f : int -> int [@@zero_alloc opt arity 42] end
+module type S_opt_arity_42 =
+  sig val f : int -> int [@@zero_alloc opt arity 42] end
+module type S_arity_42_opt_strict =
   sig val f : int -> int [@@zero_alloc strict opt arity 42] end
-module type S8_5 =
+module type S_opt_arity_42_strict =
   sig val f : int -> int [@@zero_alloc strict opt arity 42] end
-module type S8_6 =
+module type S_opt_strict_arity_42 =
   sig val f : int -> int [@@zero_alloc strict opt arity 42] end
 |}]
 
 (**************************************************)
 (* Test 9: arity n in structures gives warning 47 *)
 
-module M9_1 = struct
+module M_struct_arity_let_1 = struct
   let[@zero_alloc arity 2] f x y = x + y
 end
 
@@ -778,10 +799,11 @@ Line 2, characters 7-17:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 The "arity" field is only supported on "zero_alloc" in signatures
 
-module M9_1 : sig val f : int -> int -> int [@@zero_alloc] end
+module M_struct_arity_let_1 :
+  sig val f : int -> int -> int [@@zero_alloc] end
 |}]
 
-module M9_2 = struct
+module M_struct_arity_let_2 = struct
   let[@zero_alloc arity 2] f = fun x y -> x + y
 end
 [%%expect{|
@@ -791,10 +813,11 @@ Line 2, characters 7-17:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 The "arity" field is only supported on "zero_alloc" in signatures
 
-module M9_2 : sig val f : int -> int -> int [@@zero_alloc] end
+module M_struct_arity_let_2 :
+  sig val f : int -> int -> int [@@zero_alloc] end
 |}]
 
-module M9_3 = struct
+module M_struct_arity_let_fun_1 = struct
   let f = fun[@zero_alloc arity 2]  x y -> x + y
 end
 [%%expect{|
@@ -804,10 +827,11 @@ Line 2, characters 15-25:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 The "arity" field is only supported on "zero_alloc" in signatures
 
-module M9_3 : sig val f : int -> int -> int [@@zero_alloc] end
+module M_struct_arity_let_fun_1 :
+  sig val f : int -> int -> int [@@zero_alloc] end
 |}]
 
-module M9_4 = struct
+module M_struct_arity_let_fun_2 = struct
   let f x =
     if x = 42 then
       fun[@zero_alloc arity 1] y -> y
@@ -821,5 +845,5 @@ Line 4, characters 11-21:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
 The "arity" field is only supported on "zero_alloc" in signatures
 
-module M9_4 : sig val f : int -> int -> int end
+module M_struct_arity_let_fun_2 : sig val f : int -> int -> int end
 |}]

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -223,7 +223,8 @@ Error: Signature mismatch:
          val f : 'a -> 'a
        is not included in
          val f : 'a -> 'a [@@zero_alloc]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
 |}]
 
 module M_opt : S_bad_inc_base = struct
@@ -244,7 +245,7 @@ Error: Signature mismatch:
          val f : 'a -> 'a [@@zero_alloc opt]
        is not included in
          val f : 'a -> 'a [@@zero_alloc]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
 module type S_bad_inc_opt = sig
@@ -270,7 +271,8 @@ Error: Signature mismatch:
          val f : 'a -> 'a
        is not included in
          val f : 'a -> 'a [@@zero_alloc opt]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
 |}]
 
 module type S_bad_inc_strict = sig
@@ -296,7 +298,8 @@ Error: Signature mismatch:
          val f : 'a -> 'a
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
 |}]
 
 module M_assume : S_bad_inc_strict = struct
@@ -317,7 +320,7 @@ Error: Signature mismatch:
          val f : 'a -> 'a [@@zero_alloc]
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
 module M_opt : S_bad_inc_strict = struct
@@ -338,7 +341,7 @@ Error: Signature mismatch:
          val f : 'a -> 'a [@@zero_alloc opt]
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
 module M_strict_opt : S_bad_inc_strict = struct
@@ -359,7 +362,7 @@ Error: Signature mismatch:
          val f : 'a -> 'a [@@zero_alloc strict opt]
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
 module M_assume_nrn : S_bad_inc_strict = struct
@@ -380,7 +383,7 @@ Error: Signature mismatch:
          val f : 'a -> 'a [@@zero_alloc]
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
 module type S_strict_opt = sig
@@ -406,7 +409,8 @@ Error: Signature mismatch:
          val f : 'a -> 'a
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict opt]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
 |}]
 
 module M_assume : S_strict_opt = struct
@@ -427,7 +431,7 @@ Error: Signature mismatch:
          val f : 'a -> 'a [@@zero_alloc]
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict opt]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
 module M_opt : S_strict_opt = struct
@@ -448,7 +452,7 @@ Error: Signature mismatch:
          val f : 'a -> 'a [@@zero_alloc opt]
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict opt]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
 module M_assume_nrn : S_strict_opt = struct
@@ -469,7 +473,7 @@ Error: Signature mismatch:
          val f : 'a -> 'a [@@zero_alloc]
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict opt]
-       The former provides a weaker "zero_alloc" guarantee than the latter
+       The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
 (**********************************************************)

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures_native.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures_native.ml
@@ -1,0 +1,15 @@
+(* TEST
+   native;
+*)
+
+(* This test is just checking that zero_alloc attributes in signatures don't
+   result in warning 199 when compiling to native code (which was a bug in the
+   initial implementation. *)
+
+module type S = sig
+  type t
+
+  val[@zero_alloc] f : int -> int
+
+  val[@zero_alloc arity 3] g : t
+end

--- a/ocaml/testsuite/tests/warnings/w53.compilers.reference
+++ b/ocaml/testsuite/tests/warnings/w53.compilers.reference
@@ -1083,132 +1083,122 @@ File "w53.ml", line 479, characters 19-29:
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 480, characters 17-27:
-480 |   val x : int [@@zero_alloc] (* rejected *)
-                       ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 481, characters 24-34:
-481 |   val f : int -> int [@@zero_alloc] (* rejected *)
-                              ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 483, characters 22-32:
-483 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53.ml", line 482, characters 22-32:
+482 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 483, characters 45-55:
-483 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53.ml", line 482, characters 45-55:
+482 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                                                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 484, characters 39-49:
-484 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53.ml", line 483, characters 39-49:
+483 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 485, characters 12-22:
-485 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53.ml", line 484, characters 12-22:
+484 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 487, characters 9-19:
-487 |   class[@zero_alloc] c : (* rejected *)
+File "w53.ml", line 486, characters 9-19:
+486 |   class[@zero_alloc] c : (* rejected *)
                ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "w53.ml", line 488, characters 11-21:
+488 |       val[@zero_alloc] foo : int * int (* rejected *)
+                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
 File "w53.ml", line 489, characters 11-21:
-489 |       val[@zero_alloc] foo : int * int (* rejected *)
+489 |       val[@zero_alloc] bar : int -> int (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 490, characters 11-21:
-490 |       val[@zero_alloc] bar : int -> int (* rejected *)
-                 ^^^^^^^^^^
+File "w53.ml", line 490, characters 14-24:
+490 |       method[@zero_alloc] baz : int * int (* rejected *)
+                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
 File "w53.ml", line 491, characters 14-24:
-491 |       method[@zero_alloc] baz : int * int (* rejected *)
+491 |       method[@zero_alloc] boz : int -> int (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 492, characters 14-24:
-492 |       method[@zero_alloc] boz : int -> int (* rejected *)
-                    ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53.ml", line 497, characters 21-31:
-497 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
+File "w53.ml", line 496, characters 21-31:
+496 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 498, characters 19-29:
-498 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
+File "w53.ml", line 497, characters 19-29:
+497 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 499, characters 22-32:
-499 |   let x : int = 42 [@@zero_alloc] (* rejected *)
+File "w53.ml", line 498, characters 22-32:
+498 |   let x : int = 42 [@@zero_alloc] (* rejected *)
                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 501, characters 7-17:
-501 |   let[@zero_alloc] w = 42 (* rejected *)
+File "w53.ml", line 500, characters 7-17:
+500 |   let[@zero_alloc] w = 42 (* rejected *)
              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 505, characters 22-32:
-505 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53.ml", line 504, characters 22-32:
+504 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 505, characters 45-55:
-505 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53.ml", line 504, characters 45-55:
+504 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                                                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 506, characters 39-49:
-506 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53.ml", line 505, characters 39-49:
+505 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 507, characters 12-22:
-507 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53.ml", line 506, characters 12-22:
+506 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 509, characters 9-19:
-509 |   class[@zero_alloc] foo _y = (* rejected *)
+File "w53.ml", line 508, characters 9-19:
+508 |   class[@zero_alloc] foo _y = (* rejected *)
                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 511, characters 10-20:
-511 |     (fun[@zero_alloc] z -> (* rejected *)
+File "w53.ml", line 510, characters 10-20:
+510 |     (fun[@zero_alloc] z -> (* rejected *)
                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 513, characters 11-21:
-513 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
+File "w53.ml", line 512, characters 11-21:
+512 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 515, characters 14-24:
-515 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
+File "w53.ml", line 514, characters 14-24:
+514 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 527, characters 14-24:
-527 |     ((boz x)[@zero_alloc assume]) (* rejected *)
+File "w53.ml", line 526, characters 14-24:
+526 |     ((boz x)[@zero_alloc assume]) (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 532, characters 7-17:
-532 |   let[@zero_alloc assume] foo = (* rejected *)
+File "w53.ml", line 531, characters 7-17:
+531 |   let[@zero_alloc assume] foo = (* rejected *)
              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 536, characters 7-17:
-536 |   let[@zero_alloc] bar = (* rejected *)
+File "w53.ml", line 535, characters 7-17:
+535 |   let[@zero_alloc] bar = (* rejected *)
              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/warnings/w53.ml
+++ b/ocaml/testsuite/tests/warnings/w53.ml
@@ -477,8 +477,7 @@ end
 module type TestZeroAllocSig = sig
   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
   type s1 = Foo1 [@zero_alloc] (* rejected *)
-  val x : int [@@zero_alloc] (* rejected *)
-  val f : int -> int [@@zero_alloc] (* rejected *)
+  val f : int -> int [@@zero_alloc] (* accepted *)
 
   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)

--- a/ocaml/testsuite/tests/warnings/w53_zero_alloc_all.compilers.reference
+++ b/ocaml/testsuite/tests/warnings/w53_zero_alloc_all.compilers.reference
@@ -8,132 +8,122 @@ File "w53_zero_alloc_all.ml", line 20, characters 19-29:
                         ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 21, characters 17-27:
-21 |   val x : int [@@zero_alloc] (* rejected *)
-                      ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 22, characters 24-34:
-22 |   val f : int -> int [@@zero_alloc] (* rejected *)
-                             ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 24, characters 22-32:
-24 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53_zero_alloc_all.ml", line 23, characters 22-32:
+23 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 24, characters 45-55:
-24 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53_zero_alloc_all.ml", line 23, characters 45-55:
+23 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                                                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 25, characters 39-49:
-25 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 24, characters 39-49:
+24 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 26, characters 12-22:
-26 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53_zero_alloc_all.ml", line 25, characters 12-22:
+25 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 28, characters 9-19:
-28 |   class[@zero_alloc] c : (* rejected *)
+File "w53_zero_alloc_all.ml", line 27, characters 9-19:
+27 |   class[@zero_alloc] c : (* rejected *)
               ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "w53_zero_alloc_all.ml", line 29, characters 11-21:
+29 |       val[@zero_alloc] foo : int * int (* rejected *)
+                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
 File "w53_zero_alloc_all.ml", line 30, characters 11-21:
-30 |       val[@zero_alloc] foo : int * int (* rejected *)
+30 |       val[@zero_alloc] bar : int -> int (* rejected *)
                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 31, characters 11-21:
-31 |       val[@zero_alloc] bar : int -> int (* rejected *)
-                ^^^^^^^^^^
+File "w53_zero_alloc_all.ml", line 31, characters 14-24:
+31 |       method[@zero_alloc] baz : int * int (* rejected *)
+                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
 File "w53_zero_alloc_all.ml", line 32, characters 14-24:
-32 |       method[@zero_alloc] baz : int * int (* rejected *)
+32 |       method[@zero_alloc] boz : int -> int (* rejected *)
                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 33, characters 14-24:
-33 |       method[@zero_alloc] boz : int -> int (* rejected *)
-                   ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
-File "w53_zero_alloc_all.ml", line 38, characters 21-31:
-38 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 37, characters 21-31:
+37 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
                           ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 39, characters 19-29:
-39 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 38, characters 19-29:
+38 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
                         ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 40, characters 22-32:
-40 |   let x : int = 42 [@@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 39, characters 22-32:
+39 |   let x : int = 42 [@@zero_alloc] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 42, characters 7-17:
-42 |   let[@zero_alloc] w = 42 (* rejected *)
+File "w53_zero_alloc_all.ml", line 41, characters 7-17:
+41 |   let[@zero_alloc] w = 42 (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 46, characters 22-32:
-46 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53_zero_alloc_all.ml", line 45, characters 22-32:
+45 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 46, characters 45-55:
-46 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53_zero_alloc_all.ml", line 45, characters 45-55:
+45 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                                                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 47, characters 39-49:
-47 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53_zero_alloc_all.ml", line 46, characters 39-49:
+46 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 48, characters 12-22:
-48 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53_zero_alloc_all.ml", line 47, characters 12-22:
+47 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 50, characters 9-19:
-50 |   class[@zero_alloc] foo _y = (* rejected *)
+File "w53_zero_alloc_all.ml", line 49, characters 9-19:
+49 |   class[@zero_alloc] foo _y = (* rejected *)
               ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 52, characters 10-20:
-52 |     (fun[@zero_alloc] z -> (* rejected *)
+File "w53_zero_alloc_all.ml", line 51, characters 10-20:
+51 |     (fun[@zero_alloc] z -> (* rejected *)
                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 54, characters 11-21:
-54 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
+File "w53_zero_alloc_all.ml", line 53, characters 11-21:
+53 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 56, characters 14-24:
-56 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
+File "w53_zero_alloc_all.ml", line 55, characters 14-24:
+55 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 68, characters 14-24:
-68 |     ((boz x)[@zero_alloc assume]) (* rejected *)
+File "w53_zero_alloc_all.ml", line 67, characters 14-24:
+67 |     ((boz x)[@zero_alloc assume]) (* rejected *)
                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 73, characters 7-17:
-73 |   let[@zero_alloc assume] foo = (* rejected *)
+File "w53_zero_alloc_all.ml", line 72, characters 7-17:
+72 |   let[@zero_alloc assume] foo = (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53_zero_alloc_all.ml", line 77, characters 7-17:
-77 |   let[@zero_alloc] bar = (* rejected *)
+File "w53_zero_alloc_all.ml", line 76, characters 7-17:
+76 |   let[@zero_alloc] bar = (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/warnings/w53_zero_alloc_all.ml
+++ b/ocaml/testsuite/tests/warnings/w53_zero_alloc_all.ml
@@ -18,8 +18,7 @@
 module type TestZeroAllocSig = sig
   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
   type s1 = Foo1 [@zero_alloc] (* rejected *)
-  val x : int [@@zero_alloc] (* rejected *)
-  val f : int -> int [@@zero_alloc] (* rejected *)
+  val f : int -> int [@@zero_alloc] (* accepted *)
 
   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)

--- a/ocaml/toplevel/native/topeval.ml
+++ b/ocaml/toplevel/native/topeval.ml
@@ -132,7 +132,8 @@ let name_expression ~loc ~attrs sort exp =
       val_kind = Val_reg;
       val_loc = loc;
       val_attributes = attrs;
-      val_uid = Uid.internal_not_actually_unique; }
+      val_uid = Uid.internal_not_actually_unique;
+      val_zero_alloc = Default_check }
    in
    let sg = [Sig_value(id, vd, Exported)] in
    let pat =

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -375,7 +375,8 @@ let report_value_mismatch first second env ppf err =
   | Zero_alloc { missing_entirely } ->
     pr "The former provides a weaker \"zero_alloc\" guarantee than the latter.";
     if missing_entirely then
-      pr "@ Hint: Add a \"zero_alloc\" attribute to the implementation."
+      pr "@ Hint: Add a \"zero_alloc\" attribute (without opt) to the \
+          implementation."
   | Zero_alloc_arity (n1, n2) ->
     pr "zero_alloc arity mismatch:@ \
         When using \"zero_alloc\" in a signature, the syntactic arity of@ \

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -22,6 +22,8 @@ open Typedtree
 
 type position = Errortrace.position = First | Second
 
+module ZA = Zero_alloc_utils
+
 (* Inclusion between value descriptions *)
 
 type primitive_mismatch =
@@ -40,6 +42,8 @@ type value_mismatch =
   | Primitive_mismatch of primitive_mismatch
   | Not_a_primitive
   | Type of Errortrace.moregen_error
+  | Zero_alloc
+  | Zero_alloc_arity of int * int
 
 exception Dont_match of value_mismatch
 
@@ -86,6 +90,64 @@ let primitive_descriptions pd1 pd2 =
   else
     native_repr_args pd1.prim_native_repr_args pd2.prim_native_repr_args
 
+let zero_alloc za1 za2 =
+  (* The core of the check here is that we translate both attributes into the
+     abstract domain and use the existing inclusion check from there, ensuring
+     what we do in the typechecker matches the backend.
+
+     There are a few additional details:
+
+     - [opt] is not captured by the abstract domain, so we need a special check
+       for it.  But it doesn't interact at all with the abstract domain - it's
+       just about whether or not the check happens - so this special check can
+       be fully separate.
+     - [arity] is also not captured by the abstract domain - it exists only for
+       use here, in typechecking.  If the arities do not match, we issue an
+       error. It's essential for the soundness of the way we (will, in the next
+       PR) use zero_alloc in signatures that the apparent arity of the type in
+       the signature matches the syntactic arity of the function.
+     - [ignore] can not appear in zero_alloc attributes in signatures, and is
+       erased from structure items when computing their signature, so we don't
+       need to consider it here.
+     *)
+  let open Builtin_attributes in
+  (* abstract domain check *)
+  let abstract_value za =
+    match za with
+    | Default_check | Ignore_assert_all _ -> ZA.Assume_info.Value.top ()
+    | Check { strict; _ } ->
+      ZA.Assume_info.Value.of_annotation ~strict ~never_returns_normally:false
+    | Assume { strict; never_returns_normally } ->
+      ZA.Assume_info.Value.of_annotation ~strict ~never_returns_normally
+  in
+  let v1 = abstract_value za1 in
+  let v2 = abstract_value za2 in
+  if not (ZA.Assume_info.Value.lessequal v1 v2) then
+    raise (Dont_match Zero_alloc);
+  (* opt check *)
+  begin match za1, za2 with
+  | Check { opt = opt1; _ }, Check { opt = opt2; _ } ->
+    if opt1 && not opt2 then
+      raise (Dont_match Zero_alloc)
+  | (Check _ | Default_check | Assume _ | Ignore_assert_all _), _ -> ()
+  end;
+  (* arity check *)
+  let get_arity = function
+    | Check { arity; _ } | Assume { arity; _ } -> Some arity
+    | Default_check | Ignore_assert_all _ -> None
+  in
+  match get_arity za1, get_arity za2 with
+  | Some arity1, Some arity2 ->
+    (* Check *)
+    if not (arity1 = arity2) then
+      raise (Dont_match (Zero_alloc_arity (arity1, arity2)))
+  | Some _, None -> ()
+    (* Forgetting zero_alloc info is fine *)
+  | None, Some _ ->
+    (* Fabricating it is not, but earlier cases should have ruled this out *)
+    Misc.fatal_error "Includecore.check_attributes"
+  | None, None -> ()
+
 let value_descriptions ~loc env name
     (vd1 : Types.value_description)
     (vd2 : Types.value_description) =
@@ -95,6 +157,7 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
+  zero_alloc vd1.val_zero_alloc vd2.val_zero_alloc;
   match vd1.val_kind with
   | Val_prim p1 -> begin
      match vd2.val_kind with
@@ -303,6 +366,14 @@ let report_value_mismatch first second env ppf err =
       Printtyp.report_moregen_error ppf Type_scheme env trace
         (fun ppf -> Format.fprintf ppf "The type")
         (fun ppf -> Format.fprintf ppf "is not compatible with the type")
+  | Zero_alloc ->
+    pr "The former provides a weaker \"zero_alloc\" guarantee than the latter"
+  | Zero_alloc_arity (n1, n2) ->
+    pr "zero_alloc arity mismatch:@ \
+        When using \"zero_alloc\" in a signature, the syntactic arity of@ \
+        the implementation must match the function type in the interface.@ \
+        Here the former is %d and the latter is %d."
+      n1 n2
 
 let report_type_inequality env ppf err =
   Printtyp.report_equality_error ppf Type_scheme env err

--- a/ocaml/typing/includecore.mli
+++ b/ocaml/typing/includecore.mli
@@ -36,6 +36,8 @@ type value_mismatch =
   | Primitive_mismatch of primitive_mismatch
   | Not_a_primitive
   | Type of Errortrace.moregen_error
+  | Zero_alloc
+  | Zero_alloc_arity of int * int
 
 exception Dont_match of value_mismatch
 

--- a/ocaml/typing/includecore.mli
+++ b/ocaml/typing/includecore.mli
@@ -36,7 +36,7 @@ type value_mismatch =
   | Primitive_mismatch of primitive_mismatch
   | Not_a_primitive
   | Type of Errortrace.moregen_error
-  | Zero_alloc
+  | Zero_alloc of { missing_entirely : bool }
   | Zero_alloc_arity of int * int
 
 exception Dont_match of value_mismatch

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1998,7 +1998,7 @@ let tree_of_value_description id decl =
               if strict then " strict" else "";
               if opt then " opt" else "";
               if arity = apparent_arity then "" else
-                Printf.sprintf " (arity %d)" arity;
+                Printf.sprintf " arity %d" arity;
              ] }]
     | Assume { strict; never_returns_normally; arity; _ } ->
       [{ oattr_name =
@@ -2007,7 +2007,7 @@ let tree_of_value_description id decl =
               if strict then " strict" else "";
               if never_returns_normally then " never_returns_normally" else "";
               if arity = apparent_arity then "" else
-                Printf.sprintf " (arity %d)" arity;
+                Printf.sprintf " arity %d" arity;
              ]
        }]
   in

--- a/ocaml/typing/subst.ml
+++ b/ocaml/typing/subst.ml
@@ -740,6 +740,7 @@ let rec subst_lazy_value_description s descr =
   { val_type = Wrap.substitute ~compose Keep s descr.val_type;
     val_kind = descr.val_kind;
     val_loc = loc s descr.val_loc;
+    val_zero_alloc = descr.val_zero_alloc;
     val_attributes = attrs s descr.val_attributes;
     val_uid = descr.val_uid;
   }

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -446,7 +446,7 @@ and class_type_aux env virt self_scope scty =
         match l with
         | Position _ -> ctyp Ttyp_call_pos (Ctype.newconstr Predef.path_lexing_position [])
         | Optional _ | Labelled _ | Nolabel ->
-          transl_simple_type ~new_var_jkind:Any env ~closed:false Alloc.Const.legacy sty 
+          transl_simple_type ~new_var_jkind:Any env ~closed:false Alloc.Const.legacy sty
       in
       let ty = cty.ctyp_type in
       let ty =
@@ -1269,10 +1269,10 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
       if not_nolabel_function cl.cl_type then begin
         match l with
         | Nolabel | Labelled _ -> ()
-        | Optional _ -> 
+        | Optional _ ->
           Location.prerr_warning pat.pat_loc
             Warnings.Unerasable_optional_argument;
-        | Position _ -> 
+        | Position _ ->
           Location.prerr_warning pat.pat_loc
             Warnings.Unerasable_position_argument;
       end;
@@ -1353,7 +1353,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                        (not optional && l' = Nolabel)
                     then
                       (remaining_sargs, use_arg sarg l')
-                    else if optional && label_is_absent_in_remaining_args () 
+                    else if optional && label_is_absent_in_remaining_args ()
                     then (sargs, eliminate_optional_arg ())
                     else if Btype.is_position l && label_is_absent_in_remaining_args ()
                     then (sargs, eliminate_position_arg ())
@@ -1417,9 +1417,9 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
         Typecore.type_let In_class_def val_env rec_flag sdefs in
       let (vals, met_env) =
         List.fold_right
-          (fun (id, modes_and_sorts) (vals, met_env) ->
+          (fun (id, modes_and_sorts, _) (vals, met_env) ->
              List.iter
-               (fun (loc, mode, sort, _) ->
+               (fun (loc, mode, sort) ->
                   Typecore.escape ~loc ~env:val_env ~reason:Other mode;
                   if not (Jkind.Sort.(equate sort value))
                   then

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -489,6 +489,7 @@ let enter_ancestor_met ~loc name ~sign ~meths ~cl_num ~ty ~attrs met_env =
   let desc =
     { val_type = ty; val_kind = kind;
       val_attributes = attrs;
+      val_zero_alloc = Builtin_attributes.Default_check;
       Types.val_loc = loc;
       val_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) }
   in
@@ -504,6 +505,7 @@ let add_self_met loc id sign self_var_kind vars cl_num
   let desc =
     { val_type = ty; val_kind = kind;
       val_attributes = attrs;
+      val_zero_alloc = Builtin_attributes.Default_check;
       Types.val_loc = loc;
       val_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) }
   in
@@ -520,6 +522,7 @@ let add_instance_var_met loc label id sign cl_num attrs met_env =
     { val_type = ty; val_kind = kind;
       val_attributes = attrs;
       Types.val_loc = loc;
+      val_zero_alloc = Builtin_attributes.Default_check;
       val_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) }
   in
   Env.add_value id desc met_env
@@ -1416,7 +1419,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
         List.fold_right
           (fun (id, modes_and_sorts) (vals, met_env) ->
              List.iter
-               (fun (loc, mode, sort) ->
+               (fun (loc, mode, sort, _) ->
                   Typecore.escape ~loc ~env:val_env ~reason:Other mode;
                   if not (Jkind.Sort.(equate sort value))
                   then
@@ -1447,6 +1450,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                {val_type = expr.exp_type;
                 val_kind = Val_ivar (Immutable, cl_num);
                 val_attributes = [];
+                val_zero_alloc = Builtin_attributes.Default_check;
                 Types.val_loc = vd.val_loc;
                 val_uid = vd.val_uid;
                }
@@ -1455,7 +1459,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
              ((id', expr)
               :: vals,
               Env.add_value id' desc met_env))
-          (let_bound_idents_with_modes_and_sorts defs)
+          (let_bound_idents_with_modes_sorts_and_checks defs)
           ([], met_env)
       in
       let cl = class_expr cl_num val_env met_env virt self_scope scl' in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -5041,7 +5041,7 @@ let add_check_attribute expr attributes =
   | Texp_function fn ->
     let default_arity = function_arity fn.params fn.body in
     let za =
-      get_property_attribute ~is_arity_allowed:false ~default_arity attributes
+      get_property_attribute ~in_signature:false ~default_arity attributes
         Zero_alloc
     in
     begin match za with
@@ -5388,7 +5388,7 @@ and type_expect_
       let assume_zero_alloc =
         let default_arity = List.length args in
         let zero_alloc =
-          Builtin_attributes.get_property_attribute ~is_arity_allowed:false
+          Builtin_attributes.get_property_attribute ~in_signature:false
             ~default_arity sfunct.pexp_attributes Zero_alloc
         in
         Builtin_attributes.assume_zero_alloc ~is_check_allowed:false zero_alloc
@@ -8865,7 +8865,7 @@ and type_n_ary_function
               (filter_ty_ret_exn ret_ty Nolabel ~force_tpoly:true : type_expr)
     end;
     let zero_alloc =
-      Builtin_attributes.get_property_attribute ~is_arity_allowed:false
+      Builtin_attributes.get_property_attribute ~in_signature:false
         ~default_arity:syntactic_arity attributes Zero_alloc
     in
     re

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -1091,11 +1091,13 @@ let iter_pattern_variables_type f : pattern_variable list -> unit =
 
 let add_pattern_variables ?check ?check_as env pv =
   List.fold_right
-    (fun {pv_id; pv_uid; pv_mode; pv_type; pv_loc; pv_as_var; pv_attributes} env ->
+    (fun {pv_id; pv_uid; pv_mode; pv_type; pv_loc; pv_as_var; pv_attributes}
+      env ->
        let check = if pv_as_var then check_as else check in
        Env.add_value ?check ~mode:pv_mode pv_id
          {val_type = pv_type; val_kind = Val_reg; Types.val_loc = pv_loc;
           val_attributes = pv_attributes;
+          val_zero_alloc = Builtin_attributes.Default_check;
           val_uid = pv_uid
          } env
     )
@@ -2879,6 +2881,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             { val_type = pv_type
             ; val_kind = Val_reg
             ; val_attributes = pv_attributes
+            ; val_zero_alloc = Builtin_attributes.Default_check
             ; val_loc = pv_loc
             ; val_uid = pv_uid
             }
@@ -2889,6 +2892,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             { val_type = pv_type
             ; val_kind = Val_ivar (Immutable, cl_num)
             ; val_attributes = pv_attributes
+            ; val_zero_alloc = Builtin_attributes.Default_check
             ; val_loc = pv_loc
             ; val_uid = pv_uid
             }
@@ -5035,7 +5039,12 @@ let add_check_attribute expr attributes =
   in
   match expr.exp_desc with
   | Texp_function fn ->
-    begin match get_property_attribute attributes Zero_alloc with
+    let default_arity = function_arity fn.params fn.body in
+    let za =
+      get_property_attribute ~is_arity_allowed:false ~default_arity attributes
+        Zero_alloc
+    in
+    begin match za with
     | Default_check -> expr
     | (Ignore_assert_all _ | Check _ | Assume _) as check ->
       begin match fn.zero_alloc with
@@ -5377,9 +5386,10 @@ and type_expect_
         type_application env loc expected_mode pm funct funct_mode sargs rt
       in
       let assume_zero_alloc =
+        let default_arity = List.length args in
         let zero_alloc =
-          Builtin_attributes.get_property_attribute sfunct.pexp_attributes
-            Zero_alloc
+          Builtin_attributes.get_property_attribute ~is_arity_allowed:false
+            ~default_arity sfunct.pexp_attributes Zero_alloc
         in
         Builtin_attributes.assume_zero_alloc ~is_check_allowed:false zero_alloc
       in
@@ -7391,6 +7401,7 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
         let desc =
           { val_type = ty; val_kind = Val_reg;
             val_attributes = [];
+            val_zero_alloc = Builtin_attributes.Default_check;
             val_loc = Location.none;
             val_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
           }
@@ -8764,7 +8775,7 @@ and type_n_ary_function
         region_locked;
       }
     in
-    let { function_ = exp_type, params, body;
+    let { function_ = exp_type, result_params, body;
           newtypes; params_contain_gadt = contains_gadt;
           ret_info; fun_alloc_mode;
         } =
@@ -8783,6 +8794,8 @@ and type_n_ary_function
             "[ret_info] can't be None -- that indicates a function with \
              no parameters."
     in
+    let params = List.map (fun { param } -> param) result_params in
+    let syntactic_arity = function_arity params body in
     (* Require that the n-ary function is known to have at least n arrows
         in the type. This prevents GADT equations introduced by the parameters
         from hiding arrows from the resulting type.
@@ -8829,12 +8842,6 @@ and type_n_ary_function
                       "Jkind_error not expected as this point; this should \
                        have been caught when the function was typechecked."
               in
-              let syntactic_arity =
-                List.length params +
-                (match body with
-                | Tfunction_body _ -> 0
-                | Tfunction_cases _ -> 1)
-              in
               let err =
                 Function_arity_type_clash
                   { syntactic_arity;
@@ -8849,7 +8856,7 @@ and type_n_ary_function
               filter_ty_ret_exn ret_ty param.fp_arg_label
                 ~force_tpoly:(not has_poly))
             exp_type
-            params
+            result_params
         in
         match body with
         | Tfunction_body _ -> ()
@@ -8857,9 +8864,9 @@ and type_n_ary_function
             ignore
               (filter_ty_ret_exn ret_ty Nolabel ~force_tpoly:true : type_expr)
     end;
-    let params = List.map (fun { param } -> param) params in
     let zero_alloc =
-      Builtin_attributes.get_property_attribute attributes Zero_alloc
+      Builtin_attributes.get_property_attribute ~is_arity_allowed:false
+        ~default_arity:syntactic_arity attributes Zero_alloc
     in
     re
       { exp_desc =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2679,7 +2679,7 @@ let transl_value_decl env loc valdecl =
         count_arrows 0 ty
       in
       let zero_alloc =
-        Builtin_attributes.get_property_attribute ~is_arity_allowed:true
+        Builtin_attributes.get_property_attribute ~in_signature:true
           ~default_arity valdecl.pval_attributes Zero_alloc
       in
       begin match zero_alloc with

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -119,6 +119,7 @@ type error =
   | Non_value_sort_not_upstream_compatible of Jkind.Sort.const
   | Zero_alloc_attr_unsupported of Builtin_attributes.check_attribute
   | Zero_alloc_attr_bad_arity
+  | Zero_alloc_attr_opt
 
 open Typedtree
 
@@ -2686,7 +2687,11 @@ let transl_value_decl env loc valdecl =
       | Default_check -> ()
       | Check za ->
         if za.arity = 0 then
-          raise (Error(valdecl.pval_loc, Zero_alloc_attr_bad_arity))
+          raise (Error(valdecl.pval_loc, Zero_alloc_attr_bad_arity));
+        if za.opt then
+          (* CR ccasinghino: It would be nice to support opt, but it's not
+             obvious what its meaning should be. *)
+          raise (Error(valdecl.pval_loc, Zero_alloc_attr_opt));
       | Assume _ | Ignore_assert_all _ ->
         raise (Error(valdecl.pval_loc, Zero_alloc_attr_unsupported zero_alloc))
       end;
@@ -3500,7 +3505,8 @@ let report_error ppf = function
          @ Found no arrows in this declaration's type.\
          @ Hint: You can write \"[@zero_alloc arity n]\" to specify the arity\
          @ of an alias.@]"
-
+  | Zero_alloc_attr_opt ->
+    fprintf ppf "@[\"zero_alloc opt\" is not supported in signatures.@]"
 
 let () =
   Location.register_error_of_exn

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -3498,7 +3498,8 @@ let report_error ppf = function
     fprintf ppf
       "@[In signatures, zero_alloc is only supported on function declarations.\
          @ Found no arrows in this declaration's type.\
-         @ Hint: You can add \"(arity n)\" to specify the arity of an alias.@]"
+         @ Hint: You can write \"[@zero_alloc arity n]\" to specify the arity\
+         @ of an alias.@]"
 
 
 let () =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -117,6 +117,8 @@ type error =
   | Modalities_on_value_description
   | Missing_unboxed_attribute_on_non_value_sort of Jkind.Sort.const
   | Non_value_sort_not_upstream_compatible of Jkind.Sort.const
+  | Zero_alloc_attr_unsupported of Builtin_attributes.check_attribute
+  | Zero_alloc_attr_bad_arity
 
 open Typedtree
 
@@ -2668,8 +2670,29 @@ let transl_value_decl env loc valdecl =
   let v =
   match valdecl.pval_prim with
     [] when Env.is_in_signature env ->
+      let default_arity =
+        let rec count_arrows n ty =
+          match get_desc ty with
+          | Tarrow (_, _, t2, _) -> count_arrows (n+1) t2
+          | _ -> n
+        in
+        count_arrows 0 ty
+      in
+      let zero_alloc =
+        Builtin_attributes.get_property_attribute ~is_arity_allowed:true
+          ~default_arity valdecl.pval_attributes Zero_alloc
+      in
+      begin match zero_alloc with
+      | Default_check -> ()
+      | Check za ->
+        if za.arity = 0 then
+          raise (Error(valdecl.pval_loc, Zero_alloc_attr_bad_arity))
+      | Assume _ | Ignore_assert_all _ ->
+        raise (Error(valdecl.pval_loc, Zero_alloc_attr_unsupported zero_alloc))
+      end;
       { val_type = ty; val_kind = Val_reg; Types.val_loc = loc;
         val_attributes = valdecl.pval_attributes;
+        val_zero_alloc = zero_alloc;
         val_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
       }
   | [] ->
@@ -2709,6 +2732,7 @@ let transl_value_decl env loc valdecl =
       check_unboxable env loc ty;
       { val_type = ty; val_kind = Val_prim prim; Types.val_loc = loc;
         val_attributes = valdecl.pval_attributes;
+        val_zero_alloc = Builtin_attributes.Default_check;
         val_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
       }
   in
@@ -3461,6 +3485,21 @@ let report_error ppf = function
          the use of -extension-universe (no_extensions|\
          upstream_compatible).@]"
       Jkind.Sort.format_const sort
+  | Zero_alloc_attr_unsupported ca ->
+      let variety = match ca with
+        | Default_check | Check _ -> assert false
+        | Assume _ -> "assume"
+        | Ignore_assert_all _ -> "ignore"
+      in
+      fprintf ppf
+        "@[zero_alloc \"%s\" attributes are not supported in signatures@]"
+        variety
+  | Zero_alloc_attr_bad_arity ->
+    fprintf ppf
+      "@[In signatures, zero_alloc is only supported on function declarations.\
+         @ Found no arrows in this declaration's type.\
+         @ Hint: You can add \"(arity n)\" to specify the arity of an alias.@]"
+
 
 let () =
   Location.register_error_of_exn

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -163,6 +163,7 @@ type error =
   | Non_value_sort_not_upstream_compatible of Jkind.Sort.const
   | Zero_alloc_attr_unsupported of Builtin_attributes.check_attribute
   | Zero_alloc_attr_bad_arity
+  | Zero_alloc_attr_opt
 
 exception Error of Location.t * error
 

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -162,7 +162,8 @@ type error =
   | Missing_unboxed_attribute_on_non_value_sort of Jkind.Sort.const
   | Non_value_sort_not_upstream_compatible of Jkind.Sort.const
   | Zero_alloc_attr_unsupported of Builtin_attributes.check_attribute
-  | Zero_alloc_attr_bad_arity
+  | Zero_alloc_attr_non_function
+  | Zero_alloc_attr_bad_user_arity
   | Zero_alloc_attr_opt
 
 exception Error of Location.t * error

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -161,6 +161,8 @@ type error =
   | Modalities_on_value_description
   | Missing_unboxed_attribute_on_non_value_sort of Jkind.Sort.const
   | Non_value_sort_not_upstream_compatible of Jkind.Sort.const
+  | Zero_alloc_attr_unsupported of Builtin_attributes.check_attribute
+  | Zero_alloc_attr_bad_arity
 
 exception Error of Location.t * error
 

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -1037,13 +1037,20 @@ let rev_let_bound_idents_full bindings =
   List.iter (fun vb -> iter_bound_idents add vb.vb_pat) bindings;
   !idents_full
 
-let let_bound_idents_with_modes_and_sorts bindings =
+let let_bound_idents_with_modes_sorts_and_checks bindings =
   let modes_and_sorts = Ident.Tbl.create 3 in
   let f id sloc _ _uid mode sort =
-    Ident.Tbl.add modes_and_sorts id (sloc.loc, mode, sort)
+    Ident.Tbl.add modes_and_sorts id
+      (sloc.loc, mode, sort, Builtin_attributes.Default_check)
   in
   List.iter (fun vb ->
-    iter_pattern_full ~both_sides_of_or:true f vb.vb_sort vb.vb_pat)
+    iter_pattern_full ~both_sides_of_or:true f vb.vb_sort vb.vb_pat;
+     match vb.vb_pat.pat_desc, vb.vb_expr.exp_desc with
+     | Tpat_var (id, _, _, _), Texp_function fn ->
+       let (loc, mode, sort, _) = Ident.Tbl.find modes_and_sorts id in
+       Ident.Tbl.replace modes_and_sorts id (loc, mode, sort, fn.zero_alloc)
+     | _ -> ()
+  )
     bindings;
   List.rev_map
     (fun (id, _, _, _) -> id, List.rev (Ident.Tbl.find_all modes_and_sorts id))
@@ -1124,3 +1131,9 @@ let rec exp_is_nominal exp =
   | Texp_field (parent, _, _, _) | Texp_send (parent, _, _) ->
       exp_is_nominal parent
   | _ -> false
+
+let function_arity params body =
+  List.length params +
+  match body with
+  | Tfunction_body _ -> 0
+  | Tfunction_cases _ -> 1

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -1038,22 +1038,24 @@ let rev_let_bound_idents_full bindings =
   !idents_full
 
 let let_bound_idents_with_modes_sorts_and_checks bindings =
-  let modes_and_sorts = Ident.Tbl.create 3 in
+  let modes_sorts_and_checks = Ident.Tbl.create 3 in
   let f id sloc _ _uid mode sort =
-    Ident.Tbl.add modes_and_sorts id
+    Ident.Tbl.add modes_sorts_and_checks id
       (sloc.loc, mode, sort, Builtin_attributes.Default_check)
   in
   List.iter (fun vb ->
     iter_pattern_full ~both_sides_of_or:true f vb.vb_sort vb.vb_pat;
      match vb.vb_pat.pat_desc, vb.vb_expr.exp_desc with
      | Tpat_var (id, _, _, _), Texp_function fn ->
-       let (loc, mode, sort, _) = Ident.Tbl.find modes_and_sorts id in
-       Ident.Tbl.replace modes_and_sorts id (loc, mode, sort, fn.zero_alloc)
+       let (loc, mode, sort, _) = Ident.Tbl.find modes_sorts_and_checks id in
+       Ident.Tbl.replace modes_sorts_and_checks id
+         (loc, mode, sort, fn.zero_alloc)
      | _ -> ()
   )
     bindings;
   List.rev_map
-    (fun (id, _, _, _) -> id, List.rev (Ident.Tbl.find_all modes_and_sorts id))
+    (fun (id, _, _, _) ->
+       id, List.rev (Ident.Tbl.find_all modes_sorts_and_checks id))
     (rev_let_bound_idents_full bindings)
 
 let let_bound_idents_full bindings =

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -1038,24 +1038,26 @@ let rev_let_bound_idents_full bindings =
   !idents_full
 
 let let_bound_idents_with_modes_sorts_and_checks bindings =
-  let modes_sorts_and_checks = Ident.Tbl.create 3 in
+  let modes_and_sorts = Ident.Tbl.create 3 in
   let f id sloc _ _uid mode sort =
-    Ident.Tbl.add modes_sorts_and_checks id
-      (sloc.loc, mode, sort, Builtin_attributes.Default_check)
+    Ident.Tbl.add modes_and_sorts id (sloc.loc, mode, sort)
   in
-  List.iter (fun vb ->
-    iter_pattern_full ~both_sides_of_or:true f vb.vb_sort vb.vb_pat;
-     match vb.vb_pat.pat_desc, vb.vb_expr.exp_desc with
-     | Tpat_var (id, _, _, _), Texp_function fn ->
-       let (loc, mode, sort, _) = Ident.Tbl.find modes_sorts_and_checks id in
-       Ident.Tbl.replace modes_sorts_and_checks id
-         (loc, mode, sort, fn.zero_alloc)
-     | _ -> ()
-  )
-    bindings;
+  let checks =
+    List.fold_left (fun checks vb ->
+      iter_pattern_full ~both_sides_of_or:true f vb.vb_sort vb.vb_pat;
+       match vb.vb_pat.pat_desc, vb.vb_expr.exp_desc with
+       | Tpat_var (id, _, _, _), Texp_function fn ->
+         Ident.Map.add id fn.zero_alloc checks
+       | _ -> checks
+    ) Ident.Map.empty bindings
+  in
   List.rev_map
     (fun (id, _, _, _) ->
-       id, List.rev (Ident.Tbl.find_all modes_sorts_and_checks id))
+       let zero_alloc =
+         Option.value (Ident.Map.find_opt id checks)
+           ~default:Builtin_attributes.Default_check
+       in
+       id, List.rev (Ident.Tbl.find_all modes_and_sorts id), zero_alloc)
     (rev_let_bound_idents_full bindings)
 
 let let_bound_idents_full bindings =

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -1107,9 +1107,10 @@ val exists_pattern: (pattern -> bool) -> pattern -> bool
 val let_bound_idents: value_binding list -> Ident.t list
 val let_bound_idents_full:
     value_binding list -> (Ident.t * string loc * Types.type_expr * Uid.t) list
-val let_bound_idents_with_modes_and_sorts:
+val let_bound_idents_with_modes_sorts_and_checks:
   value_binding list
-  -> (Ident.t * (Location.t * Mode.Value.l * Jkind.sort) list) list
+  -> (Ident.t * (Location.t * Mode.Value.l * Jkind.sort
+                 * Builtin_attributes.check_attribute) list) list
 
 (** Alpha conversion of patterns *)
 val alpha_pat:
@@ -1132,3 +1133,6 @@ val split_pattern:
 (** Whether an expression looks nice as the subject of a sentence in a error
     message. *)
 val exp_is_nominal : expression -> bool
+
+(** Calculates the syntactic arity of a function based on its parameters and body. *)
+val function_arity : function_param list -> function_body -> int

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -1115,14 +1115,15 @@ val let_bound_idents_full:
    Note that:
    * The list associated with each ident can only have more than one element in
      the case of or pattern, where the ident is bound on both sides.
-   * Check attributes are only supported in the case of a simple variable
-     pattern bound to a function ([Default_check] will be returned in all other
-     cases).
+   * We return just one check_attribute per identifier, because this attribute
+     can only be something other than [Default_check] in the case of a simple
+     variable pattern bound to a function (in which case the list will also
+     have just one element).
 *)
 val let_bound_idents_with_modes_sorts_and_checks:
   value_binding list
-  -> (Ident.t * (Location.t * Mode.Value.l * Jkind.sort
-                 * Builtin_attributes.check_attribute) list) list
+  -> (Ident.t * (Location.t * Mode.Value.l * Jkind.sort) list
+              * Builtin_attributes.check_attribute) list
 
 (** Alpha conversion of patterns *)
 val alpha_pat:

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -1107,6 +1107,18 @@ val exists_pattern: (pattern -> bool) -> pattern -> bool
 val let_bound_idents: value_binding list -> Ident.t list
 val let_bound_idents_full:
     value_binding list -> (Ident.t * string loc * Types.type_expr * Uid.t) list
+
+(* [let_bound_idents_with_modes_sorts_and_checks] finds all the idents in the
+   let bindings and computes their modes, sorts, and whether they have any check
+   attributes (zero_alloc).
+
+   Note that:
+   * The list associated with each ident can only have more than one element in
+     the case of or pattern, where the ident is bound on both sides.
+   * Check attributes are only supported in the case of a simple variable
+     pattern bound to a function ([Default_check] will be returned in all other
+     cases).
+*)
 val let_bound_idents_with_modes_sorts_and_checks:
   value_binding list
   -> (Ident.t * (Location.t * Mode.Value.l * Jkind.sort

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -2795,7 +2795,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
            will be marked as being used during the signature inclusion test. *)
         let items, shape_map =
           List.fold_left
-            (fun (acc, shape_map) (id, modes) ->
+            (fun (acc, shape_map) (id, id_info) ->
               List.iter
                 (fun (loc, mode, sort, _) ->
                    Typecore.escape ~loc ~env:newenv ~reason:Other mode;
@@ -2806,13 +2806,13 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
                    then raise (Error (loc, env,
                                    Toplevel_nonvalue (Ident.name id,sort)))
                 )
-                modes;
+                id_info;
               let zero_alloc =
                 (* We only allow "Check" attributes in signatures.  Here we
                    convert "Assume"s in structures to the equivalent "Check" for
                    the signature. *)
                 let open Builtin_attributes in
-                match[@warning "+9"] modes with
+                match[@warning "+9"] id_info with
                 | [(_, _, _, (Default_check | Ignore_assert_all _))] ->
                   Default_check
                 | [(_, _, _, (Check _ as zero_alloc))] -> zero_alloc
@@ -2821,7 +2821,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
                   Check { strict; property; arity; loc; opt = false }
                 | _ -> Default_check
               in
-              let (first_loc, _, _, _) = List.hd modes in
+              let (first_loc, _, _, _) = List.hd id_info in
               Signature_names.check_value names first_loc id;
               let vd =  Env.find_value (Pident id) newenv in
               let vd = Subst.Lazy.force_value_description vd in

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -2815,7 +2815,14 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
                 match[@warning "+9"] id_info with
                 | [(_, _, _, (Default_check | Ignore_assert_all _))] ->
                   Default_check
-                | [(_, _, _, (Check _ as zero_alloc))] -> zero_alloc
+                | [(_, _, _, (Check c as zero_alloc))] when not c.opt ->
+                  zero_alloc
+                | [(_, _, _, (Check _))] ->
+                  (* CR ccasinghino: We'd like to opt in signatures, but for now
+                     we don't, and must make sure you can't get it in a
+                     signature by writing it in a structure and using module
+                     type of. *)
+                  Default_check
                 | [(_, _, _, Assume { property; strict; arity; loc;
                                       never_returns_normally = _ })] ->
                   Check { strict; property; arity; loc; opt = false }

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -412,6 +412,7 @@ module type Wrapped = sig
     { val_type: type_expr wrapped;                (* Type of the value *)
       val_kind: value_kind;
       val_loc: Location.t;
+      val_zero_alloc: Builtin_attributes.check_attribute;
       val_attributes: Parsetree.attributes;
       val_uid: Uid.t;
     }
@@ -486,10 +487,12 @@ module Map_wrapped(From : Wrapped)(To : Wrapped) = struct
       | Unit -> To.Unit
       | Named (id,mty) -> To.Named (id, module_type m mty)
 
-  let value_description m {val_type; val_kind; val_attributes; val_loc; val_uid} =
+  let value_description m {val_type; val_kind; val_zero_alloc;
+                           val_attributes; val_loc; val_uid} =
     To.{
       val_type = m.map_type_expr m val_type;
       val_kind;
+      val_zero_alloc;
       val_attributes;
       val_loc;
       val_uid

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -709,6 +709,7 @@ module type Wrapped = sig
     { val_type: type_expr wrapped;                (* Type of the value *)
       val_kind: value_kind;
       val_loc: Location.t;
+      val_zero_alloc: Builtin_attributes.check_attribute;
       val_attributes: Parsetree.attributes;
       val_uid: Uid.t;
     }

--- a/ocaml/utils/zero_alloc_utils.mli
+++ b/ocaml/utils/zero_alloc_utils.mli
@@ -6,6 +6,8 @@
 module type WS = sig
   type t
 
+  val empty : t
+
   val join : t -> t -> t
 
   val meet : t -> t -> t
@@ -80,6 +82,9 @@ module Make (Witnesses : WS) : sig
         (i.e., [nor] component is Safe, others are Top.  *)
     val relaxed : Witnesses.t -> t
 
+    (** Constructs a value from a user annotation. The witness will be empty. *)
+    val of_annotation : strict:bool -> never_returns_normally:bool -> t
+
     val print : witnesses:bool -> Format.formatter -> t -> unit
 
     (** Use [compare] for structural comparison of terms, for example
@@ -126,6 +131,8 @@ module Assume_info : sig
 
   module Witnesses : sig
     type t = unit
+
+    val empty : t
 
     val join : t -> t -> t
 

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -831,3 +831,22 @@
  (enabled_if (= %{context_name} "main"))
  (deps test_all_opt3.output test_all_opt3.output.corrected)
  (action (diff test_all_opt3.output test_all_opt3.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_arity.output.corrected)
+ (deps (:ml test_arity.ml) filter.sh)
+ (action
+   (with-outputs-to test_arity.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_arity.output test_arity.output.corrected)
+ (action (diff test_arity.output test_arity.output.corrected)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -138,4 +138,6 @@ let () =
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_flags:"-zero-alloc-check opt"
     ~extra_dep:None ~exit_code:2 "test_all_opt3";
+  print_test_expected_output ~cutoff:default_cutoff
+    ~extra_dep:None ~exit_code:2 "test_arity";
   ()

--- a/tests/backend/checkmach/test_arity.ml
+++ b/tests/backend/checkmach/test_arity.ml
@@ -1,0 +1,10 @@
+
+(* These tests check that the backend check does what we expect on functions
+   used in an interesting example in the typing tests for zero_alloc in
+   signatures (see [ocaml/testsuite/tests/typing-zero-alloc/signatures.ml]). *)
+
+let[@zero_alloc] f_zero_alloc x y =
+  if x = y+1 then fun z -> (z,z) else fun z -> (z,0)
+
+let[@zero_alloc] f_not_zero_alloc x y z =
+  if x = y+1 then (z,z) else (z,0)

--- a/tests/backend/checkmach/test_arity.output
+++ b/tests/backend/checkmach/test_arity.output
@@ -1,0 +1,8 @@
+File "test_arity.ml", line 9, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_arity.f_not_zero_alloc (camlTest_arity.f_not_zero_alloc_HIDE_STAMP)
+
+File "test_arity.ml", line 10, characters 18-23:
+Error: allocation of 24 bytes
+
+File "test_arity.ml", line 10, characters 29-34:
+Error: allocation of 24 bytes


### PR DESCRIPTION
This PR allows writing `[@zero_alloc]` in signatures.  Any implementing module is required to have a `[@zero_alloc]` attribute on the corresponding definition.  This is the second of three PRs in the "zero_alloc in signatures" series.  The final PR will allow other compilation units to make use of the information this PR adds to signatures.

What does `[@zero_alloc]` in a signature mean about a corresponding value in a module? One wants it to mean that the implementation must be zero alloc. Of course, the typechecker is too early to check that property accurately. So really what is means, from the perspective of the typechecker, is that the corresponding value is annotated such that it will be checked for zero_alloc in the backend. Which works out to the same thing for the user.

The annotations need not match exactly. For example, if the value is annotated such that it will be checked "more strictly" than the signature implies, that's fine. Details in a comment at the relevant place in the code.

The main complication is arity. The way we will use this information in the final PR relies on our ability to determine when a function is fully applied, even if all we know about it is the `value_description` we got from a `cmi` file. As such, we record the arity that we understand the function to have, based on the number of arrows in its type, in the `value_description`, and check that against the syntactic arity of the function.  The user can override the arity we would calculate from the type (useful, for example, when the type is an alias).

The actual implementation is straightforward. We make `zero_alloc` part of value descriptions in module types (not part of function types proper).  There are two bits that are a little complex mainly due to constraints of the existing code:
*  In typemod, where we actually need to find out whether a pattern variable that we're making a `value_description` for has a `zero_alloc` annotation. I made a slightly gross (in my mind) change to `Typedtree.let_bound_idents_with_modes_and_sorts` to support this, which seemed the only solution short of a substantial refactoring of how pattern variables are treated here.
* The parsing of the optional `(arity n)` in `zero_alloc` payloads is unpleasant. We considered a few other ways to write this, but this was the only one that seemed parseable at all. The existing code was already unpleasant (these payloads are interpreted as function applications by the ocaml parser and then re-interpreted by `builtin_attributes`).  If the reviewers insist that now is the moment to burn it down and try an entirely different approach, I'll relent.

Review: @ncik-roberts to review the core of the typechecker changes, and the design.  @gretay-js also to review the design.  @Ekdohibs will need to sign off for the chamelon changes.

There are two commits.  The first just makes it so there is only one place we translate zero_alloc attributes to the abstract domain, rather than having two versions that could get out of sync.  @gretay-js does this conflict with your other in-flight PRs?  We could undo it if so.  The second has the bulk of the changes.