### PR TITLE
Fix function return layout bug

### DIFF
--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1288,20 +1288,8 @@ and transl_apply ~scopes
    [trans_curried_function]).
 *)
 and transl_function_without_attributes
-    ~scopes ~return_sort ~return_mode ~mode ~region loc repr params body =
-  let return_layout =
-    match body with
-    | Tfunction_body exp ->
-        layout_exp return_sort exp
-    | Tfunction_cases { fc_cases = { c_rhs; _ } :: _ } ->
-        layout_exp return_sort c_rhs
-    | Tfunction_cases { fc_cases = [] } ->
-        (* ppxes can generate empty function cases, which compiles to
-           a function that always raises Match_failure. We try less
-           hard to calculate a detailed layout that the middle-end can
-           use for optimizations. *)
-        layout_of_sort loc return_sort
-  in
+    ~scopes ~return_sort ~return_layout ~return_mode ~mode ~region loc repr
+    params body =
   match
     transl_tupled_function ~scopes loc params body
       ~return_sort ~return_mode ~return_layout ~mode ~region
@@ -1569,6 +1557,9 @@ and transl_function ~in_new_scope ~scopes e params body
         region = sregion;
       }
   in
+  let return_layout =
+    function_return_layout e.exp_env e.exp_loc return_sort e.exp_type
+  in
   (* [ret_mode] may differ from [sreturn_mode] if:
        - [e] is a method. (See [fuse_method_arity].)
        - [e] is a function whose arity exceeds [Lambda.max_arity].
@@ -1578,7 +1569,7 @@ and transl_function ~in_new_scope ~scopes e params body
     event_function ~scopes e
       (function repr ->
          transl_function_without_attributes
-           ~mode ~return_sort ~return_mode
+           ~mode ~return_sort ~return_layout ~return_mode
            ~scopes e.exp_loc repr ~region params body)
   in
   let attr =
@@ -2018,6 +2009,7 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
       (transl_exp ~scopes let_.bop_exp_sort let_.bop_exp) ands
   in
   let func =
+    let return_layout = layout_exp case_sort case.c_rhs in
     let return_mode = alloc_heap (* XXX fixme: use result of is_function_type *) in
     let (kind, params, return, _region, ret_mode), body =
       event_function ~scopes case.c_rhs
@@ -2025,7 +2017,7 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
            let loc = case.c_rhs.exp_loc in
            let ghost_loc = { loc with loc_ghost = true } in
            transl_function_without_attributes ~scopes ~region:true
-             ~return_sort:case_sort ~mode:alloc_heap ~return_mode
+             ~return_sort:case_sort ~return_layout ~mode:alloc_heap ~return_mode
              loc repr []
              (Tfunction_cases
                 { fc_cases = [case]; fc_param = param; fc_partial = partial;

--- a/ocaml/testsuite/tests/syntactic-arity/flambda_kind.ml
+++ b/ocaml/testsuite/tests/syntactic-arity/flambda_kind.ml
@@ -1,0 +1,23 @@
+(* TEST
+   flambda2;
+   native;
+*)
+
+[@@@ocaml.flambda_o3]
+
+type _ value =
+  | Int : int value
+  | Float : float value
+
+let[@inline never] get (type a) : a value -> a = function
+  | Int -> 3
+  | Float -> 3.
+
+let[@inline] update (type a) (v : a value) (x : a) : a =
+  match v with
+  | Int -> x + 1
+  | Float -> x +. 1.
+
+let run x = update x (get x)
+
+let (_ : float) = run Float


### PR DESCRIPTION
#1817 introduced a bug where `translcore` computed a function's return layout according only to its first case if it was written with the `function` syntax. This PR fixes that bug by computing the return layout the same way it was computed prior to #1817.

For example, the function `get` would get a return layout of `Pvalue Pintval` even though a float is returned out of the second case:

```ocaml
type _ value =
  | Int : int value
  | Float : float value

let get (type a) : a value -> a = function
  | Int -> 0
  | Float -> 0.
```

You can turn this into a flambda2 middle-end crash. (I haven't been able to turn it into a miscompilation, but I theorize this is possible.) This PR adds the crashing test as a regression test.

The same bug exists upstream; I'll post the corresponding PR there after this is reviewed.