### PR TITLE
Move zero alloc annotations into a separate file

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -102,10 +102,10 @@ let mk_heap_reduction_threshold f =
 ;;
 
 let mk_zero_alloc_check f =
-  let annotations = Clflags.Annotations.(List.map to_string all) in
+  let annotations = Zero_alloc_annotations.(List.map to_string all) in
   "-zero-alloc-check", Arg.Symbol (annotations, f),
   " Check that annotated functions do not allocate \
-   and do not have indirect calls. "^Clflags.Annotations.doc
+   and do not have indirect calls. "^Zero_alloc_annotations.doc
 
 let mk_dcheckmach f =
   "-dcheckmach", Arg.Unit f, " (undocumented)"
@@ -933,7 +933,7 @@ module Flambda_backend_options_impl = struct
     Flambda_backend_flags.heap_reduction_threshold := x
 
   let zero_alloc_check s =
-    match Clflags.Annotations.of_string s with
+    match Zero_alloc_annotations.of_string s with
     | None -> () (* this should not occur as we use Arg.Symbol *)
     | Some a ->
       Clflags.zero_alloc_check := a
@@ -1214,7 +1214,7 @@ module Extra_params = struct
     | "basic-block-sections" -> set' Flambda_backend_flags.basic_block_sections
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
     | "zero-alloc-check" ->
-      (match Clflags.Annotations.of_string v with
+      (match Zero_alloc_annotations.of_string v with
        | Some a -> Clflags.zero_alloc_check := a; true
        | None ->
          raise

--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -29,6 +29,7 @@ utils/ccomp.cmx : \
     utils/ccomp.cmi
 utils/ccomp.cmi :
 utils/clflags.cmo : \
+    utils/zero_alloc_annotations.cmi \
     utils/profile.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
@@ -36,6 +37,7 @@ utils/clflags.cmo : \
     utils/arg_helper.cmi \
     utils/clflags.cmi
 utils/clflags.cmx : \
+    utils/zero_alloc_annotations.cmx \
     utils/profile.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
@@ -43,6 +45,7 @@ utils/clflags.cmx : \
     utils/arg_helper.cmx \
     utils/clflags.cmi
 utils/clflags.cmi : \
+    utils/zero_alloc_annotations.cmi \
     utils/profile.cmi \
     utils/misc.cmi
 utils/compilation_unit.cmo : \
@@ -282,6 +285,11 @@ utils/warnings.cmx : \
     utils/misc.cmx \
     utils/warnings.cmi
 utils/warnings.cmi :
+utils/zero_alloc_annotations.cmo : \
+    utils/zero_alloc_annotations.cmi
+utils/zero_alloc_annotations.cmx : \
+    utils/zero_alloc_annotations.cmi
+utils/zero_alloc_annotations.cmi :
 utils/zero_alloc_utils.cmo : \
     utils/zero_alloc_utils.cmi
 utils/zero_alloc_utils.cmx : \
@@ -401,6 +409,7 @@ parsing/attr_helper.cmi : \
     parsing/asttypes.cmi
 parsing/builtin_attributes.cmo : \
     utils/zero_alloc_utils.cmi \
+    utils/zero_alloc_annotations.cmi \
     utils/warnings.cmi \
     parsing/parsetree.cmi \
     utils/misc.cmi \
@@ -414,6 +423,7 @@ parsing/builtin_attributes.cmo : \
     parsing/builtin_attributes.cmi
 parsing/builtin_attributes.cmx : \
     utils/zero_alloc_utils.cmx \
+    utils/zero_alloc_annotations.cmx \
     utils/warnings.cmx \
     parsing/parsetree.cmi \
     utils/misc.cmx \
@@ -690,6 +700,7 @@ typing/annot.cmi : \
 typing/btype.cmo : \
     typing/types.cmi \
     typing/path.cmi \
+    parsing/parsetree.cmi \
     utils/local_store.cmi \
     typing/ident.cmi \
     parsing/asttypes.cmi \
@@ -697,6 +708,7 @@ typing/btype.cmo : \
 typing/btype.cmx : \
     typing/types.cmx \
     typing/path.cmx \
+    parsing/parsetree.cmi \
     utils/local_store.cmx \
     typing/ident.cmx \
     parsing/asttypes.cmi \
@@ -704,6 +716,7 @@ typing/btype.cmx : \
 typing/btype.cmi : \
     typing/types.cmi \
     typing/path.cmi \
+    parsing/parsetree.cmi \
     typing/jkind.cmi \
     parsing/asttypes.cmi
 typing/cmt2annot.cmo : \
@@ -1449,8 +1462,7 @@ typing/printtyp.cmi : \
     parsing/location.cmi \
     typing/ident.cmi \
     typing/errortrace.cmi \
-    typing/env.cmi \
-    parsing/asttypes.cmi
+    typing/env.cmi
 typing/printtyped.cmo : \
     utils/zero_alloc_utils.cmi \
     typing/types.cmi \
@@ -1932,6 +1944,7 @@ typing/typedecl.cmi : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/language_extension.cmi \
     typing/jkind.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
@@ -7055,6 +7068,7 @@ toplevel/genprintval.cmo : \
     typing/env.cmi \
     typing/datarepr.cmi \
     typing/ctype.cmi \
+    utils/clflags.cmi \
     typing/btype.cmi \
     parsing/asttypes.cmi \
     toplevel/genprintval.cmi
@@ -7076,6 +7090,7 @@ toplevel/genprintval.cmx : \
     typing/env.cmx \
     typing/datarepr.cmx \
     typing/ctype.cmx \
+    utils/clflags.cmx \
     typing/btype.cmx \
     parsing/asttypes.cmi \
     toplevel/genprintval.cmi
@@ -7264,7 +7279,6 @@ toplevel/topprinters.cmo : \
     typing/mode.cmi \
     typing/ident.cmi \
     typing/ctype.cmi \
-    parsing/asttypes.cmi \
     toplevel/topprinters.cmi
 toplevel/topprinters.cmx : \
     typing/types.cmx \
@@ -7273,7 +7287,6 @@ toplevel/topprinters.cmx : \
     typing/mode.cmx \
     typing/ident.cmx \
     typing/ctype.cmx \
-    parsing/asttypes.cmi \
     toplevel/topprinters.cmi
 toplevel/topprinters.cmi : \
     typing/types.cmi
@@ -7412,7 +7425,6 @@ toplevel/byte/trace.cmo : \
     bytecomp/meta.cmi \
     parsing/longident.cmi \
     typing/ctype.cmi \
-    parsing/asttypes.cmi \
     toplevel/byte/trace.cmi
 toplevel/byte/trace.cmx : \
     typing/types.cmx \
@@ -7425,7 +7437,6 @@ toplevel/byte/trace.cmx : \
     bytecomp/meta.cmx \
     parsing/longident.cmx \
     typing/ctype.cmx \
-    parsing/asttypes.cmi \
     toplevel/byte/trace.cmi
 toplevel/byte/trace.cmi : \
     typing/types.cmi \

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -1467,14 +1467,14 @@ tools/ocamldep$(EXE): OC_BYTECODE_LINKFLAGS += -compat-32
 ocamlprof_LIBRARIES =
 ocamlprof_MODULES = \
   config build_path_prefix_map misc identifiable numbers arg_helper \
-  local_store load_path clflags terminfo warnings location longident \
-  docstrings syntaxerr ast_helper camlinternalMenhirLib parser pprintast \
-  lexer parse ocamlprof
+  local_store load_path zero_alloc_annotations clflags terminfo warnings \
+  location longident docstrings syntaxerr ast_helper camlinternalMenhirLib \
+  parser pprintast lexer parse ocamlprof
 
 ocamlcp_ocamloptp_MODULES = \
   config build_path_prefix_map misc profile warnings identifiable numbers \
-  arg_helper local_store load_path clflags terminfo location ccomp compenv \
-  main_args ocamlcp_common
+  arg_helper local_store load_path zero_alloc_annotations clflags terminfo \
+  location ccomp compenv main_args ocamlcp_common zero_alloc_annotations
 
 ocamlcp_LIBRARIES =
 ocamlcp_MODULES = $(ocamlcp_ocamloptp_MODULES) ocamlcp
@@ -1491,7 +1491,7 @@ ocamlmklib_MODULES = config build_path_prefix_map misc ocamlmklib
 ocamlmktop_LIBRARIES =
 ocamlmktop_MODULES = \
   config build_path_prefix_map misc identifiable numbers arg_helper \
-  local_store load_path clflags profile ccomp ocamlmktop
+  local_store load_path zero_alloc_annotations clflags profile ccomp ocamlmktop
 
 # Reading cmt files
 

--- a/ocaml/compilerlibs/Makefile.compilerlibs
+++ b/ocaml/compilerlibs/Makefile.compilerlibs
@@ -34,6 +34,7 @@ UTILS = \
   utils/arg_helper.cmo \
   utils/local_store.cmo \
   utils/load_path.cmo \
+  utils/zero_alloc_annotations.cmo \
   utils/clflags.cmo \
   utils/debug.cmo \
   utils/language_extension_kernel.cmo \

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -77,7 +77,7 @@
    local_store target_system compilation_unit import_info linkage_name symbol
    lazy_backtrack diffing diffing_with_keys
    language_extension_kernel language_extension
-   zero_alloc_utils
+   zero_alloc_utils zero_alloc_annotations
 
    ;; PARSING
    location longident docstrings printast syntaxerr ast_helper
@@ -248,6 +248,7 @@
     (identifiable.mli as compiler-libs/identifiable.mli)
     (numbers.mli as compiler-libs/numbers.mli)
     (arg_helper.mli as compiler-libs/arg_helper.mli)
+    (zero_alloc_annotations.mli as compiler-libs/zero_alloc_annotations.mli)
     (clflags.mli as compiler-libs/clflags.mli)
     (language_extension.mli as compiler-libs/language_extension.mli)
     (profile.mli as compiler-libs/profile.mli)

--- a/ocaml/otherlibs/dynlink/Makefile
+++ b/ocaml/otherlibs/dynlink/Makefile
@@ -84,6 +84,7 @@ COMPILERLIBS_SOURCES=\
   utils/arg_helper.ml \
   utils/local_store.ml \
   utils/load_path.ml \
+  utils/zero_alloc_annotations.ml \
   utils/clflags.ml \
   utils/debug.ml \
   utils/language_extension_kernel.ml \

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -54,6 +54,7 @@
     identifiable
     numbers
     arg_helper
+    zero_alloc_annotations
     clflags
     debug
     language_extension_kernel
@@ -148,6 +149,7 @@
 (copy_files ../../utils/identifiable.ml)
 (copy_files ../../utils/numbers.ml)
 (copy_files ../../utils/arg_helper.ml)
+(copy_files ../../utils/zero_alloc_annotations.ml)
 (copy_files ../../utils/clflags.ml)
 (copy_files ../../utils/debug.ml)
 (copy_files ../../utils/language_extension_kernel.ml)
@@ -214,6 +216,7 @@
 (copy_files ../../utils/identifiable.mli)
 (copy_files ../../utils/numbers.mli)
 (copy_files ../../utils/arg_helper.mli)
+(copy_files ../../utils/zero_alloc_annotations.mli)
 (copy_files ../../utils/clflags.mli)
 (copy_files ../../utils/debug.mli)
 (copy_files ../../utils/language_extension_kernel.mli)

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -603,10 +603,10 @@ let parse_attribute_with_ident_payload attr ~name ~f =
 let zero_alloc_attribute (attr : Parsetree.attribute)  =
   parse_attribute_with_ident_payload attr
     ~name:"zero_alloc" ~f:(function
-      | "check" -> Clflags.zero_alloc_check := Clflags.Annotations.Check_default
-      | "check_opt" -> Clflags.zero_alloc_check := Clflags.Annotations.Check_opt_only
-      | "check_all" -> Clflags.zero_alloc_check := Clflags.Annotations.Check_all
-      | "check_none" -> Clflags.zero_alloc_check := Clflags.Annotations.No_check
+      | "check" -> Clflags.zero_alloc_check := Zero_alloc_annotations.Check_default
+      | "check_opt" -> Clflags.zero_alloc_check := Zero_alloc_annotations.Check_opt_only
+      | "check_all" -> Clflags.zero_alloc_check := Zero_alloc_annotations.Check_all
+      | "check_none" -> Clflags.zero_alloc_check := Zero_alloc_annotations.No_check
       | "all" ->
         Clflags.zero_alloc_check_assert_all := true
       | _ ->

--- a/ocaml/tools/Makefile
+++ b/ocaml/tools/Makefile
@@ -83,7 +83,8 @@ ocamldep.opt$(EXE): $(call byte2native, $(OCAMLDEP))
 # The profiler
 
 OCAMLPROF=config.cmo build_path_prefix_map.cmo misc.cmo identifiable.cmo \
-  numbers.cmo arg_helper.cmo clflags.cmo debug.cmo terminfo.cmo \
+  numbers.cmo arg_helper.cmo zero_alloc_annotations.cmo clflags.cmo \
+  debug.cmo terminfo.cmo \
   warnings.cmo location.cmo longident.cmo docstrings.cmo \
   syntaxerr.cmo ast_helper.cmo \
   language_extension_kernel.cmo language_extension.cmo \
@@ -101,7 +102,7 @@ opt.opt: profiling.cmx
 OCAMLCP = config.cmo build_path_prefix_map.cmo misc.cmo profile.cmo \
           warnings.cmo identifiable.cmo numbers.cmo arg_helper.cmo \
           language_extension_kernel.cmo language_extension.cmo \
-	  clflags.cmo local_store.cmo \
+	  	  zero_alloc_annotations.cmo clflags.cmo local_store.cmo \
           terminfo.cmo location.cmo load_path.cmo ccomp.cmo compenv.cmo \
           main_args.cmo
 
@@ -136,8 +137,9 @@ ocamlmklib.opt$(EXE): $(call byte2native, $(OCAMLMKLIB))
 # To make custom toplevels
 
 OCAMLMKTOP=config.cmo build_path_prefix_map.cmo misc.cmo \
-       identifiable.cmo numbers.cmo arg_helper.cmo clflags.cmo \
-       local_store.cmo load_path.cmo profile.cmo ccomp.cmo ocamlmktop.cmo
+       identifiable.cmo numbers.cmo arg_helper.cmo zero_alloc_annotations.cmo \
+	   clflags.cmo local_store.cmo load_path.cmo profile.cmo ccomp.cmo \
+	   ocamlmktop.cmo
 
 ocamlmktop$(EXE): $(OCAMLMKTOP)
 ocamlmktop.opt$(EXE): $(call byte2native, $(OCAMLMKTOP))

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -648,39 +648,7 @@ let create_usage_msg program =
 let print_arguments program =
   Arg.usage !arg_spec (create_usage_msg program)
 
-module Annotations = struct
-  type t = Check_default | Check_all | Check_opt_only | No_check
-
-  let all = [ Check_default; Check_all; Check_opt_only; No_check ]
-
-  let to_string = function
-    | Check_default -> "default"
-    | Check_all -> "all"
-    | Check_opt_only -> "opt"
-    | No_check -> "none"
-
-  let equal t1 t2 =
-    match t1, t2 with
-    | Check_default, Check_default -> true
-    | Check_all, Check_all -> true
-    | No_check, No_check -> true
-    | Check_opt_only, Check_opt_only -> true
-    | (Check_default | Check_all | Check_opt_only | No_check), _ -> false
-
-  let of_string v =
-    let f t =
-      if String.equal (to_string t) v then Some t else None
-    in
-    List.find_map f all
-
-  let doc =
-    "\n\    The argument specifies which annotations to check: \n\
-     \      \"opt\" means attributes with \"opt\" payload and is intended for debugging;\n\
-     \      \"default\" means attributes without \"opt\" payload; \n\
-     \      \"all\" covers both \"opt\" and \"default\" and is intended for optimized builds."
-end
-
-let zero_alloc_check = ref Annotations.Check_default    (* -zero-alloc-check *)
+let zero_alloc_check = ref Zero_alloc_annotations.Check_default    (* -zero-alloc-check *)
 let zero_alloc_check_assert_all = ref false (* -zero-alloc-check-assert-all *)
 
 let no_auto_include_otherlibs = ref false      (* -no-auto-include-otherlibs *)

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -293,16 +293,8 @@ val print_arguments : string -> unit
 (* [reset_arguments ()] clear all declared arguments *)
 val reset_arguments : unit -> unit
 
-(* [Annotations] specifies which zero_alloc attributes to check. *)
-module Annotations : sig
-  type t = Check_default | Check_all | Check_opt_only | No_check
-  val all : t list
-  val to_string : t -> string
-  val of_string : string -> t option
-  val equal : t -> t -> bool
-  val doc : string
-end
-val zero_alloc_check : Annotations.t ref
+(* [zero_alloc_check] specifies which zero_alloc attributes to check. *)
+val zero_alloc_check : Zero_alloc_annotations.t ref
 val zero_alloc_check_assert_all : bool ref
 
 val no_auto_include_otherlibs : bool ref

--- a/ocaml/utils/zero_alloc_annotations.ml
+++ b/ocaml/utils/zero_alloc_annotations.ml
@@ -1,3 +1,30 @@
+(******************************************************************************
+ *                             flambda-backend                                *
+ *                         Greta Yorsh, Jane Street                           *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2024 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
 type t = Check_default | Check_all | Check_opt_only | No_check
 
 let all = [ Check_default; Check_all; Check_opt_only; No_check ]

--- a/ocaml/utils/zero_alloc_annotations.ml
+++ b/ocaml/utils/zero_alloc_annotations.ml
@@ -1,0 +1,29 @@
+type t = Check_default | Check_all | Check_opt_only | No_check
+
+let all = [ Check_default; Check_all; Check_opt_only; No_check ]
+
+let to_string = function
+  | Check_default -> "default"
+  | Check_all -> "all"
+  | Check_opt_only -> "opt"
+  | No_check -> "none"
+
+let equal t1 t2 =
+  match t1, t2 with
+  | Check_default, Check_default -> true
+  | Check_all, Check_all -> true
+  | No_check, No_check -> true
+  | Check_opt_only, Check_opt_only -> true
+  | (Check_default | Check_all | Check_opt_only | No_check), _ -> false
+
+let of_string v =
+  let f t =
+    if String.equal (to_string t) v then Some t else None
+  in
+  List.find_map f all
+
+let doc =
+  "\n\    The argument specifies which annotations to check: \n\
+    \      \"opt\" means attributes with \"opt\" payload and is intended for debugging;\n\
+    \      \"default\" means attributes without \"opt\" payload; \n\
+    \      \"all\" covers both \"opt\" and \"default\" and is intended for optimized builds."

--- a/ocaml/utils/zero_alloc_annotations.mli
+++ b/ocaml/utils/zero_alloc_annotations.mli
@@ -1,0 +1,6 @@
+type t = Check_default | Check_all | Check_opt_only | No_check
+val all : t list
+val to_string : t -> string
+val of_string : string -> t option
+val equal : t -> t -> bool
+val doc : string

--- a/ocaml/utils/zero_alloc_annotations.mli
+++ b/ocaml/utils/zero_alloc_annotations.mli
@@ -1,3 +1,30 @@
+(******************************************************************************
+ *                             flambda-backend                                *
+ *                         Greta Yorsh, Jane Street                           *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2024 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
 type t = Check_default | Check_all | Check_opt_only | No_check
 val all : t list
 val to_string : t -> string


### PR DESCRIPTION
Merlin now cares about the `-zero-alloc-check` flag, which means it needs the `Clflags.Annotations` module. This is currently located in the `clflags.ml` file. However, this file doesn't get merged into Merlin. This makes me worried that a change to the module could quietly break Merlin. This PR does step 1 of resolving this, which is separating out the module into a separate file. Step 2 (which I'm not sure if it's necessary or will be done automatically) is updating Merlin to merge this new file when running the import script.