### PR TITLE
Clean up mode error printing

### DIFF
--- a/ocaml/testsuite/tests/typing-local/crossing.ml
+++ b/ocaml/testsuite/tests/typing-local/crossing.ml
@@ -54,8 +54,9 @@ let f : local_ _ -> _ =
 Line 2, characters 14-15:
 2 |   fun x -> f' x
                   ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 (* 2. constructor argument crosses mode at construction *)
@@ -71,7 +72,7 @@ let f : local_ _ -> bar =
 Line 2, characters 21-22:
 2 |   fun n -> Bar0 (42, n)
                          ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* 3. record field crosses mode at construction *)
@@ -87,7 +88,7 @@ let f : local_ _ -> foo =
 Line 2, characters 24-25:
 2 |   fun n -> {x = 42; y = n}
                             ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* 4. expression crosses mode when being constrained *)
@@ -103,7 +104,7 @@ let f : local_ _ -> _ =
 Line 2, characters 12-13:
 2 |   fun n -> (n : string)
                 ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* 5. polymorphic variant arguments crosses mode on construction*)
@@ -119,7 +120,7 @@ let f : local_ _ -> [> `Text of string] =
 Line 2, characters 17-18:
 2 |   fun n -> `Text n
                      ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* tuple elements crosses mode at construction *)
@@ -135,7 +136,7 @@ let f : local_ _ -> string * string =
 Line 2, characters 12-13:
 2 |   fun n -> (n, n)
                 ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* array elements crosses mode at construction *)
@@ -151,7 +152,7 @@ let f: local_ _ -> string array =
 Line 2, characters 13-14:
 2 |   fun n -> [|n; n|]
                  ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* after discussion with sdolan, we agree that
@@ -179,7 +180,7 @@ let f : local_ foo -> _ =
 Line 2, characters 11-14:
 2 |   fun r -> r.y
                ^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* the expected type is not considered when mode crossing the result of
@@ -215,8 +216,9 @@ val g : string -> string = <fun>
 Line 6, characters 6-22:
 6 |     g (local_ "world")
           ^^^^^^^^^^^^^^^^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 (* the result of function application crosses mode *)
@@ -244,7 +246,7 @@ let g : _ -> _ =
 Line 2, characters 28-29:
 2 |   fun () -> let x = f () in x
                                 ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* constructor argument crosses modes upon pattern matching *)
@@ -276,7 +278,7 @@ let f : local_ bar -> _ =
 Line 4, characters 21-22:
 4 |     | Bar0 (_, y) -> y
                          ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* record fields crosses modes upon pattern matching *)
@@ -306,7 +308,7 @@ let f : local_ foo -> _ =
 Line 4, characters 16-17:
 4 |     | {y; _} -> y
                     ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* constraint crosses modes upon pattern matching  *)
@@ -322,7 +324,7 @@ let f : local_ _ -> _ =
 Line 2, characters 22-23:
 2 |   fun (x : string) -> x
                           ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 

--- a/ocaml/testsuite/tests/typing-local/exclave.ml
+++ b/ocaml/testsuite/tests/typing-local/exclave.ml
@@ -62,7 +62,7 @@ let foo x =
 Line 5, characters 8-9:
 5 |     ref y
             ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* following we check error detection *)
@@ -84,7 +84,7 @@ let foo x =
 Line 3, characters 10-25:
 3 |   let z = exclave_ Some y in
               ^^^^^^^^^^^^^^^
-Error: Exclave expression should only be in tail position of the current region
+Error: Exclave expression should only be in tail position of the current region.
 |}]
 
 (* following we test WHILE loop *)
@@ -108,7 +108,7 @@ let foo () =
 Line 3, characters 4-17:
 3 |     (exclave_ ());
         ^^^^^^^^^^^^^
-Error: Exclave expression should only be in tail position of the current region
+Error: Exclave expression should only be in tail position of the current region.
 |}]
 
 (* following we test FOR loop *)
@@ -129,7 +129,7 @@ let foo () =
 Line 3, characters 4-17:
 3 |     (exclave_ ());
         ^^^^^^^^^^^^^
-Error: Exclave expression should only be in tail position of the current region
+Error: Exclave expression should only be in tail position of the current region.
 |}]
 
 type t = { x : int option }
@@ -162,7 +162,7 @@ type data = { mutable a : string; }
 Line 6, characters 9-10:
 6 |   x.a <- z;
              ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let foo x =

--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -9,8 +9,8 @@ let leak n =
 Line 3, characters 2-3:
 3 |   r
       ^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 external idint : local_ int -> int = "%identity"
@@ -40,8 +40,8 @@ let leak n =
 Line 3, characters 2-3:
 3 |   r
       ^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let leak n =
@@ -51,8 +51,8 @@ let leak n =
 Line 3, characters 2-3:
 3 |   r
       ^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let leak n =
@@ -62,8 +62,8 @@ let leak n =
 Line 3, characters 2-3:
 3 |   f
       ^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let leak n =
@@ -73,8 +73,8 @@ let leak n =
 Line 3, characters 2-3:
 3 |   f
       ^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 (* If both type and mode are wrong, complain about type *)
@@ -268,8 +268,8 @@ let apply2 x = f4 x x
 Line 1, characters 15-21:
 1 | let apply2 x = f4 x x
                    ^^^^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
   Hint: This is a partial application
         Adding 2 more arguments will make the value non-local
 |}]
@@ -278,8 +278,8 @@ let apply3 x = f4 x x x
 Line 1, characters 15-23:
 1 | let apply3 x = f4 x x x
                    ^^^^^^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -316,8 +316,8 @@ let apply1 x = g x
 Line 1, characters 15-18:
 1 | let apply1 x = g x
                    ^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -339,8 +339,8 @@ let apply3_wrapped x = (g x x) x
 Line 1, characters 23-32:
 1 | let apply3_wrapped x = (g x x) x
                            ^^^^^^^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -396,32 +396,33 @@ let app1 (f : a:int -> b:local_ int ref -> unit -> unit) = f ~b:(local_ ref 42) 
 Line 1, characters 64-79:
 1 | let app1 (f : a:int -> b:local_ int ref -> unit -> unit) = f ~b:(local_ ref 42) ()
                                                                     ^^^^^^^^^^^^^^^
-Error: This value escapes its region
-  Hint: It is captured by a partial application
+Error: This value escapes its region.
+  Hint: It is captured by a partial application.
 |}]
 let app2 (f : a:int -> b:local_ int ref -> unit -> unit) = f ~b:(local_ ref 42)
 [%%expect{|
 Line 1, characters 64-79:
 1 | let app2 (f : a:int -> b:local_ int ref -> unit -> unit) = f ~b:(local_ ref 42)
                                                                     ^^^^^^^^^^^^^^^
-Error: This value escapes its region
-  Hint: It is captured by a partial application
+Error: This value escapes its region.
+  Hint: It is captured by a partial application.
 |}]
 let app3 (f : a:int -> b:local_ int ref -> unit) = f ~b:(local_ ref 42)
 [%%expect{|
 Line 1, characters 56-71:
 1 | let app3 (f : a:int -> b:local_ int ref -> unit) = f ~b:(local_ ref 42)
                                                             ^^^^^^^^^^^^^^^
-Error: This value escapes its region
-  Hint: It is captured by a partial application
+Error: This value escapes its region.
+  Hint: It is captured by a partial application.
 |}]
 let app4 (f : b:local_ int ref -> a:int -> unit) = f ~b:(local_ ref 42)
 [%%expect{|
 Line 1, characters 56-71:
 1 | let app4 (f : b:local_ int ref -> a:int -> unit) = f ~b:(local_ ref 42)
                                                             ^^^^^^^^^^^^^^^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 let app42 (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
   f ~a:(local_ ref 1) 2 ~c:4
@@ -446,8 +447,9 @@ let app43 (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
 Line 2, characters 7-21:
 2 |   f ~a:(local_ ref 1) 2
            ^^^^^^^^^^^^^^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 let app5 (f : b:local_ int ref -> a:int -> unit) = f ~a:42
 [%%expect{|
@@ -481,8 +483,8 @@ let app4' (f : b:local_ int ref -> a:int -> unit) = f ~b:(ref 42)
 Line 1, characters 52-65:
 1 | let app4' (f : b:local_ int ref -> a:int -> unit) = f ~b:(ref 42)
                                                         ^^^^^^^^^^^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -536,8 +538,8 @@ let rapp3 (f : a:int -> unit -> local_ int ref) = f ~a:1 ()
 Line 1, characters 50-59:
 1 | let rapp3 (f : a:int -> unit -> local_ int ref) = f ~a:1 ()
                                                       ^^^^^^^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let bug1 () =
@@ -551,8 +553,8 @@ let bug1 () =
 Line 7, characters 2-5:
 7 |   res
       ^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 let bug2 () =
   let foo : a:local_ string -> (b:local_ string -> (c:int -> unit)) =
@@ -637,7 +639,7 @@ let bug4 : local_ (string -> foo:string -> unit) -> (string -> unit) =
 Line 2, characters 11-25:
 2 |   fun f -> f ~foo:"hello"
                ^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -660,8 +662,8 @@ let bug4' () =
 Line 3, characters 25-31:
 3 |   let local_ perm ~foo = f ~foo in
                              ^^^^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
   Hint: This is a partial application
         Adding 1 more argument may make the value non-local
 |}]
@@ -682,8 +684,8 @@ let appopt2 (f : ?a:local_ int ref -> unit -> unit) =
 Line 3, characters 2-5:
 3 |   res
       ^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 (* In principle. it would be sound to allow this one:
@@ -695,8 +697,8 @@ let appopt3 (f : ?a:local_ int ref -> int -> int -> unit) =
 Line 3, characters 2-5:
 3 |   res
       ^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let optret1 (f : ?x:int -> local_ (y:unit -> unit -> int)) = f ()
@@ -704,8 +706,8 @@ let optret1 (f : ?x:int -> local_ (y:unit -> unit -> int)) = f ()
 Line 1, characters 61-65:
 1 | let optret1 (f : ?x:int -> local_ (y:unit -> unit -> int)) = f ()
                                                                  ^^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]
@@ -721,7 +723,7 @@ let eta (local_ f : ?a:bool -> unit -> int) = (f : unit -> int)
 Line 1, characters 47-48:
 1 | let eta (local_ f : ?a:bool -> unit -> int) = (f : unit -> int)
                                                    ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let etajoin p (f : ?b:bool -> unit -> int) (local_ g : unit -> int) =
@@ -749,7 +751,7 @@ let foo ?(local_ x = local_ "hello") () = x;;
 Line 1, characters 21-35:
 1 | let foo ?(local_ x = local_ "hello") () = x;;
                          ^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let foo ?(local_ x = local_ "hello") () = local_ x;;
@@ -757,7 +759,7 @@ let foo ?(local_ x = local_ "hello") () = local_ x;;
 Line 1, characters 21-35:
 1 | let foo ?(local_ x = local_ "hello") () = local_ x;;
                          ^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (*
@@ -779,7 +781,7 @@ val baduse : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c lazy_t = <fun>
 Line 2, characters 20-45:
 2 | let result = baduse (fun a b -> local_ (a,b)) 1 2
                         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function is local-returning, but was expected otherwise
+Error: This function is local-returning, but was expected otherwise.
 |}]
 
 (*
@@ -843,7 +845,7 @@ let heap_closure () =
 Line 10, characters 24-26:
 10 |   let _force_heap = ref fn in
                              ^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let local_closure () =
@@ -871,7 +873,7 @@ let toplevel_stack = local_ {contents=42}
 Line 1, characters 21-41:
 1 | let toplevel_stack = local_ {contents=42}
                          ^^^^^^^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 module M = struct
@@ -886,7 +888,7 @@ let _ = local_ {contents=42}
 Line 1, characters 8-28:
 1 | let _ = local_ {contents=42}
             ^^^^^^^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 
@@ -900,7 +902,7 @@ module type T = sig val x : int option end
 Line 4, characters 50-51:
 4 |   let _m : (module T) = local_ (module struct let x = thing end) in
                                                       ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 let local_module () =
   let thing = local_ Some 1 in
@@ -912,7 +914,7 @@ let local_module () =
 Line 4, characters 30-31:
 4 |     let module M = struct let x = thing end in
                                   ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 let obj () =
   let thing = local_ Some 1 in
@@ -953,7 +955,7 @@ let leak_id =
 Line 2, characters 24-25:
 2 |   use_locally (fun x -> x) 42
                             ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let leak_ref =
@@ -964,7 +966,7 @@ let leak_ref =
 Line 3, characters 43-44:
 3 |   use_locally (fun x -> r.contents <- Some x; x) 42
                                                ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let leak_ref_2 =
@@ -984,7 +986,7 @@ let leak_ref_3 =
 Line 3, characters 64-65:
 3 |   use_locally' (fun x -> let _ = local_ r in r.contents <- Some x; x) 42
                                                                     ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 
@@ -1001,7 +1003,7 @@ let do_leak_exn =
 Line 2, characters 66-67:
 2 |   use_locally (fun x -> let _exn = local_ raise (Invalid_argument x) in "bluh") "blah"
                                                                       ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* handled exceptions are known to be global *)
@@ -1059,7 +1061,7 @@ let bar (local_ (m : (module S))) =
 Line 2, characters 19-20:
 2 |   let (module M) = m in
                        ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let bar (local_ m) =
@@ -1069,7 +1071,7 @@ let bar (local_ m) =
 Line 2, characters 22-23:
 2 |   let module M = (val m : S) in
                           ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* Don't escape through a lazy value *)
@@ -1169,7 +1171,7 @@ let foo (local_ x) =
 Line 4, characters 10-11:
 4 |       let y = x in
               ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let foo (local_ x) =
@@ -1279,7 +1281,7 @@ let foo (local_ x) =
 Line 3, characters 14-15:
 3 |   let rec g = x :: g in
                   ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* Cannot pass local values to tail calls *)
@@ -1294,8 +1296,9 @@ val print : local_ string ref -> unit = <fun>
 Line 5, characters 8-9:
 5 |   print r
             ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let local_cb (local_ f) = f ()
@@ -1349,8 +1352,9 @@ let foo x =
 Line 4, characters 2-5:
 4 |   foo ()
       ^^^
-Error: This value escapes its region
-  Hint: This function cannot be local, because it is the function in a tail call
+Error: This value escapes its region.
+  Hint: This function cannot be local,
+  because it is the function in a tail call.
 |}]
 
 let foo x =
@@ -1379,8 +1383,8 @@ let foo x =
 Line 3, characters 2-3:
 3 |   r
       ^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let foo x =
@@ -1479,8 +1483,8 @@ let foo : 'a -> unit = fun (local_ x) -> ()
 Line 1, characters 23-43:
 1 | let foo : 'a -> unit = fun (local_ x) -> ()
                            ^^^^^^^^^^^^^^^^^^^^
-Error: This function takes a local parameter,
-       but was expected to take a global parameter.
+Error: This function takes a parameter at local,
+       but was expected to take a parameter at global.
 |}]
 
 (* Return mode must be greater than the type *)
@@ -1495,7 +1499,7 @@ let foo : unit -> string = fun () -> local_ "hello"
 Line 1, characters 27-51:
 1 | let foo : unit -> string = fun () -> local_ "hello"
                                ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function is local-returning, but was expected otherwise
+Error: This function is local-returning, but was expected otherwise.
 |}]
 
 (* Unboxed type constructors do not affect regionality *)
@@ -1533,8 +1537,8 @@ let foo y =
 Line 3, characters 2-7:
 3 |   x.imm
       ^^^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 let foo (local_ x) = x.mut
 [%%expect{|
@@ -1568,8 +1572,8 @@ let foo y =
 Line 3, characters 2-5:
 3 |   imm
       ^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 let foo (local_ { mut }) = mut
 [%%expect{|
@@ -1612,7 +1616,7 @@ let foo (local_ mut) =
 Line 2, characters 12-15:
 2 |   let _ = { mut } in
                 ^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 let foo () =
   let mut = local_ ref 5 in
@@ -1622,7 +1626,7 @@ let foo () =
 Line 3, characters 12-15:
 3 |   let _ = { mut } in
                 ^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 let foo (local_ gbl) =
   let _ = { gbl } in
@@ -1631,7 +1635,7 @@ let foo (local_ gbl) =
 Line 2, characters 12-15:
 2 |   let _ = { gbl } in
                 ^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 let foo () =
   let gbl = local_ ref 5 in
@@ -1641,7 +1645,7 @@ let foo () =
 Line 3, characters 12-15:
 3 |   let _ = { gbl } in
                 ^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* Global fields are preserved in module inclusion *)
@@ -1720,8 +1724,9 @@ let foo (local_ x) y =
 Line 4, characters 29-30:
 4 |   | Some _, Some b -> escape b
                                  ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let foo (local_ x) y =
@@ -1734,8 +1739,9 @@ let foo (local_ x) y =
 Line 5, characters 11-12:
 5 |     escape b
                ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let foo p (local_ x) y z =
@@ -1757,8 +1763,9 @@ let foo p (local_ x) y (local_ z) =
 Line 5, characters 9-10:
 5 |   escape b;;
              ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let foo p (local_ x) y z =
@@ -1770,8 +1777,9 @@ let foo p (local_ x) y z =
 Line 5, characters 9-10:
 5 |   escape a;;
              ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let foo p (local_ x) y z =
@@ -1784,8 +1792,9 @@ let foo p (local_ x) y z =
 Line 6, characters 9-10:
 6 |   escape b;;
              ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 (* [as] patterns *)
@@ -1806,8 +1815,9 @@ let foo (local_ x) =
 Line 4, characters 26-27:
 4 |   | Some _ as y -> escape y
                               ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let foo (local_ x) =
@@ -1820,8 +1830,9 @@ val foo : local_ int -> unit = <fun>
 Line 3, characters 21-22:
 3 |   | 0 as y -> escape y
                          ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let foo (local_ x) =
@@ -1834,8 +1845,9 @@ val foo : local_ char -> unit = <fun>
 Line 3, characters 28-29:
 3 |   | 'a'..'e' as y -> escape y
                                 ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let foo (local_ x) =
@@ -1846,8 +1858,9 @@ let foo (local_ x) =
 Line 3, characters 23-24:
 3 |   | 1.1 as y -> escape y
                            ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let foo (local_ x) =
@@ -1866,8 +1879,9 @@ let foo (local_ x) =
 Line 3, characters 28-29:
 3 |   | (`Foo _) as y -> escape y
                                 ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let foo (local_ x) =
@@ -1877,8 +1891,9 @@ let foo (local_ x) =
 Line 3, characters 35-36:
 3 |   | (None | Some _) as y -> escape y
                                        ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let foo (local_ x) =
@@ -1888,8 +1903,9 @@ let foo (local_ x) =
 Line 3, characters 33-34:
 3 |   | (Some _|None) as y -> escape y
                                      ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 type foo = [`Foo | `Bar]
@@ -1912,8 +1928,9 @@ type foo = [ `Bar of int | `Foo ]
 Line 5, characters 24-25:
 5 |   | #foo as y -> escape y
                             ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 (* Primitives *)
@@ -2074,8 +2091,9 @@ val testbool1 : (local_ int ref -> bool) -> bool = <fun>
 Line 3, characters 63-64:
 3 | let testbool2 f = let local_ r = ref 42 in true && (false || f r)
                                                                    ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 (* boolean operator when at tail of function makes the function local-returning
@@ -2101,7 +2119,7 @@ external strange_and : bool -> 'a option -> 'a option = "%sequand"
 Line 5, characters 19-20:
 5 |   strange_and true x
                        ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* mode-crossing using unary + *)
@@ -2135,7 +2153,7 @@ end
 Line 2, characters 35-36:
 2 |   let (Some z, _, _) | (None, Some z, _)
                                        ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 module M = struct
@@ -2146,7 +2164,7 @@ end
 Line 2, characters 12-13:
 2 |   let (Some z, _, _) | (None, Some z, _)
                 ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* Example of backtracking after mode error *)
@@ -2557,7 +2575,7 @@ let f (local_ s : string) =
 Line 2, characters 8-9:
 2 |   GFoo (s, "bar")
             ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let f =
@@ -2567,7 +2585,7 @@ let f =
 Line 3, characters 8-9:
 3 |   GFoo (s, "bar")
             ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* s' extracted from x as global *)
@@ -2600,8 +2618,8 @@ let f (s : string) =
 Line 4, characters 20-22:
 4 |   | GFoo (_, s') -> s'
                         ^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 (* and regional gives regional *)
@@ -2613,7 +2631,7 @@ let f (local_ x : gfoo) =
 Line 3, characters 24-26:
 3 |   | GFoo (_, s') -> ref s'
                             ^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* Test of array.*)
@@ -2628,7 +2646,7 @@ let f (local_ x : string) = ref [: x; "foo" :]
 Line 1, characters 35-36:
 1 | let f (local_ x : string) = ref [: x; "foo" :]
                                        ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* constructing local iarray from local elements is fine *)
@@ -2652,7 +2670,7 @@ let f (local_ a : string iarray) =
 Line 3, characters 22-23:
 3 |   | [: x; _ :] -> ref x
                           ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* a test that was passing type check *)
@@ -2664,8 +2682,8 @@ let unsafe_globalize (local_ s : string) : string =
 Line 3, characters 14-16:
 3 |   | [:s':] -> s'
                   ^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let f (local_ a : string iarray) =
@@ -2694,7 +2712,7 @@ let f (local_ x : string) = local_ [| x |]
 Line 1, characters 38-39:
 1 | let f (local_ x : string) = local_ [| x |]
                                           ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* constructing local array from global elements is allowed *)
@@ -2731,8 +2749,8 @@ end
 Line 11, characters 13-59:
 11 |   let f () = fold_until [] ~init:0 ~f:(fun _ _ -> Right ())
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
   Hint: This is a partial application
         Adding 1 more argument will make the value non-local
 |}]

--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -1483,8 +1483,8 @@ let foo : 'a -> unit = fun (local_ x) -> ()
 Line 1, characters 23-43:
 1 | let foo : 'a -> unit = fun (local_ x) -> ()
                            ^^^^^^^^^^^^^^^^^^^^
-Error: This function takes a parameter at local,
-       but was expected to take a parameter at global.
+Error: This function takes a parameter which is local,
+       but was expected to take a parameter which is global.
 |}]
 
 (* Return mode must be greater than the type *)

--- a/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
@@ -83,7 +83,7 @@ let string_escape = let local_ x : string = "hello" in x
 Line 1, characters 55-56:
 1 | let string_escape = let local_ x : string = "hello" in x
                                                            ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let int_escape = let local_ x : int = 5 in x
@@ -98,7 +98,7 @@ let string_list_escape = let local_ x : string list = ["hi";"bye"] in x
 Line 1, characters 70-71:
 1 | let string_list_escape = let local_ x : string list = ["hi";"bye"] in x
                                                                           ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let int_list_escape = let local_ x : int list = [4;5] in x
@@ -107,7 +107,7 @@ let int_list_escape = let local_ x : int list = [4;5] in x
 Line 1, characters 57-58:
 1 | let int_list_escape = let local_ x : int list = [4;5] in x
                                                              ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let hidden_string_escape =
@@ -117,7 +117,7 @@ let hidden_string_escape =
 Line 2, characters 65-66:
 2 |   let local_ x : Hidden_string.t = Hidden_string.hide "hello" in x
                                                                      ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let hidden_int_escape =
@@ -136,7 +136,7 @@ let hidden_string_list_escape =
 Line 4, characters 5-6:
 4 |   in x
          ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let hidden_int_list_escape =
@@ -148,7 +148,7 @@ let hidden_int_list_escape =
 Line 4, characters 5-6:
 4 |   in x
          ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let float_escape = let local_ x : float = 3.14 in x
@@ -157,7 +157,7 @@ let float_escape = let local_ x : float = 3.14 in x
 Line 1, characters 50-51:
 1 | let float_escape = let local_ x : float = 3.14 in x
                                                       ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let float_u_escape () = let local_ x : float# = #3.14 in x
@@ -180,7 +180,7 @@ let float_u_record_escape =
 Line 2, characters 63-64:
 2 |   let local_ x : float_u_record = { x = #3.14; y = #2.718 } in x
                                                                    ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let float_u_record_list_escape =
@@ -190,7 +190,7 @@ let float_u_record_list_escape =
 Line 2, characters 45-46:
 2 |   let local_ x : float_u_record list = [] in x
                                                  ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 type r = {x : float; y : float}
@@ -211,7 +211,7 @@ let function_escape = let local_ x : int -> int = fun y -> y in x
 Line 1, characters 64-65:
 1 | let function_escape = let local_ x : int -> int = fun y -> y in x
                                                                     ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let function_list_escape =
@@ -221,7 +221,7 @@ let function_list_escape =
 Line 2, characters 71-72:
 2 |   let local_ x : (int -> int) list = [(fun y -> y); fun z -> z + 1] in x
                                                                            ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let string_duplicate = let once_ x : string = "hello" in Fun.id x
@@ -231,7 +231,7 @@ let string_duplicate = let once_ x : string = "hello" in Fun.id x
 Line 1, characters 64-65:
 1 | let string_duplicate = let once_ x : string = "hello" in Fun.id x
                                                                     ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let int_duplicate = let once_ x : int = 5 in Fun.id x
@@ -247,7 +247,7 @@ let string_list_duplicate = let once_ x : string list = ["hi";"bye"] in Fun.id x
 Line 1, characters 79-80:
 1 | let string_list_duplicate = let once_ x : string list = ["hi";"bye"] in Fun.id x
                                                                                    ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let int_list_duplicate = let once_ x : int list = [4;5] in Fun.id x
@@ -257,7 +257,7 @@ let int_list_duplicate = let once_ x : int list = [4;5] in Fun.id x
 Line 1, characters 66-67:
 1 | let int_list_duplicate = let once_ x : int list = [4;5] in Fun.id x
                                                                       ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let hidden_string_duplicate =
@@ -267,7 +267,7 @@ let hidden_string_duplicate =
 Line 2, characters 71-72:
 2 |   let once_ x : Hidden_string.t = Hidden_string.hide "hello" in Fun.id x
                                                                            ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let hidden_int_duplicate =
@@ -286,7 +286,7 @@ let hidden_string_list_duplicate =
 Line 4, characters 12-13:
 4 |   in Fun.id x
                 ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let hidden_int_list_duplicate =
@@ -299,7 +299,7 @@ let hidden_int_list_duplicate =
 Line 4, characters 12-13:
 4 |   in Fun.id x
                 ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let float_duplicate = let once_ x : float = 3.14 in Fun.id x
@@ -309,7 +309,7 @@ let float_duplicate = let once_ x : float = 3.14 in Fun.id x
 Line 1, characters 59-60:
 1 | let float_duplicate = let once_ x : float = 3.14 in Fun.id x
                                                                ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let float_u_duplicate () = let once_ x : float# = #3.14 in Float_u.id x
@@ -333,7 +333,7 @@ let float_u_record_duplicate =
 Line 2, characters 69-70:
 2 |   let once_ x : float_u_record = { x = #3.14; y = #2.718 } in Fun.id x
                                                                          ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let float_u_record_list_duplicate =
@@ -344,7 +344,7 @@ let float_u_record_list_duplicate =
 Line 2, characters 51-52:
 2 |   let once_ x : float_u_record list = [] in Fun.id x
                                                        ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let function_duplicate = let once_ x : int -> int = fun y -> y in Fun.id x
@@ -353,7 +353,7 @@ let function_duplicate = let once_ x : int -> int = fun y -> y in Fun.id x
 Line 1, characters 73-74:
 1 | let function_duplicate = let once_ x : int -> int = fun y -> y in Fun.id x
                                                                              ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let function_list_duplicate =
@@ -363,7 +363,7 @@ let function_list_duplicate =
 Line 2, characters 77-78:
 2 |   let once_ x : (int -> int) list = [(fun y -> y); fun z -> z + 1] in Fun.id x
                                                                                  ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let unique (unique_ x) = x
@@ -434,7 +434,7 @@ let hidden_string_unshare =
 Line 2, characters 75-76:
 2 |   let x : Hidden_string.t = Hidden_string.hide "hello" in ignore x; unique x
                                                                                ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let hidden_int_unshare =
@@ -461,7 +461,7 @@ let hidden_string_list_unshare =
 Line 4, characters 22-23:
 4 |   in ignore x; unique x
                           ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let hidden_int_list_unshare =
@@ -520,7 +520,7 @@ val imm_escape : unit -> int = <fun>
 Line 1, characters 33-44:
 1 | let imm_escape () = Immediate.id (local_ 42) [@nontail]
                                      ^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let hidden_float_u_unshare () =
@@ -603,5 +603,5 @@ let foo : (string -> string) -> (string -> string) @ unique
 Line 2, characters 13-14:
 2 |   = fun f -> f
                  ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]

--- a/ocaml/testsuite/tests/typing-modal-kinds/expected_mode.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/expected_mode.ml
@@ -61,7 +61,7 @@ let string_escape : local_ _ -> string * string = fun x -> x, x
 Line 1, characters 59-60:
 1 | let string_escape : local_ _ -> string * string = fun x -> x, x
                                                                ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let int_escape : local_ _ -> int * int = fun x -> x, x
@@ -76,7 +76,7 @@ let string_list_escape : local_ _ -> string list * string list = fun x -> x, x
 Line 1, characters 74-75:
 1 | let string_list_escape : local_ _ -> string list * string list = fun x -> x, x
                                                                               ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let int_list_escape : local_ _ -> int list * int list = fun x -> x, x
@@ -85,7 +85,7 @@ let int_list_escape : local_ _ -> int list * int list = fun x -> x, x
 Line 1, characters 65-66:
 1 | let int_list_escape : local_ _ -> int list * int list = fun x -> x, x
                                                                      ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let hidden_string_escape : local_ _ -> Hidden_string.t * Hidden_string.t =
@@ -95,7 +95,7 @@ let hidden_string_escape : local_ _ -> Hidden_string.t * Hidden_string.t =
 Line 2, characters 11-12:
 2 |   fun x -> x, x
                ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let hidden_int_escape : local_ _ -> Hidden_int.t * Hidden_int.t =
@@ -112,7 +112,7 @@ let float_escape : local_ _ -> float * float = fun x -> x, x
 Line 1, characters 56-57:
 1 | let float_escape : local_ _ -> float * float = fun x -> x, x
                                                             ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* CR layouts v2.8: The following should pass, even in principal mode. *)
@@ -125,7 +125,7 @@ val float_u_escape : local_ float# -> (float#, float#) Float_u.pair = <fun>
 Line 2, characters 27-28:
 2 |   fun x -> Float_u.mk_pair x x [@nontail]
                                ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let hidden_float_u_escape :
@@ -140,7 +140,7 @@ val hidden_float_u_escape :
 Line 3, characters 27-28:
 3 |   fun x -> Float_u.mk_pair x x [@nontail]
                                ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let float_u_record_escape : local_ _ -> float_u_record * float_u_record =
@@ -150,7 +150,7 @@ let float_u_record_escape : local_ _ -> float_u_record * float_u_record =
 Line 2, characters 11-12:
 2 |   fun x -> x, x
                ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let float_u_record_list_escape :
@@ -161,7 +161,7 @@ let float_u_record_list_escape :
 Line 3, characters 11-12:
 3 |   fun x -> x, x
                ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let function_escape : local_ _ -> (int -> int) * (int -> int) = fun x -> x, x
@@ -170,7 +170,7 @@ let function_escape : local_ _ -> (int -> int) * (int -> int) = fun x -> x, x
 Line 1, characters 73-74:
 1 | let function_escape : local_ _ -> (int -> int) * (int -> int) = fun x -> x, x
                                                                              ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let function_list_escape : local_ _ -> (int -> int) list * (int -> int) list =
@@ -180,7 +180,7 @@ let function_list_escape : local_ _ -> (int -> int) list * (int -> int) list =
 Line 2, characters 11-12:
 2 |   fun x -> x, x
                ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let string_duplicate : once_ _ -> string = fun x -> x
@@ -189,7 +189,7 @@ let string_duplicate : once_ _ -> string = fun x -> x
 Line 1, characters 52-53:
 1 | let string_duplicate : once_ _ -> string = fun x -> x
                                                         ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let int_duplicate : once_ _ -> int = fun x -> x
@@ -204,7 +204,7 @@ let string_list_duplicate : once_ _ -> string list = fun x -> x
 Line 1, characters 62-63:
 1 | let string_list_duplicate : once_ _ -> string list = fun x -> x
                                                                   ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let int_list_duplicate : once_ _ -> int list = fun x -> x
@@ -213,7 +213,7 @@ let int_list_duplicate : once_ _ -> int list = fun x -> x
 Line 1, characters 56-57:
 1 | let int_list_duplicate : once_ _ -> int list = fun x -> x
                                                             ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let hidden_string_duplicate : once_ _ -> Hidden_string.t =
@@ -223,7 +223,7 @@ let hidden_string_duplicate : once_ _ -> Hidden_string.t =
 Line 2, characters 11-12:
 2 |   fun x -> x
                ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let hidden_int_duplicate : once_ _ -> Hidden_int.t =
@@ -239,7 +239,7 @@ let float_duplicate : once_ _ -> float = fun x -> x
 Line 1, characters 50-51:
 1 | let float_duplicate : once_ _ -> float = fun x -> x
                                                       ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let float_u_duplicate : once_ _ -> float# = fun x -> x
@@ -262,7 +262,7 @@ let float_u_record_duplicate : once_ _ -> float_u_record =
 Line 2, characters 11-12:
 2 |   fun x -> x
                ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let float_u_record_list_duplicate :
@@ -273,7 +273,7 @@ let float_u_record_list_duplicate :
 Line 3, characters 11-12:
 3 |   fun x -> x
                ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let function_duplicate : once_ _ -> (int -> int) = fun x -> x
@@ -282,7 +282,7 @@ let function_duplicate : once_ _ -> (int -> int) = fun x -> x
 Line 1, characters 60-61:
 1 | let function_duplicate : once_ _ -> (int -> int) = fun x -> x
                                                                 ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let function_list_duplicate : once_ _ -> (int -> int) list =
@@ -292,7 +292,7 @@ let function_list_duplicate : once_ _ -> (int -> int) list =
 Line 2, characters 11-12:
 2 |   fun x -> x
                ^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let string_unshare : _ -> unique_ string = fun x -> x
@@ -301,7 +301,7 @@ let string_unshare : _ -> unique_ string = fun x -> x
 Line 1, characters 52-53:
 1 | let string_unshare : _ -> unique_ string = fun x -> x
                                                         ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let int_unshare : _ -> unique_ int = fun x -> x
@@ -316,7 +316,7 @@ let string_list_unshare : _ -> unique_ string list = fun x -> x
 Line 1, characters 62-63:
 1 | let string_list_unshare : _ -> unique_ string list = fun x -> x
                                                                   ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let int_list_unshare : _ -> unique_ int list = fun x -> x
@@ -325,7 +325,7 @@ let int_list_unshare : _ -> unique_ int list = fun x -> x
 Line 1, characters 56-57:
 1 | let int_list_unshare : _ -> unique_ int list = fun x -> x
                                                             ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let hidden_string_unshare : _ -> unique_ Hidden_string.t =
@@ -335,7 +335,7 @@ let hidden_string_unshare : _ -> unique_ Hidden_string.t =
 Line 2, characters 11-12:
 2 |   fun x -> x
                ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let hidden_int_unshare : _ -> unique_ Hidden_int.t =
@@ -351,7 +351,7 @@ let float_unshare : _ -> unique_ float = fun x -> x
 Line 1, characters 50-51:
 1 | let float_unshare : _ -> unique_ float = fun x -> x
                                                       ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let float_u_unshare : _ -> unique_ float# = fun x -> x
@@ -374,7 +374,7 @@ let float_u_record_unshare : _ -> unique_ float_u_record =
 Line 2, characters 11-12:
 2 |   fun x -> x
                ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let float_u_record_list_unshare :
@@ -385,7 +385,7 @@ let float_u_record_list_unshare :
 Line 3, characters 11-12:
 3 |   fun x -> x
                ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let function_unshare : _ -> unique_ (int -> int) = fun x -> x
@@ -394,7 +394,7 @@ let function_unshare : _ -> unique_ (int -> int) = fun x -> x
 Line 1, characters 60-61:
 1 | let function_unshare : _ -> unique_ (int -> int) = fun x -> x
                                                                 ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let function_list_unshare : _ -> unique_ (int -> int) list =
@@ -404,5 +404,5 @@ let function_list_unshare : _ -> unique_ (int -> int) list =
 Line 2, characters 11-12:
 2 |   fun x -> x
                ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]

--- a/ocaml/testsuite/tests/typing-modal-kinds/principal.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/principal.ml
@@ -14,8 +14,8 @@ let string_escape_l (local_ y) = let Pair (x, _) = Pair (y, "hello") in x
 Line 1, characters 72-73:
 1 | let string_escape_l (local_ y) = let Pair (x, _) = Pair (y, "hello") in x
                                                                             ^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let string_escape_r (local_ y) = let Pair (x, _) = Pair ("hello", y) in x
@@ -24,8 +24,8 @@ let string_escape_r (local_ y) = let Pair (x, _) = Pair ("hello", y) in x
 Line 1, characters 72-73:
 1 | let string_escape_r (local_ y) = let Pair (x, _) = Pair ("hello", y) in x
                                                                             ^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let int_escape_l (local_ y) = let Pair (x, _) = Pair (y, 5) in x
@@ -36,8 +36,8 @@ val int_escape_l : local_ int -> int = <fun>
 Line 1, characters 63-64:
 1 | let int_escape_l (local_ y) = let Pair (x, _) = Pair (y, 5) in x
                                                                    ^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let int_escape_r (local_ y) = let Pair (x, _) = Pair (5, y) in x
@@ -48,8 +48,8 @@ val int_escape_r : local_ int -> int = <fun>
 Line 1, characters 63-64:
 1 | let int_escape_r (local_ y) = let Pair (x, _) = Pair (5, y) in x
                                                                    ^
-Error: This value escapes its region
-  Hint: Cannot return a local value without an "exclave_" annotation
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let string_escape_expected_l : local_ _ -> _ pair = fun x -> Pair (x, "hello")
@@ -58,7 +58,7 @@ let string_escape_expected_l : local_ _ -> _ pair = fun x -> Pair (x, "hello")
 Line 1, characters 67-68:
 1 | let string_escape_expected_l : local_ _ -> _ pair = fun x -> Pair (x, "hello")
                                                                        ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let string_escape_expected_r : local_ _ -> _ pair = fun x -> Pair ("hello", x)
@@ -67,7 +67,7 @@ let string_escape_expected_r : local_ _ -> _ pair = fun x -> Pair ("hello", x)
 Line 1, characters 76-77:
 1 | let string_escape_expected_r : local_ _ -> _ pair = fun x -> Pair ("hello", x)
                                                                                 ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 
@@ -78,7 +78,7 @@ let int_escape_expected_l : local_ _ -> _ pair = fun x -> Pair (x, 5)
 Line 1, characters 64-65:
 1 | let int_escape_expected_l : local_ _ -> _ pair = fun x -> Pair (x, 5)
                                                                     ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let int_escape_expected_r : local_ _ -> _ pair = fun x -> Pair (5, x)
@@ -89,7 +89,7 @@ val int_escape_expected_r : local_ int -> int pair = <fun>
 Line 1, characters 67-68:
 1 | let int_escape_expected_r : local_ _ -> _ pair = fun x -> Pair (5, x)
                                                                        ^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let escape : 'a -> unit = fun _ -> ()
@@ -109,8 +109,9 @@ val pattern_l : local_ int pair -> unit = <fun>
 Line 3, characters 26-27:
 3 |   | Pair (y, 0) -> escape y
                               ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]
 
 let pattern_r (local_ x) =
@@ -124,6 +125,7 @@ val pattern_r : local_ int pair -> unit = <fun>
 Line 3, characters 26-27:
 3 |   | Pair (0, y) -> escape y
                               ^
-Error: This value escapes its region
-  Hint: This argument cannot be local, because it is an argument in a tail call
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
 |}]

--- a/ocaml/testsuite/tests/typing-modes/modes.ml
+++ b/ocaml/testsuite/tests/typing-modes/modes.ml
@@ -8,7 +8,7 @@ let local_ foo : string @@ unique = "hello"
 Line 1, characters 4-43:
 1 | let local_ foo : string @@ unique = "hello"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let local_ foo @ unique = "hello"
@@ -16,7 +16,7 @@ let local_ foo @ unique = "hello"
 Line 1, characters 4-33:
 1 | let local_ foo @ unique = "hello"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let local_ foo : 'a. 'a -> 'a @@ unique = fun x -> x
@@ -24,7 +24,7 @@ let local_ foo : 'a. 'a -> 'a @@ unique = fun x -> x
 Line 1, characters 4-52:
 1 | let local_ foo : 'a. 'a -> 'a @@ unique = fun x -> x
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let foo : type a. a -> a @@ unique = fun x -> x
@@ -37,7 +37,7 @@ let (x, y) @ local unique = "hello", "world"
 Line 1, characters 4-44:
 1 | let (x, y) @ local unique = "hello", "world"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let (x, y) : _ @@ local unique = "hello", "world"
@@ -45,7 +45,7 @@ let (x, y) : _ @@ local unique = "hello", "world"
 Line 1, characters 4-49:
 1 | let (x, y) : _ @@ local unique = "hello", "world"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 let foo @ foo = "hello"
@@ -76,7 +76,7 @@ let foo = ("hello" : _ @@ local)
 Line 1, characters 10-32:
 1 | let foo = ("hello" : _ @@ local)
               ^^^^^^^^^^^^^^^^^^^^^^
-Error: This value escapes its region
+Error: This value escapes its region.
 |}]
 
 (* this is not mode annotation *)

--- a/ocaml/testsuite/tests/typing-unique/unique.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique.ml
@@ -141,7 +141,7 @@ let f () =
 Line 4, characters 12-13:
 4 |     unique_ k
                 ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
   Hint: This identifier cannot be used uniquely,
   because it was defined outside of the for-loop.
 |}]
@@ -157,7 +157,7 @@ let f =
 Line 5, characters 14-15:
 5 |     let _ = g a in ()
                   ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
   Hint: This identifier cannot be used uniquely,
   because it was defined outside of the for-loop.
 |}]
@@ -215,7 +215,7 @@ let once_ foo = "foo"
 Line 1, characters 4-21:
 1 | let once_ foo = "foo"
         ^^^^^^^^^^^^^^^^^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 (* the following is fine - we relax many to once *)
@@ -237,7 +237,7 @@ let foo y = unique_ x
 Line 1, characters 20-21:
 1 | let foo y = unique_ x
                         ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 
@@ -303,7 +303,7 @@ let higher_order3 (f : 'a -> 'b) (unique_ x : 'a) = unique_ f x
 Line 1, characters 60-63:
 1 | let higher_order3 (f : 'a -> 'b) (unique_ x : 'a) = unique_ f x
                                                                 ^^^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let higher_order4 (f : unique_ 'a -> 'b) (x : 'a) = f (shared_id x)
@@ -311,7 +311,7 @@ let higher_order4 (f : unique_ 'a -> 'b) (x : 'a) = f (shared_id x)
 Line 1, characters 54-67:
 1 | let higher_order4 (f : unique_ 'a -> 'b) (x : 'a) = f (shared_id x)
                                                           ^^^^^^^^^^^^^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let higher_order5 (unique_ x) = let f (unique_ x) = unique_ x in higher_order f x
@@ -357,7 +357,7 @@ let inf3 : bool -> float -> unique_ float -> float = fun b y x ->
 Line 2, characters 58-59:
 2 |   let _ = shared_id y in let unique_ z = if b then x else y in z
                                                               ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let inf4 (b : bool) (y : float) (unique_ x : float) =
@@ -467,7 +467,7 @@ let curry =
 Line 3, characters 2-15:
 3 |   foo ~a:3 ~c:4
       ^^^^^^^^^^^^^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let curry =
@@ -477,7 +477,7 @@ let curry =
 Line 3, characters 2-15:
 3 |   foo ~a:3 ~c:4
       ^^^^^^^^^^^^^
-Error: Found a once value where a many value was expected
+Error: This value is once but expected to be many.
 |}]
 
 let curry =
@@ -557,8 +557,8 @@ let curry : unique_ box -> (unique_ box -> unit) = fun b1 b2 -> ()
 Line 1, characters 51-66:
 1 | let curry : unique_ box -> (unique_ box -> unit) = fun b1 b2 -> ()
                                                        ^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a once value,
-       but expected to be many.
+Error: This function when partially applied returns a value at once,
+       but expected to be at many.
 |}]
 
 let curry : unique_ box -> (unique_ box -> unit) = fun b1 -> function | b2 -> ()
@@ -566,8 +566,8 @@ let curry : unique_ box -> (unique_ box -> unit) = fun b1 -> function | b2 -> ()
 Line 1, characters 51-80:
 1 | let curry : unique_ box -> (unique_ box -> unit) = fun b1 -> function | b2 -> ()
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a once value,
-       but expected to be many.
+Error: This function when partially applied returns a value at once,
+       but expected to be at many.
 |}]
 
 (* For nested functions, inner functions are not constrained *)

--- a/ocaml/testsuite/tests/typing-unique/unique.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique.ml
@@ -557,8 +557,8 @@ let curry : unique_ box -> (unique_ box -> unit) = fun b1 b2 -> ()
 Line 1, characters 51-66:
 1 | let curry : unique_ box -> (unique_ box -> unit) = fun b1 b2 -> ()
                                                        ^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value at once,
-       but expected to be at many.
+Error: This function when partially applied returns a value which is once,
+       but expected to be many.
 |}]
 
 let curry : unique_ box -> (unique_ box -> unit) = fun b1 -> function | b2 -> ()
@@ -566,8 +566,8 @@ let curry : unique_ box -> (unique_ box -> unit) = fun b1 -> function | b2 -> ()
 Line 1, characters 51-80:
 1 | let curry : unique_ box -> (unique_ box -> unit) = fun b1 -> function | b2 -> ()
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value at once,
-       but expected to be at many.
+Error: This function when partially applied returns a value which is once,
+       but expected to be many.
 |}]
 
 (* For nested functions, inner functions are not constrained *)

--- a/ocaml/testsuite/tests/typing-unique/unique_analysis.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique_analysis.ml
@@ -186,7 +186,7 @@ let or_patterns1 : unique_ float list -> float list -> float =
 Line 3, characters 37-38:
 3 |   | z :: _, _ | _, z :: _ -> unique_ z
                                          ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let or_patterns2 : float list -> unique_ float list -> float =
@@ -197,7 +197,7 @@ let or_patterns2 : float list -> unique_ float list -> float =
 Line 3, characters 37-38:
 3 |   | z :: _, _ | _, z :: _ -> unique_ z
                                          ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]
 
 let or_patterns3 p =

--- a/ocaml/testsuite/tests/typing-unique/unique_mod_class.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique_mod_class.ml
@@ -19,7 +19,7 @@ val unique_id : unique_ 'a -> unit = <fun>
 Line 8, characters 20-21:
 8 |   val bar = unique_ x
                         ^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
   Hint: This identifier cannot be used uniquely,
   because it is defined in a class.
 |}]
@@ -149,5 +149,5 @@ module M : sig val foo : string end
 Line 7, characters 12-17:
 7 |   unique_id M.foo
                 ^^^^^
-Error: Found a shared value where a unique value was expected
+Error: This value is shared but expected to be unique.
 |}]

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1342,7 +1342,9 @@ module Comonadic_with_regionality = struct
 
   open Obj
 
-  let proj ax m = Solver.via_monotone (C.proj_obj ax obj) (Proj (Obj.obj, ax)) m
+  let proj_obj ax = C.proj_obj ax obj
+
+  let proj ax m = Solver.via_monotone (proj_obj ax) (Proj (Obj.obj, ax)) m
 
   let meet_const c m =
     Solver.via_monotone obj (Meet_with c) (Solver.disallow_right m)
@@ -1405,7 +1407,9 @@ module Comonadic_with_locality = struct
 
   open Obj
 
-  let proj ax m = Solver.via_monotone (C.proj_obj ax obj) (Proj (Obj.obj, ax)) m
+  let proj_obj ax = C.proj_obj ax obj
+
+  let proj ax m = Solver.via_monotone (proj_obj ax) (Proj (Obj.obj, ax)) m
 
   let meet_const c m =
     Solver.via_monotone obj (Meet_with c) (Solver.disallow_right m)
@@ -1471,7 +1475,9 @@ module Monadic = struct
 
   open Obj
 
-  let proj ax m = Solver.via_monotone (C.proj_obj ax obj) (Proj (Obj.obj, ax)) m
+  let proj_obj ax = C.proj_obj ax obj
+
+  let proj ax m = Solver.via_monotone (proj_obj ax) (Proj (Obj.obj, ax)) m
 
   (* The monadic fragment is inverted. Most of the inversion logic is taken care
      by [Solver_polarized], but some remain, such as the [Min_with] below which
@@ -1541,6 +1547,10 @@ module Value = struct
         (Comonadic.Const.t, 'a) Axis.t
         -> (('a, 'd) mode_comonadic, 'a, 'd) axis
 
+  let proj_obj : type m a d. (m, a, d) axis -> a C.obj = function
+    | Monadic ax -> Monadic.proj_obj ax
+    | Comonadic ax -> Comonadic.proj_obj ax
+
   type ('a, 'b, 'c) modes =
     { regionality : 'a;
       linearity : 'b;
@@ -1605,6 +1615,11 @@ module Value = struct
       let monadic = Monadic.join m0.monadic m1.monadic in
       let comonadic = Comonadic.join m0.comonadic m1.comonadic in
       merge { monadic; comonadic }
+
+    let print_axis : type m a d. (m, a, d) axis -> _ -> a -> unit =
+     fun ax ppf a ->
+      let obj = proj_obj ax in
+      C.print obj ppf a
   end
 
   let min = { comonadic = Comonadic.min; monadic = Monadic.min }
@@ -1836,6 +1851,10 @@ module Alloc = struct
     | Comonadic :
         (Comonadic.Const.t, 'a) Axis.t
         -> (('a, 'd) mode_comonadic, 'a, 'd) axis
+
+  let proj_obj : type m a d. (m, a, d) axis -> a C.obj = function
+    | Monadic ax -> Monadic.proj_obj ax
+    | Comonadic ax -> Comonadic.proj_obj ax
 
   type ('a, 'b, 'c) modes =
     { locality : 'a;
@@ -2127,6 +2146,11 @@ module Alloc = struct
       let { comonadic; _ } = split m in
       let monadic = Monadic.min in
       merge { comonadic; monadic }
+
+    let print_axis : type m a d. (m, a, d) axis -> _ -> a -> unit =
+     fun ax ppf a ->
+      let obj = proj_obj ax in
+      C.print obj ppf a
 
     let split = split
 

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -261,17 +261,6 @@ module type S = sig
       include Common with type error := error and module Const := Const
     end
 
-    type ('a, 'b, 'c) modes =
-      { regionality : 'a;
-        linearity : 'b;
-        uniqueness : 'c
-      }
-
-    module Const :
-      Lattice
-        with type t =
-          (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
-
     (** Represents a mode axis in this product whose constant is ['a], and
         whose variable is ['m] given the allowness ['d]. *)
     type ('m, 'a, 'd) axis =
@@ -281,6 +270,22 @@ module type S = sig
       | Comonadic :
           (Comonadic.Const.t, 'a) Axis.t
           -> (('a, 'd) mode_comonadic, 'a, 'd) axis
+
+    type ('a, 'b, 'c) modes =
+      { regionality : 'a;
+        linearity : 'b;
+        uniqueness : 'c
+      }
+
+    module Const : sig
+      include
+        Lattice
+          with type t =
+            (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
+
+      (** Prints a constant on any axis. *)
+      val print_axis : ('m, 'a, 'd) axis -> Format.formatter -> 'a -> unit
+    end
 
     type error = Error : ('m, 'a, 'd) axis * 'a Solver.error -> error
 
@@ -338,6 +343,16 @@ module type S = sig
       val meet_const : Const.t -> ('l * 'r) t -> ('l * disallowed) t
     end
 
+    (** Represents a mode axis in this product whose constant is ['a], and
+        whose variable is ['m] given the allowness ['d]. *)
+    type ('m, 'a, 'd) axis =
+      | Monadic :
+          (Monadic.Const.t, 'a) Axis.t
+          -> (('a, 'd) mode_monadic, 'a, 'd) axis
+      | Comonadic :
+          (Comonadic.Const.t, 'a) Axis.t
+          -> (('a, 'd) mode_comonadic, 'a, 'd) axis
+
     type ('loc, 'lin, 'uni) modes =
       { locality : 'loc;
         linearity : 'lin;
@@ -377,17 +392,10 @@ module type S = sig
 
       (** Similar to [Alloc.partial_apply] but for constants *)
       val partial_apply : t -> t
-    end
 
-    (** Represents a mode axis in this product whose constant is ['a], and
-        whose variable is ['m] given the allowness ['d]. *)
-    type ('m, 'a, 'd) axis =
-      | Monadic :
-          (Monadic.Const.t, 'a) Axis.t
-          -> (('a, 'd) mode_monadic, 'a, 'd) axis
-      | Comonadic :
-          (Comonadic.Const.t, 'a) Axis.t
-          -> (('a, 'd) mode_comonadic, 'a, 'd) axis
+      (** Prints a constant on any axis. *)
+      val print_axis : ('m, 'a, 'd) axis -> Format.formatter -> 'a -> unit
+    end
 
     type error = Error : ('m, 'a, 'd) axis * 'a Solver.error -> error
 

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -9462,17 +9462,19 @@ let escaping_hint (failure_reason : Value.error) submode_reason
          global, then exclave_ won't solve the problem. *)
       [ Location.msg
           "@[Hint: Cannot return a local value without an@ \
-           \"exclave_\" annotation@]" ]
+           \"exclave_\" annotation.@]" ]
     | _, Return -> []
     | _, Tailcall_argument ->
       [ Location.msg
-          "@[Hint: This argument cannot be local, because it is an argument in a tail call@]" ]
+          "@[Hint: This argument cannot be local,@ \
+           because it is an argument in a tail call.@]" ]
     | _, Tailcall_function ->
       [ Location.msg
-          "@[Hint: This function cannot be local, because it is the function in a tail call@]" ]
+          "@[Hint: This function cannot be local,@ \
+           because it is the function in a tail call.@]" ]
     | _, Partial_application ->
       [ Location.msg
-          "@[Hint: It is captured by a partial application@]" ]
+          "@[Hint: It is captured by a partial application.@]" ]
     end
   | _, _ -> []
   end
@@ -10121,16 +10123,13 @@ let report_error ~loc env = function
         | Error (Comonadic Areality, _) ->
           escaping_hint fail_reason submode_reason closure_context
       in
-      Location.errorf ~loc ~sub "%t" begin
+      Location.errorf ~loc ~sub "@[%t@]" begin
         match fail_reason with
         | Error (Comonadic Areality, _) ->
-            Format.dprintf "This value escapes its region"
-        | Error (Monadic Uniqueness, {left; right}) ->
-            Format.dprintf "Found a %a value where a %a value was expected"
-              Uniqueness.Const.print left Uniqueness.Const.print right
-        | Error (Comonadic Linearity, {left; right}) ->
-            Format.dprintf "Found a %a value where a %a value was expected"
-              Linearity.Const.print left Linearity.Const.print right
+            Format.dprintf "This value escapes its region."
+        | Error (ax, {left; right}) ->
+            Format.dprintf "This value is %a but expected to be %a."
+              (Value.Const.print_axis ax) left (Value.Const.print_axis ax) right
         end
   | Local_application_complete (lbl, loc_kind) ->
       let sub =
@@ -10155,35 +10154,29 @@ let report_error ~loc env = function
       Location.errorf ~loc ~sub
         "@[This application is complete, but surplus arguments were provided afterwards.@ \
          When passing or calling a local value, extra arguments are passed in a separate application.@]"
-  | Param_mode_mismatch (s, mkind) ->
-      let print_error f (step, {Solver.left; Solver.right}) =
-        let actual, expected =
-          match (step : equate_step) with
-          | Left_le_right -> left, right
-          | Right_le_left -> right, left
-        in
-        Location.errorf ~loc
-          "@[This function takes a %a parameter,@ \
-           but was expected to take a %a parameter.@]"
-          f actual f expected
-      in begin
-      match mkind with
-      | Error (Comonadic Areality, e) ->
-          print_error Locality.Const.print (s, e)
-      | Error (Monadic Uniqueness, e) ->
-          print_error Uniqueness.Const.print (s, e)
-      | Error (Comonadic Linearity, e) ->
-          print_error Linearity.Const.print (s, e)
-      end
+  | Param_mode_mismatch (s, Error (ax, {left; right})) ->
+      let actual, expected =
+        match s with
+        | Left_le_right -> left, right
+        | Right_le_left -> right, left
+      in
+      Location.errorf ~loc
+        "@[This function takes a parameter at %a,@ \
+        but was expected to take a parameter at %a.@]"
+        (Alloc.Const.print_axis ax) actual (Alloc.Const.print_axis ax) expected
   | Uncurried_function_escapes e -> begin
       match e with
       | Error (Comonadic Areality, _) ->
-          Location.errorf ~loc "This function or one of its parameters escape their region @ \
-          when it is partially applied."
+          Location.errorf ~loc
+            "This function or one of its parameters escape their region@ \
+            when it is partially applied."
       | Error (Monadic Uniqueness, _) -> assert false
       | Error (Comonadic Linearity, {left; right}) ->
-          Location.errorf ~loc "This function when partially applied returns a %a value,@ \
-          but expected to be %a." Linearity.Const.print left Linearity.Const.print right
+          Location.errorf ~loc
+            "This function when partially applied returns a value at %a,@ \
+              but expected to be at %a."
+            Linearity.Const.print left
+            Linearity.Const.print right
     end
   | Local_return_annotation_mismatch _ ->
       Location.errorf ~loc
@@ -10197,7 +10190,7 @@ let report_error ~loc env = function
          | `Not_a_tailcall -> "is not on a tail call")
   | Exclave_in_nontail_position ->
       Location.errorf ~loc
-        "Exclave expression should only be in tail position of the current region"
+        "Exclave expression should only be in tail position of the current region."
   | Exclave_returns_not_local ->
       Location.errorf ~loc
         "This expression was expected to be not local, but is an exclave expression,@ \
@@ -10207,11 +10200,11 @@ let report_error ~loc env = function
         "Optional parameters cannot be polymorphic"
   | Function_returns_local ->
       Location.errorf ~loc
-        "This function is local-returning, but was expected otherwise"
+        "This function is local-returning, but was expected otherwise."
   | Tail_call_local_returning ->
       Location.errorf ~loc
-        "@[This application is local-returning, but is at the tail @ \
-          position of a function that is not local-returning@]"
+        "@[This application is local-returning, but is at the tail@ \
+          position of a function that is not local-returning.@]"
   | Unboxed_int_literals_not_supported ->
       Location.errorf ~loc
         "@[Unboxed int literals aren't supported yet.@]"

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -10161,8 +10161,8 @@ let report_error ~loc env = function
         | Right_le_left -> right, left
       in
       Location.errorf ~loc
-        "@[This function takes a parameter at %a,@ \
-        but was expected to take a parameter at %a.@]"
+        "@[This function takes a parameter which is %a,@ \
+        but was expected to take a parameter which is %a.@]"
         (Alloc.Const.print_axis ax) actual (Alloc.Const.print_axis ax) expected
   | Uncurried_function_escapes e -> begin
       match e with
@@ -10173,8 +10173,8 @@ let report_error ~loc env = function
       | Error (Monadic Uniqueness, _) -> assert false
       | Error (Comonadic Linearity, {left; right}) ->
           Location.errorf ~loc
-            "This function when partially applied returns a value at %a,@ \
-              but expected to be at %a."
+            "This function when partially applied returns a value which is %a,@ \
+              but expected to be %a."
             Linearity.Const.print left
             Linearity.Const.print right
     end


### PR DESCRIPTION
This PR cleans up the following things:
- Have a generic `print_axis` that works on any axis, so that `typecore.ml` does't need to mention specific axes when possible.
- Add some missing periods.
- Rephrase the error messages so articles "a" "an" is not followed by mode constants.
- Break long lines.