### PR TITLE
Add partial adjoints of `join_with` and `meet_with`

### DIFF
--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1049,7 +1049,10 @@ module Lattices_mono = struct
       let g' = left_adjoint mid g in
       Compose (g', f')
     | Join_with c -> Subtract c
-    | Meet_with _ -> Id
+    | Meet_with _c ->
+      (* The downward closure of [Meet_with c]'s image is all [x <= c].
+         For those, [x <= meet c y] is equivalent to [x <= y]. *)
+      Id
     | Imply c -> Meet_with c
     | Comonadic_to_monadic _ -> Monadic_to_comonadic_min
     | Monadic_to_comonadic_max -> Comonadic_to_monadic dst
@@ -1077,7 +1080,10 @@ module Lattices_mono = struct
       Compose (g', f')
     | Meet_with c -> Imply c
     | Subtract c -> Join_with c
-    | Join_with _ -> Id
+    | Join_with _c ->
+      (* The upward closure of [Join_with c]'s image is all [x >= c].
+         For those, [join c y <= x] is equivalent to [y <= x]. *)
+      Id
     | Comonadic_to_monadic _ -> Monadic_to_comonadic_max
     | Monadic_to_comonadic_min -> Comonadic_to_monadic dst
     | Local_to_regional -> Regional_to_local

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -303,13 +303,13 @@ module type S = sig
 
     val min_with : ('m, 'a, 'l * 'r) axis -> 'm -> ('l * disallowed) t
 
-    val meet_with : (_, 'a, _) axis -> 'a -> ('l * 'r) t -> ('l * disallowed) t
+    val meet_with : (_, 'a, _) axis -> 'a -> ('l * 'r) t -> ('l * 'r) t
 
-    val join_with : (_, 'a, _) axis -> 'a -> ('l * 'r) t -> (disallowed * 'r) t
+    val join_with : (_, 'a, _) axis -> 'a -> ('l * 'r) t -> ('l * 'r) t
 
     val comonadic_to_monadic : ('l * 'r) Comonadic.t -> ('r * 'l) Monadic.t
 
-    val meet_const : Const.t -> ('l * 'r) t -> ('l * disallowed) t
+    val meet_const : Const.t -> ('l * 'r) t -> ('l * 'r) t
 
     val imply : Const.t -> ('l * 'r) t -> (disallowed * 'r) t
   end
@@ -335,7 +335,7 @@ module type S = sig
 
       include Common with module Const := Const
 
-      val meet_const : Const.t -> ('l * 'r) t -> ('l * disallowed) t
+      val meet_const : Const.t -> ('l * 'r) t -> ('l * 'r) t
     end
 
     type ('loc, 'lin, 'uni) modes =
@@ -405,15 +405,15 @@ module type S = sig
 
     val min_with : ('m, 'a, 'l * 'r) axis -> 'm -> ('l * disallowed) t
 
-    val meet_with : (_, 'a, _) axis -> 'a -> ('l * 'r) t -> ('l * disallowed) t
+    val meet_with : (_, 'a, _) axis -> 'a -> ('l * 'r) t -> ('l * 'r) t
 
-    val join_with : (_, 'a, _) axis -> 'a -> ('l * 'r) t -> (disallowed * 'r) t
+    val join_with : (_, 'a, _) axis -> 'a -> ('l * 'r) t -> ('l * 'r) t
 
     val zap_to_legacy : lr -> Const.t
 
     val zap_to_ceil : ('l * allowed) t -> Const.t
 
-    val meet_const : Const.t -> ('l * 'r) t -> ('l * disallowed) t
+    val meet_const : Const.t -> ('l * 'r) t -> ('l * 'r) t
 
     val imply : Const.t -> ('l * 'r) t -> (disallowed * 'r) t
 

--- a/ocaml/typing/solver_intf.mli
+++ b/ocaml/typing/solver_intf.mli
@@ -120,32 +120,34 @@ module type Lattices_mono = sig
 
   (* Usual notion of adjunction:
      Given two morphisms [f : A -> B] and [g : B -> A], we require [f a <= b]
-      iff [a <= g b].
+      iff [a <= g b] for each [a \in A] and [b \in B].
 
-     Our solver accepts a wider notion of adjunction and only requires the same
-     condition on convex sublattices. To be specific, if [f] and [g] form a
-      usual adjunction between [A] and [B], and [A] is a convex sublattice of
-     [A'], and [B] is a convex sublattice of [B'], we say that [f] and [g]
-     form a partial adjunction between [A'] and [B']. We do not require [f] to
-     be defined on [A'\A]. Similar for [g].
+     Our solver accepts a wider notion of adjunction: Given two morphisms [f : A
+     -> B] and [g : B -> A], we require [f a <= b] iff [a <= g b] for each [a]
+      in the downward closure of [g]'s image and [b \in B].
 
-     Definition of convex sublattice can be found at:
-     https://en.wikipedia.org/wiki/Lattice_(order)#Sublattices
+     We say [f] is a partial left adjoint of [g], because [f] is only
+     constrained in part of its domain. As a result, [f] is not unique, since
+     its valuation out of the constrained range can be arbitrarily chosen.
 
-     For example: Define [A = B = {0, 1, 2}] with total ordering. Define both
-     [f] and [g] to be the identity function. Obviously [f] and [g] form a usual
-     adjunction. Now, further define [A'] = [A], and [B'] = [{0, 1, 2, 3}] with
-     total ordering. Obviously [A] is a convex sublattice of [A'], and [B] of
-     [B']. Then we say [f] and [g] forms a partial adjunction between [A'] and
-     [B'].
+     Dually, we can define the concept of partial right adjoint. Since partial
+     adjoints are not unique, they don't form a pair: i.e., a partial left
+     joint of a partial right adjoint of [f] is not [f] in general.
 
-     The feature allows the user to invoke [f a <= b'], where [a \in A] and [b'
-     \in B']. Similarly, they can invoke [a' <= g b], where [a' \in A'] and [b
-     \in B].
+     Concretely, the solver provides/requires the following guarantees
+     (continuing the example above):
 
-     Moreover, if [a' \in A'\A], it is still fine to apply [f] to [a'], but the
-     result should not be used as a left mode. This is unfortunately not
-     enforcable by the ocaml type system, and we have to rely on user's caution.
+     For the user of the [Solvers_polarized].
+     - [g] applied to a right mode [m] can be used as a right mode without
+     any restriction.
+     - [f] applied to to a left mode [m] can be used as a left mode, given that
+     the [m] is fully within the downward closure of [g]. This is unfortunately
+     not enforcable by the ocaml type system, and we have to rely on user's
+     caution.
+
+     For the supplier of the [Lattices_mono]:
+     - The result of [left_adjoint g] is applied only on the downward closure of
+     [g]'s image.
   *)
 
   (* Note that [left_adjoint] and [right_adjoint] returns a [morph] weaker than

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -417,12 +417,6 @@ let meet_regional mode =
 let meet_global mode =
   Value.meet [mode; (Value.max_with (Comonadic Areality) Regionality.global)]
 
-let meet_many mode =
-  Value.meet [mode; (Value.max_with (Comonadic Linearity) Linearity.many)]
-
-let join_shared mode =
-  Value.join [mode; Value.min_with (Monadic Uniqueness) Uniqueness.shared]
-
 let value_regional_to_local mode =
   mode
   |> value_to_alloc_r2l
@@ -430,25 +424,15 @@ let value_regional_to_local mode =
 
 (* Describes how a modality affects field projection. Returns the mode
    of the projection given the mode of the record. *)
-let modality_unbox_left global_flag mode =
-  let mode = Value.disallow_right mode in
+let apply_modality
+  : type l r. _ -> (l * r) Value.t -> (l * r) Value.t
+  = fun global_flag mode ->
   match global_flag with
   | Global_flag.Global ->
       mode
       |> Value.meet_with (Comonadic Areality) Regionality.Const.Global
-      |> join_shared
+      |> Value.join_with (Monadic Uniqueness) Uniqueness.Const.Shared
       |> Value.meet_with (Comonadic Linearity) Linearity.Const.Many
-  | Global_flag.Unrestricted -> mode
-
-(* Describes how a modality affects record construction. Gives the
-   expected mode of the field given the expected mode of the record. *)
-let modality_box_right global_flag mode =
-  match global_flag with
-  | Global_flag.Global ->
-      mode
-      |> meet_global
-      |> Value.join_with (Monadic Uniqueness) Uniqueness.Const.max
-      |> meet_many
   | Global_flag.Unrestricted -> mode
 
 let mode_default mode =
@@ -462,7 +446,7 @@ let mode_legacy = mode_default Value.legacy
 
 let mode_modality modality expected_mode =
   expected_mode.mode
-  |> modality_box_right modality
+  |> apply_modality modality
   |> mode_default
 
 (* used when entering a function;
@@ -799,11 +783,14 @@ let has_poly_constraint spat =
 
 (** Mode cross a left mode *)
 let mode_cross_left env ty mode =
-  if not (is_principal ty) then Value.disallow_right mode else
-  let jkind = type_jkind_purely env ty in
-  let upper_bounds = Jkind.get_modal_upper_bounds jkind in
-  let upper_bounds = Const.alloc_as_value upper_bounds in
-  Value.meet_const upper_bounds mode
+  let mode =
+    if not (is_principal ty) then mode else
+    let jkind = type_jkind_purely env ty in
+    let upper_bounds = Jkind.get_modal_upper_bounds jkind in
+    let upper_bounds = Const.alloc_as_value upper_bounds in
+    Value.meet_const upper_bounds mode
+  in
+  mode |> Value.disallow_right
 
 (** Mode cross a mode whose monadic fragment is a right mode, and whose comonadic
     fragment is a left mode. *)
@@ -2392,7 +2379,7 @@ and type_pat_aux
       (* CR zqian: decouple mutable and global modality *)
       if Types.is_mutable mutability then Global else Unrestricted
     in
-    let alloc_mode = modality_unbox_left modalities alloc_mode.mode in
+    let alloc_mode = apply_modality modalities alloc_mode.mode in
     let alloc_mode = simple_pat_mode alloc_mode in
     let pl = List.map (fun p -> type_pat ~alloc_mode tps Value p ty_elt) spl in
     rvp {
@@ -2635,7 +2622,7 @@ and type_pat_aux
       let args =
         List.map2
           (fun p (ty, gf) ->
-             let alloc_mode = modality_unbox_left gf alloc_mode.mode in
+             let alloc_mode = apply_modality gf alloc_mode.mode in
              let alloc_mode = simple_pat_mode alloc_mode in
              type_pat ~alloc_mode tps Value p ty)
           sargs (List.combine ty_args_ty ty_args_gf)
@@ -2678,7 +2665,7 @@ and type_pat_aux
       let type_label_pat (label_lid, label, sarg) =
         let ty_arg =
           solve_Ppat_record_field ~refine loc env label label_lid record_ty in
-        let mode = modality_unbox_left label.lbl_global alloc_mode.mode in
+        let mode = apply_modality label.lbl_global alloc_mode.mode in
         let alloc_mode = simple_pat_mode mode in
         (label_lid, label, type_pat tps Value ~alloc_mode sarg ty_arg)
       in
@@ -5634,7 +5621,7 @@ and type_expect_
                   unify_exp_types loc env ty_arg1 ty_arg2;
                   with_explanation (fun () ->
                     unify_exp_types loc env (instance ty_expected) ty_res2);
-                  let mode = modality_unbox_left lbl.lbl_global mode in
+                  let mode = apply_modality lbl.lbl_global mode in
                   check_construct_mutability lbl.lbl_mut argument_mode;
                   let argument_mode =
                     mode_modality lbl.lbl_global argument_mode
@@ -5684,7 +5671,7 @@ and type_expect_
           ty_arg
         end ~post:generalize_structure
       in
-      let mode = modality_unbox_left label.lbl_global rmode in
+      let mode = apply_modality label.lbl_global rmode in
       let boxing : texp_field_boxing =
         let is_float_boxing =
           match label.lbl_repres with


### PR DESCRIPTION
This PR adds the partial left adjoint of `meet_with`, which we call `Restrict_below`, and the partial right adjoint of `join_with`, which we call `Restrict_above`.

- Recall that our mode solver supports certain form of partial adjunction (See solver_intf.mli), which this PR satisfies.
- This simplifies the definition of modalities and (in the future) mode crossing.

To justify the morphism composition reduction added:
- `Restrict_below _` composed with any `m` is just `m`. If the rest of the type checker is sound, `Restrict_below` will never be applied to values out of its defined range, and will act just as identity.
- `Imply c0 (Meet_with c1 x)` reduces to `Imply c0 x`, if `c0 <= c1`. Proof:
By adjunction, `Imply c0 (Meet_with c1 x)` is characterised as the biggest `y` such that `Meet_with c0 y <= Meet_with c1 x` holds. This reduces to `Meet_with c0 y <= c1` and `Meet_with c0 y <= x`. The former is trivial given `c0 <= c1`. Therefore only the latter matters, which is equivalent to `y <= Imply c0 x`. That is, we want the biggest `y` such that `y <= Imply c0 x` holds, which gives `Imply c0 x`.

The other reduction is dual.