### PR TITLE
Use correct debuginfo values for Ialloc

### DIFF
--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -1016,7 +1016,7 @@ method emit_expr_aux (env:environment) exp ~bound_name : Reg.t array option =
               in
               self#insert_debug env (Iop op) dbg [||] rd;
               add_naming_op_for_bound_name rd;
-              self#emit_stores env new_args rd;
+              self#emit_stores env dbg new_args rd;
               set_traps_for_raise env;
               ret rd
           | Iprobe _ ->
@@ -1444,7 +1444,7 @@ method insert_move_extcall_arg env _ty_arg src dst =
      for example a "32-bit move" instruction for int32 arguments. *)
   self#insert_moves env src dst
 
-method emit_stores env data regs_addr =
+method emit_stores env dbg data regs_addr =
   let a =
     ref (Arch.offset_addressing Arch.identity_addressing (-Arch.size_int)) in
   List.iter
@@ -1465,13 +1465,14 @@ method emit_stores env data regs_addr =
                     Onetwentyeight_unaligned
                   | Val | Addr | Int ->  Word_val
                 in
-                self#insert env
+                self#insert_debug env
                             (Iop(Istore(kind, !a, false)))
+                            dbg
                             (Array.append [|r|] regs_addr) [||];
                 a := Arch.offset_addressing !a (size_component r.typ)
               done
           | _ ->
-              self#insert env (Iop op) (Array.append regs regs_addr) [||];
+              self#insert_debug env (Iop op) dbg (Array.append regs regs_addr) [||];
               a := Arch.offset_addressing !a (size_expr env e))
     data
 

--- a/backend/selectgen.mli
+++ b/backend/selectgen.mli
@@ -114,7 +114,7 @@ class virtual selector_generic : object
     environment -> Cmm.exttype list -> Cmm.expression list -> Reg.t array * int
     (* Can be overridden to deal with stack-based calling conventions *)
   method emit_stores :
-    environment -> Cmm.expression list -> Reg.t array -> unit
+    environment -> Debuginfo.t -> Cmm.expression list -> Reg.t array -> unit
     (* Fill a freshly allocated block.  Can be overridden for architectures
        that do not provide Arch.offset_addressing. *)
 


### PR DESCRIPTION
The store instructions emitted by `Selectgen` for the `Ialloc` code sequence seem to have the wrong debuginfo values at present.  I think they should have the debuginfo of the allocation, not that of the initializer for the relevant field, which might be in a completely different source location.