### PR TITLE
asm_targets/ changes for DWARF inlined frames

### DIFF
--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -305,9 +305,9 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     (* CR poechsel: use the arguments *)
     A.emit_line "between_labels_64_bit"
 
-  let between_labels_64_bit_with_offsets ?comment:comment' ~upper ~upper_offset
-      ~lower ~lower_offset () =
-    Option.iter D.comment comment';
+  let between_labels_64_bit_with_offsets ?comment ~upper ~upper_offset ~lower
+      ~lower_offset () =
+    Option.iter D.comment comment;
     let upper_offset = Targetint.to_int64 upper_offset in
     let lower_offset = Targetint.to_int64 lower_offset in
     let expr =
@@ -321,11 +321,11 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     in
     const_machine_width (force_assembly_time_constant expr)
 
-  let between_symbol_in_current_unit_and_label_offset ?comment:comment' ~upper
-      ~lower ~offset_upper () =
+  let between_symbol_in_current_unit_and_label_offset ?comment ~upper ~lower
+      ~offset_upper () =
     (* CR mshinwell: add checks, as above: check_symbol_in_current_unit lower;
        check_symbol_and_label_in_same_section lower upper; *)
-    Option.iter D.comment comment';
+    Option.iter D.comment comment;
     if Targetint.compare offset_upper Targetint.zero = 0
     then
       let expr =

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -247,14 +247,14 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
         let lab = D.const_label (Asm_symbol.encode sym) in
         const_machine_width lab)
 
-  let label ?comment:comment' lab =
-    Option.iter D.comment comment';
+  let label ?comment lab =
+    Option.iter D.comment comment;
     let lab = D.const_label (Asm_label.encode lab) in
     const_machine_width lab
 
-  let label_plus_offset ?comment:comment' lab ~offset_in_bytes =
+  let label_plus_offset ?comment lab ~offset_in_bytes =
     let offset_in_bytes = Targetint.to_int64 offset_in_bytes in
-    Option.iter D.comment comment';
+    Option.iter D.comment comment;
     let lab = D.const_label (Asm_label.encode lab) in
     const_machine_width (D.const_add lab (D.const_int64 offset_in_bytes))
 

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -247,13 +247,23 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
         let lab = D.const_label (Asm_symbol.encode sym) in
         const_machine_width lab)
 
-  let label ?comment:_ _lab =
-    (* CR poechsel: use the arguments *)
-    A.emit_line "label"
+  let label ?comment:comment' lab =
+    Option.iter D.comment comment';
+    let lab = D.const_label (Asm_label.encode lab) in
+    const_machine_width lab
 
-  let symbol_plus_offset _sym ~offset_in_bytes:_ =
-    (* CR poechsel: use the arguments *)
-    A.emit_line "symbol_plus_offset"
+  let label_plus_offset ?comment:comment' lab ~offset_in_bytes =
+    let offset_in_bytes = Targetint.to_int64 offset_in_bytes in
+    Option.iter D.comment comment';
+    let lab = D.const_label (Asm_label.encode lab) in
+    const_machine_width (D.const_add lab (D.const_int64 offset_in_bytes))
+
+  let symbol_plus_offset symbol ~offset_in_bytes =
+    let offset_in_bytes = Targetint.to_int64 offset_in_bytes in
+    const_machine_width
+      (D.const_add
+         (D.const_label (Asm_symbol.encode symbol))
+         (D.const_int64 offset_in_bytes))
 
   let new_temp_var () =
     let id = !temp_var_counter in
@@ -294,6 +304,22 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
   let between_labels_64_bit ?comment:_ ~upper:_ ~lower:_ () =
     (* CR poechsel: use the arguments *)
     A.emit_line "between_labels_64_bit"
+
+  let between_labels_64_bit_with_offsets ?comment:comment' ~upper ~upper_offset
+      ~lower ~lower_offset () =
+    Option.iter D.comment comment';
+    let upper_offset = Targetint.to_int64 upper_offset in
+    let lower_offset = Targetint.to_int64 lower_offset in
+    let expr =
+      D.const_sub
+        (D.const_add
+           (D.const_label (Asm_label.encode upper))
+           (D.const_int64 upper_offset))
+        (D.const_add
+           (D.const_label (Asm_label.encode lower))
+           (D.const_int64 lower_offset))
+    in
+    const_machine_width (force_assembly_time_constant expr)
 
   let between_symbol_in_current_unit_and_label_offset ?comment:comment' ~upper
       ~lower ~offset_upper () =
@@ -358,7 +384,90 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     in
     const ~width expr
 
-  let offset_into_dwarf_section_symbol ?comment:_ ~width:_ _section _symbol =
-    (* CR poechsel: use the arguments *)
-    A.emit_line "offset_into_dwarf_section_symbol"
+  let offset_into_dwarf_section_symbol ?comment
+      ~(width : Dwarf_flags.dwarf_format) section upper =
+    (* CR mshinwell: code from previous DWARF work:
+
+       let upper_section = Asm_symbol.section upper in if not (Asm_section.equal
+       upper_section (DWARF section)) then Misc.fatal_errorf "Symbol %a (in
+       section %a) not in section %a" Asm_symbol.print upper Asm_section.print
+       upper_section Asm_section.print (Asm_section.DWARF section); *)
+    (* The macOS assembler doesn't seem to allow "distance to undefined symbol
+       from start of given section". As such we do not allow this function to be
+       used for undefined symbols on macOS at the moment. Relevant link:
+       <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82005>. *)
+    (* CR mshinwell: try again to make this work on macOS, maybe using
+     * something like the last .quad in the example below:
+     *
+     * extunit.s
+     *
+     *   .section __DWARF,__debug_info,regular,debug
+     *   .quad 0x12345678
+     *   .globl extunit_die
+     * extunit_die:
+     *   .quad 0xffffdddd
+     *
+     * ---
+     *
+     * unit.s
+     *
+     *   .section __DWARF,__debug_info,regular,debug
+     * Ldebug_info:
+     *   .quad 0x11112222
+     *   .globl unit_die
+     * unit_die1:
+     *   .quad 0x9999888
+     * unit_die:
+     *   .quad 0xaaaabbbb
+     *   .quad unit_die - __debug_info
+     *   .set dist, unit_die - Ldebug_info
+     *   .quad dist
+     *   .quad extunit_die - __debug_info
+     *)
+    let comment =
+      if not !Clflags.keep_asm_file
+      then None
+      else
+        match comment with
+        | None ->
+          Some
+            (Format.asprintf "offset into %s"
+               (Asm_section.to_string (DWARF section)))
+        | Some comment ->
+          Some
+            (Format.asprintf "%s (offset into %s)" comment
+               (Asm_section.to_string (DWARF section)))
+    in
+    Option.iter D.comment comment;
+    let expr =
+      if is_macos ()
+      then
+        let in_current_unit =
+          true
+          (* CR mshinwell: old code was:
+
+             Compilation_unit.equal (Compilation_unit.get_current_exn ())
+             (Asm_symbol.compilation_unit upper) *)
+        in
+        if in_current_unit
+        then
+          let lower = Asm_label.for_dwarf_section section in
+          (* Same note as in [offset_into_dwarf_section_label] applies here. *)
+          force_assembly_time_constant
+            (D.const_sub
+               (D.const_label (Asm_symbol.encode upper))
+               (D.const_label (Asm_label.encode lower)))
+        else
+          Misc.fatal_errorf
+            "Don't know how to encode offset from start of section XXX to \
+             undefined symbol %a on macOS (current compilation unit %a, symbol \
+             in compilation unit XXX)"
+            (* Asm_section.print upper_section *) Asm_symbol.print upper
+            Compilation_unit.print
+            (Compilation_unit.get_current_exn ())
+            Compilation_unit.print
+        (* (Asm_symbol.compilation_unit upper) *)
+      else D.const_label (Asm_symbol.encode upper)
+    in
+    match width with Thirty_two -> D.long expr | Sixty_four -> D.qword expr
 end

--- a/backend/asm_targets/asm_directives_intf.ml
+++ b/backend/asm_targets/asm_directives_intf.ml
@@ -188,6 +188,9 @@ module type S = sig
   (** Emit a machine-width reference to the given label. *)
   val label : ?comment:string -> Asm_label.t -> unit
 
+  val label_plus_offset :
+    ?comment:string -> Asm_label.t -> offset_in_bytes:Targetint.t -> unit
+
   (** Emit a machine-width reference to the address formed by adding the given
       byte offset to the address of the given symbol. The symbol may be in a
       compilation unit and/or section different from the current one. *)
@@ -216,6 +219,15 @@ module type S = sig
       64-bit-wide reference. The labels must be in the same section. *)
   val between_labels_64_bit :
     ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
+
+  val between_labels_64_bit_with_offsets :
+    ?comment:string ->
+    upper:Asm_label.t ->
+    upper_offset:Targetint.t ->
+    lower:Asm_label.t ->
+    lower_offset:Targetint.t ->
+    unit ->
+    unit
 
   (** Emit a machine-width reference giving the displacement between the [lower]
       symbol and the sum of the address of the [upper] label plus

--- a/backend/asm_targets/asm_symbol.ml
+++ b/backend/asm_targets/asm_symbol.ml
@@ -47,6 +47,8 @@ include Identifiable.Make (Thing)
 
 let create name = name
 
+let to_raw_string t = t
+
 let escape name =
   let escaped_nb = ref 0 in
   for i = 0 to String.length name - 1 do

--- a/backend/asm_targets/asm_symbol.mli
+++ b/backend/asm_targets/asm_symbol.mli
@@ -34,3 +34,5 @@ val create : string -> t
 (* If [without_prefix] is not provided [encode] will prefix the symbol using the
    (architecture-dependent) prefix for symbols, for example "_" on macOS. *)
 val encode : ?without_prefix:unit -> t -> string
+
+val to_raw_string : t -> string


### PR DESCRIPTION
Various fairly minor changes ported from old DWARF work to provide `Asm_directives` functionality required for the inlined frames work.  A bit of tidying up needs doing here but not much.