### PR TITLE
Asm_directives for arm64; move frame_size etc into Proc for amd64+arm64

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -105,26 +105,20 @@ let frame_required = ref false
 let contains_calls = ref false
 
 let frame_size () =
-  Stack_check.frame_size
+  Proc.frame_size
     ~stack_offset:!stack_offset
-    ~frame_required:!frame_required
     ~num_stack_slots
     ~contains_calls:!contains_calls
 
-let slot_offset loc cl =
-  match loc with
-  | Incoming n -> frame_size() + n
-  | Local n ->
-      if num_stack_slots.(2) > 0 || cl >= 2 then assert_simd_enabled ();
-      (!stack_offset +
-        (* Preserves original ordering (int -> float) *)
-        match cl with
-        | 2 -> n * 16
-        | 0 -> num_stack_slots.(2) * 16 + n * 8
-        | 1 -> num_stack_slots.(2) * 16 + num_stack_slots.(0) * 8 + n * 8
-        | _ -> Misc.fatal_error "Unknown register class")
-  | Outgoing n -> n
-  | Domainstate _ -> assert false (* not a stack slot *)
+let slot_offset loc stack_class =
+  let offset =
+    Proc.slot_offset loc ~stack_class ~stack_offset:!stack_offset
+      ~fun_contains_calls:!contains_calls ~fun_num_stack_slots:num_stack_slots
+  in
+  match offset with
+  | Bytes_relative_to_stack_pointer n -> n
+  | Bytes_relative_to_domainstate_pointer _ ->
+    Misc.fatal_errorf "Not a stack slot"
 
 let emit_stack_offset n =
   if n < 0

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -651,10 +651,7 @@ let max_register_pressure =
 
 (* Layout of the stack frame *)
 
-let initial_stack_offset ~num_stack_slots ~contains_calls =
-  (8 * num_stack_slots.(0))
-  + (8 * num_stack_slots.(1))
-  + if contains_calls then 8 else 0
+let initial_stack_offset ~num_stack_slots:_ ~contains_calls:_ = 0
 
 let trap_frame_size_in_bytes = 16
 

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -100,32 +100,24 @@ let prologue_required = ref false
 let contains_calls = ref false
 
 let initial_stack_offset () =
-  Stack_check.initial_stack_offset ~contains_calls:!contains_calls
+  Proc.initial_stack_offset ~contains_calls:!contains_calls
     ~num_stack_slots
 
 let frame_size () =
-  Stack_check.frame_size
+  Proc.frame_size
     ~stack_offset:!stack_offset
-    ~frame_required:(frame_required
-      ~fun_contains_calls:!contains_calls
-      ~fun_num_stack_slots:num_stack_slots)
     ~contains_calls:!contains_calls
     ~num_stack_slots
 
-let slot_offset loc cl =
-  match loc with
-    Incoming n ->
-      assert (n >= 0);
-      frame_size() + n
-  | Local n ->
-      !stack_offset +
-      (if cl = 0
-       then n * 8
-       else num_stack_slots.(0) * 8 + n * 8)
-  | Outgoing n ->
-      assert (n >= 0);
-      n
-  | Domainstate _ -> assert false (* not a satck slot *)
+let slot_offset loc stack_class =
+  let offset =
+    Proc.slot_offset loc ~stack_class ~stack_offset:!stack_offset
+      ~fun_contains_calls:!contains_calls ~fun_num_stack_slots:num_stack_slots
+  in
+  match offset with
+  | Bytes_relative_to_stack_pointer n -> n
+  | Bytes_relative_to_domainstate_pointer _ ->
+    Misc.fatal_errorf "Not a stack slot"
 
 (* Output a stack reference *)
 
@@ -1268,6 +1260,126 @@ let data l =
   `	.align  3\n`;
   List.iter emit_item l
 
+let emit_line str = emit_string (str ^ "\n")
+
+let file_emitter ~file_num ~file_name =
+  emit_line (Printf.sprintf ".file %d %S" file_num file_name)
+
+let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
+  module Asm_targets.Asm_directives.Make(struct
+    let emit_line = emit_line
+
+    let get_file_num file_name =
+      Emitaux.get_file_num ~file_emitter file_name
+
+    let debugging_comments_in_asm_files =
+      !Flambda_backend_flags.dasm_comments
+
+    module D = struct
+      type constant =
+        | Int64 of Int64.t
+        | Label of string
+        | Add of constant * constant
+        | Sub of constant * constant
+
+      let rec string_of_constant const =
+        match const with
+        | Int64 n -> Int64.to_string n
+        | Label s -> s
+        | Add (c1, c2) ->
+          Printf.sprintf "(%s + %s)"
+            (string_of_constant c1) (string_of_constant c2)
+        | Sub (c1, c2) ->
+          Printf.sprintf "(%s - %s)"
+            (string_of_constant c1) (string_of_constant c2)
+
+      let const_int64 num = Int64 num
+      let const_label str = Label str
+      let const_add c1 c2 = Add (c1, c2)
+      let const_sub c1 c2 = Sub (c1, c2)
+
+      type data_type =
+        | NONE
+        | DWORD
+        | QWORD
+        | VEC128
+
+      let file = file_emitter
+
+      let loc ~file_num ~line ~col ?discriminator () =
+        ignore discriminator;
+        emit_line (Printf.sprintf ".loc %d %d %d" file_num line col)
+
+      let comment str =
+        emit_line (Printf.sprintf "; %s" str)
+
+      let label ?data_type str =
+        let _ = data_type in
+        emit_line (Printf.sprintf "%s:" str)
+
+      let section ?delayed:_ name flags args =
+        match name, flags, args with
+        | [".data" ], _, _ -> emit_line "\t.data"
+        | [".text" ], _, _ -> emit_line "\t.text"
+        | name, flags, args ->
+          emit_string (Printf.sprintf "\t.section %s"
+            (String.concat "," name));
+          begin match flags with
+          | None -> ()
+          | Some flags -> emit_string (Printf.sprintf ",%S" flags)
+          end;
+          begin match args with
+          | [] -> ()
+          | _ ->
+            emit_string (Printf.sprintf ",%s" (String.concat "," args))
+          end;
+          emit_string "\n"
+
+      let text () = emit_line "\t.text"
+
+      let new_line () = emit_line ""
+
+      let global sym = emit_line (Printf.sprintf "\t.globl %s" sym)
+
+      let protected sym =
+        if not macosx then emit_line (Printf.sprintf "\t.protected %s" sym)
+
+      let type_ sym typ_ = emit_line (Printf.sprintf "\t.type %s,%s" sym typ_)
+
+      let byte const =
+        emit_line
+          (Printf.sprintf "\t.byte %s" (string_of_constant const))
+
+      let word const =
+        emit_line
+          (Printf.sprintf "\t.short %s" (string_of_constant const))
+
+      let long const =
+        emit_line
+          (Printf.sprintf "\t.long %s" (string_of_constant const))
+
+      let qword const =
+        emit_line
+          (Printf.sprintf "\t.quad %s" (string_of_constant const))
+
+      let bytes str =
+        emit_line (Printf.sprintf "\t.ascii %S" str)
+
+      let uleb128 const =
+        emit_line
+          (Printf.sprintf "\t.uleb128 %s" (string_of_constant const))
+
+      let sleb128 const =
+        emit_line
+          (Printf.sprintf "\t.sleb128 %s" (string_of_constant const))
+
+      let direct_assignment var const =
+        emit_line
+          (Printf.sprintf "\t.set %s,%s" var (string_of_constant const))
+    end
+  end)
+)
+
 (* Beginning / end of an assembly file *)
 
 let begin_assembly _unix =
@@ -1290,9 +1402,12 @@ let begin_assembly _unix =
     `	nop\n`;
     `	.align	3\n`
   end;
-  ()
+  let lbl_end = Cmm_helpers.make_symbol "code_end" in
+  Emitaux.Dwarf_helpers.begin_dwarf ~build_asm_directives
+    ~code_begin:lbl_begin ~code_end:lbl_end
+    ~file_emitter
 
-let end_assembly _dwarf =
+let end_assembly () =
   let lbl_end = Cmm_helpers.make_symbol "code_end" in
   emit_named_text_section lbl_end;
   `	.globl	{emit_symbol lbl_end}\n`;
@@ -1325,6 +1440,8 @@ let end_assembly _dwarf =
       efa_string = (fun s -> emit_string_directive "	.asciz	" s) };
   emit_symbol_type emit_symbol lbl "object";
   emit_symbol_size lbl;
+  if not !Flambda_backend_flags.internal_assembler then
+    Emitaux.Dwarf_helpers.emit_dwarf ();
   begin match Config.system with
   | "linux" ->
       (* Mark stack as non-executable *)

--- a/backend/arm64/stack_check.ml
+++ b/backend/arm64/stack_check.ml
@@ -18,23 +18,6 @@
 
 let stack_threshold_size = Config.stack_threshold * 8 (* bytes *)
 
-let initial_stack_offset ~num_stack_slots ~contains_calls =
-  (8 * num_stack_slots.(0))
-  + (8 * num_stack_slots.(1))
-  + if contains_calls then 8 else 0
-
-let frame_size :
-    stack_offset:int ->
-    frame_required:bool ->
-    num_stack_slots:int array ->
-    contains_calls:bool ->
-    int =
- fun ~stack_offset ~frame_required:_ ~num_stack_slots ~contains_calls ->
-  let sz =
-    stack_offset + initial_stack_offset ~num_stack_slots ~contains_calls
-  in
-  Misc.align sz 16
-
 let linear : Linear.fundecl -> Linear.fundecl =
  fun fundecl ->
   match Config.runtime5 with

--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -78,13 +78,8 @@ type cfg_info =
 
 let build_cfg_info : Cfg.t -> cfg_info =
  fun cfg ->
-  let frame_required =
-    Proc.frame_required ~fun_contains_calls:cfg.fun_contains_calls
-      ~fun_num_stack_slots:cfg.fun_num_stack_slots
-  in
   let frame_size =
-    Stack_check.frame_size ~stack_offset:0 ~frame_required
-      ~num_stack_slots:cfg.fun_num_stack_slots
+    Proc.frame_size ~stack_offset:0 ~num_stack_slots:cfg.fun_num_stack_slots
       ~contains_calls:cfg.fun_contains_calls
   in
   let init =

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -59,7 +59,10 @@ module Vars = struct
   end = struct
     type t = { stack_offset : int }
 
-    let create () = { stack_offset = Proc.initial_stack_offset }
+    let create () =
+      { (* This does not include the [Proc.initial_stack_offset] (see below). *)
+        stack_offset = 0
+      }
 
     let advance_over_instruction t (insn : L.instruction) =
       let stack_offset =
@@ -100,13 +103,19 @@ module Vars = struct
 
     let create reg subrange_state ~fun_contains_calls ~fun_num_stack_slots =
       let reg = RD.reg reg in
-      let stack_offset = Subrange_state.stack_offset subrange_state in
+      let initial_stack_offset =
+        Proc.initial_stack_offset ~contains_calls:fun_contains_calls
+          ~num_stack_slots:fun_num_stack_slots
+      in
+      let stack_offset =
+        Subrange_state.stack_offset subrange_state + initial_stack_offset
+      in
       let offset =
         match reg.loc with
         | Stack loc ->
           let frame_size =
-            Proc.frame_size ~stack_offset ~fun_contains_calls
-              ~fun_num_stack_slots
+            Proc.frame_size ~stack_offset ~contains_calls:fun_contains_calls
+              ~num_stack_slots:fun_num_stack_slots
           in
           let slot_offset =
             Proc.slot_offset loc

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -499,7 +499,8 @@ module Dwarf_helpers = struct
     match can_emit_dwarf,
           Target_system.architecture (),
           Target_system.derived_system () with
-    | true, X86_64, _ -> sourcefile_for_dwarf := Some sourcefile
+    | true, (X86_64 | AArch64), _ ->
+      sourcefile_for_dwarf := Some sourcefile
     | true, _, _
     | false, _, _ -> ()
 

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -70,7 +70,9 @@ val is_destruction_point : more_destruction_points:bool -> Cfg_intf.S.terminator
 
 (* Info for laying out the stack frame *)
 
-val initial_stack_offset : int
+val initial_stack_offset : num_stack_slots:int array
+  -> contains_calls:bool -> int
+
 val trap_frame_size_in_bytes : int
 
 val frame_required :
@@ -80,8 +82,8 @@ val frame_required :
 
 val frame_size :
   stack_offset:int ->
-  fun_contains_calls:bool ->
-  fun_num_stack_slots:int array ->
+  contains_calls:bool ->
+  num_stack_slots:int array ->
   int
 
 type slot_offset = private

--- a/backend/stack_check.mli
+++ b/backend/stack_check.mli
@@ -18,17 +18,4 @@
 
 val stack_threshold_size : int
 
-val initial_stack_offset :
-  num_stack_slots:int array -> contains_calls:bool -> int
-
-(* CR mshinwell: We should maybe remove [frame_required]. For example this isn't
-   required on arm64, and on amd64 we should be able to compute it using the
-   other parameters here. *)
-val frame_size :
-  stack_offset:int ->
-  frame_required:bool ->
-  num_stack_slots:int array ->
-  contains_calls:bool ->
-  int
-
 val linear : Linear.fundecl -> Linear.fundecl


### PR DESCRIPTION
Implements `Asm_directives` for arm64 targets and also a few other things required for DWARF inlined frames (but not specific to debugging support).  I will discuss this with @xclerc in due course.

Includes #2483 