### PR TITLE
Add Compute_ranges.get_singleton

### DIFF
--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -283,8 +283,8 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
          keeping things fast---but we still populate ranges for all parent
          blocks, thus avoiding any post-processing, by using [K.all_parents]
          here. *)
-      (* CR mshinwell: this seems to be broken (e.g. removing parents when it shouldn't
-         be) *)
+      (* CR mshinwell: this seems to be broken (e.g. removing parents when it
+         shouldn't be) *)
       KS.fold
         (fun key result ->
           List.fold_left

--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -120,6 +120,17 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
 
     let fold t ~init ~f = List.fold_left f init t.subranges
 
+    type get_singleton =
+      | No_ranges
+      | One_subrange of Subrange.t
+      | More_than_one_subrange
+
+    let get_singleton t =
+      match t.subranges with
+      | [] -> No_ranges
+      | [subrange] -> One_subrange subrange
+      | _ :: _ :: _ -> More_than_one_subrange
+
     let no_subranges t = match t.subranges with [] -> true | _ -> false
 
     let rewrite_labels_and_remove_empty_subranges t ~env =
@@ -272,6 +283,8 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
          keeping things fast---but we still populate ranges for all parent
          blocks, thus avoiding any post-processing, by using [K.all_parents]
          here. *)
+      (* CR mshinwell: this seems to be broken (e.g. removing parents when it shouldn't
+         be) *)
       KS.fold
         (fun key result ->
           List.fold_left

--- a/backend/debug/compute_ranges_intf.ml
+++ b/backend/debug/compute_ranges_intf.ml
@@ -216,6 +216,8 @@ module type S = sig
     (** The label at the start of the range. *)
     val start_pos : t -> Linear.label
 
+    (* CR mshinwell: use Targetint.t *)
+
     (** How many bytes from the label at [start_pos] the range actually
         commences. If this value is zero, then the first byte of the range has
         the address of the label given by [start_pos]. *)
@@ -251,6 +253,13 @@ module type S = sig
 
     (** Fold over all subranges within the given range. *)
     val fold : t -> init:'a -> f:('a -> Subrange.t -> 'a) -> 'a
+
+    type get_singleton = private
+      | No_ranges
+      | One_subrange of Subrange.t
+      | More_than_one_subrange
+
+    val get_singleton : t -> get_singleton
   end
 
   (** The type holding information on computed ranges. *)


### PR DESCRIPTION
This adds a simple function to `Compute_ranges`, for extracting a unique subrange from a range when one such exists.  A couple of CRs are also added.