### PR TITLE
Fix make depend for jane street stdlib modules

### DIFF
--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -690,6 +690,7 @@ typing/annot.cmi : \
 typing/btype.cmo : \
     typing/types.cmi \
     typing/path.cmi \
+    parsing/parsetree.cmi \
     utils/local_store.cmi \
     typing/ident.cmi \
     parsing/asttypes.cmi \
@@ -697,6 +698,7 @@ typing/btype.cmo : \
 typing/btype.cmx : \
     typing/types.cmx \
     typing/path.cmx \
+    parsing/parsetree.cmi \
     utils/local_store.cmx \
     typing/ident.cmx \
     parsing/asttypes.cmi \
@@ -704,6 +706,7 @@ typing/btype.cmx : \
 typing/btype.cmi : \
     typing/types.cmi \
     typing/path.cmi \
+    parsing/parsetree.cmi \
     typing/jkind.cmi \
     parsing/asttypes.cmi
 typing/cmt2annot.cmo : \
@@ -1449,8 +1452,7 @@ typing/printtyp.cmi : \
     parsing/location.cmi \
     typing/ident.cmi \
     typing/errortrace.cmi \
-    typing/env.cmi \
-    parsing/asttypes.cmi
+    typing/env.cmi
 typing/printtyped.cmo : \
     utils/zero_alloc_utils.cmi \
     typing/types.cmi \
@@ -1756,7 +1758,6 @@ typing/typecore.cmo : \
     typing/typedtree.cmi \
     typing/typedecl.cmi \
     typing/subst.cmi \
-    typing/solver.cmi \
     typing/shape.cmi \
     typing/rec_check.cmi \
     typing/printtyp.cmi \
@@ -1799,7 +1800,6 @@ typing/typecore.cmx : \
     typing/typedtree.cmx \
     typing/typedecl.cmx \
     typing/subst.cmx \
-    typing/solver.cmx \
     typing/shape.cmx \
     typing/rec_check.cmx \
     typing/printtyp.cmx \
@@ -1932,6 +1932,7 @@ typing/typedecl.cmi : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/language_extension.cmi \
     typing/jkind.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
@@ -7055,6 +7056,7 @@ toplevel/genprintval.cmo : \
     typing/env.cmi \
     typing/datarepr.cmi \
     typing/ctype.cmi \
+    utils/clflags.cmi \
     typing/btype.cmi \
     parsing/asttypes.cmi \
     toplevel/genprintval.cmi
@@ -7076,6 +7078,7 @@ toplevel/genprintval.cmx : \
     typing/env.cmx \
     typing/datarepr.cmx \
     typing/ctype.cmx \
+    utils/clflags.cmx \
     typing/btype.cmx \
     parsing/asttypes.cmi \
     toplevel/genprintval.cmi
@@ -7264,7 +7267,6 @@ toplevel/topprinters.cmo : \
     typing/mode.cmi \
     typing/ident.cmi \
     typing/ctype.cmi \
-    parsing/asttypes.cmi \
     toplevel/topprinters.cmi
 toplevel/topprinters.cmx : \
     typing/types.cmx \
@@ -7273,7 +7275,6 @@ toplevel/topprinters.cmx : \
     typing/mode.cmx \
     typing/ident.cmx \
     typing/ctype.cmx \
-    parsing/asttypes.cmi \
     toplevel/topprinters.cmi
 toplevel/topprinters.cmi : \
     typing/types.cmi
@@ -7412,7 +7413,6 @@ toplevel/byte/trace.cmo : \
     bytecomp/meta.cmi \
     parsing/longident.cmi \
     typing/ctype.cmi \
-    parsing/asttypes.cmi \
     toplevel/byte/trace.cmi
 toplevel/byte/trace.cmx : \
     typing/types.cmx \
@@ -7425,7 +7425,6 @@ toplevel/byte/trace.cmx : \
     bytecomp/meta.cmx \
     parsing/longident.cmx \
     typing/ctype.cmx \
-    parsing/asttypes.cmi \
     toplevel/byte/trace.cmi
 toplevel/byte/trace.cmi : \
     typing/types.cmi \

--- a/ocaml/driver/makedepend.ml
+++ b/ocaml/driver/makedepend.ml
@@ -100,14 +100,38 @@ let add_to_synonym_list synonyms suffix =
 (* Find file 'name' (capitalized) in search path *)
 let find_module_in_load_path name =
   let names = List.map (fun ext -> name ^ ext) (!mli_synonyms @ !ml_synonyms) in
+  let uname = String.uncapitalize_ascii name in
   let unames =
-    let uname = String.uncapitalize_ascii name in
     List.map (fun ext -> uname ^ ext) (!mli_synonyms @ !ml_synonyms)
+  in
+  let stdlib_unames =
+    (* Jane Street: This is a hack to deal with the fact that we refer to our
+       custom stdlib modules with names like [Stdlib__Int32_u] from within the
+       stdlib.
+
+       Dependencies are calculated by looking at all modules mentioned by the
+       code in question and checking to see if there is a corresponding ml file.
+       But in our case there is no corresponding ml file, because the references
+       look like `Stdlib__Int32_u.foo` and the ml file's name is just
+       `int32_u.ml`.  This is unlike normal stdlib modules, which are exposed
+       with names that match their ml files.  So, the code here just teaches
+       make depend to optionally ignore a `Stdlib__` prefix for the purposes of
+       checking for a matching ml file. *)
+    let stdlib_prefix = "stdlib__" in
+    if String.starts_with ~prefix:stdlib_prefix uname then
+      let plen = String.length stdlib_prefix in
+      let uname =
+        String.sub name plen (String.length name - plen)
+      in
+      let uname = String.uncapitalize_ascii uname in
+      List.map (fun ext -> uname ^ ext) (!mli_synonyms @ !ml_synonyms)
+    else
+      []
   in
   let rec find_in_array a pos =
     if pos >= Array.length a then None else begin
       let s = a.(pos) in
-      if List.mem s names || List.mem s unames then
+      if List.mem s names || List.mem s unames || List.mem s stdlib_unames then
         Some s
       else
         find_in_array a (pos + 1)

--- a/ocaml/ocamldoc/.depend
+++ b/ocaml/ocamldoc/.depend
@@ -480,8 +480,7 @@ odoc_info.cmi : \
     odoc_extension.cmi \
     odoc_exception.cmi \
     odoc_class.cmi \
-    ../parsing/location.cmi \
-    ../parsing/asttypes.cmi
+    ../parsing/location.cmi
 odoc_latex.cmo : \
     odoc_to_text.cmi \
     odoc_messages.cmi \
@@ -594,8 +593,7 @@ odoc_misc.cmx : \
 odoc_misc.cmi : \
     ../typing/types.cmi \
     odoc_types.cmi \
-    ../parsing/longident.cmi \
-    ../parsing/asttypes.cmi
+    ../parsing/longident.cmi
 odoc_module.cmo : \
     ../typing/types.cmi \
     odoc_value.cmi \
@@ -743,6 +741,7 @@ odoc_see_lexer.cmx : \
 odoc_see_lexer.cmi : \
     odoc_parser.cmi
 odoc_sig.cmo : \
+    ../typing/typetexp.cmi \
     ../typing/types.cmi \
     ../typing/typedtree.cmi \
     ../parsing/parsetree.cmi \
@@ -769,6 +768,7 @@ odoc_sig.cmo : \
     ../parsing/asttypes.cmi \
     odoc_sig.cmi
 odoc_sig.cmx : \
+    ../typing/typetexp.cmx \
     ../typing/types.cmx \
     ../typing/typedtree.cmx \
     ../parsing/parsetree.cmi \
@@ -950,7 +950,6 @@ odoc_value.cmo : \
     odoc_parameter.cmi \
     odoc_name.cmi \
     odoc_misc.cmi \
-    ../parsing/asttypes.cmi \
     odoc_value.cmi
 odoc_value.cmx : \
     ../typing/types.cmx \
@@ -958,7 +957,6 @@ odoc_value.cmx : \
     odoc_parameter.cmx \
     odoc_name.cmx \
     odoc_misc.cmx \
-    ../parsing/asttypes.cmi \
     odoc_value.cmi
 odoc_value.cmi : \
     ../typing/types.cmi \

--- a/ocaml/stdlib/.depend
+++ b/ocaml/stdlib/.depend
@@ -541,10 +541,14 @@ stdlib__Int64.cmx : int64.ml \
 stdlib__Int64.cmi : int64.mli \
     stdlib.cmi
 stdlib__Int64_u.cmo : int64_u.ml \
+    stdlib__Nativeint_u.cmi \
+    stdlib__Int32_u.cmi \
     stdlib.cmi \
     stdlib__Int64.cmi \
     stdlib__Int64_u.cmi
 stdlib__Int64_u.cmx : int64_u.ml \
+    stdlib__Nativeint_u.cmx \
+    stdlib__Int32_u.cmx \
     stdlib.cmx \
     stdlib__Int64.cmx \
     stdlib__Int64_u.cmi
@@ -666,10 +670,12 @@ stdlib__Nativeint.cmx : nativeint.ml \
 stdlib__Nativeint.cmi : nativeint.mli \
     stdlib.cmi
 stdlib__Nativeint_u.cmo : nativeint_u.ml \
+    stdlib__Int32_u.cmi \
     stdlib.cmi \
     stdlib__Nativeint.cmi \
     stdlib__Nativeint_u.cmi
 stdlib__Nativeint_u.cmx : nativeint_u.ml \
+    stdlib__Int32_u.cmx \
     stdlib.cmx \
     stdlib__Nativeint.cmx \
     stdlib__Nativeint_u.cmi


### PR DESCRIPTION
This PR fixes an issue with the dependency calculation used by make depend.  This has been broken since we merged #2113.  To observe this problem, try to make depend and then bootstrap in the upstream build - it will fail with errors like:

```
File "ocaml/stdlib/nativeint_u.ml", line 97, characters 36-60:
97 |   of_nativeint (Nativeint.of_int32 (Stdlib__Int32_u.to_int32 x))
                                         ^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Stdlib__Int32_u
make[2]: *** [Makefile:218: stdlib__Nativeint_u.cmo] Error 2
```

The issue is that `ocamlc -depend` has a heuristic for finding the build artifacts associated with the modules mentioned in an ml file, and the heuristic is defeated by the fact that we only expose our stdlib modules with names like "Stdlib__Int32_u", and not just "Int32_u".

This adds some pretty kludgy special logic to `ocamlc -depend` to fix this issue.  I'm far from certain this is the best solution!  But it does seem to work, as evidenced by the fact that with these changes I was able to generate the new `ocaml/stdlib/.depend` included in this PR.  This file now lists the dependency of, for example, `stdlib__Nativeint_u.cmo` on `stdlib__Int32_u.cmo`, which the previous `-depend` logic could not do.  And, correspondingly, `make bootstrap` now works again.

(There are some other unrelated changes in the `.depend` files, presumably because these files have grown out of date while they have been impossible to update accurately.)