### PR TITLE
Disable macos build for now to unblock progress

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,10 @@ jobs:
             ocamlparam: '_,Oclassic=1'
             disable_testcases: 'ocaml/testsuite/tests/typing-local/regression_cmm_unboxing.ml ocaml/testsuite/tests/int64-unboxing/test.ml'
 
-          - name: flambda2_macos
-            config: --enable-middle-end=flambda2 --disable-warn-error
-            os: macos-latest
+          # CR ccasinghino: Understand why the macos build is failing and reenable
+          #  - name: flambda2_macos
+          #    config: --enable-middle-end=flambda2 --disable-warn-error
+          #    os: macos-latest
 
           - name: irc
             config: --enable-middle-end=flambda2


### PR DESCRIPTION
CI is failing on macos, for mysterious reasons.

I tried to fix the initial error (missing autoconf) by just installing it in #2495, that got a little farther but then hit [weird assembler errors](https://github.com/ocaml-flambda/flambda-backend/actions/runs/8836586309/job/24263504780?pr=2495)

I don't think we care very much about the macos build, and so we should just diable it to unblock progress while this issue persists.