### PR TITLE
Use a fixed macos version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,13 @@ jobs:
             ocamlparam: '_,Oclassic=1'
             disable_testcases: 'ocaml/testsuite/tests/typing-local/regression_cmm_unboxing.ml ocaml/testsuite/tests/int64-unboxing/test.ml'
 
+          # CR ccasinghino: We encountered build errors (missing autoconf, and
+          # then other errors) when `macos-latest` started referring to version
+          # 14.  So we've put a fixed version below for now, but we should
+          # eventually fix this.
           - name: flambda2_macos
             config: --enable-middle-end=flambda2 --disable-warn-error
-            os: macos-latest
+            os: macos-12
 
           - name: irc
             config: --enable-middle-end=flambda2


### PR DESCRIPTION
Hopefully this resolves the build errors we're seeing on macos in CI.  We should figure out some other fix that allows us to use the latest macos, but this will get us unstuck for now.