### PR TITLE
DWARF inlined frames: middle end

### DIFF
--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -31,7 +31,7 @@ type get_imported_code = unit -> Exported_code.t
 type t =
   { round : int;
     typing_env : TE.t;
-    inlined_debuginfo : Debuginfo.t;
+    inlined_debuginfo : Inlined_debuginfo.t;
     can_inline : bool;
     inlining_state : Inlining_state.t;
     propagating_float_consts : bool;
@@ -48,11 +48,6 @@ type t =
     inlining_history_tracker : Inlining_history.Tracker.t;
     loopify_state : Loopify_state.t
   }
-
-let print_debuginfo ppf dbg =
-  if Debuginfo.is_none dbg
-  then Format.pp_print_string ppf "None"
-  else Debuginfo.print_compact ppf dbg
 
 let [@ocamlformat "disable"] print ppf { round; typing_env;
                 inlined_debuginfo; can_inline;
@@ -84,7 +79,7 @@ let [@ocamlformat "disable"] print ppf { round; typing_env;
       )@]"
     round
     TE.print typing_env
-    print_debuginfo inlined_debuginfo
+    Inlined_debuginfo.print inlined_debuginfo
     can_inline
     Inlining_state.print inlining_state
     propagating_float_consts
@@ -112,7 +107,7 @@ let create ~round ~(resolver : resolver)
   in
   { round;
     typing_env;
-    inlined_debuginfo = Debuginfo.none;
+    inlined_debuginfo = Inlined_debuginfo.none;
     can_inline = true;
     inlining_state = Inlining_state.default ~round;
     propagating_float_consts;
@@ -193,7 +188,7 @@ let enter_set_of_closures
     } =
   { round;
     typing_env = TE.closure_env typing_env;
-    inlined_debuginfo = Debuginfo.none;
+    inlined_debuginfo = Inlined_debuginfo.none;
     can_inline;
     inlining_state;
     propagating_float_consts;
@@ -461,12 +456,6 @@ let define_code t ~code_id ~code =
   let all_code = Code_id.Map.add code_id code t.all_code in
   { t with typing_env; all_code }
 
-let set_inlined_debuginfo t dbg = { t with inlined_debuginfo = dbg }
-
-let get_inlined_debuginfo t = t.inlined_debuginfo
-
-let add_inlined_debuginfo t dbg = Debuginfo.inline t.inlined_debuginfo dbg
-
 let cse t = t.cse
 
 let comparison_results t = t.comparison_results
@@ -519,6 +508,14 @@ let set_inlining_arguments arguments t =
     inlining_state = Inlining_state.with_arguments arguments t.inlining_state
   }
 
+let set_inlined_debuginfo t ~from =
+  { t with inlined_debuginfo = from.inlined_debuginfo }
+
+let set_inlined_debuginfo' t inlined_debuginfo = { t with inlined_debuginfo }
+
+let add_inlined_debuginfo t dbg =
+  Inlined_debuginfo.rewrite t.inlined_debuginfo dbg
+
 let enter_inlined_apply ~called_code ~apply ~was_inline_always t =
   let arguments =
     Inlining_state.arguments t.inlining_state
@@ -543,8 +540,12 @@ let enter_inlined_apply ~called_code ~apply ~was_inline_always t =
         in
         Inlining_state.increment_depth t.inlining_state ~by)
   in
+  let inlined_debuginfo =
+    Inlined_debuginfo.create ~called_code_id:(Code.code_id called_code)
+      ~apply_dbg:(Apply.dbg apply)
+  in
   { t with
-    inlined_debuginfo = Apply.dbg apply;
+    inlined_debuginfo;
     inlining_state;
     inlining_history_tracker =
       Inlining_history.Tracker.enter_inlined_apply

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -511,7 +511,11 @@ let set_inlining_arguments arguments t =
 let set_inlined_debuginfo t ~from =
   { t with inlined_debuginfo = from.inlined_debuginfo }
 
-let set_inlined_debuginfo' t inlined_debuginfo = { t with inlined_debuginfo }
+let merge_inlined_debuginfo t ~from_apply_expr =
+  { t with
+    inlined_debuginfo =
+      Inlined_debuginfo.merge t.inlined_debuginfo ~from_apply_expr
+  }
 
 let add_inlined_debuginfo t dbg =
   Inlined_debuginfo.rewrite t.inlined_debuginfo dbg

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -508,6 +508,9 @@ let set_inlining_arguments arguments t =
     inlining_state = Inlining_state.with_arguments arguments t.inlining_state
   }
 
+(* CR mshinwell/gbury: we might be dropping [Enter_inlined_apply] context here
+   when mixing code compiled in classic and Simplify modes *)
+
 let set_inlined_debuginfo t ~from =
   { t with inlined_debuginfo = from.inlined_debuginfo }
 

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -149,7 +149,7 @@ val find_code_exn : t -> Code_id.t -> Code_or_metadata.t
 
 val set_inlined_debuginfo : t -> from:t -> t
 
-val set_inlined_debuginfo' : t -> Inlined_debuginfo.t -> t
+val merge_inlined_debuginfo : t -> from_apply_expr:Inlined_debuginfo.t -> t
 
 val add_inlined_debuginfo : t -> Debuginfo.t -> Debuginfo.t
 

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -147,11 +147,11 @@ val mem_code : t -> Code_id.t -> bool
 (** This function raises if the code ID is unbound. *)
 val find_code_exn : t -> Code_id.t -> Code_or_metadata.t
 
-val set_inlined_debuginfo : t -> Debuginfo.t -> t
+val set_inlined_debuginfo : t -> from:t -> t
+
+val set_inlined_debuginfo' : t -> Inlined_debuginfo.t -> t
 
 val add_inlined_debuginfo : t -> Debuginfo.t -> Debuginfo.t
-
-val get_inlined_debuginfo : t -> Debuginfo.t
 
 val round : t -> int
 

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -20,9 +20,9 @@ module DE = Downwards_env
 module FT = Flambda2_types.Function_type
 module VB = Bound_var
 
-let make_inlined_body ~callee ~unroll_to ~params ~args ~my_closure ~my_region
-    ~my_depth ~rec_info ~body ~exn_continuation ~return_continuation
-    ~apply_exn_continuation ~apply_return_continuation =
+let make_inlined_body ~callee ~called_code_id ~unroll_to ~params ~args
+    ~my_closure ~my_region ~my_depth ~rec_info ~body ~exn_continuation
+    ~return_continuation ~apply_exn_continuation ~apply_return_continuation =
   let callee, rec_info =
     match callee with
     | None ->
@@ -68,10 +68,10 @@ let make_inlined_body ~callee ~unroll_to ~params ~args ~my_closure ~my_region
       ~body ~free_names_of_body:Unknown
     |> Expr.create_let
   in
-  Inlining_helpers.make_inlined_body ~callee ~params ~args ~my_closure
-    ~my_region ~my_depth ~rec_info ~body ~exn_continuation ~return_continuation
-    ~apply_exn_continuation ~apply_return_continuation ~bind_params ~bind_depth
-    ~apply_renaming:Expr.apply_renaming
+  Inlining_helpers.make_inlined_body ~callee ~called_code_id ~params ~args
+    ~my_closure ~my_region ~my_depth ~rec_info ~body ~exn_continuation
+    ~return_continuation ~apply_exn_continuation ~apply_return_continuation
+    ~bind_params ~bind_depth ~apply_renaming:Expr.apply_renaming
 
 let wrap_inlined_body_for_exn_extra_args ~extra_args ~apply_exn_continuation
     ~apply_return_continuation ~result_arity ~make_inlined_body =
@@ -143,7 +143,8 @@ let inline dacc ~apply ~unroll_to ~was_inline_always function_decl =
            ~free_names_of_body:_
          ->
         let make_inlined_body () =
-          make_inlined_body ~callee ~region_inlined_into ~unroll_to
+          make_inlined_body ~callee ~called_code_id:(Code.code_id code)
+            ~region_inlined_into ~unroll_to
             ~params:(Bound_parameters.to_list params)
             ~args ~my_closure ~my_region ~my_depth ~rec_info ~body
             ~exn_continuation ~return_continuation

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -223,10 +223,7 @@ let compute_handler_env ?cut_after uses ~is_recursive ~env_at_fork
         (DE.inlining_history_tracker env_at_fork)
         handler_env
     in
-    let handler_env =
-      DE.set_inlined_debuginfo handler_env
-        (DE.get_inlined_debuginfo env_at_fork)
-    in
+    let handler_env = DE.set_inlined_debuginfo handler_env ~from:env_at_fork in
     let handler_env =
       DE.set_at_unit_toplevel_state handler_env
         (DE.at_unit_toplevel env_at_fork)

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -42,8 +42,7 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     Simplify_primitive_result.create named ~try_reify:false dacc
   | Enter_inlined_apply { dbg } ->
     let dacc =
-      DA.map_denv dacc ~f:(fun denv ->
-          DE.set_inlined_debuginfo denv (DE.add_inlined_debuginfo denv dbg))
+      DA.map_denv dacc ~f:(fun denv -> DE.set_inlined_debuginfo' denv dbg)
     in
     let named = Named.create_simple Simple.const_unit in
     let ty = T.this_tagged_immediate Targetint_31_63.zero in

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -42,7 +42,8 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     Simplify_primitive_result.create named ~try_reify:false dacc
   | Enter_inlined_apply { dbg } ->
     let dacc =
-      DA.map_denv dacc ~f:(fun denv -> DE.set_inlined_debuginfo' denv dbg)
+      DA.map_denv dacc ~f:(fun denv ->
+          DE.merge_inlined_debuginfo denv ~from_apply_expr:dbg)
     in
     let named = Named.create_simple Simple.const_unit in
     let ty = T.this_tagged_immediate Targetint_31_63.zero in

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -17,10 +17,10 @@
 open! Flambda.Import
 module RC = Apply.Result_continuation
 
-let make_inlined_body ~callee ~region_inlined_into ~params ~args ~my_closure
-    ~my_region ~my_depth ~rec_info ~body ~exn_continuation ~return_continuation
-    ~apply_exn_continuation ~apply_return_continuation ~bind_params ~bind_depth
-    ~apply_renaming =
+let make_inlined_body ~callee ~called_code_id:_ ~region_inlined_into ~params
+    ~args ~my_closure ~my_region ~my_depth ~rec_info ~body ~exn_continuation
+    ~return_continuation ~apply_exn_continuation ~apply_return_continuation
+    ~bind_params ~bind_depth ~apply_renaming =
   let renaming = Renaming.empty in
   let renaming =
     match (apply_return_continuation : RC.t) with

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.mli
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.mli
@@ -16,6 +16,7 @@
 
 val make_inlined_body :
   callee:Simple.t option ->
+  called_code_id:Code_id.t ->
   region_inlined_into:Alloc_mode.For_allocations.t ->
   params:'param list ->
   args:Simple.List.t ->

--- a/middle_end/flambda2/term_basics/inlined_debuginfo.ml
+++ b/middle_end/flambda2/term_basics/inlined_debuginfo.ml
@@ -26,39 +26,79 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-type t =
-  { dbg : Debuginfo.t;
-    function_symbol : Linkage_name.t;
-    uid : string
-  }
+(* In classic mode and when running Simplify on classic-mode-generated code, we
+   may encounter multiple [Enter_inlined_apply] primitives, before reaching any
+   particular [Debuginfo.t]. As such we need to keep a stack of these so we
+   don't lose information. *)
+module One_step = struct
+  type t =
+    { dbg : Debuginfo.t;
+      function_symbol : Linkage_name.t;
+      uid : string
+    }
 
-(* CR mshinwell/poechsel: if this becomes the flambda2 replacement for
-   [Debuginfo.t] we could maybe avoid making the uids in the same way, and add a
-   "below" constructor or something to identify different instances of
-   inlining. *)
+  (* CR mshinwell/poechsel: if this becomes the flambda2 replacement for
+     [Debuginfo.t] we could maybe avoid making the uids in the same way, and add
+     a "below" constructor or something to identify different instances of
+     inlining. *)
 
-(* CR mshinwell/poechsel: maybe this could be integrated with the inlining
-   histories *)
+  (* CR mshinwell/poechsel: maybe this could be integrated with the inlining
+     histories *)
 
-let print_debuginfo ppf dbg =
-  if Debuginfo.is_none dbg
-  then Format.pp_print_string ppf "None"
-  else Debuginfo.print_compact ppf dbg
+  let print_debuginfo ppf dbg =
+    if Debuginfo.is_none dbg
+    then Format.pp_print_string ppf "None"
+    else Debuginfo.print_compact ppf dbg
 
-let print ppf { dbg; function_symbol; uid } =
-  Format.fprintf ppf
-    "@[<hov 1>(@[<hov 1>(dbg@ %a)@]@ @[<hov 1>(function_symbol@ %a)@]@ @[<hov \
-     1>(uid@ %a)@])@]"
-    print_debuginfo dbg Linkage_name.print function_symbol
-    Format.pp_print_string uid
+  let print ppf { dbg; function_symbol; uid } =
+    Format.fprintf ppf
+      "@[<hov 1>(@[<hov 1>(dbg@ %a)@]@ @[<hov 1>(function_symbol@ %a)@]@ \
+       @[<hov 1>(uid@ %a)@])@]"
+      print_debuginfo dbg Linkage_name.print function_symbol
+      Format.pp_print_string uid
 
-let none =
-  { dbg = Debuginfo.none;
-    function_symbol = Linkage_name.of_string "";
-    uid = ""
-  }
+  let compare t1 t2 =
+    let c = Debuginfo.compare t1.dbg t2.dbg in
+    if c <> 0
+    then c
+    else
+      let c = Linkage_name.compare t1.function_symbol t2.function_symbol in
+      if c <> 0 then c else String.compare t1.uid t2.uid
 
-let is_none t = Debuginfo.compare t.dbg Debuginfo.none = 0
+  let rewrite t dbg_from_inlined_body =
+    if Debuginfo.is_none t.dbg
+    then dbg_from_inlined_body
+    else
+      let dbg_from_inlined_body =
+        (* uids of _all_ [Debuginfo.t] values in the body of the function being
+           inlined get freshened (consistently, for any given inlining).
+
+           See the doc comment in the .mli for further details. *)
+        Debuginfo.mapi_items dbg_from_inlined_body
+          ~f:(fun n ({ dinfo_function_symbol; _ } as item : Debuginfo.item) ->
+            let dinfo_function_symbol =
+              if n = 0
+              then Some (Linkage_name.to_string t.function_symbol)
+              else dinfo_function_symbol
+            in
+            Debuginfo.item_with_uid_and_function_symbol item
+              ~dinfo_uid:(Some t.uid) ~dinfo_function_symbol)
+      in
+      (* Note that [t.dbg] might not be a singleton -- however everything should
+         be ok in terms of each frame (except the first) being annotated with a
+         uid and function symbol in [t.dbg]. *)
+      Debuginfo.inline t.dbg dbg_from_inlined_body
+end
+
+(* The head of the list is the most recent inlining. *)
+type t = One_step.t list
+
+let none = []
+
+let is_none t = match t with [] -> true | _ :: _ -> false
+
+let print ppf t =
+  Format.fprintf ppf "@[<hov 1>%a@]" (Format.pp_print_list One_step.print) t
 
 let inlining_counter = ref 0
 
@@ -70,36 +110,15 @@ let create ~called_code_id ~apply_dbg =
     Hashtbl.hash (apply_dbg, function_symbol, !inlining_counter)
     |> string_of_int
   in
-  { dbg = apply_dbg; function_symbol; uid }
+  [{ One_step.dbg = apply_dbg; function_symbol; uid }]
 
-let rewrite t dbg_from_inlined_body =
-  if is_none t
-  then dbg_from_inlined_body
-  else
-    let dbg_from_inlined_body =
-      (* uids of _all_ [Debuginfo.t] values in the body of the function being
-         inlined get freshened (consistently, for any given inlining).
+let merge t ~from_apply_expr = from_apply_expr @ t
 
-         See the doc comment in the .mli for further details. *)
-      Debuginfo.mapi_items dbg_from_inlined_body
-        ~f:(fun n ({ dinfo_function_symbol; _ } as item : Debuginfo.item) ->
-          let dinfo_function_symbol =
-            if n = 0
-            then Some (Linkage_name.to_string t.function_symbol)
-            else dinfo_function_symbol
-          in
-          Debuginfo.item_with_uid_and_function_symbol item
-            ~dinfo_uid:(Some t.uid) ~dinfo_function_symbol)
-    in
-    (* Note that [t.dbg] might not be a singleton -- however everything should
-       be ok in terms of each frame (except the first) being annotated with a
-       uid and function symbol in [t.dbg]. *)
-    Debuginfo.inline t.dbg dbg_from_inlined_body
+let compare t1 t2 = List.compare One_step.compare t1 t2
 
-let compare t1 t2 =
-  let c = Debuginfo.compare t1.dbg t2.dbg in
-  if c <> 0
-  then c
-  else
-    let c = Linkage_name.compare t1.function_symbol t2.function_symbol in
-    if c <> 0 then c else String.compare t1.uid t2.uid
+let rewrite t dbg =
+  (* This could be optimized in terms of freshening uids, but for the moment use
+     a more obviously-correct implementation. *)
+  List.fold_left
+    (fun dbg one_step -> One_step.rewrite one_step dbg)
+    dbg (List.rev t)

--- a/middle_end/flambda2/term_basics/inlined_debuginfo.ml
+++ b/middle_end/flambda2/term_basics/inlined_debuginfo.ml
@@ -26,6 +26,14 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
+(* CR mshinwell/poechsel: if this becomes the flambda2 replacement for
+   [Debuginfo.t] we could maybe avoid making the uids in the same way, and add a
+   "below" constructor or something to identify different instances of
+   inlining. *)
+
+(* CR mshinwell/poechsel: maybe this could be integrated with the inlining
+   histories *)
+
 (* In classic mode and when running Simplify on classic-mode-generated code, we
    may encounter multiple [Enter_inlined_apply] primitives, before reaching any
    particular [Debuginfo.t]. As such we need to keep a stack of these so we
@@ -36,14 +44,6 @@ module One_step = struct
       function_symbol : Linkage_name.t;
       uid : string
     }
-
-  (* CR mshinwell/poechsel: if this becomes the flambda2 replacement for
-     [Debuginfo.t] we could maybe avoid making the uids in the same way, and add
-     a "below" constructor or something to identify different instances of
-     inlining. *)
-
-  (* CR mshinwell/poechsel: maybe this could be integrated with the inlining
-     histories *)
 
   let print_debuginfo ppf dbg =
     if Debuginfo.is_none dbg
@@ -89,6 +89,11 @@ module One_step = struct
          uid and function symbol in [t.dbg]. *)
       Debuginfo.inline t.dbg dbg_from_inlined_body
 end
+
+(* The most recent [Enter_inlined_apply] primitive that we have encountered,
+   corresponding to the deepest inlining, is at the head of the list. This means
+   that it will be the first to be applied to the [Debuginfo.t] from an inlined
+   body by [rewrite], below. *)
 
 type t = One_step.t list
 

--- a/middle_end/flambda2/term_basics/inlined_debuginfo.ml
+++ b/middle_end/flambda2/term_basics/inlined_debuginfo.ml
@@ -90,7 +90,6 @@ module One_step = struct
       Debuginfo.inline t.dbg dbg_from_inlined_body
 end
 
-(* The head of the list is the most recent inlining. *)
 type t = One_step.t list
 
 let none = []
@@ -119,6 +118,4 @@ let compare t1 t2 = List.compare One_step.compare t1 t2
 let rewrite t dbg =
   (* This could be optimized in terms of freshening uids, but for the moment use
      a more obviously-correct implementation. *)
-  List.fold_left
-    (fun dbg one_step -> One_step.rewrite one_step dbg)
-    dbg (List.rev t)
+  List.fold_left (fun dbg one_step -> One_step.rewrite one_step dbg) dbg t

--- a/middle_end/flambda2/term_basics/inlined_debuginfo.ml
+++ b/middle_end/flambda2/term_basics/inlined_debuginfo.ml
@@ -1,0 +1,105 @@
+(******************************************************************************
+ *                             flambda-backend                                *
+ *                       Mark Shinwell, Jane Street                           *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2024 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+type t =
+  { dbg : Debuginfo.t;
+    function_symbol : Linkage_name.t;
+    uid : string
+  }
+
+(* CR mshinwell/poechsel: if this becomes the flambda2 replacement for
+   [Debuginfo.t] we could maybe avoid making the uids in the same way, and add a
+   "below" constructor or something to identify different instances of
+   inlining. *)
+
+(* CR mshinwell/poechsel: maybe this could be integrated with the inlining
+   histories *)
+
+let print_debuginfo ppf dbg =
+  if Debuginfo.is_none dbg
+  then Format.pp_print_string ppf "None"
+  else Debuginfo.print_compact ppf dbg
+
+let print ppf { dbg; function_symbol; uid } =
+  Format.fprintf ppf
+    "@[<hov 1>(@[<hov 1>(dbg@ %a)@]@ @[<hov 1>(function_symbol@ %a)@]@ @[<hov \
+     1>(uid@ %a)@])@]"
+    print_debuginfo dbg Linkage_name.print function_symbol
+    Format.pp_print_string uid
+
+let none =
+  { dbg = Debuginfo.none;
+    function_symbol = Linkage_name.of_string "";
+    uid = ""
+  }
+
+let is_none t = Debuginfo.compare t.dbg Debuginfo.none = 0
+
+let inlining_counter = ref 0
+
+let create ~called_code_id ~apply_dbg =
+  let function_symbol = Code_id.linkage_name called_code_id in
+  let uid =
+    incr inlining_counter;
+    (* CR mshinwell: consider improving this *)
+    Hashtbl.hash (apply_dbg, function_symbol, !inlining_counter)
+    |> string_of_int
+  in
+  { dbg = apply_dbg; function_symbol; uid }
+
+let rewrite t dbg_from_inlined_body =
+  if is_none t
+  then dbg_from_inlined_body
+  else
+    let dbg_from_inlined_body =
+      (* uids of _all_ [Debuginfo.t] values in the body of the function being
+         inlined get freshened (consistently, for any given inlining).
+
+         See the doc comment in the .mli for further details. *)
+      Debuginfo.mapi_items dbg_from_inlined_body
+        ~f:(fun n ({ dinfo_function_symbol; _ } as item : Debuginfo.item) ->
+          let dinfo_function_symbol =
+            if n = 0
+            then Some (Linkage_name.to_string t.function_symbol)
+            else dinfo_function_symbol
+          in
+          Debuginfo.item_with_uid_and_function_symbol item
+            ~dinfo_uid:(Some t.uid) ~dinfo_function_symbol)
+    in
+    (* Note that [t.dbg] might not be a singleton -- however everything should
+       be ok in terms of each frame (except the first) being annotated with a
+       uid and function symbol in [t.dbg]. *)
+    Debuginfo.inline t.dbg dbg_from_inlined_body
+
+let compare t1 t2 =
+  let c = Debuginfo.compare t1.dbg t2.dbg in
+  if c <> 0
+  then c
+  else
+    let c = Linkage_name.compare t1.function_symbol t2.function_symbol in
+    if c <> 0 then c else String.compare t1.uid t2.uid

--- a/middle_end/flambda2/term_basics/inlined_debuginfo.mli
+++ b/middle_end/flambda2/term_basics/inlined_debuginfo.mli
@@ -1,0 +1,80 @@
+(******************************************************************************
+ *                             flambda-backend                                *
+ *                       Mark Shinwell, Jane Street                           *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2024 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Information required to rewrite [Debuginfo.t] values in the body of an
+    inlined function.  These rewrites do three things:
+
+    1. augment the inlined frame information directly in the [Debuginfo.t]
+    values (c.f. [Debuginfo.inline]);
+
+    2. allow the backend to distinguish between different instances of
+    inlining, by assigning each such instance a unique identifier;
+
+    3. allow the backend to determine the function symbol for each inlined
+    frame specified by a [Debuginfo.t] value.
+
+    Points 2 and 3 are required for the generation of DWARF inlined frame
+    information. *)
+
+(** A value of type [t] represents one instance of inlining out a
+    particular function application. *)
+type t
+
+val print : Format.formatter -> t -> unit
+
+val compare : t -> t -> int
+
+val none : t
+
+val is_none : t -> bool
+
+(** [create ~called_code_id ~apply_dbg] should be used when a function
+    application (i.e. [Apply_expr] term) with debuginfo [apply_dbg] is
+    to be inlined out.  [create] must be called for each such instance of
+    inlining. *)
+val create : called_code_id:Code_id.t -> apply_dbg:Debuginfo.t -> t
+
+(** For an instance of inlining [t] and a debuginfo value [dbg] occurring in
+    the body of the corresponding function to be inlined, return a new
+    debuginfo value to replace the old one.
+
+    The new debuginfo value will consistently have the same, fresh, uid on every
+    item corresponding to the inlined body (i.e. every item except those at the
+    head of the list, which are those---typically just one item in fact---that
+    came from the [apply_dbg] passed to [create]).
+
+    In addition, the first (outermost, less deep inlining) debuginfo item
+    arising from the inlined body is annotated with the function symbol from the
+    application term being inlined out.  Inductively, in association with the
+    general propagation of [Debuginfo.t] values by Flambda 2, the consequence is
+    that [Debuginfo.t] values returned from this function end up annotated with
+    function symbols at all points except the outermost frame. (The symbol for
+    that frame will be known by the backend, since it is the function into which
+    everything is ultimately being inlined.)
+*)
+val rewrite : t -> Debuginfo.t -> Debuginfo.t

--- a/middle_end/flambda2/term_basics/inlined_debuginfo.mli
+++ b/middle_end/flambda2/term_basics/inlined_debuginfo.mli
@@ -59,6 +59,10 @@ val is_none : t -> bool
     inlining. *)
 val create : called_code_id:Code_id.t -> apply_dbg:Debuginfo.t -> t
 
+(** Merge an existing value of type [t] with [from_apply_expr], the latter
+    corresponding to an [Apply_expr] term that is being inlined out. *)
+val merge : t -> from_apply_expr:t -> t
+
 (** For an instance of inlining [t] and a debuginfo value [dbg] occurring in
     the body of the corresponding function to be inlined, return a new
     debuginfo value to replace the old one.

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -76,6 +76,8 @@ and let_expr =
     defining_expr : named
   }
 
+(* CR mshinwell/xclerc: use a different [Debuginfo.t] type (not least so that
+   freshening of uids etc causes less allocation) *)
 and named =
   | Simple of Simple.t
   | Prim of Flambda_primitive.t * Debuginfo.t

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -823,7 +823,7 @@ type nullary_primitive =
   | Probe_is_enabled of { name : string }
   | Begin_region
   | Begin_try_region
-  | Enter_inlined_apply of { dbg : Debuginfo.t }
+  | Enter_inlined_apply of { dbg : Inlined_debuginfo.t }
 
 let nullary_primitive_eligible_for_cse = function
   | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Begin_region
@@ -839,7 +839,7 @@ let compare_nullary_primitive p1 p2 =
   | Begin_region, Begin_region -> 0
   | Begin_try_region, Begin_try_region -> 0
   | Enter_inlined_apply { dbg = dbg1 }, Enter_inlined_apply { dbg = dbg2 } ->
-    Debuginfo.compare dbg1 dbg2
+    Inlined_debuginfo.compare dbg1 dbg2
   | ( Invalid _,
       ( Optimised_out _ | Probe_is_enabled _ | Begin_region | Begin_try_region
       | Enter_inlined_apply _ ) ) ->
@@ -880,7 +880,7 @@ let print_nullary_primitive ppf p =
   | Begin_try_region -> Format.pp_print_string ppf "Begin_try_region"
   | Enter_inlined_apply { dbg } ->
     Format.fprintf ppf "@[<hov 1>(Enter_inlined_apply@ %a)@]"
-      Debuginfo.print_compact dbg
+      Inlined_debuginfo.print dbg
 
 let result_kind_of_nullary_primitive p : result_kind =
   match p with

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -287,7 +287,7 @@ type nullary_primitive =
   | Begin_try_region
       (** Starting delimiter of local allocation region, when used for a "try"
           body. *)
-  | Enter_inlined_apply of { dbg : Debuginfo.t }
+  | Enter_inlined_apply of { dbg : Inlined_debuginfo.t }
       (** Used in classic mode to denote the start of an inlined function body.
           This is then used in to_cmm to correctly add inlined debuginfo. *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -255,7 +255,12 @@ let enter_function_body env ~return_continuation ~exn_continuation =
 
 (* Debuginfo *)
 
-let enter_inlined_apply t inlined_debuginfo = { t with inlined_debuginfo }
+let enter_inlined_apply t new_inlined_debuginfo =
+  { t with
+    inlined_debuginfo =
+      Inlined_debuginfo.merge t.inlined_debuginfo
+        ~from_apply_expr:new_inlined_debuginfo
+  }
 
 let set_inlined_debuginfo t inlined_debuginfo = { t with inlined_debuginfo }
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -35,7 +35,7 @@ type cont =
       { handler_params : Bound_parameters.t;
         handler_params_occurrences : Num_occurrences.t Variable.Map.t;
         handler_body : Flambda.Expr.t;
-        handler_body_inlined_debuginfo : Debuginfo.t
+        handler_body_inlined_debuginfo : Inlined_debuginfo.t
       }
 
 type extra_info = Untag of Cmm.expression
@@ -131,7 +131,7 @@ type t =
        This is relative to the flambda expression being currently translated,
        i.e. either the unit initialization code, or the body of a function. This
        information is reset when entering a new function. *)
-    inlined_debuginfo : Debuginfo.t;
+    inlined_debuginfo : Inlined_debuginfo.t;
     (* Debuginfo corresponding to inlined functions. *)
     return_continuation : Continuation.t;
     (* The (non-exceptional) return continuation of the current context (used to
@@ -238,7 +238,7 @@ let create offsets functions_info ~trans_prim ~return_continuation
     offsets;
     functions_info;
     trans_prim;
-    inlined_debuginfo = Debuginfo.none;
+    inlined_debuginfo = Inlined_debuginfo.none;
     stages = [];
     bindings = Variable.Map.empty;
     inline_once_aliases = Variable.Map.empty;
@@ -255,13 +255,12 @@ let enter_function_body env ~return_continuation ~exn_continuation =
 
 (* Debuginfo *)
 
-let enter_inlined_apply t dbg =
-  let inlined_debuginfo = Debuginfo.inline t.inlined_debuginfo dbg in
-  { t with inlined_debuginfo }
+let enter_inlined_apply t inlined_debuginfo = { t with inlined_debuginfo }
 
 let set_inlined_debuginfo t inlined_debuginfo = { t with inlined_debuginfo }
 
-let add_inlined_debuginfo t dbg = Debuginfo.inline t.inlined_debuginfo dbg
+let add_inlined_debuginfo t dbg =
+  Inlined_debuginfo.rewrite t.inlined_debuginfo dbg
 
 (* Continuations *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -101,10 +101,10 @@ val add_inlined_debuginfo : t -> Debuginfo.t -> Debuginfo.t
 
 (** Adjust the inlined debuginfo in the env to represent the fact
     that we entered the inlined body of a function. *)
-val enter_inlined_apply : t -> Debuginfo.t -> t
+val enter_inlined_apply : t -> Inlined_debuginfo.t -> t
 
 (** Set the inlined debuginfo. *)
-val set_inlined_debuginfo : t -> Debuginfo.t -> t
+val set_inlined_debuginfo : t -> Inlined_debuginfo.t -> t
 
 (** {2 Continuations} *)
 
@@ -300,7 +300,7 @@ type cont = private
       { handler_params : Bound_parameters.t;
         handler_params_occurrences : Num_occurrences.t Variable.Map.t;
         handler_body : Flambda.Expr.t;
-        handler_body_inlined_debuginfo : Debuginfo.t
+        handler_body_inlined_debuginfo : Inlined_debuginfo.t
       }
 
 (** Record that the given continuation should be compiled to a jump, creating a

--- a/ocaml/lambda/debuginfo.mli
+++ b/ocaml/lambda/debuginfo.mli
@@ -34,6 +34,8 @@ module Scoped_location : sig
 
   val string_of_scopes : scopes -> string
 
+  val compilation_unit : scopes -> Compilation_unit.t option
+
   val empty_scopes : scopes
   val enter_anonymous_function :
     scopes:scopes -> assume_zero_alloc:ZA.Assume_info.t -> scopes
@@ -71,7 +73,16 @@ type item = private {
   dinfo_end_bol: int;
   dinfo_end_line: int;
   dinfo_scopes: Scoped_location.scopes;
+  (** See the [Inlined_debuginfo] module in Flambda 2 for an explanation
+      of the uid and function symbol fields.  (They are used for generation
+      of DWARF inlined frame information.)  These fields should only be
+      set to [Some] by Flambda 2. *)
+  dinfo_uid: string option;
+  dinfo_function_symbol: string option;
 }
+
+val item_with_uid_and_function_symbol : item -> dinfo_uid:string option
+  -> dinfo_function_symbol:string option -> item
 
 type t
 
@@ -90,6 +101,12 @@ val none : t
 
 val is_none : t -> bool
 
+val of_items : item list -> t
+
+val mapi_items : t -> f:(int -> item -> item) -> t
+
+val to_items : t -> item list
+
 val to_string : t -> string
 
 val from_location : Scoped_location.t -> t
@@ -101,6 +118,9 @@ val inline : t -> t -> t
 val compare : t -> t -> int
 
 val print_compact : Format.formatter -> t -> unit
+
+(** Like [print_compact] but also prints uid and function symbol info. *)
+val print_compact_extended : Format.formatter -> t -> unit
 
 val merge : into:t -> t -> t
 


### PR DESCRIPTION
This PR makes fairly minor changes in/around the middle end to support generation of DWARF inlined frame information.

In `Debuginfo.t` two new fields are added, which enable the tracking of different instances of inlining, together with the ability to obtain the code ID (function symbol) corresponding to any particular inlined frame.  (The type of the latter, which is used for reliable referencing of DWARF abstract instance DIEs from concrete inlined instance DIEs, should really be `Code_id.t` but that is not available in `Debuginfo`.)  There are further details in the comment on the new `Inlined_debuginfo` module, which in due course should probably be extended to provide a new type of debuginfo for the middle end, replacing `Debuginfo.t`.

The existing infrastructure for generating `Debuginfo.t` values with inlined frames in Flambda 2 has been refactored and made to take advantage of the `Inlined_debuginfo` module.  I will do some testing before merging to check that this hasn't altered the debuginfo propagation.

cc @poechsel and @xclerc with whom this has been discussed in person.  @Gbury maybe you could cast an independent eye over the Flambda 2 parts.