### PR TITLE
Track external symbols

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -533,6 +533,7 @@ let compile_implementation unix ?toplevel ~pipeline
     (fun () ->
       Compilation_unit.Set.iter Compilenv.require_global
         program.required_globals;
+      Compilenv.record_external_symbols ();
       match pipeline with
       | Direct_to_cmm direct_to_cmm ->
         let cmm_phrases =

--- a/backend/asmlibrarian.ml
+++ b/backend/asmlibrarian.ml
@@ -96,7 +96,8 @@ let create_archive file_list lib_name =
              li_imports_cmx =
                mk_bitmap cmxs cmx_index unit.ui_imports_cmx
                  ~find:Compilation_unit.Tbl.find
-                 ~get_name:Import_info.cu })
+                 ~get_name:Import_info.cu;
+             li_external_symbols = Array.of_list unit.ui_external_symbols })
          descr_list
        in
        let infos =

--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -205,6 +205,7 @@ let build_package_cmx members cmxfile =
           List.exists (fun info -> info.ui_force_link) units;
       ui_export_info;
       ui_checks;
+      ui_external_symbols = union (List.map (fun info -> info.ui_external_symbols) units);
     } in
   Compilenv.write_unit_info pkg_infos cmxfile
 

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -56,7 +56,9 @@ type unit_infos =
     mutable ui_generic_fns: generic_fns;  (* Generic functions needed *)
     mutable ui_export_info: Flambda2_cmx.Flambda_cmx_format.t option;
     mutable ui_checks: Checks.t;
-    mutable ui_force_link: bool }         (* Always linked *)
+    mutable ui_force_link: bool;          (* Always linked *)
+    mutable ui_external_symbols: string list; (* Set of external symbols *)
+  }
 
 type unit_infos_raw =
   { uir_unit: Compilation_unit.t;
@@ -71,6 +73,7 @@ type unit_infos_raw =
                                       relative to byte immediately after
                                       this record *)
     uir_sections_length: int;      (* Byte length of all sections *)
+    uir_external_symbols: string array;
   }
 
 (* Each .a library has a matching .cmxa file that provides the following
@@ -82,7 +85,9 @@ type lib_unit_info =
     li_defines: Compilation_unit.t list;
     li_force_link: bool;
     li_imports_cmi : Bitmap.t;  (* subset of lib_imports_cmi *)
-    li_imports_cmx : Bitmap.t } (* subset of lib_imports_cmx *)
+    li_imports_cmx : Bitmap.t;  (* subset of lib_imports_cmx *)
+    li_external_symbols: string array;
+  }
 
 type library_infos =
   { lib_imports_cmi: Import_info.t array;

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -80,7 +80,7 @@ let reset compilation_unit =
 let record_external_symbols () =
   current_unit.ui_external_symbols <- (List.filter_map (fun prim ->
       if not (Primitive.native_name_is_external prim) then None
-      else begin Some (Primitive.native_name prim) end)
+      else Some (Primitive.native_name prim))
       !Translmod.primitive_declarations)
 
 let current_unit_infos () =

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -76,6 +76,8 @@ val require_global: Compilation_unit.t -> unit
 
 val read_library_info: string -> library_infos
 
+val record_external_symbols : unit -> unit
+
 (* CR mshinwell: see comment in .ml
 val ensure_sharing_between_cmi_and_cmx_imports :
   (_ * (Compilation_unit.t * _) option) list ->


### PR DESCRIPTION
Export in the cmx / cmxa the set of C symbols the current module / library depends on.

We say that a file `foo.ml` depends on `foo` if it contains at list one statement `external xxx = "foo"`

This will be used internally to track the precise set of symbols that must be included when linking together OCaml binaries 