### PR TITLE
Add back support for `zero_alloc opt` in signatures

### DIFF
--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -16,34 +16,24 @@ module type S_payloads_base = sig
   val[@zero_alloc] f : int -> int
 end
 
-module type S_payloads_strict = sig
-  val[@zero_alloc strict] f : int -> int
-end
-
-[%%expect{|
-module type S_payloads_base = sig val f : int -> int [@@zero_alloc] end
-module type S_payloads_strict =
-  sig val f : int -> int [@@zero_alloc strict] end
-|}]
-
 module type S_payloads_opt = sig
   val[@zero_alloc opt] f : int -> int
 end
-[%%expect{|
-Line 2, characters 2-37:
-2 |   val[@zero_alloc opt] f : int -> int
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: "zero_alloc opt" is not supported in signatures.
-|}]
+
+module type S_payloads_strict = sig
+  val[@zero_alloc strict] f : int -> int
+end
 
 module type S_payloads_strict_opt = sig
   val[@zero_alloc strict opt] f : int -> int
 end
 [%%expect{|
-Line 2, characters 2-44:
-2 |   val[@zero_alloc strict opt] f : int -> int
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: "zero_alloc opt" is not supported in signatures.
+module type S_payloads_base = sig val f : int -> int [@@zero_alloc] end
+module type S_payloads_opt = sig val f : int -> int [@@zero_alloc opt] end
+module type S_payloads_strict =
+  sig val f : int -> int [@@zero_alloc strict] end
+module type S_payloads_strict_opt =
+  sig val f : int -> int [@@zero_alloc strict opt] end
 |}]
 
 module type S_payloads_assume = sig
@@ -106,54 +96,53 @@ module M_assume_strict : S_good_inc_base
 module M_assume_strict_nrn : S_good_inc_base
 |}]
 
-(* CR ccasinghino: The below should work once we allow opt in signatures. *)
-(* module type S_good_inc_opt = sig
- *   val[@zero_alloc opt] f : 'a -> 'a
- * end
- *
- * module M_base : S_good_inc_opt = struct
- *   let[@zero_alloc] f x = x
- * end
- *
- * module M_opt : S_good_inc_opt = struct
- *   let[@zero_alloc opt] f x = x
- * end
- *
- * module M_assume : S_good_inc_opt = struct
- *   let[@zero_alloc assume] f x = x
- * end
- *
- * module M_assume_nrn : S_good_inc_opt = struct
- *   let[@zero_alloc assume never_returns_normally] f x = x
- * end
- *
- * module M_strict : S_good_inc_opt = struct
- *   let[@zero_alloc strict] f x = x
- * end
- *
- * module M_strict_opt : S_good_inc_opt = struct
- *   let[@zero_alloc strict opt] f x = x
- * end
- *
- * module M_assume_strict : S_good_inc_opt = struct
- *   let[@zero_alloc assume strict] f x = x
- * end
- *
- * module M_assume_strict_nrn : S_good_inc_opt = struct
- *   let[@zero_alloc assume strict never_returns_normally] f x = x
- * end
- *
- * [%%expect{|
- * module type S_good_inc_opt = sig val f : 'a -> 'a [@@zero_alloc opt] end
- * module M_base : S_good_inc_opt
- * module M_opt : S_good_inc_opt
- * module M_assume : S_good_inc_opt
- * module M_assume_nrn : S_good_inc_opt
- * module M_strict : S_good_inc_opt
- * module M_strict_opt : S_good_inc_opt
- * module M_assume_strict : S_good_inc_opt
- * module M_assume_strict_nrn : S_good_inc_opt
- * |}] *)
+module type S_good_inc_opt = sig
+  val[@zero_alloc opt] f : 'a -> 'a
+end
+
+module M_base : S_good_inc_opt = struct
+  let[@zero_alloc] f x = x
+end
+
+module M_opt : S_good_inc_opt = struct
+  let[@zero_alloc opt] f x = x
+end
+
+module M_assume : S_good_inc_opt = struct
+  let[@zero_alloc assume] f x = x
+end
+
+module M_assume_nrn : S_good_inc_opt = struct
+  let[@zero_alloc assume never_returns_normally] f x = x
+end
+
+module M_strict : S_good_inc_opt = struct
+  let[@zero_alloc strict] f x = x
+end
+
+module M_strict_opt : S_good_inc_opt = struct
+  let[@zero_alloc strict opt] f x = x
+end
+
+module M_assume_strict : S_good_inc_opt = struct
+  let[@zero_alloc assume strict] f x = x
+end
+
+module M_assume_strict_nrn : S_good_inc_opt = struct
+  let[@zero_alloc assume strict never_returns_normally] f x = x
+end
+
+[%%expect{|
+module type S_good_inc_opt = sig val f : 'a -> 'a [@@zero_alloc opt] end
+module M_base : S_good_inc_opt
+module M_opt : S_good_inc_opt
+module M_assume : S_good_inc_opt
+module M_assume_nrn : S_good_inc_opt
+module M_strict : S_good_inc_opt
+module M_strict_opt : S_good_inc_opt
+module M_assume_strict : S_good_inc_opt
+module M_assume_strict_nrn : S_good_inc_opt
+|}]
 
 module type S_good_inc_strict = sig
   val[@zero_alloc strict] f : 'a -> 'a
@@ -179,35 +168,34 @@ module M_assume_strict : S_good_inc_strict
 module M_assume_strict_nrn : S_good_inc_strict
 |}]
 
-(* CR ccasinghino: The below should work once we allow opt in signatures. *)
-(* module type S_good_inc_strict_opt = sig
- *   val[@zero_alloc strict opt] f : 'a -> 'a
- * end
- *
- * module M_strict : S_good_inc_strict_opt = struct
- *   let[@zero_alloc strict] f x = x
- * end
- *
- * module M_strict_opt : S_good_inc_strict_opt = struct
- *   let[@zero_alloc strict opt] f x = x
- * end
- *
- * module M_assume_strict : S_good_inc_strict_opt = struct
- *   let[@zero_alloc assume strict] f x = x
- * end
- *
- * module M_assume_strict_nrn : S_good_inc_strict_opt = struct
- *   let[@zero_alloc assume strict never_returns_normally] f x = x
- * end
- *
- * [%%expect{|
- * module type S_good_inc_strict_opt =
- *   sig val f : 'a -> 'a [@@zero_alloc strict opt] end
- * module M_strict : S_good_inc_strict_opt
- * module M_strict_opt : S_good_inc_strict_opt
- * module M_assume_strict : S_good_inc_strict_opt
- * module M_assume_strict_nrn : S_good_inc_strict_opt
- * |}] *)
+module type S_good_inc_strict_opt = sig
+  val[@zero_alloc strict opt] f : 'a -> 'a
+end
+
+module M_strict : S_good_inc_strict_opt = struct
+  let[@zero_alloc strict] f x = x
+end
+
+module M_strict_opt : S_good_inc_strict_opt = struct
+  let[@zero_alloc strict opt] f x = x
+end
+
+module M_assume_strict : S_good_inc_strict_opt = struct
+  let[@zero_alloc assume strict] f x = x
+end
+
+module M_assume_strict_nrn : S_good_inc_strict_opt = struct
+  let[@zero_alloc assume strict never_returns_normally] f x = x
+end
+
+[%%expect{|
+module type S_good_inc_strict_opt =
+  sig val f : 'a -> 'a [@@zero_alloc strict opt] end
+module M_strict : S_good_inc_strict_opt
+module M_strict_opt : S_good_inc_strict_opt
+module M_assume_strict : S_good_inc_strict_opt
+module M_assume_strict_nrn : S_good_inc_strict_opt
+|}]
 
 
 (*********************************)
@@ -237,7 +225,7 @@ Error: Signature mismatch:
        is not included in
          val f : 'a -> 'a [@@zero_alloc]
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
+       Hint: Add a "zero_alloc" attribute to the implementation.
 |}]
 
 module M_opt : S_bad_inc_base = struct
@@ -251,44 +239,42 @@ Lines 1-3, characters 32-3:
 3 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : 'a -> 'a end
+         sig val f : 'a -> 'a [@@zero_alloc opt] end
        is not included in
          S_bad_inc_base
        Values do not match:
-         val f : 'a -> 'a
+         val f : 'a -> 'a [@@zero_alloc opt]
        is not included in
          val f : 'a -> 'a [@@zero_alloc]
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
 |}]
 
-(* CR ccasinghino: The below should work once we allow opt in signatures. *)
-(* module type S_bad_inc_opt = sig
- *   val[@zero_alloc opt] f : 'a -> 'a
- * end
- *
- * module M_absent : S_bad_inc_opt = struct
- *   let f x = x
- * end
- *
- * [%%expect{|
- * module type S_bad_inc_opt = sig val f : 'a -> 'a [@@zero_alloc opt] end
- * Lines 5-7, characters 34-3:
- * 5 | ..................................struct
- * 6 |   let f x = x
- * 7 | end
- * Error: Signature mismatch:
- *        Modules do not match:
- *          sig val f : 'a -> 'a end
- *        is not included in
- *          S_bad_inc_opt
- *        Values do not match:
- *          val f : 'a -> 'a
- *        is not included in
- *          val f : 'a -> 'a [@@zero_alloc opt]
- *        The former provides a weaker "zero_alloc" guarantee than the latter.
- *        Hint: Add a "zero_alloc" attribute to the implementation.
- * |}] *)
+module type S_bad_inc_opt = sig
+  val[@zero_alloc opt] f : 'a -> 'a
+end
+
+module M_absent : S_bad_inc_opt = struct
+  let f x = x
+end
+
+[%%expect{|
+module type S_bad_inc_opt = sig val f : 'a -> 'a [@@zero_alloc opt] end
+Lines 5-7, characters 34-3:
+5 | ..................................struct
+6 |   let f x = x
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a end
+       is not included in
+         S_bad_inc_opt
+       Values do not match:
+         val f : 'a -> 'a
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc opt]
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}]
 
 module type S_bad_inc_strict = sig
   val[@zero_alloc strict] f : 'a -> 'a
@@ -314,7 +300,7 @@ Error: Signature mismatch:
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
+       Hint: Add a "zero_alloc" attribute to the implementation.
 |}]
 
 module M_base : S_bad_inc_strict = struct
@@ -369,15 +355,14 @@ Lines 1-3, characters 34-3:
 3 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : 'a -> 'a end
+         sig val f : 'a -> 'a [@@zero_alloc opt] end
        is not included in
          S_bad_inc_strict
        Values do not match:
-         val f : 'a -> 'a
+         val f : 'a -> 'a [@@zero_alloc opt]
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
 |}]
 
 module M_strict_opt : S_bad_inc_strict = struct
@@ -391,15 +376,14 @@ Lines 1-3, characters 41-3:
 3 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : 'a -> 'a end
+         sig val f : 'a -> 'a [@@zero_alloc strict opt] end
        is not included in
          S_bad_inc_strict
        Values do not match:
-         val f : 'a -> 'a
+         val f : 'a -> 'a [@@zero_alloc strict opt]
        is not included in
          val f : 'a -> 'a [@@zero_alloc strict]
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
 |}]
 
 module M_assume_nrn : S_bad_inc_strict = struct
@@ -423,96 +407,95 @@ Error: Signature mismatch:
        The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
-(* CR ccasinghino: The below should work once we allow opt in signatures. *)
-(* module type S_strict_opt = sig
- *   val[@zero_alloc strict opt] f : 'a -> 'a
- * end
- *
- * module M_absent : S_strict_opt = struct
- *   let f x = x
- * end
- *
- * [%%expect{|
- * module type S_strict_opt = sig val f : 'a -> 'a [@@zero_alloc strict opt] end
- * Lines 5-7, characters 33-3:
- * 5 | .................................struct
- * 6 |   let f x = x
- * 7 | end
- * Error: Signature mismatch:
- *        Modules do not match:
- *          sig val f : 'a -> 'a end
- *        is not included in
- *          S_strict_opt
- *        Values do not match:
- *          val f : 'a -> 'a
- *        is not included in
- *          val f : 'a -> 'a [@@zero_alloc strict opt]
- *        The former provides a weaker "zero_alloc" guarantee than the latter.
- *        Hint: Add a "zero_alloc" attribute to the implementation.
- * |}]
- *
- * module M_assume : S_strict_opt = struct
- *   let[@zero_alloc assume] f x = x
- * end
- *
- * [%%expect{|
- * Lines 1-3, characters 33-3:
- * 1 | .................................struct
- * 2 |   let[@zero_alloc assume] f x = x
- * 3 | end
- * Error: Signature mismatch:
- *        Modules do not match:
- *          sig val f : 'a -> 'a [@@zero_alloc] end
- *        is not included in
- *          S_strict_opt
- *        Values do not match:
- *          val f : 'a -> 'a [@@zero_alloc]
- *        is not included in
- *          val f : 'a -> 'a [@@zero_alloc strict opt]
- *        The former provides a weaker "zero_alloc" guarantee than the latter.
- * |}]
- *
- * module M_opt : S_strict_opt = struct
- *   let[@zero_alloc opt] f x = x
- * end
- *
- * [%%expect{|
- * Lines 1-3, characters 30-3:
- * 1 | ..............................struct
- * 2 |   let[@zero_alloc opt] f x = x
- * 3 | end
- * Error: Signature mismatch:
- *        Modules do not match:
- *          sig val f : 'a -> 'a [@@zero_alloc opt] end
- *        is not included in
- *          S_strict_opt
- *        Values do not match:
- *          val f : 'a -> 'a [@@zero_alloc opt]
- *        is not included in
- *          val f : 'a -> 'a [@@zero_alloc strict opt]
- *        The former provides a weaker "zero_alloc" guarantee than the latter.
- * |}]
- *
- * module M_assume_nrn : S_strict_opt = struct
- *   let[@zero_alloc assume never_returns_normally] f x = x
- * end
- *
- * [%%expect{|
- * Lines 1-3, characters 37-3:
- * 1 | .....................................struct
- * 2 |   let[@zero_alloc assume never_returns_normally] f x = x
- * 3 | end
- * Error: Signature mismatch:
- *        Modules do not match:
- *          sig val f : 'a -> 'a [@@zero_alloc] end
- *        is not included in
- *          S_strict_opt
- *        Values do not match:
- *          val f : 'a -> 'a [@@zero_alloc]
- *        is not included in
- *          val f : 'a -> 'a [@@zero_alloc strict opt]
- *        The former provides a weaker "zero_alloc" guarantee than the latter.
- * |}] *)
+module type S_strict_opt = sig
+  val[@zero_alloc strict opt] f : 'a -> 'a
+end
+
+module M_absent : S_strict_opt = struct
+  let f x = x
+end
+
+[%%expect{|
+module type S_strict_opt = sig val f : 'a -> 'a [@@zero_alloc strict opt] end
+Lines 5-7, characters 33-3:
+5 | .................................struct
+6 |   let f x = x
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a end
+       is not included in
+         S_strict_opt
+       Values do not match:
+         val f : 'a -> 'a
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict opt]
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}]
+
+module M_assume : S_strict_opt = struct
+  let[@zero_alloc assume] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 33-3:
+1 | .................................struct
+2 |   let[@zero_alloc assume] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc] end
+       is not included in
+         S_strict_opt
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict opt]
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+|}]
+
+module M_opt : S_strict_opt = struct
+  let[@zero_alloc opt] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 30-3:
+1 | ..............................struct
+2 |   let[@zero_alloc opt] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc opt] end
+       is not included in
+         S_strict_opt
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc opt]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict opt]
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+|}]
+
+module M_assume_nrn : S_strict_opt = struct
+  let[@zero_alloc assume never_returns_normally] f x = x
+end
+
+[%%expect{|
+Lines 1-3, characters 37-3:
+1 | .....................................struct
+2 |   let[@zero_alloc assume never_returns_normally] f x = x
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a [@@zero_alloc] end
+       is not included in
+         S_strict_opt
+       Values do not match:
+         val f : 'a -> 'a [@@zero_alloc]
+       is not included in
+         val f : 'a -> 'a [@@zero_alloc strict opt]
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+|}]
 
 (*************************************************************************)
 (* Test 4: Requires valid arity, inferred or provided, without expansion *)
@@ -822,8 +805,6 @@ Error: Signature mismatch:
 (*************************************)
 (* Test 8: Parsing "arity n" works *)
 
-(* CR ccasinghino: when we have support for opt, add tests for all the
-   combinations here. *)
 module type S_arity_42 = sig
   val[@zero_alloc arity 42] f : int -> int
 end
@@ -836,12 +817,30 @@ module type S_strict_arity_42 = sig
   val[@zero_alloc strict arity 42] f : int -> int
 end
 
+module type S_arity_42_opt_strict = sig
+  val[@zero_alloc arity 42 opt strict] f : int -> int
+end
+
+module type S_opt_arity_42_strict = sig
+  val[@zero_alloc opt arity 42 strict] f : int -> int
+end
+
+module type S_opt_strict_arity_42 = sig
+  val[@zero_alloc opt strict arity 42] f : int -> int
+end
+
 [%%expect{|
 module type S_arity_42 = sig val f : int -> int [@@zero_alloc arity 42] end
 module type S_arity_42_strict =
   sig val f : int -> int [@@zero_alloc strict arity 42] end
 module type S_strict_arity_42 =
   sig val f : int -> int [@@zero_alloc strict arity 42] end
+module type S_arity_42_opt_strict =
+  sig val f : int -> int [@@zero_alloc strict opt arity 42] end
+module type S_opt_arity_42_strict =
+  sig val f : int -> int [@@zero_alloc strict opt arity 42] end
+module type S_opt_strict_arity_42 =
+  sig val f : int -> int [@@zero_alloc strict opt arity 42] end
 |}]
 
 (**************************************************)
@@ -942,7 +941,7 @@ Error: Signature mismatch:
        is not included in
          val f : int -> int [@@zero_alloc]
        The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute (without opt) to the implementation.
+       Hint: Add a "zero_alloc" attribute to the implementation.
 |}]
 
 module M_strict_for_mto = struct

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -375,8 +375,7 @@ let report_value_mismatch first second env ppf err =
   | Zero_alloc { missing_entirely } ->
     pr "The former provides a weaker \"zero_alloc\" guarantee than the latter.";
     if missing_entirely then
-      pr "@ Hint: Add a \"zero_alloc\" attribute (without opt) to the \
-          implementation."
+      pr "@ Hint: Add a \"zero_alloc\" attribute to the implementation."
   | Zero_alloc_arity (n1, n2) ->
     pr "zero_alloc arity mismatch:@ \
         When using \"zero_alloc\" in a signature, the syntactic arity of@ \

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -120,7 +120,6 @@ type error =
   | Zero_alloc_attr_unsupported of Builtin_attributes.check_attribute
   | Zero_alloc_attr_non_function
   | Zero_alloc_attr_bad_user_arity
-  | Zero_alloc_attr_opt
 
 open Typedtree
 
@@ -2691,10 +2690,6 @@ let transl_value_decl env loc valdecl =
           raise (Error(valdecl.pval_loc, Zero_alloc_attr_non_function));
         if za.arity <= 0 then
           raise (Error(valdecl.pval_loc, Zero_alloc_attr_bad_user_arity));
-        if za.opt then
-          (* CR ccasinghino: It would be nice to support opt, but it's not
-             obvious what its meaning should be. *)
-          raise (Error(valdecl.pval_loc, Zero_alloc_attr_opt));
       | Assume _ | Ignore_assert_all _ ->
         raise (Error(valdecl.pval_loc, Zero_alloc_attr_unsupported zero_alloc))
       end;
@@ -3511,8 +3506,6 @@ let report_error ppf = function
   | Zero_alloc_attr_bad_user_arity ->
     fprintf ppf
       "@[Invalid zero_alloc attribute: arity must be greater than 0.@]"
-  | Zero_alloc_attr_opt ->
-    fprintf ppf "@[\"zero_alloc opt\" is not supported in signatures.@]"
 
 let () =
   Location.register_error_of_exn

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -164,7 +164,6 @@ type error =
   | Zero_alloc_attr_unsupported of Builtin_attributes.check_attribute
   | Zero_alloc_attr_non_function
   | Zero_alloc_attr_bad_user_arity
-  | Zero_alloc_attr_opt
 
 exception Error of Location.t * error
 

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -2814,13 +2814,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
                 let open Builtin_attributes in
                 match[@warning "+9"] zero_alloc with
                 | Default_check | Ignore_assert_all _ -> Default_check
-                | Check c when not c.opt -> zero_alloc
-                | Check _ ->
-                  (* CR ccasinghino: We'd like to allow opt in signatures, but
-                     for now we don't, and must make sure you can't get it in a
-                     signature by writing it in a structure and using module
-                     type of. *)
-                  Default_check
+                | Check _ -> zero_alloc
                 | Assume { property; strict; arity; loc;
                            never_returns_normally = _ } ->
                   Check { strict; property; arity; loc; opt = false }


### PR DESCRIPTION
This adds back the support for `[@zero_alloc opt]` in signatures, which we removed from #2470 because we were unsure about its semantics.  But now we have a plan.

For posterity, we were worried about a couple things:

Q: How can the next PR in this series, which uses information from signatures to influence zero_alloc checking in a client module, know whether it's OK to use a `zero_alloc opt` attribute from a signature?  We don't know whether the other module will be compiled with the `-zero-alloc-check all` flag, so we don't know if the implementation will have been checked.

A: In practice, this setting is enabled or disabled on a whole-build basis, and we're not worried about people trying to subvert that. Or, to put it another way, we're codifying that the meaning of `zero_alloc opt` is about a whole build done with one setting.

Q: How can we implement the next PR, if we don't have some corresponding notion of `[@zero_alloc assume opt]`?  If we implement `zero_alloc opt` in a signature with a regular `zero_alloc assume`, we're unsound - you can prove `zero_alloc` facts with this when you should only be able to prove `zero_alloc opt` facts.

A: We're going to add a `[@zero_alloc assume]` in the client when compiling with `-zero-alloc-check all`, and not otherwise  We were concerned about examples like this:
```ocaml
module type S = sig
  val[@zero_alloc opt] f : int -> int
end

module F(X:S) = struct
  let[@zero_alloc] g x = X.f x
end
```
It seems bad for the assertion on `g` to check successfully: we don't know it's `zero_alloc`, we only know it's `zero_alloc opt`.  With the plan above, this check will succeed when compiling with optimization and fail otherwise.  That's a little sad, but there's not really any way to miss the fact that the check fails on normal fast builds.  And, actually, we already have this exact problem without the signatures support.  If you set up two files like this:
```ocaml
(* A.ml *)
let[@zero_alloc] f x =
  match B.k x with
  | Some x -> x
  | None -> 42

(* B.ml *)
let k x = Some x
```
Then the check on `f` will pass only when compiling with optimization, due to cross module inlining.
