### PR TITLE
Add check that variables binding result of primitives are the correct kind

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1014,6 +1014,22 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
            generated. *)
         body acc body_env
       | _ -> (
+        (match defining_expr with
+        | Prim (prim, _) ->
+          let kind = Flambda_kind.With_subkind.kind kind in
+          let result_kind =
+            match Flambda_primitive.result_kind prim with
+            | Unit -> Flambda_kind.value
+            | Singleton result_kind -> result_kind
+          in
+          if not (Flambda_kind.equal kind result_kind)
+          then
+            Misc.fatal_errorf
+              "Incompatible kinds when binding %a: this variable has kind %a, \
+               but is bound to the result of %a which has kind %a@."
+              Variable.print var Flambda_kind.print kind Flambda_primitive.print
+              prim Flambda_kind.print result_kind
+        | Simple _ | Static_consts _ | Set_of_closures _ | Rec_info _ -> ());
         let bound_pattern =
           Bound_pattern.singleton (VB.create var Name_mode.normal)
         in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1791,7 +1791,7 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
             CC.close_switch acc ccenv ~condition_dbg scrutinee_tag block_switch
           in
           CC.close_let acc ccenv
-            [scrutinee_tag, Flambda_kind.With_subkind.naked_immediate]
+            [scrutinee_tag, Flambda_kind.With_subkind.tagged_immediate]
             Not_user_visible (Get_tag scrutinee) ~body
         in
         if switch.sw_numblocks = 0
@@ -1817,7 +1817,7 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
             in
             let region = Env.current_region env in
             CC.close_let acc ccenv
-              [is_scrutinee_int, Flambda_kind.With_subkind.naked_immediate]
+              [is_scrutinee_int, Flambda_kind.With_subkind.tagged_immediate]
               Not_user_visible
               (Prim
                  { prim = Pisint { variant_only = true };


### PR DESCRIPTION
This caught two places where we put invalid kinds, which were thankfully not dangerous.