### PR TITLE
Zero alloc: assume error means never raises

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -266,14 +266,16 @@ end = struct
     { strict : bool;  (** strict or relaxed? *)
       assume : bool;
       never_returns_normally : bool;
+      never_raises : bool;
       loc : Location.t
           (** Source location of the annotation, used for error messages. *)
     }
 
   let get_loc t = t.loc
 
-  let expected_value { strict; never_returns_normally; _ } =
-    Value.of_annotation ~strict ~never_returns_normally
+  let expected_value
+      { strict; never_returns_normally; assume = _; loc = _; never_raises } =
+    Value.of_annotation ~strict ~never_returns_normally ~never_raises
 
   let valid t v =
     (* Use Value.lessequal but ignore witnesses. *)
@@ -295,10 +297,23 @@ end = struct
         (fun (c : Cmm.codegen_option) ->
           match c with
           | Check { property; strict; loc } when property = spec ->
-            Some { strict; assume = false; never_returns_normally = false; loc }
-          | Assume { property; strict; never_returns_normally; loc }
+            Some
+              { strict;
+                assume = false;
+                never_returns_normally = false;
+                never_raises = false;
+                loc
+              }
+          | Assume
+              { property; strict; never_returns_normally; never_raises; loc }
             when property = spec ->
-            Some { strict; assume = true; never_returns_normally; loc }
+            Some
+              { strict;
+                assume = true;
+                never_returns_normally;
+                never_raises;
+                loc
+              }
           | Check _ | Assume _ | Reduce_code_size | No_CSE
           | Use_linscan_regalloc ->
             None)

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -319,6 +319,7 @@ type codegen_option =
   | No_CSE
   | Use_linscan_regalloc
   | Assume of { property: property; strict: bool; never_returns_normally: bool;
+                never_raises: bool;
                 loc: Location.t }
   | Check of { property: property; strict: bool; loc : Location.t; }
 

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -321,6 +321,7 @@ type codegen_option =
   | No_CSE
   | Use_linscan_regalloc
   | Assume of { property: property; strict: bool; never_returns_normally: bool;
+                never_raises: bool;
                 loc: Location.t }
   | Check of { property: property; strict: bool; loc: Location.t }
 

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -26,7 +26,7 @@ type t =
       { property : Property.t;
         strict : bool;
         never_returns_normally : bool;
-        never_raises:bool;
+        never_raises : bool;
         loc : Location.t
       }
   | Check of
@@ -38,7 +38,8 @@ type t =
 let print ppf t =
   match t with
   | Default_check -> ()
-  | Assume { property; strict; never_returns_normally; never_raises; loc = _ } ->
+  | Assume { property; strict; never_returns_normally; never_raises; loc = _ }
+    ->
     Format.fprintf ppf "@[assume_%a%s%s%s@]" Property.print property
       (if strict then "_strict" else "")
       (if never_returns_normally then "_never_returns_normally" else "")
@@ -56,7 +57,9 @@ let from_lambda : Lambda.check_attribute -> Location.t -> t =
     then Check { property = Zero_alloc; strict = false; loc }
     else Default_check
   | Ignore_assert_all Zero_alloc -> Default_check
-  | Assume { property; strict; never_returns_normally; never_raises; loc; arity = _ } ->
+  | Assume
+      { property; strict; never_returns_normally; never_raises; loc; arity = _ }
+    ->
     Assume
       { property = Property.from_lambda property;
         strict;
@@ -76,14 +79,21 @@ let equal x y =
       Check { property = p2; strict = s2; loc = loc2 } ) ->
     Property.equal p1 p2 && Bool.equal s1 s2 && Location.compare loc1 loc2 = 0
   | ( Assume
-        { property = p1; strict = s1; never_returns_normally = n1; never_raises = r1;
-          loc = loc1 },
+        { property = p1;
+          strict = s1;
+          never_returns_normally = n1;
+          never_raises = r1;
+          loc = loc1
+        },
       Assume
-        { property = p2; strict = s2; never_returns_normally = n2; never_raises = r2;
-          loc = loc2 }
-    ) ->
+        { property = p2;
+          strict = s2;
+          never_returns_normally = n2;
+          never_raises = r2;
+          loc = loc2
+        } ) ->
     Property.equal p1 p2 && Bool.equal s1 s2 && Bool.equal n1 n2
-                                                  && Bool.equal r1 r2
+    && Bool.equal r1 r2
     && Location.compare loc1 loc2 = 0
   | (Default_check | Check _ | Assume _), _ -> false
 

--- a/middle_end/flambda2/terms/check_attribute.ml
+++ b/middle_end/flambda2/terms/check_attribute.ml
@@ -26,6 +26,7 @@ type t =
       { property : Property.t;
         strict : bool;
         never_returns_normally : bool;
+        never_raises:bool;
         loc : Location.t
       }
   | Check of
@@ -37,10 +38,11 @@ type t =
 let print ppf t =
   match t with
   | Default_check -> ()
-  | Assume { property; strict; never_returns_normally; loc = _ } ->
-    Format.fprintf ppf "@[assume_%a%s%s@]" Property.print property
+  | Assume { property; strict; never_returns_normally; never_raises; loc = _ } ->
+    Format.fprintf ppf "@[assume_%a%s%s%s@]" Property.print property
       (if strict then "_strict" else "")
       (if never_returns_normally then "_never_returns_normally" else "")
+      (if never_raises then "_never_raises" else "")
   | Check { property; strict; loc = _ } ->
     Format.fprintf ppf "@[assert_%a%s@]" Property.print property
       (if strict then "_strict" else "")
@@ -54,11 +56,12 @@ let from_lambda : Lambda.check_attribute -> Location.t -> t =
     then Check { property = Zero_alloc; strict = false; loc }
     else Default_check
   | Ignore_assert_all Zero_alloc -> Default_check
-  | Assume { property; strict; never_returns_normally; loc; arity = _ } ->
+  | Assume { property; strict; never_returns_normally; never_raises; loc; arity = _ } ->
     Assume
       { property = Property.from_lambda property;
         strict;
         never_returns_normally;
+        never_raises;
         loc
       }
   | Check { property; strict; opt; loc; arity = _ } ->
@@ -73,11 +76,14 @@ let equal x y =
       Check { property = p2; strict = s2; loc = loc2 } ) ->
     Property.equal p1 p2 && Bool.equal s1 s2 && Location.compare loc1 loc2 = 0
   | ( Assume
-        { property = p1; strict = s1; never_returns_normally = n1; loc = loc1 },
+        { property = p1; strict = s1; never_returns_normally = n1; never_raises = r1;
+          loc = loc1 },
       Assume
-        { property = p2; strict = s2; never_returns_normally = n2; loc = loc2 }
+        { property = p2; strict = s2; never_returns_normally = n2; never_raises = r2;
+          loc = loc2 }
     ) ->
     Property.equal p1 p2 && Bool.equal s1 s2 && Bool.equal n1 n2
+                                                  && Bool.equal r1 r2
     && Location.compare loc1 loc2 = 0
   | (Default_check | Check _ | Assume _), _ -> false
 

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -20,7 +20,7 @@ type t =
       { property : Property.t;
         strict : bool;
         never_returns_normally : bool;
-        never_raises:bool;
+        never_raises : bool;
         loc : Location.t
       }
   | Check of

--- a/middle_end/flambda2/terms/check_attribute.mli
+++ b/middle_end/flambda2/terms/check_attribute.mli
@@ -20,6 +20,7 @@ type t =
       { property : Property.t;
         strict : bool;
         never_returns_normally : bool;
+        never_raises:bool;
         loc : Location.t
       }
   | Check of

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -327,11 +327,12 @@ let transl_property : Check_attribute.Property.t -> Cmm.property = function
 let transl_check_attrib : Check_attribute.t -> Cmm.codegen_option list =
   function
   | Default_check -> []
-  | Assume { property; strict; never_returns_normally; loc } ->
+  | Assume { property; strict; never_returns_normally; never_raises; loc } ->
     [ Assume
         { property = transl_property property;
           strict;
           never_returns_normally;
+          never_raises;
           loc
         } ]
   | Check { property; strict; loc } ->

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -640,6 +640,7 @@ type check_attribute = Builtin_attributes.check_attribute =
   | Assume of { property: property;
                 strict: bool;
                 never_returns_normally: bool;
+                never_raises: bool;
                 arity: int;
                 loc: Location.t;
               }

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -521,6 +521,7 @@ type check_attribute = Builtin_attributes.check_attribute =
   | Assume of { property: property;
                 strict: bool;
                 never_returns_normally: bool;
+                never_raises: bool;
                 arity: int;
                 loc: Location.t;
               }

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -854,7 +854,7 @@ let zero_alloc_lookup_table =
                 arity; loc; });
     (["assume"; "error"],
      fun arity loc ->
-       Assume { property; strict = false; never_returns_normally = true;
+       Assume { property; strict = true; never_returns_normally = true;
                 never_raises = true;
                 arity; loc; });
     (["ignore"], fun _ _ -> Ignore_assert_all property)

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -691,6 +691,7 @@ type check_attribute =
   | Assume of { property: property;
                 strict: bool;
                 never_returns_normally: bool;
+                never_raises: bool;
                 arity: int;
                 loc: Location.t;
               }
@@ -825,6 +826,7 @@ let zero_alloc_lookup_table =
     (["assume"],
      fun arity loc ->
        Assume { property; strict = false; never_returns_normally = false;
+                never_raises = false;
                 arity; loc; });
     (["strict"],
      fun arity loc ->
@@ -838,18 +840,22 @@ let zero_alloc_lookup_table =
     (["assume"; "strict"],
      fun arity loc ->
        Assume { property; strict = true; never_returns_normally = false;
+                never_raises = false;
                 arity; loc; });
     (["assume"; "never_returns_normally"],
      fun arity loc ->
        Assume { property; strict = false; never_returns_normally = true;
+                never_raises = false;
                 arity; loc; });
     (["assume"; "never_returns_normally"; "strict"],
      fun arity loc ->
        Assume { property; strict = true; never_returns_normally = true;
+                never_raises = false;
                 arity; loc; });
     (["assume"; "error"],
      fun arity loc ->
        Assume { property; strict = false; never_returns_normally = true;
+                never_raises = true;
                 arity; loc; });
     (["ignore"], fun _ _ -> Ignore_assert_all property)
   ]
@@ -926,8 +932,8 @@ let assume_zero_alloc ~is_check_allowed check : Zero_alloc_utils.Assume_info.t =
   match check with
   | Default_check -> Zero_alloc_utils.Assume_info.none
   | Ignore_assert_all Zero_alloc -> Zero_alloc_utils.Assume_info.none
-  | Assume { property=Zero_alloc; strict; never_returns_normally; } ->
-    Zero_alloc_utils.Assume_info.create ~strict ~never_returns_normally
+  | Assume { property=Zero_alloc; strict; never_returns_normally; never_raises; } ->
+    Zero_alloc_utils.Assume_info.create ~strict ~never_returns_normally ~never_raises
   | Check { property=Zero_alloc; loc; _ } ->
     if not is_check_allowed then begin
       let name = "zero_alloc" in

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -257,6 +257,7 @@ type check_attribute =
   | Assume of { property: property;
                 strict: bool;
                 never_returns_normally: bool;
+                never_raises: bool;
                 arity: int;
                 loc: Location.t;
               }

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -258,6 +258,10 @@ type check_attribute =
                 strict: bool;
                 never_returns_normally: bool;
                 never_raises: bool;
+                (* [never_raises=true] the function never returns
+                   via an exception. The function (directly or transitively)
+                   may raise exceptions that do not escape, i.e.,
+                   handled before the function returns. *)
                 arity: int;
                 loc: Location.t;
               }

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -117,8 +117,10 @@ let zero_alloc za1 za2 =
     | Default_check | Ignore_assert_all _ -> ZA.Assume_info.Value.top ()
     | Check { strict; _ } ->
       ZA.Assume_info.Value.of_annotation ~strict ~never_returns_normally:false
-    | Assume { strict; never_returns_normally } ->
+        ~never_raises:false
+    | Assume { strict; never_returns_normally; never_raises; } ->
       ZA.Assume_info.Value.of_annotation ~strict ~never_returns_normally
+        ~never_raises
   in
   let v1 = abstract_value za1 in
   let v2 = abstract_value za2 in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -5087,6 +5087,7 @@ let zero_alloc_of_application ~num_args attrs funct =
           property = Zero_alloc;
           strict = c.strict;
           never_returns_normally = false;
+          never_raises = false;
           arity = c.arity;
           loc = c.loc
         }

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -2816,7 +2816,8 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
                 | Default_check | Ignore_assert_all _ -> Default_check
                 | Check _ -> zero_alloc
                 | Assume { property; strict; arity; loc;
-                           never_returns_normally = _ } ->
+                           never_returns_normally = _;
+                           never_raises = _} ->
                   Check { strict; property; arity; loc; opt = false }
               in
               let (first_loc, _, _) = List.hd id_info in

--- a/ocaml/utils/zero_alloc_utils.ml
+++ b/ocaml/utils/zero_alloc_utils.ml
@@ -137,8 +137,9 @@ module Make (Witnesses : WS) = struct
 
     let relaxed w = { nor = V.Safe; exn = V.Top w; div = V.Top w }
 
-    let of_annotation ~strict ~never_returns_normally =
+    let of_annotation ~strict ~never_returns_normally ~never_raises =
       let res = if strict then safe else relaxed Witnesses.empty in
+      let res = if never_raises then { res with exn = V.Bot } else res in
       if never_returns_normally then { res with nor = V.Bot } else res
 
     let print ~witnesses ppf { nor; exn; div } =
@@ -211,8 +212,8 @@ module Assume_info = struct
 
   let none = No_assume
 
-  let create ~strict ~never_returns_normally =
-    Assume (Value.of_annotation ~strict ~never_returns_normally)
+  let create ~strict ~never_returns_normally ~never_raises =
+    Assume (Value.of_annotation ~strict ~never_returns_normally ~never_raises)
 
   let get_value t = match t with No_assume -> None | Assume v -> Some v
 

--- a/ocaml/utils/zero_alloc_utils.mli
+++ b/ocaml/utils/zero_alloc_utils.mli
@@ -83,7 +83,8 @@ module Make (Witnesses : WS) : sig
     val relaxed : Witnesses.t -> t
 
     (** Constructs a value from a user annotation. The witness will be empty. *)
-    val of_annotation : strict:bool -> never_returns_normally:bool -> t
+    val of_annotation :
+      strict:bool -> never_returns_normally:bool -> never_raises:bool -> t
 
     val print : witnesses:bool -> Format.formatter -> t -> unit
 
@@ -113,7 +114,8 @@ module Assume_info : sig
 
   val none : t
 
-  val create : strict:bool -> never_returns_normally:bool -> t
+  val create :
+    strict:bool -> never_returns_normally:bool -> never_raises:bool -> t
 
   val compare : t -> t -> int
 

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -959,3 +959,22 @@
  (enabled_if (= %{context_name} "main"))
  (deps test_assume_inlining.output test_assume_inlining.output.corrected)
  (action (diff test_assume_inlining.output test_assume_inlining.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_assume_error.output.corrected)
+ (deps (:ml test_assume_error.ml) filter.sh)
+ (action
+   (with-outputs-to test_assume_error.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_error.output test_assume_error.output.corrected)
+ (action (diff test_assume_error.output test_assume_error.output.corrected)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -179,4 +179,6 @@ let () =
     ~exit_code:2 "test_signatures_separate_b";
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_dep:None ~exit_code:2 "test_assume_inlining";
+  print_test_expected_output ~cutoff:default_cutoff
+    ~extra_dep:None ~exit_code:2 "test_assume_error";
   ()

--- a/tests/backend/checkmach/test_assume_error.ml
+++ b/tests/backend/checkmach/test_assume_error.ml
@@ -152,7 +152,7 @@ module A5 = struct
 end
 
 (* A6: shows that "assume error" is not enough to prove "strict",
-   because the call to [string_of_int] is not known to not diverge.
+   because the call to [string_of_int] may allocate and is not known to not diverge.
 *)
 module A6 = struct
   let[@inline never][@local never] h s = [Random.int s ; Random.int s]

--- a/tests/backend/checkmach/test_assume_error.ml
+++ b/tests/backend/checkmach/test_assume_error.ml
@@ -1,0 +1,225 @@
+(* A1: zero_alloc check fails on [foo] because there is an allocation on the
+   path to exceptional return from the call to [f x].
+   This exception is handled in foo and then [foo] returns normally,
+   making this allocation on a normal return of [foo].
+*)
+module A1 = struct
+  let[@inline never][@local never] h s = [Random.int s ; Random.int s]
+
+  let[@inline never][@local never][@zero_alloc] g x =
+    if x < 0 then Sys.opaque_identity (x+1) else raise (Failure ((string_of_int) x))
+
+  let[@inline never][@local never] handle_exn exn =
+    (match exn with
+     | Failure s -> print_string s; print_newline ()
+     | _ -> failwith "Boo");
+    0
+  ;;
+
+  let[@zero_alloc] f x =
+    match g x with
+    | exception exn ->
+      (handle_exn[@zero_alloc assume never_returns_normally]) exn
+      |> h |> List.hd  (* ignore this allocation *)
+    | answer -> (answer * 2)
+
+  let[@zero_alloc] foo x =
+    try f x with
+    | _ -> 0
+end
+
+(* A2 is a more elaborate version of A1 with more allocations in [foo]
+   that are all correctly reported. *)
+module A2 = struct
+  let[@inline never][@local never] h s = [Random.int s ; Random.int s]
+
+  let[@inline never][@local never][@zero_alloc] g x =
+    if x < 0 then Sys.opaque_identity (x+1) else raise (Failure ((string_of_int) x))
+
+  let[@inline never][@local never] handle_exn exn =
+    (match exn with
+     | Failure s -> print_string s; print_newline ()
+     | _ -> failwith "Boo");
+    0
+  ;;
+
+  let[@zero_alloc] f x =
+    match g x with
+    | exception exn ->
+      (handle_exn[@zero_alloc assume never_returns_normally]) exn
+      |> h |> List.hd  (* ignore this allocation *)
+    | answer -> (answer * 2)
+
+  let[@zero_alloc] foo x =
+    try let y = f x in (x,y) with
+    | _ ->
+      Printf.printf "BOO %x" x;  (* ignore this indirect call *)
+      (x,0)
+end
+
+(* A3: shows that "assume error" causes the check to ignore allocations
+   in [foo] that come after the exceptional return from [f x]
+   and correctly report allocations that happen after normal return
+   from [f x]. *)
+module A3 = struct
+  let[@inline never][@local never] h s = [Random.int s ; Random.int s]
+
+  let[@inline never][@local never][@zero_alloc] g x =
+    if x < 0 then Sys.opaque_identity (x+1) else raise (Failure ((string_of_int) x))
+
+  let[@inline never][@local never] handle_exn exn =
+    (match exn with
+     | Failure s -> print_string s; print_newline ()
+     | _ -> failwith "Boo");
+    0
+  ;;
+
+  let[@zero_alloc] f x =
+    match g x with
+    | exception exn ->
+      (handle_exn[@zero_alloc assume error]) exn
+      |> h |> List.hd  (* ignore this allocation *)
+    | answer -> (answer * 2)
+
+  let[@zero_alloc] foo x =
+    try
+      let y = f x in
+      (x,y)  (* report this allocation *)
+    with
+    | _ ->
+      Printf.printf "BOO %x" x;  (* ignore this indirect call *)
+      (x,0)
+end
+
+(* A4: is a succesful version of A3, without allocation after normal return
+   from [f x]. *)
+module A4 = struct
+  let[@inline never][@local never] h s = [Random.int s ; Random.int s]
+
+  let[@inline never][@local never][@zero_alloc] g x =
+    if x < 0 then Sys.opaque_identity (x+1) else raise (Failure ((string_of_int) x))
+
+  let[@inline never][@local never] handle_exn exn =
+    (match exn with
+     | Failure s -> print_string s; print_newline ()
+     | _ -> failwith "Boo");
+    0
+  ;;
+
+  let[@zero_alloc] f x =
+    match g x with
+    | exception exn ->
+      (handle_exn[@zero_alloc assume error]) exn
+      |> h |> List.hd  (* ignore this allocation *)
+    | answer -> (answer * 2)
+
+  let[@zero_alloc] foo x =
+    try f x
+    with
+    | _ ->
+      Printf.printf "BOO %x" x;  (* ignore this indirect call *)
+      0
+end
+
+(* A5: same as A4 but with "assume error" on the function definition instead
+   of the call site. *)
+module A5 = struct
+  let[@inline never][@local never] h s = [Random.int s ; Random.int s]
+
+  let[@inline never][@local never][@zero_alloc] g x =
+    if x < 0 then Sys.opaque_identity (x+1) else raise (Failure ((string_of_int) x))
+
+  let[@inline never][@local never][@zero_alloc assume error] handle_exn exn =
+    (match exn with
+     | Failure s -> print_string s; print_newline ()
+     | _ -> failwith "Boo");
+    0
+  ;;
+
+  let[@zero_alloc] f x =
+    match g x with
+    | exception exn ->
+      handle_exn exn
+      |> h |> List.hd  (* ignore this allocation *)
+    | answer -> (answer * 2)
+
+  let[@zero_alloc] foo x =
+    try f x
+    with
+    | _ ->
+      Printf.printf "BOO %x" x;  (* ignore this indirect call *)
+      0
+end
+
+(* A6: shows that "assume error" is not enough to prove "strict",
+   because the call to [string_of_int] is not known to not diverge.
+*)
+module A6 = struct
+  let[@inline never][@local never] h s = [Random.int s ; Random.int s]
+
+  let[@inline never][@local never][@zero_alloc] g x =
+    if x < 0 then Sys.opaque_identity (x+1) else raise (Failure ((string_of_int) x))
+
+  let[@inline never][@local never][@zero_alloc assume error] handle_exn exn =
+    (match exn with
+     | Failure s -> print_string s; print_newline ()
+     | _ -> failwith "Boo");
+    0
+  ;;
+
+  let[@zero_alloc strict] f x =
+    match g x with
+    | exception exn ->
+      handle_exn exn
+      |> h |> List.hd  (* ignore this allocation *)
+    | answer -> (answer * 2)
+
+end
+
+(* A7 is the same as A6 but without [string_of_int] and we can prove strict annotation on
+   [f]*)
+module A7 = struct
+  let[@inline never][@local never] h s = [Random.int s ; Random.int s]
+
+  let[@inline never][@local never][@zero_alloc] g x =
+    if x < 0 then Sys.opaque_identity (x+1) else raise (Failure "boo")
+
+  let[@inline never][@local never][@zero_alloc assume error] handle_exn exn =
+    (match exn with
+     | Failure s -> print_string s; print_newline ()
+     | _ -> failwith "Boo");
+    0
+  ;;
+
+  let[@zero_alloc strict] f x =
+    match g x with
+    | exception exn ->
+      handle_exn exn
+      |> h |> List.hd  (* ignore this allocation *)
+    | answer -> (answer * 2)
+
+end
+
+(* A8 is the same as A7 but with "assume never_returns_normally" only instead of
+   "assume error" and it is not enough to prove "strict" on [f]. *)
+module A8 = struct
+  let[@inline never][@local never] h s = [Random.int s ; Random.int s]
+
+  let[@inline never][@local never][@zero_alloc] g x =
+    if x < 0 then Sys.opaque_identity (x+1) else raise (Failure "boo")
+
+  let[@inline never][@local never][@zero_alloc assume never_returns_normally] handle_exn exn =
+    (match exn with
+     | Failure s -> print_string s; print_newline ()
+     | _ -> failwith "Boo");
+    0
+  ;;
+
+  let[@zero_alloc strict] f x =
+    match g x with
+    | exception exn ->
+      handle_exn exn
+      |> h |> List.hd  (* ignore this allocation *)
+    | answer -> (answer * 2)
+
+end

--- a/tests/backend/checkmach/test_assume_error.output
+++ b/tests/backend/checkmach/test_assume_error.output
@@ -1,0 +1,47 @@
+File "test_assume_error.ml", line 26, characters 7-17:
+Error: Annotation check for zero_alloc failed on function Test_assume_error.A1.foo (camlTest_assume_error.foo_HIDE_STAMP)
+
+File "test_assume_error.ml", line 27, characters 8-11:
+Error: called function may allocate (direct call camlTest_assume_error.g_HIDE_STAMP) (test_assume_error.ml:27,8--11;test_assume_error.ml:20,10--13)
+
+File "test_assume_error.ml", line 27, characters 8-11:
+Error: called function may allocate (direct call camlTest_assume_error.handle_exn_HIDE_STAMP) (test_assume_error.ml:27,8--11;test_assume_error.ml:22,6--65)
+
+File "test_assume_error.ml", line 53, characters 7-17:
+Error: Annotation check for zero_alloc failed on function Test_assume_error.A2.foo (camlTest_assume_error.foo_HIDE_STAMP)
+
+File "test_assume_error.ml", line 56, characters 6-30:
+Error: called function may allocate (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP) (test_assume_error.ml:56,6--30;printf.ml:37,17--35;printf.ml:33,21--43;printf.ml:26,2--63)
+
+File "test_assume_error.ml", line 54, characters 16-19:
+Error: called function may allocate (direct call camlTest_assume_error.g_HIDE_STAMP) (test_assume_error.ml:54,16--19;test_assume_error.ml:47,10--13)
+
+File "test_assume_error.ml", line 54, characters 16-19:
+Error: called function may allocate (direct call camlTest_assume_error.handle_exn_HIDE_STAMP) (test_assume_error.ml:54,16--19;test_assume_error.ml:49,6--65)
+
+File "test_assume_error.ml", line 54, characters 23-28:
+Error: allocation of 24 bytes
+
+File "test_assume_error.ml", line 56, characters 6-30:
+Error: called function may allocate (indirect call)
+
+File "test_assume_error.ml", line 57, characters 6-11:
+Error: allocation of 24 bytes
+
+File "test_assume_error.ml", line 84, characters 7-17:
+Error: Annotation check for zero_alloc failed on function Test_assume_error.A3.foo (camlTest_assume_error.foo_HIDE_STAMP)
+
+File "test_assume_error.ml", line 87, characters 6-11:
+Error: allocation of 24 bytes
+
+File "test_assume_error.ml", line 170, characters 7-17:
+Error: Annotation check for zero_alloc strict failed on function Test_assume_error.A6.f (camlTest_assume_error.f_HIDE_STAMP)
+
+File "test_assume_error.ml", line 171, characters 10-13:
+Error: called function may allocate on a path to diverge (direct call camlTest_assume_error.g_HIDE_STAMP)
+
+File "test_assume_error.ml", line 218, characters 7-17:
+Error: Annotation check for zero_alloc strict failed on function Test_assume_error.A8.f (camlTest_assume_error.f_HIDE_STAMP)
+
+File "test_assume_error.ml", line 221, characters 6-20:
+Error: called function may allocate on a path to exceptional return (direct call camlTest_assume_error.handle_exn_HIDE_STAMP)


### PR DESCRIPTION
On top of #2501. 
Change the meaning of `[@zero_alloc assume error]` to "never raises" in addition to "never returns normally".

Add `never_raise` field to `Builtin_primitives.Zero_alloc.Assume` and propagate it to the backend, similarly to the existing `never_returns_normally` field. 

Adds a test. 
