### PR TITLE
Fix a bug with warning 199 and `-stop-after typing`

### DIFF
--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -139,9 +139,9 @@ let implementation ~hook_parse_tree ~hook_typed_tree info ~backend =
       let typed = typecheck_impl info parsed in
       hook_typed_tree typed;
       if Clflags.(should_stop_after Compiler_pass.Typing) then () else begin
-        backend info typed
+        backend info typed;
+        Builtin_attributes.warn_unchecked_property ()
       end;
     end;
-    Builtin_attributes.warn_unchecked_property ();
     Warnings.check_fatal ();
   )

--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -140,8 +140,9 @@ let implementation ~hook_parse_tree ~hook_typed_tree info ~backend =
       hook_typed_tree typed;
       if Clflags.(should_stop_after Compiler_pass.Typing) then () else begin
         backend info typed;
-        Builtin_attributes.warn_unchecked_property ()
       end;
     end;
+    if not (Clflags.(should_stop_after Compiler_pass.Selection)) then
+      Builtin_attributes.warn_unchecked_property ();
     Warnings.check_fatal ();
   )

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -850,3 +850,10 @@
  (enabled_if (= %{context_name} "main"))
  (deps test_arity.output test_arity.output.corrected)
  (action (diff test_arity.output test_arity.output.corrected)))
+
+(rule
+ (alias runtest)
+ (deps stop_after_typing.ml)
+ (target stop_after_typing.cmi)
+ (enabled_if (= %{context_name} "main"))
+ (action (run %{bin:ocamlopt.opt} stop_after_typing.ml -g -c -stop-after typing -O3 -warn-error +a)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -21,6 +21,24 @@ let () =
 |};
     Buffer.output_buffer Out_channel.stdout buf
   in
+  let print_cmi_target name =
+    let subst = function
+      | "enabled_if" -> enabled_if
+      | "name" -> name
+      | _ -> "assert false"
+    in
+    Buffer.clear buf;
+    Buffer.add_substitute buf subst
+    {|
+(rule
+ (alias runtest)
+ (deps ${name}.ml)
+ (target ${name}.cmi)
+ ${enabled_if}
+ (action (run %{bin:ocamlopt.opt} ${name}.ml -g -c -stop-after typing -O3 -warn-error +a)))
+|};
+    Buffer.output_buffer Out_channel.stdout buf
+  in
   let print_test_expected_output ?(extra_flags="-zero-alloc-check default") ~cutoff ~extra_dep ~exit_code name =
     let ml_deps =
       let s =
@@ -140,4 +158,5 @@ let () =
     ~extra_dep:None ~exit_code:2 "test_all_opt3";
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_dep:None ~exit_code:2 "test_arity";
+  print_cmi_target "stop_after_typing";
   ()

--- a/tests/backend/checkmach/stop_after_typing.ml
+++ b/tests/backend/checkmach/stop_after_typing.ml
@@ -1,0 +1,4 @@
+(* This just checks we don't get a warning 199 (unchecked zero alloc attribute)
+   if we stop after typing. *)
+
+let[@zero_alloc] f x = x


### PR DESCRIPTION
This fixes a bug, introduced by #2400, where warning 199 (unchecked zero_alloc attributes) will be issued for `zero_alloc` annotated definitions when the `-stop-after typing` flag is passed.

The issue is simple: The attributes are added to the table but never removed in this case, so they are still there when we check it.  We just shouldn't check the table at all if this flag is passed.  What is a little surprising is that the bug doesn't happen for, e.g., `-stop-after lambda` and `-stop-after middle_end`.  The reason is just that those flags cause the compiler to exit via a different code path and the place where we look for unchecked zero_alloc attributes is never reached.

This adds a test, which requires a little infastructure in the zero_alloc tests to support `-stop-after typing`, but happily that will turn out to be useful in cleaning up the tests of #2506 