### PR TITLE
Stop checking layout enabledness in parser

### DIFF
--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -862,7 +862,7 @@ module Constant : sig
   type loc := Lexing.position * Lexing.position
 
   val value : Parsetree.constant -> t
-  val unboxed : loc:loc -> Jane_syntax.Layouts.constant -> t
+  val unboxed : Jane_syntax.Layouts.constant -> t
   val to_expression : loc:loc -> t -> expression
   val to_pattern : loc:loc -> t -> pattern
 end = struct
@@ -872,13 +872,7 @@ end = struct
 
   let value x = Value x
 
-  let assert_unboxed_literals ~loc =
-    Language_extension.(
-      Jane_syntax_parsing.assert_extension_enabled ~loc Layouts Stable)
-
-  let unboxed ~loc x =
-    assert_unboxed_literals ~loc:(make_loc loc);
-    Unboxed x
+  let unboxed x = Unboxed x
 
   let to_expression ~loc : t -> expression = function
     | Value const_value ->
@@ -905,7 +899,7 @@ let with_sign sign num =
 let unboxed_int sloc int_loc sign (n, m) =
   match m with
   | Some m ->
-      Constant.unboxed ~loc:int_loc (Integer (with_sign sign n, m))
+      Constant.unboxed (Integer (with_sign sign n, m))
   | None ->
       if Language_extension.is_enabled unboxed_literals_extension then
         raise
@@ -913,19 +907,12 @@ let unboxed_int sloc int_loc sign (n, m) =
       else
         not_expecting sloc "line number directive"
 
-let unboxed_float sloc sign (f, m) =
-  Constant.unboxed ~loc:sloc (Float (with_sign sign f, m))
-
-(* Unboxed float type *)
-
-let assert_unboxed_type ~loc =
-    Language_extension.(
-      Jane_syntax_parsing.assert_extension_enabled ~loc Layouts Stable)
+let unboxed_float sign (f, m) =
+  Constant.unboxed (Float (with_sign sign f, m))
 
 (* Invariant: [lident] must end with an [Lident] that ends with a ["#"]. *)
 let unboxed_type sloc lident tys =
   let loc = make_loc sloc in
-  assert_unboxed_type ~loc;
   Ptyp_constr (mkloc lident loc, tys)
 %}
 
@@ -4632,7 +4619,7 @@ value_constant:
 ;
 unboxed_constant:
   | HASH_INT          { unboxed_int $sloc $sloc Positive $1 }
-  | HASH_FLOAT        { unboxed_float $sloc Positive $1 }
+  | HASH_FLOAT        { unboxed_float Positive $1 }
 ;
 constant:
     value_constant    { Constant.value $1 }
@@ -4649,9 +4636,9 @@ signed_constant:
     signed_value_constant { Constant.value $1 }
   | unboxed_constant      { $1 }
   | MINUS HASH_INT        { unboxed_int $sloc $loc($2) Negative $2 }
-  | MINUS HASH_FLOAT      { unboxed_float $sloc Negative $2 }
+  | MINUS HASH_FLOAT      { unboxed_float Negative $2 }
   | PLUS HASH_INT         { unboxed_int $sloc $loc($2) Positive $2 }
-  | PLUS HASH_FLOAT       { unboxed_float $sloc Positive $2 }
+  | PLUS HASH_FLOAT       { unboxed_float Positive $2 }
 ;
 
 /* Identifiers and long identifiers */

--- a/ocaml/testsuite/tests/parsetree/test.ml
+++ b/ocaml/testsuite/tests/parsetree/test.ml
@@ -189,4 +189,20 @@ let () =
         ~prefixes:["extension."; "jane."; "test."])
       (fun () -> check_all_printed_attributes_and_extensions_start_with text
                     ~prefix:"test"));
+  (* Additionally check that merely parsing doesn't attempt
+     to check extensions enabledness. This is actually an important property.
+     That's because ppxes run the parser code in a separate process from the
+     compiler, and ppxes always enable extensions to the max. So checks
+     in the parser are ineffective in a common mode of running the
+     compiler.
+  *)
+  Language_extension.disable_all ();
+  match from_file Parse.implementation "source_jane_street.ml" with
+  | (_ : _ list) -> ()
+  | exception _ ->
+      print_endline
+        "Failed to parse with all extensions disabled after successfully\
+        \ parsing with all extensions enabled. Does the parser check for\
+        \ extension enabledness, which is almost certainly a bug? (See the\
+        \ comment by this test.)"
 ;;

--- a/ocaml/testsuite/tests/parsetree/test.reference
+++ b/ocaml/testsuite/tests/parsetree/test.reference
@@ -1,1 +1,0 @@
-Failed to parse with all extensions disabled after successfully parsing with all extensions enabled. Does the parser check for extension enabledness, which is almost certainly a bug? (See the comment by this test.)

--- a/ocaml/testsuite/tests/parsetree/test.reference
+++ b/ocaml/testsuite/tests/parsetree/test.reference
@@ -1,0 +1,1 @@
+Failed to parse with all extensions disabled after successfully parsing with all extensions enabled. Does the parser check for extension enabledness, which is almost certainly a bug? (See the comment by this test.)

--- a/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats_disabled.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-float64/unboxed_floats_disabled.compilers.reference
@@ -1,4 +1,4 @@
 File "unboxed_floats.ml", line 75, characters 11-16:
 75 |   let pi = #3.14 in
                 ^^^^^
-Error: This construct requires the stable version of the extension "layouts", which is disabled and cannot be used
+Error: The extension "layouts" is disabled and cannot be used


### PR DESCRIPTION
Fix a bug where extensions were checked in the parser. This is bad because extension-checking relies on mutable state, and there are some workflows where the parser runs in ppxes (which have all extensions enabled) and not the main compiler process (which usually has some extensions disabled).

The two lingering cases:
  * unboxed literals. The error message is now a little worse but this is basically fine as the extension is enabled by default.
  * `float#`. We no longer attempt to do any check that `float#` is permitted. We didn't even try for `int32#`, etc. I resolve the irregularity in favor of deleting the `float#` check, but it would be easy to add a check in `typetexp.ml` for all unboxed types if that seems better. (I don't have context on why the decision was made the way it was for `int32#`.)

Testing: I add a regression test that fails in the first commit.