### PR TITLE
Zero alloc assume on inlined trywith

### DIFF
--- a/backend/checkmach.ml
+++ b/backend/checkmach.ml
@@ -833,10 +833,11 @@ end = struct
   let transform_call t ~next ~exn callee w ~desc dbg =
     report t next ~msg:"transform_call next" ~desc dbg;
     report t exn ~msg:"transform_call exn" ~desc dbg;
+    let v = find_callee t callee ~desc dbg w in
     let effect =
       match Metadata.assume_value dbg ~can_raise:true w with
-      | Some v -> v
-      | None -> find_callee t callee ~desc dbg w
+      | Some v' -> Value.meet v v'
+      | None -> v
     in
     transform t ~next ~exn ~effect desc dbg
 

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1972,7 +1972,7 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
           |> List.split
         in
         let mode = transl_alloc_mode_r alloc_mode in
-        static_catch (transl_list ~scopes argl) val_ids
+        static_catch (transl_list ~scopes:(trywith_body_scopes scopes) argl) val_ids
           (Matching.for_multiple_match ~scopes ~return_layout e.exp_loc
              lvars mode val_cases partial)
     | arg, [] ->
@@ -1983,7 +1983,8 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
     | arg, _ :: _ ->
         let val_id = Typecore.name_pattern "val" (List.map fst val_cases) in
         let arg_layout = layout_exp arg_sort arg in
-        static_catch [transl_exp ~scopes arg_sort arg] [val_id, arg_layout]
+        static_catch [transl_exp ~scopes:(trywith_body_scopes scopes)
+                        arg_sort arg] [val_id, arg_layout]
           (Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
              e.exp_loc None (Lvar val_id) val_cases partial)
   in

--- a/ocaml/utils/zero_alloc_utils.ml
+++ b/ocaml/utils/zero_alloc_utils.ml
@@ -215,4 +215,8 @@ module Assume_info = struct
   let get_value t = match t with No_assume -> None | Assume v -> Some v
 
   let is_none t = match t with No_assume -> true | Assume _ -> false
+
+  let strict = Assume Value.safe
+
+  let meet_with_strict t = meet t strict
 end

--- a/ocaml/utils/zero_alloc_utils.mli
+++ b/ocaml/utils/zero_alloc_utils.mli
@@ -124,6 +124,8 @@ module Assume_info : sig
 
   val is_none : t -> bool
 
+  val meet_with_strict : t -> t
+
   module Witnesses : sig
     type t = unit
 

--- a/tests/backend/checkmach/dune.inc
+++ b/tests/backend/checkmach/dune.inc
@@ -831,3 +831,22 @@
  (enabled_if (= %{context_name} "main"))
  (deps test_all_opt3.output test_all_opt3.output.corrected)
  (action (diff test_all_opt3.output test_all_opt3.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_assume_inlining.output.corrected)
+ (deps (:ml test_assume_inlining.ml) filter.sh)
+ (action
+   (with-outputs-to test_assume_inlining.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -checkmach-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_inlining.output test_assume_inlining.output.corrected)
+ (action (diff test_assume_inlining.output test_assume_inlining.output.corrected)))

--- a/tests/backend/checkmach/gen/gen_dune.ml
+++ b/tests/backend/checkmach/gen/gen_dune.ml
@@ -138,4 +138,6 @@ let () =
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_flags:"-zero-alloc-check opt"
     ~extra_dep:None ~exit_code:2 "test_all_opt3";
+  print_test_expected_output ~cutoff:default_cutoff
+    ~extra_dep:None ~exit_code:2 "test_assume_inlining";
   ()

--- a/tests/backend/checkmach/test_assume_fail.ml
+++ b/tests/backend/checkmach/test_assume_fail.ml
@@ -58,7 +58,7 @@ let[@zero_alloc strict] test61 x = test60 x
 (* allocations on the path to a call labeled [@zero_alloc assume never_returns_normally]
    do not count for the normal check, but do count for the strict check *)
 
-let[@inline never] test62 x = [x;x]
+let[@inline never] test62 x = if List.length x > 0 then [x;x] else failwith (string_of_int (List.length x))
 
 let[@zero_alloc] test63 x =
   let p = [x;x+1] in

--- a/tests/backend/checkmach/test_assume_inlining.ml
+++ b/tests/backend/checkmach/test_assume_inlining.ml
@@ -1,0 +1,111 @@
+exception Exn of int
+
+(* don't inline bar : passes *)
+module A1 = struct
+  let[@inline never] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline never] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline never] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end
+
+(* inline bar : fails *)
+
+module A2 = struct
+  let[@inline never] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline always] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end
+
+
+(* inline bar and assume f is strict: passes *)
+
+module A3 = struct
+  let[@inline never][@zero_alloc assume strict] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline never] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end
+
+(* inline bar and assume f is strict and f is inlined: passes *)
+
+module A4 = struct
+  let[@inline always][@zero_alloc assume strict] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline never] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end
+
+
+(* inline bar and assume g never returns normally: passes *)
+
+module A5 = struct
+  let[@inline never] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline never][@zero_alloc assume never_returns_normally] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end
+
+
+(* inline bar and assume g never returns normally and inline g: passes *)
+
+module A6 = struct
+  let[@inline never] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline always][@zero_alloc assume never_returns_normally] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    bar x
+end

--- a/tests/backend/checkmach/test_assume_inlining.ml
+++ b/tests/backend/checkmach/test_assume_inlining.ml
@@ -109,3 +109,69 @@ module A6 = struct
   let[@zero_alloc] foo x =
     bar x
 end
+
+(* same as A2 but the assume is on the call and not the definition of bar:
+   fails. Needs change in the middle-end to propagate the assume to
+   try-with body as strict after inlining. *)
+module A7 = struct
+  let[@inline never] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline always] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@inline always] bar x =
+    try
+      f x
+    with
+    | Exn n -> g x n
+
+  let[@zero_alloc] foo x =
+    (bar[@zero_alloc assume]) x
+end
+
+(* Show that propagating assume to inlined trywith body is not sound
+   in some cases. When bar is not inlined - the check fails. *)
+module A8 = struct
+  let[@inline never][@zero_alloc] f x = if x = 0 then
+      raise (Exn x) else x * x
+
+  let[@inline never][@zero_alloc] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@inline never][@zero_alloc assume] bar x =
+    try
+      f x
+    with
+    | Exn n -> n
+
+  let[@zero_alloc] foo x =
+    try bar x with
+    | _ ->
+      (Sys.opaque_identity 0)
+end
+
+(* Same as A8 except bar is inlined and the check passes.
+   Inlining does not eliminate any annotations in this case,
+   the check passes because of the heuristic we use to
+   propagate "assume" when try-with body is inlined.
+*)
+module A9 = struct
+  let[@inline never][@zero_alloc] f x = if x = 0 then
+      raise (Exn x) else x * x
+
+  let[@inline never][@zero_alloc] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@inline always][@zero_alloc assume] bar x =
+    try
+      f x
+    with
+    | Exn n -> n
+
+  let[@zero_alloc] foo x =
+    try bar x with
+    | _ ->
+      (Sys.opaque_identity 0)
+end
+
+

--- a/tests/backend/checkmach/test_assume_inlining.ml
+++ b/tests/backend/checkmach/test_assume_inlining.ml
@@ -175,3 +175,20 @@ module A9 = struct
 end
 
 
+(* Same as A2 but using "match-exception" instead of "try-with". *)
+module A10 = struct
+  let[@inline never] f x = if x = 0 then raise (Exn x) else x * x
+
+  let[@inline always] g x n =
+    let y = x+n in if  y > 10 then raise (Exn y) else y
+
+  let[@zero_alloc assume][@inline always] bar x =
+    match
+      f x
+    with
+    | exception (Exn n) -> g x n
+    | r -> r
+
+  let[@zero_alloc] foo x =
+    bar x
+end

--- a/tests/backend/checkmach/test_assume_inlining.ml
+++ b/tests/backend/checkmach/test_assume_inlining.ml
@@ -17,7 +17,7 @@ module A1 = struct
     bar x
 end
 
-(* inline bar : fails *)
+(* inline bar : passes *)
 
 module A2 = struct
   let[@inline never] f x = if x = 0 then raise (Exn x) else x * x

--- a/tests/backend/checkmach/test_assume_inlining.output
+++ b/tests/backend/checkmach/test_assume_inlining.output
@@ -1,5 +1,1 @@
-File "test_assume_inlining.ml", line 34, characters 7-17:
-Error: Annotation check for zero_alloc failed on function Test_assume_inlining.A2.foo (camlTest_assume_inlining.foo_HIDE_STAMP)
 
-File "test_assume_inlining.ml", line 35, characters 4-9:
-Error: called function may allocate (direct call camlTest_assume_inlining.f_HIDE_STAMP) (test_assume_inlining.ml:35,4--9;test_assume_inlining.ml:30,6--9)

--- a/tests/backend/checkmach/test_assume_inlining.output
+++ b/tests/backend/checkmach/test_assume_inlining.output
@@ -1,1 +1,11 @@
+File "test_assume_inlining.ml", line 128, characters 7-17:
+Error: Annotation check for zero_alloc failed on function Test_assume_inlining.A7.foo (camlTest_assume_inlining.foo_HIDE_STAMP)
 
+File "test_assume_inlining.ml", line 129, characters 4-31:
+Error: called function may allocate (direct call camlTest_assume_inlining.f_HIDE_STAMP) (test_assume_inlining.ml:129,4--31;test_assume_inlining.ml:124,6--9)
+
+File "test_assume_inlining.ml", line 147, characters 7-17:
+Error: Annotation check for zero_alloc failed on function Test_assume_inlining.A8.foo (camlTest_assume_inlining.foo_HIDE_STAMP)
+
+File "test_assume_inlining.ml", line 148, characters 8-13:
+Error: called function may allocate (direct call camlTest_assume_inlining.bar_HIDE_STAMP)

--- a/tests/backend/checkmach/test_assume_inlining.output
+++ b/tests/backend/checkmach/test_assume_inlining.output
@@ -1,0 +1,5 @@
+File "test_assume_inlining.ml", line 34, characters 7-17:
+Error: Annotation check for zero_alloc failed on function Test_assume_inlining.A2.foo (camlTest_assume_inlining.foo_HIDE_STAMP)
+
+File "test_assume_inlining.ml", line 35, characters 4-9:
+Error: called function may allocate (direct call camlTest_assume_inlining.f_HIDE_STAMP) (test_assume_inlining.ml:35,4--9;test_assume_inlining.ml:30,6--9)


### PR DESCRIPTION
On top of #2458. 
Attempts to fix the second issue described in #2458: when a function annotated with `[@zero_alloc assume]` is inlined and the function's body contains `try E with ...` or `match E with | exception ... `, then `E` is annotated with a "strict" assume instead of a relaxed assume. This is a draft because 
1) It only works for "assume" on functions and not on calls.  We propagate "assume" on inlined calls in Flambda2, and I don't know how to implement this heuristics on top of the special handling of inlined debug info in Flambda2.
2) In some rare cases, there is a soundness problem: the check fails when the function is not inlined and passes when the function is inlined, even though there is no difference no difference in allocations. For example, the check on `foo` passes when `bar` is inlined but fails with `bar` is not inlined. 

```
let[@inline never][@zero_alloc] f x = if x = 0 then  raise (Exn x) else x * x
let[@inline never][@zero_alloc] g x n = let y = x+n in if  y > 10 then raise (Exn y) else y
let[@zero_alloc assume] bar x =
    try
      f x
    with
    | Exn n -> n

let[@zero_alloc] foo x =
    try bar x with
    | _ ->
      (Sys.opaque_identity 0)
``` 