### PR TITLE
Install flambda2_numbers stubs

### DIFF
--- a/dune
+++ b/dune
@@ -462,6 +462,12 @@
   (external/gc-timings/libgc_timings_stubs.a
    as
    compiler-libs/libgc_timings_stubs_native.a)
+  (middle_end/flambda2/numbers/libflambda2_numbers_stubs.a
+   as
+   compiler-libs/libflambda2_numbers_stubs.a)
+  (middle_end/flambda2/numbers/libflambda2_numbers_stubs.a
+   as
+   compiler-libs/libflambda2_numbers_stubs_native.a)
   ; for special_dune compat
   (ocamloptcomp_with_flambda2.cma as compiler-libs/ocamloptcomp.cma)
   (ocamloptcomp_with_flambda2.cmxa as compiler-libs/ocamloptcomp.cmxa)


### PR DESCRIPTION
`flambda2_numbers` now has C stubs, so the associated archive needs to be installed alongside other libraries that get linked into compiler code. Checked that the resulting installation can now properly link programs using the compiler libs.