### PR TITLE
Remove leftover non-applicable comments

### DIFF
--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -15,19 +15,9 @@
 
 (** Helpers for Intel code generators *)
 
-(* The DSL* modules expose functions to emit x86/x86_64 instructions
+(* The DSL* modules expose functions to emit x86_64 instructions
    using a syntax close to AT&T (in particular, arguments are reversed compared
    to the official Intel syntax).
-
-   Some notes:
-
-     - Unary floating point instructions such as fadd/fmul/fstp/fld/etc.
-       come with a single version supporting both the single and double
-       precision instructions.  (As with Intel syntax.)
-
-     - A legacy bug in GAS:
-   https://sourceware.org/binutils/docs-2.22/as/i386_002dBugs.html#i386_002dBugs
-       is not replicated here.  It is managed by X86_gas.
 *)
 
 

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -15,7 +15,7 @@
 
 (** Helpers for Intel code generators *)
 
-(* The DSL* modules expose functions to emit x86/x86_64 instructions
+(* The DSL* modules expose functions to emit x86_64 instructions
    using a syntax close to the official Intel syntax, except that
    source and destination operands are reversed as in the AT&T
    syntax:

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -387,30 +387,6 @@ let print_instr b = function
   | TZCNT (arg1, arg2) -> i2_s b "tzcnt" arg1 arg2
   | SSE42 CRC32 (arg1, arg2) -> i2_s b "crc32" arg1 arg2
 
-(* bug:
-   https://sourceware.org/binutils/docs-2.22/as/i386_002dBugs.html#i386_002dBugs
-
-   The AT&T syntax has a bug for fsub/fdiv/fsubr/fdivr instructions when
-   the source register is %st and the destination is %st(i).  In those
-   case, AT&T use fsub (resp. fsubr) in place of fsubr (resp. fsub),
-   and idem for fdiv/fdivr.
-
-   Concretely, AT&T syntax interpretation of:
-
-      fsub  %st, %st(3)
-
-   should normally be:
-
-      %st(3) := %st(3) - %st
-
-   but it should actually be interpreted as:
-
-      %st(3) := %st - %st(3)
-
-   which means the FSUBR instruction should be used.
-*)
-
-
 let print_line b = function
   | Ins instr -> print_instr b instr
 


### PR DESCRIPTION
#1555 removed support for 80387 floating-point instructions, since amd64 systems use SSE instructions instead. However, it kept the comments mentioning a historical bug in the AT&T assembler, for which a workaround had to be implemented, while removing the workaround code.

This PR mops up these comments.

Similarly to #1555, the original files in `ocaml/` are kept unchanged.