### PR TITLE
Disable upstream CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,20 +91,10 @@ jobs:
             build_ocamlparam: '_,w=-46,regalloc=gi,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=GI_PRIORITY_HEURISTICS:interval-length,regalloc-param=GI_SELECTION_HEURISTICS:first-available,regalloc-param=GI_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1,cfg-cse-optimize=1'
             check_arch: true
 
-          - name: build_upstream_closure
-            config: --enable-middle-end=upstream-closure
-            os: ubuntu-20.04
-
-          - name: build_upstream_closure_runtime5
-            config: --enable-middle-end=upstream-closure --enable-runtime5
-            os: ubuntu-20.04
-            expected_fail: true
-
     env:
       J: "3"
       # On macOS, the testsuite is slow, so run only on push to main (#507)
       run_testsuite: "${{matrix.os != 'macos-latest' || (github.event_name == 'push' && github.event.ref == 'refs/heads/main')}}"
-      build_upstream: "${{matrix.name == 'build_upstream_closure'}}"
       expected_fail: "${{matrix.expected_fail == true}}"
 
     steps:
@@ -212,13 +202,8 @@ jobs:
       run: |
         if [ $run_testsuite = true ]; then target=ci; else target=compiler; fi
         export PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH
-        if [ $build_upstream = true ]; then \
-          make -j$J build_and_test_upstream \
-            || (if [ $expected_fail = true ]; then exit 0; else exit 1; fi); \
-        else \
-          make $target \
-            || (if [ $expected_fail = true ]; then exit 0; else exit 1; fi); \
-        fi
+        make $target \
+          || (if [ $expected_fail = true ]; then exit 0; else exit 1; fi);
       env:
         BUILD_OCAMLPARAM: ${{ matrix.build_ocamlparam }}
         OCAMLPARAM: ${{ matrix.ocamlparam }}


### PR DESCRIPTION
The PR you've all been waiting for.

We believe we can disable the "upstream" builds now.  Apart from the fact they don't currently work for runtime5, they cost a lot of maintenance time, especially for changes such as those editing `Lambda`.  The reason for keeping them was so that an OPAM build could be done from the `ocaml/` subtree, but thanks to recent work by @chambart (followed up by @avsm), we can ditch them.  It will no longer be necessary to use anything other than the `dune` builds when developing.

The relevant links for the OPAM repo work that enable installation of a full flambda-backend are:
* https://github.com/ocaml-flambda/flambda-backend/blob/main/HACKING.md#testing-the-compiler-built-locally-with-opam-new-method
* https://github.com/ocaml/opam-repository/pull/25757

I currently plan to follow up with PRs to remove some parts of the `ocaml/` subtree that we won't use any more (in particular `asmcomp/` and hopefully all of `middle_end/`).