### PR TITLE
New mode crossing representation

### DIFF
--- a/ocaml/testsuite/tests/typing-local/crossing.ml
+++ b/ocaml/testsuite/tests/typing-local/crossing.ml
@@ -484,3 +484,15 @@ let foo (local_ x : int) =
 [%%expect{|
 val foo : local_ int -> (int -> int) ref = <fun>
 |}]
+
+(* During record update, the original record's type does NOT help with
+mode-crossing. *)
+let foo (local_ r : foo) =
+  let bar = {r with y = "hello"} in
+  ref bar
+[%%expect{|
+Line 3, characters 6-9:
+3 |   ref bar
+          ^^^
+Error: This value escapes its region.
+|}]

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -5666,8 +5666,8 @@ let mode_cross_left env ty mode =
      the types here aren't principal. In any case, leaving the check out
      now; will return and figure this out later. *)
   let jkind = type_jkind_purely env ty in
-  let upper_bounds = Jkind.get_modal_upper_bounds jkind in
-  Alloc.meet_const upper_bounds mode
+  let crossing = Jkind.get_mode_crossing jkind in
+  Crossing.apply_left_alloc crossing mode
 
 (* CR layouts v2.8: merge with Typecore.expect_mode_cross when [Value]
    and [Alloc] get unified *)
@@ -5675,8 +5675,8 @@ let mode_cross_right env ty mode =
   (* CR layouts v2.8: This should probably check for principality. See
      similar comment in [mode_cross_left]. *)
   let jkind = type_jkind_purely env ty in
-  let upper_bounds = Jkind.get_modal_upper_bounds jkind in
-  Alloc.imply upper_bounds mode
+  let crossing = Jkind.get_mode_crossing jkind in
+  Crossing.apply_right_alloc crossing mode
 
 let rec build_subtype env (visited : transient_expr list)
     (loops : (int * type_expr) list) posi level t =

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -215,6 +215,10 @@ val instance_prim:
         Primitive.description -> type_expr ->
         type_expr * Mode.Locality.lr option * Jkind.Sort.t option
 
+val mode_cross_left : Env.t -> type_expr -> ('l * 'r) Alloc.t -> ('l * disallowed) Alloc.t
+
+val mode_cross_right : Env.t -> type_expr -> ('l * 'r) Alloc.t -> (disallowed * 'r) Alloc.t
+
 (* The following two are about the scenario where we partially apply a function
 [A -> B -> C] to [A] and get back [B -> C]. The mode of the three are
 constrained. *)

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -215,6 +215,19 @@ val instance_prim:
         Primitive.description -> type_expr ->
         type_expr * Mode.Locality.lr option * Jkind.Sort.t option
 
+(* The following two are about the scenario where we partially apply a function
+[A -> B -> C] to [A] and get back [B -> C]. The mode of the three are
+constrained. *)
+
+(** Returns the lower bound needed for [B -> C] in relation to [A] *)
+val close_over :
+        (('l * allowed) Alloc.Monadic.t,
+        (allowed * 'r) Alloc.Comonadic.t) monadic_comonadic
+        -> Alloc.l
+
+(** Returns the lower bound needed for [B -> C] in relation to [A -> B -> C] *)
+val partial_apply : (allowed * 'r) Alloc.t -> Alloc.l
+
 (** Given (a @ m1 -> b -> c) @ m0, where [m0] and [m1] are modes expressed by
     user-syntax, [curry_mode m0 m1] gives the mode we implicitly interpret b->c
     to have. *)

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -432,8 +432,8 @@ val sort_of_jkind : t -> sort
     Never does mutation. *)
 val get_layout : t -> Layout.Const.t option
 
-(** Gets the maximum modes for types of this jkind. *)
-val get_modal_upper_bounds : t -> Mode.Alloc.Const.t
+(** Gets the mode crossing for types of this jkind. *)
+val get_mode_crossing : t -> Mode.Crossing.t
 
 (** Gets the maximum mode on the externality axis for types of this jkind. *)
 val get_externality_upper_bound : t -> Externality.t

--- a/ocaml/typing/jkind_types.ml
+++ b/ocaml/typing/jkind_types.ml
@@ -357,12 +357,10 @@ module Nullability = struct
     | Maybe_null
 end
 
-module Modes = Mode.Alloc.Const
-
 module Jkind_desc = struct
   type 'type_expr t =
     { layout : Layout.t;
-      modes_upper_bounds : Modes.t;
+      mode_crossing : Mode.Crossing.t;
       externality_upper_bound : Externality.t;
       nullability_upper_bound : Nullability.t
     }
@@ -393,7 +391,7 @@ type 'type_expr t =
 module Const = struct
   type 'type_expr t =
     { layout : Layout.Const.t;
-      modes_upper_bounds : Modes.t;
+      mode_crossing : Mode.Crossing.t;
       externality_upper_bound : Externality.t;
       nullability_upper_bound : Nullability.t
     }

--- a/ocaml/typing/jkind_types.mli
+++ b/ocaml/typing/jkind_types.mli
@@ -120,12 +120,10 @@ module Nullability : sig
     | Maybe_null
 end
 
-module Modes = Mode.Alloc.Const
-
 module Jkind_desc : sig
   type 'type_expr t =
     { layout : Layout.t;
-      modes_upper_bounds : Modes.t;
+      mode_crossing : Mode.Crossing.t;
       externality_upper_bound : Externality.t;
       nullability_upper_bound : Nullability.t
     }
@@ -150,7 +148,7 @@ type 'type_expr t =
 module Const : sig
   type 'type_expr t =
     { layout : Layout.Const.t;
-      modes_upper_bounds : Modes.t;
+      mode_crossing : Mode.Crossing.t;
       externality_upper_bound : Externality.t;
       nullability_upper_bound : Nullability.t
     }

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1138,8 +1138,8 @@ module Lattices_mono = struct
     match maybe_compose dst f g with Some m -> m | None -> Compose (f, g)
 
   let rec left_adjoint :
-      type a b l.
-      b obj -> (a, b, l * allowed) morph -> (b, a, allowed * disallowed) morph =
+      type a b l l'.
+      b obj -> (a, b, l * allowed) morph -> (b, a, l' * disallowed) morph =
    fun dst f ->
     match f with
     | Id -> Id
@@ -1168,8 +1168,8 @@ module Lattices_mono = struct
       Map_comonadic f'
 
   and right_adjoint :
-      type a b r.
-      b obj -> (a, b, allowed * r) morph -> (b, a, disallowed * allowed) morph =
+      type a b r r'.
+      b obj -> (a, b, allowed * r) morph -> (b, a, disallowed * r') morph =
    fun dst f ->
     match f with
     | Id -> Id

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -359,11 +359,9 @@ module type S = sig
       a0] for axes where [a] is [a0] and [b] isn't. *)
       val diff : t -> t -> Option.t
 
-      (** Similar to [Alloc.close_over] but for constants *)
-      val close_over : t -> t
-
-      (** Similar to [Alloc.partial_apply] but for constants *)
-      val partial_apply : t -> t
+      (** Dualize a monadic fragment to the comonadic fragment, and set the
+          areality axis to min. *)
+      val monadic_to_comonadic_min : Monadic.Const.t -> Comonadic.Const.t
 
       (** Prints a constant on any axis. *)
       val print_axis : ('m, 'a, 'd) axis -> Format.formatter -> 'a -> unit
@@ -404,17 +402,10 @@ module type S = sig
 
     val imply : Const.t -> ('l * 'r) t -> (disallowed * 'r) t
 
-    (* The following two are about the scenario where we partially apply a
-       function [A -> B -> C] to [A] and get back [B -> C]. The mode of the
-       three are constrained. *)
-
-    (** Returns the lower bound needed for [B -> C] in relation to [A] *)
-    val close_over :
-      (('l * allowed) Monadic.t, (allowed * 'r) Comonadic.t) monadic_comonadic ->
-      l
-
-    (** Returns the lower bound needed for [B -> C] in relation to [A -> B -> C] *)
-    val partial_apply : (allowed * 'r) t -> l
+    (** Dualize a monadic fragment to the comonadic fragment, and set the
+          areality axis to min. *)
+    val monadic_to_comonadic_min :
+      ('l * 'r) Monadic.t -> ('r * disallowed) Comonadic.t
   end
 
   (** The most general mode. Used in most type checking,

--- a/ocaml/typing/solver_intf.mli
+++ b/ocaml/typing/solver_intf.mli
@@ -183,11 +183,11 @@ module type Lattices_mono = sig
 
   (** Give left adjoint of a morphism  *)
   val left_adjoint :
-    'b obj -> ('a, 'b, 'l * allowed) morph -> ('b, 'a, left_only) morph
+    'b obj -> ('a, 'b, 'l * allowed) morph -> ('b, 'a, 'l_ * disallowed) morph
 
   (** Give the right adjoint of a morphism *)
   val right_adjoint :
-    'b obj -> ('a, 'b, allowed * 'r) morph -> ('b, 'a, right_only) morph
+    'b obj -> ('a, 'b, allowed * 'r) morph -> ('b, 'a, disallowed * 'r_) morph
 
   include Allow_disallow with type ('a, 'b, 'd) sided = ('a, 'b, 'd) morph
 

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -3516,8 +3516,8 @@ let check_curried_application_complete ~env ~app_loc args =
           in
           raise (Error(loc, env, Curried_application_complete (lbl, e, loc_kind)))
       in
-      submode (Alloc.partial_apply mode_fun) mode_ret;
-      submode (Alloc.close_over mode_arg) mode_ret;
+      submode (Ctype.partial_apply mode_fun) mode_ret;
+      submode (Ctype.close_over mode_arg) mode_ret;
       loop has_commuted rest
   in
   loop false args
@@ -3744,8 +3744,8 @@ let type_omitted_parameters expected_mode env ty_ret mode_ret args =
              in
              let closed_args = new_closed_args @ closed_args in
              let open_args = [] in
-             let mode_closed_args = List.map Alloc.close_over closed_args in
-             let mode_partial_fun = Alloc.partial_apply mode_fun in
+             let mode_closed_args = List.map close_over closed_args in
+             let mode_partial_fun = partial_apply mode_fun in
              let mode_closure, _ =
                Alloc.newvar_above (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
@@ -6715,14 +6715,14 @@ and type_function
                      mode-crossed differently. *)
                   let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_alloc_mode
+                    Alloc.submode (close_over arg_mode) fun_alloc_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
                   begin match
-                    Alloc.submode (Alloc.partial_apply alloc_mode) fun_alloc_mode
+                    Alloc.submode (partial_apply alloc_mode) fun_alloc_mode
                   with
                     | Ok () -> ()
                     | Error e ->


### PR DESCRIPTION
This is based on #2344, because we need to support calculating the mode crossing of "a @@ m" where `m` is modality.

This PR refactors the mode-crossing logic, without any observable changes. Future PRs based on this will enable more mode crossing.