### PR TITLE
Fix initialization of unboxed numbers in static blocks

### DIFF
--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -333,6 +333,13 @@ type fundecl =
     fun_dbg : Debuginfo.t;
   }
 
+(** When data items that are less than 64 bits wide occur in blocks, whose
+    fields are 64-bits wide, the following rules apply:
+
+    - For int32, the value is sign extended.
+    - For float32, the value is zero extended.  It is ok to rely on
+      zero-initialization of the data section to achieve this.
+*)
 type data_item =
     Cdefine_symbol of symbol
   | Cint8 of int

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3233,7 +3233,8 @@ let emit_boxed_nativeint_constant_fields n cont =
 
 let emit_float32_constant symb f cont =
   emit_block symb boxedfloat32_header
-    (Csymbol_address (global_symbol caml_float32_ops) :: Csingle f :: cont)
+    (Csymbol_address (global_symbol caml_float32_ops)
+    :: Csingle f :: Cint32 0n :: cont)
 
 let emit_float_constant symb f cont =
   emit_block symb float_header (Cdouble f :: cont)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3232,9 +3232,11 @@ let emit_boxed_nativeint_constant_fields n cont =
   Csymbol_address (global_symbol caml_nativeint_ops) :: Cint n :: cont
 
 let emit_float32_constant symb f cont =
+  (* Here we are relying on the fact that the data section is zero initialized
+     by just using [Csingle] and not worrying about the high 64 bits of the
+     relevant field. *)
   emit_block symb boxedfloat32_header
-    (Csymbol_address (global_symbol caml_float32_ops)
-    :: Csingle f :: Cint32 0n :: cont)
+    (Csymbol_address (global_symbol caml_float32_ops) :: Csingle f :: cont)
 
 let emit_float_constant symb f cont =
   emit_block symb float_header (Cdouble f :: cont)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3218,9 +3218,11 @@ let emit_string_constant_fields s cont =
   Cstring s :: Cskip n :: Cint8 n :: cont
 
 let emit_boxed_int32_constant_fields n cont =
-  let n = Nativeint.of_int32 n in
-  Csymbol_address (global_symbol caml_int32_ops)
-  :: Cint32 n :: Cint32 0n :: cont
+  let n =
+    (* This will sign extend. *)
+    Nativeint.of_int32 n
+  in
+  Csymbol_address (global_symbol caml_int32_ops) :: Cint n :: cont
 
 let emit_boxed_int64_constant_fields n cont =
   let lo = Int64.to_nativeint n in

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -859,6 +859,11 @@ let complex_im c dbg =
 
 let return_unit dbg c = Csequence (c, Cconst_int (1, dbg))
 
+let strided_field_address ptr ~index ~stride dbg =
+  if index * stride = 0
+  then ptr
+  else Cop (Cadda, [ptr; Cconst_int (index * stride, dbg)], dbg)
+
 let field_address ?(memory_chunk = Word_val) ptr n dbg =
   if n = 0
   then ptr

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -154,7 +154,7 @@ val mk_load_mut : memory_chunk -> operation
 
 (** [strided_field_address ptr ~index ~stride dbg] returns an expression for the
     address of the [index]th field of the block pointed to by [ptr]. The field
-    width is detrmined by [stride]. *)
+    width is determined by [stride]. *)
 val strided_field_address :
   expression -> index:int -> stride:int -> Debuginfo.t -> expression
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -152,6 +152,12 @@ val return_unit : Debuginfo.t -> expression -> expression
 (** Non-atomic load of a mutable field *)
 val mk_load_mut : memory_chunk -> operation
 
+(** [strided_field_address ptr ~index ~stride dbg] returns an expression for the
+    address of the [index]th field of the block pointed to by [ptr]. The field
+    width is detrmined by [stride]. *)
+val strided_field_address :
+  expression -> index:int -> stride:int -> Debuginfo.t -> expression
+
 (** [field_address ptr n dbg] returns an expression for the address of the [n]th
     field of the block pointed to by [ptr].  [memory_chunk] is only used for
     computation of the field width; it defaults to a memory chunk matching the

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -171,8 +171,10 @@ end = struct
               | Naked_number Naked_immediate -> Immediate
               | Naked_number Naked_float32 -> Naked_float32
               | Naked_number Naked_float -> Naked_float
-              | Naked_number Naked_int32 -> Naked_int32
-              | Naked_number Naked_int64 | Naked_number Naked_nativeint ->
+              (* Int32s are not tightly packed and are loaded via Word_int. *)
+              | Naked_number Naked_int32
+              | Naked_number Naked_int64
+              | Naked_number Naked_nativeint ->
                 Naked_int64
               | Naked_number Naked_vec128 -> Naked_vec128
               | Region | Rec_info ->

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -167,7 +167,12 @@ end = struct
               } ->
             let update_kind =
               match Flambda_kind.With_subkind.kind kind with
-              | Value -> C.Update_kind.values
+              | Value ->
+                if Flambda_kind.With_subkind.Subkind.equal
+                     (Flambda_kind.With_subkind.subkind kind)
+                     Tagged_immediate
+                then C.Update_kind.tagged_immediates
+                else C.Update_kind.pointers
               | Naked_number Naked_int32
               (* Int32s are not tightly packed, but we write all 64 bits for
                  backwards compatability. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -173,16 +173,17 @@ end = struct
                      Tagged_immediate
                 then C.Update_kind.tagged_immediates
                 else C.Update_kind.pointers
-              | Naked_number Naked_int32
-              (* Int32s are not tightly packed, but we write all 64 bits for
-                 backwards compatability. *)
               | Naked_number Naked_immediate
               | Naked_number Naked_int64
               | Naked_number Naked_nativeint ->
                 C.Update_kind.naked_int64s
               | Naked_number Naked_float -> C.Update_kind.naked_floats
-              | Naked_number Naked_float32 -> C.Update_kind.naked_float32_fields
               | Naked_number Naked_vec128 -> C.Update_kind.naked_vec128_fields
+              (* Int32s/Float32s are not tightly packed, so we only write the
+                 bottom 32 bits of the slot. The upper bits will be zero as the
+                 closure block is static. *)
+              | Naked_number Naked_int32 -> C.Update_kind.naked_int32_fields
+              | Naked_number Naked_float32 -> C.Update_kind.naked_float32_fields
               | Region | Rec_info ->
                 Misc.fatal_errorf "Unexpected value slot kind."
             in

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -168,13 +168,15 @@ end = struct
             let update_kind =
               match Flambda_kind.With_subkind.kind kind with
               | Value -> C.Update_kind.values
+              | Naked_number Naked_int32
+              (* Int32s are not tightly packed, but we write all 64 bits for
+                 backwards compatability. *)
               | Naked_number Naked_immediate
               | Naked_number Naked_int64
               | Naked_number Naked_nativeint ->
                 C.Update_kind.naked_int64s
               | Naked_number Naked_float -> C.Update_kind.naked_floats
               | Naked_number Naked_float32 -> C.Update_kind.naked_float32_fields
-              | Naked_number Naked_int32 -> C.Update_kind.naked_int32_fields
               | Naked_number Naked_vec128 -> C.Update_kind.naked_vec128_fields
               | Region | Rec_info ->
                 Misc.fatal_errorf "Unexpected value slot kind."

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -165,18 +165,17 @@ end = struct
                 closure_symbol_for_updates;
                 _
               } ->
-            let update_kind : C.Update_kind.t =
+            let update_kind =
               match Flambda_kind.With_subkind.kind kind with
-              | Value -> Value
-              | Naked_number Naked_immediate -> Immediate
-              | Naked_number Naked_float32 -> Naked_float32
-              | Naked_number Naked_float -> Naked_float
-              (* Int32s are not tightly packed and are loaded via Word_int. *)
-              | Naked_number Naked_int32
+              | Value -> C.Update_kind.values
+              | Naked_number Naked_immediate
               | Naked_number Naked_int64
               | Naked_number Naked_nativeint ->
-                Naked_int64
-              | Naked_number Naked_vec128 -> Naked_vec128
+                C.Update_kind.naked_int64s
+              | Naked_number Naked_float -> C.Update_kind.naked_floats
+              | Naked_number Naked_float32 -> C.Update_kind.naked_float32_fields
+              | Naked_number Naked_int32 -> C.Update_kind.naked_int32_fields
+              | Naked_number Naked_vec128 -> C.Update_kind.naked_vec128_fields
               | Region | Rec_info ->
                 Misc.fatal_errorf "Unexpected value slot kind."
             in

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -165,8 +165,21 @@ end = struct
                 closure_symbol_for_updates;
                 _
               } ->
+            let update_kind : C.Update_kind.t =
+              match Flambda_kind.With_subkind.kind kind with
+              | Value -> Value
+              | Naked_number Naked_immediate -> Immediate
+              | Naked_number Naked_float32 -> Naked_float32
+              | Naked_number Naked_float -> Naked_float
+              | Naked_number Naked_int32 -> Naked_int32
+              | Naked_number Naked_int64 | Naked_number Naked_nativeint ->
+                Naked_int64
+              | Naked_number Naked_vec128 -> Naked_vec128
+              | Region | Rec_info ->
+                Misc.fatal_errorf "Unexpected value slot kind."
+            in
             let env, res, updates =
-              C.make_update env res dbg Word_val
+              C.make_update env res dbg update_kind
                 ~symbol:(C.symbol ~dbg closure_symbol_for_updates)
                 v
                 ~index:(slot_offset - function_slot_offset_for_updates)

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -283,8 +283,6 @@ module Update_kind = struct
 
   let naked_vec128s = { kind = Naked_vec128; stride = 16 }
 
-  let naked_int32_fields = { kind = Naked_int32; stride = Arch.size_addr }
-
   let naked_float32_fields = { kind = Naked_float32; stride = Arch.size_addr }
 
   let naked_vec128_fields = { kind = Naked_vec128; stride = Arch.size_addr }

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -286,6 +286,8 @@ module Update_kind = struct
 
   let naked_vec128s = { kind = Naked_vec128; stride = 16 }
 
+  let naked_int32_fields = { kind = Naked_int32; stride = Arch.size_addr }
+
   let naked_float32_fields = { kind = Naked_float32; stride = Arch.size_addr }
 
   let naked_vec128_fields = { kind = Naked_vec128; stride = Arch.size_addr }

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -262,8 +262,8 @@ module Update_kind = struct
   type t =
     | Value
     | Immediate
-    | Naked_int64
     | Naked_int32
+    | Naked_int64
     | Naked_float
     | Naked_float32
     | Naked_vec128

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -86,9 +86,8 @@ let memory_chunk_of_kind (kind : Flambda_kind.With_subkind.t) : Cmm.memory_chunk
     | Immediate_array | Unboxed_int32_array | Unboxed_int64_array
     | Unboxed_nativeint_array | Value_array | Generic_array ->
       Word_val)
-  | Naked_number (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate)
-    ->
-    Word_int
+  | Naked_number (Naked_int64 | Naked_nativeint | Naked_immediate) -> Word_int
+  | Naked_number Naked_int32 -> Thirtytwo_signed
   | Naked_number Naked_float -> Double
   | Naked_number Naked_float32 -> Single { reg = Float32 }
   | Naked_number Naked_vec128 ->
@@ -259,14 +258,36 @@ let invalid res ~message =
   call_expr, res
 
 module Update_kind = struct
-  type t =
+  type kind =
     | Value
-    | Immediate
     | Naked_int32
     | Naked_int64
     | Naked_float
     | Naked_float32
     | Naked_vec128
+
+  type t =
+    { kind : kind;
+      stride : int
+    }
+
+  let values = { kind = Value; stride = Arch.size_addr }
+
+  let naked_int32s = { kind = Naked_int32; stride = 4 }
+
+  let naked_int64s = { kind = Naked_int64; stride = 8 }
+
+  let naked_floats = { kind = Naked_float; stride = Arch.size_float }
+
+  let naked_float32s = { kind = Naked_float32; stride = 4 }
+
+  let naked_vec128s = { kind = Naked_vec128; stride = 16 }
+
+  let naked_int32_fields = { kind = Naked_int32; stride = Arch.size_addr }
+
+  let naked_float32_fields = { kind = Naked_float32; stride = Arch.size_addr }
+
+  let naked_vec128_fields = { kind = Naked_vec128; stride = Arch.size_addr }
 end
 
 let make_update env res dbg (kind : Update_kind.t) ~symbol var ~index
@@ -276,9 +297,8 @@ let make_update env res dbg (kind : Update_kind.t) ~symbol var ~index
   in
   let cmm =
     let must_use_setfield =
-      match kind with
+      match kind.kind with
       | Value -> Some Lambda.Pointer
-      | Immediate -> Some Lambda.Immediate
       | Naked_int32 | Naked_int64 | Naked_float | Naked_float32 | Naked_vec128
         ->
         (* The GC never sees these fields, so we can avoid using
@@ -289,19 +309,25 @@ let make_update env res dbg (kind : Update_kind.t) ~symbol var ~index
     in
     match must_use_setfield with
     | Some imm_or_ptr ->
+      assert (kind.stride = Arch.size_addr);
       Cmm_helpers.setfield index imm_or_ptr Root_initialization symbol cmm dbg
     | None ->
       let memory_chunk : Cmm.memory_chunk =
-        match kind with
-        | Value | Immediate ->
-          Misc.fatal_errorf "update_kind requires using setfield."
+        match kind.kind with
+        | Value -> Misc.fatal_errorf "update_kind requires using setfield."
         | Naked_int32 -> Thirtytwo_signed
         | Naked_int64 -> Word_int
         | Naked_float -> Double
         | Naked_float32 -> Single { reg = Float32 }
         | Naked_vec128 -> Onetwentyeight_unaligned
       in
-      let addr = field_address ~memory_chunk symbol index dbg in
+      let addr =
+        if index * kind.stride = 0
+        then symbol
+        else
+          Cmm.(
+            Cop (Cadda, [symbol; Cconst_int (index * kind.stride, dbg)], dbg))
+      in
       store ~dbg memory_chunk Initialization ~addr ~new_value:cmm
   in
   let update =

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -323,8 +323,7 @@ let make_update env res dbg (kind : Update_kind.t) ~symbol var ~index
     | None ->
       let memory_chunk : Cmm.memory_chunk =
         match kind.kind with
-        | Pointer | Immediate ->
-          Misc.fatal_errorf "update_kind requires using setfield."
+        | Pointer | Immediate -> Word_val
         | Naked_int32 -> Thirtytwo_signed
         | Naked_int64 -> Word_int
         | Naked_float -> Double

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -322,7 +322,9 @@ let make_update env res dbg ({ kind; stride } : Update_kind.t) ~symbol var
       else
         match kind with
         | Pointer -> Some Pointer
-        | Immediate -> Some Immediate
+        | Immediate ->
+          (* See [caml_initialize]; we can avoid this function in this case. *)
+          None
         | Naked_int32 | Naked_int64 | Naked_float | Naked_float32 | Naked_vec128
           ->
           (* The GC never sees these fields, so we can avoid using
@@ -338,7 +340,8 @@ let make_update env res dbg ({ kind; stride } : Update_kind.t) ~symbol var
     | None ->
       let memory_chunk : Cmm.memory_chunk =
         match kind with
-        | Pointer | Immediate -> Word_val
+        | Pointer -> Word_val
+        | Immediate -> Word_int
         | Naked_int32 ->
           (* Cmm expressions representing int32 values are always sign extended.
              By using [Word_int] in the "fields" cases (see [Update_kind],

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -326,13 +326,7 @@ let make_update env res dbg (kind : Update_kind.t) ~symbol var ~index
         | Naked_float32 -> Single { reg = Float32 }
         | Naked_vec128 -> Onetwentyeight_unaligned
       in
-      let addr =
-        if index * kind.stride = 0
-        then symbol
-        else
-          Cmm.(
-            Cop (Cadda, [symbol; Cconst_int (index * kind.stride, dbg)], dbg))
-      in
+      let addr = strided_field_address symbol ~stride:kind.stride ~index dbg in
       store ~dbg memory_chunk Initialization ~addr ~new_value:cmm
   in
   let update =

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -183,6 +183,9 @@ let const_static cst =
            (tag_targetint (Targetint_31_63.to_targetint i))) ]
   | Naked_float f -> [cfloat (Numeric_types.Float_by_bit_pattern.to_float f)]
   | Naked_float32 f ->
+    (* Here we are relying on the data section being zero initialized to
+       maintain the invariant that statically-allocated float32 values are zero
+       padded. *)
     [cfloat32 (Numeric_types.Float32_by_bit_pattern.to_float f)]
   | Naked_int32 i -> [cint (Nativeint.of_int32 i)]
   (* We don't compile flambda-backend in 32-bit mode, so nativeint is 64
@@ -345,7 +348,6 @@ let make_update env res dbg ({ kind; stride } : Update_kind.t) ~symbol var
         | Naked_int64 -> Word_int
         | Naked_float -> Double
         | Naked_float32 ->
-          (* XXX need to check that other float32 places do zero initialize *)
           (* In the case where [kind.stride > 4] we are relying on the fact that
              the data section is zero initialized, in order that the high 32
              bits of the 64-bit field are deterministic, which is important for

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -93,10 +93,11 @@ module Update_kind : sig
 
   val tagged_immediates : t
 
-  (** Tightly packed; the byte offset is [index * 4]. *)
+  (** Tightly packed; the byte offset is [index * 4].  ([index] is as for
+      [make_update], below.) *)
   val naked_int32s : t
 
-  (** Assumes each field is a word; the byte offset is [index * addr_size]. *)
+  (** Assumes each field is a word; the byte offset is [index * size_addr]. *)
   val naked_int32_fields : t
 
   (** Tightly packed; the byte offset is [index * 8]. *)
@@ -108,13 +109,14 @@ module Update_kind : sig
   (** Tightly packed; the byte offset is [index * 4]. *)
   val naked_float32s : t
 
-  (** Assumes each field is a word; the byte offset is [index * addr_size]. *)
+  (** Assumes each field is a word; the byte offset is [index * size_addr]. *)
   val naked_float32_fields : t
 
-  (** Assumes each field is two words; the byte offset is [index * 16]. *)
+  (** Tightly packed (two words each); the byte offset is [index * 16]. *)
   val naked_vec128s : t
 
-  (** Assumes each field is a word; the byte offset is [index * addr_size]. *)
+  (** Assumes each field is a word; the byte offset is [index * size_addr].
+      Note that in this case the index is still based on word-width fields! *)
   val naked_vec128_fields : t
 end
 

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -93,8 +93,6 @@ module Update_kind : sig
 
   val naked_int32s : t
 
-  val naked_int32_fields : t
-
   val naked_int64s : t
 
   val naked_floats : t

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -95,6 +95,8 @@ module Update_kind : sig
 
   val naked_int32s : t
 
+  val naked_int32_fields : t
+
   val naked_int64s : t
 
   val naked_floats : t

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -87,14 +87,25 @@ val invalid :
   To_cmm_result.t -> message:string -> Cmm.expression * To_cmm_result.t
 
 module Update_kind : sig
-  type t =
-    | Value
-    | Immediate
-    | Naked_int32
-    | Naked_int64
-    | Naked_float
-    | Naked_float32
-    | Naked_vec128
+  type t
+
+  val values : t
+
+  val naked_int32s : t
+
+  val naked_int32_fields : t
+
+  val naked_int64s : t
+
+  val naked_floats : t
+
+  val naked_float32s : t
+
+  val naked_float32_fields : t
+
+  val naked_vec128s : t
+
+  val naked_vec128_fields : t
 end
 
 (** Make an update to a statically-allocated block. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -93,28 +93,28 @@ module Update_kind : sig
 
   val tagged_immediates : t
 
-  (* Tightly packed; the byte offset is [index * 4]. *)
+  (** Tightly packed; the byte offset is [index * 4]. *)
   val naked_int32s : t
 
-  (* Assumes each field is a word; the byte offset is [index * addr_size]. *)
+  (** Assumes each field is a word; the byte offset is [index * addr_size]. *)
   val naked_int32_fields : t
 
-  (* Tightly packed; the byte offset is [index * 8]. *)
+  (** Tightly packed; the byte offset is [index * 8]. *)
   val naked_int64s : t
 
-  (* Tightly packed; the byte offset is [index * size_float]. *)
+  (** Tightly packed; the byte offset is [index * size_float]. *)
   val naked_floats : t
 
-  (* Tightly packed; the byte offset is [index * 4]. *)
+  (** Tightly packed; the byte offset is [index * 4]. *)
   val naked_float32s : t
 
-  (* Assumes each field is a word; the byte offset is [index * addr_size]. *)
+  (** Assumes each field is a word; the byte offset is [index * addr_size]. *)
   val naked_float32_fields : t
 
-  (* Assumes each field is two words; the byte offset is [index * 16]. *)
+  (** Assumes each field is two words; the byte offset is [index * 16]. *)
   val naked_vec128s : t
 
-  (* Assumes each field is a word; the byte offset is [index * addr_size]. *)
+  (** Assumes each field is a word; the byte offset is [index * addr_size]. *)
   val naked_vec128_fields : t
 end
 

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -90,8 +90,8 @@ module Update_kind : sig
   type t =
     | Value
     | Immediate
-    | Naked_int64
     | Naked_int32
+    | Naked_int64
     | Naked_float
     | Naked_float32
     | Naked_vec128

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -89,7 +89,9 @@ val invalid :
 module Update_kind : sig
   type t
 
-  val values : t
+  val pointers : t
+
+  val tagged_immediates : t
 
   val naked_int32s : t
 

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -93,20 +93,28 @@ module Update_kind : sig
 
   val tagged_immediates : t
 
+  (* Tightly packed; the byte offset is [index * 4]. *)
   val naked_int32s : t
 
+  (* Assumes each field is a word; the byte offset is [index * addr_size]. *)
   val naked_int32_fields : t
 
+  (* Tightly packed; the byte offset is [index * 8]. *)
   val naked_int64s : t
 
+  (* Tightly packed; the byte offset is [index * size_float]. *)
   val naked_floats : t
 
+  (* Tightly packed; the byte offset is [index * 4]. *)
   val naked_float32s : t
 
+  (* Assumes each field is a word; the byte offset is [index * addr_size]. *)
   val naked_float32_fields : t
 
+  (* Assumes each field is two words; the byte offset is [index * 16]. *)
   val naked_vec128s : t
 
+  (* Assumes each field is a word; the byte offset is [index * addr_size]. *)
   val naked_vec128_fields : t
 end
 

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -86,20 +86,23 @@ val bound_parameters :
 val invalid :
   To_cmm_result.t -> message:string -> Cmm.expression * To_cmm_result.t
 
-type update_kind =
-  | Word_val
-  | Word_int
-  | Single of { reg : Cmm.float_width }
-  | Double
-  | Thirtytwo_signed
-  | Onetwentyeight_unaligned
+module Update_kind : sig
+  type t =
+    | Value
+    | Immediate
+    | Naked_int64
+    | Naked_int32
+    | Naked_float
+    | Naked_float32
+    | Naked_vec128
+end
 
 (** Make an update to a statically-allocated block. *)
 val make_update :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Debuginfo.t ->
-  update_kind ->
+  Update_kind.t ->
   symbol:Cmm.expression ->
   Variable.t ->
   index:int ->

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -21,6 +21,7 @@ end
 
 module SC = Static_const
 module R = To_cmm_result
+module UK = C.Update_kind
 
 let static_value res v =
   match (v : Field_of_static_block.t) with
@@ -46,8 +47,8 @@ let rec static_block_updates symb env res acc i = function
       (* CR mshinwell/mslater: It would be nice to know if [var] is an
          immediate. *)
       let env, res, acc =
-        C.make_update env res dbg C.Update_kind.pointers
-          ~symbol:(C.symbol ~dbg symb) var ~index:i ~prev_updates:acc
+        C.make_update env res dbg UK.pointers ~symbol:(C.symbol ~dbg symb) var
+          ~index:i ~prev_updates:acc
       in
       static_block_updates symb env res acc (i + 1) r)
 
@@ -67,8 +68,8 @@ let rec static_unboxed_int_array_updates symb env res acc maybe_int32 i =
     | Var (var, dbg) ->
       let kind =
         match maybe_int32 with
-        | Int64_or_nativeint -> C.Update_kind.naked_int64s
-        | Int32 -> C.Update_kind.naked_int32s
+        | Int64_or_nativeint -> UK.naked_int64s
+        | Int32 -> UK.naked_int32s
       in
       let env, res, acc =
         C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symb) var ~index:i
@@ -83,8 +84,8 @@ let rec static_float_array_updates symb env res acc i = function
     | Const _ -> static_float_array_updates symb env res acc (i + 1) r
     | Var (var, dbg) ->
       let env, res, acc =
-        C.make_update env res dbg C.Update_kind.naked_floats
-          ~symbol:(C.symbol ~dbg symb) var ~index:i ~prev_updates:acc
+        C.make_update env res dbg UK.naked_floats ~symbol:(C.symbol ~dbg symb)
+          var ~index:i ~prev_updates:acc
       in
       static_float_array_updates symb env res acc (i + 1) r)
 
@@ -208,8 +209,8 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let transl = Numeric_types.Float32_by_bit_pattern.to_float in
     let structured f = Cmmgen_state.Const_float32 f in
     let res, env, updates =
-      static_boxed_number ~kind:C.Update_kind.naked_float32_fields ~env ~symbol
-        ~default ~emit:C.emit_float32_constant ~transl ~structured v res updates
+      static_boxed_number ~kind:UK.naked_float32_fields ~env ~symbol ~default
+        ~emit:C.emit_float32_constant ~transl ~structured v res updates
     in
     env, res, updates
   | Block_like symbol, Boxed_float v ->
@@ -217,24 +218,22 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let transl = Numeric_types.Float_by_bit_pattern.to_float in
     let structured f = Cmmgen_state.Const_float f in
     let res, env, updates =
-      static_boxed_number ~kind:C.Update_kind.naked_floats ~env ~symbol ~default
+      static_boxed_number ~kind:UK.naked_floats ~env ~symbol ~default
         ~emit:C.emit_float_constant ~transl ~structured v res updates
     in
     env, res, updates
   | Block_like symbol, Boxed_int32 v ->
     let structured i = Cmmgen_state.Const_int32 i in
     let res, env, updates =
-      static_boxed_number ~kind:C.Update_kind.naked_int32_fields ~env ~symbol
-        ~default:0l ~emit:C.emit_int32_constant ~transl:Fun.id ~structured v res
-        updates
+      static_boxed_number ~kind:UK.naked_int32_fields ~env ~symbol ~default:0l
+        ~emit:C.emit_int32_constant ~transl:Fun.id ~structured v res updates
     in
     env, res, updates
   | Block_like symbol, Boxed_int64 v ->
     let structured i = Cmmgen_state.Const_int64 i in
     let res, env, updates =
-      static_boxed_number ~kind:C.Update_kind.naked_int64s ~env ~symbol
-        ~default:0L ~emit:C.emit_int64_constant ~transl:Fun.id ~structured v res
-        updates
+      static_boxed_number ~kind:UK.naked_int64s ~env ~symbol ~default:0L
+        ~emit:C.emit_int64_constant ~transl:Fun.id ~structured v res updates
     in
     env, res, updates
   | Block_like symbol, Boxed_nativeint v ->
@@ -242,7 +241,7 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let transl = C.nativeint_of_targetint in
     let structured i = Cmmgen_state.Const_nativeint i in
     let res, env, updates =
-      static_boxed_number ~kind:C.Update_kind.naked_int64s ~env ~symbol ~default
+      static_boxed_number ~kind:UK.naked_int64s ~env ~symbol ~default
         ~emit:C.emit_nativeint_constant ~transl ~structured v res updates
     in
     env, res, updates
@@ -260,8 +259,8 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let res, env, updates =
       (* Unaligned because boxed vec128 constants are not aligned during code
          emission. Aligning them would complicate block layout. *)
-      static_boxed_number ~kind:C.Update_kind.naked_vec128s ~env ~symbol
-        ~default ~emit:C.emit_vec128_constant ~transl ~structured v res updates
+      static_boxed_number ~kind:UK.naked_vec128s ~env ~symbol ~default
+        ~emit:C.emit_vec128_constant ~transl ~structured v res updates
     in
     env, res, updates
   | Block_like s, (Immutable_float_block fields | Immutable_float_array fields)

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -43,6 +43,8 @@ let rec static_block_updates symb env res acc i = function
     | Symbol _ | Tagged_immediate _ ->
       static_block_updates symb env res acc (i + 1) r
     | Dynamically_computed (var, dbg) ->
+      (* CR mshinwell/mslater: It would be nice to know if [var] is an
+         immediate. *)
       let env, res, acc =
         C.make_update env res dbg C.Update_kind.pointers
           ~symbol:(C.symbol ~dbg symb) var ~index:i ~prev_updates:acc
@@ -206,7 +208,7 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let transl = Numeric_types.Float32_by_bit_pattern.to_float in
     let structured f = Cmmgen_state.Const_float32 f in
     let res, env, updates =
-      static_boxed_number ~kind:C.Update_kind.naked_float32s ~env ~symbol
+      static_boxed_number ~kind:C.Update_kind.naked_float32_fields ~env ~symbol
         ~default ~emit:C.emit_float32_constant ~transl ~structured v res updates
     in
     env, res, updates
@@ -222,7 +224,7 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
   | Block_like symbol, Boxed_int32 v ->
     let structured i = Cmmgen_state.Const_int32 i in
     let res, env, updates =
-      static_boxed_number ~kind:C.Update_kind.naked_int32s ~env ~symbol
+      static_boxed_number ~kind:C.Update_kind.naked_int32_fields ~env ~symbol
         ~default:0l ~emit:C.emit_int32_constant ~transl:Fun.id ~structured v res
         updates
     in

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -44,7 +44,7 @@ let rec static_block_updates symb env res acc i = function
       static_block_updates symb env res acc (i + 1) r
     | Dynamically_computed (var, dbg) ->
       let env, res, acc =
-        C.make_update env res dbg C.Update_kind.values
+        C.make_update env res dbg C.Update_kind.pointers
           ~symbol:(C.symbol ~dbg symb) var ~index:i ~prev_updates:acc
       in
       static_block_updates symb env res acc (i + 1) r)

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -44,7 +44,7 @@ let rec static_block_updates symb env res acc i = function
       static_block_updates symb env res acc (i + 1) r
     | Dynamically_computed (var, dbg) ->
       let env, res, acc =
-        C.make_update env res dbg Word_val ~symbol:(C.symbol ~dbg symb) var
+        C.make_update env res dbg Value ~symbol:(C.symbol ~dbg symb) var
           ~index:i ~prev_updates:acc
       in
       static_block_updates symb env res acc (i + 1) r)
@@ -63,10 +63,10 @@ let rec static_unboxed_int_array_updates symb env res acc maybe_int32 i =
     | Const _ ->
       static_unboxed_int_array_updates symb env res acc maybe_int32 (i + 1) r
     | Var (var, dbg) ->
-      let kind : C.update_kind =
+      let kind : C.Update_kind.t =
         match maybe_int32 with
-        | Int64_or_nativeint -> Word_int
-        | Int32 -> Thirtytwo_signed
+        | Int64_or_nativeint -> Naked_int64
+        | Int32 -> Naked_int32
       in
       let env, res, acc =
         C.make_update env res dbg kind ~symbol:(C.symbol ~dbg symb) var ~index:i
@@ -81,8 +81,8 @@ let rec static_float_array_updates symb env res acc i = function
     | Const _ -> static_float_array_updates symb env res acc (i + 1) r
     | Var (var, dbg) ->
       let env, res, acc =
-        C.make_update env res dbg Double ~symbol:(C.symbol ~dbg symb) var
-          ~index:i ~prev_updates:acc
+        C.make_update env res dbg C.Update_kind.Naked_float
+          ~symbol:(C.symbol ~dbg symb) var ~index:i ~prev_updates:acc
       in
       static_float_array_updates symb env res acc (i + 1) r)
 
@@ -206,10 +206,8 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let transl = Numeric_types.Float32_by_bit_pattern.to_float in
     let structured f = Cmmgen_state.Const_float32 f in
     let res, env, updates =
-      static_boxed_number
-        ~kind:(Single { reg = Float32 })
-        ~env ~symbol ~default ~emit:C.emit_float32_constant ~transl ~structured
-        v res updates
+      static_boxed_number ~kind:C.Update_kind.Naked_float32 ~env ~symbol
+        ~default ~emit:C.emit_float32_constant ~transl ~structured v res updates
     in
     env, res, updates
   | Block_like symbol, Boxed_float v ->
@@ -217,22 +215,24 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let transl = Numeric_types.Float_by_bit_pattern.to_float in
     let structured f = Cmmgen_state.Const_float f in
     let res, env, updates =
-      static_boxed_number ~kind:Double ~env ~symbol ~default
+      static_boxed_number ~kind:C.Update_kind.Naked_float ~env ~symbol ~default
         ~emit:C.emit_float_constant ~transl ~structured v res updates
     in
     env, res, updates
   | Block_like symbol, Boxed_int32 v ->
     let structured i = Cmmgen_state.Const_int32 i in
     let res, env, updates =
-      static_boxed_number ~kind:Word_int ~env ~symbol ~default:0l
-        ~emit:C.emit_int32_constant ~transl:Fun.id ~structured v res updates
+      static_boxed_number ~kind:C.Update_kind.Naked_int32 ~env ~symbol
+        ~default:0l ~emit:C.emit_int32_constant ~transl:Fun.id ~structured v res
+        updates
     in
     env, res, updates
   | Block_like symbol, Boxed_int64 v ->
     let structured i = Cmmgen_state.Const_int64 i in
     let res, env, updates =
-      static_boxed_number ~kind:Word_int ~env ~symbol ~default:0L
-        ~emit:C.emit_int64_constant ~transl:Fun.id ~structured v res updates
+      static_boxed_number ~kind:C.Update_kind.Naked_int64 ~env ~symbol
+        ~default:0L ~emit:C.emit_int64_constant ~transl:Fun.id ~structured v res
+        updates
     in
     env, res, updates
   | Block_like symbol, Boxed_nativeint v ->
@@ -240,7 +240,7 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let transl = C.nativeint_of_targetint in
     let structured i = Cmmgen_state.Const_nativeint i in
     let res, env, updates =
-      static_boxed_number ~kind:Word_int ~env ~symbol ~default
+      static_boxed_number ~kind:C.Update_kind.Naked_int64 ~env ~symbol ~default
         ~emit:C.emit_nativeint_constant ~transl ~structured v res updates
     in
     env, res, updates
@@ -258,7 +258,7 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let res, env, updates =
       (* Unaligned because boxed vec128 constants are not aligned during code
          emission. Aligning them would complicate block layout. *)
-      static_boxed_number ~kind:Onetwentyeight_unaligned ~env ~symbol ~default
+      static_boxed_number ~kind:C.Update_kind.Naked_vec128 ~env ~symbol ~default
         ~emit:C.emit_vec128_constant ~transl ~structured v res updates
     in
     env, res, updates


### PR DESCRIPTION
Flambda2 was incorrectly initializing unboxed static closure slots and static constants.

- Closure slots were all assumed to be `Word_val`, which was interpreted as a pointer and hence passed to setfield. It would then call `caml_initialize` with a gc-unfriendly value, like an unboxed float. This also wouldn't fully copy a vec128.

- Static constant boxed int64s and int64 arrays were incorrectly calling setfield with the unboxed int64 value due to using `Word_int`.
 
- When `Config.runtime5` was set, `make_update` unconditionally used setfield.

- Naked vec128s would be written off the end of the closure block (this won't actually occur until unboxed vectors are exposed).

I found this in #2519, which re-enabled the assertion that we do not move between float & int registers. That was triggered when attempting to pass an unboxed float to `caml_initialize`.