### PR TITLE
Ban void in mixed products

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments.ml
@@ -498,3 +498,4 @@ Line 1, characters 31-41:
 Error: Type float# has layout float64.
        Inlined records may not yet contain types of this layout.
 |}]
+

--- a/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments_alpha.ml
@@ -454,3 +454,35 @@ Line 1, characters 31-41:
 Error: Type float# has layout float64.
        Inlined records may not yet contain types of this layout.
 |}]
+
+(* Void is not allowed in mixed constructors, for now *)
+
+type t_void : void
+
+type t_void_in_value_prefix = A of t_void * string * float#
+[%%expect {|
+type t_void : void
+Line 3, characters 30-59:
+3 | type t_void_in_value_prefix = A of t_void * string * float#
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type t_void has layout void.
+       Structures with non-value elements may not yet contain types of this layout.
+|}]
+
+type t_void_in_flat_suffix = A of int * float# * t_void
+[%%expect {|
+Line 1, characters 29-55:
+1 | type t_void_in_flat_suffix = A of int * float# * t_void
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type t_void has layout void.
+       Structures with non-value elements may not yet contain types of this layout.
+|}]
+
+type t_void_at_border_of_prefix_and_suffix = A of string * t_void * float#
+[%%expect {|
+Line 1, characters 45-74:
+1 | type t_void_at_border_of_prefix_and_suffix = A of string * t_void * float#
+                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type t_void has layout void.
+       Structures with non-value elements may not yet contain types of this layout.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/mixed_records.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_records.ml
@@ -268,3 +268,4 @@ Lines 2-37, characters 0-3:
 Error: The enabled layouts extension does not allow for mixed records.
        You must enable -extension layouts_alpha to use this feature.
 |}];;
+

--- a/ocaml/testsuite/tests/typing-layouts/mixed_records_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_records_alpha.ml
@@ -231,3 +231,45 @@ Lines 2-37, characters 0-3:
 37 |   }
 Error: Mixed records may contain at most 254 value fields prior to the flat suffix, but this one contains 255.
 |}];;
+
+(* Void is not allowed in mixed records, for now *)
+
+type t_void : void
+
+type t_void_in_value_prefix = { x : t_void; y : string; z : float# }
+[%%expect {|
+type t_void : void
+Line 3, characters 0-68:
+3 | type t_void_in_value_prefix = { x : t_void; y : string; z : float# }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type t_void has layout void.
+       Structures with non-value elements may not yet contain types of this layout.
+|}]
+
+type t_void_in_flat_suffix = { x : int; y : float#; z : t_void }
+[%%expect {|
+Line 1, characters 0-64:
+1 | type t_void_in_flat_suffix = { x : int; y : float#; z : t_void }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type t_void has layout void.
+       Structures with non-value elements may not yet contain types of this layout.
+|}]
+
+type t_void_at_border_of_prefix_and_suffix =
+  { x : string; y : t_void; z : float# }
+[%%expect {|
+Lines 1-2, characters 0-40:
+1 | type t_void_at_border_of_prefix_and_suffix =
+2 |   { x : string; y : t_void; z : float# }
+Error: Type t_void has layout void.
+       Structures with non-value elements may not yet contain types of this layout.
+|}]
+
+type t_void_in_all_float_mixed_record = { x : t_void; y : float#; z : float }
+[%%expect {|
+Line 1, characters 0-77:
+1 | type t_void_in_all_float_mixed_record = { x : t_void; y : float#; z : float }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type t_void has layout void.
+       Structures with non-value elements may not yet contain types of this layout.
+|}]

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -78,6 +78,7 @@ type jkind_sort_loc =
   | Cstr_tuple of { unboxed : bool }
   | Record of { unboxed : bool }
   | Inlined_record of { unboxed : bool }
+  | Mixed_product
   | External
   | External_with_layout_poly
 


### PR DESCRIPTION
I'm 90% sure that mixed products with void components would be miscompiled somewhere along the line. This PR records this observation as a typing error rather than letting this be a silent footgun when we eventually get around to supporting void properly.