### PR TITLE
Support for mixed blocks in Flambda2 types

### DIFF
--- a/middle_end/flambda2/classic_mode_types/value_approximation.ml
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.ml
@@ -28,7 +28,8 @@ type 'code t =
         code : 'code;
         symbol : Symbol.t option
       }
-  | Block_approximation of Tag.t * 'code t array * Alloc_mode.For_types.t
+  | Block_approximation of
+      Tag.Scannable.t * 'code t array * Alloc_mode.For_types.t
 
 let rec print fmt = function
   | Value_unknown -> Format.fprintf fmt "?"
@@ -41,7 +42,8 @@ let rec print fmt = function
     if len < 1
     then Format.fprintf fmt "{}"
     else (
-      Format.fprintf fmt "@[<hov 2>{%a:%a" Tag.print tag print fields.(0);
+      Format.fprintf fmt "@[<hov 2>{%a:%a" Tag.Scannable.print tag print
+        fields.(0);
       for i = 1 to len - 1 do
         Format.fprintf fmt "@ %a" print fields.(i)
       done;

--- a/middle_end/flambda2/classic_mode_types/value_approximation.mli
+++ b/middle_end/flambda2/classic_mode_types/value_approximation.mli
@@ -28,7 +28,8 @@ type 'code t =
         code : 'code;
         symbol : Symbol.t option
       }
-  | Block_approximation of Tag.t * 'code t array * Alloc_mode.For_types.t
+  | Block_approximation of
+      Tag.Scannable.t * 'code t array * Alloc_mode.For_types.t
 
 val print : Format.formatter -> 'a t -> unit
 

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1053,7 +1053,6 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
             ( Variadic
                 (Make_block (Values (tag, _), Immutable, alloc_mode), fields),
               _ ) -> (
-          let tag' = Tag.Scannable.to_tag tag in
           let approxs =
             List.map (find_value_approximation body_env) fields |> Array.of_list
           in
@@ -1071,7 +1070,7 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
             let acc =
               Acc.add_symbol_approximation acc sym
                 (Value_approximation.Block_approximation
-                   (tag', approxs, Alloc_mode.For_allocations.as_type alloc_mode))
+                   (tag, approxs, Alloc_mode.For_allocations.as_type alloc_mode))
             in
             body acc body_env
           | Computed_static static_fields ->
@@ -1095,7 +1094,7 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
             in
             let approx =
               Value_approximation.Block_approximation
-                (tag', approxs, Alloc_mode.For_allocations.as_type alloc_mode)
+                (tag, approxs, Alloc_mode.For_allocations.as_type alloc_mode)
             in
             let acc = Acc.add_symbol_approximation acc symbol approx in
             let acc, body = body acc body_env in
@@ -1105,7 +1104,7 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
               defining_expr ~body
           | Dynamic_block ->
             let body_env =
-              Env.add_block_approximation body_env var tag' approxs
+              Env.add_block_approximation body_env var tag approxs
                 (Alloc_mode.For_allocations.as_type alloc_mode)
             in
             bind acc body_env)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -494,7 +494,6 @@ module Acc = struct
             | Tagged_immediate i -> Value_int i
             | Dynamically_computed _ -> Value_unknown
           in
-          let tag = Tag.Scannable.to_tag tag in
           let fields = List.map approx_of_field fields |> Array.of_list in
           Block_approximation (tag, fields, Alloc_mode.For_types.unknown ())
         else Value_unknown

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -169,7 +169,7 @@ module Env : sig
   val add_block_approximation :
     t ->
     Variable.t ->
-    Tag.t ->
+    Tag.Scannable.t ->
     value_approximation array ->
     Alloc_mode.For_types.t ->
     t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -999,8 +999,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
     let mutability = Mutability.from_lambda mutability in
     let tag = Tag.Scannable.create_exn tag in
-    let shape = P.Mixed_block_kind.from_lambda shape in
-    [Variadic (Make_mixed_block (tag, shape, mutability, mode), args)]
+    let shape = K.Mixed_block_shape.from_lambda shape in
+    [Variadic (Make_block (Mixed (tag, shape), mutability, mode), args)]
   | Pmakearray (lambda_array_kind, mutability, mode), _ -> (
     let args = List.flatten args in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
@@ -1447,7 +1447,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       Naked_floats { size = Unknown }
     in
     [Binary (Block_load (block_access, mutability), arg, Simple field)]
-  | Pmixedfield (field, read, sem), [[arg]] -> (
+  | Pmixedfield (field, read, shape, sem), [[arg]] -> (
     let imm = Targetint_31_63.of_int field in
     check_non_negative_imm imm "Pmixedfield";
     let field = Simple.const (Reg_width_const.tagged_immediate imm) in
@@ -1461,10 +1461,11 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
           Flat_suffix
             (match read with
             | Flat_read flat_element ->
-              P.Mixed_block_flat_element.from_lambda flat_element
-            | Flat_read_float_boxed _ -> Float_boxed)
+              K.from_lambda_flat_element flat_element
+            | Flat_read_float_boxed _ -> K.naked_float)
       in
-      Mixed { tag = Unknown; field_kind; size = Unknown }
+      let shape = K.Mixed_block_shape.from_lambda shape in
+      Mixed { tag = Unknown; field_kind; shape; size = Unknown }
     in
     let block_access : H.expr_primitive =
       Binary (Block_load (block_access, mutability), arg, Simple field)
@@ -1510,7 +1511,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     [ Ternary
         (Block_set (block_access, init_or_assign), block, Simple field, value)
     ]
-  | ( Psetmixedfield (field, write, initialization_or_assignment),
+  | ( Psetmixedfield (field, write, shape, initialization_or_assignment),
       [[block]; [value]] ) ->
     let imm = Targetint_31_63.of_int field in
     check_non_negative_imm imm "Psetmixedfield";
@@ -1523,9 +1524,10 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
               Value_prefix
                 (convert_block_access_field_kind immediate_or_pointer)
             | Mwrite_flat_suffix flat ->
-              Flat_suffix (P.Mixed_block_flat_element.from_lambda flat));
-          size = Unknown;
-          tag = Unknown
+              Flat_suffix (K.from_lambda_flat_element flat));
+          shape = K.Mixed_block_shape.from_lambda shape;
+          tag = Unknown;
+          size = Unknown
         }
     in
     let init_or_assign = convert_init_or_assign initialization_or_assignment in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1460,8 +1460,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         | Mread_flat_suffix read ->
           Flat_suffix
             (match read with
-            | Flat_read flat_element ->
-              K.from_lambda_flat_element flat_element
+            | Flat_read flat_element -> K.from_lambda_flat_element flat_element
             | Flat_read_float_boxed _ -> K.naked_float)
       in
       let shape = K.Mixed_block_shape.from_lambda shape in

--- a/middle_end/flambda2/identifiers/reg_width_const.ml
+++ b/middle_end/flambda2/identifiers/reg_width_const.ml
@@ -40,3 +40,20 @@ let is_tagged_immediate t =
   | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
   | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ ->
     None
+
+let of_int_of_kind (kind : Flambda_kind.t) i =
+  match kind with
+  | Value -> tagged_immediate (Targetint_31_63.of_int i)
+  | Naked_number Naked_float ->
+    naked_float (Numeric_types.Float_by_bit_pattern.create (float_of_int i))
+  | Naked_number Naked_float32 ->
+    naked_float32 (Numeric_types.Float32_by_bit_pattern.create (float_of_int i))
+  | Naked_number Naked_immediate -> naked_immediate (Targetint_31_63.of_int i)
+  | Naked_number Naked_int32 -> naked_int32 (Int32.of_int i)
+  | Naked_number Naked_int64 -> naked_int64 (Int64.of_int i)
+  | Naked_number Naked_nativeint -> naked_nativeint (Targetint_32_64.of_int i)
+  | Naked_number Naked_vec128 ->
+    let i = Int64.of_int i in
+    naked_vec128 (Vector_types.Vec128.Bit_pattern.of_bits { high = i; low = i })
+  | Region | Rec_info ->
+    Misc.fatal_errorf "Invalid kind %a" Flambda_kind.print kind

--- a/middle_end/flambda2/identifiers/reg_width_const.mli
+++ b/middle_end/flambda2/identifiers/reg_width_const.mli
@@ -25,3 +25,7 @@ val of_descr : Descr.t -> t
 val is_naked_immediate : t -> Targetint_31_63.t option
 
 val is_tagged_immediate : t -> Targetint_31_63.t option
+
+(** Create a numeric constant of the given kind ([Region] and [Rec_info] are
+    forbidden). *)
+val of_int_of_kind : Flambda_kind.t -> int -> t

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -188,8 +188,8 @@ module Mixed_block_shape = struct
     lambda_shape.value_prefix_len
 
   let equal t1 t2 =
-    Int.equal (Array.length t1.fields) (Array.length t2.fields) &&
-    Array.for_all2 equal t1.fields t2.fields
+    Int.equal (Array.length t1.fields) (Array.length t2.fields)
+    && Array.for_all2 equal t1.fields t2.fields
 
   let compare t1 t2 =
     let length1 = Array.length t1.fields in
@@ -212,8 +212,7 @@ module Mixed_block_shape = struct
       List.init shape.value_prefix_len (fun _ -> Value)
     in
     let flat_suffix_shape =
-      List.map from_lambda_flat_element
-        (Array.to_list shape.flat_suffix)
+      List.map from_lambda_flat_element (Array.to_list shape.flat_suffix)
     in
     { fields = Array.of_list (value_prefix_shape @ flat_suffix_shape);
       lambda_shape = shape

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -79,6 +79,16 @@ let region = Region
 
 let rec_info = Rec_info
 
+let from_lambda_flat_element (elt : Lambda.flat_element) =
+  match elt with
+  | Imm -> Value
+  | Float_boxed -> Naked_number Naked_float
+  | Float64 -> Naked_number Naked_float
+  | Float32 -> Naked_number Naked_float32
+  | Bits32 -> Naked_number Naked_int32
+  | Bits64 -> Naked_number Naked_int64
+  | Word -> Naked_number Naked_nativeint
+
 let to_lambda (t : t) : Lambda.layout =
   match t with
   | Value -> Pvalue Pgenval
@@ -162,6 +172,94 @@ let is_naked_float t =
       | Naked_nativeint | Naked_vec128 )
   | Region | Rec_info ->
     false
+
+module Mixed_block_shape = struct
+  type kind = t
+
+  type t =
+    { fields : kind array;
+      (* For compiling to Cmm, we need the lambda shape *)
+      lambda_shape : Lambda.mixed_block_shape
+    }
+
+  let field_kinds { fields; lambda_shape = _ } = fields
+
+  let value_prefix_size { fields = _; lambda_shape } =
+    lambda_shape.value_prefix_len
+
+  let equal t1 t2 = Array.for_all2 equal t1.fields t2.fields
+
+  let compare t1 t2 =
+    let length1 = Array.length t1.fields in
+    let length2 = Array.length t2.fields in
+    let c = Int.compare length1 length2 in
+    if c <> 0
+    then c
+    else
+      let exception Result of int in
+      try
+        for i = 0 to length1 - 1 do
+          let c = compare t1.fields.(i) t2.fields.(i) in
+          if c <> 0 then raise_notrace (Result c)
+        done;
+        0
+      with Result c -> c
+
+  let from_lambda (shape : Lambda.mixed_block_shape) =
+    let value_prefix_shape =
+      List.init shape.value_prefix_len (fun _ -> Value)
+    in
+    let flat_suffix_shape =
+      List.map from_lambda_flat_element
+        (Array.to_list shape.flat_suffix)
+    in
+    { fields = Array.of_list (value_prefix_shape @ flat_suffix_shape);
+      lambda_shape = shape
+    }
+
+  let to_lambda { fields = _; lambda_shape } = lambda_shape
+end
+
+module Block_shape = struct
+  type t =
+    | Value_only
+    | Float_record
+    | Mixed_record of Mixed_block_shape.t
+
+  let equal shape1 shape2 =
+    match shape1, shape2 with
+    | Value_only, Value_only -> true
+    | Float_record, Float_record -> true
+    | Mixed_record shape1, Mixed_record shape2 ->
+      Mixed_block_shape.equal shape1 shape2
+    | (Value_only | Float_record | Mixed_record _), _ -> false
+
+  let compare shape1 shape2 =
+    match shape1, shape2 with
+    | Value_only, Value_only -> 0
+    | Value_only, _ -> -1
+    | _, Value_only -> 1
+    | Float_record, Float_record -> 0
+    | Float_record, _ -> -1
+    | _, Float_record -> 1
+    | Mixed_record kinds1, Mixed_record kinds2 ->
+      Mixed_block_shape.compare kinds1 kinds2
+
+  let print ppf shape =
+    match shape with
+    | Value_only -> Format.fprintf ppf "Values"
+    | Float_record -> Format.fprintf ppf "Floats"
+    | Mixed_record { fields; lambda_shape = _ } ->
+      Format.fprintf ppf "Mixed@ (@[<h>";
+      Array.iter (fun k -> Format.fprintf ppf "%a@ " print k) fields;
+      Format.fprintf ppf "@])"
+
+  let element_kind shape index =
+    match shape with
+    | Value_only -> Value
+    | Float_record -> Naked_number Naked_float
+    | Mixed_record shape -> (Mixed_block_shape.field_kinds shape).(index)
+end
 
 module Standard_int = struct
   type t =
@@ -333,7 +431,8 @@ module With_subkind = struct
       | Tagged_immediate
       | Variant of
           { consts : Targetint_31_63.Set.t;
-            non_consts : kind_and_subkind list Tag.Scannable.Map.t
+            non_consts :
+              (Block_shape.t * kind_and_subkind list) Tag.Scannable.Map.t
           }
       | Float_block of { num_fields : int }
       | Float_array
@@ -383,8 +482,10 @@ module With_subkind = struct
             let field_lists2 = Tag.Scannable.Map.data non_consts2 in
             assert (List.compare_lengths field_lists1 field_lists2 = 0);
             List.for_all2
-              (fun fields1 fields2 ->
-                if List.compare_lengths fields1 fields2 <> 0
+              (fun (shape1, fields1) (shape2, fields2) ->
+                if not (Block_shape.equal shape1 shape2)
+                then false
+                else if List.compare_lengths fields1 fields2 <> 0
                 then false
                 else
                   List.for_all2
@@ -450,7 +551,7 @@ module With_subkind = struct
           let print_field ppf { kind = _; subkind } = print ppf subkind in
           Format.fprintf ppf "%t=Variant((consts (%a))@ (non_consts (%a)))%t"
             colour Targetint_31_63.Set.print consts
-            (Tag.Scannable.Map.print (fun ppf fields ->
+            (Tag.Scannable.Map.print (fun ppf (_shape, fields) ->
                  Format.fprintf ppf "[%a]"
                    (Format.pp_print_list ~pp_sep:Format.pp_print_space
                       print_field)
@@ -578,7 +679,8 @@ module With_subkind = struct
       create value
         (Variant
            { consts = Targetint_31_63.Set.empty;
-             non_consts = Tag.Scannable.Map.singleton tag fields
+             non_consts =
+               Tag.Scannable.Map.singleton tag (Block_shape.Value_only, fields)
            })
     | None -> Misc.fatal_errorf "Tag %a is not scannable" Tag.print tag
 
@@ -623,45 +725,68 @@ module With_subkind = struct
     | Pboxedvectorval (Pvec128 _) -> boxed_vec128
     | Pintval -> tagged_immediate
     | Pvariant { consts; non_consts } -> (
-      let all_uniform_non_consts =
-        List.map
-          (fun (tag, (shape : Lambda.constructor_shape)) ->
-            match shape with
-            | Constructor_uniform shape -> Some (tag, shape)
-            | Constructor_mixed _ -> None)
-          non_consts
-        |> Misc.Stdlib.List.some_if_all_elements_are_some
-      in
-      match all_uniform_non_consts with
-      | None ->
-        (* CR mixed blocks v2: have a better representation of mixed blocks in
-           the flambda2 middle end so that they can be optimized more. *)
-        any_value
-      | Some non_consts -> (
-        match consts, non_consts with
-        | [], [] -> Misc.fatal_error "[Pvariant] with no constructors at all"
-        | [], [(tag, fields)] when tag = Obj.double_array_tag ->
-          (* If we have [Obj.double_array_tag] here, this is always an all-float
-             block, not an array. *)
-          float_block ~num_fields:(List.length fields)
-        | [], _ :: _ | _ :: _, [] | _ :: _, _ :: _ ->
-          let consts =
-            Targetint_31_63.Set.of_list
-              (List.map (fun const -> Targetint_31_63.of_int const) consts)
-          in
-          let non_consts =
-            List.fold_left
-              (fun non_consts (tag, fields) ->
-                match Tag.Scannable.create tag with
-                | Some tag ->
-                  Tag.Scannable.Map.add tag
-                    (List.map from_lambda_value_kind fields)
-                    non_consts
-                | None ->
-                  Misc.fatal_errorf "Non-scannable tag %d in [Pvariant]" tag)
-              Tag.Scannable.Map.empty non_consts
-          in
-          create value (Variant { consts; non_consts })))
+      match consts, non_consts with
+      | [], [] -> Misc.fatal_error "[Pvariant] with no constructors at all"
+      | [], [(tag, shape)] when tag = Obj.double_array_tag ->
+        (* If we have [Obj.double_array_tag] here, this is always an all-float
+           block, not an array. *)
+        (* CR vlaviron: change the Lambda type *)
+        let num_fields =
+          match shape with
+          | Constructor_uniform fields -> List.length fields
+          | Constructor_mixed _ -> assert false
+        in
+        float_block ~num_fields
+      | [], _ :: _ | _ :: _, [] | _ :: _, _ :: _ ->
+        let consts =
+          Targetint_31_63.Set.of_list
+            (List.map (fun const -> Targetint_31_63.of_int const) consts)
+        in
+        let non_consts =
+          List.fold_left
+            (fun non_consts (tag, shape) ->
+              match Tag.Scannable.create tag with
+              | Some tag ->
+                let shape_and_fields =
+                  match (shape : Lambda.constructor_shape) with
+                  | Constructor_uniform fields ->
+                    ( Block_shape.Value_only,
+                      List.map from_lambda_value_kind fields )
+                  | Constructor_mixed { value_prefix; flat_suffix } ->
+                    let lambda_shape : Lambda.mixed_block_shape =
+                      { value_prefix_len = List.length value_prefix;
+                        flat_suffix = Array.of_list flat_suffix
+                      }
+                    in
+                    let fields =
+                      let flat_element_kind (elt : Lambda.flat_element) =
+                        match elt with
+                        | Imm -> tagged_immediate
+                        | Float_boxed -> naked_float
+                        | Float64 -> naked_float
+                        | Float32 -> naked_float32
+                        | Bits32 -> naked_int32
+                        | Bits64 -> naked_int64
+                        | Word -> naked_nativeint
+                      in
+                      let prefix =
+                        List.map from_lambda_value_kind value_prefix
+                      in
+                      let suffix = List.map flat_element_kind flat_suffix in
+                      prefix @ suffix
+                    in
+                    let shape =
+                      Block_shape.Mixed_record
+                        (Mixed_block_shape.from_lambda lambda_shape)
+                    in
+                    shape, fields
+                in
+                Tag.Scannable.Map.add tag shape_and_fields non_consts
+              | None ->
+                Misc.fatal_errorf "Non-scannable tag %d in [Pvariant]" tag)
+            Tag.Scannable.Map.empty non_consts
+        in
+        create value (Variant { consts; non_consts }))
     | Parrayval Pfloatarray -> float_array
     | Parrayval Pintarray -> immediate_array
     | Parrayval Paddrarray -> value_array

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -187,7 +187,9 @@ module Mixed_block_shape = struct
   let value_prefix_size { fields = _; lambda_shape } =
     lambda_shape.value_prefix_len
 
-  let equal t1 t2 = Array.for_all2 equal t1.fields t2.fields
+  let equal t1 t2 =
+    Int.equal (Array.length t1.fields) (Array.length t2.fields) &&
+    Array.for_all2 equal t1.fields t2.fields
 
   let compare t1 t2 =
     let length1 = Array.length t1.fields in

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -188,6 +188,11 @@ module Mixed_block_shape = struct
   let value_prefix_size { fields = _; lambda_shape } =
     lambda_shape.value_prefix_len
 
+  (* This function has two meanings. The first is to say whether two shapes are
+     equivalent (which is why the lambda shape is not compared directly). The
+     second is to tell whether two shapes are compatible. Currently this matches
+     with equivalence, but if we introduce subkinds this will have to be split
+     into two functions. *)
   let equal t1 t2 =
     Int.equal t1.lambda_shape.value_prefix_len t2.lambda_shape.value_prefix_len
     && Int.equal (Array.length t1.fields) (Array.length t2.fields)
@@ -236,6 +241,7 @@ module Block_shape = struct
     | Float_record
     | Mixed_record of Mixed_block_shape.t
 
+  (* Some users rely on shapes not being compatible if they're not equal. *)
   let equal shape1 shape2 =
     match shape1, shape2 with
     | Value_only, Value_only -> true

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -100,6 +100,9 @@ module Block_shape : sig
     | Float_record
     | Mixed_record of Mixed_block_shape.t
 
+  (** For now if two block shapes do not compare as equal they will be
+      incompatible. If that changes, a [compatible] function will be
+      introduced. *)
   val equal : t -> t -> bool
 
   val compare : t -> t -> int

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -72,9 +72,42 @@ val is_value : t -> bool
 
 val is_naked_float : t -> bool
 
+val from_lambda_flat_element : Lambda.flat_element -> t
+
 val to_lambda : t -> Lambda.layout
 
 include Container_types.S with type t := t
+
+module Mixed_block_shape : sig
+  type t
+
+  val from_lambda : Lambda.mixed_block_shape -> t
+
+  val field_kinds : t -> kind array
+
+  val value_prefix_size : t -> int
+
+  val to_lambda : t -> Lambda.mixed_block_shape
+
+  val equal : t -> t -> bool
+
+  val compare : t -> t -> int
+end
+
+module Block_shape : sig
+  type t =
+    | Value_only
+    | Float_record
+    | Mixed_record of Mixed_block_shape.t
+
+  val equal : t -> t -> bool
+
+  val compare : t -> t -> int
+
+  val print : Format.formatter -> t -> unit
+
+  val element_kind : t -> int -> kind
+end
 
 module Standard_int : sig
   (** "Standard" because these correspond to the usual representations of tagged
@@ -150,7 +183,7 @@ module With_subkind : sig
       | Tagged_immediate
       | Variant of
           { consts : Targetint_31_63.Set.t;
-            non_consts : with_subkind list Tag.Scannable.Map.t
+            non_consts : (Block_shape.t * with_subkind list) Tag.Scannable.Map.t
           }
       | Float_block of { num_fields : int }
       | Float_array

--- a/middle_end/flambda2/lattices/or_unknown.ml
+++ b/middle_end/flambda2/lattices/or_unknown.ml
@@ -18,6 +18,8 @@ type 'a t =
   | Known of 'a
   | Unknown
 
+let known x = Known x
+
 let print f ppf t =
   let colour = Flambda_colours.top_or_bottom_type in
   match t with

--- a/middle_end/flambda2/lattices/or_unknown.mli
+++ b/middle_end/flambda2/lattices/or_unknown.mli
@@ -18,6 +18,8 @@ type 'a t =
   | Known of 'a
   | Unknown
 
+val known : 'a -> 'a t
+
 val print : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
 
 val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -210,11 +210,6 @@ type block_access_kind =
         field_kind : block_access_field_kind
       }
   | Naked_floats of { size : targetint option }
-  | Mixed of
-      { tag : tag_scannable option;
-        size : targetint option;
-        field_kind : Flambda_primitive.Mixed_block_access_field_kind.t
-      }
 
 type standard_int = Flambda_kind.Standard_int.t =
   | Tagged_immediate

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -273,7 +273,9 @@ let rec subkind : Fexpr.subkind -> Flambda_kind.With_subkind.Subkind.t =
     let non_consts =
       non_consts
       |> List.map (fun (tag, sk) ->
-             tag_scannable tag, List.map value_kind_with_subkind sk)
+             ( tag_scannable tag,
+               ( Flambda_kind.Block_shape.Value_only,
+                 List.map value_kind_with_subkind sk ) ))
       |> Tag.Scannable.Map.of_list
     in
     Variant { consts; non_consts }
@@ -439,14 +441,14 @@ let block_access_kind (ak : Fexpr.block_access_kind) :
   | Naked_floats { size = s } ->
     let size = size s in
     Naked_floats { size }
-  | Mixed { tag; size = s; field_kind } ->
-    let tag : Tag.Scannable.t Or_unknown.t =
-      match tag with
-      | Some tag -> Known (tag |> tag_scannable)
-      | None -> Unknown
-    in
-    let s = size s in
-    Mixed { tag; size = s; field_kind }
+  | Mixed _ -> Misc.fatal_error "Mixed records not supported"
+(* let tag : Tag.Scannable.t Or_unknown.t = *)
+(*   match tag with *)
+(*   | Some tag -> Known (tag |> tag_scannable) *)
+(*   | None -> Unknown *)
+(* in *)
+(* let s = size s in *)
+(* Mixed { tag; size = s; field_kind } *)
 
 let binop (binop : Fexpr.binop) : Flambda_primitive.binary_primitive =
   match binop with

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -441,14 +441,6 @@ let block_access_kind (ak : Fexpr.block_access_kind) :
   | Naked_floats { size = s } ->
     let size = size s in
     Naked_floats { size }
-  | Mixed _ -> Misc.fatal_error "Mixed records not supported"
-(* let tag : Tag.Scannable.t Or_unknown.t = *)
-(*   match tag with *)
-(*   | Some tag -> Known (tag |> tag_scannable) *)
-(*   | None -> Unknown *)
-(* in *)
-(* let s = size s in *)
-(* Mixed { tag; size = s; field_kind } *)
 
 let binop (binop : Fexpr.binop) : Flambda_primitive.binary_primitive =
   match binop with

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -571,14 +571,7 @@ let block_access_kind (bk : Flambda_primitive.Block_access_kind.t) :
   | Naked_floats { size = s } ->
     let size = s |> size in
     Naked_floats { size }
-  | Mixed { tag; size = s; shape = _; field_kind } ->
-    let size = s |> size in
-    let tag =
-      match tag with
-      | Unknown -> None
-      | Known tag -> Some (tag |> Tag.Scannable.to_int)
-    in
-    Mixed { tag; size; field_kind }
+  | Mixed _ -> Misc.fatal_error "Mixed blocks not supported in fexpr"
 
 let binop (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
   match op with

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -449,7 +449,7 @@ and variant_subkind consts non_consts : Fexpr.subkind =
   in
   let non_consts =
     non_consts |> Tag.Scannable.Map.bindings
-    |> List.map (fun (tag, sk) ->
+    |> List.map (fun (tag, (_shape, sk)) ->
            Tag.Scannable.to_int tag, List.map kind_with_subkind sk)
   in
   Variant { consts; non_consts }
@@ -571,7 +571,7 @@ let block_access_kind (bk : Flambda_primitive.Block_access_kind.t) :
   | Naked_floats { size = s } ->
     let size = s |> size in
     Naked_floats { size }
-  | Mixed { tag; size = s; field_kind } ->
+  | Mixed { tag; size = s; shape = _; field_kind } ->
     let size = s |> size in
     let tag =
       match tag with
@@ -623,7 +623,7 @@ let varop env (op : Flambda_primitive.variadic_primitive) : Fexpr.varop =
     let tag = tag |> Tag.Scannable.to_int in
     let alloc = alloc_mode_for_allocations env alloc in
     Make_block (tag, mutability, alloc)
-  | Make_block (Naked_floats, _, _) | Make_array _ | Make_mixed_block _ ->
+  | Make_block ((Naked_floats | Mixed _), _, _) | Make_array _ ->
     Misc.fatal_errorf "TODO: Variadic primitive: %a"
       Flambda_primitive.Without_args.print
       (Flambda_primitive.Without_args.Variadic op)

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -482,8 +482,8 @@ let block_access_kind ppf (access_kind : block_access_kind) =
     | Value_prefix Any_value -> ()
     | Value_prefix Immediate -> Format.fprintf ppf "@ imm"
     | Flat_suffix flat ->
-      Format.fprintf ppf "@ %s"
-        (Flambda_primitive.Mixed_block_flat_element.to_string flat)
+      Format.fprintf ppf "@ %a"
+        Flambda_kind.print flat
   in
   match access_kind with
   | Values { field_kind; tag; size } ->

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -481,9 +481,7 @@ let block_access_kind ppf (access_kind : block_access_kind) =
     match field_kind with
     | Value_prefix Any_value -> ()
     | Value_prefix Immediate -> Format.fprintf ppf "@ imm"
-    | Flat_suffix flat ->
-      Format.fprintf ppf "@ %a"
-        Flambda_kind.print flat
+    | Flat_suffix flat -> Format.fprintf ppf "@ %a" Flambda_kind.print flat
   in
   match access_kind with
   | Values { field_kind; tag; size } ->

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -476,23 +476,12 @@ let block_access_kind ppf (access_kind : block_access_kind) =
     | Any_value -> ()
     | Immediate -> Format.fprintf ppf "@ imm"
   in
-  let pp_mixed_field_kind ppf
-      (field_kind : Flambda_primitive.Mixed_block_access_field_kind.t) =
-    match field_kind with
-    | Value_prefix Any_value -> ()
-    | Value_prefix Immediate -> Format.fprintf ppf "@ imm"
-    | Flat_suffix flat -> Format.fprintf ppf "@ %a" Flambda_kind.print flat
-  in
   match access_kind with
   | Values { field_kind; tag; size } ->
     Format.fprintf ppf "%a%a%a" pp_field_kind field_kind
       (pp_option ~space:Before (pp_like "tag(%a)" Format.pp_print_int))
       tag pp_size size
   | Naked_floats { size } -> Format.fprintf ppf "@ float%a" pp_size size
-  | Mixed { tag; field_kind; size } ->
-    Format.fprintf ppf "%a%a%a" pp_mixed_field_kind field_kind
-      (pp_option ~space:Before (pp_like "tag(%a)" Format.pp_print_int))
-      tag pp_size size
 
 let string_accessor_width ppf saw =
   Format.fprintf ppf "%s"

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
@@ -239,6 +239,13 @@ let blocks_to_unbox ~escaping ~source_info ~required_names =
                         (fun _ -> Flambda_kind.With_subkind.naked_float)
                         fields
                   }
+                | Mixed (tag, shape) ->
+                  let fields_kinds =
+                    List.map Flambda_kind.With_subkind.anything
+                      (Array.to_list
+                         (Flambda_kind.Mixed_block_shape.field_kinds shape))
+                  in
+                  { tag = Tag.Scannable.to_tag tag; mut; fields_kinds }
               in
               Variable.Map.add var block_to_unbox map)
         map elt.mutable_let_prims_rev)

--- a/middle_end/flambda2/simplify/simplify_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive.ml
@@ -168,7 +168,9 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
       let arg_tys = List.map snd args_with_tys in
       let arg_tys_and_expected_kinds =
         match P.args_kind_of_variadic_primitive variadic_prim with
-        | Variadic arg_kinds -> List.combine arg_tys arg_kinds
+        | Variadic_mixed arg_kinds ->
+          List.combine arg_tys
+            (Array.to_list (K.Mixed_block_shape.field_kinds arg_kinds))
         | Variadic_all_of_kind kind ->
           List.map (fun arg_ty -> arg_ty, kind) arg_tys
       in

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -84,11 +84,11 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
       let fields = field_tys in
       match is_mutable with
       | Immutable ->
-        T.immutable_block ~is_unique:false tag ~field_kind:K.value ~fields
-          Alloc_mode.For_types.heap
+        T.immutable_block ~is_unique:false tag ~shape:K.Block_shape.Value_only
+          ~fields Alloc_mode.For_types.heap
       | Immutable_unique ->
-        T.immutable_block ~is_unique:true tag ~field_kind:K.value ~fields
-          Alloc_mode.For_types.heap
+        T.immutable_block ~is_unique:true tag ~shape:K.Block_shape.Value_only
+          ~fields Alloc_mode.For_types.heap
       | Mutable -> T.any_value
     in
     let dacc = bind_result_sym ty in

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -288,7 +288,7 @@ let rebuild_switch_with_single_arg_to_same_destination uacc ~dacc_before_switch
   let uacc =
     let fields = List.map Field_of_static_block.tagged_immediate consts in
     let block_type =
-      T.immutable_block ~is_unique:false Tag.zero ~field_kind:K.value
+      T.immutable_block ~is_unique:false Tag.zero ~shape:Value_only
         Alloc_mode.For_types.heap
         ~fields:
           (List.map

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -22,7 +22,7 @@ let simplify_make_block ~original_prim ~(block_kind : P.Block_kind.t)
   let env_extension : _ Or_bottom.t =
     match block_kind with
     | Naked_floats | Mixed _ ->
-      (* No useful subkinf information *)
+      (* No useful subkind information *)
       Ok TEE.empty
     | Values (_tag, field_kinds) ->
       if List.compare_lengths args_with_tys field_kinds <> 0

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -36,13 +36,12 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
   match decision with
   | Do_not_unbox _ -> denv
   | Unbox (Unique_tag_and_size { tag; shape; fields }) ->
-    let _, denv =
-      List.fold_left
-        (fun (index, denv) ({ epa = { param = var; _ }; _ } : U.field_decision) ->
+    let denv =
+      Misc.Stdlib.List.fold_lefti
+        (fun index denv ({ epa = { param = var; _ }; _ } : U.field_decision) ->
           let v = VB.create var Name_mode.normal in
-          ( succ index,
-            DE.define_variable denv v (K.Block_shape.element_kind shape index) ))
-        (0, denv) fields
+          DE.define_variable denv v (K.Block_shape.element_kind shape index))
+        denv fields
     in
     let type_of_var index (field : U.field_decision) =
       T.alias_type_of
@@ -143,15 +142,11 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     let denv =
       Tag.Scannable.Map.fold
         (fun _ (shape, block_fields) denv ->
-          snd
-          @@ List.fold_left
-               (fun (index, denv)
-                    ({ epa = { param = var; _ }; _ } : U.field_decision) ->
-                 let v = VB.create var Name_mode.normal in
-                 ( succ index,
-                   DE.define_variable denv v
-                     (K.Block_shape.element_kind shape index) ))
-               (0, denv) block_fields)
+          Misc.Stdlib.List.fold_lefti
+            (fun index denv ({ epa = { param = var; _ }; _ } : U.field_decision) ->
+              let v = VB.create var Name_mode.normal in
+              DE.define_variable denv v (K.Block_shape.element_kind shape index))
+            denv block_fields)
         fields_by_tag denv
     in
     let non_const_ctors =

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -35,23 +35,23 @@ let denv_of_number_decision naked_kind shape param_var naked_var denv : DE.t =
 let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
   match decision with
   | Do_not_unbox _ -> denv
-  | Unbox (Unique_tag_and_size { tag; fields }) ->
-    let field_kind =
-      if Tag.equal tag Tag.double_array_tag then K.naked_float else K.value
-    in
-    let denv =
+  | Unbox (Unique_tag_and_size { tag; shape; fields }) ->
+    let _, denv =
       List.fold_left
-        (fun denv ({ epa = { param = var; _ }; _ } : U.field_decision) ->
+        (fun (index, denv) ({ epa = { param = var; _ }; _ } : U.field_decision) ->
           let v = VB.create var Name_mode.normal in
-          DE.define_variable denv v field_kind)
-        denv fields
+          ( succ index,
+            DE.define_variable denv v (K.Block_shape.element_kind shape index) ))
+        (0, denv) fields
     in
-    let type_of_var (field : U.field_decision) =
-      T.alias_type_of field_kind (Simple.var field.epa.param)
+    let type_of_var index (field : U.field_decision) =
+      T.alias_type_of
+        (K.Block_shape.element_kind shape index)
+        (Simple.var field.epa.param)
     in
-    let field_types = List.map type_of_var fields in
+    let field_types = List.mapi type_of_var fields in
     let shape =
-      T.immutable_block ~is_unique:false tag ~field_kind ~fields:field_types
+      T.immutable_block ~is_unique:false tag ~shape ~fields:field_types
         (Alloc_mode.For_types.unknown ())
     in
     let denv = add_equation_on_var denv param_var shape in
@@ -142,21 +142,26 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     in
     let denv =
       Tag.Scannable.Map.fold
-        (fun _ block_fields denv ->
-          List.fold_left
-            (fun denv ({ epa = { param = var; _ }; _ } : U.field_decision) ->
-              let v = VB.create var Name_mode.normal in
-              DE.define_variable denv v K.value)
-            denv block_fields)
+        (fun _ (shape, block_fields) denv ->
+          snd
+          @@ List.fold_left
+               (fun (index, denv)
+                    ({ epa = { param = var; _ }; _ } : U.field_decision) ->
+                 let v = VB.create var Name_mode.normal in
+                 ( succ index,
+                   DE.define_variable denv v
+                     (K.Block_shape.element_kind shape index) ))
+               (0, denv) block_fields)
         fields_by_tag denv
     in
     let non_const_ctors =
       Tag.Scannable.Map.map
-        (fun block_fields ->
-          List.map
-            (fun (field : U.field_decision) ->
-              T.alias_type_of K.value (Simple.var field.epa.param))
-            block_fields)
+        (fun (shape, block_fields) ->
+          ( shape,
+            List.map
+              (fun (field : U.field_decision) ->
+                T.alias_type_of K.value (Simple.var field.epa.param))
+              block_fields ))
         fields_by_tag
     in
     let shape =
@@ -165,7 +170,7 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     let denv = add_equation_on_var denv param_var shape in
     (* Recurse on the fields *)
     Tag.Scannable.Map.fold
-      (fun _ block_fields denv ->
+      (fun _ (_shape, block_fields) denv ->
         List.fold_left
           (fun denv (field : U.field_decision) ->
             denv_of_decision denv ~param_var:field.epa.param field.decision)

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -161,13 +161,12 @@ and make_optimistic_fields ~add_tag_to_name ~depth ~recursive tenv param_type
       (Simple.var epa.param)
   in
   let field_types = List.mapi type_of_var field_vars in
-  let _, tenv =
-    List.fold_left
-      (fun (index, acc) { Extra_param_and_args.param = var; args = _ } ->
+  let tenv =
+    Misc.Stdlib.List.fold_lefti
+      (fun index acc { Extra_param_and_args.param = var; args = _ } ->
         let name = Bound_name.create (Name.var var) Name_mode.normal in
-        ( succ index,
-          TE.add_definition acc name (K.Block_shape.element_kind shape index) ))
-      (0, tenv) field_vars
+        TE.add_definition acc name (K.Block_shape.element_kind shape index))
+      tenv field_vars
   in
   let shape =
     T.immutable_block ~is_unique:false tag ~shape ~fields:field_types

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -87,13 +87,13 @@ let rec make_optimistic_decision ~depth ~recursive tenv ~param_type : U.decision
       then Do_not_unbox Max_depth_exceeded
       else
         match T.prove_unique_tag_and_size tenv param_type with
-        | Proved (tag, size) when unbox_blocks -> (
+        | Proved (tag, shape, size) when unbox_blocks -> (
           let fields =
             make_optimistic_fields ~add_tag_to_name:false ~depth ~recursive tenv
-              param_type tag size
+              param_type tag shape size
           in
           match fields with
-          | Some fields -> Unbox (Unique_tag_and_size { tag; fields })
+          | Some fields -> Unbox (Unique_tag_and_size { tag; shape; fields })
           | None -> Do_not_unbox All_fields_invalid)
         | Proved _ | Unknown -> (
           match T.prove_variant_like tenv param_type with
@@ -107,10 +107,14 @@ let rec make_optimistic_decision ~depth ~recursive tenv ~param_type : U.decision
             in
             let fields_by_tag =
               Tag.Scannable.Map.filter_map
-                (fun scannable_tag size ->
+                (fun scannable_tag (size, shape) ->
                   let tag = Tag.Scannable.to_tag scannable_tag in
-                  make_optimistic_fields ~add_tag_to_name:true ~depth ~recursive
-                    tenv param_type tag size)
+                  match
+                    make_optimistic_fields ~add_tag_to_name:true ~depth
+                      ~recursive tenv param_type tag shape size
+                  with
+                  | None -> None
+                  | Some decision -> Some (shape, decision))
                 non_const_ctors_with_sizes
             in
             if Tag.Scannable.Map.is_empty fields_by_tag
@@ -119,9 +123,9 @@ let rec make_optimistic_decision ~depth ~recursive tenv ~param_type : U.decision
               match
                 const_ctors, Tag.Scannable.Map.get_singleton fields_by_tag
               with
-              | Zero, Some (scannable_tag, fields) ->
+              | Zero, Some (scannable_tag, (shape, fields)) ->
                 let tag = Tag.Scannable.to_tag scannable_tag in
-                Unbox (Unique_tag_and_size { tag; fields })
+                Unbox (Unique_tag_and_size { tag; shape; fields })
               | (Zero | At_least_one _), _ ->
                 Unbox (Variant { tag; const_ctors; fields_by_tag }))
           | Proved _ | Unknown -> (
@@ -137,14 +141,12 @@ let rec make_optimistic_decision ~depth ~recursive tenv ~param_type : U.decision
             | Proved _ | Unknown -> Do_not_unbox Incomplete_parameter_type)))
 
 and make_optimistic_fields ~add_tag_to_name ~depth ~recursive tenv param_type
-    (tag : Tag.t) size =
-  let field_kind, field_base_name =
-    if Tag.equal tag Tag.double_array_tag
-    then K.naked_float, "unboxed_float_field"
-    else K.value, "unboxed_field"
-  in
-  let field_kind_with_subkind =
-    K.With_subkind.create field_kind K.With_subkind.Subkind.Anything
+    (tag : Tag.t) (shape : K.Block_shape.t) size =
+  let field_base_name =
+    match shape with
+    | Value_only -> "unboxed_field"
+    | Float_record -> "unboxed_float_field"
+    | Mixed_record _ -> "unboxed_mixed_field"
   in
   let field_name n =
     Format.asprintf "%s%a_%d" field_base_name (pp_tag add_tag_to_name) tag n
@@ -153,19 +155,22 @@ and make_optimistic_fields ~add_tag_to_name ~depth ~recursive tenv param_type
     List.init (Targetint_31_63.to_int size) (fun i ->
         Extra_param_and_args.create ~name:(field_name i))
   in
-  let type_of_var (epa : Extra_param_and_args.t) =
-    T.alias_type_of field_kind (Simple.var epa.param)
+  let type_of_var index (epa : Extra_param_and_args.t) =
+    T.alias_type_of
+      (K.Block_shape.element_kind shape index)
+      (Simple.var epa.param)
   in
-  let field_types = List.map type_of_var field_vars in
-  let tenv =
+  let field_types = List.mapi type_of_var field_vars in
+  let _, tenv =
     List.fold_left
-      (fun acc { Extra_param_and_args.param = var; args = _ } ->
+      (fun (index, acc) { Extra_param_and_args.param = var; args = _ } ->
         let name = Bound_name.create (Name.var var) Name_mode.normal in
-        TE.add_definition acc name field_kind)
-      tenv field_vars
+        ( succ index,
+          TE.add_definition acc name (K.Block_shape.element_kind shape index) ))
+      (0, tenv) field_vars
   in
   let shape =
-    T.immutable_block ~is_unique:false tag ~field_kind ~fields:field_types
+    T.immutable_block ~is_unique:false tag ~shape ~fields:field_types
       (Alloc_mode.For_types.unknown ())
   in
   match T.meet tenv param_type shape with
@@ -184,7 +189,7 @@ and make_optimistic_fields ~add_tag_to_name ~depth ~recursive tenv param_type
             make_optimistic_decision ~depth:(depth + 1) ~recursive tenv
               ~param_type:var_type
           in
-          { epa; decision; kind = field_kind_with_subkind })
+          { epa; decision; kind = K.With_subkind.anything (T.kind var_type) })
         field_vars field_types
     in
     Some fields

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -171,6 +171,39 @@ let compute_extra_arg_for_number kind unboxer epa rewrite_id ~typing_env_at_use
   let epa = Extra_param_and_args.update_param_args epa rewrite_id extra_arg in
   Unbox (Number (kind, epa))
 
+(* Helpers for the block case *)
+(* ************************** *)
+
+let access_kind_and_dummy_const tag shape fields index :
+    P.Block_access_kind.t * _ =
+  let size = Or_unknown.Known (Targetint_31_63.of_int (List.length fields)) in
+  match (shape : K.Block_shape.t) with
+  | Value_only ->
+    ( Values
+        { size;
+          tag = Known (Option.get (Tag.Scannable.of_tag tag));
+          field_kind = Any_value
+        },
+      Const.const_zero )
+  | Float_record ->
+    ( Naked_floats { size },
+      Const.naked_float Numeric_types.Float_by_bit_pattern.zero )
+  | Mixed_record shape ->
+    let field_kind, const =
+      let field_kind = (K.Mixed_block_shape.field_kinds shape).(index) in
+      if index < K.Mixed_block_shape.value_prefix_size shape
+      then
+        (* CR vlaviron: we're not trying to infer if this can only be an
+           immediate. In most cases it should be fine, as the primitive will get
+           simplified away. *)
+        P.Mixed_block_access_field_kind.Value_prefix Any_value, Const.const_zero
+      else
+        ( P.Mixed_block_access_field_kind.Flat_suffix field_kind,
+          Const.of_int_of_kind field_kind 0 )
+    in
+    let tag = Or_unknown.Known (Option.get (Tag.Scannable.of_tag tag)) in
+    Mixed { tag; size; shape; field_kind }, const
+
 (* Recursive descent on decisions *)
 (* ****************************** *)
 
@@ -244,42 +277,13 @@ and compute_extra_args_for_one_decision_and_use_aux ~(pass : U.pass) rewrite_id
 
 and compute_extra_args_for_block ~pass rewrite_id ~typing_env_at_use
     arg_being_unboxed tag (shape : K.Block_shape.t) fields : U.decision =
-  let size = Or_unknown.Known (Targetint_31_63.of_int (List.length fields)) in
-  let access_kind_and_const index : P.Block_access_kind.t * _ =
-    match shape with
-    | Value_only ->
-      ( Values
-          { size;
-            tag = Known (Option.get (Tag.Scannable.of_tag tag));
-            field_kind = Any_value
-          },
-        Const.const_zero )
-    | Float_record ->
-      ( Naked_floats { size },
-        Const.naked_float Numeric_types.Float_by_bit_pattern.zero )
-    | Mixed_record shape ->
-      let field_kind, const =
-        let field_kind = (K.Mixed_block_shape.field_kinds shape).(index) in
-        if index < K.Mixed_block_shape.value_prefix_size shape
-        then
-          (* CR vlaviron: we're not trying to infer if this can only be an
-             immediate. In most cases it should be fine, as the primitive will
-             get simplified away. *)
-          ( P.Mixed_block_access_field_kind.Value_prefix Any_value,
-            Const.const_zero )
-        else
-          ( P.Mixed_block_access_field_kind.Flat_suffix field_kind,
-            Const.of_int_of_kind field_kind 0 )
-      in
-      let tag = Or_unknown.Known (Option.get (Tag.Scannable.of_tag tag)) in
-      Mixed { tag; size; shape; field_kind }, const
-  in
   let _, fields =
     List.fold_left_map
       (fun field_nth ({ epa; decision; kind } : U.field_decision) :
            (_ * U.field_decision) ->
         let bak, invalid_const =
-          access_kind_and_const (Targetint_31_63.to_int field_nth)
+          access_kind_and_dummy_const tag shape fields
+            (Targetint_31_63.to_int field_nth)
         in
         let unboxer =
           Unboxers.Field.unboxer ~invalid_const bak ~index:field_nth
@@ -371,48 +375,18 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
   let fields_by_tag =
     Tag.Scannable.Map.mapi
       (fun tag_decision (shape, block_fields) ->
-        let size = List.length block_fields in
         (* See doc/unboxing.md about invalid constants, poison and aliases. *)
         let invalid_const = Const.const_int (Targetint_31_63.of_int 0xbaba) in
-        let bak index : Flambda_primitive.Block_access_kind.t =
-          match (shape : K.Block_shape.t) with
-          | Value_only ->
-            Values
-              { size = Known (Targetint_31_63.of_int size);
-                tag = Known tag_decision;
-                field_kind = Any_value
-              }
-          | Float_record ->
-            (* CR vlaviron: I suspect that this case is unreachable. At least
-               the previous version of this code didn't handle it, and it seems
-               likely that float records were handled by the unique tag and size
-               case instead. *)
-            Naked_floats { size = Known (Targetint_31_63.of_int size) }
-          | Mixed_record shape ->
-            let field_kind =
-              let field_kind =
-                (K.Mixed_block_shape.field_kinds shape).(index)
-              in
-              if index < K.Mixed_block_shape.value_prefix_size shape
-              then
-                (* CR vlaviron: we're not trying to infer if this can only be an
-                   immediate. In most cases it should be fine, as the primitive
-                   will get simplified away. *)
-                P.Mixed_block_access_field_kind.Value_prefix Any_value
-              else P.Mixed_block_access_field_kind.Flat_suffix field_kind
-            in
-            Mixed
-              { tag = Known tag_decision;
-                size = Known (Targetint_31_63.of_int size);
-                shape;
-                field_kind
-              }
-        in
         let new_fields_decisions, _ =
           List.fold_left
             (fun (new_decisions, field_nth)
                  ({ epa; decision; kind } : U.field_decision) ->
-              let bak = bak (Targetint_31_63.to_int field_nth) in
+              let bak, _const =
+                access_kind_and_dummy_const
+                  (Tag.Scannable.to_tag tag_decision)
+                  shape block_fields
+                  (Targetint_31_63.to_int field_nth)
+              in
               let new_extra_arg, new_arg_being_unboxed =
                 if are_there_non_const_ctors_at_use
                    && Tag.Scannable.equal tag_at_use_site tag_decision

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -262,8 +262,9 @@ and compute_extra_args_for_block ~pass rewrite_id ~typing_env_at_use
         let field_kind = (K.Mixed_block_shape.field_kinds shape).(index) in
         if index < K.Mixed_block_shape.value_prefix_size shape
         then
-          (* CR vlaviron: we're not trying to infer if this can only be an immediate.
-             In most cases it should be fine, as the primitive will get simplified away. *)
+          (* CR vlaviron: we're not trying to infer if this can only be an
+             immediate. In most cases it should be fine, as the primitive will
+             get simplified away. *)
           ( P.Mixed_block_access_field_kind.Value_prefix Any_value,
             Const.const_zero )
         else
@@ -389,14 +390,16 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
             Naked_floats { size = Known (Targetint_31_63.of_int size) }
           | Mixed_record shape ->
             let field_kind =
-              let field_kind = (K.Mixed_block_shape.field_kinds shape).(index) in
+              let field_kind =
+                (K.Mixed_block_shape.field_kinds shape).(index)
+              in
               if index < K.Mixed_block_shape.value_prefix_size shape
               then
-                (* CR vlaviron: we're not trying to infer if this can only be an immediate.
-                   In most cases it should be fine, as the primitive will get simplified away. *)
+                (* CR vlaviron: we're not trying to infer if this can only be an
+                   immediate. In most cases it should be fine, as the primitive
+                   will get simplified away. *)
                 P.Mixed_block_access_field_kind.Value_prefix Any_value
-              else
-                P.Mixed_block_access_field_kind.Flat_suffix field_kind
+              else P.Mixed_block_access_field_kind.Flat_suffix field_kind
             in
             Mixed
               { tag = Known tag_decision;

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
@@ -54,12 +54,14 @@ end
 type unboxing_decision =
   | Unique_tag_and_size of
       { tag : Tag.t;
+        shape : K.Block_shape.t;
         fields : field_decision list
       }
   | Variant of
       { tag : Extra_param_and_args.t;
         const_ctors : const_ctors_decision;
-        fields_by_tag : field_decision list Tag.Scannable.Map.t
+        fields_by_tag :
+          (K.Block_shape.t * field_decision list) Tag.Scannable.Map.t
       }
   | Closure_single_entry of
       { function_slot : Function_slot.t;
@@ -110,17 +112,18 @@ let rec print_decision ppf = function
   | Do_not_unbox reason ->
     Format.fprintf ppf "@[<hov 1>(do_not_unbox@ %a)@]" print_do_not_unbox_reason
       reason
-  | Unbox (Unique_tag_and_size { tag; fields }) ->
+  | Unbox (Unique_tag_and_size { tag; shape; fields }) ->
     Format.fprintf ppf
-      "@[<v 1>(unique_tag_and_size@ @[<h>(static_tag %a)@]@ @[<hv 2>(fields@ \
-       %a)@])@]"
-      Tag.print tag print_fields_decisions fields
+      "@[<v 1>(unique_tag_and_size@ @[<h>(static_tag %a)@]@ @[<h>(shape %a)@]@ \
+       @[<hv 2>(fields@ %a)@])@]"
+      Tag.print tag K.Block_shape.print shape print_fields_decisions fields
   | Unbox (Variant { tag; const_ctors; fields_by_tag }) ->
     Format.fprintf ppf
       "@[<v 2>(variant@ @[<hov>(tag %a)@]@ @[<hv 2>(const_ctors@ %a)@]@ @[<v \
        2>(fields_by_tag@ %a)@])@]"
       Extra_param_and_args.print tag print_const_ctor_num const_ctors
-      (Tag.Scannable.Map.print print_fields_decisions)
+      (Tag.Scannable.Map.print (fun ppf (_shape, fields) ->
+           print_fields_decisions ppf fields))
       fields_by_tag
   | Unbox (Closure_single_entry { function_slot; vars_within_closure }) ->
     Format.fprintf ppf

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
@@ -42,12 +42,14 @@ end
 type unboxing_decision =
   | Unique_tag_and_size of
       { tag : Tag.t;
+        shape : Flambda_kind.Block_shape.t;
         fields : field_decision list
       }
   | Variant of
       { tag : Extra_param_and_args.t;
         const_ctors : const_ctors_decision;
-        fields_by_tag : field_decision list Tag.Scannable.Map.t
+        fields_by_tag :
+          (Flambda_kind.Block_shape.t * field_decision list) Tag.Scannable.Map.t
       }
   | Closure_single_entry of
       { function_slot : Function_slot.t;

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -159,13 +159,7 @@ let block_set (kind : Flambda_primitive.Block_access_kind.t)
     does_not_need_caml_c_call_extcall_size (* caml_modify *)
   | Values _, (Assignment Local | Initialization) -> 1 (* cadda + store *)
   | Naked_floats _, (Assignment _ | Initialization) -> 1
-  | ( Mixed
-        { field_kind =
-            ( Value_prefix _
-            | Flat_suffix _
-            );
-          _
-        },
+  | ( Mixed { field_kind = Value_prefix _ | Flat_suffix _; _ },
       (Assignment _ | Initialization) ) ->
     1
 

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -162,9 +162,8 @@ let block_set (kind : Flambda_primitive.Block_access_kind.t)
   | ( Mixed
         { field_kind =
             ( Value_prefix _
-            | Flat_suffix
-                (Imm | Float_boxed | Float64 | Float32 | Bits32 | Bits64 | Word)
-              );
+            | Flat_suffix _
+            );
           _
         },
       (Assignment _ | Initialization) ) ->
@@ -420,8 +419,7 @@ let variadic_prim_size prim args =
   | Make_block (_, _mut, _alloc_mode)
   (* CR mshinwell: I think Make_array for a generic array ("Anything") is more
      expensive than the other cases *)
-  | Make_array (_, _mut, _alloc_mode)
-  | Make_mixed_block (_, _, _mut, _alloc_mode) ->
+  | Make_array (_, _mut, _alloc_mode) ->
     alloc_size + List.length args
 
 let prim (prim : Flambda_primitive.t) =

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1835,14 +1835,14 @@ type variadic_primitive =
 
 let variadic_primitive_eligible_for_cse p ~args =
   match p with
-  | Make_block (_, _, Local _) | Make_array (_, Immutable, Local _) -> false
-  | Make_block (_, Immutable, Heap) | Make_array (_, Immutable, _) ->
+  | Make_block (_, _, Local _) | Make_array (_, _, Local _) -> false
+  | Make_block (_, Mutable, _) | Make_array (_, Mutable, _) -> false
+  | Make_block (_, Immutable_unique, _) | Make_array (_, Immutable_unique, _) ->
+    false
+  | Make_block (_, Immutable, Heap) | Make_array (_, Immutable, Heap) ->
     (* See comment in [unary_primitive_eligible_for_cse], above, on [Box_number]
        case. *)
     List.exists (fun arg -> Simple.is_var arg) args
-  | Make_block (_, Immutable_unique, _) | Make_array (_, Immutable_unique, _) ->
-    false
-  | Make_block (_, Mutable, _) | Make_array (_, Mutable, _) -> false
 
 let compare_variadic_primitive p1 p2 =
   match p1, p2 with

--- a/middle_end/flambda2/terms/removed_operations.ml
+++ b/middle_end/flambda2/terms/removed_operations.ml
@@ -56,7 +56,7 @@ let prim (prim : Flambda_primitive.t) =
   | Nullary _ -> zero
   | Binary (_, _, _) | Ternary (_, _, _, _) -> { zero with prim = 1 }
   | Variadic (prim, _) -> (
-    match prim with Make_block _ | Make_array _ | Make_mixed_block _ -> alloc)
+    match prim with Make_block _ | Make_array _ -> alloc)
   [@@ocaml.warning "-fragile-match"]
 
 let branch = { zero with branch = 1 }

--- a/middle_end/flambda2/tests/api_tests/extension_meet.ml
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.ml
@@ -32,20 +32,22 @@ let _test_recursive_meet () =
   let env = TE.add_definition env nb_v Flambda_kind.value in
   let alias name = T.alias_type_of Flambda_kind.value (Simple.name name) in
   let mk_block_type name =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
-      Alloc_mode.For_types.heap
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only Alloc_mode.For_types.heap
       ~fields:[alias name]
   in
   let env = TE.add_equation env n_x (mk_block_type n_y) in
   let env = TE.add_equation env n_y (mk_block_type n_z) in
   let env = TE.add_equation env n_z (mk_block_type n_x) in
   let ty1 =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only
       ~fields:[alias n_v; alias n_v]
       Alloc_mode.For_types.heap
   in
   let ty2 =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only
       ~fields:[alias n_x; alias n_y]
       Alloc_mode.For_types.heap
   in
@@ -71,12 +73,14 @@ let _test_bottom_detection () =
       (Simple.const (Reg_width_const.const_int (Targetint_31_63.of_int n)))
   in
   let ty1 =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only
       ~fields:[alias n_x; alias n_x]
       Alloc_mode.For_types.heap
   in
   let ty2 =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only
       ~fields:[const 0; const 1]
       Alloc_mode.For_types.heap
   in
@@ -102,18 +106,21 @@ let _test_bottom_recursive () =
       (Simple.const (Reg_width_const.const_int (Targetint_31_63.of_int n)))
   in
   let ty_x =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only
       ~fields:[T.unknown Flambda_kind.value; alias n_x]
       Alloc_mode.For_types.heap
   in
   let env = TE.add_equation env n_x ty_x in
   let ty_cell2 =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only
       ~fields:[const 1; T.unknown Flambda_kind.value]
       Alloc_mode.For_types.heap
   in
   let ty_cell1 =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only
       ~fields:[const 0; ty_cell2]
       Alloc_mode.For_types.heap
   in
@@ -146,17 +153,20 @@ let test_double_recursion () =
   let env = TE.add_definition env nb_z Flambda_kind.value in
   let alias name = T.alias_type_of Flambda_kind.value (Simple.name name) in
   let ty_x =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only
       ~fields:[alias n_x; alias n_y; alias n_z]
       Alloc_mode.For_types.heap
   in
   let ty_y =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only
       ~fields:[alias n_y; alias n_z; alias n_x]
       Alloc_mode.For_types.heap
   in
   let ty_z =
-    T.immutable_block ~is_unique:false Tag.zero ~field_kind:Flambda_kind.value
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:Flambda_kind.Block_shape.Value_only
       ~fields:[alias n_z; alias n_x; alias n_y]
       Alloc_mode.For_types.heap
   in

--- a/middle_end/flambda2/tests/meet_test.ml
+++ b/middle_end/flambda2/tests/meet_test.ml
@@ -21,8 +21,9 @@ let test_meet_chains_two_vars () =
   let env = TE.add_definition env (Bound_name.create_var var1') K.value in
   let env =
     TE.add_equation env (Name.var var1)
-      (T.immutable_block ~is_unique:false Tag.zero ~field_kind:K.value
-         Alloc_mode.For_types.heap ~fields:[T.any_tagged_immediate])
+      (T.immutable_block ~is_unique:false Tag.zero
+         ~shape:K.Block_shape.Value_only Alloc_mode.For_types.heap
+         ~fields:[T.any_tagged_immediate])
   in
   let var2 = Variable.create "var2" in
   let var2' = Bound_var.create var2 Name_mode.normal in
@@ -54,8 +55,9 @@ let test_meet_chains_three_vars () =
   let env = TE.add_definition env (Bound_name.create_var var1') K.value in
   let env =
     TE.add_equation env (Name.var var1)
-      (T.immutable_block ~is_unique:false Tag.zero ~field_kind:K.value
-         Alloc_mode.For_types.heap ~fields:[T.any_tagged_immediate])
+      (T.immutable_block ~is_unique:false Tag.zero
+         ~shape:K.Block_shape.Value_only Alloc_mode.For_types.heap
+         ~fields:[T.any_tagged_immediate])
   in
   let var2 = Variable.create "var2" in
   let var2' = Bound_var.create var2 Name_mode.normal in
@@ -102,18 +104,24 @@ let meet_variants_don't_lose_aliases () =
   let ty1 =
     let non_const_ctors =
       Tag.Scannable.Map.of_list
-        [ Tag.Scannable.create_exn 0, [T.alias_type_of K.value (Simple.var vx)];
-          Tag.Scannable.create_exn 1, [T.alias_type_of K.value (Simple.var vy)]
-        ]
+        [ ( Tag.Scannable.create_exn 0,
+            (K.Block_shape.Value_only, [T.alias_type_of K.value (Simple.var vx)])
+          );
+          ( Tag.Scannable.create_exn 1,
+            (K.Block_shape.Value_only, [T.alias_type_of K.value (Simple.var vy)])
+          ) ]
     in
     T.variant ~const_ctors ~non_const_ctors Alloc_mode.For_types.heap
   in
   let ty2 =
     let non_const_ctors =
       Tag.Scannable.Map.of_list
-        [ Tag.Scannable.create_exn 0, [T.alias_type_of K.value (Simple.var va)];
-          Tag.Scannable.create_exn 1, [T.alias_type_of K.value (Simple.var vb)]
-        ]
+        [ ( Tag.Scannable.create_exn 0,
+            (K.Block_shape.Value_only, [T.alias_type_of K.value (Simple.var va)])
+          );
+          ( Tag.Scannable.create_exn 1,
+            (K.Block_shape.Value_only, [T.alias_type_of K.value (Simple.var vb)])
+          ) ]
     in
     T.variant ~const_ctors ~non_const_ctors Alloc_mode.For_types.heap
   in
@@ -148,14 +156,14 @@ let test_meet_two_blocks () =
   let env = defines env [block1; block2; field1; field2] in
   let env =
     TE.add_equation env (Name.var block1)
-      (T.immutable_block ~is_unique:false Tag.zero ~field_kind:K.value
-         Alloc_mode.For_types.heap
+      (T.immutable_block ~is_unique:false Tag.zero
+         ~shape:K.Block_shape.Value_only Alloc_mode.For_types.heap
          ~fields:[T.alias_type_of K.value (Simple.var field1)])
   in
   let env =
     TE.add_equation env (Name.var block2)
-      (T.immutable_block ~is_unique:false Tag.zero ~field_kind:K.value
-         Alloc_mode.For_types.heap
+      (T.immutable_block ~is_unique:false Tag.zero
+         ~shape:K.Block_shape.Value_only Alloc_mode.For_types.heap
          ~fields:[T.alias_type_of K.value (Simple.var field2)])
   in
   (* let test b1 b2 env =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -92,6 +92,10 @@ let make_block ~dbg kind alloc_mode args =
   | Values (tag, _) -> C.make_alloc ~mode dbg (Tag.Scannable.to_int tag) args
   | Naked_floats ->
     C.make_float_alloc ~mode dbg (Tag.to_int Tag.double_array_tag) args
+  | Mixed (tag, shape) ->
+    C.make_mixed_alloc ~mode dbg (Tag.Scannable.to_int tag)
+      (K.Mixed_block_shape.to_lambda shape)
+      args
 
 let block_load ~dbg (kind : P.Block_access_kind.t) (mutability : Mutability.t)
     ~block ~index =
@@ -106,15 +110,21 @@ let block_load ~dbg (kind : P.Block_access_kind.t) (mutability : Mutability.t)
   | Naked_floats _ -> C.unboxed_float_array_ref block index dbg
   | Mixed { field_kind = Flat_suffix field_kind; _ } -> (
     match field_kind with
-    | Imm -> C.get_field_computed Immediate mutability ~block ~index dbg
-    | Float_boxed | Float64 ->
+    | Value ->
+      (* The flat suffix cannot store scannable values, so this must be an immediate *)
+      C.get_field_computed Immediate mutability ~block ~index dbg
+    | Naked_number Naked_float ->
       (* CR layouts v5.1: We should use the mutability here to generate better
          code if the load is immutable. *)
       C.unboxed_float_array_ref block index dbg
-    | Float32 -> C.get_field_unboxed_float32 mutability ~block ~index dbg
-    | Bits32 -> C.get_field_unboxed_int32 mutability ~block ~index dbg
-    | Bits64 | Word ->
-      C.get_field_unboxed_int64_or_nativeint mutability ~block ~index dbg)
+    | Naked_number Naked_float32 -> C.get_field_unboxed_float32 mutability ~block ~index dbg
+    | Naked_number Naked_int32 -> C.get_field_unboxed_int32 mutability ~block ~index dbg
+    | Naked_number (Naked_int64 | Naked_nativeint) ->
+      C.get_field_unboxed_int64_or_nativeint mutability ~block ~index dbg
+    | Naked_number Naked_vec128 ->
+      Misc.fatal_error "Naked_vec128 not supported in mixed blocks"
+    | Naked_number Naked_immediate | Region | Rec_info ->
+      Misc.fatal_errorf "Unexpected kind in mixed block field: %a" K.print field_kind)
 
 let block_set ~dbg (kind : P.Block_access_kind.t) (init : P.Init_or_assign.t)
     ~block ~index ~new_value =
@@ -130,13 +140,18 @@ let block_set ~dbg (kind : P.Block_access_kind.t) (init : P.Init_or_assign.t)
     | Naked_floats _ -> C.float_array_set block index new_value dbg
     | Mixed { field_kind = Flat_suffix field_kind; _ } -> (
       match field_kind with
-      | Imm ->
+      | Value ->
+        (* See comment in [block_load] about assuming [Immediate] *)
         C.setfield_computed Immediate init_or_assign block index new_value dbg
-      | Float_boxed | Float64 -> C.float_array_set block index new_value dbg
-      | Float32 -> C.setfield_unboxed_float32 block index new_value dbg
-      | Bits32 -> C.setfield_unboxed_int32 block index new_value dbg
-      | Bits64 | Word ->
-        C.setfield_unboxed_int64_or_nativeint block index new_value dbg)
+      | Naked_number Naked_float -> C.float_array_set block index new_value dbg
+      | Naked_number Naked_float32 -> C.setfield_unboxed_float32 block index new_value dbg
+      | Naked_number Naked_int32 -> C.setfield_unboxed_int32 block index new_value dbg
+      | Naked_number (Naked_int64 | Naked_nativeint) ->
+        C.setfield_unboxed_int64_or_nativeint block index new_value dbg
+      | Naked_number Naked_vec128 ->
+        Misc.fatal_error "Naked_vec128 not supported in mixed blocks"
+      | Naked_number Naked_immediate | Region | Rec_info ->
+        Misc.fatal_errorf "Unexpected kind in mixed block field: %a" K.print field_kind)
   in
   C.return_unit dbg expr
 
@@ -155,13 +170,6 @@ let make_array ~dbg kind alloc_mode args =
   | Naked_int64s -> C.allocate_unboxed_int64_array ~elements:args mode dbg
   | Naked_nativeints ->
     C.allocate_unboxed_nativeint_array ~elements:args mode dbg
-
-let make_mixed_block ~dbg tag shape alloc_mode args =
-  check_alloc_fields args;
-  let mode = Alloc_mode.For_allocations.to_lambda alloc_mode in
-  let tag = Tag.Scannable.to_int tag in
-  let shape = P.Mixed_block_kind.to_lambda shape in
-  C.make_mixed_alloc ~mode dbg tag shape args
 
 let array_length ~dbg arr (kind : P.Array_kind.t) =
   match kind with
@@ -819,8 +827,6 @@ let variadic_primitive _env dbg f args =
   match (f : P.variadic_primitive) with
   | Make_block (kind, _mut, alloc_mode) -> make_block ~dbg kind alloc_mode args
   | Make_array (kind, _mut, alloc_mode) -> make_array ~dbg kind alloc_mode args
-  | Make_mixed_block (tag, shape, _mut, alloc_mode) ->
-    make_mixed_block ~dbg tag shape alloc_mode args
 
 let arg ?consider_inlining_effectful_expressions ~dbg env res simple =
   C.simple ?consider_inlining_effectful_expressions ~dbg env res simple
@@ -887,8 +893,7 @@ let consider_inlining_effectful_expressions p =
      that the Cmm translation for such primitive both respects right-to-left
      evaluation order and does not duplicate any arguments. *)
   match[@ocaml.warning "-4"] (p : P.t) with
-  | Variadic ((Make_block _ | Make_array _ | Make_mixed_block _), _) ->
-    Some true
+  | Variadic ((Make_block _ | Make_array _), _) -> Some true
   | Nullary _ | Unary _ | Binary _ | Ternary _ -> None
 
 let prim_simple env res dbg p =
@@ -939,8 +944,7 @@ let prim_simple env res dbg p =
     let effs = Ece.join (Ece.join x.effs y.effs) z.effs in
     let expr = ternary_primitive env dbg ternary x.cmm y.cmm z.cmm in
     Env.simple expr free_vars, None, env, res, effs
-  | Variadic
-      (((Make_block _ | Make_array _ | Make_mixed_block _) as variadic), l) ->
+  | Variadic (((Make_block _ | Make_array _) as variadic), l) ->
     let args, free_vars, env, res, effs =
       arg_list ?consider_inlining_effectful_expressions ~dbg env res l
     in
@@ -975,8 +979,7 @@ let prim_complex env res dbg p =
       let To_cmm_env.{ env; res; expr = z } = arg env res z in
       let effs = Ece.join (Ece.join x.effs y.effs) z.effs in
       prim', [x; y; z], effs, env, res
-    | Variadic
-        (((Make_block _ | Make_array _ | Make_mixed_block _) as variadic), l) ->
+    | Variadic (((Make_block _ | Make_array _) as variadic), l) ->
       let prim' = P.Without_args.Variadic variadic in
       let args, env, res, effs =
         arg_list' ?consider_inlining_effectful_expressions ~dbg env res l

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -111,20 +111,24 @@ let block_load ~dbg (kind : P.Block_access_kind.t) (mutability : Mutability.t)
   | Mixed { field_kind = Flat_suffix field_kind; _ } -> (
     match field_kind with
     | Value ->
-      (* The flat suffix cannot store scannable values, so this must be an immediate *)
+      (* The flat suffix cannot store scannable values, so this must be an
+         immediate *)
       C.get_field_computed Immediate mutability ~block ~index dbg
     | Naked_number Naked_float ->
       (* CR layouts v5.1: We should use the mutability here to generate better
          code if the load is immutable. *)
       C.unboxed_float_array_ref block index dbg
-    | Naked_number Naked_float32 -> C.get_field_unboxed_float32 mutability ~block ~index dbg
-    | Naked_number Naked_int32 -> C.get_field_unboxed_int32 mutability ~block ~index dbg
+    | Naked_number Naked_float32 ->
+      C.get_field_unboxed_float32 mutability ~block ~index dbg
+    | Naked_number Naked_int32 ->
+      C.get_field_unboxed_int32 mutability ~block ~index dbg
     | Naked_number (Naked_int64 | Naked_nativeint) ->
       C.get_field_unboxed_int64_or_nativeint mutability ~block ~index dbg
     | Naked_number Naked_vec128 ->
       Misc.fatal_error "Naked_vec128 not supported in mixed blocks"
     | Naked_number Naked_immediate | Region | Rec_info ->
-      Misc.fatal_errorf "Unexpected kind in mixed block field: %a" K.print field_kind)
+      Misc.fatal_errorf "Unexpected kind in mixed block field: %a" K.print
+        field_kind)
 
 let block_set ~dbg (kind : P.Block_access_kind.t) (init : P.Init_or_assign.t)
     ~block ~index ~new_value =
@@ -144,14 +148,17 @@ let block_set ~dbg (kind : P.Block_access_kind.t) (init : P.Init_or_assign.t)
         (* See comment in [block_load] about assuming [Immediate] *)
         C.setfield_computed Immediate init_or_assign block index new_value dbg
       | Naked_number Naked_float -> C.float_array_set block index new_value dbg
-      | Naked_number Naked_float32 -> C.setfield_unboxed_float32 block index new_value dbg
-      | Naked_number Naked_int32 -> C.setfield_unboxed_int32 block index new_value dbg
+      | Naked_number Naked_float32 ->
+        C.setfield_unboxed_float32 block index new_value dbg
+      | Naked_number Naked_int32 ->
+        C.setfield_unboxed_int32 block index new_value dbg
       | Naked_number (Naked_int64 | Naked_nativeint) ->
         C.setfield_unboxed_int64_or_nativeint block index new_value dbg
       | Naked_number Naked_vec128 ->
         Misc.fatal_error "Naked_vec128 not supported in mixed blocks"
       | Naked_number Naked_immediate | Region | Rec_info ->
-        Misc.fatal_errorf "Unexpected kind in mixed block field: %a" K.print field_kind)
+        Misc.fatal_errorf "Unexpected kind in mixed block field: %a" K.print
+          field_kind)
   in
   C.return_unit dbg expr
 

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1250,8 +1250,12 @@ end = struct
         TG.alias_type_of Flambda_kind.value (Simple.symbol symbol)
       | Block_approximation (tag, fields, alloc_mode) ->
         let fields = List.map type_from_approx (Array.to_list fields) in
-        MTC.immutable_block ~is_unique:false tag ~field_kind:Flambda_kind.value
-          ~fields alloc_mode
+        let shape : Flambda_kind.Block_shape.t =
+          if Tag.equal tag Tag.double_array_tag
+          then Float_record
+          else Value_only
+        in
+        MTC.immutable_block ~is_unique:false tag ~shape ~fields alloc_mode
       | Closure_approximation
           { code_id;
             function_slot;
@@ -1415,12 +1419,15 @@ end = struct
             then
               match TG.Row_like_for_blocks.get_singleton blocks with
               | None -> Value_unknown
-              | Some ((tag, _size), fields, alloc_mode) ->
+              | Some
+                  (tag, (Value_only | Float_record), _size, fields, alloc_mode)
+                ->
                 let fields =
                   List.map type_to_approx
                     (TG.Product.Int_indexed.components fields)
                 in
                 Block_approximation (tag, Array.of_list fields, alloc_mode)
+              | Some (_, Mixed_record _, _, _, _) -> Value_unknown
             else Value_unknown))
       | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
       | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -461,7 +461,7 @@ val any_block : t
 val immutable_block :
   is_unique:bool ->
   Tag.t ->
-  field_kind:Flambda_kind.t ->
+  shape:Flambda_kind.Block_shape.t ->
   Alloc_mode.For_types.t ->
   fields:t list ->
   t
@@ -472,7 +472,7 @@ val immutable_block :
 val immutable_block_with_size_at_least :
   tag:Tag.t Or_unknown.t ->
   n:Targetint_31_63.t ->
-  field_kind:Flambda_kind.t ->
+  shape:Flambda_kind.Block_shape.t ->
   field_n_minus_one:Variable.t ->
   t
 
@@ -480,7 +480,7 @@ val mutable_block : Alloc_mode.For_types.t -> t
 
 val variant :
   const_ctors:t ->
-  non_const_ctors:t list Tag.Scannable.Map.t ->
+  non_const_ctors:(Flambda_kind.Block_shape.t * t list) Tag.Scannable.Map.t ->
   Alloc_mode.For_types.t ->
   t
 
@@ -593,7 +593,8 @@ val meet_naked_nativeints :
 
 type variant_like_proof = private
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
-    non_const_ctors_with_sizes : Targetint_31_63.t Tag.Scannable.Map.t
+    non_const_ctors_with_sizes :
+      (Targetint_31_63.t * Flambda_kind.Block_shape.t) Tag.Scannable.Map.t
   }
 
 val meet_variant_like : Typing_env.t -> t -> variant_like_proof meet_shortcut
@@ -634,10 +635,15 @@ val prove_is_or_is_not_a_boxed_float :
   Typing_env.t -> t -> bool proof_of_property
 
 val prove_unique_tag_and_size :
-  Typing_env.t -> t -> (Tag.t * Targetint_31_63.t) proof_of_property
+  Typing_env.t ->
+  t ->
+  (Tag.t * Flambda_kind.Block_shape.t * Targetint_31_63.t) proof_of_property
 
 val prove_unique_fully_constructed_immutable_heap_block :
-  Typing_env.t -> t -> (Tag_and_size.t * Simple.t list) proof_of_property
+  Typing_env.t ->
+  t ->
+  (Tag.t * Flambda_kind.Block_shape.t * Targetint_31_63.t * Simple.t list)
+  proof_of_property
 
 val prove_is_int : Typing_env.t -> t -> bool proof_of_property
 

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -34,13 +34,7 @@ let unknown (kind : K.t) =
 let unknown_like t = unknown (TG.kind t)
 
 let unknown_from_shape (shape : K.Block_shape.t) index =
-  let kind =
-    match shape with
-    | Value_only -> K.value
-    | Float_record -> K.naked_float
-    | Mixed_record fields -> (K.Mixed_block_shape.field_kinds fields).(index)
-  in
-  unknown kind
+  unknown (K.Block_shape.element_kind shape index)
 
 let bottom (kind : K.t) =
   match kind with
@@ -175,13 +169,7 @@ let immutable_block_with_size_at_least ~tag ~n ~shape ~field_n_minus_one =
   let n = Targetint_31_63.to_int n in
   let field_tys =
     List.init n (fun index ->
-        let field_kind =
-          match (shape : K.Block_shape.t) with
-          | Value_only -> K.value
-          | Float_record -> K.naked_float
-          | Mixed_record kinds ->
-            (K.Mixed_block_shape.field_kinds kinds).(index)
-        in
+        let field_kind = K.Block_shape.element_kind shape index in
         if index < n - 1
         then unknown field_kind
         else TG.alias_type_of field_kind (Simple.var field_n_minus_one))

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -21,6 +21,8 @@ val unknown : Flambda_kind.t -> Type_grammar.t
 
 val unknown_like : Type_grammar.t -> Type_grammar.t
 
+val unknown_from_shape : Flambda_kind.Block_shape.t -> int -> Type_grammar.t
+
 val bottom : Flambda_kind.t -> Type_grammar.t
 
 val bottom_like : Type_grammar.t -> Type_grammar.t
@@ -107,7 +109,7 @@ val blocks_with_these_tags :
 val immutable_block :
   is_unique:bool ->
   Tag.t ->
-  field_kind:Flambda_kind.t ->
+  shape:Flambda_kind.Block_shape.t ->
   Alloc_mode.For_types.t ->
   fields:Type_grammar.t list ->
   Type_grammar.t
@@ -115,13 +117,14 @@ val immutable_block :
 val immutable_block_with_size_at_least :
   tag:Tag.t Or_unknown.t ->
   n:Targetint_31_63.t ->
-  field_kind:Flambda_kind.t ->
+  shape:Flambda_kind.Block_shape.t ->
   field_n_minus_one:Variable.t ->
   Type_grammar.t
 
 val variant :
   const_ctors:Type_grammar.t ->
-  non_const_ctors:Type_grammar.t list Tag.Scannable.Map.t ->
+  non_const_ctors:
+    (Flambda_kind.Block_shape.t * Type_grammar.t list) Tag.Scannable.Map.t ->
   Alloc_mode.For_types.t ->
   Type_grammar.t
 

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -2738,7 +2738,9 @@ module Row_like_for_blocks = struct
       match Tag.Map.get_singleton known_tags with
       | None -> None
       | Some (_tag, Unknown) -> None
-      (* CR pchambart: We lose the tag information when we don't know the shape. Example where this could matter: in Provers.prove_physical_equality this could miss some physical inequality *)
+      (* CR pchambart: We lose the tag information when we don't know the shape.
+         Example where this could matter: in Provers.prove_physical_equality
+         this could miss some physical inequality *)
       | Some (tag, Known { maps_to; index; env_extension = _ }) -> (
         (* If this is a singleton all the information from the env_extension is
            already part of the environment *)
@@ -2751,8 +2753,10 @@ module Row_like_for_blocks = struct
 
   let get_field t index : _ Or_unknown_or_bottom.t =
     match get_singleton t with
-    (* CR pchambart vlaviron: This is missing the 'Other' case. It would be easy to be efficient to get the the field when there is only the 'Other' case.
-      Also we could be slightly better when there are multiple tags with exactly the same type: we could do a trivial join *)
+    (* CR pchambart vlaviron: This is missing the 'Other' case. It would be easy
+       to be efficient to get the the field when there is only the 'Other' case.
+       Also we could be slightly better when there are multiple tags with
+       exactly the same type: we could do a trivial join *)
     | None -> Unknown
     | Some (_tag, _shape, size, maps_to, _alloc_mode) -> (
       if Targetint_31_63.( <= ) size index

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -2738,6 +2738,7 @@ module Row_like_for_blocks = struct
       match Tag.Map.get_singleton known_tags with
       | None -> None
       | Some (_tag, Unknown) -> None
+      (* CR pchambart: We lose the tag information when we don't know the shape. Example where this could matter: in Provers.prove_physical_equality this could miss some physical inequality *)
       | Some (tag, Known { maps_to; index; env_extension = _ }) -> (
         (* If this is a singleton all the information from the env_extension is
            already part of the environment *)
@@ -2750,6 +2751,8 @@ module Row_like_for_blocks = struct
 
   let get_field t index : _ Or_unknown_or_bottom.t =
     match get_singleton t with
+    (* CR pchambart vlaviron: This is missing the 'Other' case. It would be easy to be efficient to get the the field when there is only the 'Other' case.
+      Also we could be slightly better when there are multiple tags with exactly the same type: we could do a trivial join *)
     | None -> Unknown
     | Some (_tag, _shape, size, maps_to, _alloc_mode) -> (
       if Targetint_31_63.( <= ) size index

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -102,7 +102,7 @@ and ('lattice, 'shape) row_like_index = private
     shape : 'shape
   }
 
-and ('lattice, 'shape, 'maps_to) row_like_case =
+and ('lattice, 'shape, 'maps_to) row_like_case = private
   { maps_to : 'maps_to;
     index : ('lattice, 'shape) row_like_index;
     env_extension : env_extension
@@ -111,13 +111,13 @@ and ('lattice, 'shape, 'maps_to) row_like_case =
 and row_like_block_case =
   (Block_size.t, Flambda_kind.Block_shape.t, t array) row_like_case
 
-and row_like_for_blocks =
+and row_like_for_blocks = private
   { known_tags : row_like_block_case Or_unknown.t Tag.Map.t;
     other_tags : row_like_block_case Or_bottom.t;
     alloc_mode : Alloc_mode.For_types.t
   }
 
-and row_like_for_closures =
+and row_like_for_closures = private
   { known_closures :
       (Set_of_closures_contents.t, unit, closures_entry) row_like_case
       Function_slot.Map.t;

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -93,11 +93,11 @@ and head_of_kind_rec_info = Rec_info_expr.t
 
 and head_of_kind_region = unit
 
-and 'lattice row_like_index_domain =
+and 'lattice row_like_index_domain = private
   | Known of 'lattice
   | At_least of 'lattice
 
-and ('lattice, 'shape) row_like_index =
+and ('lattice, 'shape) row_like_index = private
   { domain : 'lattice row_like_index_domain;
     shape : 'shape
   }

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -1095,7 +1095,7 @@ and meet_row_like :
           else (
             result_is_t1 := false;
             result_is_t2 := false);
-          Some (TG.Row_like_case.create ~maps_to ~index ~env_extension)))
+          Some (Or_unknown.Known (TG.Row_like_case.create ~maps_to ~index ~env_extension))))
   in
   let meet_knowns case1 case2 :
       ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option =
@@ -1126,9 +1126,7 @@ and meet_row_like :
             result_is_t2 := false;
             Some (Known other_case))
         | Known case1 ->
-          Option.map
-            (fun case -> Or_unknown.Known case)
-            (meet_case base_env case1 other_case)))
+            meet_case base_env case1 other_case))
     | None, Some case2 -> (
       match other1 with
       | Bottom ->
@@ -1148,8 +1146,6 @@ and meet_row_like :
             result_is_t2 := false;
             Some (Known other_case))
         | Known case2 ->
-          Option.map
-            (fun case -> Or_unknown.Known case)
             (meet_case base_env other_case case2)))
     | Some case1, Some case2 -> (
       match case1, case2 with
@@ -1177,8 +1173,6 @@ and meet_row_like :
           result_is_t1 := false;
           Some (Known case))
       | Known case1, Known case2 ->
-        Option.map
-          (fun case -> Or_unknown.Known case)
           (meet_case base_env case1 case2))
   in
   let known =

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -371,9 +371,7 @@ let[@inline always] meet_unknown meet_contents ~contents_is_bottom env
   | _, Unknown -> Ok (Left_input, env)
   | Unknown, _ -> Ok (Right_input, env)
   | Known contents1, Known contents2 ->
-    map_result
-      ~f:(fun contents -> Or_unknown.Known contents)
-      (meet_contents env contents1 contents2)
+    map_result ~f:Or_unknown.known (meet_contents env contents1 contents2)
 
 let[@inline always] join_unknown join_contents (env : Join_env.t)
     (or_unknown1 : _ Or_unknown.t) (or_unknown2 : _ Or_unknown.t) :
@@ -1245,8 +1243,8 @@ and meet_row_like_for_closures env
   let merge_map_known merge_case known1 known2 =
     Function_slot.Map.merge
       (fun fslot case1 case2 ->
-        let case1 = Option.map (fun case -> Or_unknown.Known case) case1 in
-        let case2 = Option.map (fun case -> Or_unknown.Known case) case2 in
+        let case1 = Option.map Or_unknown.known case1 in
+        let case2 = Option.map Or_unknown.known case2 in
         match merge_case fslot case1 case2 with
         | None -> None
         | Some (Or_unknown.Known case) -> Some case
@@ -1869,8 +1867,8 @@ and join_row_like_for_closures env
   let merge_map_known join_case known1 known2 =
     Function_slot.Map.merge
       (fun function_slot case1 case2 ->
-        let case1 = Option.map (fun case -> Or_unknown.Known case) case1 in
-        let case2 = Option.map (fun case -> Or_unknown.Known case) case2 in
+        let case1 = Option.map Or_unknown.known case1 in
+        let case2 = Option.map Or_unknown.known case2 in
         match (join_case function_slot case1 case2 : _ Or_unknown.t option) with
         | None -> None
         | Some (Known case) -> Some case

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -1095,7 +1095,9 @@ and meet_row_like :
           else (
             result_is_t1 := false;
             result_is_t2 := false);
-          Some (Or_unknown.Known (TG.Row_like_case.create ~maps_to ~index ~env_extension))))
+          Some
+            (Or_unknown.Known
+               (TG.Row_like_case.create ~maps_to ~index ~env_extension))))
   in
   let meet_knowns case1 case2 :
       ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option =
@@ -1125,8 +1127,7 @@ and meet_row_like :
             result_is_t1 := false;
             result_is_t2 := false;
             Some (Known other_case))
-        | Known case1 ->
-            meet_case base_env case1 other_case))
+        | Known case1 -> meet_case base_env case1 other_case))
     | None, Some case2 -> (
       match other1 with
       | Bottom ->
@@ -1145,8 +1146,7 @@ and meet_row_like :
             result_is_t1 := false;
             result_is_t2 := false;
             Some (Known other_case))
-        | Known case2 ->
-            (meet_case base_env other_case case2)))
+        | Known case2 -> meet_case base_env other_case case2))
     | Some case1, Some case2 -> (
       match case1, case2 with
       | Unknown, Unknown ->
@@ -1172,8 +1172,7 @@ and meet_row_like :
           join_result_env env;
           result_is_t1 := false;
           Some (Known case))
-      | Known case1, Known case2 ->
-          (meet_case base_env case1 case2))
+      | Known case1, Known case2 -> meet_case base_env case1 case2)
   in
   let known =
     merge_map_known
@@ -1192,7 +1191,8 @@ and meet_row_like :
     | Ok other1, Ok other2 -> (
       match meet_case base_env other1 other2 with
       | None -> Bottom
-      | Some r -> Ok r)
+      | Some Unknown -> Misc.fatal_error "meet_case should not produce Unknown"
+      | Some (Known r) -> Ok r)
   in
   if is_empty_map_known known
      && match other with Bottom -> true | Ok _ -> false

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -1091,15 +1091,13 @@ and meet_row_like :
             (Or_unknown.Known
                (TG.Row_like_case.create ~maps_to ~index ~env_extension))))
   in
-  let meet_knowns case1 case2 :
+  let meet_knowns
+      (case1 :
+        ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option)
+      (case2 :
+        ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option) :
       ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option =
-    match
-      ( (case1
-          : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option),
-        (case2
-          : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option)
-      )
-    with
+    match case1, case2 with
     | None, None -> None
     | Some case1, None -> (
       match other2 with

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -1729,24 +1729,21 @@ and join_row_like :
     match join_shape i1.shape i2.shape with
     | Unknown -> Unknown
     | Known shape -> (
+      let return_index domain =
+        Or_unknown.Known (TG.Row_like_index.create ~domain ~shape)
+      in
       match i1.domain, i2.domain with
       | Known i1', Known i2' ->
         if equal_index i1' i2'
-        then Known (TG.Row_like_index.create ~domain:i1.domain ~shape)
+        then return_index i1.domain
         else
           (* We can't represent exactly the union, This is the best
              approximation *)
-          Known
-            (TG.Row_like_index.create
-               ~domain:(TG.Row_like_index_domain.at_least (inter_index i1' i2'))
-               ~shape)
+          return_index (TG.Row_like_index_domain.at_least (inter_index i1' i2'))
       | Known i1', At_least i2'
       | At_least i1', Known i2'
       | At_least i1', At_least i2' ->
-        Known
-          (TG.Row_like_index.create
-             ~domain:(TG.Row_like_index_domain.at_least (inter_index i1' i2'))
-             ~shape))
+        return_index (TG.Row_like_index_domain.at_least (inter_index i1' i2')))
   in
   let join_case join_env
       (case1 : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t)

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -737,15 +737,13 @@ and meet_row_like :
               (Or_unknown.Known
                  (TG.Row_like_case.create ~maps_to ~index ~env_extension)))))
   in
-  let meet_knowns case1 case2 :
+  let meet_knowns
+      (case1 :
+        ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option)
+      (case2 :
+        ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option) :
       ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option =
-    match
-      ( (case1
-          : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option),
-        (case2
-          : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option)
-      )
-    with
+    match case1, case2 with
     | None, None -> None
     | Some case1, None -> (
       match other2 with

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -754,9 +754,7 @@ and meet_row_like :
           join_env_extension other_case.env_extension;
           Some (Known other_case)
         | Known case1 ->
-          Option.map
-            (fun case -> Or_unknown.Known case)
-            (meet_case case1 other_case)))
+          Option.map Or_unknown.known (meet_case case1 other_case)))
     | None, Some case2 -> (
       match other1 with
       | Bottom -> None
@@ -766,9 +764,7 @@ and meet_row_like :
           join_env_extension other_case.env_extension;
           Some (Known other_case)
         | Known case2 ->
-          Option.map
-            (fun case -> Or_unknown.Known case)
-            (meet_case other_case case2)))
+          Option.map Or_unknown.known (meet_case other_case case2)))
     | Some case1, Some case2 -> (
       match case1, case2 with
       | Unknown, Unknown ->
@@ -778,7 +774,7 @@ and meet_row_like :
         join_env_extension case.env_extension;
         Some (Known case)
       | Known case1, Known case2 ->
-        Option.map (fun case -> Or_unknown.Known case) (meet_case case1 case2))
+        Option.map Or_unknown.known (meet_case case1 case2))
   in
   let known =
     merge_map_known
@@ -837,8 +833,8 @@ and meet_row_like_for_closures env
   let merge_map_known merge_case known1 known2 =
     Function_slot.Map.merge
       (fun fslot case1 case2 ->
-        let case1 = Option.map (fun case -> Or_unknown.Known case) case1 in
-        let case2 = Option.map (fun case -> Or_unknown.Known case) case2 in
+        let case1 = Option.map Or_unknown.known case1 in
+        let case2 = Option.map Or_unknown.known case2 in
         match merge_case fslot case1 case2 with
         | None -> None
         | Some (Or_unknown.Known case) -> Some case
@@ -1603,8 +1599,8 @@ and join_row_like_for_closures env
   let merge_map_known join_case known1 known2 =
     Function_slot.Map.merge
       (fun function_slot case1 case2 ->
-        let case1 = Option.map (fun case -> Or_unknown.Known case) case1 in
-        let case2 = Option.map (fun case -> Or_unknown.Known case) case2 in
+        let case1 = Option.map Or_unknown.known case1 in
+        let case2 = Option.map Or_unknown.known case2 in
         match (join_case function_slot case1 case2 : _ Or_unknown.t option) with
         | None -> None
         | Some (Known case) -> Some case

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -1444,8 +1444,8 @@ and join_row_like :
       join_shape:('shape -> 'shape -> 'shape Or_unknown.t) ->
       merge_map_known:
         (('row_tag ->
-         ('lattice, 'shape, 'maps_to) TG.Row_like_case.t option ->
-         ('lattice, 'shape, 'maps_to) TG.Row_like_case.t option ->
+         ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option ->
+         ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option ->
          ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option) ->
         'known ->
         'known ->
@@ -1499,11 +1499,16 @@ and join_row_like :
         in
         TG.Row_like_case.create ~maps_to ~index ~env_extension)
   in
-  let join_knowns case1 case2 :
+  let join_knowns
+      (case1 :
+        ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option)
+      (case2 :
+        ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option) :
       ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option =
     match case1, case2 with
     | None, None -> None
-    | Some case1, None -> (
+    | Some Unknown, _ | _, Some Unknown -> Some Unknown
+    | Some (Known case1), None -> (
       let only_case1 () =
         (* cf. Type_descr.join_head_or_unknown_or_bottom, we need to join these
            to ensure that free variables not present in the target env are
@@ -1521,7 +1526,7 @@ and join_row_like :
       match other2 with
       | Bottom -> only_case1 ()
       | Ok other_case -> Some (join_case join_env case1 other_case))
-    | None, Some case2 -> (
+    | None, Some (Known case2) -> (
       let only_case2 () =
         (* See at the other bottom case *)
         let join_env =
@@ -1536,7 +1541,8 @@ and join_row_like :
       match other1 with
       | Bottom -> only_case2 ()
       | Ok other_case -> Some (join_case join_env other_case case2))
-    | Some case1, Some case2 -> Some (join_case join_env case1 case2)
+    | Some (Known case1), Some (Known case2) ->
+      Some (join_case join_env case1 case2)
   in
   let known =
     merge_map_known
@@ -1581,22 +1587,11 @@ and join_row_like_for_blocks env
   let join_shape shape1 shape2 : _ Or_unknown.t =
     if K.Block_shape.equal shape1 shape2 then Known shape1 else Unknown
   in
-  let merge_map_known join_case known1 known2 =
-    Tag.Map.merge
-      (fun tag (case1 : _ Or_unknown.t option) (case2 : _ Or_unknown.t option) :
-           _ Or_unknown.t option ->
-        match case1, case2 with
-        | None, case | case, None -> case
-        | Some Unknown, Some _ | Some _, Some Unknown -> Some Unknown
-        | Some (Known case1), Some (Known case2) ->
-          join_case tag (Some case1) (Some case2))
-      known1 known2
-  in
   Or_unknown.map
     (join_row_like ~join_maps_to:join_int_indexed_product
        ~equal_index:TG.Block_size.equal ~inter_index:TG.Block_size.inter
-       ~join_shape ~merge_map_known env ~known1 ~known2 ~other1 ~other2)
-    ~f:(fun (known_tags, other_tags) ->
+       ~join_shape ~merge_map_known:Tag.Map.merge env ~known1 ~known2 ~other1
+       ~other2) ~f:(fun (known_tags, other_tags) ->
       let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
       TG.Row_like_for_blocks.create_raw ~known_tags ~other_tags ~alloc_mode)
 
@@ -1608,17 +1603,13 @@ and join_row_like_for_closures env
   let merge_map_known join_case known1 known2 =
     Function_slot.Map.merge
       (fun function_slot case1 case2 ->
-        match case1, case2 with
-        | None, case | case, None -> case
-        | Some case1, Some case2 -> (
-          match
-            (join_case function_slot (Some case1) (Some case2)
-              : _ Or_unknown.t option)
-          with
-          | None -> None
-          | Some (Known case) -> Some case
-          | Some Unknown ->
-            Misc.fatal_error "Join row_like case for closures returned Unknown"))
+        let case1 = Option.map (fun case -> Or_unknown.Known case) case1 in
+        let case2 = Option.map (fun case -> Or_unknown.Known case) case2 in
+        match (join_case function_slot case1 case2 : _ Or_unknown.t option) with
+        | None -> None
+        | Some (Known case) -> Some case
+        | Some Unknown ->
+          Misc.fatal_error "Join row_like case for closures returned Unknown")
       known1 known2
   in
   match

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -1461,24 +1461,21 @@ and join_row_like :
     match join_shape i1.shape i2.shape with
     | Unknown -> Unknown
     | Known shape -> (
+      let return_index domain =
+        Or_unknown.Known (TG.Row_like_index.create ~domain ~shape)
+      in
       match i1.domain, i2.domain with
       | Known i1', Known i2' ->
         if equal_index i1' i2'
-        then Known (TG.Row_like_index.create ~domain:i1.domain ~shape)
+        then return_index i1.domain
         else
           (* We can't represent exactly the union, This is the best
              approximation *)
-          Known
-            (TG.Row_like_index.create
-               ~domain:(TG.Row_like_index_domain.at_least (inter_index i1' i2'))
-               ~shape)
+          return_index (TG.Row_like_index_domain.at_least (inter_index i1' i2'))
       | Known i1', At_least i2'
       | At_least i1', Known i2'
       | At_least i1', At_least i2' ->
-        Known
-          (TG.Row_like_index.create
-             ~domain:(TG.Row_like_index_domain.at_least (inter_index i1' i2'))
-             ~shape))
+        return_index (TG.Row_like_index_domain.at_least (inter_index i1' i2')))
   in
   let join_case join_env
       (case1 : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t)

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -614,33 +614,37 @@ and meet_head_of_kind_rec_info _env t1 _t2 : _ Or_bottom.t =
 and meet_head_of_kind_region _env () () : _ Or_bottom.t = Ok ((), TEE.empty)
 
 and meet_row_like :
-      'index 'maps_to 'row_tag 'known.
+      'lattice 'shape 'maps_to 'row_tag 'known.
       meet_maps_to:
         (Meet_env.t -> 'maps_to -> 'maps_to -> ('maps_to * TEE.t) Or_bottom.t) ->
-      equal_index:('index -> 'index -> bool) ->
-      subset_index:('index -> 'index -> bool) ->
-      union_index:('index -> 'index -> 'index) ->
+      equal_index:('lattice -> 'lattice -> bool) ->
+      subset_index:('lattice -> 'lattice -> bool) ->
+      union_index:('lattice -> 'lattice -> 'lattice) ->
+      meet_shape:('shape -> 'shape -> 'shape Or_bottom.t) ->
       is_empty_map_known:('known -> bool) ->
       get_singleton_map_known:
-        ('known -> ('row_tag * ('index, 'maps_to) TG.Row_like_case.t) option) ->
+        ('known ->
+        ('row_tag * ('lattice, 'shape, 'maps_to) TG.Row_like_case.t) option) ->
       merge_map_known:
         (('row_tag ->
-         ('index, 'maps_to) TG.Row_like_case.t option ->
-         ('index, 'maps_to) TG.Row_like_case.t option ->
-         ('index, 'maps_to) TG.Row_like_case.t option) ->
+         ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option ->
+         ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option ->
+         ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option) ->
         'known ->
         'known ->
         'known) ->
       Meet_env.t ->
       known1:'known ->
       known2:'known ->
-      other1:('index, 'maps_to) TG.Row_like_case.t Or_bottom.t ->
-      other2:('index, 'maps_to) TG.Row_like_case.t Or_bottom.t ->
-      ('known * ('index, 'maps_to) TG.Row_like_case.t Or_bottom.t * TEE.t)
+      other1:('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_bottom.t ->
+      other2:('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_bottom.t ->
+      ('known
+      * ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_bottom.t
+      * TEE.t)
       Or_bottom.t =
- fun ~meet_maps_to ~equal_index ~subset_index ~union_index ~is_empty_map_known
-     ~get_singleton_map_known ~merge_map_known meet_env ~known1 ~known2 ~other1
-     ~other2 ->
+ fun ~meet_maps_to ~equal_index ~subset_index ~union_index ~meet_shape
+     ~is_empty_map_known ~get_singleton_map_known ~merge_map_known meet_env
+     ~known1 ~known2 ~other1 ~other2 ->
   let env_extension = ref None in
   let need_join =
     (* The returned env_extension is the join of the env_extension produced by
@@ -681,23 +685,36 @@ and meet_row_like :
       assert need_join;
       env_extension := Some (join_env_extension join_env ext2 ext)
   in
-  let meet_index (i1 : 'index TG.row_like_index) (i2 : 'index TG.row_like_index)
-      : 'index TG.row_like_index Or_bottom.t =
-    match i1, i2 with
-    | Known i1', Known i2' -> if equal_index i1' i2' then Ok i1 else Bottom
-    | Known known, At_least at_least | At_least at_least, Known known ->
-      if subset_index at_least known
-      then
-        (* [at_least] is included in [known] hence [Known known] is included in
-           [At_least at_least], hence [Known known] \inter [At_least at_least] =
-           [Known known] *)
-        Ok (TG.Row_like_index.known known)
-      else Bottom
-    | At_least i1', At_least i2' ->
-      Ok (TG.Row_like_index.at_least (union_index i1' i2'))
+  let meet_index (i1 : ('lattice, 'shape) TG.row_like_index)
+      (i2 : ('lattice, 'shape) TG.row_like_index) :
+      ('lattice, 'shape) TG.row_like_index Or_bottom.t =
+    match meet_shape i1.shape i2.shape with
+    | Bottom -> Bottom
+    | Ok shape -> (
+      match i1.domain, i2.domain with
+      | Known i1', Known i2' ->
+        if equal_index i1' i2'
+        then Ok (TG.Row_like_index.create ~domain:i1.domain ~shape)
+        else Bottom
+      | Known known, At_least at_least | At_least at_least, Known known ->
+        if subset_index at_least known
+        then
+          (* [at_least] is included in [known] hence [Known known] is included
+             in [At_least at_least], hence [Known known] \inter [At_least
+             at_least] = [Known known] *)
+          Ok
+            (TG.Row_like_index.create
+               ~domain:(TG.Row_like_index_domain.known known)
+               ~shape)
+        else Bottom
+      | At_least i1', At_least i2' ->
+        Ok
+          (TG.Row_like_index.create
+             ~domain:(TG.Row_like_index_domain.at_least (union_index i1' i2'))
+             ~shape))
   in
-  let meet_case (case1 : ('index, 'maps_to) TG.Row_like_case.t)
-      (case2 : ('index, 'maps_to) TG.Row_like_case.t) =
+  let meet_case (case1 : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t)
+      (case2 : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t) =
     match meet_index case1.index case2.index with
     | Bottom -> None
     | Ok index -> (
@@ -718,25 +735,57 @@ and meet_row_like :
             in
             Some (TG.Row_like_case.create ~maps_to ~index ~env_extension))))
   in
-  let meet_knowns case1 case2 : ('index, 'maps_to) TG.Row_like_case.t option =
-    match case1, case2 with
+  let meet_knowns case1 case2 :
+      ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option =
+    match
+      ( (case1
+          : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option),
+        (case2
+          : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option)
+      )
+    with
     | None, None -> None
     | Some case1, None -> (
       match other2 with
       | Bottom -> None
-      | Ok other_case -> meet_case case1 other_case)
+      | Ok other_case -> (
+        match case1 with
+        | Unknown ->
+          join_env_extension other_case.env_extension;
+          Some (Known other_case)
+        | Known case1 ->
+          Option.map
+            (fun case -> Or_unknown.Known case)
+            (meet_case case1 other_case)))
     | None, Some case2 -> (
       match other1 with
       | Bottom -> None
-      | Ok other_case -> meet_case other_case case2)
-    | Some case1, Some case2 -> meet_case case1 case2
+      | Ok other_case -> (
+        match case2 with
+        | Unknown ->
+          join_env_extension other_case.env_extension;
+          Some (Known other_case)
+        | Known case2 ->
+          Option.map
+            (fun case -> Or_unknown.Known case)
+            (meet_case other_case case2)))
+    | Some case1, Some case2 -> (
+      match case1, case2 with
+      | Unknown, Unknown ->
+        join_env_extension TEE.empty;
+        Some Unknown
+      | Known case, Unknown | Unknown, Known case ->
+        join_env_extension case.env_extension;
+        Some (Known case)
+      | Known case1, Known case2 ->
+        Option.map (fun case -> Or_unknown.Known case) (meet_case case1 case2))
   in
   let known =
     merge_map_known
       (fun _tag case1 case2 -> meet_knowns case1 case2)
       known1 known2
   in
-  let other : ('index, 'maps_to) TG.Row_like_case.t Or_bottom.t =
+  let other : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_bottom.t =
     match other1, other2 with
     | Bottom, _ | _, Bottom -> Bottom
     | Ok other1, Ok other2 -> (
@@ -759,11 +808,19 @@ and meet_row_like_for_blocks env
     ({ known_tags = known2; other_tags = other2; alloc_mode = alloc_mode2 } :
       TG.Row_like_for_blocks.t) : (TG.Row_like_for_blocks.t * TEE.t) Or_bottom.t
     =
+  let meet_shape shape1 shape2 : _ Or_bottom.t =
+    if K.Block_shape.equal shape1 shape2 then Ok shape1 else Bottom
+  in
+  let get_singleton_map_known known =
+    match (Tag.Map.get_singleton known : (_ * _ Or_unknown.t) option) with
+    | Some (tag, Known case) -> Some (tag, case)
+    | Some (_, Unknown) | None -> None
+  in
   let<* known_tags, other_tags, env_extension =
     meet_row_like ~meet_maps_to:meet_int_indexed_product
       ~equal_index:TG.Block_size.equal ~subset_index:TG.Block_size.subset
-      ~union_index:TG.Block_size.union ~is_empty_map_known:Tag.Map.is_empty
-      ~get_singleton_map_known:Tag.Map.get_singleton
+      ~union_index:TG.Block_size.union ~meet_shape
+      ~is_empty_map_known:Tag.Map.is_empty ~get_singleton_map_known
       ~merge_map_known:Tag.Map.merge env ~known1 ~known2 ~other1 ~other2
   in
   let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
@@ -776,15 +833,27 @@ and meet_row_like_for_closures env
     ({ known_closures = known2; other_closures = other2 } :
       TG.Row_like_for_closures.t) :
     (TG.Row_like_for_closures.t * TEE.t) Or_bottom.t =
+  let meet_shape () () = Or_bottom.Ok () in
+  let merge_map_known merge_case known1 known2 =
+    Function_slot.Map.merge
+      (fun fslot case1 case2 ->
+        let case1 = Option.map (fun case -> Or_unknown.Known case) case1 in
+        let case2 = Option.map (fun case -> Or_unknown.Known case) case2 in
+        match merge_case fslot case1 case2 with
+        | None -> None
+        | Some (Or_unknown.Known case) -> Some case
+        | Some Or_unknown.Unknown ->
+          Misc.fatal_error "Unknown case in closure meet")
+      known1 known2
+  in
   let<+ known_closures, other_closures, env_extension =
     meet_row_like ~meet_maps_to:meet_closures_entry
       ~equal_index:Set_of_closures_contents.equal
       ~subset_index:Set_of_closures_contents.subset
-      ~union_index:Set_of_closures_contents.union
+      ~union_index:Set_of_closures_contents.union ~meet_shape
       ~is_empty_map_known:Function_slot.Map.is_empty
-      ~get_singleton_map_known:Function_slot.Map.get_singleton
-      ~merge_map_known:Function_slot.Map.merge env ~known1 ~known2 ~other1
-      ~other2
+      ~get_singleton_map_known:Function_slot.Map.get_singleton ~merge_map_known
+      env ~known1 ~known2 ~other1 ~other2
   in
   ( TG.Row_like_for_closures.create_raw ~known_closures ~other_closures,
     env_extension )
@@ -895,44 +964,36 @@ and meet_product_value_slot_indexed env
   in
   TG.Product.Value_slot_indexed.create components_by_index, env_extension
 
-and meet_int_indexed_product env (prod1 : TG.Product.Int_indexed.t)
-    (prod2 : TG.Product.Int_indexed.t) : _ Or_bottom.t =
-  if not (K.equal prod1.kind prod2.kind)
-  then Bottom
-  else
-    let fields1 = prod1.fields in
-    let fields2 = prod2.fields in
-    let any_bottom = ref false in
-    let env_extension = ref TEE.empty in
-    let length = max (Array.length fields1) (Array.length fields2) in
-    let fields =
-      Array.init length (fun index ->
-          let get_opt fields =
-            if index >= Array.length fields then None else Some fields.(index)
-          in
-          match get_opt fields1, get_opt fields2 with
-          | None, None -> assert false
-          | Some t, None | None, Some t -> t
-          | Some ty1, Some ty2 -> (
-            match meet env ty1 ty2 with
-            | Ok (ty, env_extension') -> (
-              match meet_env_extension env !env_extension env_extension' with
-              | Bottom ->
-                any_bottom := true;
-                MTC.bottom_like ty1
-              | Ok extension ->
-                env_extension := extension;
-                ty)
+and meet_int_indexed_product env (fields1 : TG.Product.Int_indexed.t)
+    (fields2 : TG.Product.Int_indexed.t) : _ Or_bottom.t =
+  let any_bottom = ref false in
+  let env_extension = ref TEE.empty in
+  let length = max (Array.length fields1) (Array.length fields2) in
+  let fields =
+    Array.init length (fun index ->
+        let get_opt fields =
+          if index >= Array.length fields then None else Some fields.(index)
+        in
+        match get_opt fields1, get_opt fields2 with
+        | None, None -> assert false
+        | Some t, None | None, Some t -> t
+        | Some ty1, Some ty2 -> (
+          match meet env ty1 ty2 with
+          | Ok (ty, env_extension') -> (
+            match meet_env_extension env !env_extension env_extension' with
             | Bottom ->
               any_bottom := true;
-              MTC.bottom_like ty1))
-    in
-    if !any_bottom
-    then Bottom
-    else
-      Ok
-        ( TG.Product.Int_indexed.create_from_array prod1.kind fields,
-          !env_extension )
+              MTC.bottom_like ty1
+            | Ok extension ->
+              env_extension := extension;
+              ty)
+          | Bottom ->
+            any_bottom := true;
+            MTC.bottom_like ty1))
+  in
+  if !any_bottom
+  then Bottom
+  else Ok (TG.Product.Int_indexed.create_from_array fields, !env_extension)
 
 and meet_function_type (env : Meet_env.t)
     (func_type1 : TG.Function_type.t Or_unknown_or_bottom.t)
@@ -1291,7 +1352,7 @@ and join_variant env ~(blocks1 : TG.Row_like_for_blocks.t Or_unknown.t)
     ~(imms2 : TG.t Or_unknown.t) :
     (TG.Row_like_for_blocks.t Or_unknown.t * TG.t Or_unknown.t) Or_unknown.t =
   let blocks_join env b1 b2 : _ Or_unknown.t =
-    Known (join_row_like_for_blocks env b1 b2)
+    join_row_like_for_blocks env b1 b2
   in
   let blocks = join_unknown blocks_join env blocks1 blocks2 in
   let imms = join_unknown (join ?bound_name:None) env imms1 imms2 in
@@ -1376,63 +1437,70 @@ and join_head_of_kind_region _env () () : _ Or_unknown.t = Known ()
    results from generic [join]s without needing to propagate them. *)
 
 and join_row_like :
-      'index 'maps_to 'row_tag 'known.
-      join_maps_to:(Join_env.t -> 'maps_to -> 'maps_to -> 'maps_to) ->
-      maps_to_field_kind:('maps_to -> K.t) option ->
-      equal_index:('index -> 'index -> bool) ->
-      inter_index:('index -> 'index -> 'index) ->
+      'lattice 'shape 'maps_to 'row_tag 'known.
+      join_maps_to:(Join_env.t -> 'shape -> 'maps_to -> 'maps_to -> 'maps_to) ->
+      equal_index:('lattice -> 'lattice -> bool) ->
+      inter_index:('lattice -> 'lattice -> 'lattice) ->
+      join_shape:('shape -> 'shape -> 'shape Or_unknown.t) ->
       merge_map_known:
         (('row_tag ->
-         ('index, 'maps_to) TG.Row_like_case.t option ->
-         ('index, 'maps_to) TG.Row_like_case.t option ->
-         ('index, 'maps_to) TG.Row_like_case.t option) ->
+         ('lattice, 'shape, 'maps_to) TG.Row_like_case.t option ->
+         ('lattice, 'shape, 'maps_to) TG.Row_like_case.t option ->
+         ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option) ->
         'known ->
         'known ->
         'known) ->
       Join_env.t ->
       known1:'known ->
       known2:'known ->
-      other1:('index, 'maps_to) TG.Row_like_case.t Or_bottom.t ->
-      other2:('index, 'maps_to) TG.Row_like_case.t Or_bottom.t ->
-      'known * ('index, 'maps_to) TG.Row_like_case.t Or_bottom.t =
- fun ~join_maps_to ~maps_to_field_kind ~equal_index ~inter_index
-     ~merge_map_known join_env ~known1 ~known2 ~other1 ~other2 ->
-  let join_index (i1 : 'index TG.row_like_index) (i2 : 'index TG.row_like_index)
-      : 'index TG.row_like_index =
-    match i1, i2 with
-    | Known i1', Known i2' ->
-      if equal_index i1' i2'
-      then i1
-      else
-        (* We can't represent exactly the union, This is the best
-           approximation *)
-        TG.Row_like_index.at_least (inter_index i1' i2')
-    | Known i1', At_least i2'
-    | At_least i1', Known i2'
-    | At_least i1', At_least i2' ->
-      TG.Row_like_index.at_least (inter_index i1' i2')
+      other1:('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_bottom.t ->
+      other2:('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_bottom.t ->
+      ('known * ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_bottom.t)
+      Or_unknown.t =
+ fun ~join_maps_to ~equal_index ~inter_index ~join_shape ~merge_map_known
+     join_env ~known1 ~known2 ~other1 ~other2 ->
+  let join_index (i1 : ('lattice, 'shape) TG.row_like_index)
+      (i2 : ('lattice, 'shape) TG.row_like_index) :
+      ('lattice, 'shape) TG.row_like_index Or_unknown.t =
+    match join_shape i1.shape i2.shape with
+    | Unknown -> Unknown
+    | Known shape -> (
+      match i1.domain, i2.domain with
+      | Known i1', Known i2' ->
+        if equal_index i1' i2'
+        then Known (TG.Row_like_index.create ~domain:i1.domain ~shape)
+        else
+          (* We can't represent exactly the union, This is the best
+             approximation *)
+          Known
+            (TG.Row_like_index.create
+               ~domain:(TG.Row_like_index_domain.at_least (inter_index i1' i2'))
+               ~shape)
+      | Known i1', At_least i2'
+      | At_least i1', Known i2'
+      | At_least i1', At_least i2' ->
+        Known
+          (TG.Row_like_index.create
+             ~domain:(TG.Row_like_index_domain.at_least (inter_index i1' i2'))
+             ~shape))
   in
-  let matching_kinds (case1 : ('index, 'maps_to) TG.Row_like_case.t)
-      (case2 : ('index, 'maps_to) TG.Row_like_case.t) =
-    match maps_to_field_kind with
-    | None -> true
-    | Some maps_to_field_kind ->
-      K.equal
-        (maps_to_field_kind case1.maps_to)
-        (maps_to_field_kind case2.maps_to)
-  in
-  let join_case join_env (case1 : ('index, 'maps_to) TG.Row_like_case.t)
-      (case2 : ('index, 'maps_to) TG.Row_like_case.t) =
+  let join_case join_env
+      (case1 : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t)
+      (case2 : ('lattice, 'shape, 'maps_to) TG.Row_like_case.t) : _ Or_unknown.t
+      =
     let index = join_index case1.index case2.index in
-    let maps_to = join_maps_to join_env case1.maps_to case2.maps_to in
-    let env_extension =
-      join_env_extension join_env case1.env_extension case2.env_extension
-    in
-    TG.Row_like_case.create ~maps_to ~index ~env_extension
+    Or_unknown.map index
+      ~f:(fun (index : ('lattice, 'shape) TG.Row_like_index.t) ->
+        let maps_to =
+          join_maps_to join_env index.shape case1.maps_to case2.maps_to
+        in
+        let env_extension =
+          join_env_extension join_env case1.env_extension case2.env_extension
+        in
+        TG.Row_like_case.create ~maps_to ~index ~env_extension)
   in
-  let join_knowns case1 case2 : ('index, 'maps_to) TG.Row_like_case.t option =
-    (* We assume that if tags are equals, the products will contains values of
-       the same kinds. *)
+  let join_knowns case1 case2 :
+      ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_unknown.t option =
     match case1, case2 with
     | None, None -> None
     | Some case1, None -> (
@@ -1440,7 +1508,7 @@ and join_row_like :
         (* cf. Type_descr.join_head_or_unknown_or_bottom, we need to join these
            to ensure that free variables not present in the target env are
            cleaned out of the types. Same below *)
-        (* CR pchambart: This seams terribly inefficient. *)
+        (* CR pchambart: This seems terribly inefficient. *)
         let join_env =
           Join_env.create
             (Join_env.target_join_env join_env)
@@ -1452,11 +1520,7 @@ and join_row_like :
       in
       match other2 with
       | Bottom -> only_case1 ()
-      | Ok other_case ->
-        if matching_kinds case1 other_case
-        then Some (join_case join_env case1 other_case)
-        else (* If kinds don't match, the tags can't match *)
-          only_case1 ())
+      | Ok other_case -> Some (join_case join_env case1 other_case))
     | None, Some case2 -> (
       let only_case2 () =
         (* See at the other bottom case *)
@@ -1471,10 +1535,7 @@ and join_row_like :
       in
       match other1 with
       | Bottom -> only_case2 ()
-      | Ok other_case ->
-        if matching_kinds other_case case2
-        then Some (join_case join_env other_case case2)
-        else only_case2 ())
+      | Ok other_case -> Some (join_case join_env other_case case2))
     | Some case1, Some case2 -> Some (join_case join_env case1 case2)
   in
   let known =
@@ -1482,9 +1543,10 @@ and join_row_like :
       (fun _tag case1 case2 -> join_knowns case1 case2)
       known1 known2
   in
-  let other : ('index, 'maps_to) TG.Row_like_case.t Or_bottom.t =
+  let other :
+      ('lattice, 'shape, 'maps_to) TG.Row_like_case.t Or_bottom.t Or_unknown.t =
     match other1, other2 with
-    | Bottom, Bottom -> Bottom
+    | Bottom, Bottom -> Known Bottom
     | Ok other1, Bottom ->
       (* See the previous cases *)
       let env =
@@ -1494,7 +1556,7 @@ and join_row_like :
           ~right_env:(Join_env.left_join_env join_env)
       in
       let other1 = join_case env other1 other1 in
-      Ok other1
+      Or_unknown.map other1 ~f:(fun other1 -> Or_bottom.Ok other1)
     | Bottom, Ok other2 ->
       (* See the previous cases *)
       let env =
@@ -1504,38 +1566,73 @@ and join_row_like :
           ~right_env:(Join_env.right_join_env join_env)
       in
       let other2 = join_case env other2 other2 in
-      Ok other2
-    | Ok other1, Ok other2 -> Ok (join_case join_env other1 other2)
+      Or_unknown.map other2 ~f:(fun other2 -> Or_bottom.Ok other2)
+    | Ok other1, Ok other2 ->
+      Or_unknown.map (join_case join_env other1 other2) ~f:(fun case ->
+          Or_bottom.Ok case)
   in
-  known, other
+  Or_unknown.map other ~f:(fun other -> known, other)
 
 and join_row_like_for_blocks env
     ({ known_tags = known1; other_tags = other1; alloc_mode = alloc_mode1 } :
       TG.Row_like_for_blocks.t)
     ({ known_tags = known2; other_tags = other2; alloc_mode = alloc_mode2 } :
       TG.Row_like_for_blocks.t) =
-  let known_tags, other_tags =
-    join_row_like ~join_maps_to:join_int_indexed_product
-      ~maps_to_field_kind:(Some TG.Product.Int_indexed.field_kind)
-      ~equal_index:TG.Block_size.equal ~inter_index:TG.Block_size.inter
-      ~merge_map_known:Tag.Map.merge env ~known1 ~known2 ~other1 ~other2
+  let join_shape shape1 shape2 : _ Or_unknown.t =
+    if K.Block_shape.equal shape1 shape2 then Known shape1 else Unknown
   in
-  let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-  TG.Row_like_for_blocks.create_raw ~known_tags ~other_tags ~alloc_mode
+  let merge_map_known join_case known1 known2 =
+    Tag.Map.merge
+      (fun tag (case1 : _ Or_unknown.t option) (case2 : _ Or_unknown.t option) :
+           _ Or_unknown.t option ->
+        match case1, case2 with
+        | None, case | case, None -> case
+        | Some Unknown, Some _ | Some _, Some Unknown -> Some Unknown
+        | Some (Known case1), Some (Known case2) ->
+          join_case tag (Some case1) (Some case2))
+      known1 known2
+  in
+  Or_unknown.map
+    (join_row_like ~join_maps_to:join_int_indexed_product
+       ~equal_index:TG.Block_size.equal ~inter_index:TG.Block_size.inter
+       ~join_shape ~merge_map_known env ~known1 ~known2 ~other1 ~other2)
+    ~f:(fun (known_tags, other_tags) ->
+      let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
+      TG.Row_like_for_blocks.create_raw ~known_tags ~other_tags ~alloc_mode)
 
 and join_row_like_for_closures env
     ({ known_closures = known1; other_closures = other1 } :
       TG.Row_like_for_closures.t)
     ({ known_closures = known2; other_closures = other2 } :
       TG.Row_like_for_closures.t) : TG.Row_like_for_closures.t =
-  let known_closures, other_closures =
-    join_row_like ~join_maps_to:join_closures_entry ~maps_to_field_kind:None
+  let merge_map_known join_case known1 known2 =
+    Function_slot.Map.merge
+      (fun function_slot case1 case2 ->
+        match case1, case2 with
+        | None, case | case, None -> case
+        | Some case1, Some case2 -> (
+          match
+            (join_case function_slot (Some case1) (Some case2)
+              : _ Or_unknown.t option)
+          with
+          | None -> None
+          | Some (Known case) -> Some case
+          | Some Unknown ->
+            Misc.fatal_error "Join row_like case for closures returned Unknown"))
+      known1 known2
+  in
+  match
+    join_row_like
+      ~join_maps_to:(fun env () x y -> join_closures_entry env x y)
       ~equal_index:Set_of_closures_contents.equal
       ~inter_index:Set_of_closures_contents.inter
-      ~merge_map_known:Function_slot.Map.merge env ~known1 ~known2 ~other1
-      ~other2
-  in
-  TG.Row_like_for_closures.create_raw ~known_closures ~other_closures
+      ~join_shape:(fun () () -> Or_unknown.Known ())
+      ~merge_map_known env ~known1 ~known2 ~other1 ~other2
+  with
+  | Known (known_closures, other_closures) ->
+    TG.Row_like_for_closures.create_raw ~known_closures ~other_closures
+  | Unknown ->
+    Misc.fatal_error "Join row_like case for closures returned Unknown"
 
 and join_closures_entry env
     ({ function_types = function_types1;
@@ -1607,15 +1704,8 @@ and join_value_slot_indexed_product env
   in
   TG.Product.Value_slot_indexed.create value_slot_components_by_index
 
-and join_int_indexed_product env
-    ({ fields = fields1; kind = kind1 } : TG.Product.Int_indexed.t)
-    ({ fields = fields2; kind = kind2 } : TG.Product.Int_indexed.t) :
-    TG.Product.Int_indexed.t =
-  if not (K.equal kind1 kind2)
-  then
-    Misc.fatal_errorf
-      "join_int_indexed_product between mismatching kinds %a and %a@." K.print
-      kind1 K.print kind2;
+and join_int_indexed_product env shape (fields1 : TG.Product.Int_indexed.t)
+    (fields2 : TG.Product.Int_indexed.t) : TG.Product.Int_indexed.t =
   let length1 = Array.length fields1 in
   let length2 = Array.length fields2 in
   let length = min length1 length2 in
@@ -1642,10 +1732,10 @@ and join_int_indexed_product env
           then fields1.(index)
           else
             match join env fields1.(index) fields2.(index) with
-            | Unknown -> MTC.unknown kind1
+            | Unknown -> MTC.unknown_from_shape shape index
             | Known ty -> ty)
   in
-  TG.Product.Int_indexed.create_from_array kind1 fields
+  TG.Product.Int_indexed.create_from_array fields
 
 and join_function_type (env : Join_env.t)
     (func_type1 : TG.Function_type.t Or_unknown_or_bottom.t)

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -74,7 +74,8 @@ val meet_naked_vec128s :
 
 type variant_like_proof = private
   { const_ctors : Targetint_31_63.Set.t Or_unknown.t;
-    non_const_ctors_with_sizes : Targetint_31_63.t Tag.Scannable.Map.t
+    non_const_ctors_with_sizes :
+      (Targetint_31_63.t * Flambda_kind.Block_shape.t) Tag.Scannable.Map.t
   }
 
 val meet_variant_like :
@@ -118,7 +119,7 @@ val prove_is_or_is_not_a_boxed_float :
 val prove_unique_tag_and_size :
   Typing_env.t ->
   Type_grammar.t ->
-  (Tag.t * Targetint_31_63.t) proof_of_property
+  (Tag.t * Flambda_kind.Block_shape.t * Targetint_31_63.t) proof_of_property
 
 val prove_is_int : Typing_env.t -> Type_grammar.t -> bool proof_of_property
 
@@ -131,7 +132,8 @@ val prove_get_tag :
 val prove_unique_fully_constructed_immutable_heap_block :
   Typing_env.t ->
   Type_grammar.t ->
-  (Tag_and_size.t * Simple.t list) proof_of_property
+  (Tag.t * Flambda_kind.Block_shape.t * Targetint_31_63.t * Simple.t list)
+  proof_of_property
 
 val meet_is_naked_number_array :
   Typing_env.t ->

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -383,7 +383,7 @@ let comp_primitive stack_info p sz args =
      instructions for the ufloat primitives. *)
   | Pufloatfield (n, _sem) -> Kgetfloatfield n
   | Psetufloatfield (n, _init) -> Ksetfloatfield n
-  | Pmixedfield (n, _, _sem) ->
+  | Pmixedfield (n, _, _, _sem) ->
       (* CR layouts: This will need reworking if we ever want bytecode
          to unbox fields that are written with unboxed types in the source
          language. *)
@@ -391,7 +391,7 @@ let comp_primitive stack_info p sz args =
          aren't stored flat like they are in native code.
       *)
       Kgetfield n
-  | Psetmixedfield (n, _shape, _init) ->
+  | Psetmixedfield (n, _, _shape, _init) ->
       (* See the comment in the [Pmixedfield] case. *)
       Ksetfield n
   | Pduprecord _ -> Kccall("caml_obj_dup", 1)

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -152,10 +152,12 @@ type primitive =
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int * field_read_semantics * alloc_mode
   | Pufloatfield of int * field_read_semantics
-  | Pmixedfield of int * mixed_block_read * field_read_semantics
+  | Pmixedfield of
+      int * mixed_block_read * mixed_block_shape * field_read_semantics
   | Psetfloatfield of int * initialization_or_assignment
   | Psetufloatfield of int * initialization_or_assignment
-  | Psetmixedfield of int * mixed_block_write * initialization_or_assignment
+  | Psetmixedfield of
+      int * mixed_block_write * mixed_block_shape * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* Unboxed products *)
   | Pmake_unboxed_product of layout list
@@ -1678,7 +1680,7 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pfield _ | Pfield_computed _ | Psetfield _ | Psetfield_computed _ -> None
   | Pfloatfield (_, _, m) -> Some m
   | Pufloatfield _ -> None
-  | Pmixedfield (_, read, _) -> begin
+  | Pmixedfield (_, read, _, _) -> begin
       match read with
       | Mread_value_prefix _ -> None
       | Mread_flat_suffix (Flat_read_float_boxed m) -> Some m
@@ -1872,7 +1874,7 @@ let primitive_result_layout (p : primitive) =
   | Pbox_float (f, _) -> layout_boxed_float f
   | Pufloatfield _ -> Punboxed_float Pfloat64
   | Punbox_float float_kind -> Punboxed_float float_kind
-  | Pmixedfield (_, kind, _) -> layout_of_mixed_field kind
+  | Pmixedfield (_, kind, _, _) -> layout_of_mixed_field kind
   | Pccall { prim_native_repr_res = _, repr_res } -> layout_of_extern_repr repr_res
   | Praise _ -> layout_bottom
   | Psequor | Psequand | Pnot

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -109,13 +109,15 @@ type primitive =
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int * field_read_semantics * alloc_mode
   | Pufloatfield of int * field_read_semantics
-  | Pmixedfield of int * mixed_block_read * field_read_semantics
+  | Pmixedfield of
+      int * mixed_block_read * mixed_block_shape * field_read_semantics
   (* [Pmixedfield] is an access to either the flat suffix or value prefix of a
      mixed record.
   *)
   | Psetfloatfield of int * initialization_or_assignment
   | Psetufloatfield of int * initialization_or_assignment
-  | Psetmixedfield of int * mixed_block_write * initialization_or_assignment
+  | Psetmixedfield of
+      int * mixed_block_write * mixed_block_shape * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* Unboxed products *)
   | Pmake_unboxed_product of layout list

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -1819,7 +1819,8 @@ let get_expr_args_constr ~scopes head (arg, _mut, sort, layout) rem =
                 in
                 Mread_flat_suffix flat_read
           in
-          Pmixedfield (pos, read, Reads_agree)
+          let shape = Lambda.transl_mixed_product_shape shape in
+          Pmixedfield (pos, read, shape, Reads_agree)
     in
     let jkind = cstr.cstr_arg_jkinds.(field) in
     let sort = Jkind.sort_of_jkind jkind in
@@ -2191,7 +2192,10 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
                 in
                 Mread_flat_suffix read
             in
-            Lprim (Pmixedfield (lbl.lbl_pos, read, sem), [ arg ], loc),
+            let shape : Lambda.mixed_block_shape =
+              { value_prefix_len; flat_suffix }
+            in
+            Lprim (Pmixedfield (lbl.lbl_pos, read, shape, sem), [ arg ], loc),
             lbl_sort, lbl_layout
       in
       let str = if Types.is_mutable lbl.lbl_mut then StrictOpt else Alias in

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -467,7 +467,7 @@ let primitive ppf = function
   | Pufloatfield (n, sem) ->
       fprintf ppf "ufloatfield%a %i"
         field_read_semantics sem n
-  | Pmixedfield (n, read, sem) ->
+  | Pmixedfield (n, read, _shape, sem) ->
       fprintf ppf "mixedfield%a %i %a"
         field_read_semantics sem n mixed_block_read read
   | Psetfloatfield (n, init) ->
@@ -488,7 +488,7 @@ let primitive ppf = function
         | Assignment Modify_maybe_stack -> "(maybe-stack)"
       in
       fprintf ppf "setufloatfield%s %i" init n
-  | Psetmixedfield (n, write, init) ->
+  | Psetmixedfield (n, write, _shape, init) ->
       let init =
         match init with
         | Heap_initialization -> "(heap-init)"

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -623,7 +623,10 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
               in
               Mread_flat_suffix flat_read
           in
-          Lprim (Pmixedfield (lbl.lbl_pos, read, sem), [targ],
+          let shape : Lambda.mixed_block_shape =
+            { value_prefix_len; flat_suffix }
+          in
+          Lprim (Pmixedfield (lbl.lbl_pos, read, shape, sem), [targ],
                   of_location ~scopes e.exp_loc)
       end
   | Texp_setfield(arg, arg_mode, id, lbl, newval) ->
@@ -655,7 +658,10 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
               let flat_element = flat_suffix.(lbl.lbl_num - value_prefix_len) in
               Mwrite_flat_suffix flat_element
            in
-           Psetmixedfield(lbl.lbl_pos, write, mode)
+           let shape : Lambda.mixed_block_shape =
+             { value_prefix_len; flat_suffix }
+           in
+           Psetmixedfield(lbl.lbl_pos, write, shape, mode)
         end
       in
       Lprim(access, [transl_exp ~scopes Jkind.Sort.for_record arg;
@@ -1743,7 +1749,10 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                       in
                       Mread_flat_suffix read
                    in
-                   Pmixedfield (i, read, sem)
+                   let shape : Lambda.mixed_block_shape =
+                     { value_prefix_len; flat_suffix }
+                   in
+                   Pmixedfield (i, read, shape, sem)
                in
                Lprim(access, [Lvar init_id],
                      of_location ~scopes loc),
@@ -1848,8 +1857,11 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                     in
                     Mwrite_flat_suffix flat_element
                 in
+                let shape : Lambda.mixed_block_shape =
+                  { value_prefix_len; flat_suffix }
+                in
                 Psetmixedfield
-                  (lbl.lbl_pos, write, Assignment modify_heap)
+                  (lbl.lbl_pos, write, shape, Assignment modify_heap)
               end
           in
           Lsequence(Lprim(upd, [Lvar copy_id;

--- a/ocaml/testsuite/tests/flambda/flambda2_row_like_join.ml
+++ b/ocaml/testsuite/tests/flambda/flambda2_row_like_join.ml
@@ -1,0 +1,46 @@
+(* TEST *)
+
+(* Tests a corner case of the Flambda2 join algorithm.
+   This checks that joining a row-like type where the tags are known,
+   with a row-like type where the tag is not known, correctly
+   takes both sides into account. *)
+
+(* GADTs allow us to hide kind information *)
+type _ t = A : (int * int) t | B : (int * int) t
+
+let[@inline never] f (type a) (x : a) (cond : a t) =
+  let result : a =
+    match cond with
+    | A -> (0, 1) (* Known tag *)
+    | B -> begin
+        let r = fst x in (* Creates an equation on [x] with unknown tag *)
+        ignore (Sys.opaque_identity r);
+        x
+      end
+  in
+  (* At this point, [result] has been joined with no kind information.
+     If everything went well, we should know that:
+     - It can have tag 0 (as branch A has this tag)
+     - It can have any tag (as branch B doesn't restrict the tag)
+     The point of this test is to check that the approximation for
+     [result] doesn't assume that if it has tag 0, it must have come
+     from branch A. *)
+  (* We now need to cast it back to a tuple: *)
+  let result : int * int = match cond with A -> result | B -> result in
+  (* Then we need to actually introduce the constraint on the tag.
+     This is done by storing it into a block with a known shape: *)
+  let ignored : (unit * (int * int)) = (), result in
+  (* Now, if we wrongly assumed that only branch A has tag 0,
+     we would be able to propagate that information here and replace
+     [a + b] by the constant 1.*)
+  let a, b = result in
+  (* [ignored] is returned to make sure we don't remove the block
+     creation primitive that adds the tag constraint *)
+  a + b, ignored
+
+let test () =
+  let r, _ = f (2, 3) B in
+  assert (r == 5);
+  ()
+
+let () = test ()

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -168,6 +168,14 @@ module Stdlib = struct
         if a' == a && l' == l then l0 else a' :: l'
       | [] -> []
 
+    let fold_lefti f accu l =
+      let rec aux f i accu l =
+        match l with
+        | [] -> accu
+        | a::l -> aux f (succ i) (f i accu a) l
+      in
+      aux f 0 accu l
+
     let chunks_of n l =
       if n <= 0 then raise (Invalid_argument "chunks_of");
       (* Invariant: List.length l = remaining *)

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -143,6 +143,10 @@ module Stdlib : sig
     (** [map_sharing f l] is [map f l]. If for all elements of the list
         [f e == e] then [map_sharing f l == l] *)
 
+    val fold_lefti : (int -> 'a -> 'b -> 'a) -> 'a -> 'b list -> 'a
+    (** [fold_lefti f init l] is like [fold_left] but also takes as parameter
+        the zero-based index of the element *)
+
     val chunks_of : int -> 'a t -> 'a t t
     (** [chunks_of n t] returns a list of nonempty lists whose
         concatenation is equal to the original list. Every list has [n]


### PR DESCRIPTION
As title says.
This includes support for unboxing, but not lifting/reification yet (although that shouldn't be too complicated to add on top of this PR).

There are a few details that I still find annoying but that I have left for now to avoid losing too much time. The issues are mostly about the various types used to represent information about mixed blocks. I can incorporate suggestions in this PR, but it's also something that we can change later if we want to (it's mostly mechanical).