### PR TITLE
Bugfix for a statmemprof test

### DIFF
--- a/ocaml/testsuite/tests/statmemprof/moved_while_blocking.ml
+++ b/ocaml/testsuite/tests/statmemprof/moved_while_blocking.ml
@@ -84,8 +84,7 @@ let global = ref static_ref
 let thread_fn () =
   await t2_begin;
   say "T2: alloc\n";
-  let r = ref 0 in
-  global := r;
+  global := ref 0;
   say "T2: minor GC\n";
   Gc.minor ();
   global := static_ref;


### PR DESCRIPTION
Bytecode keeps named values alive until the end of their scope rather just to their last use. This fact nondeterministically breaks one statmemprof test, which relies on a value being collected after its last use.

Inlining the definition (which is used only once) instead of naming it makes both behave the same.