### PR TITLE
Enable stack checks on arm64

### DIFF
--- a/backend/amd64/stack_check.ml
+++ b/backend/amd64/stack_check.ml
@@ -18,30 +18,14 @@
 
 let stack_threshold_size = Config.stack_threshold * 8 (* bytes *)
 
+let stack_offset = 0
+
+let trap_size = 16
+
 let linear : Linear.fundecl -> Linear.fundecl =
  fun fundecl ->
   match Config.runtime5 with
   | false -> fundecl
   | true ->
-    let frame_size =
-      Proc.frame_size ~stack_offset:0
-        ~num_stack_slots:fundecl.fun_num_stack_slots
-        ~contains_calls:fundecl.fun_contains_calls
-    in
-    let { Emitaux.max_frame_size; contains_nontail_calls } =
-      Emitaux.preproc_stack_check ~fun_body:fundecl.fun_body ~frame_size
-        ~trap_size:16
-    in
-    let insert_stack_check =
-      contains_nontail_calls || max_frame_size >= stack_threshold_size
-    in
-    if insert_stack_check
-    then
-      let fun_body =
-        Linear.instr_cons
-          (Lstackcheck { max_frame_size_bytes = max_frame_size })
-          [||] [||] ~available_before:fundecl.fun_body.available_before
-          ~available_across:fundecl.fun_body.available_across fundecl.fun_body
-      in
-      { fundecl with fun_body }
-    else fundecl
+    Emitaux.add_stack_checks_if_needed fundecl ~stack_offset
+      ~stack_threshold_size ~trap_size

--- a/backend/arm64/stack_check.ml
+++ b/backend/arm64/stack_check.ml
@@ -18,8 +18,14 @@
 
 let stack_threshold_size = Config.stack_threshold * 8 (* bytes *)
 
+let stack_offset = 0
+
+let trap_size = 16
+
 let linear : Linear.fundecl -> Linear.fundecl =
  fun fundecl ->
   match Config.runtime5 with
   | false -> fundecl
-  | true -> Misc.fatal_error "stack checks are not supported on arm64"
+  | true ->
+    Emitaux.add_stack_checks_if_needed fundecl ~stack_offset
+      ~stack_threshold_size ~trap_size

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -567,3 +567,26 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
         assert false
   in
   loop fun_body frame_size frame_size false
+
+let add_stack_checks_if_needed (fundecl : Linear.fundecl) ~stack_offset ~stack_threshold_size ~trap_size =
+  let frame_size =
+    Proc.frame_size ~stack_offset
+      ~num_stack_slots:fundecl.fun_num_stack_slots
+      ~contains_calls:fundecl.fun_contains_calls
+  in
+  let { max_frame_size; contains_nontail_calls } =
+    preproc_stack_check ~fun_body:fundecl.fun_body ~frame_size ~trap_size
+  in
+  let insert_stack_check =
+    contains_nontail_calls || max_frame_size >= stack_threshold_size
+  in
+  if insert_stack_check
+  then
+    let fun_body =
+      Linear.instr_cons
+        (Lstackcheck { max_frame_size_bytes = max_frame_size })
+        [||] [||] ~available_before:fundecl.fun_body.available_before
+        ~available_across:fundecl.fun_body.available_across fundecl.fun_body
+    in
+    { fundecl with fun_body }
+  else fundecl

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -137,3 +137,10 @@ val preproc_stack_check:
   frame_size:int ->
   trap_size:int ->
   preproc_stack_check_result
+
+val add_stack_checks_if_needed:
+  Linear.fundecl ->
+  stack_offset:int ->
+  stack_threshold_size:int ->
+  trap_size:int ->
+  Linear.fundecl


### PR DESCRIPTION
This pull request enables the stack checks
on arm64, when the `cfg-stack-check` is
set to `false` (_i.e._ stack checks are added
to the `Linear` IR). Before this pull request,
a fatal error was raised.

This is done by factoring out the code
adding the check if needed (moving from
`amd64/stack_check.ml` to `emitaux.ml`),
since both supported architectures use the
same condition to decide whether checks
are needed.

This leaves the `Stack_check` module
almost empty, only calling the shared
implementation with architecture-dependent
parameters. At this point, the `Stack_check`
module could as well be removed; if not
now, that will probably happen when only
the CFG pipeline is available.