### PR TITLE
Support `stack_ exp` syntax

### DIFF
--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -4,6 +4,10 @@ open Mode
 
 let dummy_jkind = Jkind.Primitive.value ~why:(Unknown "dummy_layout")
 let dummy_value_mode = Value.disallow_right Value.legacy
+
+let dummy_alloc_mode =
+  { mode = Alloc.disallow_left Alloc.legacy; closure_context = None }
+
 let mkTvar name = Tvar { name; jkind = dummy_jkind }
 
 let mkTarrow (label, t1, t2, comm) =
@@ -31,21 +35,20 @@ let mkTexp_apply
   in
   Texp_apply (exp, args, pos, mode, za)
 
-type texp_tuple_identifier = string option list * Alloc.r
+type texp_tuple_identifier = string option list * alloc_mode
 
 let mkTexp_tuple ?id exps =
   let labels, alloc =
     match id with
-    | None -> (List.map (fun _ -> None) exps, Alloc.disallow_left Alloc.legacy)
+    | None -> (List.map (fun _ -> None) exps, dummy_alloc_mode)
     | Some id -> id
   in
   let exps = List.combine labels exps in
   Texp_tuple (exps, alloc)
 
-type texp_construct_identifier = Alloc.r option
+type texp_construct_identifier = alloc_mode option
 
-let mkTexp_construct ?id:(mode = Some (Alloc.disallow_left Alloc.legacy))
-    (name, desc, args) =
+let mkTexp_construct ?id:(mode = Some dummy_alloc_mode) (name, desc, args) =
   Texp_construct (name, desc, args, mode)
 
 type texp_function_param_identifier = {
@@ -88,7 +91,7 @@ type texp_function = {
 }
 
 type texp_function_identifier = {
-  alloc_mode : Alloc.r;
+  alloc_mode : alloc_mode;
   ret_sort : Jkind.sort;
   region : bool;
   ret_mode : Alloc.l;
@@ -115,7 +118,7 @@ let texp_function_param_identifier_defaults =
 
 let texp_function_defaults =
   {
-    alloc_mode = Alloc.disallow_left Alloc.legacy;
+    alloc_mode = dummy_alloc_mode;
     ret_sort = Jkind.Sort.value;
     ret_mode = Alloc.disallow_right Alloc.legacy;
     region = false;

--- a/ocaml/boot/menhir/parser.mli
+++ b/ocaml/boot/menhir/parser.mli
@@ -19,6 +19,7 @@ type token =
   | STRUCT
   | STRING of (string * Location.t * string option)
   | STAR
+  | STACK
   | SIG
   | SEMISEMI
   | SEMI

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -290,7 +290,7 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
         (function (Texp_poly _, _, _) -> true | _ -> false)
         exp_extra
     ->
-      begin match transl_alloc_mode_r method_.alloc_mode with
+      begin match transl_alloc_mode method_.alloc_mode with
       | Alloc_heap -> ()
       | Alloc_local ->
           (* If we support locally-allocated objects, we'll also have to
@@ -466,7 +466,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         Lconst(Const_block(0, List.map extract_constant ll))
       with Not_constant ->
         Lprim(Pmakeblock(0, Immutable, Some shape,
-                         transl_alloc_mode_r alloc_mode),
+                         transl_alloc_mode alloc_mode),
               ll,
               (of_location ~scopes e.exp_loc))
       end
@@ -508,7 +508,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           begin match const_block with
           | Some const_block -> const_block
           | None ->
-            let alloc_mode = transl_alloc_mode_r (Option.get alloc_mode) in
+            let alloc_mode = transl_alloc_mode (Option.get alloc_mode) in
             let makeblock =
               match cstr.cstr_shape with
               | Constructor_uniform_value ->
@@ -534,7 +534,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                that out by checking that the sort list is empty *)
             lam)
           else
-            let alloc_mode = transl_alloc_mode_r (Option.get alloc_mode) in
+            let alloc_mode = transl_alloc_mode (Option.get alloc_mode) in
             let makeblock =
               match cstr.cstr_shape with
               | Constructor_uniform_value ->
@@ -569,13 +569,13 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                                    extract_constant lam]))
           with Not_constant ->
             Lprim(Pmakeblock(0, Immutable, None,
-                             transl_alloc_mode_r alloc_mode),
+                             transl_alloc_mode alloc_mode),
                   [Lconst(const_int tag); lam],
                   of_location ~scopes e.exp_loc)
       end
   | Texp_record {fields; representation; extended_expression; alloc_mode} ->
       transl_record ~scopes e.exp_loc e.exp_env
-        (Option.map transl_alloc_mode_r alloc_mode)
+        (Option.map transl_alloc_mode alloc_mode)
         fields representation extended_expression
   | Texp_field(arg, id, lbl, float) ->
       let targ = transl_exp ~scopes Jkind.Sort.for_record arg in
@@ -595,7 +595,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
             | Boxing (alloc_mode, _) -> alloc_mode
             | Non_boxing _ -> assert false
           in
-          let mode = transl_alloc_mode_r alloc_mode in
+          let mode = transl_alloc_mode alloc_mode in
           Lprim (Pfloatfield (lbl.lbl_pos, sem, mode), [targ],
                  of_location ~scopes e.exp_loc)
         | Record_ufloat ->
@@ -614,7 +614,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                 | Float_boxed ->
                   (match float with
                     | Boxing (mode, _) ->
-                        flat_read_float_boxed (transl_alloc_mode_r mode)
+                        flat_read_float_boxed (transl_alloc_mode mode)
                     | Non_boxing _ ->
                         Misc.fatal_error
                           "expected typechecking to make [float] boxing mode\
@@ -668,7 +668,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                      transl_exp ~scopes lbl_sort newval],
             of_location ~scopes e.exp_loc)
   | Texp_array (amut, element_sort, expr_list, alloc_mode) ->
-      let mode = transl_alloc_mode_r alloc_mode in
+      let mode = transl_alloc_mode alloc_mode in
       let kind = array_kind e element_sort in
       let ll =
         transl_list ~scopes
@@ -1578,7 +1578,7 @@ and transl_function ~in_new_scope ~scopes e params body
       ~alloc_mode ~ret_mode:sreturn_mode ~ret_sort:sreturn_sort ~region:sregion
       ~zero_alloc =
   let attrs = e.exp_attributes in
-  let mode = transl_alloc_mode_r alloc_mode in
+  let mode = transl_alloc_mode alloc_mode in
   let assume_zero_alloc =
     Builtin_attributes.assume_zero_alloc ~is_check_allowed:true zero_alloc
   in
@@ -1966,7 +1966,7 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
     match arg, exn_cases with
     | {exp_desc = Texp_tuple (argl, alloc_mode)}, [] ->
       assert (static_handlers = []);
-      let mode = transl_alloc_mode_r alloc_mode in
+      let mode = transl_alloc_mode alloc_mode in
       let argl =
         List.map (fun (_, a) -> (a, Jkind.Sort.for_tuple_element)) argl
       in
@@ -1985,7 +1985,7 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
             argl
           |> List.split
         in
-        let mode = transl_alloc_mode_r alloc_mode in
+        let mode = transl_alloc_mode alloc_mode in
         static_catch (transl_list ~scopes argl) val_ids
           (Matching.for_multiple_match ~scopes ~return_layout e.exp_loc
              lvars mode val_cases partial)

--- a/ocaml/lambda/translmode.ml
+++ b/ocaml/lambda/translmode.ml
@@ -35,6 +35,9 @@ let transl_alloc_mode_r mode =
   (* we only take the locality axis *)
   Alloc.proj (Comonadic Areality) mode |> transl_locality_mode_r
 
+let transl_alloc_mode (mode : Typedtree.alloc_mode) =
+  transl_alloc_mode_r mode.mode
+
 let transl_modify_mode locality =
   match Locality.zap_to_floor locality with
   | Global -> modify_heap

--- a/ocaml/lambda/translmode.mli
+++ b/ocaml/lambda/translmode.mli
@@ -20,4 +20,6 @@ val transl_alloc_mode_l : (allowed * 'r) Alloc.t -> Lambda.alloc_mode
 
 val transl_alloc_mode_r : ('l * allowed) Alloc.t -> Lambda.alloc_mode
 
+val transl_alloc_mode : Typedtree.alloc_mode -> Lambda.alloc_mode
+
 val transl_modify_mode : (allowed * 'r) Locality.t -> Lambda.modify_mode

--- a/ocaml/parsing/ast_helper.ml
+++ b/ocaml/parsing/ast_helper.ml
@@ -223,6 +223,7 @@ module Exp = struct
     mk ?loc ?attrs (Pexp_letop {let_; ands; body})
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pexp_extension a)
   let unreachable ?loc ?attrs () = mk ?loc ?attrs Pexp_unreachable
+  let stack ?loc ?attrs e = mk ?loc ?attrs (Pexp_stack e)
 
   let case lhs ?guard rhs =
     {

--- a/ocaml/parsing/ast_helper.mli
+++ b/ocaml/parsing/ast_helper.mli
@@ -201,6 +201,7 @@ module Exp:
                -> binding_op list -> expression -> expression
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> expression
     val unreachable: ?loc:loc -> ?attrs:attrs -> unit -> expression
+    val stack : ?loc:loc -> ?attrs:attrs -> expression -> expression
 
     val case: pattern -> ?guard:expression -> expression -> case
     val binding_op: str -> pattern -> expression -> loc -> binding_op

--- a/ocaml/parsing/ast_iterator.ml
+++ b/ocaml/parsing/ast_iterator.ml
@@ -660,6 +660,7 @@ module E = struct
         sub.expr sub body
     | Pexp_extension x -> sub.extension sub x
     | Pexp_unreachable -> ()
+    | Pexp_stack e -> sub.expr sub e
 
   let iter_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =
     iter_loc sub pbop_op;

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -780,6 +780,7 @@ module E = struct
           (List.map (sub.binding_op sub) ands) (sub.expr sub body)
     | Pexp_extension x -> extension ~loc ~attrs (sub.extension sub x)
     | Pexp_unreachable -> unreachable ~loc ~attrs ()
+    | Pexp_stack e -> stack ~loc ~attrs (sub.expr sub e)
 
   let map_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =
     let open Exp in

--- a/ocaml/parsing/depend.ml
+++ b/ocaml/parsing/depend.ml
@@ -328,6 +328,7 @@ let rec add_expr bv exp =
       | Ok { arg; _ } -> add_expr bv arg
       end
   | Pexp_extension e -> handle_extension e
+  | Pexp_stack e -> add_expr bv e
   | Pexp_unreachable -> ()
 
 and add_expr_jane_syntax bv : Jane_syntax.Expression.t -> _ = function

--- a/ocaml/parsing/lexer.mll
+++ b/ocaml/parsing/lexer.mll
@@ -84,6 +84,7 @@ let keyword_table =
     "private", PRIVATE;
     "rec", REC;
     "sig", SIG;
+    "stack_", STACK;
     "struct", STRUCT;
     "then", THEN;
     "to", TO;

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -1042,6 +1042,7 @@ let unboxed_type sloc lident tys =
 %token HASH_SUFFIX            "# "
 %token <string> HASHOP        "##" (* just an example *)
 %token SIG                    "sig"
+%token STACK                  "stack_"
 %token STAR                   "*"
 %token <string * Location.t * string option>
        STRING                 "\"hello\"" (* just an example *)
@@ -1133,7 +1134,7 @@ The precedences must be listed from low to high.
 %nonassoc BACKQUOTE BANG BEGIN CHAR FALSE FLOAT HASH_FLOAT INT HASH_INT OBJECT
           LBRACE LBRACELESS LBRACKET LBRACKETBAR LBRACKETCOLON LIDENT LPAREN
           NEW PREFIXOP STRING TRUE UIDENT
-          LBRACKETPERCENT QUOTED_STRING_EXPR
+          LBRACKETPERCENT QUOTED_STRING_EXPR STACK
 
 
 /* Entry points */
@@ -2811,6 +2812,8 @@ fun_expr:
 %inline expr_:
   | simple_expr nonempty_llist(labeled_simple_expr)
       { mkexp ~loc:$sloc (Pexp_apply($1, $2)) }
+  | STACK simple_expr
+      { mkexp ~loc:$sloc (Pexp_stack $2) }
   | labeled_tuple %prec below_COMMA
       { pexp_ltuple $sloc $1 }
   | mkrhs(constr_longident) simple_expr %prec below_HASH

--- a/ocaml/parsing/parsetree.mli
+++ b/ocaml/parsing/parsetree.mli
@@ -440,6 +440,7 @@ and expression_desc =
             - [let* P0 = E00 and* P1 = E01 in E1] *)
   | Pexp_extension of extension  (** [[%id]] *)
   | Pexp_unreachable  (** [.] *)
+  | Pexp_stack of expression (** stack_ exp *)
 
 and case =
     {

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -933,6 +933,9 @@ and expression ?(jane_syntax_parens = false) ctxt f x =
                 end (e,l)
         end
 
+    | Pexp_stack e ->
+        (* Similar to the common case of [Pexp_apply] *)
+        pp f "@[<hov2>stack_@ %a@]" (expression2 reset_ctxt)  e
     | Pexp_construct (li, Some eo)
       when not (is_simple_construct (view_expr x))-> (* Not efficient FIXME*)
         (match view_expr x with

--- a/ocaml/parsing/printast.ml
+++ b/ocaml/parsing/printast.ml
@@ -384,6 +384,9 @@ and expression i ppf x =
       payload i ppf arg
   | Pexp_unreachable ->
       line i ppf "Pexp_unreachable"
+  | Pexp_stack e ->
+      line i ppf "Pexp_stack\n";
+      expression i ppf e
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_string_loc

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -34,6 +34,11 @@ module Example = struct
      end"
 
   let local_exp = parse expression "let x = foo (local_ x) in local_ y"
+  let stack_exp = parse expression
+    "let x = stack_ 42 in \
+     let y = stack_ (f x) in \
+     let z = foo (stack_ 42) in \
+     foo (stack_ (f x))"
 
   let modal_kind_struct =
     parse module_expr "struct \
@@ -178,6 +183,7 @@ end = struct
   let modality_val = test "modality_val" module_type Example.modality_val
 
   let local_exp = test "local_exp" expression Example.local_exp
+  let stack_exp = test "stack_exp" expression Example.stack_exp
 
   let longident = test "longident" longident Example.longident
   let expression = test "expression" expression Example.expression

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -17,6 +17,10 @@ modality_val: sig val t : string -> local_ string @@ foo bar end
 
 local_exp: let x = foo (local_ x) in local_ y
 
+stack_exp:
+  let x = stack_ 42 in
+  let y = stack_ (f x) in let z = foo (stack_ 42) in foo (stack_ (f x))
+
 longident: No.Longidents.Require.extensions
 
 expression: [x for x = 1 to 10]
@@ -117,6 +121,10 @@ modality_cstrarg:
 modality_val: sig val t : string -> local_ string @@ foo bar end
 
 local_exp: let x = foo (local_ x) in local_ y
+
+stack_exp:
+  let x = stack_ 42 in
+  let y = stack_ (f x) in let z = foo (stack_ 42) in foo (stack_ (f x))
 
 longident: No.Longidents.Require.extensions
 

--- a/ocaml/testsuite/tests/typing-modes/stack.ml
+++ b/ocaml/testsuite/tests/typing-modes/stack.ml
@@ -117,3 +117,37 @@ let f () = exclave_ stack_ (3, 5)
 [%%expect{|
 val f : unit -> local_ int * int = <fun>
 |}]
+
+let f () =
+    let g = stack_ (fun x -> x) in
+    g 42
+[%%expect{|
+Line 3, characters 4-5:
+3 |     g 42
+        ^
+Error: This value escapes its region.
+  Hint: This function cannot be local,
+  because it is the function in a tail call.
+|}]
+
+let f () =
+    (stack_ (fun x -> x)) 42
+[%%expect{|
+Line 2, characters 12-24:
+2 |     (stack_ (fun x -> x)) 42
+                ^^^^^^^^^^^^
+Error: This allocation cannot be on the stack.
+  Hint: This function cannot be stack-allocated,
+  because it is the function in a tail call.
+|}]
+
+let f () =
+    List.length (stack_ [1; 2; 3])
+[%%expect{|
+Line 2, characters 24-33:
+2 |     List.length (stack_ [1; 2; 3])
+                            ^^^^^^^^^
+Error: This allocation cannot be on the stack.
+  Hint: This argument cannot be stack-allocated,
+  because it is an argument in a tail call.
+|}]

--- a/ocaml/testsuite/tests/typing-modes/stack.ml
+++ b/ocaml/testsuite/tests/typing-modes/stack.ml
@@ -252,3 +252,41 @@ Line 4, characters 17-31:
                      ^^^^^^^^^^^^^^
 Error: Stack allocating modules is unsupported yet.
 |}]
+
+(* stack_ works shallowly *)
+let f () =
+  let r = ref "hello" in
+  let _ = stack_ (r.contents, r.contents) in
+  r.contents
+[%%expect{|
+val f : unit -> string = <fun>
+|}]
+
+let f () =
+  let r = "hello" in
+  let _ = stack_ (r, r) in
+  r
+[%%expect{|
+val f : unit -> string = <fun>
+|}]
+
+type t = { x : int list; y : int list @@ global }
+
+let mk () =
+  let r = stack_ { x = [1;2;3]; y = [4;5;6] } in
+  r.y
+[%%expect{|
+type t = { x : int list; global_ y : int list; }
+val mk : unit -> int list = <fun>
+|}]
+
+let mk () =
+  let r = stack_ { x = [1;2;3]; y = [4;5;6] } in
+  r.x
+[%%expect{|
+Line 3, characters 2-5:
+3 |   r.x
+      ^^^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
+|}]

--- a/ocaml/testsuite/tests/typing-modes/stack.ml
+++ b/ocaml/testsuite/tests/typing-modes/stack.ml
@@ -1,0 +1,103 @@
+(* TEST
+expect;
+*)
+
+let f = ref (stack_ (fun x -> x))
+[%%expect{|
+Line 1, characters 20-32:
+1 | let f = ref (stack_ (fun x -> x))
+                        ^^^^^^^^^^^^
+Error: This allocation cannot be on stack.
+|}]
+
+let f = ref (stack_ (2, 3))
+[%%expect{|
+Line 1, characters 20-26:
+1 | let f = ref (stack_ (2, 3))
+                        ^^^^^^
+Error: This allocation cannot be on stack.
+|}]
+
+type t = Foo | Bar of int
+
+let f = ref (stack_ Foo)
+[%%expect{|
+type t = Foo | Bar of int
+Line 3, characters 20-23:
+3 | let f = ref (stack_ Foo)
+                        ^^^
+Error: This expression is not an allocation.
+|}]
+
+let f = ref (stack_ (Bar 42))
+[%%expect{|
+Line 1, characters 20-28:
+1 | let f = ref (stack_ (Bar 42))
+                        ^^^^^^^^
+Error: This allocation cannot be on stack.
+|}]
+
+type r = {x : string} [@@unboxed]
+
+let f = ref (stack_ {x = "hello"})
+[%%expect{|
+type r = { x : string; } [@@unboxed]
+Line 3, characters 20-33:
+3 | let f = ref (stack_ {x = "hello"})
+                        ^^^^^^^^^^^^^
+Error: This expression is not an allocation.
+|}]
+
+type r = {x : string}
+
+let f = ref (stack_ {x = "hello"})
+[%%expect{|
+type r = { x : string; }
+Line 3, characters 20-33:
+3 | let f = ref (stack_ {x = "hello"})
+                        ^^^^^^^^^^^^^
+Error: This allocation cannot be on stack.
+|}]
+
+type r = {x : float; y : string}
+
+let f (r : r) = ref (stack_ r.x)
+[%%expect{|
+type r = { x : float; y : string; }
+Line 3, characters 28-31:
+3 | let f (r : r) = ref (stack_ r.x)
+                                ^^^
+Error: This expression is not an allocation.
+|}]
+
+type r = {x : float; y : float}
+let f (r : r) = ref (stack_ r.x)
+[%%expect{|
+type r = { x : float; y : float; }
+Line 2, characters 28-31:
+2 | let f (r : r) = ref (stack_ r.x)
+                                ^^^
+Error: This allocation cannot be on stack.
+|}]
+
+let f = ref (stack_ [| 42; 56 |])
+[%%expect{|
+Line 1, characters 20-32:
+1 | let f = ref (stack_ [| 42; 56 |])
+                        ^^^^^^^^^^^^
+Error: This allocation cannot be on stack.
+|}]
+
+(* tail-position stack_ does not indicate local-returning *)
+let f () = stack_ (3, 5)
+[%%expect{|
+Line 1, characters 18-24:
+1 | let f () = stack_ (3, 5)
+                      ^^^^^^
+Error: This allocation cannot be on stack.
+|}]
+
+let f () = exclave_ stack_ (3, 5)
+[%%expect{|
+val f : unit -> local_ int * int = <fun>
+|}]

--- a/ocaml/testsuite/tests/typing-modes/stack.ml
+++ b/ocaml/testsuite/tests/typing-modes/stack.ml
@@ -7,7 +7,7 @@ let f = ref (stack_ (fun x -> x))
 Line 1, characters 20-32:
 1 | let f = ref (stack_ (fun x -> x))
                         ^^^^^^^^^^^^
-Error: This allocation cannot be on stack.
+Error: This allocation cannot be on the stack.
 |}]
 
 let f = ref (stack_ (2, 3))
@@ -15,7 +15,7 @@ let f = ref (stack_ (2, 3))
 Line 1, characters 20-26:
 1 | let f = ref (stack_ (2, 3))
                         ^^^^^^
-Error: This allocation cannot be on stack.
+Error: This allocation cannot be on the stack.
 |}]
 
 type t = Foo | Bar of int
@@ -34,7 +34,7 @@ let f = ref (stack_ (Bar 42))
 Line 1, characters 20-28:
 1 | let f = ref (stack_ (Bar 42))
                         ^^^^^^^^
-Error: This allocation cannot be on stack.
+Error: This allocation cannot be on the stack.
 |}]
 
 type r = {x : string} [@@unboxed]
@@ -56,7 +56,7 @@ type r = { x : string; }
 Line 3, characters 20-33:
 3 | let f = ref (stack_ {x = "hello"})
                         ^^^^^^^^^^^^^
-Error: This allocation cannot be on stack.
+Error: This allocation cannot be on the stack.
 |}]
 
 type r = {x : float; y : string}
@@ -77,7 +77,7 @@ type r = { x : float; y : float; }
 Line 2, characters 28-31:
 2 | let f (r : r) = ref (stack_ r.x)
                                 ^^^
-Error: This allocation cannot be on stack.
+Error: This allocation cannot be on the stack.
 |}]
 
 let f = ref (stack_ [| 42; 56 |])
@@ -85,7 +85,7 @@ let f = ref (stack_ [| 42; 56 |])
 Line 1, characters 20-32:
 1 | let f = ref (stack_ [| 42; 56 |])
                         ^^^^^^^^^^^^
-Error: This allocation cannot be on stack.
+Error: This allocation cannot be on the stack.
 |}]
 
 (* tail-position stack_ does not indicate local-returning *)
@@ -94,7 +94,7 @@ let f () = stack_ (3, 5)
 Line 1, characters 18-24:
 1 | let f () = stack_ (3, 5)
                       ^^^^^^
-Error: This allocation cannot be on stack.
+Error: This allocation cannot be on the stack.
 |}]
 
 let f () = exclave_ stack_ (3, 5)

--- a/ocaml/testsuite/tests/typing-modes/stack.ml
+++ b/ocaml/testsuite/tests/typing-modes/stack.ml
@@ -3,6 +3,11 @@ flags += "-extension comprehensions";
 expect;
 *)
 
+let ignore_local : 'a @ local -> unit = fun _ -> ()
+[%%expect{|
+val ignore_local : local_ 'a -> unit = <fun>
+|}]
+
 let f = ref (stack_ (fun x -> x))
 [%%expect{|
 Line 1, characters 20-32:
@@ -17,6 +22,11 @@ Line 1, characters 20-26:
 1 | let f = ref (stack_ (2, 3))
                         ^^^^^^
 Error: This allocation cannot be on the stack.
+|}]
+
+let f = ignore_local (stack_ (2, 3))
+[%%expect{|
+val f : unit = ()
 |}]
 
 type t = Foo | Bar of int
@@ -38,6 +48,11 @@ Line 1, characters 20-28:
 Error: This allocation cannot be on the stack.
 |}]
 
+let f = ignore_local (stack_ (Bar 42))
+[%%expect{|
+val f : unit = ()
+|}]
+
 let f = ref (stack_ `Foo)
 [%%expect{|
 Line 1, characters 20-24:
@@ -52,6 +67,11 @@ Line 1, characters 20-29:
 1 | let f = ref (stack_ (`Bar 42))
                         ^^^^^^^^^
 Error: This allocation cannot be on the stack.
+|}]
+
+let f = ignore_local (stack_ (`Bar 42))
+[%%expect{|
+val f : unit = ()
 |}]
 
 type r = {x : string} [@@unboxed]
@@ -76,6 +96,11 @@ Line 3, characters 20-33:
 Error: This allocation cannot be on the stack.
 |}]
 
+let f = ignore_local (stack_ {x = "hello"})
+[%%expect{|
+val f : unit = ()
+|}]
+
 type r = {x : float; y : string}
 
 let f (r : r) = ref (stack_ r.x)
@@ -97,12 +122,22 @@ Line 2, characters 28-31:
 Error: This allocation cannot be on the stack.
 |}]
 
+let f (r : r) = ignore_local (stack_ r.x) [@nontail]
+[%%expect{|
+val f : r -> unit = <fun>
+|}]
+
 let f = ref (stack_ [| 42; 56 |])
 [%%expect{|
 Line 1, characters 20-32:
 1 | let f = ref (stack_ [| 42; 56 |])
                         ^^^^^^^^^^^^
 Error: This allocation cannot be on the stack.
+|}]
+
+let f = ignore_local (stack_ [| 42; 56 |])
+[%%expect{|
+val f : unit = ()
 |}]
 
 (* tail-position stack_ does not indicate local-returning *)

--- a/ocaml/testsuite/tests/typing-modes/stack.ml
+++ b/ocaml/testsuite/tests/typing-modes/stack.ml
@@ -37,6 +37,22 @@ Line 1, characters 20-28:
 Error: This allocation cannot be on the stack.
 |}]
 
+let f = ref (stack_ `Foo)
+[%%expect{|
+Line 1, characters 20-24:
+1 | let f = ref (stack_ `Foo)
+                        ^^^^
+Error: This expression is not an allocation.
+|}]
+
+let f = ref (stack_ (`Bar 42))
+[%%expect{|
+Line 1, characters 20-29:
+1 | let f = ref (stack_ (`Bar 42))
+                        ^^^^^^^^^
+Error: This allocation cannot be on the stack.
+|}]
+
 type r = {x : string} [@@unboxed]
 
 let f = ref (stack_ {x = "hello"})

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -403,6 +403,9 @@ and expression_extra i ppf x attrs =
             (fun loc -> Printf.sprintf "\"%s\"" loc.txt)
             modes.txt));
       attributes i ppf attrs;
+  | Texp_stack ->
+      line i ppf "Texp_stack\n";
+      attributes i ppf attrs
 
 and alloc_mode: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
   = fun i ppf m -> line i ppf "alloc_mode %a\n" (Mode.Alloc.print ()) m

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -371,7 +371,7 @@ and function_body i ppf (body : function_body) =
         fc_arg_sort; fc_param = _; fc_partial = _; fc_env = _; fc_ret_type = _ }
     ->
       line i ppf "Tfunction_cases %a\n" fmt_location fc_loc;
-      alloc_mode i ppf fc_arg_mode;
+      alloc_mode_raw i ppf fc_arg_mode;
       line i ppf "%a\n" Jkind.Sort.format fc_arg_sort;
       attributes (i+1) ppf fc_attributes;
       Option.iter (fun e -> expression_extra (i+1) ppf e []) fc_exp_extra;
@@ -407,8 +407,10 @@ and expression_extra i ppf x attrs =
       line i ppf "Texp_stack\n";
       attributes i ppf attrs
 
-and alloc_mode: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
+and alloc_mode_raw: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
   = fun i ppf m -> line i ppf "alloc_mode %a\n" (Mode.Alloc.print ()) m
+
+and alloc_mode i ppf (m : alloc_mode) = alloc_mode_raw i ppf m.mode
 
 and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
 

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -282,6 +282,7 @@ let extra sub = function
   | Texp_newtype _ -> ()
   | Texp_poly cto -> Option.iter (sub.typ sub) cto
   | Texp_mode_coerce _ -> ()
+  | Texp_stack -> ()
 
 let function_param sub { fp_loc; fp_kind; fp_newtypes; _ } =
   sub.location sub fp_loc;

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -369,6 +369,7 @@ let extra sub = function
   | Texp_newtype _ as d -> d
   | Texp_poly cto -> Texp_poly (Option.map (sub.typ sub) cto)
   | Texp_mode_coerce modes -> Texp_mode_coerce modes
+  | Texp_stack as d -> d
 
 let function_body sub body =
   match body with

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -10278,7 +10278,7 @@ let report_error ~loc env = function
          automatically if ommitted. It cannot be passed with '?'.@]" label
   | Cannot_stack_allocate ->
       Location.errorf ~loc
-        "This allocation cannot be on stack."
+        "This allocation cannot be on the stack."
   | Not_allocation ->
       Location.errorf ~loc
         "This expression is not an allocation."

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -237,7 +237,7 @@ type error =
   | Modes_on_pattern
   | Invalid_label_for_src_pos of arg_label
   | Nonoptional_call_pos_label of string
-  | Cannot_stack_allocate
+  | Cannot_stack_allocate of Env.closure_context option
   | Not_allocation
 
 exception Error of Location.t * Env.t * error
@@ -602,7 +602,13 @@ let register_allocation_value_mode mode =
     [expected_mode]. Returns the mode of the allocation, and the expected mode
     of potential subcomponents. *)
 let register_allocation (expected_mode : expected_mode) =
-  let alloc_mode, mode = register_allocation_value_mode expected_mode.mode in
+  let alloc_mode, mode =
+    register_allocation_value_mode expected_mode.mode
+  in
+  let alloc_mode =
+    { mode = alloc_mode;
+      closure_context = expected_mode.closure_context }
+  in
   alloc_mode, mode_default mode
 
 let optimise_allocations () =
@@ -6463,9 +6469,10 @@ and type_expect_
       | Texp_array (_, _, _, alloc_mode)
       | Texp_field (_, _, _, Boxing (alloc_mode, _)) ->
         begin match Locality.submode Locality.local
-          (Alloc.proj (Comonadic Areality) alloc_mode) with
+          (Alloc.proj (Comonadic Areality) alloc_mode.mode) with
         | Ok () -> ()
-        | Error _ -> raise (Error (exp.exp_loc, env, Cannot_stack_allocate))
+        | Error _ -> raise (Error (exp.exp_loc, env,
+            Cannot_stack_allocate alloc_mode.closure_context))
         end
       | _ ->
         raise (Error (exp.exp_loc, env, Not_allocation))
@@ -7747,6 +7754,10 @@ and type_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
   let arity = List.length sexpl in
   assert (arity >= 2);
   let alloc_mode, argument_mode = register_allocation_value_mode expected_mode.mode in
+  let alloc_mode =
+    { mode = alloc_mode;
+      closure_context = expected_mode.closure_context }
+  in
   (* CR layouts v5: non-values in tuples *)
   let labeled_subtypes =
     List.map (fun (label, _) -> label,
@@ -8945,11 +8956,15 @@ and type_n_ary_function
       Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
         ~default_arity:syntactic_arity attributes
     in
+    let alloc_mode =
+      { mode = Mode.Alloc.disallow_left fun_alloc_mode;
+        closure_context = expected_mode.closure_context }
+    in
     re
       { exp_desc =
           Texp_function
             { params; body; region = region_locked; ret_sort;
-              alloc_mode = Mode.Alloc.disallow_left fun_alloc_mode; ret_mode;
+              alloc_mode; ret_mode;
               zero_alloc
             };
         exp_loc = loc;
@@ -9521,6 +9536,20 @@ let report_type_expected_explanation expl ppf =
       because "a when-clause in a comprehension"
   | Error_message_attr msg ->
       fprintf ppf "@\n@[%s@]" msg
+
+let stack_hint (context : Env.closure_context option) =
+  match context with
+  | Some Return -> []
+  | Some Tailcall_argument ->
+    [ Location.msg
+        "@[Hint: This argument cannot be stack-allocated,@ \
+         because it is an argument in a tail call.@]" ]
+  | Some Tailcall_function ->
+    [ Location.msg
+        "@[Hint: This function cannot be stack-allocated,@ \
+         because it is the function in a tail call.@]" ]
+  | Some Partial_application -> assert false
+  | None -> []
 
 let escaping_hint (failure_reason : Value.error) submode_reason
       (context : Env.closure_context option) =
@@ -10276,9 +10305,10 @@ let report_error ~loc env = function
     Location.errorf ~loc
       "@[the argument labeled '%s' is a [%%call_pos] argument, filled in @ \
          automatically if ommitted. It cannot be passed with '?'.@]" label
-  | Cannot_stack_allocate ->
-      Location.errorf ~loc
-        "This allocation cannot be on the stack."
+  | Cannot_stack_allocate closure_context ->
+      let sub = stack_hint closure_context in
+      Location.errorf ~loc ~sub
+        "@[This allocation cannot be on the stack.@]"
   | Not_allocation ->
       Location.errorf ~loc
         "This expression is not an allocation."

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -186,6 +186,13 @@ type contention_context =
   | Read_mutable
   | Write_mutable
 
+type unsupported_stack_allocation =
+  | Lazy
+  | Module
+  | Object
+  | List_comprehension
+  | Array_comprehension
+
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
   | Constructor_labeled_arg
@@ -304,6 +311,7 @@ type error =
   | Invalid_label_for_src_pos of arg_label
   | Nonoptional_call_pos_label of string
   | Cannot_stack_allocate of Env.closure_context option
+  | Unsupported_stack_allocation of unsupported_stack_allocation
   | Not_allocation
 
 exception Error of Location.t * Env.t * error

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -303,6 +303,8 @@ type error =
   | Modes_on_pattern
   | Invalid_label_for_src_pos of arg_label
   | Nonoptional_call_pos_label of string
+  | Cannot_stack_allocate
+  | Not_allocation
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -303,7 +303,7 @@ type error =
   | Modes_on_pattern
   | Invalid_label_for_src_pos of arg_label
   | Nonoptional_call_pos_label of string
-  | Cannot_stack_allocate
+  | Cannot_stack_allocate of Env.closure_context option
   | Not_allocation
 
 exception Error of Location.t * Env.t * error

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -54,8 +54,13 @@ type unique_barrier = Mode.Uniqueness.r option
 
 type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
+type alloc_mode = {
+  mode : Mode.Alloc.r;
+  closure_context : Env.closure_context option;
+}
+
 type texp_field_boxing =
-  | Boxing of Mode.Alloc.r * unique_use
+  | Boxing of alloc_mode * unique_use
   | Non_boxing of unique_use
 
 let shared_many_use =
@@ -146,7 +151,7 @@ and expression_desc =
         region : bool;
         ret_mode : Mode.Alloc.l;
         ret_sort : Jkind.sort;
-        alloc_mode : Mode.Alloc.r;
+        alloc_mode : alloc_mode;
         zero_alloc : Builtin_attributes.zero_alloc_attribute;
       }
   | Texp_apply of
@@ -154,21 +159,21 @@ and expression_desc =
         Mode.Locality.l * Zero_alloc_utils.Assume_info.t
   | Texp_match of expression * Jkind.sort * computation case list * partial
   | Texp_try of expression * value case list
-  | Texp_tuple of (string option * expression) list * Mode.Alloc.r
+  | Texp_tuple of (string option * expression) list * alloc_mode
   | Texp_construct of
-      Longident.t loc * constructor_description * expression list * Mode.Alloc.r option
-  | Texp_variant of label * (expression * Mode.Alloc.r) option
+      Longident.t loc * constructor_description * expression list * alloc_mode option
+  | Texp_variant of label * (expression * alloc_mode) option
   | Texp_record of {
       fields : ( Types.label_description * record_label_definition ) array;
       representation : Types.record_representation;
       extended_expression : expression option;
-      alloc_mode : Mode.Alloc.r option
+      alloc_mode : alloc_mode option
     }
   | Texp_field of
       expression * Longident.t loc * label_description * texp_field_boxing
   | Texp_setfield of
       expression * Mode.Locality.l * Longident.t loc * label_description * expression
-  | Texp_array of mutability * Jkind.Sort.t * expression list * Mode.Alloc.r
+  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode
   | Texp_list_comprehension of comprehension
   | Texp_array_comprehension of mutability * Jkind.sort * comprehension
   | Texp_ifthenelse of expression * expression * expression option

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -127,6 +127,7 @@ and exp_extra =
   | Texp_poly of core_type option
   | Texp_newtype of string * Jkind.annotation option
   | Texp_mode_coerce of Jane_syntax.Mode_expr.t
+  | Texp_stack
 
 and arg_label = Types.arg_label =
   | Nolabel

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -72,8 +72,13 @@ type unique_barrier = Mode.Uniqueness.r option
 
 type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
+type alloc_mode = {
+  mode : Mode.Alloc.r;
+  closure_context : Env.closure_context option;
+}
+
 type texp_field_boxing =
-  | Boxing of Mode.Alloc.r * unique_use
+  | Boxing of alloc_mode * unique_use
   (** Projection requires boxing. [unique_use] describes the usage of the
       unboxed field as argument to boxing. *)
   | Non_boxing of unique_use
@@ -266,7 +271,7 @@ and expression_desc =
         (* Mode where the function allocates, ie local for a function of
            type 'a -> local_ 'b, and heap for a function of type 'a -> 'b *)
         ret_sort : Jkind.sort;
-        alloc_mode : Mode.Alloc.r;
+        alloc_mode : alloc_mode;
         (* Mode at which the closure is allocated *)
         zero_alloc : Builtin_attributes.zero_alloc_attribute
         (* zero-alloc attributes *)
@@ -313,7 +318,7 @@ and expression_desc =
          *)
   | Texp_try of expression * value case list
         (** try E with P1 -> E1 | ... | PN -> EN *)
-  | Texp_tuple of (string option * expression) list * Mode.Alloc.r
+  | Texp_tuple of (string option * expression) list * alloc_mode
         (** [Texp_tuple(el)] represents
             - [(E1, ..., En)]       when [el] is [(None, E1);...;(None, En)],
             - [(L1:E1, ..., Ln:En)] when [el] is [(Some L1, E1);...;(Some Ln, En)],
@@ -321,7 +326,7 @@ and expression_desc =
           *)
   | Texp_construct of
       Longident.t loc * Types.constructor_description *
-      expression list * Mode.Alloc.r option
+      expression list * alloc_mode option
         (** C                []
             C E              [E]
             C (E1, ..., En)  [E1;...;En]
@@ -330,7 +335,7 @@ and expression_desc =
             or [None] if the constructor is [Cstr_unboxed] or [Cstr_constant],
             in which case it does not need allocation.
          *)
-  | Texp_variant of label * (expression * Mode.Alloc.r) option
+  | Texp_variant of label * (expression * alloc_mode) option
         (** [alloc_mode] is the allocation mode of the variant,
             or [None] if the variant has no argument,
             in which case it does not need allocation.
@@ -339,7 +344,7 @@ and expression_desc =
       fields : ( Types.label_description * record_label_definition ) array;
       representation : Types.record_representation;
       extended_expression : expression option;
-      alloc_mode : Mode.Alloc.r option
+      alloc_mode : alloc_mode option
     }
         (** { l1=P1; ...; ln=Pn }           (extended_expression = None)
             { E0 with l1=P1; ...; ln=Pn }   (extended_expression = Some E0)
@@ -363,7 +368,7 @@ and expression_desc =
       expression * Mode.Locality.l * Longident.t loc *
       Types.label_description * expression
     (** [alloc_mode] translates to the [modify_mode] of the record *)
-  | Texp_array of Types.mutability * Jkind.Sort.t * expression list * Mode.Alloc.r
+  | Texp_array of Types.mutability * Jkind.Sort.t * expression list * alloc_mode
   | Texp_list_comprehension of comprehension
   | Texp_array_comprehension of Types.mutability * Jkind.sort * comprehension
   | Texp_ifthenelse of expression * expression * expression option

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -219,6 +219,8 @@ and exp_extra =
         (** fun (type t : immediate) ->  *)
   | Texp_mode_coerce of Jane_syntax.Mode_expr.t
         (** local_ E *)
+  | Texp_stack
+        (** stack_ E *)
 
 (* CR modes: Consider fusing [Texp_mode_coerce] and [Texp_constraint] when
    the syntax changes.

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -459,6 +459,7 @@ let exp_extra sub (extra, loc, attrs) sexp =
         Jane_syntax.Modes.expr_of ~loc
           (Coerce (modes, sexp))
         |> add_jane_syntax_attributes
+    | Texp_stack -> Pexp_stack sexp
   in
   Exp.mk ~loc ~attrs:!attrs desc
 
@@ -560,7 +561,8 @@ let expression sub exp =
                       (Pcoerce (Option.map (sub.typ sub) ty1, sub.typ sub ty2))
                 | Some (Texp_constraint ty) ->
                     Some (Pconstraint (sub.typ sub ty))
-                | Some (Texp_poly _ | Texp_newtype _ | Texp_mode_coerce _)
+                | Some (Texp_poly _ | Texp_newtype _ | Texp_mode_coerce _
+                    | Texp_stack)
                 | None -> None
               in
               let constraint_ =

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -409,6 +409,9 @@ and expression i ppf x =
       payload i ppf arg
   | Pexp_unreachable ->
       line i ppf "Pexp_unreachable"
+  | Pexp_stack e ->
+      line i ppf "Pexp_stack\n";
+      expression i ppf e
   )
 
 and value_description i ppf x =


### PR DESCRIPTION
This adds the support for `stack_ exp` syntax, which forces the allocation `exp` to be on stack. If `exp` is not an allocation, an error is issued.

The error message has room for improvement: currently no hints are given if the allocation cannot be on stack. Some solutions:
- Inside the typedtree of `exp`, annotate allocation mode with reasons (inherited from `expected_mode`). This is my preferred approach.
- Add extra field `alloc_stack:bool` to `expected_mode`, and `register_allocation` will read that field and force stack allocation. The function works on `expected_mode` so has the hints . This sounds bad idea.

But maybe it's fine without the hints? Let's see what the reviewer says.

Also the docs in `ocaml/jane/doc` need an overhaul. To begin with, we should distinguish `local_` from "stack allocation". That sounds like a big task that I will do in a future PR.