### PR TITLE
Fix for missing stub inlining in classic mode

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2186,9 +2186,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
   in
   let inlining_decision =
     if Flambda_features.classic_mode ()
-    then Inlining.definition_inlining_decision inline cost_metrics
-    else if stub
-    then Function_decl_inlining_decision_type.Stub
+    then Inlining.definition_inlining_decision inline cost_metrics ~stub
     else Function_decl_inlining_decision_type.Not_yet_decided
   in
   let loopify : Loopify_attribute.t =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -121,16 +121,21 @@ module Inlining = struct
     let magic_scale_constant = 20. in
     int_of_float (inline_threshold *. magic_scale_constant)
 
-  let definition_inlining_decision inline cost_metrics =
+  let definition_inlining_decision inline cost_metrics ~stub =
     let inline_threshold = threshold () in
     let code_size = Cost_metrics.size cost_metrics in
     match (inline : Inline_attribute.t) with
     | Never_inline ->
       Function_decl_inlining_decision_type.Never_inline_attribute
-    | Always_inline | Available_inline ->
-      Function_decl_inlining_decision_type.Attribute_inline
+    | Always_inline -> Function_decl_inlining_decision_type.Attribute_inline
+    | Available_inline ->
+      if stub
+      then Function_decl_inlining_decision_type.Stub
+      else Function_decl_inlining_decision_type.Attribute_inline
     | Unroll _ | Default_inline ->
-      if Code_size.to_int code_size <= inline_threshold
+      if stub
+      then Function_decl_inlining_decision_type.Stub
+      else if Code_size.to_int code_size <= inline_threshold
       then
         Function_decl_inlining_decision_type.Small_function
           { size = code_size;
@@ -421,9 +426,10 @@ module Acc = struct
                 Inlining.definition_inlining_decision
                   (Code_metadata.inline metadata)
                   (Code_metadata.cost_metrics metadata)
+                  ~stub:(Code_metadata.stub metadata)
               with
-              | Attribute_inline | Small_function _ -> approx
-              | Not_yet_decided | Never_inline_attribute | Stub | Recursive
+              | Attribute_inline | Small_function _ | Stub -> approx
+              | Not_yet_decided | Never_inline_attribute | Recursive
               | Function_body_too_large _ | Speculatively_inlinable _
               | Functor _ ->
                 Value_approximation.Closure_approximation

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -100,6 +100,7 @@ module Inlining : sig
   val definition_inlining_decision :
     Inline_attribute.t ->
     Cost_metrics.t ->
+    stub:bool ->
     Function_decl_inlining_decision_type.t
 end
 


### PR DESCRIPTION
The basic stub inlining strategy in classic mode doesn't match up with Simplify and I'm not sure why.  This PR aims to correct it.

The current situation was seen to be producing confusing results as a result of #2357.  A functor that was not previously inlinable, as it contained functions, became inlinable.  However there was a functor coercion stub (because of the ordering of declarations in the `.mli` file) and so the functor itself was not directly exposed in the interface.  Before the aforementioned PR, the stub just contained a call to the original functor; but after the PR, this call was inlined.  As a result, the stub went way over the inlining threshold, and despite being a stub was not written into the `.cmx` file.  Fixing this is the first part of this PR.

At which point, even if the inlining threshold is raised, the stub is blackholed because of the code that looks at approximations upon `.cmx` loading.  Any stub would be forced to metadata-only, thus preventing inlining.  So this is the second part of the fix.

I am unclear as to why either of these pieces of code were in the state prior to this PR, but maybe there is something I am missing here.  I don't think there should be any performance concerns since we're not descending into the bodies of inlined functions unlike in Simplify.

I have wondered on and off, after intermittent user reports of problems with optional argument wrappers, whether there might be a lingering problem with stub inlining - and this could very well be it.

@lthls could you please look at this asap?

@Keryan-dev do you happen to remember any previous relevant discussions?