### PR TITLE
Fix CI warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
       # run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install afl-fuzz
 
     - name: Cache OCaml 4.14, dune and menhir
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache
       with:
         path: ${{ github.workspace }}/ocaml-414/_install


### PR DESCRIPTION
This pull request simply changes the
version of the `cache` action in the
CI, in order to silence a warning.

(I have seen nothing in the changelog
of the action that would be breaking
our workflows by upgrading.)