### PR TITLE
Force .cmx loading for zero alloc in classic mode

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -267,6 +267,9 @@ let set_inlined_debuginfo t inlined_debuginfo = { t with inlined_debuginfo }
 let add_inlined_debuginfo t dbg =
   Inlined_debuginfo.rewrite t.inlined_debuginfo dbg
 
+let currently_in_inlined_body t =
+  not (Inlined_debuginfo.is_none t.inlined_debuginfo)
+
 (* Continuations *)
 
 let return_continuation env = env.return_continuation

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -106,6 +106,8 @@ val enter_inlined_apply : t -> Inlined_debuginfo.t -> t
 (** Set the inlined debuginfo. *)
 val set_inlined_debuginfo : t -> Inlined_debuginfo.t -> t
 
+val currently_in_inlined_body : t -> bool
+
 (** {2 Continuations} *)
 
 (** Returns the return continuation of the environment. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -160,7 +160,10 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         args @ [callee]
       else args
     in
-    let code_sym = To_cmm_result.symbol_of_code_id res code_id in
+    let code_sym =
+      To_cmm_result.symbol_of_code_id res code_id
+        ~currently_in_inlined_body:(Env.currently_in_inlined_body env)
+    in
     match Apply.probe apply with
     | None ->
       ( C.direct_call ~dbg

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -34,7 +34,8 @@ val create : module_symbol:Symbol.t -> reachable_names:Name_occurrences.t -> t
 val symbol : t -> Symbol.t -> Cmm.symbol
 
 (** Produce the Cmm function symbol for a piece of code. *)
-val symbol_of_code_id : t -> Code_id.t -> Cmm.symbol
+val symbol_of_code_id :
+  t -> Code_id.t -> currently_in_inlined_body:bool -> Cmm.symbol
 
 (** Create a Cmm symbol, not arising from a [Symbol.t]. *)
 val raw_symbol : t -> global:Cmm.is_global -> string -> t * Cmm.symbol

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -205,7 +205,9 @@ end = struct
         updates )
     | Function_slot { size; function_slot; last_function_slot } -> (
       let code_id = Function_slot.Map.find function_slot decls in
-      let code_symbol = R.symbol_of_code_id res code_id in
+      let code_symbol =
+        R.symbol_of_code_id res code_id ~currently_in_inlined_body:false
+      in
       let (kind, params_ty, result_ty), closure_code_pointers, dbg =
         get_func_decl_params_arity env code_id
       in
@@ -415,7 +417,9 @@ let params_and_body0 env res code_id ~fun_dbg ~check ~return_continuation
     @
     if Flambda_features.optimize_for_speed () then [] else [Cmm.Reduce_code_size]
   in
-  let fun_sym = R.symbol_of_code_id res code_id in
+  let fun_sym =
+    R.symbol_of_code_id res code_id ~currently_in_inlined_body:false
+  in
   let fun_poll =
     Env.get_code_metadata env code_id
     |> Code_metadata.poll_attribute |> Poll_attribute.to_lambda


### PR DESCRIPTION
We would like it to be the case that at the end of the middle end, all `.cmx` files corresponding to code IDs in the generated Cmm code have been loaded.  This means that the function summaries therein are readily available for the zero-alloc check later.

This already happens in Simplify mode, but in Classic mode it does not, because of the lack of traversal of the bodies of inlined functions.  This patch makes `To_cmm` load the necessary `.cmx` files when generating Cmm for inlined bodies.

@gretay-js has tested this works with zero alloc, and it gives notable improvements.