### PR TITLE
Remove legacy combined `Import_info.t` type and update all uses

### DIFF
--- a/backend/asmlibrarian.ml
+++ b/backend/asmlibrarian.ml
@@ -66,11 +66,11 @@ let create_archive file_list lib_name =
        let cmxs = Array.of_list cmxs in
        let cmi_index = Compilation_unit.Name.Tbl.create 42 in
        Array.iteri (fun i import ->
-           Compilation_unit.Name.Tbl.add cmi_index (Import_info.name import) i)
+           Compilation_unit.Name.Tbl.add cmi_index (Import_info.Intf.name import) i)
          cmis;
        let cmx_index = Compilation_unit.Tbl.create 42 in
        Array.iteri (fun i import ->
-           Compilation_unit.Tbl.add cmx_index (Import_info.cu import) i)
+           Compilation_unit.Tbl.add cmx_index (Import_info.Impl.cu import) i)
          cmxs;
        let genfns = Generic_fns.Tbl.make () in
        let mk_bitmap arr ix entries ~find ~get_name =
@@ -92,11 +92,11 @@ let create_archive file_list lib_name =
              li_imports_cmi =
                mk_bitmap cmis cmi_index unit.ui_imports_cmi
                  ~find:Compilation_unit.Name.Tbl.find
-                 ~get_name:Import_info.name;
+                 ~get_name:Import_info.Intf.name;
              li_imports_cmx =
                mk_bitmap cmxs cmx_index unit.ui_imports_cmx
                  ~find:Compilation_unit.Tbl.find
-                 ~get_name:Import_info.cu;
+                 ~get_name:Import_info.Impl.cu;
              li_external_symbols = Array.of_list unit.ui_external_symbols })
          descr_list
        in

--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -61,7 +61,7 @@ let check_cmi_consistency file_name cmis =
   try
     Array.iter
       (fun import ->
-        let name = Import_info.name import in
+        let name = Import_info.Intf.name import in
         let nonalias = Import_info.Intf.nonalias import in
         CU.Name.Tbl.replace interfaces name ();
         match nonalias with
@@ -80,8 +80,8 @@ let check_cmx_consistency file_name cmxs =
   try
     Array.iter
       (fun import ->
-        let name = Import_info.cu import in
-        let crco = Import_info.crc import in
+        let name = Import_info.Impl.cu import in
+        let crco = Import_info.Impl.crc import in
         implementations := name :: !implementations;
         match crco with
             None ->
@@ -123,7 +123,7 @@ let extract_crc_implementations () =
   Cmx_consistbl.extract !implementations crc_implementations
   |> List.map (fun (cu, crc) ->
        let crc = Option.map (fun ((), crc) -> crc) crc in
-       Import_info.create_normal cu ~crc)
+       Import_info.Impl.create cu ~crc)
 
 (* Add C objects and options and "custom" info from a library descriptor.
    See bytecomp/bytelink.ml for comments on the order of C objects. *)
@@ -163,7 +163,7 @@ let is_required name =
   with Not_found -> false
 
 let add_required by import =
-  let name = Import_info.cu import in
+  let name = Import_info.Impl.cu import in
   try
     let rq = Hashtbl.find missing_globals name in
     rq := by :: !rq

--- a/backend/asmlink.mli
+++ b/backend/asmlink.mli
@@ -28,8 +28,8 @@ val call_linker_shared: ?native_toplevel:bool -> string list -> string -> unit
 
 val reset : unit -> unit
 val check_consistency: filepath -> Cmx_format.unit_infos -> Digest.t -> unit
-val extract_crc_interfaces: unit -> Import_info.t list
-val extract_crc_implementations: unit -> Import_info.t list
+val extract_crc_interfaces: unit -> Import_info.Intf.t list
+val extract_crc_implementations: unit -> Import_info.Impl.t list
 
 type error =
   | File_not_found of filepath

--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -72,7 +72,7 @@ let check_units members =
       | PM_impl infos ->
           List.iter
             (fun import ->
-              let unit = Import_info.cu import in
+              let unit = Import_info.Impl.cu import in
               let name = CU.name unit in
               if List.mem name forbidden
               then raise(Error(Forward_reference(mb.pm_file, name))))
@@ -160,9 +160,11 @@ let make_package_object unix ~ppf_dump members targetobj targetname coercion
 let build_package_cmx members cmxfile =
   let unit_names =
     List.map (fun m -> m.pm_name) members in
-  let filter lst =
+  let filter lst ~get_name =
     List.filter (fun import ->
-      not (List.mem (Import_info.name import) unit_names)) lst in
+      not (List.mem (get_name import) unit_names)) lst in
+  let filter_cmi lst = filter lst ~get_name:Import_info.Intf.name in
+  let filter_cmx lst = filter lst ~get_name:Import_info.Impl.name in
   let union lst =
     List.fold_left
       (List.fold_left
@@ -189,11 +191,11 @@ let build_package_cmx members cmxfile =
           List.flatten (List.map (fun info -> info.ui_defines) units) @
           [ui.ui_unit];
       ui_imports_cmi =
-          (Import_info.create modname
-            ~crc_with_unit:(Some (ui.ui_unit, Env.crc_of_unit modname))) ::
-            filter (Asmlink.extract_crc_interfaces ());
+          (Import_info.Intf.create_normal modname ui.ui_unit
+            ~crc:(Env.crc_of_unit modname)) ::
+            filter_cmi (Asmlink.extract_crc_interfaces ());
       ui_imports_cmx =
-          filter(Asmlink.extract_crc_implementations());
+          filter_cmx(Asmlink.extract_crc_implementations());
       ui_generic_fns =
         { curry_fun =
             union(List.map (fun info -> info.ui_generic_fns.curry_fun) units);

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -49,9 +49,9 @@ type unit_infos =
                                           (* All compilation units in the
                                              .cmx file (i.e. [ui_unit] and
                                              any produced via [Asmpackager]) *)
-    mutable ui_imports_cmi: Import_info.t list;
+    mutable ui_imports_cmi: Import_info.Intf.t list;
                                           (* Interfaces imported *)
-    mutable ui_imports_cmx: Import_info.t list;
+    mutable ui_imports_cmx: Import_info.Impl.t list;
                                           (* Infos imported *)
     mutable ui_generic_fns: generic_fns;  (* Generic functions needed *)
     mutable ui_export_info: Flambda2_cmx.Flambda_cmx_format.t option;
@@ -63,8 +63,8 @@ type unit_infos =
 type unit_infos_raw =
   { uir_unit: Compilation_unit.t;
     uir_defines: Compilation_unit.t list;
-    uir_imports_cmi: Import_info.t array;
-    uir_imports_cmx: Import_info.t array;
+    uir_imports_cmi: Import_info.Intf.t array;
+    uir_imports_cmx: Import_info.Impl.t array;
     uir_generic_fns: generic_fns;
     uir_export_info: Flambda2_cmx.Flambda_cmx_format.raw option;
     uir_checks: Checks.Raw.t;
@@ -90,8 +90,8 @@ type lib_unit_info =
   }
 
 type library_infos =
-  { lib_imports_cmi: Import_info.t array;
-    lib_imports_cmx: Import_info.t array;
+  { lib_imports_cmi: Import_info.Intf.t array;
+    lib_imports_cmx: Import_info.Impl.t array;
     lib_units: lib_unit_info list;
     lib_generic_fns: generic_fns;
     (* In the following fields the lists are reversed with respect to

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -165,7 +165,7 @@ let get_unit_info comp_unit =
               (None, None)
           end
       in
-      let import = Import_info.create_normal comp_unit ~crc in
+      let import = Import_info.Impl.create comp_unit ~crc in
       current_unit.ui_imports_cmx <- import :: current_unit.ui_imports_cmx;
       CU.Name.Tbl.add global_infos_table cmx_name infos;
       infos

--- a/ocaml/bytecomp/bytelink.ml
+++ b/ocaml/bytecomp/bytelink.ml
@@ -199,7 +199,7 @@ let check_consistency file_name cu =
   begin try
     Array.iter
       (fun import ->
-        let name = Import_info.name import in
+        let name = Import_info.Intf.name import in
         let nonalias = Import_info.Intf.nonalias import in
         interfaces := name :: !interfaces;
         match nonalias with

--- a/ocaml/bytecomp/bytelink.mli
+++ b/ocaml/bytecomp/bytelink.mli
@@ -26,7 +26,7 @@ val reset : unit -> unit
 
 val check_consistency: filepath -> Cmo_format.compilation_unit_descr -> unit
 
-val extract_crc_interfaces: unit -> Import_info.t list
+val extract_crc_interfaces: unit -> Import_info.Intf.t list
 
 type error =
   | File_not_found of filepath

--- a/ocaml/bytecomp/bytepackager.ml
+++ b/ocaml/bytecomp/bytepackager.ml
@@ -256,7 +256,7 @@ let package_object_files ~ppf_dump files targetfile targetname coercion =
       let unit_names =
         List.map (fun m -> m.pm_name) members in
       List.filter
-        (fun import -> not (List.mem (Import_info.name import) unit_names))
+        (fun import -> not (List.mem (Import_info.Intf.name import) unit_names))
         (Bytelink.extract_crc_interfaces()) in
     let for_pack_prefix = CU.Prefix.from_clflags () in
     let modname = targetname |> CU.Name.of_string in
@@ -268,8 +268,8 @@ let package_object_files ~ppf_dump files targetfile targetname coercion =
         cu_reloc = List.rev state.relocs;
         cu_imports =
           Array.of_list
-            ((Import_info.create modname
-               ~crc_with_unit:(Some (cu_name, Env.crc_of_unit modname)))
+            (Import_info.Intf.create_normal modname
+               cu_name ~crc:(Env.crc_of_unit modname)
               :: imports);
         cu_primitives = List.rev state.primitives;
         cu_required_globals = Compilation_unit.Set.elements required_globals;

--- a/ocaml/bytecomp/symtable.ml
+++ b/ocaml/bytecomp/symtable.ml
@@ -327,7 +327,7 @@ let init_toplevel () =
     let crcintfs =
       try
         (Obj.magic (sect.read_struct Bytesections.Name.CRCS)
-         : Import_info.t array)
+         : Import_info.Intf.t array)
       with Not_found -> [| |] in
     (* Done *)
     sect.close_reader();

--- a/ocaml/bytecomp/symtable.mli
+++ b/ocaml/bytecomp/symtable.mli
@@ -32,7 +32,7 @@ val transl_const: Lambda.structured_constant -> Obj.t
 
 (* Functions for the toplevel *)
 
-val init_toplevel: unit -> Import_info.t array
+val init_toplevel: unit -> Import_info.Intf.t array
 val update_global_table: unit -> unit
 val get_global_value: Ident.t -> Obj.t
 val is_global_defined: Ident.t -> bool

--- a/ocaml/file_formats/cmi_format.ml
+++ b/ocaml/file_formats/cmi_format.ml
@@ -57,7 +57,7 @@ module Serialized = Types.Make_wrapped(struct type 'a t = int end)
 (* these type abbreviations are not exported;
    they are used to provide consistency across
    input_value and output_value usage. *)
-type crcs = Import_info.t array  (* smaller on disk than using a list *)
+type crcs = Import_info.Intf.t array  (* smaller on disk than using a list *)
 type flags = pers_flags list
 type header = {
     header_name : Compilation_unit.Name.t;

--- a/ocaml/file_formats/cmi_format.mli
+++ b/ocaml/file_formats/cmi_format.mli
@@ -30,7 +30,7 @@ type 'sg cmi_infos_generic = {
     cmi_name : Compilation_unit.Name.t;
     cmi_kind : kind;
     cmi_sign : 'sg;
-    cmi_crcs : Import_info.t array;
+    cmi_crcs : Import_info.Intf.t array;
     cmi_flags : pers_flags list;
 }
 

--- a/ocaml/file_formats/cmo_format.mli
+++ b/ocaml/file_formats/cmo_format.mli
@@ -30,7 +30,8 @@ type compilation_unit_descr =
     mutable cu_pos: int;                (* Absolute position in file *)
     cu_codesize: int;                   (* Size of code block *)
     cu_reloc: (reloc_info * int) list;  (* Relocation information *)
-    cu_imports: Import_info.t array;    (* Names and CRC of intfs imported *)
+    cu_imports: Import_info.Intf.t array;
+                                        (* Names and CRC of intfs imported *)
     cu_required_globals: Compilation_unit.t list;
                                         (* Compilation units whose
                                            initialization side effects

--- a/ocaml/file_formats/cmt_format.ml
+++ b/ocaml/file_formats/cmt_format.ml
@@ -57,7 +57,7 @@ type cmt_infos = {
   cmt_loadpath : Load_path.paths;
   cmt_source_digest : Digest.t option;
   cmt_initial_env : Env.t;
-  cmt_imports : Import_info.t array;
+  cmt_imports : Import_info.Intf.t array;
   cmt_interface_digest : Digest.t option;
   cmt_use_summaries : bool;
   cmt_uid_to_decl : item_declaration Shape.Uid.Tbl.t;
@@ -459,8 +459,8 @@ let save_cmt filename modname binary_annots sourcefile initial_env cmi shape =
          in
          let source_digest = Option.map Digest.file sourcefile in
          let compare_imports import1 import2 =
-           let modname1 = Import_info.name import1 in
-           let modname2 = Import_info.name import2 in
+           let modname1 = Import_info.Intf.name import1 in
+           let modname2 = Import_info.Intf.name import2 in
            Compilation_unit.Name.compare modname1 modname2
          in
          let get_imports () =

--- a/ocaml/file_formats/cmt_format.mli
+++ b/ocaml/file_formats/cmt_format.mli
@@ -60,7 +60,7 @@ type cmt_infos = {
   cmt_loadpath : Load_path.paths;
   cmt_source_digest : string option;
   cmt_initial_env : Env.t;
-  cmt_imports : Import_info.t array;
+  cmt_imports : Import_info.Intf.t array;
   cmt_interface_digest : Digest.t option;
   cmt_use_summaries : bool;
   cmt_uid_to_decl : item_declaration Shape.Uid.Tbl.t;

--- a/ocaml/file_formats/cmxs_format.mli
+++ b/ocaml/file_formats/cmxs_format.mli
@@ -22,8 +22,8 @@
 type dynunit = {
   dynu_name: Compilation_unit.t;
   dynu_crc: Digest.t;
-  dynu_imports_cmi: Import_info.t array;
-  dynu_imports_cmx: Import_info.t array;
+  dynu_imports_cmi: Import_info.Intf.t array;
+  dynu_imports_cmx: Import_info.Impl.t array;
   dynu_defines: Compilation_unit.t list;
 }
 

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -473,7 +473,7 @@ val save_signature:
         (* Arguments: signature, module name, module kind, file name. *)
 val save_signature_with_imports:
   alerts:alerts -> signature -> Compilation_unit.Name.t -> Cmi_format.kind
-  -> filepath -> Import_info.t array -> Cmi_format.cmi_infos_lazy
+  -> filepath -> Import_info.Intf.t array -> Cmi_format.cmi_infos_lazy
         (* Arguments: signature, module name, module kind,
            file name, imported units with their CRCs. *)
 
@@ -481,10 +481,10 @@ val save_signature_with_imports:
 val crc_of_unit: Compilation_unit.Name.t -> Digest.t
 
 (* Return the set of compilation units imported, with their CRC *)
-val imports: unit -> Import_info.t list
+val imports: unit -> Import_info.Intf.t list
 
 (* may raise Persistent_env.Consistbl.Inconsistency *)
-val import_crcs: source:string -> Import_info.t array -> unit
+val import_crcs: source:string -> Import_info.Intf.t array -> unit
 
 (* [is_imported_opaque md] returns true if [md] is an opaque imported module *)
 val is_imported_opaque: Compilation_unit.Name.t -> bool

--- a/ocaml/typing/persistent_env.ml
+++ b/ocaml/typing/persistent_env.ml
@@ -63,7 +63,7 @@ type can_load_cmis =
 
 type pers_struct = {
   ps_is_param: bool;
-  ps_crcs: Import_info.t array;
+  ps_crcs: Import_info.Intf.t array;
   ps_filename: string;
   ps_visibility: Load_path.visibility;
 }
@@ -390,10 +390,10 @@ let crc_of_unit penv f name =
   | Some (_, crc) -> crc
   | None ->
     let (ps, _pm) = find_pers_struct ~allow_hidden:true penv f true name in
-    match Array.find_opt (Import_info.has_name ~name) ps.ps_crcs with
+    match Array.find_opt (Import_info.Intf.has_name ~name) ps.ps_crcs with
     | None -> assert false
     | Some import_info ->
-      match Import_info.crc import_info with
+      match Import_info.Intf.crc import_info with
       | None -> assert false
       | Some crc -> crc
 

--- a/ocaml/typing/persistent_env.mli
+++ b/ocaml/typing/persistent_env.mli
@@ -124,10 +124,10 @@ val without_cmis : 'a t -> ('b -> 'c) -> 'b -> 'c
 
 (* may raise Consistbl.Inconsistency *)
 val import_crcs : 'a t -> source:filepath ->
-  Import_info.t array -> unit
+  Import_info.Intf.t array -> unit
 
 (* Return the set of compilation units imported, with their CRC *)
-val imports : 'a t -> Import_info.t list
+val imports : 'a t -> Import_info.Intf.t list
 
 (* Return the CRC of the interface of the given compilation unit *)
 val crc_of_unit: 'a t -> (Persistent_signature.t -> 'a)

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3621,7 +3621,7 @@ let package_units initial_env objfiles cmifile modulename =
     let unit_names = List.map fst units in
     let imports =
       List.filter (fun import ->
-          let name = Import_info.name import in
+          let name = Import_info.Intf.name import in
           not (List.mem name unit_names))
         (Env.imports()) in
     (* Write packaged signature *)

--- a/ocaml/utils/import_info.ml
+++ b/ocaml/utils/import_info.ml
@@ -14,64 +14,11 @@
 
 module CU = Compilation_unit
 
-type intf =
-  | Normal of CU.Name.t * CU.t * Digest.t
-  | Alias of CU.Name.t
-  | Parameter of CU.Name.t * Digest.t
-
-type impl =
-  | Loaded of CU.t * Digest.t
-  | Unloaded of CU.t
-
-(* CR-soon lmaurer: This combined type should go away soon, since each [t] is
-   actually statically known to be either an [intf] or an [impl] (see PR
-   #1933) *)
-type t =
-  | Intf of intf
-  | Impl of impl
-
-let create cu_name ~crc_with_unit =
-  (* This creates an [Intf] just to be minimally restrictive. Any caller that
-     cares should use the [Impl] API. *)
-  match crc_with_unit with
-  | None -> Intf (Alias cu_name)
-  | Some (cu, crc) -> Intf (Normal (cu_name, cu, crc))
-
-let create_normal cu ~crc =
-  match crc with
-  | Some crc -> Impl (Loaded (cu, crc))
-  | None -> Impl (Unloaded cu)
-
-let name t =
-  match t with
-  | Impl (Loaded (cu, _) | Unloaded cu) -> CU.name cu
-  | Intf (Normal (name, _, _) | Alias name | Parameter (name, _)) -> name
-
-let cu t =
-  match t with
-  | Intf (Normal (_, cu, _)) -> cu
-  | Impl (Loaded (cu, _) | Unloaded cu) -> cu
-  | Intf (Alias name | Parameter (name, _)) ->
-    Misc.fatal_errorf
-      "Cannot extract [Compilation_unit.t] from [Import_info.t] (for unit %a) \
-       that never received it"
-      CU.Name.print name
-
-let crc t =
-  match t with
-  | Intf (Normal (_, _, crc) | Parameter (_, crc)) -> Some crc
-  | Intf (Alias _) -> None
-  | Impl (Loaded (_, crc)) -> Some crc
-  | Impl (Unloaded _) -> None
-
-let has_name t ~name:name' = CU.Name.equal (name t) name'
-
-let dummy = Intf (Alias CU.Name.dummy)
-
 module Intf = struct
-  (* Currently this is the same type as [Impl.t] but this will change (see PR
-     #1746). *)
-  type nonrec t = t
+  type t =
+    | Normal of CU.Name.t * CU.t * Digest.t
+    | Alias of CU.Name.t
+    | Parameter of CU.Name.t * Digest.t
 
   let create_normal name cu ~crc =
     if not (CU.Name.equal (CU.name cu) name)
@@ -79,11 +26,11 @@ module Intf = struct
       Misc.fatal_errorf
         "@[<hv>Mismatched import name and compilation unit:@ %a != %a@]"
         CU.Name.print name CU.print cu;
-    Intf (Normal (name, cu, crc))
+    Normal (name, cu, crc)
 
-  let create_alias name = Intf (Alias name)
+  let create_alias name = Alias name
 
-  let create_parameter name ~crc = Intf (Parameter (name, crc))
+  let create_parameter name ~crc = Parameter (name, crc)
 
   module Nonalias = struct
     module Kind = struct
@@ -101,60 +48,45 @@ module Intf = struct
     | Some (Normal cu, crc) -> create_normal name cu ~crc
     | Some (Parameter, crc) -> create_parameter name ~crc
 
-  let expect_intf t =
-    match t with
-    | Intf intf -> intf
-    | Impl (Loaded (cu, _) | Unloaded cu) ->
-      Misc.fatal_errorf "Expected an [Import_info.Impl.t] but found %a" CU.print
-        cu
-
   let name t =
-    match expect_intf t with
+    match t with
     | Normal (name, _, _) | Alias name | Parameter (name, _) -> name
 
   let nonalias t : Nonalias.t option =
-    match expect_intf t with
+    match t with
     | Normal (_, cu, crc) -> Some (Normal cu, crc)
     | Parameter (_, crc) -> Some (Parameter, crc)
     | Alias _ -> None
 
   let crc t =
-    match expect_intf t with
+    match t with
     | Normal (_, _, crc) | Parameter (_, crc) -> Some crc
     | Alias _ -> None
 
   let has_name t ~name:name' = CU.Name.equal (name t) name'
 
-  let dummy = dummy
+  let dummy = Alias CU.Name.dummy
 end
 
 module Impl = struct
-  (* Currently this is the same type as [Intf.t] but this will change (see PR
-     #1746). *)
-  type nonrec t = t
+  type t =
+    | Loaded of CU.t * Digest.t
+    | Unloaded of CU.t
 
-  let create_loaded cu ~crc = Impl (Loaded (cu, crc))
+  let create_loaded cu ~crc = Loaded (cu, crc)
 
-  let create_unloaded cu = Impl (Unloaded cu)
+  let create_unloaded cu = Unloaded cu
 
   let create cu ~crc =
     match crc with
     | Some crc -> create_loaded cu ~crc
     | None -> create_unloaded cu
 
-  let expect_impl t =
-    match t with
-    | Impl impl -> impl
-    | Intf (Normal (name, _, _) | Alias name | Parameter (name, _)) ->
-      Misc.fatal_errorf "Expected an [Import_info.Intf.t] but found %a"
-        CU.Name.print name
-
-  let cu t = match expect_impl t with Loaded (cu, _) | Unloaded cu -> cu
+  let cu t = match t with Loaded (cu, _) | Unloaded cu -> cu
 
   let name t = CU.name (cu t)
 
-  let crc t =
-    match expect_impl t with Loaded (_, crc) -> Some crc | Unloaded _ -> None
+  let crc t = match t with Loaded (_, crc) -> Some crc | Unloaded _ -> None
 
-  let dummy = Impl (Unloaded CU.dummy)
+  let dummy = Unloaded CU.dummy
 end

--- a/ocaml/utils/import_info.mli
+++ b/ocaml/utils/import_info.mli
@@ -29,31 +29,11 @@ module CU := Compilation_unit
    here, or somewhere alongside, rather than being duplicated around the
    tree. *)
 
-(** Either an interface (.cmi) or implementation (.cmo/x) import. Should be
-    avoided in new code, in preference to [Intf.t] or [Impl.t]. *)
-type t
-
-val create : CU.Name.t -> crc_with_unit:(CU.t * string) option -> t
-
-val create_normal : CU.t -> crc:string option -> t
-
-val name : t -> CU.Name.t
-
-(** This function will cause a fatal error if a [CU.t] was not provided when the
-    supplied value of type [t] was created. *)
-val cu : t -> CU.t
-
-val crc : t -> string option
-
-val has_name : t -> name:CU.Name.t -> bool
-
-val dummy : t
-
 (** The preferred API to use for interface imports. An interface import might be
     a parameter, in which case it has a CRC but no [CU.t] (since a [CU.t] is for
     an implementation). *)
 module Intf : sig
-  type nonrec t = t
+  type t
 
   val create_normal : CU.Name.t -> CU.t -> crc:Digest.t -> t
 
@@ -92,7 +72,7 @@ module Intf : sig
 end
 
 module Impl : sig
-  type nonrec t = t
+  type t
 
   (** The import info for an implementation we depend on and whose .cmx we actually
       loaded. *)

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -57,13 +57,13 @@ let print_name_crc name crco =
 (* CR-someday mshinwell: consider moving to [Import_info.print] *)
 
 let print_intf_import import =
-  let name = Import_info.name import in
-  let crco = Import_info.crc import in
+  let name = Import_info.Intf.name import in
+  let crco = Import_info.Intf.crc import in
   print_name_crc name crco
 
 let print_impl_import import =
-  let unit = Import_info.cu import in
-  let crco = Import_info.crc import in
+  let unit = Import_info.Impl.cu import in
+  let crco = Import_info.Impl.crc import in
   print_name_crc (Compilation_unit.name unit) crco
 
 let print_line name = printf "\t%s\n" name
@@ -309,8 +309,8 @@ let dump_byte ic =
       try
         if len > 0 then match section with
           | CRCS ->
-              let imported_units : Import_info.t list =
-                (Bytesections.read_section_struct toc ic section : Import_info.t array)
+              let imported_units : Import_info.Intf.t list =
+                (Bytesections.read_section_struct toc ic section : Import_info.Intf.t array)
                 |> Array.to_list
               in
               p_list "Imported units" print_intf_import imported_units


### PR DESCRIPTION
**Depends on #1753**

#1753 introduced a split API to `Import_info` that distinguishes between imports of interfaces (i.e., .cmi imports) and imports of implementations (i.e., .cmx imports), but it retained the old combined API to minimize the changes. This PR does the remaining work of taking away the old type, which forces every occurrence of `Import_info` to pick one or the other. Because very nearly every value of `Import_info.t` was statically one flavor of import or the other, almost everything in this PR (outside of `import_info.ml`) just adds either `.Intf` or `.Impl` to something.