### PR TITLE
Disable dominator invariants

### DIFF
--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -8,8 +8,7 @@ module List = ListLabels
 
 let fatal = Misc.fatal_errorf
 
-(* CR-soon xclerc for xclerc: switch back to `false`. *)
-let debug = true
+let debug = false
 
 type doms = Label.t Label.Tbl.t
 


### PR DESCRIPTION
This pull request simply disables the
invariants run after the computation
of the dominators, because they can
be quite costly on some large files.