### PR TITLE
Zero alloc on cfg (backward dataflow)

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -277,12 +277,12 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
   ++ Profile.record ~accumulate:true "polling"
        (Polling.instrument_fundecl ~future_funcnames:funcnames)
   ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_polling
-  ++ Profile.record ~accumulate:true "zero_alloc_checker"
-       (Zero_alloc_checker.fundecl ~future_funcnames:funcnames ppf_dump)
   ++ (fun fd ->
       match !Flambda_backend_flags.cfg_cse_optimize with
       | false ->
         fd
+        ++ Profile.record ~accumulate:true "zero_alloc_checker"
+             (Zero_alloc_checker.fundecl ~future_funcnames:funcnames ppf_dump)
         ++ pass_dump_if ppf_dump dump_combine "Before allocation combining"
         ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
         ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Mach_combine
@@ -311,6 +311,8 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
               | false -> cfg_with_layout
               | true ->
                 cfg_with_layout
+                ++ Profile.record ~accumulate:true "cfg_zero_alloc_checker"
+                     (Zero_alloc_checker.cfg ~future_funcnames:funcnames ppf_dump)
                 ++ Profile.record ~accumulate:true "cfg_comballoc" Cfg_comballoc.run
                 ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cfg_combine
                 ++ Profile.record ~accumulate:true "cfg_cse" CSE.cfg_with_layout

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -350,12 +350,15 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
           | Upstream -> assert false
         end
         ++ Cfg_with_infos.cfg_with_layout
-        ++ Profile.record ~accumulate:true "cfg_validate_description" (Regalloc_validate.run cfg_description)
+        ++ Profile.record ~accumulate:true "cfg_validate_description"
+             (Regalloc_validate.run cfg_description)
         ++ Profile.record ~accumulate:true "cfg_simplify" Regalloc_utils.simplify_cfg
-          (* CR-someday gtulbalecu: The peephole optimizations must not affect liveness, otherwise
-             we would have to recompute it here. Recomputing it here breaks the CI because
-             the liveness_analysis algorithm does not work properly after register allocation. *)
-        ++ Profile.record ~accumulate:true "peephole_optimize_cfg" Peephole_optimize.peephole_optimize_cfg
+        (* CR-someday gtulbalecu: The peephole optimizations must not affect liveness,
+           otherwise we would have to recompute it here. Recomputing it here breaks the CI
+           because the liveness_analysis algorithm does not work properly after register
+           allocation. *)
+        ++ Profile.record ~accumulate:true "peephole_optimize_cfg"
+             Peephole_optimize.peephole_optimize_cfg
         ++ (fun (cfg_with_layout : Cfg_with_layout.t) ->
           match !Flambda_backend_flags.cfg_stack_checks with
           | false -> cfg_with_layout

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -160,9 +160,9 @@ let write_ir prefix =
 let should_emit () =
   not (should_stop_after Compiler_pass.Scheduling)
 
-let should_use_linscan fd =
+let should_use_linscan fun_codegen_options =
   !use_linscan ||
-  List.mem Cmm.Use_linscan_regalloc fd.Mach.fun_codegen_options
+  List.mem Cmm.Use_linscan_regalloc fun_codegen_options
 
 let if_emit_do f x = if should_emit () then f x else ()
 let emit_begin_assembly unix = if_emit_do Emit.begin_assembly unix
@@ -183,13 +183,13 @@ let emit_fundecl f =
       raise (Error (Asm_generation(fundecl.Linear.fun_name, e))))
     f
 
-let rec regalloc ~ppf_dump round fd =
+let rec regalloc ~ppf_dump round (fd : Mach.fundecl) =
   if round > 50 then
     fatal_error(fd.Mach.fun_name ^
                 ": function too complex, cannot complete register allocation");
   dump_if ppf_dump dump_live "Liveness analysis" fd;
   let num_stack_slots =
-    if should_use_linscan fd then begin
+    if should_use_linscan fd.fun_codegen_options then begin
       (* Linear Scan *)
       let intervals = Interval.build_intervals fd in
       if !dump_interval then Printmach.intervals ppf_dump intervals;
@@ -255,7 +255,7 @@ let default_allocator = Upstream
 
 let register_allocator fd : register_allocator =
   match String.lowercase_ascii !Flambda_backend_flags.regalloc with
-  | "cfg" -> if should_use_linscan fd then LS else IRC
+  | "cfg" -> if should_use_linscan fd.fun_codegen_options then LS else IRC
   | "gi" -> GI
   | "irc" -> IRC
   | "ls" -> LS
@@ -263,9 +263,14 @@ let register_allocator fd : register_allocator =
   | "" -> default_allocator
   | other -> Misc.fatal_errorf "unknown register allocator (%S)" other
 
+let is_upstream = function
+  | Upstream -> true
+  | GI | IRC | LS -> false
+
 let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
   Proc.init ();
   Reg.reset();
+  let register_allocator = register_allocator fd_cmm in
   fd_cmm
   ++ Profile.record ~accumulate:true "cmm_invariants" (cmm_invariants ppf_dump)
   ++ Profile.record ~accumulate:true "selection"
@@ -285,11 +290,9 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
              (Zero_alloc_checker.fundecl ~future_funcnames:funcnames ppf_dump)
       | true ->
         (* Will happen after `Cfgize`. *)
-        (match register_allocator fd with
-         | Upstream ->
-           fatal_error "-cfg-zero-alloc-checker should only be used with a CFG register allocator"
-         | GI | IRC | LS ->
-           ());
+        if is_upstream register_allocator then
+          fatal_error
+            "-cfg-zero-alloc-checker should only be used with a CFG register allocator";
         fd
      )
   ++ (fun fd ->
@@ -305,14 +308,12 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
         ++ pass_dump_if ppf_dump dump_cse "After CSE"
       | true ->
         (* Will happen after `Cfgize`. *)
-        (match register_allocator fd with
-         | Upstream ->
-           fatal_error "-cfg-cse-optimize should only be used with a CFG register allocator"
-         | GI | IRC | LS ->
-           ());
+        if is_upstream register_allocator then
+          fatal_error
+            "-cfg-cse-optimize should only be used with a CFG register allocator";
         fd)
   ++ Profile.record ~accumulate:true "regalloc" (fun (fd : Mach.fundecl) ->
-    match register_allocator fd with
+    match register_allocator with
       | ((GI | IRC | LS) as regalloc) ->
       fd
       ++ Profile.record ~accumulate:true "cfg" (fun fd ->

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -48,6 +48,16 @@ type basic_block =
 type codegen_option =
   | Reduce_code_size
   | No_CSE
+  | Assume_zero_alloc of
+      { strict : bool;
+        never_returns_normally : bool;
+        never_raises : bool;
+        loc : Location.t
+      }
+  | Check_zero_alloc of
+      { strict : bool;
+        loc : Location.t
+      }
 
 let rec of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list =
  fun cmm_options ->
@@ -57,8 +67,12 @@ let rec of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list =
     match hd with
     | No_CSE -> No_CSE :: of_cmm_codegen_option tl
     | Reduce_code_size -> Reduce_code_size :: of_cmm_codegen_option tl
-    | Use_linscan_regalloc | Assume_zero_alloc _ | Check_zero_alloc _ ->
-      of_cmm_codegen_option tl)
+    | Assume_zero_alloc { strict; never_returns_normally; never_raises; loc } ->
+      Assume_zero_alloc { strict; never_returns_normally; never_raises; loc }
+      :: of_cmm_codegen_option tl
+    | Check_zero_alloc { strict; loc } ->
+      Check_zero_alloc { strict; loc } :: of_cmm_codegen_option tl
+    | Use_linscan_regalloc -> of_cmm_codegen_option tl)
 
 type t =
   { blocks : basic_block Label.Tbl.t;

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -188,6 +188,8 @@ val is_pure_terminator : terminator -> bool
 
 val is_pure_basic : basic -> bool
 
+val is_pure_operation : operation -> bool
+
 val is_noop_move : basic instruction -> bool
 
 val set_stack_offset : 'a instruction -> int -> unit

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -73,6 +73,16 @@ type basic_block =
 type codegen_option =
   | Reduce_code_size
   | No_CSE
+  | Assume_zero_alloc of
+      { strict : bool;
+        never_returns_normally : bool;
+        never_raises : bool;
+        loc : Location.t
+      }
+  | Check_zero_alloc of
+      { strict : bool;
+        loc : Location.t
+      }
 
 val of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list
 

--- a/backend/cfg/cfg_dataflow.mli
+++ b/backend/cfg/cfg_dataflow.mli
@@ -106,6 +106,7 @@ module type Backward_S = sig
   val run :
     Cfg.t ->
     ?max_iteration:int ->
+    ?exnescape:domain ->
     init:domain ->
     map:'a map ->
     context ->

--- a/backend/cfg/cfg_dataflow.mli
+++ b/backend/cfg/cfg_dataflow.mli
@@ -24,18 +24,22 @@ end
 module type Forward_transfer = sig
   type domain
 
+  type context
+
   type image =
     { normal : domain;
       exceptional : domain
     }
 
-  val basic : domain -> Cfg.basic Cfg.instruction -> domain
+  val basic : domain -> Cfg.basic Cfg.instruction -> context -> domain
 
-  val terminator : domain -> Cfg.terminator Cfg.instruction -> image
+  val terminator : domain -> Cfg.terminator Cfg.instruction -> context -> image
 end
 
 module type Forward_S = sig
   type domain
+
+  type context
 
   (** Perform the dataflow analysis on the passed CFG, returning [OK _] if a
       fix-point has been reached and [Error _] otherwise, where the nested value
@@ -51,27 +55,31 @@ module type Forward_S = sig
     Cfg.t ->
     ?max_iteration:int ->
     init:domain ->
-    unit ->
+    context ->
     (domain Label.Tbl.t, unit) result
 end
 
-module Forward (D : Domain_S) (_ : Forward_transfer with type domain = D.t) :
-  Forward_S with type domain = D.t
+module Forward (D : Domain_S) (T : Forward_transfer with type domain = D.t) :
+  Forward_S with type domain = D.t and type context = T.context
 
 module type Backward_transfer = sig
   type domain
 
   type error
 
-  val basic : domain -> Cfg.basic Cfg.instruction -> (domain, error) result
+  type context
+
+  val basic :
+    domain -> Cfg.basic Cfg.instruction -> context -> (domain, error) result
 
   val terminator :
     domain ->
     exn:domain ->
     Cfg.terminator Cfg.instruction ->
+    context ->
     (domain, error) result
 
-  val exception_ : domain -> (domain, error) result
+  val exception_ : domain -> context -> (domain, error) result
 end
 
 module Instr : Identifiable.S with type t = int
@@ -88,6 +96,8 @@ module type Backward_S = sig
 
   type error
 
+  type context
+
   type _ map =
     | Block : domain Label.Tbl.t map
     | Instr : domain Instr.Tbl.t map
@@ -98,9 +108,12 @@ module type Backward_S = sig
     ?max_iteration:int ->
     init:domain ->
     map:'a map ->
-    unit ->
+    context ->
     ('a, error) Dataflow_result.t
 end
 
 module Backward (D : Domain_S) (T : Backward_transfer with type domain = D.t) :
-  Backward_S with type domain = D.t and type error = T.error
+  Backward_S
+    with type domain = D.t
+     and type error = T.error
+     and type context = T.context

--- a/backend/cfg/cfg_liveness.mli
+++ b/backend/cfg/cfg_liveness.mli
@@ -13,6 +13,10 @@ module Transfer :
   Cfg_dataflow.Backward_transfer
     with type domain = domain
      and type error = error
+     and type context = unit
 
 module Liveness :
-  Cfg_dataflow.Backward_S with type domain = domain and type error = error
+  Cfg_dataflow.Backward_S
+    with type domain = domain
+     and type error = error
+     and type context = unit

--- a/backend/cfg/cfg_with_infos.ml
+++ b/backend/cfg/cfg_with_infos.ml
@@ -5,7 +5,7 @@ type liveness = Cfg_liveness.Liveness.domain Cfg_dataflow.Instr.Tbl.t
 let liveness_analysis : Cfg_with_layout.t -> liveness =
  fun cfg_with_layout ->
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  let init = { Cfg_liveness.before = Reg.Set.empty; across = Reg.Set.empty } in
+  let init = Cfg_liveness.Domain.bot in
   match
     Cfg_liveness.Liveness.run cfg ~init ~map:Cfg_liveness.Liveness.Instr ()
   with

--- a/backend/cfg/eliminate_dead_code.ml
+++ b/backend/cfg/eliminate_dead_code.ml
@@ -21,14 +21,16 @@ end
 module Transfer = struct
   type domain = Domain.t
 
+  type context = unit
+
   type image =
     { normal : domain;
       exceptional : domain
     }
 
-  let basic value _ = value
+  let basic value _ _ = value
 
-  let terminator value _ = { normal = value; exceptional = value }
+  let terminator value _ _ = { normal = value; exceptional = value }
 end
 
 module Dataflow = Cfg_dataflow.Forward (Domain) (Transfer)

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -1065,10 +1065,13 @@ end
 module Transfer (Desc_val : Description_value) :
   Cfg_dataflow.Backward_transfer
     with type domain = Domain.t
-     and type error = Transfer_error.t = struct
+     and type error = Transfer_error.t
+     and type context = unit = struct
   type domain = Domain.t
 
   type error = Transfer_error.t
+
+  type context = unit
 
   let description = Desc_val.description
 
@@ -1164,7 +1167,7 @@ module Transfer (Desc_val : Description_value) :
              ~loc_arg:(Location.of_regs_exn loc_instr.arg)
              equations)
 
-  let basic t instr : (domain, error) result =
+  let basic t instr () : (domain, error) result =
     match Description.find_basic description instr with
     | None ->
       (match instr.desc with
@@ -1186,7 +1189,7 @@ module Transfer (Desc_val : Description_value) :
           ~destroyed:(Proc.destroyed_at_basic instr.desc |> Location.of_regs_exn)
       )
 
-  let terminator t ~exn instr =
+  let terminator t ~exn instr () =
     match Description.find_terminator description instr with
     | Some instr_before ->
       (* CR-soon azewierzejew: This is kind of fragile for [Tailcall (Self _)]
@@ -1218,7 +1221,7 @@ module Transfer (Desc_val : Description_value) :
   (* This should remove the equations for the exception value, but we do that in
      [Domain.append_equations] because there we have more information to give if
      there's an error. *)
-  let exception_ t = Ok t
+  let exception_ t () = Ok t
 end
 
 module Check_backwards (Desc_val : Description_value) =

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -1392,6 +1392,9 @@ module Annotation : sig
 
   val find : Cmm.codegen_option list -> string -> Debuginfo.t -> t option
 
+  val of_cfg :
+    Cfg.codegen_option list -> Cmm.property -> string -> Debuginfo.t -> t option
+
   val expected_value : t -> Value.t
 
   (** [valid t value] returns true if and only if the [value] satisfies the annotation,
@@ -1477,6 +1480,39 @@ end = struct
                 loc
               }
           | Reduce_code_size | No_CSE | Use_linscan_regalloc -> None)
+        codegen_options
+    in
+    match a with
+    | [] -> None
+    | [p] -> Some p
+    | _ :: _ ->
+      Misc.fatal_errorf "Unexpected duplicate annotation %a for %s"
+        Debuginfo.print_compact dbg fun_name ()
+
+  let of_cfg codegen_options spec fun_name dbg =
+    let a =
+      List.filter_map
+        (fun (c : Cfg.codegen_option) ->
+          match c with
+          | Check { property; strict; loc } when property = spec ->
+            Some
+              { strict;
+                assume = false;
+                never_returns_normally = false;
+                never_raises = false;
+                loc
+              }
+          | Assume
+              { property; strict; never_returns_normally; never_raises; loc }
+            when property = spec ->
+            Some
+              { strict;
+                assume = true;
+                never_returns_normally;
+                never_raises;
+                loc
+              }
+          | Check _ | Assume _ | Reduce_code_size | No_CSE -> None)
         codegen_options
     in
     match a with
@@ -1904,6 +1940,14 @@ module Analysis : sig
   (** Check one function. *)
   val fundecl :
     Mach.fundecl ->
+    future_funcnames:String.Set.t ->
+    Unit_info.t ->
+    Unresolved_dependencies.t ->
+    Format.formatter ->
+    unit
+
+  val cfg :
+    Cfg.t ->
     future_funcnames:String.Set.t ->
     Unit_info.t ->
     Unresolved_dependencies.t ->
@@ -2481,6 +2525,35 @@ end = struct
     let check_body t = check_instr t fd.fun_body in
     check_fun fd.fun_name fd.fun_dbg a check_body ~future_funcnames unit_info
       unresolved_deps ppf
+
+  let cfg (fd : Cfg.t) ~future_funcnames unit_info unresolved_deps ppf =
+    let a =
+      Annotation.of_cfg fd.fun_codegen_options S.property fd.fun_name fd.fun_dbg
+    in
+    let check_body t =
+      (* CR gyorsh: initialize loops with [Value.Diverges] *)
+      match
+        Check_cfg_backward.run fd ~init:Value.bot ~exnescape:Value.exn_escape
+          ~map:Instr t
+      with
+      | Ok map ->
+        let entry_block = Cfg.get_block_exn fd fd.entry_label in
+        let res =
+          Cfg_dataflow.Instr.Tbl.find map (Cfg.first_instruction_id entry_block)
+        in
+        report t res ~msg:"Check_cfg_backward result" ~desc:"fundecl" fd.fun_dbg;
+        res
+      | Aborted _ -> Misc.fatal_errorf "Analyzing function %s" fd.fun_name ()
+      | Max_iterations_reached ->
+        let res = Value.top Witnesses.empty in
+        report t res
+          ~msg:
+            "Can't reach fixpoint in max iterations, conservatively return Top"
+          ~desc:"fundecl" fd.fun_dbg;
+        res
+    in
+    check_fun fd.fun_name fd.fun_dbg a check_body ~future_funcnames unit_info
+      unresolved_deps ppf
 end
 
 (** Information about the current unit. *)
@@ -2491,6 +2564,11 @@ let unresolved_deps = Unresolved_dependencies.create ()
 let fundecl ppf_dump ~future_funcnames fd =
   Analysis.fundecl fd ~future_funcnames unit_info unresolved_deps ppf_dump;
   fd
+
+let cfg ppf_dump ~future_funcnames cl =
+  let cfg = Cfg_with_layout.cfg cl in
+  Check_zero_alloc.cfg cfg ~future_funcnames unit_info unresolved_deps ppf_dump;
+  cl
 
 let reset_unit_info () =
   Unit_info.reset unit_info;

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2545,8 +2545,7 @@ end = struct
       let operation t ~next (op : Cfg.operation) dbg =
         match op with
         | Move | Spill | Reload | Const_int _ | Const_float32 _ | Const_float _
-        | Const_symbol _ | Const_vec128 _ | Load _ | Floatop _ | Vectorcast _
-        | Scalarcast _
+        | Const_symbol _ | Const_vec128 _ | Load _ | Floatop _
         | Intop_imm
             ( ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
               | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ ),
@@ -2554,12 +2553,11 @@ end = struct
         | Intop
             ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
             | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ )
-        | Csel _ ->
+        | Reinterpret_cast _ | Static_cast _ | Csel _ ->
           assert (Cfg.is_pure_operation op);
           next
-        | Name_for_debugger _ | Valueofint | Intofvalue | Stackoffset _
-        | Probe_is_enabled _ | Opaque | Begin_region | End_region
-        | Intop_atomic _ | Store _ ->
+        | Name_for_debugger _ | Stackoffset _ | Probe_is_enabled _ | Opaque
+        | Begin_region | End_region | Intop_atomic _ | Store _ ->
           next
         | Poll ->
           (* Ignore poll points even though they may trigger an allocations,

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2584,7 +2584,7 @@ end = struct
         | Op op -> Ok (operation t ~next op i.dbg)
         | Pushtrap _ | Poptrap ->
           (* treated as no-op here, flow and handling of exceptions is
-             encorporated into the blocks and edges of the CFG *)
+             incorporated into the blocks and edges of the CFG *)
           Ok next
         | Reloadretaddr | Prologue | Stack_check _ -> Ok next
 
@@ -2597,7 +2597,7 @@ end = struct
           (* [raise_notrace] is typically used for control flow, not for
              indicating an error. Therefore, we do not ignore any allocation on
              paths to it. The following conservatively assumes that normal and
-             exn Returns are reachable. *)
+             exn returns are reachable. *)
           Value.join exn Value.safe
         | Raise (Raise_reraise | Raise_regular) -> exn
         | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2526,6 +2526,156 @@ end = struct
     check_fun fd.fun_name fd.fun_dbg a check_body ~future_funcnames unit_info
       unresolved_deps ppf
 
+  module Check_cfg_backward = struct
+    module Value = struct
+      include Value
+
+      let less_equal t1 t2 = lessequal t1 t2
+    end
+
+    module Backward_transfer = struct
+      type domain = Value.t
+
+      type context = t
+
+      type error = unit
+
+      let transform_specific t s ~next ~exn dbg =
+        let can_raise = Arch.operation_can_raise s in
+        let effect =
+          let w = create_witnesses t Arch_specific dbg in
+          match Metadata.assume_value dbg ~can_raise w with
+          | Some v -> v
+          | None -> S.transform_specific w s
+        in
+        transform t ~next ~exn ~effect "Arch.specific_operation" dbg
+
+      let transform_tailcall_imm t func dbg =
+        (* Sound to ignore [next] and [exn] because the call never returns. *)
+        let w = create_witnesses t (Direct_tailcall { callee = func }) dbg in
+        transform_call t ~next:Value.normal_return ~exn:Value.exn_escape func w
+          ~desc:("direct tailcall to " ^ func)
+          dbg
+
+      let operation t ~next (op : Cfg.operation) dbg =
+        match op with
+        | Move | Spill | Reload | Const_int _ | Const_float32 _ | Const_float _
+        | Const_symbol _ | Const_vec128 _ | Load _ | Floatop _ | Vectorcast _
+        | Scalarcast _
+        | Intop_imm
+            ( ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
+              | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ ),
+              _ )
+        | Intop
+            ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
+            | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ )
+        | Csel _ ->
+          assert (Cfg.is_pure_operation op);
+          next
+        | Name_for_debugger _ | Valueofint | Intofvalue | Stackoffset _
+        | Probe_is_enabled _ | Opaque | Begin_region | End_region
+        | Intop_atomic _ | Store _ ->
+          next
+        | Poll ->
+          (* Ignore poll points even though they may trigger an allocations,
+             because otherwise all loops would be considered allocating when
+             poll insertion is enabled. [@poll error] should be used instead. *)
+          next
+        | Alloc { mode = Alloc_local; _ } -> next
+        | Alloc { mode = Alloc_heap; bytes; dbginfo } ->
+          let w = create_witnesses t (Alloc { bytes; dbginfo }) dbg in
+          let effect =
+            match Metadata.assume_value dbg ~can_raise:false w with
+            | Some effect -> effect
+            | None -> Value.{ nor = V.top w; exn = V.bot; div = V.bot }
+          in
+          transform t ~effect ~next ~exn:Value.bot "heap allocation" dbg
+        | Specific s -> transform_specific t s ~next ~exn:Value.bot dbg
+        | Dls_get -> Misc.fatal_error "Idls_get not supported"
+
+      let basic next (i : Cfg.basic Cfg.instruction) t : (domain, error) result
+          =
+        match i.desc with
+        | Op op -> Ok (operation t ~next op i.dbg)
+        | Pushtrap _ | Poptrap ->
+          (* treated as no-op here, flow and handling of exceptions is
+             encorporated into the blocks and edges of the CFG *)
+          Ok next
+        | Reloadretaddr | Prologue | Stack_check _ -> Ok next
+
+      let terminator next ~exn (i : Cfg.terminator Cfg.instruction) t =
+        let dbg = i.dbg in
+        match i.desc with
+        | Never -> assert false
+        | Return -> Value.normal_return
+        | Raise Raise_notrace ->
+          (* [raise_notrace] is typically used for control flow, not for
+             indicating an error. Therefore, we do not ignore any allocation on
+             paths to it. The following conservatively assumes that normal and
+             exn Returns are reachable. *)
+          Value.join exn Value.safe
+        | Raise (Raise_reraise | Raise_regular) -> exn
+        | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+        | Switch _ ->
+          assert (not (Cfg.can_raise_terminator i.desc));
+          next
+        | Tailcall_self _ ->
+          (* CR gyorsh: show this be treated as a jump, without affecting the
+             summary? *)
+          transform_tailcall_imm t t.current_fun_name dbg
+        | Tailcall_func (Direct { sym_name; _ }) ->
+          transform_tailcall_imm t sym_name dbg
+        | Tailcall_func Indirect ->
+          (* Sound to ignore [next] and [exn] because the call never returns. *)
+          let w = create_witnesses t Indirect_tailcall dbg in
+          transform_top t ~next:Value.normal_return ~exn:Value.exn_escape w
+            "indirect tailcall" dbg
+        | Call_no_return { alloc = false; _ } ->
+          (* Sound to ignore [next] and [exn] because the call never returns or
+             raises. *)
+          Value.bot
+        | Call_no_return { alloc = true; func_symbol = func; _ } ->
+          (* Sound to ignore [next] because the call never returns. *)
+          (* CR gyorsh: we do not currently generate this, but may later. *)
+          let w = create_witnesses t (Extcall { callee = func }) dbg in
+          transform_top t ~next:Value.bot ~exn w
+            ("external call to " ^ func)
+            dbg
+        | Prim { op = External { alloc = false; _ }; _ } ->
+          (* Sound to ignore [exn] because external call marked as noalloc does
+             not raise. *)
+          next
+        | Prim { op = External { alloc = true; func_symbol = func; _ }; _ } ->
+          let w = create_witnesses t (Extcall { callee = func }) dbg in
+          transform_top t ~next ~exn w ("external call to " ^ func) dbg
+        | Prim { op = Probe { name; handler_code_sym; enabled_at_init = _ }; _ }
+          ->
+          let desc =
+            Printf.sprintf "probe %s handler %s" name handler_code_sym
+          in
+          let w = create_witnesses t (Probe { name; handler_code_sym }) dbg in
+          transform_call t ~next ~exn handler_code_sym w ~desc dbg
+        | Call { op = Indirect; _ } ->
+          let w = create_witnesses t Indirect_call dbg in
+          transform_top t ~next ~exn w "indirect call" dbg
+        | Call { op = Direct { sym_name = func; _ }; _ } ->
+          let w = create_witnesses t (Direct_call { callee = func }) dbg in
+          transform_call t ~next ~exn func w ~desc:("direct call to " ^ func)
+            dbg
+        | Specific_can_raise { op = s; _ } ->
+          transform_specific t s ~next ~exn dbg
+
+      let terminator next ~exn (i : Cfg.terminator Cfg.instruction) t =
+        Ok (terminator next ~exn i t)
+
+      let exception_ next _t : (domain, error) result =
+        (* enter trap handler *)
+        Ok next
+    end
+
+    include Cfg_dataflow.Backward (Value) (Backward_transfer)
+  end
+
   let cfg (fd : Cfg.t) ~future_funcnames unit_info unresolved_deps ppf =
     let a =
       Annotation.of_cfg fd.fun_codegen_options S.property fd.fun_name fd.fun_dbg

--- a/backend/zero_alloc_checker.mli
+++ b/backend/zero_alloc_checker.mli
@@ -43,6 +43,12 @@ val fundecl :
   Mach.fundecl ->
   Mach.fundecl
 
+val cfg :
+  Format.formatter ->
+  future_funcnames:Misc.Stdlib.String.Set.t ->
+  Cfg_with_layout.t ->
+  Cfg_with_layout.t
+
 (** When the check fails, [Witness.t] represents an instruction that does
     not satisfy the property. *)
 module Witness : sig

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -63,6 +63,12 @@ let mk_cfg_cse_optimize f =
 let mk_no_cfg_cse_optimize f =
   "-no-cfg-cse-optimize", Arg.Unit f, " Do not apply CSE optimizations to CFG"
 
+let mk_cfg_zero_alloc_checker f =
+  "-cfg-zero-alloc-checker", Arg.Unit f, " Apply zero_alloc checker to CFG"
+
+let mk_no_cfg_zero_alloc_checker f =
+  "-no-cfg-zero-alloc-checker", Arg.Unit f, " Do not apply zero_alloc checker to CFG"
+
 let mk_cfg_stack_checks f =
   "-cfg-stack-checks", Arg.Unit f, " Insert the stack checks on the CFG representation"
 
@@ -663,6 +669,9 @@ module type Flambda_backend_options = sig
   val cfg_cse_optimize : unit -> unit
   val no_cfg_cse_optimize : unit -> unit
 
+  val cfg_zero_alloc_checker : unit -> unit
+  val no_cfg_zero_alloc_checker : unit -> unit
+
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit
@@ -782,6 +791,9 @@ struct
 
     mk_cfg_cse_optimize F.cfg_cse_optimize;
     mk_no_cfg_cse_optimize F.no_cfg_cse_optimize;
+
+    mk_cfg_zero_alloc_checker F.cfg_zero_alloc_checker;
+    mk_no_cfg_zero_alloc_checker F.no_cfg_zero_alloc_checker;
 
     mk_cfg_stack_checks F.cfg_stack_checks;
     mk_no_cfg_stack_checks F.no_cfg_stack_checks;
@@ -932,6 +944,9 @@ module Flambda_backend_options_impl = struct
 
   let cfg_cse_optimize = set' Flambda_backend_flags.cfg_cse_optimize
   let no_cfg_cse_optimize = clear' Flambda_backend_flags.cfg_cse_optimize
+
+  let cfg_zero_alloc_checker = set' Flambda_backend_flags.cfg_zero_alloc_checker
+  let no_cfg_zero_alloc_checker = clear' Flambda_backend_flags.cfg_zero_alloc_checker
 
   let cfg_stack_checks = set' Flambda_backend_flags.cfg_stack_checks
   let no_cfg_stack_checks = clear' Flambda_backend_flags.cfg_stack_checks
@@ -1246,6 +1261,7 @@ module Extra_params = struct
     | "regalloc-validate" -> set' Flambda_backend_flags.regalloc_validate
     | "cfg-peephole-optimize" -> set' Flambda_backend_flags.cfg_peephole_optimize
     | "cfg-cse-optimize" -> set' Flambda_backend_flags.cfg_cse_optimize
+    | "cfg-zero-alloc-checker" -> set' Flambda_backend_flags.cfg_zero_alloc_checker
     | "cfg-stack-checks" -> set' Flambda_backend_flags.cfg_stack_checks
     | "cfg-stack-checks-threshold" -> set_int' Flambda_backend_flags.cfg_stack_checks_threshold
     | "dump-inlining-paths" -> set' Flambda_backend_flags.dump_inlining_paths

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -40,6 +40,9 @@ module type Flambda_backend_options = sig
   val cfg_cse_optimize : unit -> unit
   val no_cfg_cse_optimize : unit -> unit
 
+  val cfg_zero_alloc_checker : unit -> unit
+  val no_cfg_zero_alloc_checker : unit -> unit
+
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -24,6 +24,7 @@ let regalloc_validate = ref true        (* -[no-]regalloc-validate *)
 let cfg_peephole_optimize = ref true    (* -[no-]cfg-peephole-optimize *)
 
 let cfg_cse_optimize = ref false        (* -[no-]cfg-cse-optimize *)
+let cfg_zero_alloc_checker = ref false  (* -[no-]cfg-zero-alloc-checker *)
 
 let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -25,6 +25,7 @@ val regalloc_validate : bool ref
 val cfg_peephole_optimize: bool ref
 
 val cfg_cse_optimize: bool ref
+val cfg_zero_alloc_checker : bool ref
 
 val cfg_stack_checks : bool ref
 val cfg_stack_checks_threshold : int ref


### PR DESCRIPTION
Implement `zero_alloc` annotation checker on CFG. 

Uses backward analysis on CFG to make review easier: 
- transfer functions are practically the same as on Mach, and 
- we can use the existing and well-tested backward analysis on Cfg almost as is. 

The only difference between the new analysis on CFG and the existing analysis on Mach is that we don't track the `div` component on CFG. The reason is that we don't have an easy way to initialize loops on CFG with `Value.diverge` in a comparable way to `Mach`. If needed, we can implement it by computing `Cfg_loop_infos`. It would make the analysis more expensive but small tweak to `Cfg_with_infos` can fix it. The result can be reused by regalloc because the analysis does not change the CFG (it would require moving the analysis after CSE and Comballoc which do change the CFG). We should probably just drop `div` component. It's not really used for annotation checking (most annotations are "relaxed" and ignore it) and its semantics is a bit dodgy. 

Forward analysis will also be easier to review as a follow-up for this PR. Forward analysis will be a bit more efficient than backward: we need to propagate only one component instead of two/three. It will also be easier to extend, for example to implement precise handling of assume on inlined functions with try-with.

Small refactoring of `Cfg_dataflow` is included in this PR:
- Add `exnescape` to initialize the "exceptional return"  with something other than `Bot`. This is available in `Dataflow` on Mach and use by `checkmach`.
- Make `context` available to transformers. It contains "future" functions and debug printing for `zero_alloc` analysis. An alternative would be to add this state to the `domain` of the dataflow analysis, but it seems conceptually cleaner to separate and we don't need to re-define domain operations to ignore the context.

Should be easier to review commit-by-commit.

Testing:
- [x] Compiler tests on github
- [x] Compare cmx on the compiler distribution (ignoring`div` component)
- [x] Test on a large code base