### PR TITLE
Fix `include` in expect tests

### DIFF
--- a/ocaml/ocamltest/ocaml_actions.ml
+++ b/ocaml/ocamltest/ocaml_actions.ml
@@ -794,17 +794,22 @@ let cc =
 
 let run_expect_once input_file principal log env =
   let expect_flags = Sys.safe_getenv "EXPECT_FLAGS" in
-  let repo_root = "-repo-root " ^ Ocaml_directories.srcdir in
   let principal_flag = if principal then "-principal" else "" in
   let commandline =
   [
     Ocaml_commands.ocamlrun_expect_test;
     expect_flags;
+    Ocaml_flags.toplevel_default_flags;
+    Ocaml_flags.stdlib;
+    directory_flags env;
+    Ocaml_flags.include_toplevel_directory;
     flags env;
-    repo_root;
     principal_flag;
+    libraries Bytecode env;
+    binary_modules Bytecode env;
     input_file
-  ] in
+  ]
+  in
   let exit_status =
     Actions_helpers.run_cmd ~environment:default_ocaml_env log env commandline
   in

--- a/ocaml/testsuite/tests/tool-expect-test/include.ml
+++ b/ocaml/testsuite/tests/tool-expect-test/include.ml
@@ -1,0 +1,12 @@
+(* TEST
+ include unix;
+ libunix;
+ expect;
+*)
+
+(* Test that [include] works in expect tests: the Unix module is not
+   available by default. *)
+Unix.sleepf 0.01;;
+[%%expect {|
+- : unit = ()
+|}]

--- a/ocaml/testsuite/tests/tool-expect-test/include.ml
+++ b/ocaml/testsuite/tests/tool-expect-test/include.ml
@@ -1,5 +1,6 @@
 (* TEST
  include unix;
+ hasunix;
  libunix;
  expect;
 *)

--- a/ocaml/testsuite/tools/expect_test.ml
+++ b/ocaml/testsuite/tools/expect_test.ml
@@ -325,7 +325,7 @@ let read_anonymous_arg fname =
   match !main_file with
   | None -> main_file := Some fname
   | Some _ ->
-    Printf.eprintf "expect_test: multiple input files\n";
+    Printf.eprintf "expect_test: multiple input source files\n";
     exit 2
 
 let main fname =

--- a/ocaml/testsuite/tools/expect_test.ml
+++ b/ocaml/testsuite/tools/expect_test.ml
@@ -313,6 +313,7 @@ let process_expect_file fname =
   let correction = eval_expect_file fname ~file_contents in
   write_corrected ~file:corrected_fname ~file_contents correction
 
+let repo_root = ref None
 let keep_original_error_size = ref false
 let preload_objects = ref []
 let main_file = ref None
@@ -321,11 +322,11 @@ let read_anonymous_arg fname =
   if Filename.check_suffix fname ".cmo"
           || Filename.check_suffix fname ".cma"
   then preload_objects := fname :: !preload_objects
-  else
+else
   match !main_file with
   | None -> main_file := Some fname
   | Some _ ->
-    Printf.eprintf "expect_test: multiple input source files\n";
+    Printf.eprintf "expect_test: multiple input files\n";
     exit 2
 
 let main fname =
@@ -336,18 +337,26 @@ let main fname =
        ~len:(Array.length Sys.argv - !Arg.current));
   (* Ignore OCAMLRUNPARAM=b to be reproducible *)
   Printexc.record_backtrace false;
-  Compmisc.init_path ();
+  if not !Clflags.no_std_include then begin
+    match !repo_root with
+    | None -> ()
+    | Some dir ->
+        (* If we pass [-repo-root], use the stdlib from inside the
+           compiler, not the installed one. We use
+           [Compenv.last_include_dirs] to make sure that the stdlib
+           directory is the last one. *)
+        Clflags.no_std_include := true;
+        Compenv.last_include_dirs := [Filename.concat dir "stdlib"]
+  end;
+  Compmisc.init_path ~auto_include:Load_path.no_auto_include ();
   Toploop.initialize_toplevel_env ();
   let objects = List.rev (!preload_objects) in
-  let successfully_loaded =
-    List.for_all
-      ~f:(Topeval.load_file false Format.err_formatter)
-      objects
-  in
-  if not successfully_loaded then (
-    Printf.eprintf "expect_test: failed to load objects\n";
-    exit 2;
-  );
+  List.iter objects ~f:(fun obj_fname ->
+    match Topeval.load_file false Format.err_formatter obj_fname with
+    | true -> ()
+    | false ->
+      Printf.eprintf "expect_test: failed to load object %s\n" obj_fname;
+      exit 2);
   (* We are in interactive mode and should record directive error on stdout *)
   Sys.interactive := true;
   process_expect_file fname;
@@ -363,7 +372,10 @@ end);;
 
 let args =
   Arg.align
-    ( [ "-keep-original-error-size", Arg.Set keep_original_error_size,
+    ( [ "-repo-root", Arg.String (fun s -> repo_root := Some s),
+        "<dir> root of the OCaml repository. This causes the tool to use \
+         the stdlib from the current source tree rather than the installed one."
+      ; "-keep-original-error-size", Arg.Set keep_original_error_size,
         " truncate long error messages as the compiler would"
       ] @ Options.list
     )

--- a/ocaml/testsuite/tools/expect_test.ml
+++ b/ocaml/testsuite/tools/expect_test.ml
@@ -322,11 +322,11 @@ let read_anonymous_arg fname =
   if Filename.check_suffix fname ".cmo"
           || Filename.check_suffix fname ".cma"
   then preload_objects := fname :: !preload_objects
-else
+  else
   match !main_file with
   | None -> main_file := Some fname
   | Some _ ->
-    Printf.eprintf "expect_test: multiple input files\n";
+    Printf.eprintf "expect_test: multiple input source files\n";
     exit 2
 
 let main fname =

--- a/ocaml/testsuite/tools/expect_test.ml
+++ b/ocaml/testsuite/tools/expect_test.ml
@@ -321,7 +321,7 @@ let read_anonymous_arg fname =
   if Filename.check_suffix fname ".cmo"
           || Filename.check_suffix fname ".cma"
   then preload_objects := fname :: !preload_objects
-else
+  else
   match !main_file with
   | None -> main_file := Some fname
   | Some _ ->

--- a/ocaml/testsuite/tools/expect_test.ml
+++ b/ocaml/testsuite/tools/expect_test.ml
@@ -313,8 +313,20 @@ let process_expect_file fname =
   let correction = eval_expect_file fname ~file_contents in
   write_corrected ~file:corrected_fname ~file_contents correction
 
-let repo_root = ref None
 let keep_original_error_size = ref false
+let preload_objects = ref []
+let main_file = ref None
+
+let read_anonymous_arg fname =
+  if Filename.check_suffix fname ".cmo"
+          || Filename.check_suffix fname ".cma"
+  then preload_objects := fname :: !preload_objects
+else
+  match !main_file with
+  | None -> main_file := Some fname
+  | Some _ ->
+    Printf.eprintf "expect_test: multiple input files\n";
+    exit 2
 
 let main fname =
   if not !keep_original_error_size then
@@ -324,19 +336,18 @@ let main fname =
        ~len:(Array.length Sys.argv - !Arg.current));
   (* Ignore OCAMLRUNPARAM=b to be reproducible *)
   Printexc.record_backtrace false;
-  if not !Clflags.no_std_include then begin
-    match !repo_root with
-    | None -> ()
-    | Some dir ->
-        (* If we pass [-repo-root], use the stdlib from inside the
-           compiler, not the installed one. We use
-           [Compenv.last_include_dirs] to make sure that the stdlib
-           directory is the last one. *)
-        Clflags.no_std_include := true;
-        Compenv.last_include_dirs := [Filename.concat dir "stdlib"]
-  end;
-  Compmisc.init_path ~auto_include:Load_path.no_auto_include ();
+  Compmisc.init_path ();
   Toploop.initialize_toplevel_env ();
+  let objects = List.rev (!preload_objects) in
+  let successfully_loaded =
+    List.for_all
+      ~f:(Topeval.load_file false Format.err_formatter)
+      objects
+  in
+  if not successfully_loaded then (
+    Printf.eprintf "expect_test: failed to load objects\n";
+    exit 2;
+  );
   (* We are in interactive mode and should record directive error on stdout *)
   Sys.interactive := true;
   process_expect_file fname;
@@ -347,15 +358,12 @@ module Options = Main_args.Make_bytetop_options (struct
   let _stdin () = (* disabled *) ()
   let _args = Arg.read_arg
   let _args0 = Arg.read_arg0
-  let anonymous s = main s
+  let anonymous s = read_anonymous_arg s
 end);;
 
 let args =
   Arg.align
-    ( [ "-repo-root", Arg.String (fun s -> repo_root := Some s),
-        "<dir> root of the OCaml repository. This causes the tool to use \
-         the stdlib from the current source tree rather than the installed one."
-      ; "-keep-original-error-size", Arg.Set keep_original_error_size,
+    ( [ "-keep-original-error-size", Arg.Set keep_original_error_size,
         " truncate long error messages as the compiler would"
       ] @ Options.list
     )
@@ -366,9 +374,12 @@ let usage = "Usage: expect_test <options> [script-file [arguments]]\n\
 let () =
   Clflags.color := Some Misc.Color.Never;
   try
-    Arg.parse args main usage;
-    Printf.eprintf "expect_test: no input file\n";
-    exit 2
+    Arg.parse args read_anonymous_arg usage;
+    match !main_file with
+    | Some fname -> main fname
+    | None ->
+      Printf.eprintf "expect_test: no input file\n";
+      exit 2
   with exn ->
     Location.report_exception Format.err_formatter exn;
     exit 2

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -322,11 +322,11 @@ let read_anonymous_arg fname =
   if Filename.check_suffix fname ".cmo"
           || Filename.check_suffix fname ".cma"
   then preload_objects := fname :: !preload_objects
-else
+  else
   match !main_file with
   | None -> main_file := Some fname
   | Some _ ->
-    Printf.eprintf "expect_test: multiple input files\n";
+    Printf.eprintf "expect_test: multiple input source files\n";
     exit 2
 
 let main fname =


### PR DESCRIPTION
Fix `include` in expect tests, and add a test using it.

Pass the same arguments to the test runner as we do for bytecode toplevel tests.
This includes `-nostdlib` and the necessary directory flags, so we can remove the redundant `-repo-root` argument.

Load object files (anonymous args with `.cmo` or `.cma` extensions) in the expect test runner.

Our test suite uses the expect test runner under `testsuite/tools`, but I also synchronized the one under `ocaml/testsuite/tools`. The latter also passed `~auto_include:Load_path.no_auto_include` to `Compmisc.init_path`, but with my changes this should not be necessary.