### PR TITLE
Use Dune 3.15.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
       id: cache
       with:
         path: ${{ github.workspace }}/ocaml-414/_install
-        key: ${{ matrix.os }}-cache-ocaml-414-dune-361-menhir-20210419
+        key: ${{ matrix.os }}-cache-ocaml-414-dune-3152-menhir-20210419
 
     - name: Checkout OCaml 4.14
       uses: actions/checkout@master
@@ -143,7 +143,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       with:
         repository: 'ocaml/dune'
-        ref: '3.6.1'
+        ref: '3.15.2'
         path: 'dune'
 
     - name: Build dune

--- a/HACKING.md
+++ b/HACKING.md
@@ -370,8 +370,8 @@ thoroughly (e.g. `git clean -dfX`) before reconfiguring with a different prefix.
 
 Then build the compiler with the command `make _install` (this is the default
 target plus some setup in preparation for installation). As usual when building,
-a 4.14 compiler (and dune and menhir) need to be in the path. See the warnings above
-about the versions of dune and menhir to use.
+a 4.14 compiler (and dune and menhir) need to be in the path. See the warning above
+about the version of and menhir to use.
 
 Now the build part is done, we don't need to stay in the build environment
 anymore; the switch creation will likely replace it if your terminal is setup

--- a/HACKING.md
+++ b/HACKING.md
@@ -371,7 +371,7 @@ thoroughly (e.g. `git clean -dfX`) before reconfiguring with a different prefix.
 Then build the compiler with the command `make _install` (this is the default
 target plus some setup in preparation for installation). As usual when building,
 a 4.14 compiler (and dune and menhir) need to be in the path. See the warning above
-about the version of and menhir to use.
+about the version of menhir to use.
 
 Now the build part is done, we don't need to stay in the build environment
 anymore; the switch creation will likely replace it if your terminal is setup

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ One-time setup (you can also use other 4.14.x releases):
 ```
 $ opam switch 4.14.1  # or "opam switch create 4.14.1" if you haven't got that switch already
 $ eval $(opam env)
-$ opam install dune.3.8.1 menhir.20210419
+$ opam install dune.3.15.2 menhir.20210419
 ```
 
 You probably then want to fork the `ocaml-flambda/flambda-backend` repo to your own Github org.

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_INIT([The Flambda backend for OCaml],
         [flambda_backend],
         [http://github.com/ocaml-flambda/flambda_backend])
 
-DUNE_MAX_VERSION=[3.8]
+DUNE_MAX_VERSION=[3.15]
 
 AC_MSG_NOTICE([Configuring Flambda backend version AC_PACKAGE_VERSION])
 


### PR DESCRIPTION
Use Dune 3.15.2 in CI, and update docs to indicate that pinning the Dune version is no longer necessary.