### PR TITLE
Consistently use `type t` in unboxed libs

### DIFF
--- a/ocaml/otherlibs/beta/float32.ml
+++ b/ocaml/otherlibs/beta/float32.ml
@@ -18,66 +18,53 @@
 
 type t = float32
 
-external float32_of_bits : int32 -> float32
+external float32_of_bits : int32 -> t
   = "caml_float32_of_bits_bytecode" "caml_float32_of_bits"
   [@@unboxed] [@@noalloc]
 
-external neg : (float32[@local_opt]) -> (float32[@local_opt]) = "%negfloat32"
+external neg : (t[@local_opt]) -> (t[@local_opt]) = "%negfloat32"
 
-external add :
-  (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+external add : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
   = "%addfloat32"
 
-external sub :
-  (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+external sub : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
   = "%subfloat32"
 
-external mul :
-  (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+external mul : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
   = "%mulfloat32"
 
-external div :
-  (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+external div : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
   = "%divfloat32"
 
-external pow : float32 -> float32 -> float32
-  = "caml_power_float32_bytecode" "powf"
+external pow : t -> t -> t = "caml_power_float32_bytecode" "powf"
   [@@unboxed] [@@noalloc]
 
 module Operators = struct
-  external ( ~-. ) : (float32[@local_opt]) -> (float32[@local_opt])
-    = "%negfloat32"
+  external ( ~-. ) : (t[@local_opt]) -> (t[@local_opt]) = "%negfloat32"
 
-  external ( +. ) :
-    (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+  external ( +. ) : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
     = "%addfloat32"
 
-  external ( -. ) :
-    (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+  external ( -. ) : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
     = "%subfloat32"
 
-  external ( *. ) :
-    (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+  external ( *. ) : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
     = "%mulfloat32"
 
-  external ( /. ) :
-    (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+  external ( /. ) : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
     = "%divfloat32"
 
-  external ( ** ) : float32 -> float32 -> float32
-    = "caml_power_float32_bytecode" "powf"
+  external ( ** ) : t -> t -> t = "caml_power_float32_bytecode" "powf"
     [@@unboxed] [@@noalloc]
 end
 
-external fma : float32 -> float32 -> float32 -> float32
-  = "caml_fma_float32_bytecode" "fmaf"
+external fma : t -> t -> t -> t = "caml_fma_float32_bytecode" "fmaf"
   [@@unboxed] [@@noalloc]
 
-external rem : float32 -> float32 -> float32
-  = "caml_fmod_float32_bytecode" "fmodf"
+external rem : t -> t -> t = "caml_fmod_float32_bytecode" "fmodf"
   [@@unboxed] [@@noalloc]
 
-external abs : (float32[@local_opt]) -> (float32[@local_opt]) = "%absfloat32"
+external abs : (t[@local_opt]) -> (t[@local_opt]) = "%absfloat32"
 
 let zero = 0.s
 let one = 1.s
@@ -85,32 +72,32 @@ let minus_one = -1.s
 let infinity = float32_of_bits 0x7f800000l
 let neg_infinity = float32_of_bits 0xff800000l
 let nan = float32_of_bits 0x7f800001l
-let is_finite (x : float32) = sub x x = 0.s
-let is_infinite (x : float32) = div 1.s x = 0.s
-let is_nan (x : float32) = x <> x
+let is_finite (x : t) = sub x x = 0.s
+let is_infinite (x : t) = div 1.s x = 0.s
+let is_nan (x : t) = x <> x
 let pi = 0x1.921fb6p+1s
 let max_float = float32_of_bits 0x7f7fffffl
 let min_float = float32_of_bits 0x00800000l
 let epsilon = float32_of_bits 0x34000000l
 
-external of_int : int -> float32 = "%float32ofint"
-external to_int : (float32[@local_opt]) -> int = "%intoffloat32"
-external of_float : (float[@local_opt]) -> float32 = "%float32offloat"
-external to_float : (float32[@local_opt]) -> float = "%floatoffloat32"
+external of_int : int -> t = "%float32ofint"
+external to_int : (t[@local_opt]) -> int = "%intoffloat32"
+external of_float : (float[@local_opt]) -> t = "%float32offloat"
+external to_float : (t[@local_opt]) -> float = "%floatoffloat32"
 
-external of_bits : (int32[@local_opt]) -> float32
+external of_bits : (int32[@local_opt]) -> t
   = "caml_float32_of_bits_bytecode" "caml_float32_of_bits"
   [@@unboxed] [@@noalloc] [@@builtin]
 
-external to_bits : (float32[@local_opt]) -> int32
+external to_bits : (t[@local_opt]) -> int32
   = "caml_float32_to_bits_bytecode" "caml_float32_to_bits"
   [@@unboxed] [@@noalloc] [@@builtin]
 
-external of_string : string -> float32 = "caml_float32_of_string"
+external of_string : string -> t = "caml_float32_of_string"
 
 let of_string_opt s = try Some (of_string s) with Failure _ -> None
 
-external format : string -> float32 -> string = "caml_format_float32"
+external format : string -> t -> string = "caml_format_float32"
 
 let to_string f = Stdlib.valid_float_lexem (format "%.9g" f)
 
@@ -121,153 +108,150 @@ type fpclass = Stdlib.fpclass =
   | FP_infinite
   | FP_nan
 
-external classify_float : (float32[@unboxed]) -> fpclass
+external classify_float : (t[@unboxed]) -> fpclass
   = "caml_classify_float32_bytecode" "caml_classify_float32"
   [@@noalloc]
 
-external sqrt : float32 -> float32 = "caml_sqrt_float32_bytecode" "sqrtf"
+external sqrt : t -> t = "caml_sqrt_float32_bytecode" "sqrtf"
   [@@unboxed] [@@noalloc] [@@builtin]
 
-external cbrt : float32 -> float32 = "caml_cbrt_float32_bytecode" "cbrtf"
+external cbrt : t -> t = "caml_cbrt_float32_bytecode" "cbrtf"
   [@@unboxed] [@@noalloc]
 
-external exp : float32 -> float32 = "caml_exp_float32_bytecode" "expf"
+external exp : t -> t = "caml_exp_float32_bytecode" "expf"
   [@@unboxed] [@@noalloc]
 
-external exp2 : float32 -> float32 = "caml_exp2_float32_bytecode" "exp2f"
+external exp2 : t -> t = "caml_exp2_float32_bytecode" "exp2f"
   [@@unboxed] [@@noalloc]
 
-external log : float32 -> float32 = "caml_log_float32_bytecode" "logf"
+external log : t -> t = "caml_log_float32_bytecode" "logf"
   [@@unboxed] [@@noalloc]
 
-external log10 : float32 -> float32 = "caml_log10_float32_bytecode" "log10f"
+external log10 : t -> t = "caml_log10_float32_bytecode" "log10f"
   [@@unboxed] [@@noalloc]
 
-external log2 : float32 -> float32 = "caml_log2_float32_bytecode" "log2f"
+external log2 : t -> t = "caml_log2_float32_bytecode" "log2f"
   [@@unboxed] [@@noalloc]
 
-external expm1 : float32 -> float32 = "caml_expm1_float32_bytecode" "expm1f"
+external expm1 : t -> t = "caml_expm1_float32_bytecode" "expm1f"
   [@@unboxed] [@@noalloc]
 
-external log1p : float32 -> float32 = "caml_log1p_float32_bytecode" "log1pf"
+external log1p : t -> t = "caml_log1p_float32_bytecode" "log1pf"
   [@@unboxed] [@@noalloc]
 
-external cos : float32 -> float32 = "caml_cos_float32_bytecode" "cosf"
+external cos : t -> t = "caml_cos_float32_bytecode" "cosf"
   [@@unboxed] [@@noalloc]
 
-external sin : float32 -> float32 = "caml_sin_float32_bytecode" "sinf"
+external sin : t -> t = "caml_sin_float32_bytecode" "sinf"
   [@@unboxed] [@@noalloc]
 
-external tan : float32 -> float32 = "caml_tan_float32_bytecode" "tanf"
+external tan : t -> t = "caml_tan_float32_bytecode" "tanf"
   [@@unboxed] [@@noalloc]
 
-external acos : float32 -> float32 = "caml_acos_float32_bytecode" "acosf"
+external acos : t -> t = "caml_acos_float32_bytecode" "acosf"
   [@@unboxed] [@@noalloc]
 
-external asin : float32 -> float32 = "caml_asin_float32_bytecode" "asinf"
+external asin : t -> t = "caml_asin_float32_bytecode" "asinf"
   [@@unboxed] [@@noalloc]
 
-external atan : float32 -> float32 = "caml_atan_float32_bytecode" "atanf"
+external atan : t -> t = "caml_atan_float32_bytecode" "atanf"
   [@@unboxed] [@@noalloc]
 
-external atan2 : float32 -> float32 -> float32
-  = "caml_atan2_float32_bytecode" "atan2f"
+external atan2 : t -> t -> t = "caml_atan2_float32_bytecode" "atan2f"
   [@@unboxed] [@@noalloc]
 
-external hypot : float32 -> float32 -> float32
-  = "caml_hypot_float32_bytecode" "hypotf"
+external hypot : t -> t -> t = "caml_hypot_float32_bytecode" "hypotf"
   [@@unboxed] [@@noalloc]
 
-external cosh : float32 -> float32 = "caml_cosh_float32_bytecode" "coshf"
+external cosh : t -> t = "caml_cosh_float32_bytecode" "coshf"
   [@@unboxed] [@@noalloc]
 
-external sinh : float32 -> float32 = "caml_sinh_float32_bytecode" "sinhf"
+external sinh : t -> t = "caml_sinh_float32_bytecode" "sinhf"
   [@@unboxed] [@@noalloc]
 
-external tanh : float32 -> float32 = "caml_tanh_float32_bytecode" "tanhf"
+external tanh : t -> t = "caml_tanh_float32_bytecode" "tanhf"
   [@@unboxed] [@@noalloc]
 
-external acosh : float32 -> float32 = "caml_acosh_float32_bytecode" "acoshf"
+external acosh : t -> t = "caml_acosh_float32_bytecode" "acoshf"
   [@@unboxed] [@@noalloc]
 
-external asinh : float32 -> float32 = "caml_asinh_float32_bytecode" "asinhf"
+external asinh : t -> t = "caml_asinh_float32_bytecode" "asinhf"
   [@@unboxed] [@@noalloc]
 
-external atanh : float32 -> float32 = "caml_atanh_float32_bytecode" "atanhf"
+external atanh : t -> t = "caml_atanh_float32_bytecode" "atanhf"
   [@@unboxed] [@@noalloc]
 
-external erf : float32 -> float32 = "caml_erf_float32_bytecode" "erff"
+external erf : t -> t = "caml_erf_float32_bytecode" "erff"
   [@@unboxed] [@@noalloc]
 
-external erfc : float32 -> float32 = "caml_erfc_float32_bytecode" "erfcf"
+external erfc : t -> t = "caml_erfc_float32_bytecode" "erfcf"
   [@@unboxed] [@@noalloc]
 
-external trunc : float32 -> float32 = "caml_trunc_float32_bytecode" "truncf"
+external trunc : t -> t = "caml_trunc_float32_bytecode" "truncf"
   [@@unboxed] [@@noalloc]
 
-external round : float32 -> float32 = "caml_round_float32_bytecode" "roundf"
+external round : t -> t = "caml_round_float32_bytecode" "roundf"
   [@@unboxed] [@@noalloc]
 
-external ceil : float32 -> float32 = "caml_ceil_float32_bytecode" "ceilf"
+external ceil : t -> t = "caml_ceil_float32_bytecode" "ceilf"
   [@@unboxed] [@@noalloc]
 
-external floor : float32 -> float32 = "caml_floor_float32_bytecode" "floorf"
+external floor : t -> t = "caml_floor_float32_bytecode" "floorf"
   [@@unboxed] [@@noalloc]
 
 let is_integer x = x = trunc x && is_finite x
 
-external next_after : float32 -> float32 -> float32
+external next_after : t -> t -> t
   = "caml_nextafter_float32_bytecode" "nextafterf"
   [@@unboxed] [@@noalloc]
 
 let succ x = next_after x infinity
 let pred x = next_after x neg_infinity
 
-external copy_sign : float32 -> float32 -> float32
-  = "caml_copysign_float32_bytecode" "copysignf"
+external copy_sign : t -> t -> t = "caml_copysign_float32_bytecode" "copysignf"
   [@@unboxed] [@@noalloc]
 
-external sign_bit : (float32[@unboxed]) -> bool
+external sign_bit : (t[@unboxed]) -> bool
   = "caml_signbit_float32_bytecode" "caml_signbit_float32"
   [@@noalloc]
 
-external frexp : float32 -> float32 * int = "caml_frexp_float32"
+external frexp : t -> t * int = "caml_frexp_float32"
 
-external ldexp : (float32[@unboxed]) -> (int[@untagged]) -> (float32[@unboxed])
+external ldexp : (t[@unboxed]) -> (int[@untagged]) -> (t[@unboxed])
   = "caml_ldexp_float32_bytecode" "caml_ldexp_float32"
   [@@noalloc]
 
-external modf : float32 -> float32 * float32 = "caml_modf_float32"
-external compare : float32 -> float32 -> int = "%compare"
+external modf : t -> t * t = "caml_modf_float32"
+external compare : t -> t -> int = "%compare"
 
 let equal x y = compare x y = 0
 
-let[@inline] min (x : float32) (y : float32) =
+let[@inline] min (x : t) (y : t) =
   if y > x || ((not (sign_bit y)) && sign_bit x) then if is_nan y then y else x
   else if is_nan x then x
   else y
 
-let[@inline] max (x : float32) (y : float32) =
+let[@inline] max (x : t) (y : t) =
   if y > x || ((not (sign_bit y)) && sign_bit x) then if is_nan x then x else y
   else if is_nan y then y
   else x
 
-let[@inline] min_max (x : float32) (y : float32) =
+let[@inline] min_max (x : t) (y : t) =
   if is_nan x || is_nan y then (nan, nan)
   else if y > x || ((not (sign_bit y)) && sign_bit x) then (x, y)
   else (y, x)
 
-let[@inline] min_num (x : float32) (y : float32) =
+let[@inline] min_num (x : t) (y : t) =
   if y > x || ((not (sign_bit y)) && sign_bit x) then if is_nan x then y else x
   else if is_nan y then x
   else y
 
-let[@inline] max_num (x : float32) (y : float32) =
+let[@inline] max_num (x : t) (y : t) =
   if y > x || ((not (sign_bit y)) && sign_bit x) then if is_nan y then x else y
   else if is_nan x then y
   else x
 
-let[@inline] min_max_num (x : float32) (y : float32) =
+let[@inline] min_max_num (x : t) (y : t) =
   if is_nan x then (y, y)
   else if is_nan y then (x, x)
   else if y > x || ((not (sign_bit y)) && sign_bit x) then (x, y)

--- a/ocaml/otherlibs/beta/float32.mli
+++ b/ocaml/otherlibs/beta/float32.mli
@@ -31,110 +31,97 @@
 type t = float32
 (** An alias for the type of 32-bit floating-point numbers. *)
 
-val zero : float32
+val zero : t
 (** The floating point 0.s *)
 
-val one : float32
+val one : t
 (** The floating-point 1.s *)
 
-val minus_one : float32
+val minus_one : t
 (** The floating-point -1.s *)
 
-external neg : (float32[@local_opt]) -> (float32[@local_opt]) = "%negfloat32"
+external neg : (t[@local_opt]) -> (t[@local_opt]) = "%negfloat32"
 (** Unary negation. *)
 
-external add :
-  (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+external add : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
   = "%addfloat32"
 (** Floating-point addition. *)
 
-external sub :
-  (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+external sub : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
   = "%subfloat32"
 (** Floating-point subtraction. *)
 
-external mul :
-  (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+external mul : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
   = "%mulfloat32"
 (** Floating-point multiplication. *)
 
-external div :
-  (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+external div : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
   = "%divfloat32"
 (** Floating-point division. *)
 
-external pow : float32 -> float32 -> float32
-  = "caml_power_float32_bytecode" "powf"
+external pow : t -> t -> t = "caml_power_float32_bytecode" "powf"
   [@@unboxed] [@@noalloc]
 (** Exponentiation. *)
 
 (** Floating-point arithmetic operator overloads. *)
 module Operators : sig
-  external ( ~-. ) : (float32[@local_opt]) -> (float32[@local_opt])
-    = "%negfloat32"
+  external ( ~-. ) : (t[@local_opt]) -> (t[@local_opt]) = "%negfloat32"
   (** Unary negation. *)
 
-  external ( +. ) :
-    (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+  external ( +. ) : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
     = "%addfloat32"
   (** Floating-point addition. *)
 
-  external ( -. ) :
-    (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+  external ( -. ) : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
     = "%subfloat32"
   (** Floating-point subtraction. *)
 
-  external ( *. ) :
-    (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+  external ( *. ) : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
     = "%mulfloat32"
   (** Floating-point multiplication. *)
 
-  external ( /. ) :
-    (float32[@local_opt]) -> (float32[@local_opt]) -> (float32[@local_opt])
+  external ( /. ) : (t[@local_opt]) -> (t[@local_opt]) -> (t[@local_opt])
     = "%divfloat32"
   (** Floating-point division. *)
 
-  external ( ** ) : float32 -> float32 -> float32
-    = "caml_power_float32_bytecode" "powf"
+  external ( ** ) : t -> t -> t = "caml_power_float32_bytecode" "powf"
     [@@unboxed] [@@noalloc]
   (** Exponentiation. *)
 end
 
-external fma : float32 -> float32 -> float32 -> float32
-  = "caml_fma_float32_bytecode" "fmaf"
+external fma : t -> t -> t -> t = "caml_fma_float32_bytecode" "fmaf"
   [@@unboxed] [@@noalloc]
 (** [fma x y z] returns [x * y + z], with a best effort for computing
    this expression with a single rounding, using either hardware
    instructions (providing full IEEE compliance) or a software
    emulation. *)
 
-external rem : float32 -> float32 -> float32
-  = "caml_fmod_float32_bytecode" "fmodf"
+external rem : t -> t -> t = "caml_fmod_float32_bytecode" "fmodf"
   [@@unboxed] [@@noalloc]
 (** [rem a b] returns the remainder of [a] with respect to [b].  The returned
     value is [a -. n *. b], where [n] is the quotient [a /. b] rounded towards
     zero to an integer. *)
 
-val succ : float32 -> float32
+val succ : t -> t
 (** [succ x] returns the floating point number right after [x] i.e.,
    the smallest floating-point number greater than [x].  See also
    {!next_after}. *)
 
-val pred : float32 -> float32
+val pred : t -> t
 (** [pred x] returns the floating-point number right before [x] i.e.,
    the greatest floating-point number smaller than [x].  See also
    {!next_after}. *)
 
-external abs : (float32[@local_opt]) -> (float32[@local_opt]) = "%absfloat32"
+external abs : (t[@local_opt]) -> (t[@local_opt]) = "%absfloat32"
 (** [abs f] returns the absolute value of [f]. *)
 
-val infinity : float32
+val infinity : t
 (** Positive infinity. *)
 
-val neg_infinity : float32
+val neg_infinity : t
 (** Negative infinity. *)
 
-val nan : float32
+val nan : t
 (** A special floating-point value denoting the result of an
     undefined operation such as [0.0s /. 0.0s].  Stands for
     'not a number'.  Any floating-point operation with [nan] as
@@ -143,62 +130,62 @@ val nan : float32
     [=], [<], [<=], [>] and [>=] return [false] and [<>] returns [true]
     if one or both of their arguments is [nan]. *)
 
-val pi : float32
+val pi : t
 (** The constant pi. *)
 
-val max_float : float32
+val max_float : t
 (** The largest positive finite value of type [float32]. *)
 
-val min_float : float32
+val min_float : t
 (** The smallest positive, non-zero, non-denormalized value of type [float32]. *)
 
-val epsilon : float32
+val epsilon : t
 (** The difference between [1.0s] and the smallest exactly representable
     floating-point number greater than [1.0s]. *)
 
-val is_finite : float32 -> bool
+val is_finite : t -> bool
 (** [is_finite x] is [true] if and only if [x] is finite i.e., not infinite and
    not {!nan}. *)
 
-val is_infinite : float32 -> bool
+val is_infinite : t -> bool
 (** [is_infinite x] is [true] if and only if [x] is {!infinity} or
     {!neg_infinity}. *)
 
-val is_nan : float32 -> bool
+val is_nan : t -> bool
 (** [is_nan x] is [true] if and only if [x] is not a number (see {!nan}). *)
 
-val is_integer : float32 -> bool
+val is_integer : t -> bool
 (** [is_integer x] is [true] if and only if [x] is an integer. *)
 
-external of_float : (float[@local_opt]) -> float32 = "%float32offloat"
+external of_float : (float[@local_opt]) -> t = "%float32offloat"
 (** Convert a 64-bit float to the nearest representable 32-bit float. *)
 
-external to_float : (float32[@local_opt]) -> float = "%floatoffloat32"
+external to_float : (t[@local_opt]) -> float = "%floatoffloat32"
 (** Convert a 32-bit float to a 64-bit float. *)
 
-external of_int : int -> float32 = "%float32ofint"
+external of_int : int -> t = "%float32ofint"
 (** Convert an integer to floating-point. *)
 
-external to_int : (float32[@local_opt]) -> int = "%intoffloat32"
+external to_int : (t[@local_opt]) -> int = "%intoffloat32"
 (** Truncate the given floating-point number to an integer.
     The result is unspecified if the argument is [nan] or falls outside the
     range of representable integers. *)
 
-external of_bits : (int32[@local_opt]) -> float32
+external of_bits : (int32[@local_opt]) -> t
   = "caml_float32_of_bits_bytecode" "caml_float32_of_bits"
   [@@unboxed] [@@noalloc] [@@builtin]
 (** Convert a 32-bit float to a 32-bit integer, preserving the value's
     bit pattern.
     The amd64 flambda-backend compiler translates this call to MOVD. *)
 
-external to_bits : (float32[@local_opt]) -> int32
+external to_bits : (t[@local_opt]) -> int32
   = "caml_float32_to_bits_bytecode" "caml_float32_to_bits"
   [@@unboxed] [@@noalloc] [@@builtin]
 (** Convert a 32-bit integer to a 32-bit float, preserving the value's
     bit pattern.
     The amd64 flambda-backend compiler translates this call to MOVD. *)
 
-external of_string : string -> float32 = "caml_float32_of_string"
+external of_string : string -> t = "caml_float32_of_string"
 (** Convert the given string to a float.  The string is read in decimal
     (by default) or in hexadecimal (marked by [0x] or [0X]).
     The format of decimal floating-point numbers is
@@ -215,10 +202,10 @@ external of_string : string -> float32 = "caml_float32_of_string"
     @raise Failure if the given string is not a valid
     representation of a float32. *)
 
-val of_string_opt : string -> float32 option
+val of_string_opt : string -> t option
 (** Same as [of_string], but returns [None] instead of raising. *)
 
-val to_string : float32 -> string
+val to_string : t -> string
 (** Return a string representation of a floating-point number.
 
     This conversion does not involve a loss of precision. *)
@@ -232,87 +219,85 @@ type fpclass = Stdlib.fpclass =
   | FP_infinite  (** Number is positive or negative infinity *)
   | FP_nan  (** Not a number: result of an undefined operation *)
 
-external classify_float : (float32[@unboxed]) -> fpclass
+external classify_float : (t[@unboxed]) -> fpclass
   = "caml_classify_float32_bytecode" "caml_classify_float32"
   [@@noalloc]
 (** Return the class of the given floating-point number:
     normal, subnormal, zero, infinite, or not a number. *)
 
-external sqrt : float32 -> float32 = "caml_sqrt_float32_bytecode" "sqrtf"
+external sqrt : t -> t = "caml_sqrt_float32_bytecode" "sqrtf"
   [@@unboxed] [@@noalloc] [@@builtin]
 (** Square root.
     The amd64 flambda-backend compiler translates this call to SQRTSS. *)
 
-external cbrt : float32 -> float32 = "caml_cbrt_float32_bytecode" "cbrtf"
+external cbrt : t -> t = "caml_cbrt_float32_bytecode" "cbrtf"
   [@@unboxed] [@@noalloc]
 (** Cube root. *)
 
-external exp : float32 -> float32 = "caml_exp_float32_bytecode" "expf"
+external exp : t -> t = "caml_exp_float32_bytecode" "expf"
   [@@unboxed] [@@noalloc]
 (** Exponential. *)
 
-external exp2 : float32 -> float32 = "caml_exp2_float32_bytecode" "exp2f"
+external exp2 : t -> t = "caml_exp2_float32_bytecode" "exp2f"
   [@@unboxed] [@@noalloc]
 (** Base 2 exponential function. *)
 
-external log : float32 -> float32 = "caml_log_float32_bytecode" "logf"
+external log : t -> t = "caml_log_float32_bytecode" "logf"
   [@@unboxed] [@@noalloc]
 (** Natural logarithm. *)
 
-external log10 : float32 -> float32 = "caml_log10_float32_bytecode" "log10f"
+external log10 : t -> t = "caml_log10_float32_bytecode" "log10f"
   [@@unboxed] [@@noalloc]
 (** Base 10 logarithm. *)
 
-external log2 : float32 -> float32 = "caml_log2_float32_bytecode" "log2f"
+external log2 : t -> t = "caml_log2_float32_bytecode" "log2f"
   [@@unboxed] [@@noalloc]
 (** Base 2 logarithm. *)
 
-external expm1 : float32 -> float32 = "caml_expm1_float32_bytecode" "expm1f"
+external expm1 : t -> t = "caml_expm1_float32_bytecode" "expm1f"
   [@@unboxed] [@@noalloc]
 (** [expm1 x] computes [exp x -. 1.0], giving numerically-accurate results
     even if [x] is close to [0.0]. *)
 
-external log1p : float32 -> float32 = "caml_log1p_float32_bytecode" "log1pf"
+external log1p : t -> t = "caml_log1p_float32_bytecode" "log1pf"
   [@@unboxed] [@@noalloc]
 (** [log1p x] computes [log(1.0 +. x)] (natural logarithm),
     giving numerically-accurate results even if [x] is close to [0.0]. *)
 
-external cos : float32 -> float32 = "caml_cos_float32_bytecode" "cosf"
+external cos : t -> t = "caml_cos_float32_bytecode" "cosf"
   [@@unboxed] [@@noalloc]
 (** Cosine.  Argument is in radians. *)
 
-external sin : float32 -> float32 = "caml_sin_float32_bytecode" "sinf"
+external sin : t -> t = "caml_sin_float32_bytecode" "sinf"
   [@@unboxed] [@@noalloc]
 (** Sine.  Argument is in radians. *)
 
-external tan : float32 -> float32 = "caml_tan_float32_bytecode" "tanf"
+external tan : t -> t = "caml_tan_float32_bytecode" "tanf"
   [@@unboxed] [@@noalloc]
 (** Tangent.  Argument is in radians. *)
 
-external acos : float32 -> float32 = "caml_acos_float32_bytecode" "acosf"
+external acos : t -> t = "caml_acos_float32_bytecode" "acosf"
   [@@unboxed] [@@noalloc]
 (** Arc cosine.  The argument must fall within the range [[-1.0, 1.0]].
     Result is in radians and is between [0.0] and [pi]. *)
 
-external asin : float32 -> float32 = "caml_asin_float32_bytecode" "asinf"
+external asin : t -> t = "caml_asin_float32_bytecode" "asinf"
   [@@unboxed] [@@noalloc]
 (** Arc sine.  The argument must fall within the range [[-1.0, 1.0]].
     Result is in radians and is between [-pi/2] and [pi/2]. *)
 
-external atan : float32 -> float32 = "caml_atan_float32_bytecode" "atanf"
+external atan : t -> t = "caml_atan_float32_bytecode" "atanf"
   [@@unboxed] [@@noalloc]
 (** Arc tangent.
     Result is in radians and is between [-pi/2] and [pi/2]. *)
 
-external atan2 : float32 -> float32 -> float32
-  = "caml_atan2_float32_bytecode" "atan2f"
+external atan2 : t -> t -> t = "caml_atan2_float32_bytecode" "atan2f"
   [@@unboxed] [@@noalloc]
 (** [atan2 y x] returns the arc tangent of [y /. x].  The signs of [x]
     and [y] are used to determine the quadrant of the result.
     Result is in radians and is between [-pi] and [pi]. *)
 
-external hypot : float32 -> float32 -> float32
-  = "caml_hypot_float32_bytecode" "hypotf"
+external hypot : t -> t -> t = "caml_hypot_float32_bytecode" "hypotf"
   [@@unboxed] [@@noalloc]
 (** [hypot x y] returns [sqrt(x *. x +. y *. y)], that is, the length
     of the hypotenuse of a right-angled triangle with sides of length
@@ -320,53 +305,53 @@ external hypot : float32 -> float32 -> float32
     to origin.  If one of [x] or [y] is infinite, returns [infinity]
     even if the other is [nan]. *)
 
-external cosh : float32 -> float32 = "caml_cosh_float32_bytecode" "coshf"
+external cosh : t -> t = "caml_cosh_float32_bytecode" "coshf"
   [@@unboxed] [@@noalloc]
 (** Hyperbolic cosine.  Argument is in radians. *)
 
-external sinh : float32 -> float32 = "caml_sinh_float32_bytecode" "sinhf"
+external sinh : t -> t = "caml_sinh_float32_bytecode" "sinhf"
   [@@unboxed] [@@noalloc]
 (** Hyperbolic sine.  Argument is in radians. *)
 
-external tanh : float32 -> float32 = "caml_tanh_float32_bytecode" "tanhf"
+external tanh : t -> t = "caml_tanh_float32_bytecode" "tanhf"
   [@@unboxed] [@@noalloc]
 (** Hyperbolic tangent.  Argument is in radians. *)
 
-external acosh : float32 -> float32 = "caml_acosh_float32_bytecode" "acoshf"
+external acosh : t -> t = "caml_acosh_float32_bytecode" "acoshf"
   [@@unboxed] [@@noalloc]
 (** Hyperbolic arc cosine.  The argument must fall within the range
     [[1.0, inf]].
     Result is in radians and is between [0.0] and [inf]. *)
 
-external asinh : float32 -> float32 = "caml_asinh_float32_bytecode" "asinhf"
+external asinh : t -> t = "caml_asinh_float32_bytecode" "asinhf"
   [@@unboxed] [@@noalloc]
 (** Hyperbolic arc sine.  The argument and result range over the entire
     real line.
     Result is in radians. *)
 
-external atanh : float32 -> float32 = "caml_atanh_float32_bytecode" "atanhf"
+external atanh : t -> t = "caml_atanh_float32_bytecode" "atanhf"
   [@@unboxed] [@@noalloc]
 (** Hyperbolic arc tangent.  The argument must fall within the range
     [[-1.0, 1.0]].
     Result is in radians and ranges over the entire real line. *)
 
-external erf : float32 -> float32 = "caml_erf_float32_bytecode" "erff"
+external erf : t -> t = "caml_erf_float32_bytecode" "erff"
   [@@unboxed] [@@noalloc]
 (** Error function.  The argument ranges over the entire real line.
     The result is always within [[-1.0, 1.0]]. *)
 
-external erfc : float32 -> float32 = "caml_erfc_float32_bytecode" "erfcf"
+external erfc : t -> t = "caml_erfc_float32_bytecode" "erfcf"
   [@@unboxed] [@@noalloc]
 (** Complementary error function ([erfc x = 1 - erf x]).
     The argument ranges over the entire real line.
     The result is always within [[-1.0, 1.0]]. *)
 
-external trunc : float32 -> float32 = "caml_trunc_float32_bytecode" "truncf"
+external trunc : t -> t = "caml_trunc_float32_bytecode" "truncf"
   [@@unboxed] [@@noalloc]
 (** [trunc x] rounds [x] to the nearest integer whose absolute value is
    less than or equal to [x]. *)
 
-external round : float32 -> float32 = "caml_round_float32_bytecode" "roundf"
+external round : t -> t = "caml_round_float32_bytecode" "roundf"
   [@@unboxed] [@@noalloc]
 (** [round x] rounds [x] to the nearest integer with ties (fractional
    values of 0.5s) rounded away from zero, regardless of the current
@@ -376,20 +361,20 @@ external round : float32 -> float32 = "caml_round_float32_bytecode" "roundf"
    On 64-bit mingw-w64, this function may be emulated owing to a bug in the
    C runtime library (CRT) on this platform. *)
 
-external ceil : float32 -> float32 = "caml_ceil_float32_bytecode" "ceilf"
+external ceil : t -> t = "caml_ceil_float32_bytecode" "ceilf"
   [@@unboxed] [@@noalloc]
 (** Round above to an integer value.
     [ceil f] returns the least integer value greater than or equal to [f].
     The result is returned as a float32. *)
 
-external floor : float32 -> float32 = "caml_floor_float32_bytecode" "floorf"
+external floor : t -> t = "caml_floor_float32_bytecode" "floorf"
   [@@unboxed] [@@noalloc]
 (** Round below to an integer value.
     [floor f] returns the greatest integer value less than or
     equal to [f].
     The result is returned as a float32. *)
 
-external next_after : float32 -> float32 -> float32
+external next_after : t -> t -> t
   = "caml_nextafter_float32_bytecode" "nextafterf"
   [@@unboxed] [@@noalloc]
 (** [next_after x y] returns the next representable floating-point
@@ -403,79 +388,78 @@ external next_after : float32 -> float32 -> float32
    If [x] is the smallest denormalized positive number,
    [next_after x 0.s = 0.s] *)
 
-external copy_sign : float32 -> float32 -> float32
-  = "caml_copysign_float32_bytecode" "copysignf"
+external copy_sign : t -> t -> t = "caml_copysign_float32_bytecode" "copysignf"
   [@@unboxed] [@@noalloc]
 (** [copy_sign x y] returns a float whose absolute value is that of [x]
     and whose sign is that of [y].  If [x] is [nan], returns [nan].
     If [y] is [nan], returns either [x] or [-. x], but it is not
     specified which. *)
 
-external sign_bit : (float32[@unboxed]) -> bool
+external sign_bit : (t[@unboxed]) -> bool
   = "caml_signbit_float32_bytecode" "caml_signbit_float32"
   [@@noalloc]
 (** [sign_bit x] is [true] if and only if the sign bit of [x] is set.
     For example [sign_bit 1.] and [signbit 0.] are [false] while
     [sign_bit (-1.)] and [sign_bit (-0.)] are [true]. *)
 
-external frexp : float32 -> float32 * int = "caml_frexp_float32"
+external frexp : t -> t * int = "caml_frexp_float32"
 (** [frexp f] returns the pair of the significant
     and the exponent of [f].  When [f] is zero, the
     significant [x] and the exponent [n] of [f] are equal to
     zero.  When [f] is non-zero, they are defined by
     [f = x *. 2 ** n] and [0.5 <= x < 1.0]. *)
 
-external ldexp : (float32[@unboxed]) -> (int[@untagged]) -> (float32[@unboxed])
+external ldexp : (t[@unboxed]) -> (int[@untagged]) -> (t[@unboxed])
   = "caml_ldexp_float32_bytecode" "caml_ldexp_float32"
   [@@noalloc]
 (** [ldexp x n] returns [x *. 2 ** n]. *)
 
-external modf : float32 -> float32 * float32 = "caml_modf_float32"
+external modf : t -> t * t = "caml_modf_float32"
 (** [modf f] returns the pair of the fractional and integral
     part of [f]. *)
 
-val compare : float32 -> float32 -> int
+val compare : t -> t -> int
 (** [compare x y] returns [0] if [x] is equal to [y], a negative integer if [x]
     is less than [y], and a positive integer if [x] is greater than
     [y]. [compare] treats [nan] as equal to itself and less than any other float
     value.  This treatment of [nan] ensures that [compare] defines a total
     ordering relation.  *)
 
-val equal : float32 -> float32 -> bool
+val equal : t -> t -> bool
 (** The equal function for floating-point numbers, compared using {!compare}. *)
 
-val min : float32 -> float32 -> float32
+val min : t -> t -> t
 (** [min x y] returns the minimum of [x] and [y].  It returns [nan]
    when [x] or [y] is [nan].  Moreover [min (-0.s) (+0.s) = -0.s] *)
 
-val max : float32 -> float32 -> float32
+val max : t -> t -> t
 (** [max x y] returns the maximum of [x] and [y].  It returns [nan]
    when [x] or [y] is [nan].  Moreover [max (-0.s) (+0.s) = +0.s] *)
 
-val min_max : float32 -> float32 -> float32 * float32
+val min_max : t -> t -> t * t
 (** [min_max x y] is [(min x y, max x y)], just more efficient. *)
 
-val min_num : float32 -> float32 -> float32
+val min_num : t -> t -> t
 (** [min_num x y] returns the minimum of [x] and [y] treating [nan] as
    missing values.  If both [x] and [y] are [nan], [nan] is returned.
    Moreover [min_num (-0.s) (+0.s) = -0.s] *)
 
-val max_num : float32 -> float32 -> float32
+val max_num : t -> t -> t
 (** [max_num x y] returns the maximum of [x] and [y] treating [nan] as
    missing values.  If both [x] and [y] are [nan] [nan] is returned.
    Moreover [max_num (-0.s) (+0.s) = +0.s] *)
 
-val min_max_num : float32 -> float32 -> float32 * float32
+val min_max_num : t -> t -> t * t
 (** [min_max_num x y] is [(min_num x y, max_num x y)], just more
    efficient.  Note that in particular [min_max_num x nan = (x, x)]
    and [min_max_num nan y = (y, y)]. *)
 
-val seeded_hash : int -> float32 -> int
+val seeded_hash : int -> t -> int
 (** A seeded hash function for floats, with the same output value as
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}. *)
 
-val hash : float32 -> int
+val hash : t -> int
 (** An unseeded hash function for floats, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}. *)

--- a/ocaml/otherlibs/beta/float32_u.ml
+++ b/ocaml/otherlibs/beta/float32_u.ml
@@ -16,6 +16,8 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
+type t = float32#
+
 external box_float : float# -> (float[@local_opt]) = "%box_float"
 
 external unbox_float : (float[@local_opt]) -> float# = "%unbox_float"
@@ -24,9 +26,9 @@ external box_int32 : int32# -> (int32[@local_opt]) = "%box_int32"
 
 external unbox_int32 : (int32[@local_opt]) -> int32# = "%unbox_int32"
 
-external to_float32 : float32# -> (float32[@local_opt]) = "%box_float32"
+external to_float32 : t -> (float32[@local_opt]) = "%box_float32"
 
-external of_float32 : (float32[@local_opt]) -> float32# = "%unbox_float32"
+external of_float32 : (float32[@local_opt]) -> t = "%unbox_float32"
 
 (* CR layouts: Investigate whether it's worth making these things externals.
    Are there situations where the middle-end won't inline them and remove the
@@ -166,8 +168,6 @@ let[@inline always] copy_sign x y = of_float32 (Float32.copy_sign (to_float32 x)
 let[@inline always] sign_bit x = Float32.sign_bit (to_float32 x)
 
 let[@inline always] ldexp x i = of_float32 (Float32.ldexp (to_float32 x) i)
-
-type t = float32#
 
 let[@inline always] compare x y = Float32.compare (to_float32 x) (to_float32 y)
 

--- a/ocaml/otherlibs/beta/float32_u.mli
+++ b/ocaml/otherlibs/beta/float32_u.mli
@@ -33,119 +33,122 @@ open! Stdlib
     ([+.], [-.], [*.], [/.]) with [nan] as an argument return [nan], ...
 *)
 
+type t = float32#
+(** An alias for the type of unboxed 32-bit floating-point numbers. *)
+
 (* CR layouts v5: add back all the constants in this module (e.g., [zero] and
    [infinity]) when we we support [float32]s in structures. *)
 
 (* Unboxed-specific stuff at the top. *)
-external to_float32 : float32# -> (float32[@local_opt]) = "%box_float32"
+external to_float32 : t -> (float32[@local_opt]) = "%box_float32"
 (** Box a [float32#] *)
 
-external of_float32 : (float32[@local_opt]) -> float32# = "%unbox_float32"
+external of_float32 : (float32[@local_opt]) -> t = "%unbox_float32"
 (** Unbox a boxed [float32] *)
 
 (* Below here, everything also appears in [Float32], though most things are
    externals in that module. *)
 
-val neg : float32# -> float32#
+val neg : t -> t
 (** Unary negation. *)
 
-val add : float32# -> float32# -> float32#
+val add : t -> t -> t
 (** Floating-point addition. *)
 
-val sub : float32# -> float32# -> float32#
+val sub : t -> t -> t
 (** Floating-point subtraction. *)
 
-val mul : float32# -> float32# -> float32#
+val mul : t -> t -> t
 (** Floating-point multiplication. *)
 
-val div : float32# -> float32# -> float32#
+val div : t -> t -> t
 (** Floating-point division. *)
 
-val pow : float32# -> float32# -> float32#
+val pow : t -> t -> t
 (** Exponentiation. *)
 
 (** Floating-point arithmetic operator overloads. *)
 module Operators : sig
-  val ( ~-. ) : float32# -> float32#
+  val ( ~-. ) : t -> t
   (** Unary negation. *)
 
-  val ( +. ) : float32# -> float32# -> float32#
+  val ( +. ) : t -> t -> t
   (** Floating-point addition. *)
 
-  val ( -. ) : float32# -> float32# -> float32#
+  val ( -. ) : t -> t -> t
   (** Floating-point subtraction. *)
 
-  val ( *. ) : float32# -> float32# -> float32#
+  val ( *. ) : t -> t -> t
   (** Floating-point multiplication. *)
 
-  val ( /. ) : float32# -> float32# -> float32#
+  val ( /. ) : t -> t -> t
   (** Floating-point division. *)
 
-  val ( ** ) : float32# -> float32# -> float32#
+  val ( ** ) : t -> t -> t
   (** Exponentiation. *)
 end
 
-val fma : float32# -> float32# -> float32# -> float32#
+val fma : t -> t -> t -> t
 (** [fma x y z] returns [x * y + z], with a best effort for computing
    this expression with a single rounding, using either hardware
    instructions (providing full IEEE compliance) or a software
    emulation. *)
 
-val rem : float32# -> float32# -> float32#
+val rem : t -> t -> t
 (** [rem a b] returns the remainder of [a] with respect to [b].  The returned
     value is [a -. n *. b], where [n] is the quotient [a /. b] rounded towards
     zero to an integer. *)
 
-val succ : float32# -> float32#
+val succ : t -> t
 (** [succ x] returns the floating point number right after [x] i.e.,
    the smallest floating-point number greater than [x].  See also
    {!next_after}. *)
 
-val pred : float32# -> float32#
+val pred : t -> t
 (** [pred x] returns the floating-point number right before [x] i.e.,
    the greatest floating-point number smaller than [x].  See also
    {!next_after}. *)
 
-val abs : float32# -> float32#
+val abs : t -> t
 (** [abs f] returns the absolute value of [f]. *)
 
-val is_finite : float32# -> bool
+val is_finite : t -> bool
 (** [is_finite x] is [true] if and only if [x] is finite i.e., not infinite and
     not {!nan}. *)
 
-val is_infinite : float32# -> bool
+val is_infinite : t -> bool
 (** [is_infinite x] is [true] if and only if [x] is {!infinity} or
     {!neg_infinity}. *)
 
-val is_nan : float32# -> bool
+val is_nan : t -> bool
 (** [is_nan x] is [true] if and only if [x] is not a number (see {!nan}). *)
 
-val is_integer : float32# -> bool
+val is_integer : t -> bool
 (** [is_integer x] is [true] if and only if [x] is an integer. *)
 
-val of_int : int -> float32#
+val of_int : int -> t
 (** Convert an integer to floating-point. *)
 
-val to_int : float32# -> int
+val to_int : t -> int
 (** Truncate the given floating-point number to an integer.
     The result is unspecified if the argument is [nan] or falls outside the
     range of representable integers. *)
 
-val of_float : float# -> float32#
+val of_float : float# -> t
 (** Convert a 64-bit float to the nearest 32-bit float. *)
 
-val to_float : float32# -> float#
+val to_float : t -> float#
 (** Convert a 32-bit float to a 64-bit float. *)
 
-val of_bits : int32# -> float32#
+val of_bits : int32# -> t
 (** Convert a 32-bit float to a 32-bit integer, preserving the value's
     bit pattern. *)
 
-val to_bits : float32# -> int32#
+val to_bits : t -> int32#
 (** Convert a 32-bit integer to a 32-bit float, preserving the value's
     bit pattern. *)
 
-val of_string : string -> float32#
+val of_string : string -> t
 (** Convert the given string to a float.  The string is read in decimal
     (by default) or in hexadecimal (marked by [0x] or [0X]).
     The format of decimal floating-point numbers is
@@ -164,7 +167,7 @@ val of_string : string -> float32#
 
 (* CR layouts v5: Add [of_string_opt] when we allow float32s in structures. *)
 
-val to_string : float32# -> string
+val to_string : t -> string
 (** Return a string representation of a floating-point number.
 
     This conversion can involve a loss of precision. For greater control over
@@ -181,110 +184,110 @@ type fpclass = Stdlib.fpclass =
 (** The five classes of floating-point numbers, as determined by
     the {!classify_float} function. *)
 
-val classify_float : float32# -> fpclass
+val classify_float : t -> fpclass
 (** Return the class of the given floating-point number:
     normal, subnormal, zero, infinite, or not a number. *)
 
-val sqrt : float32# -> float32#
+val sqrt : t -> t
 (** Square root. *)
 
-val cbrt : float32# -> float32#
+val cbrt : t -> t
 (** Cube root. *)
 
-val exp : float32# -> float32#
+val exp : t -> t
 (** Exponential. *)
 
-val exp2 : float32# -> float32#
+val exp2 : t -> t
 (** Base 2 exponential function. *)
 
-val log : float32# -> float32#
+val log : t -> t
 (** Natural logarithm. *)
 
-val log10 : float32# -> float32#
+val log10 : t -> t
 (** Base 10 logarithm. *)
 
-val log2 : float32# -> float32#
+val log2 : t -> t
 (** Base 2 logarithm. *)
 
-val expm1 : float32# -> float32#
+val expm1 : t -> t
 (** [expm1 x] computes [exp x -. #1.0s], giving numerically-accurate results
     even if [x] is close to [#0.0s]. *)
 
-val log1p : float32# -> float32#
+val log1p : t -> t
 (** [log1p x] computes [log(#1.0s +. x)] (natural logarithm),
     giving numerically-accurate results even if [x] is close to [#0.0s]. *)
 
-val cos : float32# -> float32#
+val cos : t -> t
 (** Cosine.  Argument is in radians. *)
 
-val sin : float32# -> float32#
+val sin : t -> t
 (** Sine.  Argument is in radians. *)
 
-val tan : float32# -> float32#
+val tan : t -> t
 (** Tangent.  Argument is in radians. *)
 
-val acos : float32# -> float32#
+val acos : t -> t
 (** Arc cosine.  The argument must fall within the range [[-1.0s, 1.0s]].
     Result is in radians and is between [0.0s] and [pi]. *)
 
-val asin : float32# -> float32#
+val asin : t -> t
 (** Arc sine.  The argument must fall within the range [[-1.0s, 1.0s]].
     Result is in radians and is between [-pi/2] and [pi/2]. *)
 
-val atan : float32# -> float32#
+val atan : t -> t
 (** Arc tangent.
     Result is in radians and is between [-pi/2] and [pi/2]. *)
 
-val atan2 : float32# -> float32# -> float32#
+val atan2 : t -> t -> t
 (** [atan2 y x] returns the arc tangent of [y /. x].  The signs of [x]
     and [y] are used to determine the quadrant of the result.
     Result is in radians and is between [-pi] and [pi]. *)
 
-val hypot : float32# -> float32# -> float32#
+val hypot : t -> t -> t
 (** [hypot x y] returns [sqrt(x *. x + y *. y)], that is, the length
     of the hypotenuse of a right-angled triangle with sides of length
     [x] and [y], or, equivalently, the distance of the point [(x,y)]
     to origin.  If one of [x] or [y] is infinite, returns [infinity]
     even if the other is [nan]. *)
 
-val cosh : float32# -> float32#
+val cosh : t -> t
 (** Hyperbolic cosine.  Argument is in radians. *)
 
-val sinh : float32# -> float32#
+val sinh : t -> t
 (** Hyperbolic sine.  Argument is in radians. *)
 
-val tanh : float32# -> float32#
+val tanh : t -> t
 (** Hyperbolic tangent.  Argument is in radians. *)
 
-val acosh : float32# -> float32#
+val acosh : t -> t
 (** Hyperbolic arc cosine.  The argument must fall within the range
     [[1.0s, inf]].
     Result is in radians and is between [0.0s] and [inf]. *)
 
-val asinh : float32# -> float32#
+val asinh : t -> t
 (** Hyperbolic arc sine.  The argument and result range over the entire
     real line.
     Result is in radians. *)
 
-val atanh : float32# -> float32#
+val atanh : t -> t
 (** Hyperbolic arc tangent.  The argument must fall within the range
     [[-1.0s, 1.0s]].
     Result is in radians and ranges over the entire real line. *)
 
-val erf : float32# -> float32#
+val erf : t -> t
 (** Error function.  The argument ranges over the entire real line.
     The result is always within [[-1.0s, 1.0s]]. *)
 
-val erfc : float32# -> float32#
+val erfc : t -> t
 (** Complementary error function ([erfc x = 1 - erf x]).
     The argument ranges over the entire real line.
     The result is always within [[-1.0s, 1.0s]]. *)
 
-val trunc : float32# -> float32#
+val trunc : t -> t
 (** [trunc x] rounds [x] to the nearest integer whose absolute value is
     less than or equal to [x]. *)
 
-val round : float32# -> float32#
+val round : t -> t
 (** [round x] rounds [x] to the nearest integer with ties (fractional
    values of 0.5) rounded away from zero, regardless of the current
    rounding direction.  If [x] is an integer, [#+0.s], [#-0.s], [nan], or
@@ -293,18 +296,18 @@ val round : float32# -> float32#
    On 64-bit mingw-w64, this function may be emulated owing to a bug in the
    C runtime library (CRT) on this platform. *)
 
-val ceil : float32# -> float32#
+val ceil : t -> t
 (** Round above to an integer value.
     [ceil f] returns the least integer value greater than or equal to [f].
     The result is returned as a float. *)
 
-val floor : float32# -> float32#
+val floor : t -> t
 (** Round below to an integer value.
     [floor f] returns the greatest integer value less than or
     equal to [f].
     The result is returned as a float. *)
 
-val next_after : float32# -> float32# -> float32#
+val next_after : t -> t -> t
 (** [next_after x y] returns the next representable floating-point
    value following [x] in the direction of [y].  More precisely, if
    [y] is greater (resp. less) than [x], it returns the smallest
@@ -316,13 +319,13 @@ val next_after : float32# -> float32# -> float32#
    If [x] is the smallest denormalized positive number,
    [next_after x #0. = #0.] *)
 
-val copy_sign : float32# -> float32# -> float32#
+val copy_sign : t -> t -> t
 (** [copy_sign x y] returns a float whose absolute value is that of [x]
     and whose sign is that of [y].  If [x] is [nan], returns [nan].
     If [y] is [nan], returns either [x] or [-. x], but it is not
     specified which. *)
 
-val sign_bit : float32# -> bool
+val sign_bit : t -> bool
 (** [sign_bit x] is [true] if and only if the sign bit of [x] is set.
     For example [sign_bit #1.] and [signbit #0.] are [false] while
     [sign_bit #-1.] and [sign_bit #-0.] are [true]. *)
@@ -330,11 +333,8 @@ val sign_bit : float32# -> bool
 (* CR layouts v5: add back [frexp], [modf], [min_max] and [min_max_num] when we
    have float32s in structures. *)
 
-val ldexp : float32# -> int -> float32#
+val ldexp : t -> int -> t
 (** [ldexp x n] returns [x *. #2 ** n]. *)
-
-type t = float32#
-(** An alias for the type of unboxed floating-point numbers. *)
 
 val compare: t -> t -> int
 (** [compare x y] returns [0] if [x] is equal to [y], a negative integer if [x]
@@ -350,7 +350,7 @@ val min : t -> t -> t
 (** [min x y] returns the minimum of [x] and [y].  It returns [nan]
     when [x] or [y] is [nan].  Moreover [min #-0.s #+0.s = #-0.s] *)
 
-val max : float32# -> float32# -> float32#
+val max : t -> t -> t
 (** [max x y] returns the maximum of [x] and [y].  It returns [nan]
     when [x] or [y] is [nan].  Moreover [max #-0.s #+0.s = #+0.s] *)
 

--- a/ocaml/stdlib/float_u.ml
+++ b/ocaml/stdlib/float_u.ml
@@ -17,10 +17,11 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
+type t = float#
 
-external to_float : float# -> (float[@local_opt]) = "%box_float"
+external to_float : t -> (float[@local_opt]) = "%box_float"
 
-external of_float : (float[@local_opt]) -> float# = "%unbox_float"
+external of_float : (float[@local_opt]) -> t = "%unbox_float"
 
 (* CR layouts: Investigate whether it's worth making these things externals.
    Are there situations where the middle-end won't inline them and remove the
@@ -138,8 +139,6 @@ let[@inline always] copy_sign x y = of_float (Float.copy_sign (to_float x) (to_f
 let[@inline always] sign_bit x = Float.sign_bit (to_float x)
 
 let[@inline always] ldexp x i = of_float (Float.ldexp (to_float x) i)
-
-type t = float#
 
 let[@inline always] compare x y = Float.compare (to_float x) (to_float y)
 

--- a/ocaml/stdlib/float_u.mli
+++ b/ocaml/stdlib/float_u.mli
@@ -44,35 +44,38 @@ open! Stdlib
     ([+.], [-.], [*.], [/.]) with [nan] as an argument return [nan], ...
 *)
 
+type t = float#
+(** An alias for the type of unboxed floating-point numbers. *)
+
 (* CR layouts v5: add back all the constants in this module (e.g., [zero] and
    [infinity]) when we we support [float64]s in structures. *)
 
 (* Unboxed-specific stuff at the top. *)
-external to_float : float# -> (float[@local_opt]) = "%box_float"
+external to_float : t -> (float[@local_opt]) = "%box_float"
 (** Box a [float#] *)
 
-external of_float : (float[@local_opt]) -> float# = "%unbox_float"
+external of_float : (float[@local_opt]) -> t = "%unbox_float"
 (** Unbox a boxed [float] *)
 
 (* Below here, everything also appears in [Float], though most things are
    externals in that module. *)
 
-val neg : float# -> float#
+val neg : t -> t
 (** Unary negation. *)
 
-val add : float# -> float# -> float#
+val add : t -> t -> t
 (** Floating-point addition. *)
 
-val sub : float# -> float# -> float#
+val sub : t -> t -> t
 (** Floating-point subtraction. *)
 
-val mul : float# -> float# -> float#
+val mul : t -> t -> t
 (** Floating-point multiplication. *)
 
-val div : float# -> float# -> float#
+val div : t -> t -> t
 (** Floating-point division. *)
 
-val fma : float# -> float# -> float# -> float#
+val fma : t -> t -> t -> t
 (** [fma x y z] returns [x * y + z], with a best effort for computing
    this expression with a single rounding, using either hardware
    instructions (providing full IEEE compliance) or a software
@@ -83,49 +86,49 @@ val fma : float# -> float# -> float# -> float#
    Note: since software emulation of the fma is costly, make sure that you are
    using hardware fma support if performance matters. *)
 
-val rem : float# -> float# -> float#
+val rem : t -> t -> t
 (** [rem a b] returns the remainder of [a] with respect to [b].  The returned
     value is [a -. n *. b], where [n] is the quotient [a /. b] rounded towards
     zero to an integer. *)
 
-val succ : float# -> float#
+val succ : t -> t
 (** [succ x] returns the floating point number right after [x] i.e.,
    the smallest floating-point number greater than [x].  See also
    {!next_after}. *)
 
-val pred : float# -> float#
+val pred : t -> t
 (** [pred x] returns the floating-point number right before [x] i.e.,
    the greatest floating-point number smaller than [x].  See also
    {!next_after}. *)
 
-val abs : float# -> float#
+val abs : t -> t
 (** [abs f] returns the absolute value of [f]. *)
 
-val is_finite : float# -> bool
+val is_finite : t -> bool
 (** [is_finite x] is [true] if and only if [x] is finite i.e., not infinite and
     not {!nan}. *)
 
-val is_infinite : float# -> bool
+val is_infinite : t -> bool
 (** [is_infinite x] is [true] if and only if [x] is {!infinity} or
     {!neg_infinity}. *)
 
-val is_nan : float# -> bool
+val is_nan : t -> bool
 (** [is_nan x] is [true] if and only if [x] is not a number (see {!nan}). *)
 
 
-val is_integer : float# -> bool
+val is_integer : t -> bool
 (** [is_integer x] is [true] if and only if [x] is an integer. *)
 
 
-val of_int : int -> float#
+val of_int : int -> t
 (** Convert an integer to floating-point. *)
 
-val to_int : float# -> int
+val to_int : t -> int
 (** Truncate the given floating-point number to an integer.
     The result is unspecified if the argument is [nan] or falls outside the
     range of representable integers. *)
 
-val of_string : string -> float#
+val of_string : string -> t
 (** Convert the given string to a float.  The string is read in decimal
     (by default) or in hexadecimal (marked by [0x] or [0X]).
     The format of decimal floating-point numbers is
@@ -144,7 +147,7 @@ val of_string : string -> float#
 
 (* CR layouts v5: Add [of_string_opt] when we allow float64s in structures. *)
 
-val to_string : float# -> string
+val to_string : t -> string
 (** Return a string representation of a floating-point number.
 
     This conversion can involve a loss of precision. For greater control over
@@ -161,113 +164,113 @@ type fpclass = Stdlib.fpclass =
 (** The five classes of floating-point numbers, as determined by
     the {!classify_float} function. *)
 
-val classify_float : float# -> fpclass
+val classify_float : t -> fpclass
 (** Return the class of the given floating-point number:
     normal, subnormal, zero, infinite, or not a number. *)
 
-val pow : float# -> float# -> float#
+val pow : t -> t -> t
 (** Exponentiation. *)
 
-val sqrt : float# -> float#
+val sqrt : t -> t
 (** Square root. *)
 
-val cbrt : float# -> float#
+val cbrt : t -> t
 (** Cube root. *)
 
-val exp : float# -> float#
+val exp : t -> t
 (** Exponential. *)
 
-val exp2 : float# -> float#
+val exp2 : t -> t
 (** Base 2 exponential function. *)
 
-val log : float# -> float#
+val log : t -> t
 (** Natural logarithm. *)
 
-val log10 : float# -> float#
+val log10 : t -> t
 (** Base 10 logarithm. *)
 
-val log2 : float# -> float#
+val log2 : t -> t
 (** Base 2 logarithm. *)
 
-val expm1 : float# -> float#
+val expm1 : t -> t
 (** [expm1 x] computes [exp x -. #1.0], giving numerically-accurate results
     even if [x] is close to [#0.0]. *)
 
-val log1p : float# -> float#
+val log1p : t -> t
 (** [log1p x] computes [log(#1.0 +. x)] (natural logarithm),
     giving numerically-accurate results even if [x] is close to [#0.0]. *)
 
-val cos : float# -> float#
+val cos : t -> t
 (** Cosine.  Argument is in radians. *)
 
-val sin : float# -> float#
+val sin : t -> t
 (** Sine.  Argument is in radians. *)
 
-val tan : float# -> float#
+val tan : t -> t
 (** Tangent.  Argument is in radians. *)
 
-val acos : float# -> float#
+val acos : t -> t
 (** Arc cosine.  The argument must fall within the range [[-1.0, 1.0]].
     Result is in radians and is between [0.0] and [pi]. *)
 
-val asin : float# -> float#
+val asin : t -> t
 (** Arc sine.  The argument must fall within the range [[-1.0, 1.0]].
     Result is in radians and is between [-pi/2] and [pi/2]. *)
 
-val atan : float# -> float#
+val atan : t -> t
 (** Arc tangent.
     Result is in radians and is between [-pi/2] and [pi/2]. *)
 
-val atan2 : float# -> float# -> float#
+val atan2 : t -> t -> t
 (** [atan2 y x] returns the arc tangent of [y /. x].  The signs of [x]
     and [y] are used to determine the quadrant of the result.
     Result is in radians and is between [-pi] and [pi]. *)
 
-val hypot : float# -> float# -> float#
+val hypot : t -> t -> t
 (** [hypot x y] returns [sqrt(x *. x + y *. y)], that is, the length
     of the hypotenuse of a right-angled triangle with sides of length
     [x] and [y], or, equivalently, the distance of the point [(x,y)]
     to origin.  If one of [x] or [y] is infinite, returns [infinity]
     even if the other is [nan]. *)
 
-val cosh : float# -> float#
+val cosh : t -> t
 (** Hyperbolic cosine.  Argument is in radians. *)
 
-val sinh : float# -> float#
+val sinh : t -> t
 (** Hyperbolic sine.  Argument is in radians. *)
 
-val tanh : float# -> float#
+val tanh : t -> t
 (** Hyperbolic tangent.  Argument is in radians. *)
 
-val acosh : float# -> float#
+val acosh : t -> t
 (** Hyperbolic arc cosine.  The argument must fall within the range
     [[1.0, inf]].
     Result is in radians and is between [0.0] and [inf]. *)
 
-val asinh : float# -> float#
+val asinh : t -> t
 (** Hyperbolic arc sine.  The argument and result range over the entire
     real line.
     Result is in radians. *)
 
-val atanh : float# -> float#
+val atanh : t -> t
 (** Hyperbolic arc tangent.  The argument must fall within the range
     [[-1.0, 1.0]].
     Result is in radians and ranges over the entire real line. *)
 
-val erf : float# -> float#
+val erf : t -> t
 (** Error function.  The argument ranges over the entire real line.
     The result is always within [[-1.0, 1.0]]. *)
 
-val erfc : float# -> float#
+val erfc : t -> t
 (** Complementary error function ([erfc x = 1 - erf x]).
     The argument ranges over the entire real line.
     The result is always within [[-1.0, 1.0]]. *)
 
-val trunc : float# -> float#
+val trunc : t -> t
 (** [trunc x] rounds [x] to the nearest integer whose absolute value is
     less than or equal to [x]. *)
 
-val round : float# -> float#
+val round : t -> t
 (** [round x] rounds [x] to the nearest integer with ties (fractional
    values of 0.5) rounded away from zero, regardless of the current
    rounding direction.  If [x] is an integer, [#+0.], [#-0.], [nan], or
@@ -276,18 +279,18 @@ val round : float# -> float#
    On 64-bit mingw-w64, this function may be emulated owing to a bug in the
    C runtime library (CRT) on this platform. *)
 
-val ceil : float# -> float#
+val ceil : t -> t
 (** Round above to an integer value.
     [ceil f] returns the least integer value greater than or equal to [f].
     The result is returned as a float. *)
 
-val floor : float# -> float#
+val floor : t -> t
 (** Round below to an integer value.
     [floor f] returns the greatest integer value less than or
     equal to [f].
     The result is returned as a float. *)
 
-val next_after : float# -> float# -> float#
+val next_after : t -> t -> t
 (** [next_after x y] returns the next representable floating-point
    value following [x] in the direction of [y].  More precisely, if
    [y] is greater (resp. less) than [x], it returns the smallest
@@ -299,13 +302,13 @@ val next_after : float# -> float# -> float#
    If [x] is the smallest denormalized positive number,
    [next_after x #0. = #0.] *)
 
-val copy_sign : float# -> float# -> float#
+val copy_sign : t -> t -> t
 (** [copy_sign x y] returns a float whose absolute value is that of [x]
     and whose sign is that of [y].  If [x] is [nan], returns [nan].
     If [y] is [nan], returns either [x] or [-. x], but it is not
     specified which. *)
 
-val sign_bit : float# -> bool
+val sign_bit : t -> bool
 (** [sign_bit x] is [true] if and only if the sign bit of [x] is set.
     For example [sign_bit #1.] and [signbit #0.] are [false] while
     [sign_bit #-1.] and [sign_bit #-0.] are [true]. *)
@@ -313,11 +316,8 @@ val sign_bit : float# -> bool
 (* CR layouts v5: add back [frexp], [modf], [min_max] and [min_max_num] when we
    have floats in structures. *)
 
-val ldexp : float# -> int -> float#
+val ldexp : t -> int -> t
 (** [ldexp x n] returns [x *. #2 ** n]. *)
-
-type t = float#
-(** An alias for the type of unboxed floating-point numbers. *)
 
 val compare: t -> t -> int
 (** [compare x y] returns [0] if [x] is equal to [y], a negative integer if [x]
@@ -333,7 +333,7 @@ val min : t -> t -> t
 (** [min x y] returns the minimum of [x] and [y].  It returns [nan]
     when [x] or [y] is [nan].  Moreover [min #-0. #+0. = #-0.] *)
 
-val max : float# -> float# -> float#
+val max : t -> t -> t
 (** [max x y] returns the maximum of [x] and [y].  It returns [nan]
     when [x] or [y] is [nan].  Moreover [max #-0. #+0. = #+0.] *)
 

--- a/ocaml/stdlib/int32_u.ml
+++ b/ocaml/stdlib/int32_u.ml
@@ -17,9 +17,11 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
-external to_int32 : int32# -> (int32[@local_opt]) = "%box_int32"
+type t = int32#
 
-external of_int32 : (int32[@local_opt]) -> int32# = "%unbox_int32"
+external to_int32 : t -> (int32[@local_opt]) = "%box_int32"
+
+external of_int32 : (int32[@local_opt]) -> t = "%unbox_int32"
 
 let[@inline always] neg x = of_int32 (Int32.neg (to_int32 x))
 
@@ -81,8 +83,6 @@ let[@inline always] float_of_bits x = Int32.float_of_bits (to_int32 x)
 let[@inline always] of_string x = of_int32 (Int32.of_string x)
 
 let[@inline always] to_string x = (Int32.to_string[@inlined]) (to_int32 x)
-
-type t = int32#
 
 let[@inline always] compare x y =
   (Int32.compare[@inlined]) (to_int32 x) (to_int32 y)

--- a/ocaml/stdlib/int32_u.mli
+++ b/ocaml/stdlib/int32_u.mli
@@ -28,6 +28,9 @@ open! Stdlib
    truncating.
 *)
 
+type t = int32#
+(** An alias for the type of unboxed 32-bit integers. *)
+
 (* CR layouts v2.1: add back this comment to the above when we support
    literals.
 
@@ -40,10 +43,10 @@ open! Stdlib
 *)
 
 (* Unboxed-specific stuff at the top. *)
-external to_int32 : int32# -> (int32[@local_opt]) = "%box_int32"
+external to_int32 : t -> (int32[@local_opt]) = "%box_int32"
 (** Box a [int32#] *)
 
-external of_int32 : (int32[@local_opt]) -> int32# = "%unbox_int32"
+external of_int32 : (int32[@local_opt]) -> t = "%unbox_int32"
 (** Unbox a boxed [int32] *)
 
 (* Below here, everything also appears in [Int32], though most things are
@@ -63,48 +66,48 @@ external of_int32 : (int32[@local_opt]) -> int32# = "%unbox_int32"
  * val minus_one : int32#
  * (** The unboxed 32-bit integer -1.*) *)
 
-val neg : int32# -> int32#
+val neg : t -> t
 (** Unary negation. *)
 
-val add : int32# -> int32# -> int32#
+val add : t -> t -> t
 (** Addition. *)
 
-val sub : int32# -> int32# -> int32#
+val sub : t -> t -> t
 (** Subtraction. *)
 
-val mul : int32# -> int32# -> int32#
+val mul : t -> t -> t
 (** Multiplication. *)
 
-val div : int32# -> int32# -> int32#
+val div : t -> t -> t
 (** Integer division. This division rounds the real quotient of
    its arguments towards zero, as specified for {!Stdlib.(/)}.
 
    @raise Division_by_zero if the second
    argument is zero. *)
 
-val unsigned_div : int32# -> int32# -> int32#
+val unsigned_div : t -> t -> t
 (** Same as {!div}, except that arguments and result are interpreted as {e
     unsigned} unboxed 32-bit integers. *)
 
-val rem : int32# -> int32# -> int32#
+val rem : t -> t -> t
 (** Integer remainder.  If [y] is not zero, the result
    of [Int32_u.rem x y] satisfies the following property:
    [x = Int32_u.add (Int32_u.mul (Int32_u.div x y) y) (Int32_u.rem x y)].
    If [y = 0], [Int32_u.rem x y] raises [Division_by_zero]. *)
 
-val unsigned_rem : int32# -> int32# -> int32#
+val unsigned_rem : t -> t -> t
 (** Same as {!rem}, except that arguments and result are interpreted as {e
     unsigned} unboxed 32-bit integers. *)
 
-val succ : int32# -> int32#
+val succ : t -> t
 (** Successor.
    [Int32_u.succ x] is [Int32_u.add x Int32_u.one]. *)
 
-val pred : int32# -> int32#
+val pred : t -> t
 (** Predecessor.
    [Int32_u.pred x] is [Int32_u.sub x Int32_u.one]. *)
 
-val abs : int32# -> int32#
+val abs : t -> t
 (** Return the absolute value of its argument. *)
 
 (* val max_int : int32#
@@ -114,63 +117,63 @@ val abs : int32# -> int32#
  * (** The smallest representable unboxed 32-bit integer, -2{^31}. *)
  *)
 
-val logand : int32# -> int32# -> int32#
+val logand : t -> t -> t
 (** Bitwise logical and. *)
 
-val logor : int32# -> int32# -> int32#
+val logor : t -> t -> t
 (** Bitwise logical or. *)
 
-val logxor : int32# -> int32# -> int32#
+val logxor : t -> t -> t
 (** Bitwise logical exclusive or. *)
 
-val lognot : int32# -> int32#
+val lognot : t -> t
 (** Bitwise logical negation. *)
 
-val shift_left : int32# -> int -> int32#
+val shift_left : t -> int -> t
 (** [Int32_u.shift_left x y] shifts [x] to the left by [y] bits.
    The result is unspecified if [y < 0] or [y >= 32]. *)
 
-val shift_right : int32# -> int -> int32#
+val shift_right : t -> int -> t
 (** [Int32_u.shift_right x y] shifts [x] to the right by [y] bits.
    This is an arithmetic shift: the sign bit of [x] is replicated
    and inserted in the vacated bits.
    The result is unspecified if [y < 0] or [y >= 32]. *)
 
-val shift_right_logical : int32# -> int -> int32#
+val shift_right_logical : t -> int -> t
 (** [Int32_u.shift_right_logical x y] shifts [x] to the right
    by [y] bits.
    This is a logical shift: zeroes are inserted in the vacated bits
    regardless of the sign of [x].
    The result is unspecified if [y < 0] or [y >= 32]. *)
 
-val of_int : int -> int32#
+val of_int : int -> t
 (** Convert the given integer (type [int]) to an unboxed 32-bit integer
    (type [int32#]). On 64-bit platforms, the argument is taken
     modulo 2{^32}. *)
 
-val to_int : int32# -> int
+val to_int : t -> int
 (** Convert the given unboxed 32-bit integer (type [int32#]) to an
    integer (type [int]).  On 32-bit platforms, the 32-bit integer
    is taken modulo 2{^31}, i.e. the high-order bit is lost
    during the conversion.  On 64-bit platforms, the conversion
    is exact. *)
 
-val unsigned_to_int : int32# -> int option
+val unsigned_to_int : t -> int option
 (** Same as {!to_int}, but interprets the argument as an {e unsigned} integer.
     Returns [None] if the unsigned value of the argument cannot fit into an
     [int]. *)
 
-val of_float : float -> int32#
+val of_float : float -> t
 (** Convert the given floating-point number to an unboxed 32-bit integer,
    discarding the fractional part (truncate towards 0).
    If the truncated floating-point number is outside the range
    \[{!Int32_u.min_int}, {!Int32_u.max_int}\], no exception is raised,
    and an unspecified, platform-dependent integer is returned. *)
 
-val to_float : int32# -> float
+val to_float : t -> float
 (** Convert the given unboxed 32-bit integer to a floating-point number. *)
 
-val of_string : string -> int32#
+val of_string : string -> t
 (** Convert the given string to an unboxed 32-bit integer.
    The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the
@@ -187,26 +190,23 @@ val of_string : string -> int32#
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [int32]. *)
 
-(* val of_string_opt: string -> int32# option
+(* val of_string_opt: string -> t option
  * (** Same as [of_string], but return [None] instead of raising. *) *)
 
-val to_string : int32# -> string
+val to_string : t -> string
 (** Return the string representation of its argument, in signed decimal. *)
 
-val bits_of_float : float -> int32#
+val bits_of_float : float -> t
 (** Return the internal representation of the given float according
    to the IEEE 754 floating-point 'single format' bit layout.
    Bit 31 of the result represents the sign of the float;
    bits 30 to 23 represent the (biased) exponent; bits 22 to 0
    represent the mantissa. *)
 
-val float_of_bits : int32# -> float
+val float_of_bits : t -> float
 (** Return the floating-point number whose internal representation,
    according to the IEEE 754 floating-point 'single format' bit layout,
    is the given [int32#]. *)
-
-type t = int32#
-(** An alias for the type of unboxed 32-bit integers. *)
 
 val compare: t -> t -> int
 (** The comparison function for unboxed 32-bit integers, with the same

--- a/ocaml/stdlib/int64_u.ml
+++ b/ocaml/stdlib/int64_u.ml
@@ -17,9 +17,11 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
-external to_int64 : int64# -> (int64[@local_opt]) = "%box_int64"
+type t = int64#
 
-external of_int64 : (int64[@local_opt]) -> int64# = "%unbox_int64"
+external to_int64 : t -> (int64[@local_opt]) = "%box_int64"
+
+external of_int64 : (int64[@local_opt]) -> t = "%unbox_int64"
 
 let[@inline always] neg x = of_int64 (Int64.neg (to_int64 x))
 
@@ -99,8 +101,6 @@ let[@inline always] float_of_bits x = Int64.float_of_bits (to_int64 x)
 let[@inline always] of_string x = of_int64 (Int64.of_string x)
 
 let[@inline always] to_string x = (Int64.to_string[@inlined]) (to_int64 x)
-
-type t = int64#
 
 let[@inline always] compare x y = Int64.compare (to_int64 x) (to_int64 y)
 

--- a/ocaml/stdlib/int64_u.mli
+++ b/ocaml/stdlib/int64_u.mli
@@ -28,6 +28,9 @@ open! Stdlib
    truncating.
 *)
 
+type t = int64#
+(** An alias for the type of unboxed 64-bit integers. *)
+
 (* CR layouts v2.1: add back this comment to the above when we support
    literals.
 
@@ -40,10 +43,10 @@ open! Stdlib
 *)
 
 (* Unboxed-specific stuff at the top. *)
-external to_int64 : int64# -> (int64[@local_opt]) = "%box_int64"
+external to_int64 : t -> (int64[@local_opt]) = "%box_int64"
 (** Box a [int64#] *)
 
-external of_int64 : (int64[@local_opt]) -> int64# = "%unbox_int64"
+external of_int64 : (int64[@local_opt]) -> t = "%unbox_int64"
 (** Unbox a boxed [int64] *)
 
 (* Below here, everything also appears in [Int64], though most things are
@@ -63,48 +66,48 @@ external of_int64 : (int64[@local_opt]) -> int64# = "%unbox_int64"
  * val minus_one : int64#
  * (** The unboxed 64-bit integer -1.*) *)
 
-val neg : int64# -> int64#
+val neg : t -> t
 (** Unary negation. *)
 
-val add : int64# -> int64# -> int64#
+val add : t -> t -> t
 (** Addition. *)
 
-val sub : int64# -> int64# -> int64#
+val sub : t -> t -> t
 (** Subtraction. *)
 
-val mul : int64# -> int64# -> int64#
+val mul : t -> t -> t
 (** Multiplication. *)
 
-val div : int64# -> int64# -> int64#
+val div : t -> t -> t
 (** Integer division. This division rounds the real quotient of
    its arguments towards zero, as specified for {!Stdlib.(/)}.
 
    @raise Division_by_zero if the second
    argument is zero. *)
 
-val unsigned_div : int64# -> int64# -> int64#
+val unsigned_div : t -> t -> t
 (** Same as {!div}, except that arguments and result are interpreted as {e
     unsigned} unboxed 64-bit integers. *)
 
-val rem : int64# -> int64# -> int64#
+val rem : t -> t -> t
 (** Integer remainder.  If [y] is not zero, the result
    of [Int64_u.rem x y] satisfies the following property:
    [x = Int64_u.add (Int64_u.mul (Int64_u.div x y) y) (Int64_u.rem x y)].
    If [y = 0], [Int64_u.rem x y] raises [Division_by_zero]. *)
 
-val unsigned_rem : int64# -> int64# -> int64#
+val unsigned_rem : t -> t -> t
 (** Same as {!rem}, except that arguments and result are interpreted as {e
     unsigned} unboxed 64-bit integers. *)
 
-val succ : int64# -> int64#
+val succ : t -> t
 (** Successor.
    [Int64_u.succ x] is [Int64_u.add x Int64_u.one]. *)
 
-val pred : int64# -> int64#
+val pred : t -> t
 (** Predecessor.
    [Int64_u.pred x] is [Int64_u.sub x Int64_u.one]. *)
 
-val abs : int64# -> int64#
+val abs : t -> t
 (** Return the absolute value of its argument. *)
 
 (* val max_int : int64#
@@ -114,40 +117,40 @@ val abs : int64# -> int64#
  * (** The smallest representable unboxed 64-bit integer, -2{^63}. *)
  *)
 
-val logand : int64# -> int64# -> int64#
+val logand : t -> t -> t
 (** Bitwise logical and. *)
 
-val logor : int64# -> int64# -> int64#
+val logor : t -> t -> t
 (** Bitwise logical or. *)
 
-val logxor : int64# -> int64# -> int64#
+val logxor : t -> t -> t
 (** Bitwise logical exclusive or. *)
 
-val lognot : int64# -> int64#
+val lognot : t -> t
 (** Bitwise logical negation. *)
 
-val shift_left : int64# -> int -> int64#
+val shift_left : t -> int -> t
 (** [Int64_u.shift_left x y] shifts [x] to the left by [y] bits.
    The result is unspecified if [y < 0] or [y >= 64]. *)
 
-val shift_right : int64# -> int -> int64#
+val shift_right : t -> int -> t
 (** [Int64_u.shift_right x y] shifts [x] to the right by [y] bits.
    This is an arithmetic shift: the sign bit of [x] is replicated
    and inserted in the vacated bits.
    The result is unspecified if [y < 0] or [y >= 64]. *)
 
-val shift_right_logical : int64# -> int -> int64#
+val shift_right_logical : t -> int -> t
 (** [Int64_u.shift_right_logical x y] shifts [x] to the right
    by [y] bits.
    This is a logical shift: zeroes are inserted in the vacated bits
    regardless of the sign of [x].
    The result is unspecified if [y < 0] or [y >= 64]. *)
 
-val of_int : int -> int64#
+val of_int : int -> t
 (** Convert the given integer (type [int]) to an unboxed 64-bit integer
    (type [int64#]). *)
 
-val to_int : int64# -> int
+val to_int : t -> int
 (** Convert the given unboxed 64-bit integer (type [int64#]) to an
    integer (type [int]).  On 64-bit platforms, the 64-bit integer
    is taken modulo 2{^63}, i.e. the high-order bit is lost
@@ -155,62 +158,62 @@ val to_int : int64# -> int
    is taken modulo 2{^31}, i.e. the top 33 bits are lost
    during the conversion. *)
 
-val unsigned_to_int : int64# -> int option
+val unsigned_to_int : t -> int option
 (** Same as {!to_int}, but interprets the argument as an {e unsigned} integer.
     Returns [None] if the unsigned value of the argument cannot fit into an
     [int]. *)
 
-val of_float : float -> int64#
+val of_float : float -> t
 (** Convert the given floating-point number to an unboxed 64-bit integer,
    discarding the fractional part (truncate towards 0).
    If the truncated floating-point number is outside the range
    \[{!Int64_u.min_int}, {!Int64_u.max_int}\], no exception is raised,
    and an unspecified, platform-dependent integer is returned. *)
 
-val to_float : int64# -> float
+val to_float : t -> float
 (** Convert the given unboxed 64-bit integer to a floating-point number. *)
 
-val of_int32 : int32 -> int64#
+val of_int32 : int32 -> t
 (** Convert the given 32-bit integer (type [int32])
    to an unboxed 64-bit integer (type [int64]). *)
 
-val to_int32 : int64# -> int32
+val to_int32 : t -> int32
 (** Convert the given unboxed 64-bit integer (type [int64]) to a
    32-bit integer (type [int32]).  The 64-bit integer
    is taken modulo 2{^32}, i.e. the top 32 bits are lost
    during the conversion.  *)
 
-val of_nativeint : nativeint -> int64#
+val of_nativeint : nativeint -> t
 (** Convert the given native integer (type [nativeint])
    to an unboxed 64-bit integer (type [int64#]). *)
 
-val to_nativeint : int64# -> nativeint
+val to_nativeint : t -> nativeint
 (** Convert the given unboxed 64-bit integer (type [int64#]) to a
    native integer.  On 32-bit platforms, the 64-bit integer
    is taken modulo 2{^32}.  On 64-bit platforms,
    the conversion is exact. *)
 
-val of_int32_u : int32# -> int64#
+val of_int32_u : int32# -> t
 (** Convert the given unboxed 32-bit integer (type [int32])
    to an unboxed 64-bit integer (type [int64]). *)
 
-val to_int32_u : int64# -> int32#
+val to_int32_u : t -> int32#
 (** Convert the given unboxed 64-bit integer (type [int64]) to an
    unboxed 32-bit integer (type [int32]).  The 64-bit integer
    is taken modulo 2{^32}, i.e. the top 32 bits are lost
    during the conversion.  *)
 
-val of_nativeint_u : nativeint# -> int64#
+val of_nativeint_u : nativeint# -> t
 (** Convert the given unboxed native integer (type [nativeint])
    to an unboxed 64-bit integer (type [int64#]). *)
 
-val to_nativeint_u : int64# -> nativeint#
+val to_nativeint_u : t -> nativeint#
 (** Convert the given unboxed 64-bit integer (type [int64#]) to an
    unboxed native integer.  On 32-bit platforms, the 64-bit integer
    is taken modulo 2{^32}.  On 64-bit platforms,
    the conversion is exact. *)
 
-val of_string : string -> int64#
+val of_string : string -> t
 (** Convert the given string to an unboxed 64-bit integer.
    The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the
@@ -227,26 +230,23 @@ val of_string : string -> int64#
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [int64]. *)
 
-(* val of_string_opt: string -> int64# option
+(* val of_string_opt: string -> t option
  * (** Same as [of_string], but return [None] instead of raising. *) *)
 
-val to_string : int64# -> string
+val to_string : t -> string
 (** Return the string representation of its argument, in decimal. *)
 
-val bits_of_float : float -> int64#
+val bits_of_float : float -> t
 (** Return the internal representation of the given float according
    to the IEEE 754 floating-point 'double format' bit layout.
    Bit 63 of the result represents the sign of the float;
    bits 62 to 52 represent the (biased) exponent; bits 51 to 0
    represent the mantissa. *)
 
-val float_of_bits : int64# -> float
+val float_of_bits : t -> float
 (** Return the floating-point number whose internal representation,
    according to the IEEE 754 floating-point 'double format' bit layout,
    is the given [int64#]. *)
-
-type t = int64#
-(** An alias for the type of unboxed 64-bit integers. *)
 
 val compare: t -> t -> int
 (** The comparison function for unboxed 64-bit integers, with the same

--- a/ocaml/stdlib/nativeint_u.ml
+++ b/ocaml/stdlib/nativeint_u.ml
@@ -17,9 +17,11 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
-external to_nativeint : nativeint# -> (nativeint[@local_opt]) = "%box_nativeint"
+type t = nativeint#
 
-external of_nativeint : (nativeint[@local_opt]) -> nativeint# =
+external to_nativeint : t -> (nativeint[@local_opt]) = "%box_nativeint"
+
+external of_nativeint : (nativeint[@local_opt]) -> t =
   "%unbox_nativeint"
 
 let[@inline always] neg x = of_nativeint (Nativeint.neg (to_nativeint x))
@@ -104,8 +106,6 @@ let[@inline always] of_string x = of_nativeint (Nativeint.of_string x)
 
 let[@inline always] to_string x =
   (Nativeint.to_string[@inlined]) (to_nativeint x)
-
-type t = nativeint#
 
 let[@inline always] compare x y =
   (Nativeint.compare[@inlined]) (to_nativeint x) (to_nativeint y)

--- a/ocaml/stdlib/nativeint_u.mli
+++ b/ocaml/stdlib/nativeint_u.mli
@@ -29,6 +29,9 @@ open! Stdlib
    [nativeint#] are wrapping, not truncating.
 *)
 
+type t = nativeint#
+(** An alias for the type of unboxed native integers. *)
+
 (* CR layouts v2.1: add back this comment to the above when we support
    literals.
 
@@ -41,10 +44,10 @@ open! Stdlib
 *)
 
 (* Unboxed-specific stuff at the top. *)
-external to_nativeint : nativeint# -> (nativeint[@local_opt]) = "%box_nativeint"
+external to_nativeint : t -> (nativeint[@local_opt]) = "%box_nativeint"
 (** Box a [nativeint#] *)
 
-external of_nativeint : (nativeint[@local_opt]) -> nativeint# =
+external of_nativeint : (nativeint[@local_opt]) -> t =
   "%unbox_nativeint"
 (** Unbox a boxed [nativeint] *)
 
@@ -65,30 +68,30 @@ external of_nativeint : (nativeint[@local_opt]) -> nativeint# =
  * val minus_one : nativeint#
  * (** The unboxed native integer -1.*) *)
 
-val neg : nativeint# -> nativeint#
+val neg : t -> t
 (** Unary negation. *)
 
-val add : nativeint# -> nativeint# -> nativeint#
+val add : t -> t -> t
 (** Addition. *)
 
-val sub : nativeint# -> nativeint# -> nativeint#
+val sub : t -> t -> t
 (** Subtraction. *)
 
-val mul : nativeint# -> nativeint# -> nativeint#
+val mul : t -> t -> t
 (** Multiplication. *)
 
-val div : nativeint# -> nativeint# -> nativeint#
+val div : t -> t -> t
 (** Integer division. This division rounds the real quotient of
    its arguments towards zero, as specified for {!Stdlib.(/)}.
 
    @raise Division_by_zero if the second
    argument is zero. *)
 
-val unsigned_div : nativeint# -> nativeint# -> nativeint#
+val unsigned_div : t -> t -> t
 (** Same as {!div}, except that arguments and result are interpreted as {e
     unsigned} unboxed native integers. *)
 
-val rem : nativeint# -> nativeint# -> nativeint#
+val rem : t -> t -> t
 (** Integer remainder.  If [y] is not zero, the result
    of [Nativeint_u.rem x y] satisfies the following properties:
    [Nativeint_u.zero <= Nativeint_u.rem x y < Nativeint_u.abs y] and
@@ -96,19 +99,19 @@ val rem : nativeint# -> nativeint# -> nativeint#
                         (Nativeint_u.rem x y)].
    If [y = 0], [Nativeint_u.rem x y] raises [Division_by_zero]. *)
 
-val unsigned_rem : nativeint# -> nativeint# -> nativeint#
+val unsigned_rem : t -> t -> t
 (** Same as {!rem}, except that arguments and result are interpreted as {e
     unsigned} unboxed native integers. *)
 
-val succ : nativeint# -> nativeint#
+val succ : t -> t
 (** Successor.
    [Nativeint_u.succ x] is [Nativeint_u.add x Nativeint_u.one]. *)
 
-val pred : nativeint# -> nativeint#
+val pred : t -> t
 (** Predecessor.
    [Nativeint_u.pred x] is [Nativeint_u.sub x Nativeint_u.one]. *)
 
-val abs : nativeint# -> nativeint#
+val abs : t -> t
 (** Return the absolute value of its argument. *)
 
 val size : int
@@ -125,31 +128,31 @@ val size : int
  *    either -2{^31} on a 32-bit platform,
  *    or -2{^63} on a 64-bit platform. *) *)
 
-val logand : nativeint# -> nativeint# -> nativeint#
+val logand : t -> t -> t
 (** Bitwise logical and. *)
 
-val logor : nativeint# -> nativeint# -> nativeint#
+val logor : t -> t -> t
 (** Bitwise logical or. *)
 
-val logxor : nativeint# -> nativeint# -> nativeint#
+val logxor : t -> t -> t
 (** Bitwise logical exclusive or. *)
 
-val lognot : nativeint# -> nativeint#
+val lognot : t -> t
 (** Bitwise logical negation. *)
 
-val shift_left : nativeint# -> int -> nativeint#
+val shift_left : t -> int -> t
 (** [Nativeint_u.shift_left x y] shifts [x] to the left by [y] bits.
    The result is unspecified if [y < 0] or [y >= bitsize],
    where [bitsize] is [#32] on a 32-bit platform and
    [#64] on a 64-bit platform. *)
 
-val shift_right : nativeint# -> int -> nativeint#
+val shift_right : t -> int -> t
 (** [Nativeint_u.shift_right x y] shifts [x] to the right by [y] bits.
    This is an arithmetic shift: the sign bit of [x] is replicated
    and inserted in the vacated bits.
    The result is unspecified if [y < 0] or [y >= bitsize]. *)
 
-val shift_right_logical : nativeint# -> int -> nativeint#
+val shift_right_logical : t -> int -> t
 (** [Nativeint_u.shift_right_logical x y] shifts [x] to the right
    by [y] bits.
    This is a logical shift: zeroes are inserted in the vacated bits
@@ -157,53 +160,53 @@ val shift_right_logical : nativeint# -> int -> nativeint#
    The result is unspecified if [y < 0] or [y >= bitsize]. *)
 
 
-val of_int : int -> nativeint#
+val of_int : int -> t
 (** Convert the given integer (type [int]) to an unboxed native integer
    (type [nativeint#]). *)
 
-val to_int : nativeint# -> int
+val to_int : t -> int
 (** Convert the given unboxed native integer (type [nativeint#]) to an
    integer (type [int]).  The high-order bit is lost during
    the conversion. *)
 
-val unsigned_to_int : nativeint# -> int option
+val unsigned_to_int : t -> int option
 (** Same as {!to_int}, but interprets the argument as an {e unsigned} integer.
     Returns [None] if the unsigned value of the argument cannot fit into an
     [int]. *)
 
-val of_float : float -> nativeint#
+val of_float : float -> t
 (** Convert the given floating-point number to an unboxed native integer,
    discarding the fractional part (truncate towards 0).
    If the truncated floating-point number is outside the range
    \[{!Nativeint_u.min_int}, {!Nativeint_u.max_int}\], no exception is raised,
    and an unspecified, platform-dependent integer is returned. *)
 
-val to_float : nativeint# -> float
+val to_float : t -> float
 (** Convert the given unboxed native integer to a floating-point number. *)
 
-val of_int32 : int32 -> nativeint#
+val of_int32 : int32 -> t
 (** Convert the given 32-bit integer (type [int32])
    to an unboxed native integer. *)
 
-val to_int32 : nativeint# -> int32
+val to_int32 : t -> int32
 (** Convert the given unboxed native integer to a
    32-bit integer (type [int32]).  On 64-bit platforms,
    the 64-bit unboxed native integer is taken modulo 2{^32},
    i.e. the top 32 bits are lost.  On 32-bit platforms,
    the conversion is exact. *)
 
-val of_int32_u : int32# -> nativeint#
+val of_int32_u : int32# -> t
 (** Convert the given unboxed 32-bit integer (type [int32])
    to an unboxed native integer. *)
 
-val to_int32_u : nativeint# -> int32#
+val to_int32_u : t -> int32#
 (** Convert the given unboxed native integer to an unboxed
    32-bit integer (type [int32]).  On 64-bit platforms,
    the 64-bit unboxed native integer is taken modulo 2{^32},
    i.e. the top 32 bits are lost.  On 32-bit platforms,
    the conversion is exact. *)
 
-val of_string : string -> nativeint#
+val of_string : string -> t
 (** Convert the given string to an unboxed native integer.
    The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the
@@ -218,14 +221,11 @@ val of_string : string -> nativeint#
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [nativeint]. *)
 
-(* val of_string_opt: string -> nativeint# option
+(* val of_string_opt: string -> t option
  * (** Same as [of_string], but return [None] instead of raising. *) *)
 
-val to_string : nativeint# -> string
+val to_string : t -> string
 (** Return the string representation of its argument, in decimal. *)
-
-type t = nativeint#
-(** An alias for the type of unboxed native integers. *)
 
 val compare: t -> t -> int
 (** The comparison function for unboxed native integers, with the same

--- a/ocaml/testsuite/tests/typing-layouts-arrays/exp_and_pat_failing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/exp_and_pat_failing.ml
@@ -45,15 +45,15 @@ let f () = [|Float_u.of_int e for e = 0 to 9|]
 
 [%%expect{|
 module Float_u = Stdlib__Float_u
-val of_int : int -> float# = <fun>
+val of_int : int -> Float_u.t = <fun>
 val ( = ) : Float_u.t -> Float_u.t -> bool = <fun>
 Line 26, characters 13-29:
 26 | let f () = [|Float_u.of_int e for e = 0 to 9|]
                   ^^^^^^^^^^^^^^^^
-Error: This expression has type float# but an expression was expected of type
-         ('a : value)
-       The layout of float# is float64, because
+Error: This expression has type Float_u.t = float#
+       but an expression was expected of type ('a : value)
+       The layout of Float_u.t is float64, because
          it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
+       But the layout of Float_u.t must be a sublayout of value, because
          it's the element type of array comprehension.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -890,10 +890,10 @@ let f14_4 r =
 [%%expect{|
 module FU = Stdlib__Float_u
 type t14_1 = { x : float#; y : float#; }
-val f14_1 : t14_1 -> float# = <fun>
+val f14_1 : t14_1 -> FU.t = <fun>
 val r14 : t14_1 = {x = <abstr>; y = <abstr>}
 val sum14_1 : float = 0.419999999999999929
-val f14_2 : t14_1 -> float# = <fun>
+val f14_2 : t14_1 -> FU.t = <fun>
 val sum14_2 : float = 0.419999999999999929
 type t14_2 = { mutable a : float#; b : float#; mutable c : float#; }
 val f14_3 : t14_2 -> t14_2 = <fun>
@@ -903,5 +903,5 @@ val c : float = 27.7
 val a' : float = 42.
 val b' : float = 20.
 val c' : float = 3.1
-val f14_4 : t14_1 -> float# = <fun>
+val f14_4 : t14_1 -> FU.t = <fun>
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics_beta.ml
@@ -865,10 +865,10 @@ let f14_4 r =
 [%%expect{|
 module FU = Stdlib__Float_u
 type t14_1 = { x : float#; y : float#; }
-val f14_1 : t14_1 -> float# = <fun>
+val f14_1 : t14_1 -> FU.t = <fun>
 val r14 : t14_1 = {x = <abstr>; y = <abstr>}
 val sum14_1 : float = 0.419999999999999929
-val f14_2 : t14_1 -> float# = <fun>
+val f14_2 : t14_1 -> FU.t = <fun>
 val sum14_2 : float = 0.419999999999999929
 type t14_2 = { mutable a : float#; b : float#; mutable c : float#; }
 val f14_3 : t14_2 -> t14_2 = <fun>
@@ -878,5 +878,5 @@ val c : float = 27.7
 val a' : float = 42.
 val b' : float = 20.
 val c' : float = 3.1
-val f14_4 : t14_1 -> float# = <fun>
+val f14_4 : t14_1 -> FU.t = <fun>
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -298,7 +298,7 @@ type rf = { fieldf : ('a : float64). 'a -> 'a }
 let f { fieldf } = fieldf (Stdlib__Float_u.of_float 3.14);;
 [%%expect {|
 type rf = { fieldf : ('a : float64). 'a -> 'a; }
-val f : rf -> float# = <fun>
+val f : rf -> Stdlib__Float_u.t = <fun>
 |}]
 
 let f { field } = field "hello"

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -117,7 +117,7 @@ module M1 :
     type t : any
     type ('a : any) s = { a : 'a -> 'a; }
     type q = t s
-    val f1 : unit -> float# s
+    val f1 : unit -> Stdlib__Float_u.t s
     val f2 : unit -> string s
     val f3 : unit -> int s
   end
@@ -140,7 +140,7 @@ module M1 :
     type t : any
     type ('a : any) s = A of ('a -> 'a)
     type q = t s
-    val f1 : unit -> float# s
+    val f1 : unit -> Stdlib__Float_u.t s
     val f2 : unit -> string s
     val f3 : unit -> int s
   end
@@ -163,7 +163,7 @@ module M1 :
     type t : any
     type ('a : any) s = A of { a : 'a -> 'a; }
     type q = t s
-    val f1 : unit -> float# s
+    val f1 : unit -> Stdlib__Float_u.t s
     val f2 : unit -> string s
     val f3 : unit -> int s
   end
@@ -192,7 +192,7 @@ module M1 :
     val f0 : unit -> 'a s
     val f1 : unit -> int s
     val f2 : unit -> string s
-    val f3 : unit -> float# s
+    val f3 : unit -> Stdlib__Float_u.t s
     val f4 : unit -> int s
     val f5 : unit -> string s
   end
@@ -221,7 +221,7 @@ module M1 :
     val f0 : unit -> 'a s
     val f1 : unit -> int s
     val f2 : unit -> string s
-    val f3 : unit -> float# s
+    val f3 : unit -> Stdlib__Float_u.t s
     val f4 : unit -> int s
     val f5 : unit -> string s
   end
@@ -254,10 +254,10 @@ Line 4, characters 53-54:
 4 |   let f1 () = A {a = (fun x y -> Stdlib__Float_u.abs x)}
                                                          ^
 Error: This expression has type ('a : value)
-       but an expression was expected of type float#
-       The layout of float# is float64, because
+       but an expression was expected of type Stdlib__Float_u.t = float#
+       The layout of Stdlib__Float_u.t is float64, because
          it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
+       But the layout of Stdlib__Float_u.t must be a sublayout of value, because
          of the definition of s at line 2, characters 2-55.
 |}]
 
@@ -288,10 +288,10 @@ Line 4, characters 48-49:
 4 |   let f1 () = A (fun x y -> Stdlib__Float_u.abs x)
                                                     ^
 Error: This expression has type ('a : value)
-       but an expression was expected of type float#
-       The layout of float# is float64, because
+       but an expression was expected of type Stdlib__Float_u.t = float#
+       The layout of Stdlib__Float_u.t is float64, because
          it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
+       But the layout of Stdlib__Float_u.t must be a sublayout of value, because
          of the definition of s at line 2, characters 2-50.
 |}]
 
@@ -306,10 +306,10 @@ Line 4, characters 55-56:
 4 |   let f6 () = A {a = (fun x y -> Stdlib__Float_u.add x y)}
                                                            ^
 Error: This expression has type ('a : value)
-       but an expression was expected of type float#
-       The layout of float# is float64, because
+       but an expression was expected of type Stdlib__Float_u.t = float#
+       The layout of Stdlib__Float_u.t is float64, because
          it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
+       But the layout of Stdlib__Float_u.t must be a sublayout of value, because
          of the definition of s at line 2, characters 2-70.
 |}]
 
@@ -324,10 +324,10 @@ Line 4, characters 50-51:
 4 |   let f6 () = A (fun x y -> Stdlib__Float_u.add x y)
                                                       ^
 Error: This expression has type ('a : value)
-       but an expression was expected of type float#
-       The layout of float# is float64, because
+       but an expression was expected of type Stdlib__Float_u.t = float#
+       The layout of Stdlib__Float_u.t is float64, because
          it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
+       But the layout of Stdlib__Float_u.t must be a sublayout of value, because
          of the definition of s at line 2, characters 2-65.
 |}]
 
@@ -723,10 +723,10 @@ Line 5, characters 16-17:
 5 |     | `Bar v -> v
                     ^
 Error: This expression has type ('a : value)
-       but an expression was expected of type float#
-       The layout of float# is float64, because
+       but an expression was expected of type Stdlib__Float_u.t = float#
+       The layout of Stdlib__Float_u.t is float64, because
          it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
+       But the layout of Stdlib__Float_u.t must be a sublayout of value, because
          it's the type of the field of a polymorphic variant.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -72,10 +72,10 @@ Line 3, characters 19-20:
 3 |   Float_u.to_float x
                        ^
 Error: This expression has type ('a : value)
-       but an expression was expected of type float#
-       The layout of float# is float64, because
+       but an expression was expected of type Float_u.t = float#
+       The layout of Float_u.t is float64, because
          it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
+       But the layout of Float_u.t must be a sublayout of value, because
          of the annotation on the wildcard _ at line 2, characters 15-26.
          Custom message
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/literals.ml
+++ b/ocaml/testsuite/tests/typing-layouts/literals.ml
@@ -25,10 +25,10 @@ module Float_u = Stdlib__Float_u
 module Int32_u = Stdlib__Int32_u
 module Int64_u = Stdlib__Int64_u
 module Nativeint_u = Stdlib__Nativeint_u
-val test_float : string -> float# -> unit = <fun>
-val test_int32 : string -> int32# -> unit = <fun>
-val test_int64 : string -> int64# -> unit = <fun>
-val test_nativeint : string -> nativeint# -> unit = <fun>
+val test_float : string -> Float_u.t -> unit = <fun>
+val test_int32 : string -> Int32_u.t -> unit = <fun>
+val test_int64 : string -> Int64_u.t -> unit = <fun>
+val test_nativeint : string -> Nativeint_u.t -> unit = <fun>
 |}]
 
 (*****************************************)


### PR DESCRIPTION
Slightly refactors the `Float32`/`Float32_u`/`Int32_u`/`Int64_u`/`Nativeint_u`/`Float_u` interfaces to consistently use their `type t` alias. 