### PR TITLE
Simplify the `install` stanza of extension universe otherlibs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
       id: cache
       with:
         path: ${{ github.workspace }}/ocaml-414/_install
-        key: ${{ matrix.os }}-cache-ocaml-414-dune-361-menhir-20210419
+        key: ${{ matrix.os }}-cache-ocaml-414-dune-3152-menhir-20210419
 
     - name: Checkout OCaml 4.14
       uses: actions/checkout@master
@@ -143,7 +143,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       with:
         repository: 'ocaml/dune'
-        ref: '3.6.1'
+        ref: '3.15.2'
         path: 'dune'
 
     - name: Build dune

--- a/HACKING.md
+++ b/HACKING.md
@@ -370,8 +370,8 @@ thoroughly (e.g. `git clean -dfX`) before reconfiguring with a different prefix.
 
 Then build the compiler with the command `make _install` (this is the default
 target plus some setup in preparation for installation). As usual when building,
-a 4.14 compiler (and dune and menhir) need to be in the path. See the warnings above
-about the versions of dune and menhir to use.
+a 4.14 compiler (and dune and menhir) need to be in the path. See the warning above
+about the version of and menhir to use.
 
 Now the build part is done, we don't need to stay in the build environment
 anymore; the switch creation will likely replace it if your terminal is setup

--- a/HACKING.md
+++ b/HACKING.md
@@ -371,7 +371,7 @@ thoroughly (e.g. `git clean -dfX`) before reconfiguring with a different prefix.
 Then build the compiler with the command `make _install` (this is the default
 target plus some setup in preparation for installation). As usual when building,
 a 4.14 compiler (and dune and menhir) need to be in the path. See the warning above
-about the version of and menhir to use.
+about the version of menhir to use.
 
 Now the build part is done, we don't need to stay in the build environment
 anymore; the switch creation will likely replace it if your terminal is setup

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ One-time setup (you can also use other 4.14.x releases):
 ```
 $ opam switch 4.14.1  # or "opam switch create 4.14.1" if you haven't got that switch already
 $ eval $(opam env)
-$ opam install dune.3.8.1 menhir.20210419
+$ opam install dune.3.15.2 menhir.20210419
 ```
 
 You probably then want to fork the `ocaml-flambda/flambda-backend` repo to your own Github org.

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_INIT([The Flambda backend for OCaml],
         [flambda_backend],
         [http://github.com/ocaml-flambda/flambda_backend])
 
-DUNE_MAX_VERSION=[3.8]
+DUNE_MAX_VERSION=[3.15]
 
 AC_MSG_NOTICE([Configuring Flambda backend version AC_PACKAGE_VERSION])
 

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.5)
+(lang dune 3.11)
 (wrapped_executables false)
 (using experimental_building_ocaml_compiler_with_dune 0.1)
 (using menhir 2.1)
@@ -17,4 +17,3 @@
 (package
   (name ocaml_runtime_stdlib)
 )
-

--- a/ocaml/dune-project.jst
+++ b/ocaml/dune-project.jst
@@ -1,4 +1,4 @@
-(lang dune 2.8)
+(lang dune 3.11)
 (wrapped_executables false)
 (using experimental_building_ocaml_compiler_with_dune 0.1)
 (using menhir 2.1)

--- a/ocaml/otherlibs/alpha/dune
+++ b/ocaml/otherlibs/alpha/dune
@@ -36,14 +36,11 @@
 
 (install
  (files
-  (alpha.cmxa as alpha/alpha.cmxa)
-  (alpha.a as alpha/alpha.a)
-  (alpha.cmxs as alpha/alpha.cmxs)
-  (alpha.cma as alpha/alpha.cma)
-  (alpha.mli as alpha/alpha.mli)
-  (.alpha.objs/byte/alpha.cmi as alpha/alpha.cmi)
-  (.alpha.objs/byte/alpha.cmt as alpha/alpha.cmt)
-  (.alpha.objs/byte/alpha.cmti as alpha/alpha.cmti)
-  (.alpha.objs/native/alpha.cmx as alpha/alpha.cmx))
+  (glob_files
+   (*.{cmxa,a,cmxs,cma,mli} with_prefix alpha))
+  (glob_files
+   (.alpha.objs/byte/*.{cmi,cmt,cmti} with_prefix alpha))
+  (glob_files
+   (.alpha.objs/native/*.cmx with_prefix alpha)))
  (section lib)
  (package ocaml))

--- a/ocaml/otherlibs/beta/dune
+++ b/ocaml/otherlibs/beta/dune
@@ -36,24 +36,11 @@
 
 (install
  (files
-  (beta.cmxa as beta/beta.cmxa)
-  (beta.a as beta/beta.a)
-  (beta.cmxs as beta/beta.cmxs)
-  (beta.cma as beta/beta.cma)
-  (beta.mli as beta/beta.mli)
-  (float32.mli as beta/float32.mli)
-  (float32_u.mli as beta/float32_u.mli)
-  (.beta.objs/byte/beta.cmi as beta/beta.cmi)
-  (.beta.objs/byte/beta.cmt as beta/beta.cmt)
-  (.beta.objs/byte/beta.cmti as beta/beta.cmti)
-  (.beta.objs/native/beta.cmx as beta/beta.cmx)
-  (.beta.objs/byte/float32.cmi as beta/float32.cmi)
-  (.beta.objs/byte/float32.cmt as beta/float32.cmt)
-  (.beta.objs/byte/float32.cmti as beta/float32.cmti)
-  (.beta.objs/native/float32.cmx as beta/float32.cmx)
-  (.beta.objs/byte/float32_u.cmi as beta/float32_u.cmi)
-  (.beta.objs/byte/float32_u.cmt as beta/float32_u.cmt)
-  (.beta.objs/byte/float32_u.cmti as beta/float32_u.cmti)
-  (.beta.objs/native/float32_u.cmx as beta/float32_u.cmx))
+  (glob_files
+   (*.{cmxa,a,cmxs,cma,mli} with_prefix beta))
+  (glob_files
+   (.beta.objs/byte/*.{cmi,cmt,cmti} with_prefix beta))
+  (glob_files
+   (.beta.objs/native/*.cmx with_prefix beta)))
  (section lib)
  (package ocaml))

--- a/ocaml/otherlibs/stable/dune
+++ b/ocaml/otherlibs/stable/dune
@@ -36,14 +36,11 @@
 
 (install
  (files
-  (stable.cmxa as stable/stable.cmxa)
-  (stable.a as stable/stable.a)
-  (stable.cmxs as stable/stable.cmxs)
-  (stable.cma as stable/stable.cma)
-  (stable.mli as stable/stable.mli)
-  (.stable.objs/byte/stable.cmi as stable/stable.cmi)
-  (.stable.objs/byte/stable.cmt as stable/stable.cmt)
-  (.stable.objs/byte/stable.cmti as stable/stable.cmti)
-  (.stable.objs/native/stable.cmx as stable/stable.cmx))
+  (glob_files
+   (*.{cmxa,a,cmxs,cma,mli} with_prefix stable))
+  (glob_files
+   (.stable.objs/byte/*.{cmi,cmt,cmti} with_prefix stable))
+  (glob_files
+   (.stable.objs/native/*.cmx with_prefix stable)))
  (section lib)
  (package ocaml))

--- a/ocaml/otherlibs/upstream_compatible/dune
+++ b/ocaml/otherlibs/upstream_compatible/dune
@@ -36,22 +36,13 @@
 
 (install
  (files
-  (upstream_compatible.cmxa as upstream_compatible/upstream_compatible.cmxa)
-  (upstream_compatible.a as upstream_compatible/upstream_compatible.a)
-  (upstream_compatible.cmxs as upstream_compatible/upstream_compatible.cmxs)
-  (upstream_compatible.cma as upstream_compatible/upstream_compatible.cma)
-  (upstream_compatible.mli as upstream_compatible/upstream_compatible.mli)
-  (.upstream_compatible.objs/byte/upstream_compatible.cmi
-   as
-   upstream_compatible/upstream_compatible.cmi)
-  (.upstream_compatible.objs/byte/upstream_compatible.cmt
-   as
-   upstream_compatible/upstream_compatible.cmt)
-  (.upstream_compatible.objs/byte/upstream_compatible.cmti
-   as
-   upstream_compatible/upstream_compatible.cmti)
-  (.upstream_compatible.objs/native/upstream_compatible.cmx
-   as
-   upstream_compatible/upstream_compatible.cmx))
+  (glob_files
+   (*.{cmxa,a,cmxs,cma,mli} with_prefix upstream_compatible))
+  (glob_files
+   (.upstream_compatible.objs/byte/*.{cmi,cmt,cmti}
+    with_prefix
+    upstream_compatible))
+  (glob_files
+   (.upstream_compatible.objs/native/*.cmx with_prefix upstream_compatible)))
  (section lib)
  (package ocaml))


### PR DESCRIPTION
Bump Dune language version to 3.11 to use `glob_files` and `with_prefix`. Simplify the `install` stanza of extension universe otherlibs.

This can be extended to all other `dune` files we have later. I'm sticking with just this for now since this makes renaming otherlibs easier.