### PR TITLE
Optimized version of dominator forest

### DIFF
--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -423,7 +423,7 @@ let compute_dominator_forest_opt : Cfg.t -> doms -> dominator_tree list =
       | None -> []
       | Some labels -> labels
     in
-    { label; children = List.rev_map children_labels ~f:build_tree }
+    { label; children = List.map children_labels ~f:build_tree }
   in
   Cfg.iter_blocks cfg ~f:(fun label _block ->
       match Label.Tbl.find_opt doms label with
@@ -438,7 +438,7 @@ let compute_dominator_forest_opt : Cfg.t -> doms -> dominator_tree list =
             | Some children -> children
           in
           Label.Tbl.replace children immediate_dominator (label :: current));
-  let res = List.rev_map !roots ~f:build_tree in
+  let res = List.map !roots ~f:build_tree in
   if debug then invariant_dominator_forest cfg doms res;
   res
 

--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -390,7 +390,7 @@ let invariant_dominator_forest : Cfg.t -> doms -> dominator_tree list -> unit =
   List.iter dominator_forest ~f:(fun dominator_tree ->
       check_parent ~parent:None dominator_tree)
 
-let compute_dominator_forest : Cfg.t -> doms -> dominator_tree list =
+let compute_dominator_forest_naive : Cfg.t -> doms -> dominator_tree list =
  fun cfg doms ->
   let rec children_of parent =
     Label.Tbl.fold
@@ -413,12 +413,65 @@ let compute_dominator_forest : Cfg.t -> doms -> dominator_tree list =
   if debug then invariant_dominator_forest cfg doms res;
   res
 
+let compute_dominator_forest_opt : Cfg.t -> doms -> dominator_tree list =
+ fun cfg doms ->
+  let roots = ref [] in
+  let children = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
+  let rec build_tree (label : Label.t) : dominator_tree =
+    let children_labels =
+      match Label.Tbl.find_opt children label with
+      | None -> []
+      | Some labels -> labels
+    in
+    { label; children = List.rev_map children_labels ~f:build_tree }
+  in
+  Cfg.iter_blocks cfg ~f:(fun label _block ->
+      match Label.Tbl.find_opt doms label with
+      | None -> assert false
+      | Some immediate_dominator ->
+        if Label.equal label immediate_dominator
+        then roots := label :: !roots
+        else
+          let current =
+            match Label.Tbl.find_opt children immediate_dominator with
+            | None -> []
+            | Some children -> children
+          in
+          Label.Tbl.replace children immediate_dominator (label :: current));
+  let res = List.rev_map !roots ~f:build_tree in
+  if debug then invariant_dominator_forest cfg doms res;
+  res
+
+let sort_forest : dominator_tree list -> dominator_tree list =
+ fun trees ->
+  let compare_label left right = Label.compare left.label right.label in
+  List.sort ~cmp:compare_label trees
+
+let rec equal_tree : dominator_tree -> dominator_tree -> bool =
+ fun left right ->
+  Label.equal left.label right.label
+  && equal_forest left.children right.children
+
+and equal_forest : dominator_tree list -> dominator_tree list -> bool =
+ fun left right ->
+  match sort_forest left, sort_forest right with
+  | [], [] -> true
+  | hd_left :: tl_left, hd_right :: tl_right ->
+    equal_tree hd_left hd_right && equal_forest tl_left tl_right
+  | [], _ :: _ | _ :: _, [] -> false
+
 let build : Cfg.t -> t =
  fun cfg ->
   let doms = compute_doms cfg in
   let dominance_frontiers = compute_dominance_frontiers cfg doms in
-  let dominator_forest = compute_dominator_forest cfg doms in
-  { entry_label = cfg.entry_label; doms; dominance_frontiers; dominator_forest }
+  let dominator_forest_naive = compute_dominator_forest_naive cfg doms in
+  let dominator_forest_opt = compute_dominator_forest_opt cfg doms in
+  assert (equal_forest dominator_forest_naive dominator_forest_opt);
+  { entry_label = cfg.entry_label;
+    doms;
+    dominance_frontiers;
+    dominator_forest = dominator_forest_opt
+  }
 
 let is_dominating t left right = is_dominating t.doms left right
 


### PR DESCRIPTION
This pull request adds a new function,
namely `compute_dominator_forest_opt`,
to compute the dominator forest. The
existing version is renamed to
`compute_dominator_forest_naive`.

Instead of re-filtering the whole collection
of CFG blocks every time a node is
added to the forest, the list of children
for each node is computed in one
pass over the CFG blocks. This does
not make a difference most of the
time, but on pathological cases (_i.e._
huge CFG values), the existing
implementation can be impractically
slow.

The pull request also adds code to
checks whether the two functions
compute equivalent forests. It will
be removed in a follow-up.