### PR TITLE
Avoid CMOV with CFeq

### DIFF
--- a/tests/intrinsics/dune
+++ b/tests/intrinsics/dune
@@ -1,0 +1,5 @@
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps select_float.ml)
+ (action (run %{bin:ocamlopt.opt} %{deps} -c)))

--- a/tests/intrinsics/select_float.ml
+++ b/tests/intrinsics/select_float.ml
@@ -1,0 +1,59 @@
+(* [AMD64] Special case of [caml_csel_value] with a float comparison
+   avoid branches for [equal].
+*)
+type t = float#
+
+module Float_u = struct
+  external to_float : float# -> (float[@local_opt]) = "%box_float"
+  external of_float : (float[@local_opt]) -> float# = "%unbox_float"
+
+  let[@inline] to_bits x = (Int64.bits_of_float) (to_float x)
+  let[@inline] of_bits x = (Int64.float_of_bits) x |> of_float
+
+  let[@inline always] div x y = of_float (Float.div (to_float x) (to_float y))
+
+  external select_int64
+    :  bool
+    -> (int64[@unboxed])
+    -> (int64[@unboxed])
+    -> (int64[@unboxed])
+    = "caml_csel_value" "caml_csel_int64_unboxed"
+  [@@noalloc] [@@no_effects] [@@no_coeffects] [@@builtin]
+
+  let[@inline] select b (ifso : t) (ifnot : t) : t =
+    select_int64 b (to_bits ifso) (to_bits ifnot) |> of_bits
+
+end
+
+external float_notequal : (float[@local_opt]) -> (float[@local_opt]) -> bool = "%notequal"
+external float_equal : (float[@local_opt]) -> (float[@local_opt]) -> bool = "%equal"
+
+
+let[@inline] divide_unless_denom_zero_else
+  ~(numer : float)
+  ~(denom : float)
+  ~(else_ : float)
+  =
+  let is_denom_zero = float_equal denom 0. in
+  let numer = Float_u.of_float numer in
+  let denom = Float_u.of_float denom in
+  let else_ = Float_u.of_float else_ in
+  Float_u.select
+    is_denom_zero
+    else_
+    (Float_u.div numer denom)
+  |> Float_u.to_float
+;;
+
+let is_result_larger_than_2
+  ~(numer : float)
+  ~(denom : float)
+  ~(else_ : float)
+  =
+  let result = divide_unless_denom_zero_else
+    ~numer
+    ~denom
+    ~else_
+  in
+  Float.compare result 2. > 0
+;;


### PR DESCRIPTION
Improve code generation for `Icsel` when the condition is float equality. This condition is not directly expressible as a CMOV mnemonic. To work around it, the compile emits a jump instruction (to correctly handled the special case of Nan argument), defeating the purpose of `CMOV`.  This PR adds an ad-hoc pattern during `Selection` to detect this case, negate the condition and swap the arguments of `CMOV`.  

Added a test to exercise this special case. I'm not adding any assembly grepping, because it's too fragile.

