### PR TITLE
IRC: register synonyms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
             config: --enable-middle-end=flambda2
             os: ubuntu-latest
             build_ocamlparam: '_,w=-46,regalloc=irc,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=IRC_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1'
+            ocamlparam: '_,w=-46,regalloc=irc,regalloc-param=SPLIT_LIVE_RANGES:on,regalloc-param=IRC_SPILLING_HEURISTICS:flat-uses,regalloc-validate=1'
             check_arch: true
 
           - name: irc_frame_pointers

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -511,3 +511,19 @@ let operation_supported = function
     -> true
 
 let trap_size_in_bytes = 16
+
+let machtype_synonyms (typ : Cmm.machtype_component) : Cmm.machtype_component list =
+  match typ with
+    | Val | Addr | Int | Float -> []
+    | Vec128 ->
+      (* CR mslater: (SIMD) arm64 *)
+      fatal_error "arm64: got vec128 register"
+    | Float32 ->
+      (* CR mslater: (float32) arm64 *)
+      fatal_error "arm64: got float32 register"
+
+let reg_synonyms (reg : Reg.t) : Reg.t list =
+  match reg.loc with
+  | Reg idx ->
+    List.map (fun typ -> phys_reg typ idx) (machtype_synonyms reg.typ)
+  | Unknown | Stack (Local _ | Incoming _ | Outgoing _ | Domainstate _) -> []

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -130,3 +130,6 @@ val operation_supported : Cmm.operation -> bool
 
 (** The number of bytes each trap occupies on the stack. *)
 val trap_size_in_bytes : int
+
+val machtype_synonyms : Cmm.machtype_component -> Cmm.machtype_component list
+val reg_synonyms : Reg.t-> Reg.t list


### PR DESCRIPTION
(This is really an early draft, exploring the design space.)

This pull request tweaks the computation of IRC's
interference graph by ensuring that when we add an
edge involving an hardware register, we actually add
edges to all its synonyms.

A "synonym" is this context refers to the fact that
_e.g._ `xmm0` is represented by several `Reg.t` instance
when SIMD and/or float32 is enabled. There is indeed
one instance per machtype, even though they share
the same hardware location (and thus register class).