### PR TITLE
Revert "Simplify the `install` stanza of extension universe otherlibs"

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.11)
+(lang dune 3.5)
 (wrapped_executables false)
 (using experimental_building_ocaml_compiler_with_dune 0.1)
 (using menhir 2.1)
@@ -17,3 +17,4 @@
 (package
   (name ocaml_runtime_stdlib)
 )
+

--- a/ocaml/dune-project.jst
+++ b/ocaml/dune-project.jst
@@ -1,4 +1,4 @@
-(lang dune 3.11)
+(lang dune 2.8)
 (wrapped_executables false)
 (using experimental_building_ocaml_compiler_with_dune 0.1)
 (using menhir 2.1)

--- a/ocaml/otherlibs/alpha/dune
+++ b/ocaml/otherlibs/alpha/dune
@@ -50,11 +50,14 @@
 
 (install
  (files
-  (glob_files
-   (*.{cmxa,a,cmxs,cma,mli} with_prefix alpha))
-  (glob_files
-   (.alpha.objs/byte/*.{cmi,cmt,cmti} with_prefix alpha))
-  (glob_files
-   (.alpha.objs/native/*.cmx with_prefix alpha)))
+  (alpha.cmxa as alpha/alpha.cmxa)
+  (alpha.a as alpha/alpha.a)
+  (alpha.cmxs as alpha/alpha.cmxs)
+  (alpha.cma as alpha/alpha.cma)
+  (alpha.mli as alpha/alpha.mli)
+  (.alpha.objs/byte/alpha.cmi as alpha/alpha.cmi)
+  (.alpha.objs/byte/alpha.cmt as alpha/alpha.cmt)
+  (.alpha.objs/byte/alpha.cmti as alpha/alpha.cmti)
+  (.alpha.objs/native/alpha.cmx as alpha/alpha.cmx))
  (section lib)
  (package ocaml))

--- a/ocaml/otherlibs/beta/dune
+++ b/ocaml/otherlibs/beta/dune
@@ -50,11 +50,24 @@
 
 (install
  (files
-  (glob_files
-   (*.{cmxa,a,cmxs,cma,mli} with_prefix beta))
-  (glob_files
-   (.beta.objs/byte/*.{cmi,cmt,cmti} with_prefix beta))
-  (glob_files
-   (.beta.objs/native/*.cmx with_prefix beta)))
+  (beta.cmxa as beta/beta.cmxa)
+  (beta.a as beta/beta.a)
+  (beta.cmxs as beta/beta.cmxs)
+  (beta.cma as beta/beta.cma)
+  (beta.mli as beta/beta.mli)
+  (float32.mli as beta/float32.mli)
+  (float32_u.mli as beta/float32_u.mli)
+  (.beta.objs/byte/beta.cmi as beta/beta.cmi)
+  (.beta.objs/byte/beta.cmt as beta/beta.cmt)
+  (.beta.objs/byte/beta.cmti as beta/beta.cmti)
+  (.beta.objs/native/beta.cmx as beta/beta.cmx)
+  (.beta.objs/byte/float32.cmi as beta/float32.cmi)
+  (.beta.objs/byte/float32.cmt as beta/float32.cmt)
+  (.beta.objs/byte/float32.cmti as beta/float32.cmti)
+  (.beta.objs/native/float32.cmx as beta/float32.cmx)
+  (.beta.objs/byte/float32_u.cmi as beta/float32_u.cmi)
+  (.beta.objs/byte/float32_u.cmt as beta/float32_u.cmt)
+  (.beta.objs/byte/float32_u.cmti as beta/float32_u.cmti)
+  (.beta.objs/native/float32_u.cmx as beta/float32_u.cmx))
  (section lib)
  (package ocaml))

--- a/ocaml/otherlibs/stable/dune
+++ b/ocaml/otherlibs/stable/dune
@@ -64,11 +64,14 @@
 
 (install
  (files
-  (glob_files
-   (*.{cmxa,a,cmxs,cma,mli} with_prefix stable))
-  (glob_files
-   (.stable.objs/byte/*.{cmi,cmt,cmti} with_prefix stable))
-  (glob_files
-   (.stable.objs/native/*.cmx with_prefix stable)))
+  (stable.cmxa as stable/stable.cmxa)
+  (stable.a as stable/stable.a)
+  (stable.cmxs as stable/stable.cmxs)
+  (stable.cma as stable/stable.cma)
+  (stable.mli as stable/stable.mli)
+  (.stable.objs/byte/stable.cmi as stable/stable.cmi)
+  (.stable.objs/byte/stable.cmt as stable/stable.cmt)
+  (.stable.objs/byte/stable.cmti as stable/stable.cmti)
+  (.stable.objs/native/stable.cmx as stable/stable.cmx))
  (section lib)
  (package ocaml))

--- a/ocaml/otherlibs/upstream_compatible/dune
+++ b/ocaml/otherlibs/upstream_compatible/dune
@@ -51,13 +51,22 @@
 
 (install
  (files
-  (glob_files
-   (*.{cmxa,a,cmxs,cma,mli} with_prefix upstream_compatible))
-  (glob_files
-   (.upstream_compatible.objs/byte/*.{cmi,cmt,cmti}
-    with_prefix
-    upstream_compatible))
-  (glob_files
-   (.upstream_compatible.objs/native/*.cmx with_prefix upstream_compatible)))
+  (upstream_compatible.cmxa as upstream_compatible/upstream_compatible.cmxa)
+  (upstream_compatible.a as upstream_compatible/upstream_compatible.a)
+  (upstream_compatible.cmxs as upstream_compatible/upstream_compatible.cmxs)
+  (upstream_compatible.cma as upstream_compatible/upstream_compatible.cma)
+  (upstream_compatible.mli as upstream_compatible/upstream_compatible.mli)
+  (.upstream_compatible.objs/byte/upstream_compatible.cmi
+   as
+   upstream_compatible/upstream_compatible.cmi)
+  (.upstream_compatible.objs/byte/upstream_compatible.cmt
+   as
+   upstream_compatible/upstream_compatible.cmt)
+  (.upstream_compatible.objs/byte/upstream_compatible.cmti
+   as
+   upstream_compatible/upstream_compatible.cmti)
+  (.upstream_compatible.objs/native/upstream_compatible.cmx
+   as
+   upstream_compatible/upstream_compatible.cmx))
  (section lib)
  (package ocaml))


### PR DESCRIPTION
I don't think the breakage caused by the dune language bump for these changes is worth it, and in any case we need to announce such changes beforehand.  @dkalinichenko-js can you please make new PRs to reapply the reverted ones, without this change?

Reverts ocaml-flambda/flambda-backend#2563