### PR TITLE
Add a threshold to control the cfg-stack-check optmization

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -69,6 +69,9 @@ let mk_cfg_stack_checks f =
 let mk_no_cfg_stack_checks f =
     "-no-cfg-stack-checks", Arg.Unit f, " Insert the stack checks on the linear representation"
 
+let mk_cfg_stack_checks_threshold f =
+  "-cfg-stack-checks-threshold", Arg.Int f, "<n>  Only CFGs with fewer than n blocks will be optimized"
+
 let mk_reorder_blocks_random f =
   "-reorder-blocks-random",
   Arg.Int f,
@@ -663,6 +666,7 @@ module type Flambda_backend_options = sig
 
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
+  val cfg_stack_checks_threshold : int -> unit
 
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit
@@ -782,6 +786,7 @@ struct
 
     mk_cfg_stack_checks F.cfg_stack_checks;
     mk_no_cfg_stack_checks F.no_cfg_stack_checks;
+    mk_cfg_stack_checks_threshold F.cfg_stack_checks_threshold;
 
     mk_reorder_blocks_random F.reorder_blocks_random;
     mk_basic_block_sections F.basic_block_sections;
@@ -930,6 +935,7 @@ module Flambda_backend_options_impl = struct
 
   let cfg_stack_checks = set' Flambda_backend_flags.cfg_stack_checks
   let no_cfg_stack_checks = clear' Flambda_backend_flags.cfg_stack_checks
+  let cfg_stack_checks_threshold n = Flambda_backend_flags.cfg_stack_checks_threshold := n
 
   let reorder_blocks_random seed =
     Flambda_backend_flags.reorder_blocks_random := Some seed
@@ -1241,6 +1247,7 @@ module Extra_params = struct
     | "cfg-peephole-optimize" -> set' Flambda_backend_flags.cfg_peephole_optimize
     | "cfg-cse-optimize" -> set' Flambda_backend_flags.cfg_cse_optimize
     | "cfg-stack-checks" -> set' Flambda_backend_flags.cfg_stack_checks
+    | "cfg-stack-checks-threshold" -> set_int' Flambda_backend_flags.cfg_stack_checks_threshold
     | "dump-inlining-paths" -> set' Flambda_backend_flags.dump_inlining_paths
     | "davail" -> set' Flambda_backend_flags.davail
     | "dranges" -> set' Flambda_backend_flags.dranges

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -42,6 +42,7 @@ module type Flambda_backend_options = sig
 
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
+  val cfg_stack_checks_threshold : int -> unit
 
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -26,6 +26,7 @@ let cfg_peephole_optimize = ref true    (* -[no-]cfg-peephole-optimize *)
 let cfg_cse_optimize = ref false        (* -[no-]cfg-cse-optimize *)
 
 let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
+let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 let basic_block_sections = ref false    (* -basic-block-sections *)

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -27,6 +27,7 @@ val cfg_peephole_optimize: bool ref
 val cfg_cse_optimize: bool ref
 
 val cfg_stack_checks : bool ref
+val cfg_stack_checks_threshold : int ref
 
 val reorder_blocks_random : int option ref
 val basic_block_sections : bool ref


### PR DESCRIPTION
The cfg-stack-check optimization (pushing
the check down in the CFG) can be quite
costly when the CFG has many blocks.

#2565 helps, by optimizing the computation
of the dominator forest, but this is not
enough in some pathological cases.

Profiling showed that the remaining cost
was in the computation of back edges
(in `Cfg_loop_infos`), which means that
lazily computing the other fields of the
record would not help. Caching the result
of `is_dominating` does not help either.

Hence the threshold introduced by this
pull request, that decides to simply insert
the stack checks at the top of the function
if the CFG has too many nodes.