### PR TITLE
Add a comment about immediate64s in the flat suffix of mixed records

### DIFF
--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1223,7 +1223,16 @@ module Element_repr = struct
   let classify env loc ty jkind =
     if is_float env ty then Float_element
     else match Jkind.get_default_value jkind with
-      | Value | Immediate64 | Non_null_value -> Value_element
+      (* CR layouts v5.1: We don't allow [Immediate64] in the flat suffix of
+         mixed blocks. That's because we haven't committed to whether the
+         unboxing features of flambda2 can be used together with 32 bit
+         platforms. (If flambda2 stores unboxed things as flat in 32 bits, then
+         immediate64s can't appear in the flat suffix on backends for 32 bit
+         platforms that pass through flambda2. Further, we want typechecking
+         to remain the same in 32 bits vs. 64 bits.)
+      *)
+      | Immediate64 -> Value_element
+      | Value | Non_null_value -> Value_element
       | Immediate -> Imm_element
       | Float64 -> Unboxed_element Float64
       | Float32 -> Unboxed_element Float32

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1227,9 +1227,17 @@ module Element_repr = struct
          mixed blocks. That's because we haven't committed to whether the
          unboxing features of flambda2 can be used together with 32 bit
          platforms. (If flambda2 stores unboxed things as flat in 32 bits, then
-         immediate64s can't appear in the flat suffix on backends for 32 bit
-         platforms that pass through flambda2. Further, we want typechecking
-         to remain the same in 32 bits vs. 64 bits.)
+         immediate64s must be banned in the flat suffix with backends for 32 bit
+         platforms that pass through flambda2. Further, we want a record
+         declaration to be accepted consistently in 32 bits vs. 64 bits.
+         So, immediate64s must always be banned in the flat suffix.)
+
+         In practice, users can put immediate64s in the value prefix.
+         (We may consider teaching the middle-ends to mark immediate64s that
+         abut the non-scannable suffix as non-scannable on 64 bit platforms.)
+
+         We may revisit this decision later when we know better whether we want
+         flambda2 to unbox for 32 bit platforms.
       *)
       | Immediate64 -> Value_element
       | Value | Non_null_value -> Value_element


### PR DESCRIPTION
See #2589. (There is also internal discussion on ticket 2976.)

The goal of this PR is to help answer the question why immediate64s aren't allowed in the flat suffix of mixed blocks. I suggest @goldfirere as reviewer as he asked this question previously. (And at that point, I thought the answer was "we could, but we just haven't implemented it". Now I think it's "we don't want to yet because we want to leave the door open for unboxing on 32 bit platforms with flambda2".)