### PR TITLE
Fix float32 allocation test with --enable-dev

### DIFF
--- a/ocaml/otherlibs/stdlib_beta/float32.mli
+++ b/ocaml/otherlibs/stdlib_beta/float32.mli
@@ -418,7 +418,7 @@ external modf : t -> t * t = "caml_modf_float32"
 (** [modf f] returns the pair of the fractional and integral
     part of [f]. *)
 
-val compare : t -> t -> int
+external compare : t -> t -> int = "%compare"
 (** [compare x y] returns [0] if [x] is equal to [y], a negative integer if [x]
     is less than [y], and a positive integer if [x] is greater than
     [y]. [compare] treats [nan] as equal to itself and less than any other float


### PR DESCRIPTION
Configuring the compiler with `--enable-dev` limits its ability to do cross-module inlining, which caused an allocation test in `typing-layouts-float32/alloc.ml` to fail.

This only affected float32 because the float32 otherlib does not route the compare call into the stdlib.
Exposing compare as an external instead of a val fixes it.