### PR TITLE
Properly handle regions around recursive definitions

### DIFF
--- a/ocaml/testsuite/tests/letrec-compilation/region.ml
+++ b/ocaml/testsuite/tests/letrec-compilation/region.ml
@@ -8,4 +8,12 @@ let rec f =
   let p = local_ (fun msg -> print_string msg) in
   p "hello, ";
   p "world!";
+  print_newline ();
   fun x -> f x
+
+(* Original bug report: unused function *)
+let rec foo =
+  let _f x = x, foo in
+  function
+  | None -> foo None
+  | Some x -> x

--- a/ocaml/testsuite/tests/letrec-compilation/region.ml
+++ b/ocaml/testsuite/tests/letrec-compilation/region.ml
@@ -1,0 +1,11 @@
+(* TEST *)
+
+(* Recursive values are not allowed to be stack-allocated, but their
+   defining expressions are allowed to make allocations on the stack.
+   This can introduce a region around the whole definition. *)
+
+let rec f =
+  let p = local_ (fun msg -> print_string msg) in
+  p "hello, ";
+  p "world!";
+  fun x -> f x

--- a/ocaml/testsuite/tests/letrec-compilation/region.reference
+++ b/ocaml/testsuite/tests/letrec-compilation/region.reference
@@ -1,0 +1,1 @@
+hello, world!


### PR DESCRIPTION
Fixes an oversight in #2394: recursive values are not allowed to be allocated on the stack, but their defining expressions can still contain (temporary) stack allocations, in which case a region is inserted around the whole definition.

I think @goldfirere should review, although I can find someone else if needed.