### PR TITLE
Fix frame pointers build under runtime5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,8 @@ jobs:
             build_ocamlparam: ''
             ocamlparam: '_,O3=1'
 
-          - name: flambda2_o3_advanced_meet
-            config: --enable-middle-end=flambda2
+          - name: flambda2_o3_advanced_meet_frame_pointers_runtime5
+            config: --enable-middle-end=flambda2 --enable-frame-pointers --enable-runtime5
             os: ubuntu-latest
             build_ocamlparam: ''
             ocamlparam: '_,O3=1,flambda2-meet-algorithm=advanced'

--- a/ocaml/runtime/fiber.c
+++ b/ocaml/runtime/fiber.c
@@ -749,6 +749,7 @@ void caml_rewrite_exception_stack(struct stack_info *old_stack,
 }
 
 #ifdef WITH_FRAME_POINTERS
+#if defined(STACK_CHECKS_ENABLED)
 /* Update absolute base pointers for new stack */
 static void rewrite_frame_pointers(struct stack_info *old_stack,
     struct stack_info *new_stack)
@@ -801,6 +802,7 @@ static void rewrite_frame_pointers(struct stack_info *old_stack,
     }
   }
 }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Under runtime5 there is an unused function `rewrite_frame_pointers` which the C compiler complains about, unless stack checks are enabled.  This PR fixes that and changes one of the existing CI jobs to use runtime5 and frame pointers.

@xclerc please review