### PR TITLE
Fix mixed-block-related segfault in runtime4's `redarken_chunk`

### DIFF
--- a/ocaml/runtime4/caml/major_gc.h
+++ b/ocaml/runtime4/caml/major_gc.h
@@ -22,11 +22,16 @@
 #include "misc.h"
 
 /* An interval of a single object to be scanned.
-   The end pointer must always be one-past-the-end of a heap block,
-   but the start pointer is not necessarily the start of the block */
+   The object end pointer must always be one-past-the-end of a heap block,
+   but the start pointer is not necessarily the start of the block,
+   and the scannable end pointer is not necessarily the same as the
+   object end pointer. (The GC should not scan past the scannable
+   end pointer.)
+*/
 typedef struct {
   value* start;
-  value* end;
+  value* scannable_end;
+  value* object_end;
 } mark_entry;
 
 typedef struct {

--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -266,6 +266,8 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
 #define Bhsize_hp(hp) (Bsize_wsize (Whsize_hp (hp)))
 #define Bhsize_hd(hd) (Bsize_wsize (Whsize_hd (hd)))
 
+#define Scannable_wosize_hp(hp) (Scannable_wosize_hd (Hd_hp (hp)))
+
 #define Profinfo_val(val) (Profinfo_hd (Hd_val (val)))
 
 #ifdef ARCH_BIG_ENDIAN

--- a/ocaml/runtime4/major_gc.c
+++ b/ocaml/runtime4/major_gc.c
@@ -384,7 +384,7 @@ static int redarken_chunk(char* heap_chunk, struct mark_stack* stk) {
 
     /* Found a block */
     me.start = Op_hp(hp);
-    me.end = me.start + Wosize_hp(hp);
+    me.end = me.start + Scannable_wosize_hp(hp);
     if (Tag_hp(hp) == Closure_tag) {
       me.start += Start_env_closinfo(Closinfo_val(Val_hp(hp)));
     }

--- a/ocaml/runtime4/major_gc.c
+++ b/ocaml/runtime4/major_gc.c
@@ -166,8 +166,8 @@ static void mark_stack_prune (struct mark_stack* stk)
       if (ch->redarken_first.start > me.start)
         ch->redarken_first = me;
 
-      if (ch->redarken_end < me.end)
-        ch->redarken_end = me.end;
+      if (ch->redarken_end < me.object_end)
+        ch->redarken_end = me.object_end;
 
       if( redarken_first_chunk == NULL
           || redarken_first_chunk > (char*)chunk_addr ) {
@@ -214,7 +214,7 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, value block,
                                   uintnat offset, intnat* work)
 {
   value v;
-  int i, block_scannable_wsz, end;
+  int i, block_scannable_wsz, block_wsz, end;
   mark_entry* me;
 
   CAMLassert(Is_block(block) && Is_in_heap (block)
@@ -222,6 +222,7 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, value block,
   CAMLassert(Tag_val(block) != Infix_tag);
   CAMLassert(Tag_val(block) < No_scan_tag);
 
+  block_wsz = Wosize_val(block);
   block_scannable_wsz = Scannable_wosize_val(block);
 
 #if defined(NO_NAKED_POINTERS) || defined(NAKED_POINTERS_CHECKER)
@@ -275,7 +276,8 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, value block,
   me = &stk->stack[stk->count++];
 
   me->start = Op_val(block) + offset;
-  me->end = Op_val(block) + block_scannable_wsz;
+  me->scannable_end = Op_val(block) + block_scannable_wsz;
+  me->object_end = Op_val(block) + block_wsz;
 }
 
 #if defined(NAKED_POINTERS_CHECKER) && defined(NATIVE_CODE)
@@ -352,14 +354,15 @@ static int redarken_chunk(char* heap_chunk, struct mark_stack* stk) {
   while (1) {
     header_t* hp;
     /* Skip a prefix of fields that need no marking */
-    CAMLassert(me.start <= me.end && (header_t*)me.end <= end);
-    while (me.start < me.end &&
+    CAMLassert(me.start <= me.scannable_end &&
+               (header_t*)me.scannable_end <= end);
+    while (me.start < me.scannable_end &&
            (!Is_block(*me.start) || Is_young(*me.start))) {
       me.start++;
     }
 
     /* Push to the mark stack (if anything's left) */
-    if (me.start < me.end) {
+    if (me.start < me.scannable_end) {
       if (stk->count < stk->size/4) {
         stk->stack[stk->count++] = me;
       } else {
@@ -371,7 +374,7 @@ static int redarken_chunk(char* heap_chunk, struct mark_stack* stk) {
     }
 
     /* Find the next block that needs to be re-marked */
-    hp = (header_t*)me.end;
+    hp = (header_t*)me.object_end;
     CAMLassert(hp <= end);
     while (hp < end) {
       value v = Val_hp(hp);
@@ -384,7 +387,8 @@ static int redarken_chunk(char* heap_chunk, struct mark_stack* stk) {
 
     /* Found a block */
     me.start = Op_hp(hp);
-    me.end = me.start + Scannable_wosize_hp(hp);
+    me.scannable_end = me.start + Scannable_wosize_hp(hp);
+    me.object_end = me.start + Wosize_hp(hp);
     if (Tag_hp(hp) == Closure_tag) {
       me.start += Start_env_closinfo(Closinfo_val(Val_hp(hp)));
     }
@@ -392,7 +396,8 @@ static int redarken_chunk(char* heap_chunk, struct mark_stack* stk) {
 
   chunk->redarken_first.start =
       (value*)(heap_chunk + Chunk_size(heap_chunk));
-  chunk->redarken_first.end = chunk->redarken_first.start;
+  chunk->redarken_first.scannable_end = chunk->redarken_first.start;
+  chunk->redarken_first.object_end = chunk->redarken_first.start;
   chunk->redarken_end = (value*)heap_chunk;
 
   return 1;
@@ -644,7 +649,17 @@ Caml_noinline static intnat do_some_marking
 #endif
 
   while (1) {
-    value *scan, *obj_end, *scan_end;
+    /* * [scan] is initialized to the point where we should start scanning in
+         the object. It is then updated to keep track of the actual scanning
+         progress.
+       * [obj_scannable_end] is the point up until which it is legal to scan the
+         object.
+       * [obj_end] is a pointer to one past the end of the object.
+       * [scan_end] is where the scanning actually will progress until. It is
+         less than [obj_scannable_end] in the event that the work budget is
+         lower than what would be required to scan until that point.
+     */
+    value *scan, *obj_scannable_end, *obj_end, *scan_end;
     intnat scan_len;
 
     if (pb_enqueued > pb_dequeued + min_pb) {
@@ -672,8 +687,9 @@ Caml_noinline static intnat do_some_marking
         continue;
       }
       scan = Op_val(block);
-      obj_end = scan + Scannable_wosize_hd(hd);
-      work -= Wosize_hd(hd) - Scannable_wosize_hd(hd);
+      obj_scannable_end = scan + Scannable_wosize_hd(hd);
+      obj_end = scan + Wosize_hd(hd);
+      work -= obj_end - obj_scannable_end;
 
       if (Tag_hd (hd) == Closure_tag) {
         uintnat env_offset = Start_env_closinfo(Closinfo_val(block));
@@ -693,10 +709,11 @@ Caml_noinline static intnat do_some_marking
     } else {
       mark_entry m = stk.stack[--stk.count];
       scan = m.start;
-      obj_end = m.end;
+      obj_scannable_end = m.scannable_end;
+      obj_end = m.object_end;
     }
 
-    scan_len = obj_end - scan;
+    scan_len = obj_scannable_end - scan;
     if (work < scan_len) {
       scan_len = work;
       if (scan_len < 0) scan_len = 0;
@@ -728,10 +745,10 @@ Caml_noinline static intnat do_some_marking
 #endif
     }
 
-    if (scan < obj_end) {
+    if (scan < obj_scannable_end) {
       /* Didn't finish scanning this object, either because work <= 0,
          or the prefetch buffer filled up. Leave the rest on the stack. */
-      mark_entry m = { scan, obj_end };
+      mark_entry m = { scan, obj_scannable_end, obj_end };
       caml_prefetch(scan+1);
       if (stk.count == stk.size) {
         *Caml_state->mark_stack = stk;
@@ -740,7 +757,8 @@ Caml_noinline static intnat do_some_marking
       }
       CAML_EVENTLOG_DO({
         if (work <= 0 && pb_enqueued == pb_dequeued) {
-          CAML_EV_COUNTER(EV_C_MAJOR_MARK_SLICE_REMAIN, obj_end - scan);
+          CAML_EV_COUNTER(EV_C_MAJOR_MARK_SLICE_REMAIN,
+                          obj_scannable_end - scan);
         }
       });
       stk.stack[stk.count++] = m;

--- a/ocaml/runtime4/memory.c
+++ b/ocaml/runtime4/memory.c
@@ -306,7 +306,9 @@ char *caml_alloc_for_heap (asize_t request)
     Chunk_block (mem) = block;
   }
   Chunk_head (mem)->redarken_first.start = (value*)(mem + Chunk_size(mem));
-  Chunk_head (mem)->redarken_first.end = (value*)(mem + Chunk_size(mem));
+  Chunk_head (mem)->redarken_first.scannable_end =
+    (value*)(mem + Chunk_size(mem));
+  Chunk_head (mem)->redarken_first.object_end = (value*)(mem + Chunk_size(mem));
   Chunk_head (mem)->redarken_end = (value*)mem;
   return mem;
 }

--- a/ocaml/runtime4/minor_gc.c
+++ b/ocaml/runtime4/minor_gc.c
@@ -402,7 +402,7 @@ static void verify_minor_heap(void)
       intnat i = 0;
       if (Tag_hd(hd) == Closure_tag)
         i = Start_env_closinfo(Closinfo_val(Val_hp(p)));
-      for (; i < Wosize_hd(hd); i++) {
+      for (; i < Scannable_wosize_hd(hd); i++) {
         value v = Field(Val_hp(p), i);
         if (Is_block(v)) {
           if (Is_young(v)) CAMLassert ((value)Caml_state->young_ptr < v);


### PR DESCRIPTION
Mixed blocks allowed you to get a segfault in `redarken_chunk` in runtime 4 in code that creates mixed blocks. This PR attempts to fix that.

The root of the problem is that there are two reasons that code used to access the size stored in the header:
  * To know the start of the next object laid out linearly in memory
  * To detect how many words the GC should scan

Prior to mixed blocks, these concepts were one and the same. Mixed blocks force you to distinguish these concepts.
  * `Wosize_val` tells you where the next object is
  * `Scannable_wosize_val` tells you how far the GC can scan

The bug in `redarken_chunk` was because I mistook the surrounding code as accessing the size only for the first reason. Actually, it accessed the size for both reasons:
  * `redarken_chunk` traverses objects laid out linearly in memory, so needs to call `Wosize_val` to know where the next object starts
  * `redarken_chunk` also scans fields, so needs to call `Scannable_wosize_val` to know which fields it is allows to scan

The comment above `mark_stack_prune` provides some context here:
```
/* This function prunes the mark stack if it's about to overflow. It does so
   by building a skiplist of major heap chunks and then iterating through the
   mark stack and setting redarken_start/redarken_end on each chunk to indicate
   the range that requires redarkening. */
```
Then, `redarken_chunk` is the thing that interprets the skiplist created by `mark_stack_prune` to actually re-scan and redarken the necessary heap chunks.

This PR attempts to fix the issue by tracking the two concepts (corresponding to the two reasons) separately. We change the `mark_entry` struct to track both the end of the object and the end of the _scannable portion_ of the object.

How was this missed in the first PR?
---

I think there are two reasons:
    - the runtime 5 code is refactored in such a way that avoids the need for similar bookkeeping. The `mark_stack_prune` function there appears to only need the "how far to scan" sense.
    - it requires some effort to get the runtime to decide it wants to call `redarken_chunk`, so the mixed blocks tests didn't catch it.

The original PR #2422  mentions "signposts" that suggest that changes for mixed blocks are needed. Checking `No_scan_tag` is one of these signposts. This triggered me to do another scan through for the signposts mentioned in that PR, and I caught two more issues **in runtime4**:
  * `Obj.truncate` would call `caml_modify` on a unscannable field. (`Obj.truncate` isn't exposed in the stdlib anymore, but still it's good to fix.)
  * Some heap verification code that runs in debug mode could falsely flag an issue.
 
I fix both of these issues in this PR, but will pull them out into another one if this PR stalls

Review
---

@stedolan , could you please review? (I will solicit suggestions from others to figure out if there's a better way to test this.)