### PR TITLE
Clarify error messages for SIMD and float32

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -110,11 +110,17 @@ let command_line_options =
 
 let assert_simd_enabled () =
   if not (Language_extension.is_enabled SIMD) then
-  Misc.fatal_error "SIMD is not enabled."
+  Misc.fatal_error "SIMD is not enabled. This error might happen \
+  if you are using SIMD yourself or are linking code that uses it. \
+  Pass [-extension-universe beta] to the compiler, or set \
+  (extension_universe beta) in your library configuration file."
 
 let assert_float32_enabled () =
   if not (Language_extension.is_enabled Small_numbers) then
-  Misc.fatal_error "float32 is not enabled."
+  Misc.fatal_error "float32 is not enabled. This error might happen \
+  if you are using float32 yourself or are linking code that uses it. \
+  Pass [-extension-universe beta] to the compiler, or set \
+  (extension_universe beta) in your library configuration file."
 
 (* Specific operations for the AMD64 processor *)
 

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -112,8 +112,8 @@ let assert_simd_enabled () =
   if not (Language_extension.is_enabled SIMD) then
   Misc.fatal_error "SIMD is not enabled. This error might happen \
   if you are using SIMD yourself or are linking code that uses it. \
-  Pass [-extension-universe beta] to the compiler, or set \
-  (extension_universe beta) in your library configuration file."
+  Pass [-extension-universe stable] to the compiler, or set \
+  (extension_universe stable) in your library configuration file."
 
 let assert_float32_enabled () =
   if not (Language_extension.is_enabled Small_numbers) then


### PR DESCRIPTION
Those errors might appear even if you only link the code using the extensions. I added more information to clarify this case.