### PR TITLE
Stack checks: IPA optimization

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -2,6 +2,8 @@ cmm_helpers.ml
 cmm_helpers.mli
 cmm_builtins.ml
 cmm_builtins.mli
+stack_check_info.ml
+stack_check_info.mli
 zero_alloc_info.ml
 zero_alloc_info.mli
 zero_alloc_checker.ml

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -41,7 +41,11 @@ module Int = Numbers.Int
 [@@@ocaml.warning "-66"]
 open! Branch_relaxation
 
+let debug = true
+
 let _label s = D.label ~typ:QWORD s
+
+let after_stack_checks_suffix = "_asc"
 
 (* Override proc.ml *)
 
@@ -200,16 +204,34 @@ let label_name lbl =
 let emit_label lbl =
   label_name (Int.to_string lbl)
 
-let rel_plt (s : Cmm.symbol) =
+(* CR xclerc for xclerc: debug/test *)
+let stack_check_skipped_callees = ref Misc.Stdlib.String.Set.empty
+
+let rel_plt ?(skip_stack_check = false) (s : Cmm.symbol) =
+  let sym_name = s.sym_name in
+  let name_with_suffix s =
+    if skip_stack_check then begin
+      if debug then begin
+        stack_check_skipped_callees :=
+          Misc.Stdlib.String.Set.add sym_name !stack_check_skipped_callees;
+      end;
+      s ^ after_stack_checks_suffix
+    end else
+      s
+  in
   match s.sym_global with
-  | Local -> sym (label_name (emit_symbol s.sym_name))
+  | Local ->
+    let s = label_name (emit_symbol s.sym_name) in
+    sym (name_with_suffix s)
   | Global ->
     if windows && !Clflags.dlcode then mem__imp s.sym_name
-    else
+    else begin
       let s = emit_symbol s.sym_name in
+      let s = name_with_suffix s in
       sym (if use_plt then s ^ "@PLT" else s)
+    end
 
-let emit_call s = I.call (rel_plt s)
+let emit_call ?(skip_stack_check = false) s = I.call (rel_plt ~skip_stack_check s)
 
 let emit_jump s = I.jmp (rel_plt s)
 
@@ -471,6 +493,11 @@ let emit_call_safety_errors () =
   end
 
 (* Stack reallocation *)
+
+let stack_check_skip_callees = ref Misc.Stdlib.String.Set.empty
+
+let stack_check = ref Stack_check_info.No_checks
+
 type stack_realloc = {
   sc_label : Label.t; (* Label of the reallocation code. *)
   sc_return : Label.t; (* Label to return to after reallocation. *)
@@ -480,6 +507,9 @@ type stack_realloc = {
 let stack_realloc = ref ([] : stack_realloc list)
 
 let clear_stack_realloc () =
+  stack_check_skip_callees := Misc.Stdlib.String.Set.empty;
+  stack_check_skipped_callees := Misc.Stdlib.String.Set.empty;
+  stack_check := Stack_check_info.No_checks;
   stack_realloc := []
 
 let emit_stack_realloc () =
@@ -498,7 +528,8 @@ let emit_stack_realloc () =
        I.jmp (label sc_return))
     !stack_realloc
 
-let emit_stack_check ~size_in_bytes ~save_registers =
+(* CR xclerc for xclerc: do we need both `first` and `save_registers`? *)
+let emit_stack_check ~first ~size_in_bytes ~save_registers =
   let overflow = new_label () and ret = new_label () in
   let threshold_offset = Domainstate.stack_ctx_words * 8 + Stack_check.stack_threshold_size in
   if save_registers then I.push r10;
@@ -507,6 +538,19 @@ let emit_stack_check ~size_in_bytes ~save_registers =
   if save_registers then I.pop r10;
   I.jb (label overflow);
   def_label ret;
+  if first then begin
+    (* CR xclerc for xclerc: could be `ret` (if made global) *)
+    let lbl_asc = !function_name ^ after_stack_checks_suffix in
+    D.global (emit_symbol lbl_asc);
+    D.label (emit_symbol lbl_asc);
+    D.label (label_name (emit_symbol lbl_asc));
+    stack_check :=
+      Stack_check_info.Check_as_first_instruction {
+        size_in_bytes;
+        includes = !stack_check_skip_callees |> String.Set.elements;
+      }
+  end else
+    stack_check := Stack_check_info.Check_moved_down;
   stack_realloc := {
     sc_label = overflow;
     sc_return = ret;
@@ -1327,8 +1371,9 @@ let emit_instr ~first ~fallthrough i =
       I.call (arg i 0);
       record_frame i.live (Dbg_other i.dbg)
   | Lop(Icall_imm { func; }) ->
+      let skip_stack_check = Misc.Stdlib.String.Set.mem func.sym_name !stack_check_skip_callees in
       add_used_symbol func.sym_name;
-      emit_call func;
+      emit_call ~skip_stack_check func;
       record_frame i.live (Dbg_other i.dbg)
   | Lop(Itailcall_ind) ->
       output_epilogue (fun () -> I.jmp (arg i 0))
@@ -1871,7 +1916,7 @@ let emit_instr ~first ~fallthrough i =
           I.jmp r11
     end
   | Lstackcheck { max_frame_size_bytes; } ->
-    emit_stack_check ~size_in_bytes:max_frame_size_bytes ~save_registers:(not first)
+    emit_stack_check ~first ~size_in_bytes:max_frame_size_bytes ~save_registers:(not first)
 
 let rec emit_all ~first ~fallthrough i =
   match i.desc with
@@ -1938,7 +1983,25 @@ let fundecl fundecl =
   if Config.runtime5 && (not Config.no_stack_checks) && !Clflags.runtime_variant = "d" then begin
     emit_call (Cmm.global_symbol "caml_assert_stack_invariants");
   end;
+  stack_check_skip_callees := fundecl.fun_stack_check_skip_callees;
   emit_all ~first:true ~fallthrough:true fundecl.fun_body;
+  if debug then begin
+    let module String = Misc.Stdlib.String in
+    let print_set prefix set =
+      String.Set.iter (Printf.eprintf "%s %s\n%!" prefix) set
+    in
+    if not (String.Set.equal !stack_check_skip_callees !stack_check_skipped_callees) then begin
+      print_set "skip" !stack_check_skip_callees;
+      print_set "skipped" !stack_check_skipped_callees;
+      print_set "skip only" (String.Set.diff !stack_check_skip_callees !stack_check_skipped_callees);
+      print_set "skipped only" (String.Set.diff !stack_check_skipped_callees !stack_check_skip_callees);
+      assert false
+    end;
+  end;
+  Stack_check_info.set_value
+    (Compilenv.current_unit_infos ()).ui_stack_check_info
+    fundecl.fun_name
+    !stack_check;
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
   emit_call_safety_errors ();
@@ -2202,7 +2265,7 @@ let emit_probe_handler_wrapper p =
   let n = k + padding in
   (* Allocate stack space *)
   if Config.runtime5 && (not Config.no_stack_checks) && (n >= Stack_check.stack_threshold_size) then
-    emit_stack_check ~size_in_bytes:n ~save_registers:true;
+    emit_stack_check ~first:true ~size_in_bytes:n ~save_registers:true;
   emit_stack_offset n;
   (* Save all live hard registers *)
   let offset = aux_offset + tmp_offset + loc_offset in

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -87,6 +87,7 @@ let (pass_to_cfg : Cfg_format.cfg_unit_info Compiler_pass_map.t) =
 
 let reset () =
   Zero_alloc_checker.reset_unit_info ();
+  Stack_check_info.reset Compilenv.cached_stack_check_info;
   start_from_emit := false;
   Compiler_pass_map.iter (fun pass (cfg_unit_info : Cfg_format.cfg_unit_info) ->
     if should_save_ir_after pass then begin
@@ -263,6 +264,10 @@ let register_allocator fd : register_allocator =
   | "" -> default_allocator
   | other -> Misc.fatal_errorf "unknown register allocator (%S)" other
 
+let use_cfg_stack_checks fd_cmm =
+  !Flambda_backend_flags.cfg_stack_checks
+  && List.mem Stack_check_move_allowed fd_cmm.fun_codegen_options
+
 let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
   Proc.init ();
   Reg.reset();
@@ -336,7 +341,7 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
              the liveness_analysis algorithm does not work properly after register allocation. *)
         ++ Profile.record ~accumulate:true "peephole_optimize_cfg" Peephole_optimize.peephole_optimize_cfg
         ++ (fun (cfg_with_layout : Cfg_with_layout.t) ->
-          match !Flambda_backend_flags.cfg_stack_checks with
+          match use_cfg_stack_checks fd_cmm with
           | false -> cfg_with_layout
           | true -> Cfg_stack_checks.cfg cfg_with_layout)
         ++ Profile.record ~accumulate:true "save_cfg" save_cfg
@@ -381,7 +386,7 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
         ++ Compiler_hooks.execute_and_pipe Compiler_hooks.Cfg
         ++ pass_dump_cfg_if ppf_dump Flambda_backend_flags.dump_cfg "After cfgize"
         ++ (fun (cfg_with_layout : Cfg_with_layout.t) ->
-          match !Flambda_backend_flags.cfg_stack_checks with
+          match use_cfg_stack_checks fd_cmm with
           | false -> cfg_with_layout
           | true -> Cfg_stack_checks.cfg cfg_with_layout)
         ++ Profile.record ~accumulate:true "save_cfg" save_cfg
@@ -394,7 +399,7 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
   ++ pass_dump_linear_if ppf_dump dump_scheduling "After instruction scheduling"
   ++ Profile.record ~accumulate:true "save_linear" save_linear
   ++ (fun (fd : Linear.fundecl) ->
-    match !Flambda_backend_flags.cfg_stack_checks with
+    match use_cfg_stack_checks fd_cmm with
     | false -> Stack_check.linear fd
     | true -> fd)
   ++ Profile.record ~accumulate:true "emit_fundecl" emit_fundecl
@@ -463,6 +468,8 @@ let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename ~may_reduc
             Zero_alloc_checker.record_unit_info ppf_dump;
             Compiler_hooks.execute Compiler_hooks.Check_allocations
               Zero_alloc_checker.iter_witnesses;
+            Compilenv.cache_stack_check_info
+              (Compilenv.current_unit_infos ()).ui_stack_check_info;
             write_ir output_prefix)
          ~always:(fun () ->
              if create_asm then close_out !Emitaux.output_channel)

--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -183,6 +183,9 @@ let build_package_cmx members cmxfile =
   let ui_zero_alloc_info = Zero_alloc_info.create () in
   List.iter (fun info -> Zero_alloc_info.merge info.ui_zero_alloc_info
                            ~into:ui_zero_alloc_info) units;
+  (* CR-soon xclerc for xclerc: merge with the iter for zero_alloc *)
+  let ui_stack_check_info = Stack_check_info.create () in
+  List.iter (fun info -> Stack_check_info.merge info.ui_stack_check_info ~into:ui_stack_check_info) units;
   let modname = Compilation_unit.name ui.ui_unit in
   let pkg_infos =
     { ui_unit = ui.ui_unit;
@@ -206,6 +209,7 @@ let build_package_cmx members cmxfile =
           List.exists (fun info -> info.ui_force_link) units;
       ui_export_info;
       ui_zero_alloc_info;
+      ui_stack_check_info;
       ui_external_symbols = union (List.map (fun info -> info.ui_external_symbols) units);
     } in
   Compilenv.write_unit_info pkg_infos cmxfile

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -73,6 +73,7 @@ type basic_block =
 type codegen_option =
   | Reduce_code_size
   | No_CSE
+  | Stack_check_move_allowed
 
 val of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list
 
@@ -90,8 +91,10 @@ type t = private
     entry_label : Label.t;
         (** This label must be the first in all layouts of this cfg. *)
     fun_contains_calls : bool;  (** Precomputed at selection time. *)
-    fun_num_stack_slots : int array
+    fun_num_stack_slots : int array;
         (** Precomputed at register allocation time *)
+    fun_stack_check_skip_callees : Misc.Stdlib.String.Set.t
+        (** Callees for which the stack checks will be skipped *)
   }
 
 val create :

--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -68,7 +68,15 @@ let block_preproc_stack_check_result :
           Int.max max_instr_id instr.id ))
   in
   let max_frame_size = max_frame_size + frame_size in
-  { max_frame_size; contains_nontail_calls }, max_instr_id
+  (* CR-someday xclerc for xclerc: compute and use `max_frame_size_with_calls`
+     and `callees`. (note: we currently restrict the use of the CFG variant to
+     `caml_apply`.) *)
+  ( { max_frame_size;
+      max_frame_size_with_calls = max_frame_size;
+      callees = Misc.Stdlib.String.Set.empty;
+      contains_nontail_calls
+    },
+    max_instr_id )
 
 type cfg_info =
   { max_frame_size : int;

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -435,7 +435,10 @@ let run cfg_with_layout =
     fun_num_stack_slots;
     fun_frame_required;
     fun_prologue_required;
-    fun_section_name
+    fun_section_name;
+    fun_stack_check_move_allowed =
+      List.mem Cfg.Stack_check_move_allowed cfg.fun_codegen_options;
+    fun_stack_check_skip_callees = cfg.fun_stack_check_skip_callees
   }
 
 let layout_of_block_list : Cfg.basic_block list -> Cfg_with_layout.layout =

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -322,6 +322,7 @@ type codegen_option =
                            never_raises: bool;
                            loc: Location.t }
   | Check_zero_alloc of { strict: bool; loc : Location.t; }
+  | Stack_check_move_allowed
 
 type fundecl =
   { fun_name: symbol;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -325,6 +325,7 @@ type codegen_option =
                 never_raises: bool;
                 loc: Location.t }
   | Check_zero_alloc of { strict: bool; loc: Location.t }
+  | Stack_check_move_allowed
 
 type fundecl =
   { fun_name: symbol;

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2784,7 +2784,7 @@ let apply_function (arity, result, mode) =
     { fun_name;
       fun_args = List.map (fun (arg, ty) -> VP.create arg, ty) all_args;
       fun_body = body;
-      fun_codegen_options = [];
+      fun_codegen_options = [Stack_check_move_allowed];
       fun_dbg;
       fun_poll = Default_poll
     }

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -535,38 +535,54 @@ let report_error ppf = function
     Format.fprintf ppf "Inconsistent use of ~enabled_at_init in [%%probe %s ..] at %a"
       name Debuginfo.print_compact dbg
 
+module String = Misc.Stdlib.String
 
 type preproc_stack_check_result =
   { max_frame_size : int;
-    contains_nontail_calls : bool }
+    max_frame_size_with_calls : int;
+    callees : String.Set.t;
+    contains_nontail_calls : bool;
+  }
 
 let preproc_stack_check ~fun_body ~frame_size ~trap_size =
-  let rec loop (i:Linear.instruction) fs max_fs nontail_flag =
+  let rec loop (i:Linear.instruction) fs ~max_fs ~max_fs_calls ~callees ~nontail_flag =
     match i.desc with
       | Lend -> { max_frame_size = max_fs;
+                  max_frame_size_with_calls = max_fs_calls;
+                  callees;
                   contains_nontail_calls = nontail_flag}
       | Ladjust_stack_offset { delta_bytes } ->
         let s = fs + delta_bytes in
-        loop i.next s (max s max_fs) nontail_flag
+        loop i.next s ~max_fs:(max s max_fs) ~max_fs_calls:(max s max_fs_calls)
+ ~callees ~nontail_flag
       | Lpushtrap _ ->
         let s = fs + trap_size in
-        loop i.next s (max s max_fs) nontail_flag
+        loop i.next s ~max_fs:(max s max_fs) ~max_fs_calls:(max s max_fs_calls)
+ ~callees ~nontail_flag
       | Lpoptrap ->
-        loop i.next (fs - trap_size) max_fs nontail_flag
+        loop i.next (fs - trap_size) ~max_fs ~max_fs_calls ~callees ~nontail_flag
       | Lop (Istackoffset n) ->
         let s = fs + n in
-        loop i.next s (max s max_fs) nontail_flag
-      | Lop (Icall_ind | Icall_imm _ ) ->
-        loop i.next fs max_fs true
+        loop i.next s ~max_fs:(max s max_fs) ~max_fs_calls:(max s max_fs_calls) ~callees ~nontail_flag
+      | Lop Icall_ind ->
+        loop i.next fs ~max_fs ~max_fs_calls ~callees ~nontail_flag:true
+      | Lop (Icall_imm { func = { Cmm.sym_name; sym_global = _; }; }) ->
+        begin match Stack_check_info.get_value Compilenv.cached_stack_check_info sym_name with
+        | None | Some (No_checks | Check_moved_down) ->
+          loop i.next fs ~max_fs ~max_fs_calls ~callees ~nontail_flag:true
+        | Some Check_as_first_instruction { size_in_bytes; } ->
+          let s = fs + size_in_bytes in
+          loop i.next fs ~max_fs ~max_fs_calls:(max s max_fs_calls) ~callees:(String.Set.add sym_name callees) ~nontail_flag
+        end
       | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _
       | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _
       | Lentertrap | Lraise _ ->
-        loop i.next fs max_fs nontail_flag
+        loop i.next fs ~max_fs ~max_fs_calls ~callees ~nontail_flag
       | Lstackcheck _ ->
         (* should not be already present *)
         assert false
   in
-  loop fun_body frame_size frame_size false
+  loop fun_body frame_size ~max_fs:frame_size ~max_fs_calls:frame_size ~callees:String.Set.empty ~nontail_flag:false
 
 let add_stack_checks_if_needed (fundecl : Linear.fundecl) ~stack_offset ~stack_threshold_size ~trap_size =
   if Config.no_stack_checks then
@@ -577,20 +593,34 @@ let add_stack_checks_if_needed (fundecl : Linear.fundecl) ~stack_offset ~stack_t
         ~num_stack_slots:fundecl.fun_num_stack_slots
         ~contains_calls:fundecl.fun_contains_calls
     in
-    let { max_frame_size; contains_nontail_calls } =
+    let { max_frame_size; max_frame_size_with_calls; callees; contains_nontail_calls } =
       preproc_stack_check ~fun_body:fundecl.fun_body ~frame_size ~trap_size
     in
-    let insert_stack_check =
-      contains_nontail_calls || max_frame_size >= stack_threshold_size
+    assert (max_frame_size_with_calls >= max_frame_size);
+    let insert_stack_check : (int * String.Set.t) option =
+      match
+        max_frame_size >= stack_threshold_size,
+        max_frame_size_with_calls >= stack_threshold_size,
+        contains_nontail_calls,
+        not (String.Set.is_empty callees)
+      with
+      | (true, _, _, _) | (_, _, true, _) ->
+        (* a stack has to be emitted, so factoring out other checks is beneficial *)
+        Some (max_frame_size_with_calls, callees)
+      | false, true, false, _ | false, false, false, true ->
+        (* assume it is beneficiary to move the check(s) up the call chain *)
+        Some (max_frame_size_with_calls, callees)
+      | false, false, false, false ->
+        None
     in
-    if insert_stack_check
-    then
+    match insert_stack_check with
+    | None -> fundecl
+    | Some (max_frame_size_bytes, callees) ->
       let fun_body =
         Linear.instr_cons
-          (Lstackcheck { max_frame_size_bytes = max_frame_size })
+          (Lstackcheck { max_frame_size_bytes })
           [||] [||] ~available_before:fundecl.fun_body.available_before
           ~available_across:fundecl.fun_body.available_across fundecl.fun_body
       in
-      { fundecl with fun_body }
-    else fundecl
+      { fundecl with fun_body; fun_stack_check_skip_callees = callees }
   end

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -130,7 +130,15 @@ val report_error: Format.formatter -> error -> unit
 
 type preproc_stack_check_result =
   { max_frame_size : int;
-    contains_nontail_calls : bool }
+    (* for the function itself *)
+    max_frame_size_with_calls : int;
+    (* for the function itself *and* the calls to the functions in `callees` *)
+    callees : Misc.Stdlib.String.Set.t;
+    (* direct calls for which stack consumption is known and accounted for in
+       `max_frame_size_with_calls` *)
+    contains_nontail_calls : bool;
+    (* whether there are non-tail calls to functions not appearing in `callees` *)
+  }
 
 val preproc_stack_check:
   fun_body:Linear.instruction ->

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -65,6 +65,8 @@ type fundecl =
     fun_frame_required: bool;
     fun_prologue_required: bool;
     fun_section_name: string option;
+    fun_stack_check_move_allowed: bool;
+    fun_stack_check_skip_callees : Misc.Stdlib.String.Set.t;
   }
 
 (* Invert a test *)

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -67,6 +67,8 @@ type fundecl =
     fun_frame_required: bool;
     fun_prologue_required: bool;
     fun_section_name: string option;
+    fun_stack_check_move_allowed: bool;
+    fun_stack_check_skip_callees : Misc.Stdlib.String.Set.t;
   }
 
 val traps_to_bytes : int -> int

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -406,6 +406,7 @@ let codegen_option = function
   | Check_zero_alloc { strict; loc = _ } ->
     Printf.sprintf "assert_zero_alloc%s"
       (if strict then "_strict" else "")
+  | Stack_check_move_allowed -> "stack_check_move_allowed"
 
 let print_codegen_options ppf l =
   List.iter (fun c -> fprintf ppf " %s" (codegen_option c)) l

--- a/backend/schedgen.ml
+++ b/backend/schedgen.ml
@@ -390,6 +390,8 @@ method schedule_fundecl f =
       fun_frame_required = f.fun_frame_required;
       fun_prologue_required = f.fun_prologue_required;
       fun_section_name = f.fun_section_name;
+      fun_stack_check_move_allowed = f.fun_stack_check_move_allowed;
+      fun_stack_check_skip_callees = f.fun_stack_check_skip_callees;
     }
   end else
     f

--- a/backend/stack_check_info.ml
+++ b/backend/stack_check_info.ml
@@ -1,0 +1,76 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(* CR xclerc for xclerc: factor out with zero_alloc equivalent. *)
+
+module String = Misc.Stdlib.String
+
+type value =
+  | No_checks
+  | Check_as_first_instruction of
+      { size_in_bytes : int;
+        includes : string list (* CR-soon xclerc for xclerc: for debug/test *)
+      }
+  | Check_moved_down
+
+let string_of_value = function
+  | No_checks -> "no_checks"
+  | Check_as_first_instruction { size_in_bytes; includes } ->
+    Printf.sprintf "check_as_first_instruction %d bytes%s" size_in_bytes
+      (match includes with
+      | [] -> ""
+      | _ :: _ -> ", includes " ^ String.concat ", " includes)
+  | Check_moved_down -> "check_moved_down"
+
+(* CR xclerc for xclerc: rather use a Tbl.t? *)
+type t = { mutable stack_check : value String.Map.t }
+
+let create () = { stack_check = String.Map.empty }
+
+let reset t = t.stack_check <- String.Map.empty
+
+let merge src ~into:dst =
+  dst.stack_check
+    <- String.Map.union
+         (fun key -> Misc.fatal_errorf "duplicate symbol %s" key)
+         dst.stack_check src.stack_check
+
+let get_value t name = String.Map.find_opt name t.stack_check
+
+let set_value t name value =
+  t.stack_check
+    <- String.Map.update name
+         (function
+           | Some _ -> Misc.fatal_errorf "duplicate symbol %s" name
+           | None -> Some value)
+         t.stack_check
+
+module Raw = struct
+  (* CR xclerc for xclerc; rather use an array? *)
+  type entries = (string * value) list
+
+  type t = entries option
+
+  let print t =
+    Printf.printf "Stack checks:\n";
+    match t with
+    | None -> ()
+    | Some (entries : entries) ->
+      List.iter
+        (fun (name, value) ->
+          Printf.printf "\t\t%s = %s\n" name (string_of_value value))
+        entries
+end
+
+(* CR xclerc for xclerc: do what the zero_alloc equivalent does, and encode the
+   occurrences of `value` as mere `int`s. *)
+
+let to_raw t =
+  if String.Map.is_empty t.stack_check
+  then None
+  else Some (String.Map.bindings t.stack_check)
+
+let of_raw raw =
+  match raw with
+  | None -> create ()
+  | Some entries ->
+    { stack_check = entries |> List.to_seq |> String.Map.of_seq }

--- a/backend/stack_check_info.mli
+++ b/backend/stack_check_info.mli
@@ -1,0 +1,31 @@
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type value =
+  | No_checks
+  | Check_as_first_instruction of
+      { size_in_bytes : int;
+        includes : string list (* CR-soon xclerc for xclerc: for debug/test *)
+      }
+  | Check_moved_down
+
+type t
+
+val create : unit -> t
+
+val reset : t -> unit
+
+val merge : t -> into:t -> unit
+
+val get_value : t -> string -> value option
+
+val set_value : t -> string -> value -> unit
+
+module Raw : sig
+  type t
+
+  val print : t -> unit
+end
+
+val to_raw : t -> Raw.t
+
+val of_raw : Raw.t -> t

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -1476,7 +1476,9 @@ end = struct
                 never_raises;
                 loc
               }
-          | Reduce_code_size | No_CSE | Use_linscan_regalloc -> None)
+          | Reduce_code_size | No_CSE | Use_linscan_regalloc
+          | Stack_check_move_allowed ->
+            None)
         codegen_options
     in
     match a with

--- a/dune
+++ b/dune
@@ -134,6 +134,7 @@
   selection
   spill
   split
+  stack_check_info
   string_table
   symbol_entry
   symbol_table

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -56,6 +56,7 @@ type unit_infos =
     mutable ui_generic_fns: generic_fns;  (* Generic functions needed *)
     mutable ui_export_info: Flambda2_cmx.Flambda_cmx_format.t option;
     mutable ui_zero_alloc_info: Zero_alloc_info.t;
+    mutable ui_stack_check_info : Stack_check_info.t; (* CR-soon xclerc for xclerc: merge with zero_alloc field? *)
     mutable ui_force_link: bool;          (* Always linked *)
     mutable ui_external_symbols: string list; (* Set of external symbols *)
   }
@@ -68,6 +69,8 @@ type unit_infos_raw =
     uir_generic_fns: generic_fns;
     uir_export_info: Flambda2_cmx.Flambda_cmx_format.raw option;
     uir_zero_alloc_info: Zero_alloc_info.Raw.t;
+    uir_stack_check_info: Stack_check_info.Raw.t; (* CR-soon xclerc for xclerc: merge with zero_alloc field? *)
+
     uir_force_link: bool;
     uir_section_toc: int array;    (* Byte offsets of sections in .cmx
                                       relative to byte immediately after

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -57,6 +57,10 @@ val cached_zero_alloc_info : Zero_alloc_info.t
 val cache_zero_alloc_info : Zero_alloc_info.t -> unit
         (* [cache_zero_alloc_info c] adds [c] to [cached_zero_alloc_info] *)
 
+(* CR-soon xclerc for xclerc: share with zero_alloc *)
+val cached_stack_check_info : Stack_check_info.t
+val cache_stack_check_info : Stack_check_info.t -> unit
+
 val new_const_symbol : unit -> string
 
 val read_unit_info: string -> unit_infos * Digest.t

--- a/tests/backend/caml_apply_split_max_arity/dune
+++ b/tests/backend/caml_apply_split_max_arity/dune
@@ -22,7 +22,7 @@
    (with-outputs-to
     t.output
     (bash
-     "readelf -sW ./t.exe | grep \" caml_apply[0-9]\\{1,3\\}\" | sed \"s/.*caml_//\" | sed \"s/L\\$//\" | sort | uniq"))
+     "readelf -sW ./t.exe | grep \" caml_apply[0-9]\\{1,3\\}\" | grep -v \"_asc$\" | sed \"s/.*caml_//\" | sed \"s/L\\$//\" | sort | uniq"))
    (with-outputs-to
     stack.output
     (run ./stack.exe)))))

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -264,7 +264,9 @@ let print_cmx_infos (uir, sections, crc) =
   end;
   print_generic_fns uir.uir_generic_fns;
   printf "Force link: %s\n" (if uir.uir_force_link then "YES" else "no");
-  Zero_alloc_info.Raw.print uir.uir_zero_alloc_info
+  Zero_alloc_info.Raw.print uir.uir_zero_alloc_info;
+  Stack_check_info.Raw.print uir.uir_stack_check_info
+
 
 let print_cmxa_infos (lib : Cmx_format.library_infos) =
   printf "Extra C object files:";


### PR DESCRIPTION
This pull request implements an inter-procedural
optimization of stack checks. If, for instance,
`f` must include a check and calls `g` that must
also include a check, then `f` can perform the
check for both functions and, when calling `g`,
jump to a label after the check. It means that
the check is still present in `g`, and it is
the responsibility of the caller to decide whether
it wants to skip it or not.

In order for the optimization to be applied across
compilation units, we store in cmx files the
information about the stack check for each function.
As a simplification, the current version restricts
the shrink-wrap optmization to `caml_apply_xyz`
functions.

This is a early draft, to gather feedback; various
elements may need to be optimized, and we should
consider sharing some elements with the zero_alloc
machinery.