### PR TITLE
Revert "Refactor `Persistent_env` to separate imports from bound names"

### DIFF
--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -1321,14 +1321,11 @@ typing/patterns.cmi : \
     parsing/asttypes.cmi
 typing/persistent_env.cmo : \
     utils/warnings.cmi \
-    typing/subst.cmi \
-    typing/shape.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
     utils/lazy_backtrack.cmi \
     utils/import_info.cmi \
-    typing/ident.cmi \
     utils/consistbl.cmi \
     utils/compilation_unit.cmi \
     file_formats/cmi_format.cmi \
@@ -1336,14 +1333,11 @@ typing/persistent_env.cmo : \
     typing/persistent_env.cmi
 typing/persistent_env.cmx : \
     utils/warnings.cmx \
-    typing/subst.cmx \
-    typing/shape.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
     utils/load_path.cmx \
     utils/lazy_backtrack.cmx \
     utils/import_info.cmx \
-    typing/ident.cmx \
     utils/consistbl.cmx \
     utils/compilation_unit.cmx \
     file_formats/cmi_format.cmx \
@@ -1351,13 +1345,11 @@ typing/persistent_env.cmx : \
     typing/persistent_env.cmi
 typing/persistent_env.cmi : \
     typing/subst.cmi \
-    typing/shape.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
     utils/lazy_backtrack.cmi \
     utils/import_info.cmi \
-    typing/ident.cmi \
     utils/consistbl.cmi \
     utils/compilation_unit.cmi \
     file_formats/cmi_format.cmi

--- a/ocaml/testsuite/tests/templates/basic/bad_param_impl.ml
+++ b/ocaml/testsuite/tests/templates/basic/bad_param_impl.ml
@@ -9,6 +9,8 @@
  ocamlc_byte_exit_status = "2";
  compiler_output = "bad_param_impl.output";
  ocamlc.byte;
+ reason = "error broken, will be fixed by #1764";
+ skip;
  compiler_reference = "bad_param_impl.reference";
  check-ocamlc.byte-output;
 *)

--- a/ocaml/testsuite/tests/templates/basic/test.ml
+++ b/ocaml/testsuite/tests/templates/basic/test.ml
@@ -8,6 +8,8 @@
  compiler_output = "bad_ref_direct.output";
  ocamlc_byte_exit_status = "2";
  ocamlc.byte;
+ reason = "correct error message not yet implemented";
+ skip;
  compiler_reference = "bad_ref_direct.reference";
  check-ocamlc.byte-output;
 *)

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -173,7 +173,7 @@ let map_summary f = function
   | Env_value_unbound (s, u, r) -> Env_value_unbound (f s, u, r)
   | Env_module_unbound (s, u, r) -> Env_module_unbound (f s, u, r)
 
-type address = Persistent_env.address =
+type address =
   | Aunit of Compilation_unit.t
   | Alocal of Ident.t
   | Adot of address * int
@@ -953,24 +953,34 @@ let components_of_module ~alerts ~uid env ps path addr mty shape =
     }
   }
 
-let read_sign_of_cmi sign name uid ~shape ~address:addr ~flags =
-  let id = Ident.create_persistent (Compilation_unit.Name.to_string name) in
+let read_sign_of_cmi { Persistent_env.Persistent_signature.cmi; _ } =
+  let name =
+    match cmi.cmi_kind with
+    | Normal { cmi_impl } -> cmi_impl
+    | Parameter -> Misc.fatal_error "Unsupported import of parameter module"
+  in
+  let sign = cmi.cmi_sign in
+  let flags = cmi.cmi_flags in
+  let id = Ident.create_persistent (Compilation_unit.name_as_string name) in
   let path = Pident id in
   let alerts =
     List.fold_left (fun acc -> function Alerts s -> s | _ -> acc)
       Misc.Stdlib.String.Map.empty
       flags
   in
+  let sign = Subst.Lazy.signature Make_local Subst.identity sign in
   let md =
     { Subst.Lazy.md_type = Mty_signature sign;
       md_loc = Location.none;
       md_attributes = [];
-      md_uid = uid;
+      md_uid = Uid.of_compilation_unit_id name;
     }
   in
-  let mda_address = Lazy_backtrack.create_forced addr in
+  let mda_address = Lazy_backtrack.create_forced (Aunit name) in
   let mda_declaration = md in
-  let mda_shape = shape in
+  let mda_shape =
+    Shape.for_persistent_unit (name |> Compilation_unit.full_path_as_string)
+  in
   let mda_components =
     let mty = md.md_type in
     components_of_module ~alerts ~uid:md.md_uid
@@ -1006,7 +1016,7 @@ let check_pers_mod ~loc name =
   Persistent_env.check !persistent_env read_sign_of_cmi ~loc name
 
 let crc_of_unit name =
-  Persistent_env.crc_of_unit !persistent_env name
+  Persistent_env.crc_of_unit !persistent_env read_sign_of_cmi name
 
 let is_imported_opaque modname =
   Persistent_env.is_imported_opaque !persistent_env modname
@@ -2636,8 +2646,13 @@ let open_signature
 
 (* Read a signature from a file *)
 let read_signature modname filename ~add_binding =
-  let mty = read_pers_mod modname filename ~add_binding in
-  Subst.Lazy.force_signature mty
+  let mda =
+    read_pers_mod modname filename ~add_binding
+  in
+  let md = Subst.Lazy.force_module_decl mda.mda_declaration in
+  match md.md_type with
+  | Mty_signature sg -> sg
+  | Mty_ident _ | Mty_functor _ | Mty_alias _ | Mty_strengthen _ -> assert false
 
 let is_identchar_latin1 = function
   | 'A'..'Z' | 'a'..'z' | '_' | '\192'..'\214' | '\216'..'\246'

--- a/ocaml/typing/persistent_env.ml
+++ b/ocaml/typing/persistent_env.ml
@@ -61,36 +61,20 @@ type can_load_cmis =
   | Can_load_cmis
   | Cannot_load_cmis of Lazy_backtrack.log
 
-(* Data relating directly to a .cmi *)
-type import = {
-  imp_is_param : bool;
-  imp_impl : CU.t option;
-  imp_sign : Subst.Lazy.signature;
-  imp_filename : string;
-  imp_visibility: Load_path.visibility;
-  imp_crcs : Import_info.Intf.t array;
-  imp_flags : Cmi_format.pers_flags list;
+type pers_struct = {
+  ps_is_param: bool;
+  ps_crcs: Import_info.t array;
+  ps_filename: string;
+  ps_visibility: Load_path.visibility;
 }
 
 (* If a .cmi file is missing (or invalid), we
    store it as Missing in the cache. *)
-type import_info =
+type 'a pers_struct_info =
   | Missing
-  | Found of import
+  | Found of pers_struct * 'a
 
-type binding =
-  | Static of Compilation_unit.t (* Bound to a static constant *)
-
-(* Data relating to an actual referenceable module, with a signature and a
-   representation in memory. *)
-type 'a pers_struct_info = {
-  ps_import : import;
-  ps_val : 'a;
-}
-
-(* If you add something here, _do not forget_ to add it to [clear]! *)
 type 'a t = {
-  imports : (CU.Name.t, import_info) Hashtbl.t;
   persistent_structures :
     (CU.Name.t, 'a pers_struct_info) Hashtbl.t;
   imported_units: CU.Name.Set.t ref;
@@ -101,7 +85,6 @@ type 'a t = {
 }
 
 let empty () = {
-  imports = Hashtbl.create 17;
   persistent_structures = Hashtbl.create 17;
   imported_units = ref CU.Name.Set.empty;
   imported_opaque_units = ref CU.Name.Set.empty;
@@ -112,7 +95,6 @@ let empty () = {
 
 let clear penv =
   let {
-    imports;
     persistent_structures;
     imported_units;
     imported_opaque_units;
@@ -120,7 +102,6 @@ let clear penv =
     crc_units;
     can_load_cmis;
   } = penv in
-  Hashtbl.clear imports;
   Hashtbl.clear persistent_structures;
   imported_units := CU.Name.Set.empty;
   imported_opaque_units := CU.Name.Set.empty;
@@ -129,13 +110,13 @@ let clear penv =
   can_load_cmis := Can_load_cmis;
   ()
 
-let clear_missing {imports; _} =
+let clear_missing {persistent_structures; _} =
   let missing_entries =
     Hashtbl.fold
       (fun name r acc -> if r = Missing then name :: acc else acc)
-      imports []
+      persistent_structures []
   in
-  List.iter (Hashtbl.remove imports) missing_entries
+  List.iter (Hashtbl.remove persistent_structures) missing_entries
 
 let add_import {imported_units; _} s =
   imported_units := CU.Name.Set.add s !imported_units
@@ -143,28 +124,23 @@ let add_import {imported_units; _} s =
 let register_import_as_opaque {imported_opaque_units; _} s =
   imported_opaque_units := CU.Name.Set.add s !imported_opaque_units
 
-let find_import_info_in_cache {imports; _} import =
-  match Hashtbl.find imports import with
+let find_info_in_cache {persistent_structures; _} s =
+  match Hashtbl.find persistent_structures s with
   | exception Not_found -> None
   | Missing -> None
-  | Found imp -> Some imp
-
-let find_info_in_cache {persistent_structures; _} name =
-  match Hashtbl.find persistent_structures name with
-  | exception Not_found -> None
-  | ps -> Some ps
+  | Found (ps, pm) -> Some (ps, pm)
 
 let find_in_cache penv name =
-  find_info_in_cache penv name |> Option.map (fun ps -> ps.ps_val)
+  find_info_in_cache penv name |> Option.map (fun (_ps, pm) -> pm)
 
 let register_parameter_import ({param_imports; _} as penv) import =
-  begin match find_import_info_in_cache penv import with
+  begin match find_info_in_cache penv import with
   | None ->
       (* Not loaded yet; if it's wrong, we'll get an error at load time *)
       ()
-  | Some imp ->
-      if not imp.imp_is_param then
-        raise (Error (Not_compiled_as_parameter(import, imp.imp_filename)))
+  | Some (ps, _) ->
+      if not ps.ps_is_param then
+        raise (Error (Not_compiled_as_parameter(import, ps.ps_filename)))
   end;
   param_imports := CU.Name.Set.add import !param_imports
 
@@ -180,8 +156,8 @@ let import_crcs penv ~source crcs =
         Consistbl.check crc_units name kind crc source
   in Array.iter import_crc crcs
 
-let check_consistency penv imp =
-  try import_crcs penv ~source:imp.imp_filename imp.imp_crcs
+let check_consistency penv ps =
+  try import_crcs penv ~source:ps.ps_filename ps.ps_crcs
   with Consistbl.Inconsistency {
       unit_name = name;
       inconsistent_source = source;
@@ -193,7 +169,7 @@ let check_consistency penv imp =
     | Normal source_unit, Normal auth_unit
       when not (CU.equal source_unit auth_unit) ->
         error (Inconsistent_package_declaration_between_imports(
-            imp.imp_filename, auth_unit, source_unit))
+            ps.ps_filename, auth_unit, source_unit))
     | (Normal _ | Parameter), _ ->
       error (Inconsistent_import(name, auth, source))
 
@@ -216,12 +192,14 @@ let without_cmis penv f x =
   res
 
 let fold {persistent_structures; _} f x =
-  Hashtbl.fold (fun name ps x -> f name ps.ps_val x)
+  Hashtbl.fold (fun modname pso x -> match pso with
+      | Missing -> x
+      | Found (_, pm) -> f modname pm x)
     persistent_structures x
 
 (* Reading persistent structures from .cmi files *)
 
-let save_import penv crc modname impl flags filename =
+let save_pers_struct penv crc modname impl flags filename =
   let {crc_units; _} = penv in
   List.iter
     (function
@@ -232,16 +210,22 @@ let save_import penv crc modname impl flags filename =
   Consistbl.check crc_units modname impl crc filename;
   add_import penv modname
 
-let acknowledge_import penv ~check modname pers_sig =
+let process_pers_struct penv check modname pers_sig =
   let { Persistent_signature.filename; cmi; visibility } = pers_sig in
   let found_name = cmi.cmi_name in
   let kind = cmi.cmi_kind in
   let crcs = cmi.cmi_crcs in
   let flags = cmi.cmi_flags in
-  let sign =
-    (* Freshen identifiers bound by signature *)
-    Subst.Lazy.signature Make_local Subst.identity cmi.cmi_sign
+  let is_param =
+    match kind with
+    | Normal _ -> false
+    | Parameter -> true
   in
+  let ps = { ps_is_param = is_param;
+             ps_crcs = crcs;
+             ps_filename = filename;
+             ps_visibility = visibility;
+           } in
   if not (CU.Name.equal modname found_name) then
     error (Illegal_renaming(modname, found_name, filename));
   List.iter
@@ -252,6 +236,7 @@ let acknowledge_import penv ~check modname pers_sig =
         | Alerts _ -> ()
         | Opaque -> register_import_as_opaque penv modname)
     flags;
+  if check then check_consistency penv ps;
   begin match kind, CU.get_current () with
   | Normal { cmi_impl = imported_unit }, Some current_unit ->
       let access_allowed =
@@ -262,15 +247,6 @@ let acknowledge_import penv ~check modname pers_sig =
         error (Direct_reference_from_wrong_package (imported_unit, filename, prefix));
   | _, _ -> ()
   end;
-  let is_param =
-    match kind with
-    | Normal _ -> false
-    | Parameter -> true
-  in
-  (* CR-someday lmaurer: Consider moving this check into
-     [acknowledge_pers_struct]. It makes more sense to flag these errors when
-     the identifier is in source, rather than, say, a signature we're reading
-     from a file, especially if it's our own .mli. *)
   begin match is_param, is_registered_parameter_import penv modname with
   | true, false ->
       begin match CU.get_current () with
@@ -284,120 +260,49 @@ let acknowledge_import penv ~check modname pers_sig =
   | true, true
   | false, false -> ()
   end;
-  let impl =
-    match kind with
-    | Normal { cmi_impl } -> Some cmi_impl
-    | Parameter -> None
-  in
-  let {imports; _} = penv in
-  let import =
-    { imp_is_param = is_param;
-      imp_impl = impl;
-      imp_sign = sign;
-      imp_filename = filename;
-      imp_visibility = visibility;
-      imp_crcs = crcs;
-      imp_flags = flags;
-    }
-  in
-  if check then check_consistency penv import;
-  Hashtbl.add imports modname (Found import);
-  import
+  ps
 
-let read_import penv ~check modname filename =
-  add_import penv modname;
-  let cmi = read_cmi_lazy filename in
-  let pers_sig = { Persistent_signature.filename; cmi; visibility = Visible } in
-  acknowledge_import penv ~check modname pers_sig
-
-let check_visibility ~allow_hidden imp =
-  if not allow_hidden && imp.imp_visibility = Load_path.Hidden then raise Not_found
-
-let find_import ~allow_hidden penv ~check modname =
-  let {imports; _} = penv in
-  if CU.Name.equal modname CU.Name.predef_exn then raise Not_found;
-  match Hashtbl.find imports modname with
-  | Found imp -> check_visibility ~allow_hidden imp; imp
-  | Missing -> raise Not_found
-  | exception Not_found ->
-      match can_load_cmis penv with
-      | Cannot_load_cmis _ -> raise Not_found
-      | Can_load_cmis ->
-          let psig =
-            match !Persistent_signature.load ~allow_hidden ~unit_name:modname with
-            | Some psig -> psig
-            | None ->
-                if allow_hidden then Hashtbl.add imports modname Missing;
-                raise Not_found
-          in
-          add_import penv modname;
-          acknowledge_import penv ~check modname psig
-
-let make_binding _penv (impl : CU.t option) : binding =
-  let unit =
-    match impl with
-    | Some unit -> unit
-    | None ->
-        Misc.fatal_errorf "Can't bind a parameter statically"
-  in
-  Static unit
-
-type address =
-  | Aunit of Compilation_unit.t
-  | Alocal of Ident.t
-  | Adot of address * int
-
-type 'a sig_reader =
-  Subst.Lazy.signature
-  -> Compilation_unit.Name.t
-  -> Shape.Uid.t
-  -> shape:Shape.t
-  -> address:address
-  -> flags:Cmi_format.pers_flags list
-  -> 'a
-
-let acknowledge_pers_struct penv modname import val_of_pers_sig =
+let bind_pers_struct penv modname ps pm =
   let {persistent_structures; _} = penv in
-  let impl = import.imp_impl in
-  let sign = import.imp_sign in
-  let flags = import.imp_flags in
-  let binding = make_binding penv impl in
-  let address : address =
-    match binding with
-    | Static unit -> Aunit unit
-  in
-  let uid =
-    match binding with
-    | Static unit -> Shape.Uid.of_compilation_unit_id unit
-  in
-  let shape =
-    match binding with
-    | Static unit -> Shape.for_persistent_unit (CU.full_path_as_string unit)
-  in
-  let pm = val_of_pers_sig sign modname uid ~shape ~address ~flags in
-  let ps =
-    { ps_import = import;
-      ps_val = pm;
-    }
-  in
-  Hashtbl.add persistent_structures modname ps;
+  Hashtbl.add persistent_structures modname (Found (ps, pm))
+
+let acknowledge_pers_struct penv check modname pers_sig pm =
+  let ps = process_pers_struct penv check modname pers_sig in
+  bind_pers_struct penv modname ps pm;
   ps
 
 let read_pers_struct penv val_of_pers_sig check modname filename ~add_binding =
-  let import = read_import penv ~check modname filename in
-  if add_binding then
-    ignore
-      (acknowledge_pers_struct penv modname import val_of_pers_sig
-       : _ pers_struct_info);
-  import.imp_sign
+  add_import penv modname;
+  let cmi = read_cmi_lazy filename in
+  let pers_sig = { Persistent_signature.filename; cmi; visibility = Visible } in
+  let pm = val_of_pers_sig pers_sig in
+  let ps = process_pers_struct penv check modname pers_sig in
+  if add_binding then bind_pers_struct penv modname ps pm;
+  (ps, pm)
 
 let find_pers_struct ~allow_hidden penv val_of_pers_sig check name =
   let {persistent_structures; _} = penv in
+  if CU.Name.equal name CU.Name.predef_exn then raise Not_found;
   match Hashtbl.find persistent_structures name with
-  | ps -> check_visibility ~allow_hidden ps.ps_import; ps
+  | Found (ps, pm) when allow_hidden || ps.ps_visibility = Load_path.Visible ->
+    (ps, pm)
+  | Found _ -> raise Not_found
+  | Missing -> raise Not_found
   | exception Not_found ->
-      let import = find_import ~allow_hidden penv ~check name in
-      acknowledge_pers_struct penv name import val_of_pers_sig
+    match can_load_cmis penv with
+    | Cannot_load_cmis _ -> raise Not_found
+    | Can_load_cmis ->
+        let psig =
+          match !Persistent_signature.load ~allow_hidden ~unit_name:name with
+          | Some psig -> psig
+          | None ->
+            if allow_hidden then Hashtbl.add persistent_structures name Missing;
+            raise Not_found
+        in
+        add_import penv name;
+        let pm = val_of_pers_sig psig in
+        let ps = acknowledge_pers_struct penv check name psig pm in
+        (ps, pm)
 
 let describe_prefix ppf prefix =
   if CU.Prefix.is_empty prefix then
@@ -446,10 +351,10 @@ let check_pers_struct ~allow_hidden penv f ~loc name =
         Location.prerr_warning loc warn
 
 let read penv f modname filename ~add_binding =
-  read_pers_struct penv f true modname filename ~add_binding
+  snd (read_pers_struct penv f true modname filename ~add_binding)
 
 let find ~allow_hidden penv f name =
-  (find_pers_struct ~allow_hidden penv f true name).ps_val
+  snd (find_pers_struct ~allow_hidden penv f true name)
 
 let check ~allow_hidden penv f ~loc name =
   let {persistent_structures; _} = penv in
@@ -480,12 +385,12 @@ module Array = struct
     loop 0
 end
 
-let crc_of_unit penv name =
+let crc_of_unit penv f name =
   match Consistbl.find penv.crc_units name with
-  | Some (_impl, crc) -> crc
+  | Some (_, crc) -> crc
   | None ->
-    let import = find_import ~allow_hidden:true penv ~check:true name in
-    match Array.find_opt (Import_info.Intf.has_name ~name) import.imp_crcs with
+    let (ps, _pm) = find_pers_struct ~allow_hidden:true penv f true name in
+    match Array.find_opt (Import_info.has_name ~name) ps.ps_crcs with
     | None -> assert false
     | Some import_info ->
       match Import_info.crc import_info with
@@ -547,7 +452,7 @@ let save_cmi penv psig =
         | Normal { cmi_impl } -> Normal cmi_impl
         | Parameter -> Parameter
       in
-      save_import penv crc modname data flags filename
+      save_pers_struct penv crc modname data flags filename
     )
     ~exceptionally:(fun () -> remove_file filename)
 

--- a/ocaml/typing/persistent_env.mli
+++ b/ocaml/typing/persistent_env.mli
@@ -68,30 +68,16 @@ val clear_missing : 'a t -> unit
 
 val fold : 'a t -> (Compilation_unit.Name.t -> 'a -> 'b -> 'b) -> 'b -> 'b
 
-type address =
-  | Aunit of Compilation_unit.t
-  | Alocal of Ident.t
-  | Adot of address * int
-
-type 'a sig_reader =
-  Subst.Lazy.signature
-  -> Compilation_unit.Name.t
-  -> Shape.Uid.t
-  -> shape:Shape.t
-  -> address:address
-  -> flags:Cmi_format.pers_flags list
-  -> 'a
-
 (* If [add_binding] is false, reads the signature from the .cmi but does not
    bind the module name in the environment. *)
-val read : 'a t -> 'a sig_reader
-  -> Compilation_unit.Name.t -> filepath -> add_binding:bool -> Subst.Lazy.signature
-val find : allow_hidden:bool -> 'a t -> 'a sig_reader
+val read : 'a t -> (Persistent_signature.t -> 'a)
+  -> Compilation_unit.Name.t -> filepath -> add_binding:bool -> 'a
+val find : allow_hidden:bool -> 'a t -> (Persistent_signature.t -> 'a)
   -> Compilation_unit.Name.t -> 'a
 
 val find_in_cache : 'a t -> Compilation_unit.Name.t -> 'a option
 
-val check : allow_hidden:bool -> 'a t -> 'a sig_reader
+val check : allow_hidden:bool -> 'a t -> (Persistent_signature.t -> 'a)
   -> loc:Location.t -> Compilation_unit.Name.t -> unit
 
 (* Lets it be known that the given module is a parameter and thus is expected
@@ -144,7 +130,8 @@ val import_crcs : 'a t -> source:filepath ->
 val imports : 'a t -> Import_info.t list
 
 (* Return the CRC of the interface of the given compilation unit *)
-val crc_of_unit: 'a t -> Compilation_unit.Name.t -> Digest.t
+val crc_of_unit: 'a t -> (Persistent_signature.t -> 'a)
+  -> Compilation_unit.Name.t -> Digest.t
 
 (* Forward declaration to break mutual recursion with Typecore. *)
 val add_delayed_check_forward: ((unit -> unit) -> unit) ref


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#2585

This is causing a large (20% or more) increase in the size of various build artifacts (`.cmi`, `.cmx` etc).  I'd like to leave this out for `minus-16` (which will need to be retagged) and then we can work on the fixes.