### PR TITLE
ghost the ident inside the expression in let-puns

### DIFF
--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -122,7 +122,7 @@ let ghstr ~loc d = Str.mk ~loc:(ghost_loc loc) d
 let ghsig ~loc d = Sig.mk ~loc:(ghost_loc loc) d
 
 let ghexpvar ~loc name =
-  ghexp ~loc (Pexp_ident (mkrhs (Lident name) loc))
+  ghexp ~loc (Pexp_ident (ghrhs (Lident name) loc))
 
 let mkinfix arg1 op arg2 =
   Pexp_apply(op, [Nolabel, arg1; Nolabel, arg2])


### PR DESCRIPTION
This is the finishing touch on @ccasin's PR #2415 to fix the parser for let-punning.

Why is this additional change needed? In the original version of #2415, we ghosted the location of the pattern; some testing showed this was sufficient to silence the overlapping location check. When we changed the PR to instead ghost the expression, we didn't test again, because we assumed the two are symmetric with respect to the overlapping location check.

Turns out they're not! This is because a `Ppat_var` contains a simple located `string`, whereas a `Pexp_ident` contains a located `longident`. In `ppxlib`'s overlapping locations check, a `longident` does propagate its own location back up the parse tree in the set of "sibling" locations, while a `string` does not.

Ghosting the location of the `longident` in addition to that of the entire `expression` in `ghexpvar` suffices to silence the check.

I tested a local build of the compiler internally on some files that contain let-punned ppxs.