### PR TITLE
Fix `check_and_update_generalized_ty_jkind`

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -67,18 +67,11 @@ can't be erased for compatibility with upstream OCaml.
 module type S = sig type _ g = MkG : ('a : immediate). 'a g end
 |}];;
 
-(* CR layouts: only show the warning once; same for tests below *)
 let f (type a : immediate): a -> a = fun x -> x
 [%%expect {|
 Line 1, characters 4-5:
 1 | let f (type a : immediate): a -> a = fun x -> x
         ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-Line 1, characters 6-47:
-1 | let f (type a : immediate): a -> a = fun x -> x
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
 can't be erased for compatibility with upstream OCaml.
 
@@ -93,12 +86,6 @@ Line 1, characters 4-5:
 Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
 can't be erased for compatibility with upstream OCaml.
 
-Line 1, characters 6-31:
-1 | let f x = (x : (_ : immediate))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
 val f : ('a : immediate). 'a -> 'a = <fun>
 |}];;
 
@@ -107,12 +94,6 @@ let f v: ((_ : immediate)[@error_message "Custom message"]) = v
 Line 1, characters 4-5:
 1 | let f v: ((_ : immediate)[@error_message "Custom message"]) = v
         ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-Line 1, characters 6-63:
-1 | let f v: ((_ : immediate)[@error_message "Custom message"]) = v
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
 can't be erased for compatibility with upstream OCaml.
 
@@ -182,12 +163,6 @@ Line 1, characters 4-5:
 Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
 can't be erased for compatibility with upstream OCaml.
 
-Line 1, characters 6-49:
-1 | let f (type a : immediate64): a -> a = fun x -> x
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
 val f : ('a : immediate64). 'a -> 'a = <fun>
 |}];;
 
@@ -199,12 +174,6 @@ Line 1, characters 4-5:
 Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
 can't be erased for compatibility with upstream OCaml.
 
-Line 1, characters 6-33:
-1 | let f x = (x : (_ : immediate64))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
 val f : ('a : immediate64). 'a -> 'a = <fun>
 |}];;
 
@@ -213,12 +182,6 @@ let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
 Line 1, characters 4-5:
 1 | let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
         ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-Line 1, characters 6-65:
-1 | let f v: ((_ : immediate64)[@error_message "Custom message"]) = v
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
 can't be erased for compatibility with upstream OCaml.
 
@@ -286,12 +249,6 @@ module type S = sig type t : immediate end
 Line 5, characters 4-5:
 5 | let f (module _ : S with type t = 'a) (x : 'a) = x
         ^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
-can't be erased for compatibility with upstream OCaml.
-
-Line 5, characters 6-50:
-5 | let f (module _ : S with type t = 'a) (x : 'a) = x
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in f
 can't be erased for compatibility with upstream OCaml.
 
@@ -580,12 +537,6 @@ Line 1, characters 21-26:
 Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in fails
 can't be erased for compatibility with upstream OCaml.
 
-Line 1, characters 27-68:
-1 | let[@warning "-187"] fails (type a : immediate): a -> a = fun x -> x
-                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in fails
-can't be erased for compatibility with upstream OCaml.
-
 val fails : ('a : immediate). 'a -> 'a = <fun>
 |}]
 
@@ -603,9 +554,7 @@ can't be erased for compatibility with upstream OCaml.
 module type S1 = sig type ('a : immediate) fails = int end
 |}]
 
-(* Disabling the warning just in the signature isn't sufficient.
-
-   The check here is also ran twice for some reason. *)
+(* Disabling the warning just in the signature isn't sufficient. *)
 module M6 : sig
   [@@@warning "-187"]
   type ('a : immediate) t = 'a * 'a
@@ -613,12 +562,6 @@ end = struct
   type ('a : immediate) t = 'a * 'a
 end;;
 [%%expect{|
-Line 5, characters 2-35:
-5 |   type ('a : immediate) t = 'a * 'a
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 187 [incompatible-with-upstream]: Usage of layout immediate/immediate64 in t
-can't be erased for compatibility with upstream OCaml.
-
 Line 5, characters 2-35:
 5 |   type ('a : immediate) t = 'a * 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/ocaml/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -255,6 +255,10 @@ can't be erased for compatibility with upstream OCaml.
 val f : ('a : immediate). (module S with type t = 'a) -> 'a -> 'a = <fun>
 |}]
 
+(* CR layouts: this example should raise a warning, but it does not.
+   It's quite complicated, and missing it only means that this error
+   will be caught by the upstream compiler later. We have decided that
+   fixing this is not worth the effort. *)
 module type S = sig
   type t [@@immediate]
 end
@@ -269,7 +273,10 @@ module type S = sig type t : immediate end
 val x : int = 15
 |}]
 
-(* CR layouts: this should raise a warning *)
+(* CR layouts: this example should raise a warning, but it does not.
+   It's quite complicated, and missing it only means that this error
+   will be caught by the upstream compiler later. We have decided that
+   fixing this is not worth the effort. *)
 let y =
   ignore (fun (type a : immediate) (x : a) ->
     let module _ : S = struct

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2314,7 +2314,7 @@ let check_and_update_generalized_ty_jkind ?name ~loc ty =
                | _ -> false)
     in
     if Language_extension.erasable_extensions_only ()
-      && is_immediate jkind && not (Jkind.has_warning jkind)
+      && is_immediate jkind && not (Jkind.has_warned jkind)
     then
       let id =
         match name with

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2314,7 +2314,7 @@ let check_and_update_generalized_ty_jkind ?name ~loc ty =
                | _ -> false)
     in
     if Language_extension.erasable_extensions_only ()
-      && is_immediate jkind
+      && is_immediate jkind && not (Jkind.has_warning jkind)
     then
       let id =
         match name with
@@ -2322,24 +2322,26 @@ let check_and_update_generalized_ty_jkind ?name ~loc ty =
         | None -> "<unknown>"
       in
       Location.prerr_warning loc (Warnings.Incompatible_with_upstream
-        (Warnings.Immediate_erasure id))
-    else ()
+        (Warnings.Immediate_erasure id));
+      Jkind.with_warning jkind
+    else jkind
+  in
+  let generalization_check level jkind =
+    if level = generic_level then
+      Jkind.(update_reason jkind (Generalized (name, loc)))
+    else jkind
   in
   let rec inner ty =
     let level = get_level ty in
-    if level = generic_level && try_mark_node ty then begin
+    if try_mark_node ty then begin
       begin match get_desc ty with
       | Tvar ({ jkind; _ } as r) ->
-        immediacy_check jkind;
-        let new_jkind =
-          Jkind.(update_reason jkind (Generalized (name, loc)))
-        in
+        let new_jkind = immediacy_check jkind in
+        let new_jkind = generalization_check level new_jkind in
         set_type_desc ty (Tvar {r with jkind = new_jkind})
       | Tunivar ({ jkind; _ } as r) ->
-        immediacy_check jkind;
-        let new_jkind =
-          Jkind.(update_reason jkind (Generalized (name, loc)))
-        in
+        let new_jkind = immediacy_check jkind in
+        let new_jkind = generalization_check level new_jkind in
         set_type_desc ty (Tunivar {r with jkind = new_jkind})
       | _ -> ()
       end;

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -759,7 +759,14 @@ let format ppf t = Format.fprintf ppf "%s" (to_string t)
 let has_imported_history t =
   match t.history with Creation Imported -> true | _ -> false
 
-let update_reason t reason = { t with history = Creation reason }
+let update_reason t reason =
+  match t.history with
+  | Interact _ | Creation _ -> { t with history = Creation reason }
+  | Warning _ -> { t with history = Warning (Creation reason) }
+
+let with_warning t = { t with history = Warning t.history }
+
+let has_warning t = match t.history with Warning _ -> true | _ -> false
 
 let printtyp_path = ref (fun _ _ -> assert false)
 
@@ -1100,6 +1107,7 @@ end = struct
         fprintf ppf "@[<v 2>  %a@]@;%a@ @[<v 2>  %a@]" in_order lhs_history
           format_interact_reason reason in_order rhs_history
       | Creation c -> format_creation_reason ppf c
+      | Warning h -> fprintf ppf "warning @[<v 2>  %a@]" in_order h
     in
     fprintf ppf "@;%t has this layout history:@;@[<v 2>  %a@]" intro in_order
       t.history
@@ -1469,6 +1477,7 @@ module Debug_printers = struct
         interact_reason reason Jkind_desc.Debug_printers.t lhs_jkind history
         lhs_history Jkind_desc.Debug_printers.t rhs_jkind history rhs_history
     | Creation c -> fprintf ppf "Creation (%a)" creation_reason c
+    | Warning h -> fprintf ppf "Warning (%a)" history h
 
   let t ppf ({ jkind; history = h } : t) : unit =
     fprintf ppf "@[<v 2>{ jkind = %a@,; history = %a }@]"

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -304,9 +304,11 @@ val has_imported_history : t -> bool
 
 val update_reason : t -> creation_reason -> t
 
+(* Mark the jkind as having produced a compiler warning. *)
 val with_warning : t -> t
 
-val has_warning : t -> bool
+(* Whether this jkind has produced a compiler warning. *)
+val has_warned : t -> bool
 
 (******************************)
 (* relations *)

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -304,6 +304,10 @@ val has_imported_history : t -> bool
 
 val update_reason : t -> creation_reason -> t
 
+val with_warning : t -> t
+
+val has_warning : t -> bool
+
 (******************************)
 (* relations *)
 

--- a/ocaml/typing/jkind_types.ml
+++ b/ocaml/typing/jkind_types.ml
@@ -347,6 +347,7 @@ type 'type_expr history =
         rhs_history : 'type_expr history
       }
   | Creation of Jkind_intf.History.creation_reason
+  | Warning of 'type_expr history
 
 type 'type_expr t =
   { jkind : 'type_expr Jkind_desc.t;

--- a/ocaml/typing/jkind_types.ml
+++ b/ocaml/typing/jkind_types.ml
@@ -347,11 +347,11 @@ type 'type_expr history =
         rhs_history : 'type_expr history
       }
   | Creation of Jkind_intf.History.creation_reason
-  | Warning of 'type_expr history
 
 type 'type_expr t =
   { jkind : 'type_expr Jkind_desc.t;
-    history : 'type_expr history
+    history : 'type_expr history;
+    has_warned : bool
   }
 
 type const =

--- a/ocaml/typing/jkind_types.mli
+++ b/ocaml/typing/jkind_types.mli
@@ -126,6 +126,7 @@ type 'type_expr history =
         rhs_history : 'type_expr history
       }
   | Creation of Jkind_intf.History.creation_reason
+  | Warning of 'type_expr history
 
 type 'type_expr t =
   { jkind : 'type_expr Jkind_desc.t;

--- a/ocaml/typing/jkind_types.mli
+++ b/ocaml/typing/jkind_types.mli
@@ -126,11 +126,11 @@ type 'type_expr history =
         rhs_history : 'type_expr history
       }
   | Creation of Jkind_intf.History.creation_reason
-  | Warning of 'type_expr history
 
 type 'type_expr t =
   { jkind : 'type_expr Jkind_desc.t;
-    history : 'type_expr history
+    history : 'type_expr history;
+    has_warned : bool
   }
 
 type annotation = const * Jane_syntax.Jkind.annotation


### PR DESCRIPTION
Fix duplicated warnings raised by `check_and_update_generalized_ty_jkind` by tracking the warning in the layout history.
Run the immediacy check regardless of the type variable level.

Some complicated examples still don't raise the warning. Document them.