### PR TITLE
Fix issue with gadts and layouts

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -2541,3 +2541,27 @@ let lpoly_id (type a : any) (x : a repr) : a -> a =
 type ('a : any) repr = Float64 : ('a : float64). 'a repr | Value : 'a repr
 val lpoly_id : ('a : any). 'a repr -> 'a -> 'a = <fun>
 |}]
+
+type 'a s = 'a
+
+module M = struct
+  type t : immediate
+end
+
+module N = struct
+  type ('a,'b) eq =
+    | Refl : ('a, 'a) eq
+
+  let f (x : (M.t, 'a s) eq) : int =
+    match x with
+    | Refl -> 42
+end
+[%%expect{|
+type 'a s = 'a
+module M : sig type t : immediate end
+module N :
+  sig
+    type ('a, 'b) eq = Refl : ('a, 'a) eq
+    val f : (M.t, M.t s) eq -> int
+  end
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -2529,8 +2529,6 @@ type ('a : any) t = UFloat : float# t | Float : float t | Int : int t
 val make_pi : ('a : any). 'a t -> unit -> 'a = <fun>
 |}]
 
-(* CR layouts: This one should work, but doesn't. But at least it shouldn't
-   be the source of the kind of soundness bug we had in [not_magic]. *)
 type ('a : any) repr =
   | Float64 : ('a : float64) repr
   | Value : ('a : value) repr
@@ -2541,12 +2539,5 @@ let lpoly_id (type a : any) (x : a repr) : a -> a =
   | Value -> fun x -> x
 [%%expect{|
 type ('a : any) repr = Float64 : ('a : float64). 'a repr | Value : 'a repr
-Line 7, characters 15-25:
-7 |   | Float64 -> fun x -> x
-                   ^^^^^^^^^^
-Error: Function arguments and returns must be representable.
-       The layout of a is any, because
-         of the annotation on the abstract type declaration for a.
-       But the layout of a must be representable, because
-         we must know concretely how to pass a function argument.
+val lpoly_id : ('a : any). 'a repr -> 'a -> 'a = <fun>
 |}]

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -3380,9 +3380,14 @@ let unify3_var env jkind1 t1' t2 t2' =
 (* This is used to check whether we should add a gadt equation refining a
    Tconstr's jkind during pattern unification. *)
 let constr_jkind_refinable env t jkind =
-  match unification_jkind_check env t jkind with
-  | () -> false
-  | exception Unify_trace _ -> true
+  let snap = Btype.snapshot () in
+  let refinable =
+    match unification_jkind_check env t jkind with
+    | () -> false
+    | exception Unify_trace _ -> true
+  in
+  Btype.backtrack snap;
+  refinable
 
 (*
    1. When unifying two non-abbreviated types, one type is made a link

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -3344,7 +3344,10 @@ let unify1_var env t1 t2 =
     | _ -> assert false
   in
   occur_for Unify env t1 t2;
-  match occur_univar_for Unify env t2 with
+  match
+    occur_univar_for Unify env t2;
+    unification_jkind_check env t2 jkind
+  with
   | () ->
       begin
         try
@@ -3353,7 +3356,6 @@ let unify1_var env t1 t2 =
         with Escape e ->
           raise_for Unify (Escape e)
       end;
-      unification_jkind_check env t2 jkind;
       link_type t1 t2;
       true
   | exception Unify_trace _ when in_pattern_mode () ->
@@ -3362,11 +3364,11 @@ let unify1_var env t1 t2 =
 (* Called from unify3 *)
 let unify3_var env jkind1 t1' t2 t2' =
   occur_for Unify !env t1' t2;
-  match occur_univar_for Unify !env t2 with
-  | () -> begin
-      unification_jkind_check !env t2' jkind1;
-      link_type t1' t2
-    end
+  match
+    occur_univar_for Unify !env t2;
+    unification_jkind_check !env t2' jkind1
+  with
+  | () -> link_type t1' t2
   | exception Unify_trace _ when in_pattern_mode () ->
       reify env t1';
       reify env t2';


### PR DESCRIPTION
This fixes two bugs preventing pattern matching on a gadt couldn't from refining layouts in the expected way.

The first issue was in `Ctype.unify1_var`.  This function distinguishes failures that might be recoverable later due to a gadt equation from unrecoverable errors.  It incorrectly put layout checks into the latter category.

The second issue was in `Ctype.unify3`. During pattern unification, this function should allow for refining a `TConstr` with a gadt equation.  But in the case the `TConstr` was being unified with a variable, it did not.  The old behavior was correct before layouts, because in that case the variable can't tell us anything interesting about the constr.

I've added a few tests.  One is a demonstration that the old behavior was a soundness bug (because we would incorrectly refute a pattern match).