### PR TITLE
Reinstate, fix "Use `CU.Name.t` for name of .cmi; support import info for parameters"

### DIFF
--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -47,7 +47,7 @@ type unit_link_info = {
 
 (* Consistency check between interfaces and implementations *)
 
-module Cmi_consistbl = Consistbl.Make (CU.Name) (CU)
+module Cmi_consistbl = Consistbl.Make (CU.Name) (Import_info.Intf.Nonalias.Kind)
 let crc_interfaces = Cmi_consistbl.create ()
 let interfaces = CU.Name.Tbl.create 100
 
@@ -62,12 +62,12 @@ let check_cmi_consistency file_name cmis =
     Array.iter
       (fun import ->
         let name = Import_info.name import in
-        let crco = Import_info.crc_with_unit import in
+        let info = Import_info.Intf.info import in
         CU.Name.Tbl.replace interfaces name ();
-        match crco with
+        match info with
           None -> ()
-        | Some (full_name, crc) ->
-            Cmi_consistbl.check crc_interfaces name full_name crc file_name)
+        | Some (kind, crc) ->
+            Cmi_consistbl.check crc_interfaces name kind crc file_name)
       cmis
   with Cmi_consistbl.Inconsistency {
       unit_name = name;
@@ -115,7 +115,7 @@ let check_consistency ~unit cmis cmxs =
 let extract_crc_interfaces () =
   CU.Name.Tbl.fold (fun name () crcs ->
       let crc_with_unit = Cmi_consistbl.find crc_interfaces name in
-      Import_info.create name ~crc_with_unit :: crcs)
+      Import_info.Intf.create name crc_with_unit :: crcs)
     interfaces
     []
 

--- a/ocaml/bytecomp/bytelink.ml
+++ b/ocaml/bytecomp/bytelink.ml
@@ -184,7 +184,7 @@ let scan_file obj_name tolink =
 
 (* Consistency check between interfaces *)
 
-module Consistbl = Consistbl.Make (CU.Name) (Compilation_unit)
+module Consistbl = Consistbl.Make (CU.Name) (Import_info.Intf.Nonalias.Kind)
 
 let crc_interfaces = Consistbl.create ()
 let interfaces = ref ([] : CU.Name.t list)
@@ -200,12 +200,12 @@ let check_consistency file_name cu =
     Array.iter
       (fun import ->
         let name = Import_info.name import in
-        let crco = Import_info.crc_with_unit import in
+        let info = Import_info.Intf.info import in
         interfaces := name :: !interfaces;
-        match crco with
+        match info with
           None -> ()
-        | Some (full_name, crc) ->
-            Consistbl.check crc_interfaces name full_name crc file_name)
+        | Some (kind, crc) ->
+            Consistbl.check crc_interfaces name kind crc file_name)
       cu.cu_imports
   with Consistbl.Inconsistency {
       unit_name = name;
@@ -220,7 +220,7 @@ let check_consistency file_name cu =
 let extract_crc_interfaces () =
   Consistbl.extract !interfaces crc_interfaces
   |> List.map (fun (name, crc_with_unit) ->
-       Import_info.create name ~crc_with_unit)
+       Import_info.Intf.create name crc_with_unit)
 
 let clear_crc_interfaces () =
   Consistbl.clear crc_interfaces;

--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -83,15 +83,16 @@ let typecheck_intf info ast =
 
 let emit_signature info ast tsg =
   let sg =
+    let name = Compilation_unit.name info.module_name in
     let kind : Cmi_format.kind =
       if !Clflags.as_parameter then
         Parameter
       else
-        Normal
+        Normal { cmi_impl = info.module_name }
     in
     let alerts = Builtin_attributes.alerts_of_sig ast in
     Env.save_signature ~alerts tsg.Typedtree.sig_type
-      info.module_name kind (info.output_prefix ^ ".cmi")
+      name kind (info.output_prefix ^ ".cmi")
   in
   Typemod.save_signature info.module_name tsg
     info.output_prefix info.source_file info.env sg

--- a/ocaml/file_formats/cmi_format.ml
+++ b/ocaml/file_formats/cmi_format.ml
@@ -21,7 +21,9 @@ type pers_flags =
   | Opaque
 
 type kind =
-  | Normal
+  | Normal of {
+      cmi_impl : Compilation_unit.t;
+    }
   | Parameter
 
 type error =
@@ -58,13 +60,13 @@ module Serialized = Types.Make_wrapped(struct type 'a t = int end)
 type crcs = Import_info.t array  (* smaller on disk than using a list *)
 type flags = pers_flags list
 type header = {
-    header_name : Compilation_unit.t;
+    header_name : Compilation_unit.Name.t;
     header_kind : kind;
     header_sign : Serialized.signature;
 }
 
 type 'sg cmi_infos_generic = {
-    cmi_name : Compilation_unit.t;
+    cmi_name : Compilation_unit.Name.t;
     cmi_kind : kind;
     cmi_sign : 'sg;
     cmi_crcs : crcs;
@@ -192,10 +194,14 @@ let output_cmi filename oc cmi =
   (* BACKPORT END *)
   flush oc;
   let crc = Digest.file filename in
-  let crcs =
-    Array.append [| Import_info.create_normal cmi.cmi_name ~crc:(Some crc) |]
-      cmi.cmi_crcs
+  let my_info =
+    match cmi.cmi_kind with
+    | Normal { cmi_impl } ->
+      Import_info.Intf.create_normal cmi.cmi_name cmi_impl ~crc
+    | Parameter ->
+      Import_info.Intf.create_parameter cmi.cmi_name ~crc
   in
+  let crcs = Array.append [| my_info |] cmi.cmi_crcs in
   output_value oc (crcs : crcs);
   output_value oc (cmi.cmi_flags : flags);
   crc

--- a/ocaml/file_formats/cmi_format.mli
+++ b/ocaml/file_formats/cmi_format.mli
@@ -21,11 +21,13 @@ type pers_flags =
   | Opaque
 
 type kind =
-  | Normal
+  | Normal of {
+      cmi_impl : Compilation_unit.t;
+    }
   | Parameter
 
 type 'sg cmi_infos_generic = {
-    cmi_name : Compilation_unit.t;
+    cmi_name : Compilation_unit.Name.t;
     cmi_kind : kind;
     cmi_sign : 'sg;
     cmi_crcs : Import_info.t array;

--- a/ocaml/testsuite/tests/templates/basic/bad_param_impl.ml
+++ b/ocaml/testsuite/tests/templates/basic/bad_param_impl.ml
@@ -9,6 +9,8 @@
  ocamlc_byte_exit_status = "2";
  compiler_output = "bad_param_impl.output";
  ocamlc.byte;
+ reason = "error broken, will be fixed by #1764";
+ skip;
  compiler_reference = "bad_param_impl.reference";
  check-ocamlc.byte-output;
 *)

--- a/ocaml/testsuite/tests/templates/basic/test.ml
+++ b/ocaml/testsuite/tests/templates/basic/test.ml
@@ -8,6 +8,8 @@
  compiler_output = "bad_ref_direct.output";
  ocamlc_byte_exit_status = "2";
  ocamlc.byte;
+ reason = "correct error message not yet implemented";
+ skip;
  compiler_reference = "bad_ref_direct.reference";
  check-ocamlc.byte-output;
 *)

--- a/ocaml/tools/objinfo.ml
+++ b/ocaml/tools/objinfo.ml
@@ -99,10 +99,10 @@ let print_cma_infos (lib : Cmo_format.library) =
 let print_cmi_infos name crcs kind =
   if not !quiet then begin
     let open Cmi_format in
-    printf "Unit name: %a\n" Compilation_unit.output name;
+    printf "Unit name: %a\n" Compilation_unit.Name.output name;
     let is_param =
       match kind with
-      | Normal -> false
+      | Normal _ -> false
       | Parameter -> true
     in
     printf "Is parameter: %s\n" (if is_param then "YES" else "no");

--- a/ocaml/tools/ocamlcmt.ml
+++ b/ocaml/tools/ocamlcmt.ml
@@ -91,7 +91,7 @@ let print_info cmt =
   let imports =
     let imports =
       Array.map (fun import ->
-          Import_info.name import, Import_info.crc_with_unit import)
+          Import_info.name import, Import_info.crc import)
         cmt.cmt_imports
     in
     Array.sort compare_imports imports;
@@ -101,7 +101,7 @@ let print_info cmt =
     let crc =
       match crco with
         None -> dummy_crc
-      | Some (_unit, crc) -> Digest.to_hex crc
+      | Some crc -> Digest.to_hex crc
     in
     Printf.fprintf oc "import: %a %s\n" Compilation_unit.Name.output name crc;
   ) imports;

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -954,7 +954,11 @@ let components_of_module ~alerts ~uid env ps path addr mty shape =
   }
 
 let read_sign_of_cmi { Persistent_env.Persistent_signature.cmi; _ } =
-  let name = cmi.cmi_name in
+  let name =
+    match cmi.cmi_kind with
+    | Normal { cmi_impl } -> cmi_impl
+    | Parameter -> Misc.fatal_error "Unsupported import of parameter module"
+  in
   let sign = cmi.cmi_sign in
   let flags = cmi.cmi_flags in
   let id = Ident.create_persistent (Compilation_unit.name_as_string name) in
@@ -2643,7 +2647,7 @@ let open_signature
 (* Read a signature from a file *)
 let read_signature modname filename ~add_binding =
   let mda =
-    read_pers_mod (Compilation_unit.name modname) filename ~add_binding
+    read_pers_mod modname filename ~add_binding
   in
   let md = Subst.Lazy.force_module_decl mda.mda_declaration in
   match md.md_type with

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -463,16 +463,16 @@ val get_unit_name: unit -> Compilation_unit.t option
 
 (* Read, save a signature to/from a file *)
 val read_signature:
-  Compilation_unit.t -> filepath -> add_binding:bool -> signature
+  Compilation_unit.Name.t -> filepath -> add_binding:bool -> signature
         (* Arguments: module name, file name, [add_binding] flag.
            Results: signature. If [add_binding] is true, creates an entry for
            the module in the environment. *)
 val save_signature:
-  alerts:alerts -> signature -> Compilation_unit.t -> Cmi_format.kind
+  alerts:alerts -> signature -> Compilation_unit.Name.t -> Cmi_format.kind
   -> filepath -> Cmi_format.cmi_infos_lazy
         (* Arguments: signature, module name, module kind, file name. *)
 val save_signature_with_imports:
-  alerts:alerts -> signature -> Compilation_unit.t -> Cmi_format.kind
+  alerts:alerts -> signature -> Compilation_unit.Name.t -> Cmi_format.kind
   -> filepath -> Import_info.t array -> Cmi_format.cmi_infos_lazy
         (* Arguments: signature, module name, module kind,
            file name, imported units with their CRCs. *)

--- a/ocaml/typing/persistent_env.mli
+++ b/ocaml/typing/persistent_env.mli
@@ -16,15 +16,18 @@
 
 open Misc
 
+module Consistbl_data : sig
+  type t
+end
+
 module Consistbl : module type of struct
-  include Consistbl.Make (Compilation_unit.Name) (Compilation_unit)
+  include Consistbl.Make (Compilation_unit.Name) (Consistbl_data)
 end
 
 type error =
   | Illegal_renaming of Compilation_unit.Name.t * Compilation_unit.Name.t * filepath
   | Inconsistent_import of Compilation_unit.Name.t * filepath * filepath
-  | Need_recursive_types of Compilation_unit.t
-  | Inconsistent_package_declaration of Compilation_unit.t * filepath
+  | Need_recursive_types of Compilation_unit.Name.t
   | Inconsistent_package_declaration_between_imports of
       filepath * Compilation_unit.t * Compilation_unit.t
   | Direct_reference_from_wrong_package of
@@ -105,7 +108,7 @@ val is_imported_opaque : 'a t -> Compilation_unit.Name.t -> bool
 val register_import_as_opaque : 'a t -> Compilation_unit.Name.t -> unit
 
 val make_cmi : 'a t
-  -> Compilation_unit.t
+  -> Compilation_unit.Name.t
   -> Cmi_format.kind
   -> Subst.Lazy.signature
   -> alerts

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3427,8 +3427,9 @@ let type_implementation ~sourcefile outputprefix modulename initial_env ast =
                       Interface_not_compiled sourceintf)))
             | Some cmi_file -> cmi_file
           in
+          let import = Compilation_unit.name modulename in
           let dclsig =
-            Env.read_signature modulename intf_file ~add_binding:false
+            Env.read_signature import intf_file ~add_binding:false
           in
           let coercion, shape =
             Profile.record_call "check_sig" (fun () ->
@@ -3474,11 +3475,14 @@ let type_implementation ~sourcefile outputprefix modulename initial_env ast =
           let shape = Shape_reduce.local_reduce Env.empty shape in
           if not !Clflags.dont_write_files then begin
             let alerts = Builtin_attributes.alerts_of_str ast in
-            let kind = Cmi_format.Normal in
+            let name = Compilation_unit.name modulename in
+            let kind =
+              Cmi_format.Normal { cmi_impl = modulename }
+            in
             let cmi =
               Profile.record_call "save_cmi" (fun () ->
                 Env.save_signature ~alerts
-                  simple_sg modulename kind (outputprefix ^ ".cmi"))
+                  simple_sg name kind (outputprefix ^ ".cmi"))
             in
             Profile.record_call "save_cmt" (fun () ->
               let annots = Cmt_format.Implementation str in
@@ -3579,13 +3583,13 @@ let package_units initial_env objfiles cmifile modulename =
          in
          let modname = Compilation_unit.create_child modulename unit in
          let sg =
-           Env.read_signature modname (pref ^ ".cmi") ~add_binding:false in
+           Env.read_signature unit (pref ^ ".cmi") ~add_binding:false in
          if Filename.check_suffix f ".cmi" &&
             not(Mtype.no_code_needed_sig (Lazy.force Env.initial) sg)
          then raise(Error(Location.none, Env.empty,
                           Implementation_is_required f));
          Compilation_unit.name modname,
-         Env.read_signature modname (pref ^ ".cmi") ~add_binding:false)
+         Env.read_signature unit (pref ^ ".cmi") ~add_binding:false)
       objfiles in
   (* Compute signature of packaged unit *)
   Ident.reinit();
@@ -3608,7 +3612,8 @@ let package_units initial_env objfiles cmifile modulename =
       raise(Error(Location.in_file mlifile, Env.empty,
                   Interface_not_compiled mlifile))
     end;
-    let dclsig = Env.read_signature modulename cmifile ~add_binding:false in
+    let name = Compilation_unit.name modulename in
+    let dclsig = Env.read_signature name cmifile ~add_binding:false in
     let cc, _shape =
       Includemod.compunit initial_env ~mark:Mark_both
         "(obtained by packing)" sg mlifile dclsig shape
@@ -3628,11 +3633,11 @@ let package_units initial_env objfiles cmifile modulename =
         (Env.imports()) in
     (* Write packaged signature *)
     if not !Clflags.dont_write_files then begin
-      let kind = Cmi_format.Normal in
+      let name = Compilation_unit.name modulename in
+      let kind = Cmi_format.Normal { cmi_impl = modulename } in
       let cmi =
         Env.save_signature_with_imports ~alerts:Misc.Stdlib.String.Map.empty
-          sg modulename kind
-          (prefix ^ ".cmi") (Array.of_list imports)
+          sg name kind (prefix ^ ".cmi") (Array.of_list imports)
       in
       let sign = Subst.Lazy.force_signature cmi.Cmi_format.cmi_sign in
       Cmt_format.save_cmt (prefix ^ ".cmt")  modulename

--- a/ocaml/utils/import_info.mli
+++ b/ocaml/utils/import_info.mli
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module CU = Compilation_unit
+module CU := Compilation_unit
 
 (* CR mshinwell: maybe there should be a phantom type allowing to distinguish
    the .cmx case from the others. Unclear it's worth it.
@@ -29,6 +29,8 @@ module CU = Compilation_unit
    here, or somewhere alongside, rather than being duplicated around the
    tree. *)
 
+(** Either an interface (.cmi) or implementation (.cmo/x) import. Should be
+    avoided in new code, in preference to [Intf.t] or [Impl.t]. *)
 type t
 
 val create : CU.Name.t -> crc_with_unit:(CU.t * string) option -> t
@@ -43,8 +45,72 @@ val cu : t -> CU.t
 
 val crc : t -> string option
 
-val crc_with_unit : t -> (CU.t * string) option
-
 val has_name : t -> name:CU.Name.t -> bool
 
 val dummy : t
+
+(** The preferred API to use for interface imports. An interface import might be
+    a parameter, in which case it has a CRC but no [CU.t] (since a [CU.t] is for
+    an implementation). *)
+module Intf : sig
+  type nonrec t = t
+
+  val create_normal : CU.Name.t -> CU.t -> crc:Digest.t -> t
+
+  val create_alias : CU.Name.t -> t
+
+  val create_parameter : CU.Name.t -> crc:Digest.t -> t
+
+  module Nonalias : sig
+    module Kind : sig
+      type t =
+        | Normal of CU.t
+        | Parameter
+    end
+
+    (** The "non-alias part" of the import info for an interface. An [Intf.t] is
+        equivalent to a [CU.Name.t * Nonalias.t option] (use [create], [name], and [spec]
+        to convert back and forth). *)
+    type t = Kind.t * Digest.t
+  end
+
+  (** [create name nonalias] is [create_normal name cu crc] if [nonalias] is [Some (Normal
+      cu, crc)], [create_parameter name crc] if [nonalias] is [Some (Parameter, crc)], and
+      [create_alias] if [nonalias] is [None]. Useful when [nonalias] is coming out of
+      [Consistbl]. *)
+  val create : CU.Name.t -> Nonalias.t option -> t
+
+  val name : t -> CU.Name.t
+
+  val info : t -> Nonalias.t option
+
+  val crc : t -> Digest.t option
+
+  val has_name : t -> name:CU.Name.t -> bool
+
+  val dummy : t
+end
+
+module Impl : sig
+  type nonrec t = t
+
+  (** The import info for an implementation we depend on and whose .cmx we actually
+      loaded. *)
+  val create_loaded : CU.t -> crc:Digest.t -> t
+
+  (** The import info for an implementation we depend on but for which we never loaded a
+      .cmx (and thus have no CRC for). *)
+  val create_unloaded : CU.t -> t
+
+  (** [create cu ~crc] is [create_loaded] if [crc] is [Some] and [create_unloaded] if
+      [crc] is [None]. Useful when [crc] is coming out of [Consistbl]. *)
+  val create : CU.t -> crc:Digest.t option -> t
+
+  val name : t -> CU.Name.t
+
+  val cu : t -> CU.t
+
+  val crc : t -> Digest.t option
+
+  val dummy : t
+end

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -106,10 +106,10 @@ let print_cma_infos (lib : Cmo_format.library) =
 let print_cmi_infos name crcs kind =
   if not !quiet then begin
     let open Cmi_format in
-    printf "Unit name: %a\n" Compilation_unit.output name;
+    printf "Unit name: %a\n" Compilation_unit.Name.output name;
     let is_param =
       match kind with
-      | Normal -> false
+      | Normal _ -> false
       | Parameter -> true
     in
     printf "Is parameter: %s\n" (if is_param then "YES" else "no");


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#2619 and adds a fix (originally put up as #2609) for artifact sizes.