### PR TITLE
Combine Value and Alloc modules

### DIFF
--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -447,28 +447,28 @@ module Jkind_desc = struct
   let immediate64 =
     { layout = Layout.value;
       modes_upper_bounds =
-        { locality = Global; linearity = Many; uniqueness = Unique };
+        { areality = Global; linearity = Many; uniqueness = Unique };
       externality_upper_bound = External64
     }
 
   let immediate =
     { layout = Layout.value;
       modes_upper_bounds =
-        { locality = Global; linearity = Many; uniqueness = Unique };
+        { areality = Global; linearity = Many; uniqueness = Unique };
       externality_upper_bound = External
     }
 
   let float64 =
     { layout = Layout.float64;
       modes_upper_bounds =
-        { locality = Global; linearity = Many; uniqueness = Unique };
+        { areality = Global; linearity = Many; uniqueness = Unique };
       externality_upper_bound = External
     }
 
   let float32 =
     { layout = Layout.float32;
       modes_upper_bounds =
-        { locality = Global; linearity = Many; uniqueness = Unique };
+        { areality = Global; linearity = Many; uniqueness = Unique };
       externality_upper_bound = External
     }
 

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1236,6 +1236,8 @@ module Locality = struct
     let obj = C.Locality
   end
 
+  let comonadic_with_areality = C.Comonadic_with_locality
+
   include Common (Obj)
 
   let global = of_const Global
@@ -1269,6 +1271,8 @@ module Regionality = struct
 
     let obj = C.Regionality
   end
+
+  let comonadic_with_areality = C.Comonadic_with_regionality
 
   include Common (Obj)
 
@@ -1337,9 +1341,19 @@ let locality_as_regionality m =
 let regional_to_global m =
   S.Positive.via_monotone Locality.Obj.obj C.Regional_to_global m
 
-module Comonadic_with_regionality = struct
+module type Areality = sig
+  module Const : C.Areality
+
+  module Obj : Obj with type const = Const.t and module Solver = S.Positive
+
+  val comonadic_with_areality : Const.t C.comonadic_with C.obj
+
+  val zap_to_legacy : (Const.t, allowed * 'r) Obj.Solver.mode -> Const.t
+end
+
+module Comonadic_with (Areality : Areality) = struct
   module Const = struct
-    include C.Comonadic_with_regionality
+    include C.Comonadic_with (Areality.Const)
 
     let eq a b = le a b && le b a
   end
@@ -1349,7 +1363,7 @@ module Comonadic_with_regionality = struct
 
     module Solver = S.Positive
 
-    let obj = C.Comonadic_with_regionality
+    let obj = Areality.comonadic_with_areality
   end
 
   include Common (Obj)
@@ -1379,9 +1393,9 @@ module Comonadic_with_regionality = struct
   let meet_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
   let zap_to_legacy m =
-    let regionality = proj Areality m |> Regionality.zap_to_legacy in
+    let areality = proj Areality m |> Areality.zap_to_legacy in
     let linearity = proj Linearity m |> Linearity.zap_to_legacy in
-    regionality, linearity
+    areality, linearity
 
   let imply c m = Solver.via_monotone obj (Imply c) (Solver.disallow_left m)
 
@@ -1391,87 +1405,20 @@ module Comonadic_with_regionality = struct
   let submode_log m0 m1 ~log : _ result =
     match submode_log m0 m1 ~log with
     | Ok () -> Ok ()
-    | Error { left = reg0, lin0; right = reg1, lin1 } ->
-      if Regionality.Const.le reg0 reg1
+    | Error { left = area0, lin0; right = area1, lin1 } ->
+      if Areality.Const.le area0 area1
       then
         if Linearity.Const.le lin0 lin1
         then assert false
         else Error (Error (Linearity, { left = lin0; right = lin1 }))
-      else Error (Error (Areality, { left = reg0; right = reg1 }))
+      else Error (Error (Areality, { left = area0; right = area1 }))
 
   let submode a b = try_with_log (submode_log a b)
 
   (* override to report the offending axis *)
   let equate a b = try_with_log (equate_from_submode submode_log a b)
 end
-
-module Comonadic_with_locality = struct
-  module Const = struct
-    include C.Comonadic_with_locality
-
-    let eq a b = le a b && le b a
-  end
-
-  module Obj = struct
-    type const = Const.t
-
-    module Solver = S.Positive
-
-    let obj = C.Comonadic_with_locality
-  end
-
-  include Common (Obj)
-
-  type error = Error : (Const.t, 'a) C.Axis.t * 'a Solver.error -> error
-
-  type equate_error = equate_step * error
-
-  open Obj
-
-  let proj_obj ax = C.proj_obj ax obj
-
-  let proj ax m = Solver.via_monotone (proj_obj ax) (Proj (Obj.obj, ax)) m
-
-  let meet_const c m = Solver.via_monotone obj (Meet_with c) m
-
-  let join_const c m = Solver.via_monotone obj (Join_with c) m
-
-  let min_with ax m =
-    Solver.via_monotone Obj.obj (Min_with ax) (Solver.disallow_right m)
-
-  let max_with ax m =
-    Solver.via_monotone Obj.obj (Max_with ax) (Solver.disallow_left m)
-
-  let join_with ax c m = join_const (C.min_with Obj.obj ax c) m
-
-  let meet_with ax c m = meet_const (C.max_with Obj.obj ax c) m
-
-  let zap_to_legacy m =
-    let locality = proj Areality m |> Locality.zap_to_legacy in
-    let linearity = proj Linearity m |> Linearity.zap_to_legacy in
-    locality, linearity
-
-  let imply c m = Solver.via_monotone obj (Imply c) (Solver.disallow_left m)
-
-  let legacy = of_const Const.legacy
-
-  (* overriding to report the offending axis *)
-  let submode_log m0 m1 ~log : _ result =
-    match submode_log m0 m1 ~log with
-    | Ok () -> Ok ()
-    | Error { left = loc0, lin0; right = loc1, lin1 } ->
-      if Locality.Const.le loc0 loc1
-      then
-        if Linearity.Const.le lin0 lin1
-        then assert false
-        else Error (Error (Linearity, { left = lin0; right = lin1 }))
-      else Error (Error (Areality, { left = loc0; right = loc1 }))
-
-  let submode a b = try_with_log (submode_log a b)
-
-  (* override to report the offending axis *)
-  let equate a b = try_with_log (equate_from_submode submode_log a b)
-end
+[@@inline]
 
 module Monadic = struct
   module Const = C.Monadic
@@ -1544,8 +1491,8 @@ type ('mo, 'como) monadic_comonadic =
     comonadic : 'como
   }
 
-module Value = struct
-  module Comonadic = Comonadic_with_regionality
+module Mode (Areality : Areality) = struct
+  module Comonadic = Comonadic_with (Areality)
   module Monadic = Monadic
 
   type 'd t = ('d Monadic.t, 'd Comonadic.t) monadic_comonadic
@@ -1598,7 +1545,7 @@ module Value = struct
     { comonadic; monadic }
 
   module Const = struct
-    type t = (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
+    type t = (Areality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
 
     module Monadic = Monadic.Const
     module Comonadic = Comonadic.Const
@@ -1637,7 +1584,7 @@ module Value = struct
       type some = t
 
       type t =
-        ( Regionality.Const.t option,
+        ( Areality.Const.t option,
           Linearity.Const.t option,
           Uniqueness.Const.t option )
         modes
@@ -1655,7 +1602,7 @@ module Value = struct
 
     let diff m0 m1 =
       let diff le a0 a1 = if le a0 a1 && le a1 a0 then None else Some a0 in
-      let areality = diff Regionality.Const.le m0.areality m1.areality in
+      let areality = diff Areality.Const.le m0.areality m1.areality in
       let linearity = diff Linearity.Const.le m0.linearity m1.linearity in
       let uniqueness = diff Uniqueness.Const.le m0.uniqueness m1.uniqueness in
       { areality; linearity; uniqueness }
@@ -1665,7 +1612,7 @@ module Value = struct
       let { monadic; comonadic } = split m in
       let comonadic =
         Comonadic.join comonadic
-          (C.monadic_to_comonadic_min C.Comonadic_with_regionality monadic)
+          (C.monadic_to_comonadic_min Areality.comonadic_with_areality monadic)
       in
       let monadic = Monadic.min in
       merge { comonadic; monadic }
@@ -1927,392 +1874,10 @@ module Value = struct
     end)
   end
 end
+[@@inline]
 
-module Alloc = struct
-  module Comonadic = Comonadic_with_locality
-  module Monadic = Monadic
-
-  type 'd t = ('d Monadic.t, 'd Comonadic.t) monadic_comonadic
-
-  type l = (allowed * disallowed) t
-
-  type r = (disallowed * allowed) t
-
-  type lr = (allowed * allowed) t
-
-  type ('m, 'a, 'd) axis =
-    | Monadic :
-        (Monadic.Const.t, 'a) Axis.t
-        -> (('a, 'd) mode_monadic, 'a, 'd) axis
-    | Comonadic :
-        (Comonadic.Const.t, 'a) Axis.t
-        -> (('a, 'd) mode_comonadic, 'a, 'd) axis
-
-  let proj_obj : type m a d. (m, a, d) axis -> a C.obj = function
-    | Monadic ax -> Monadic.proj_obj ax
-    | Comonadic ax -> Comonadic.proj_obj ax
-
-  type ('a, 'b, 'c) modes =
-    { areality : 'a;
-      linearity : 'b;
-      uniqueness : 'c
-    }
-
-  let split { areality; linearity; uniqueness } =
-    let monadic = uniqueness, () in
-    let comonadic = areality, linearity in
-    { comonadic; monadic }
-
-  let merge { comonadic; monadic } =
-    let areality, linearity = comonadic in
-    let uniqueness, () = monadic in
-    { areality; linearity; uniqueness }
-
-  let min = { comonadic = Comonadic.min; monadic = Monadic.min }
-
-  let max = { comonadic = Comonadic.min; monadic = Monadic.max }
-
-  include Magic_allow_disallow (struct
-    type (_, _, 'd) sided = 'd t constraint 'd = 'l * 'r
-
-    let allow_left { monadic; comonadic } =
-      let monadic = Monadic.allow_left monadic in
-      let comonadic = Comonadic.allow_left comonadic in
-      { monadic; comonadic }
-
-    let allow_right { monadic; comonadic } =
-      let monadic = Monadic.allow_right monadic in
-      let comonadic = Comonadic.allow_right comonadic in
-      { monadic; comonadic }
-
-    let disallow_left { monadic; comonadic } =
-      let monadic = Monadic.disallow_left monadic in
-      let comonadic = Comonadic.disallow_left comonadic in
-      { monadic; comonadic }
-
-    let disallow_right { monadic; comonadic } =
-      let monadic = Monadic.disallow_right monadic in
-      let comonadic = Comonadic.disallow_right comonadic in
-      { monadic; comonadic }
-  end)
-
-  let newvar () =
-    let comonadic = Comonadic.newvar () in
-    let monadic = Monadic.newvar () in
-    { comonadic; monadic }
-
-  let newvar_above { comonadic; monadic } =
-    let comonadic, b0 = Comonadic.newvar_above comonadic in
-    let monadic, b1 = Monadic.newvar_above monadic in
-    { monadic; comonadic }, b0 || b1
-
-  let newvar_below { comonadic; monadic } =
-    let comonadic, b0 = Comonadic.newvar_below comonadic in
-    let monadic, b1 = Monadic.newvar_below monadic in
-    { monadic; comonadic }, b0 || b1
-
-  type error = Error : ('m, 'a, 'd) axis * 'a Solver.error -> error
-
-  type equate_error = equate_step * error
-
-  let submode_log { monadic = monadic0; comonadic = comonadic0 }
-      { monadic = monadic1; comonadic = comonadic1 } ~log : (_, error) result =
-    match Monadic.submode_log monadic0 monadic1 ~log with
-    | Error (Error (ax, e)) -> Error (Error (Monadic ax, e))
-    | Ok () -> (
-      match Comonadic.submode_log comonadic0 comonadic1 ~log with
-      | Error (Error (ax, e)) -> Error (Error (Comonadic ax, e))
-      | Ok () -> Ok ())
-
-  let submode a b = try_with_log (submode_log a b)
-
-  let equate a b = try_with_log (equate_from_submode submode_log a b)
-
-  let submode_exn m0 m1 =
-    match submode m0 m1 with
-    | Ok () -> ()
-    | Error _ -> invalid_arg "submode_exn"
-
-  let equate_exn m0 m1 =
-    match equate m0 m1 with Ok () -> () | Error _ -> invalid_arg "equate_exn"
-
-  let print ?verbose () ppf { monadic; comonadic } =
-    Format.fprintf ppf "%a,%a"
-      (Comonadic.print ?verbose ())
-      comonadic
-      (Monadic.print ?verbose ())
-      monadic
-
-  let legacy =
-    let comonadic = Comonadic.legacy in
-    let monadic = Monadic.legacy in
-    { comonadic; monadic }
-
-  (* Below we package up the complex projection from alloc to three axes as if
-     they live under alloc directly and uniformly. We define functions that operate
-     on modes numerically, instead of defining symbolic functions *)
-  (* type const = (LR.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes *)
-
-  let proj_monadic ax { monadic; _ } = Monadic.proj ax monadic
-
-  let proj_comonadic ax { comonadic; _ } = Comonadic.proj ax comonadic
-
-  let proj : type m a l r. (m, a, l * r) axis -> (l * r) t -> m =
-   fun ax m ->
-    match ax with
-    | Monadic ax -> proj_monadic ax m
-    | Comonadic ax -> proj_comonadic ax m
-
-  let max_with_monadic ax m =
-    let comonadic =
-      Comonadic.max |> Comonadic.disallow_left |> Comonadic.allow_right
-    in
-    let monadic = Monadic.max_with ax m in
-    { comonadic; monadic }
-
-  let max_with_comonadic ax m =
-    let comonadic = Comonadic.max_with ax m in
-    let monadic = Monadic.max |> Monadic.disallow_left |> Monadic.allow_right in
-    { comonadic; monadic }
-
-  let max_with : type m a l r. (m, a, l * r) axis -> m -> (disallowed * r) t =
-   fun ax m ->
-    match ax with
-    | Monadic ax -> max_with_monadic ax m
-    | Comonadic ax -> max_with_comonadic ax m
-
-  let min_with_monadic ax m =
-    let comonadic =
-      Comonadic.min |> Comonadic.disallow_right |> Comonadic.allow_left
-    in
-    let monadic = Monadic.min_with ax m in
-    { comonadic; monadic }
-
-  let min_with_comonadic ax m =
-    let comonadic = Comonadic.min_with ax m in
-    let monadic = Monadic.min |> Monadic.disallow_right |> Monadic.allow_left in
-    { comonadic; monadic }
-
-  let min_with : type m a l r. (m, a, l * r) axis -> m -> (l * disallowed) t =
-   fun ax m ->
-    match ax with
-    | Monadic ax -> min_with_monadic ax m
-    | Comonadic ax -> min_with_comonadic ax m
-
-  let join_with_monadic ax c { monadic; comonadic } =
-    let monadic = Monadic.join_with ax c monadic in
-    { monadic; comonadic }
-
-  let join_with_comonadic ax c { monadic; comonadic } =
-    let comonadic = Comonadic.join_with ax c comonadic in
-    { comonadic; monadic }
-
-  let join_with : type m a d l r. (m, a, d) axis -> a -> (l * r) t -> (l * r) t
-      =
-   fun ax c m ->
-    match ax with
-    | Monadic ax -> join_with_monadic ax c m
-    | Comonadic ax -> join_with_comonadic ax c m
-
-  let meet_with_monadic ax c { monadic; comonadic } =
-    let monadic = Monadic.meet_with ax c monadic in
-    { monadic; comonadic }
-
-  let meet_with_comonadic ax c { monadic; comonadic } =
-    let comonadic = Comonadic.meet_with ax c comonadic in
-    { comonadic; monadic }
-
-  let meet_with : type m a d l r. (m, a, d) axis -> a -> (l * r) t -> (l * r) t
-      =
-   fun ax c m ->
-    match ax with
-    | Monadic ax -> meet_with_monadic ax c m
-    | Comonadic ax -> meet_with_comonadic ax c m
-
-  let join l =
-    let como, mo =
-      List.fold_left
-        (fun (como, mo) { comonadic; monadic } ->
-          comonadic :: como, monadic :: mo)
-        ([], []) l
-    in
-    let comonadic = Comonadic.join como in
-    let monadic = Monadic.join mo in
-    { comonadic; monadic }
-
-  let meet l =
-    let como, mo =
-      List.fold_left
-        (fun (como, mo) { comonadic; monadic } ->
-          comonadic :: como, monadic :: mo)
-        ([], []) l
-    in
-    let comonadic = Comonadic.meet como in
-    let monadic = Monadic.meet mo in
-    { comonadic; monadic }
-
-  let comonadic_to_monadic m =
-    S.Negative.via_antitone Monadic.Obj.obj
-      (Comonadic_to_monadic Comonadic.Obj.obj) m
-
-  let monadic_to_comonadic_min m =
-    S.Positive.via_antitone Comonadic.Obj.obj Monadic_to_comonadic_min
-      (Monadic.disallow_left m)
-
-  let of_const { areality; linearity; uniqueness } =
-    let comonadic = Comonadic.of_const (areality, linearity) in
-    let monadic = Monadic.of_const (uniqueness, ()) in
-    { comonadic; monadic }
-
-  module Const = struct
-    type t = (Locality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
-
-    module Monadic = Monadic.Const
-    module Comonadic = Comonadic.Const
-
-    let min = merge { comonadic = Comonadic.min; monadic = Monadic.min }
-
-    let max = merge { comonadic = Comonadic.max; monadic = Monadic.max }
-
-    let le m0 m1 =
-      let m0 = split m0 in
-      let m1 = split m1 in
-      Comonadic.le m0.comonadic m1.comonadic && Monadic.le m0.monadic m1.monadic
-
-    let print ppf m =
-      let { monadic; comonadic } = split m in
-      Format.fprintf ppf "%a,%a" Comonadic.print comonadic Monadic.print monadic
-
-    let legacy =
-      merge { comonadic = Comonadic.legacy; monadic = Monadic.legacy }
-
-    let meet m0 m1 =
-      let m0 = split m0 in
-      let m1 = split m1 in
-      let monadic = Monadic.meet m0.monadic m1.monadic in
-      let comonadic = Comonadic.meet m0.comonadic m1.comonadic in
-      merge { monadic; comonadic }
-
-    let join m0 m1 =
-      let m0 = split m0 in
-      let m1 = split m1 in
-      let monadic = Monadic.join m0.monadic m1.monadic in
-      let comonadic = Comonadic.join m0.comonadic m1.comonadic in
-      merge { monadic; comonadic }
-
-    module Option = struct
-      type some = t
-
-      type t =
-        ( Locality.Const.t option,
-          Linearity.Const.t option,
-          Uniqueness.Const.t option )
-        modes
-
-      let none = { areality = None; uniqueness = None; linearity = None }
-
-      let value opt ~default =
-        let areality = Option.value opt.areality ~default:default.areality in
-        let uniqueness =
-          Option.value opt.uniqueness ~default:default.uniqueness
-        in
-        let linearity = Option.value opt.linearity ~default:default.linearity in
-        { areality; uniqueness; linearity }
-    end
-
-    let diff m0 m1 =
-      let diff le a0 a1 = if le a0 a1 && le a1 a0 then None else Some a0 in
-      let areality = diff Locality.Const.le m0.areality m1.areality in
-      let linearity = diff Linearity.Const.le m0.linearity m1.linearity in
-      let uniqueness = diff Uniqueness.Const.le m0.uniqueness m1.uniqueness in
-      { areality; linearity; uniqueness }
-
-    (** See [Alloc.close_over] for explanation. *)
-    let close_over m =
-      let { monadic; comonadic } = split m in
-      let comonadic =
-        Comonadic.join comonadic
-          (C.monadic_to_comonadic_min C.Comonadic_with_locality monadic)
-      in
-      let monadic = Monadic.min in
-      merge { comonadic; monadic }
-
-    (** See [Alloc.partial_apply] for explanation. *)
-    let partial_apply m =
-      let { comonadic; _ } = split m in
-      let monadic = Monadic.min in
-      merge { comonadic; monadic }
-
-    let print_axis : type m a d. (m, a, d) axis -> _ -> a -> unit =
-     fun ax ppf a ->
-      let obj = proj_obj ax in
-      C.print obj ppf a
-
-    let split = split
-
-    let merge = merge
-  end
-
-  let meet_const c { comonadic; monadic } =
-    let c = split c in
-    let comonadic = Comonadic.meet_const c.comonadic comonadic in
-    let monadic = Monadic.meet_const c.monadic monadic in
-    { monadic; comonadic }
-
-  let imply c { comonadic; monadic } =
-    let c = split c in
-    let comonadic = Comonadic.imply c.comonadic comonadic in
-    let monadic = Monadic.imply c.monadic monadic in
-    { monadic; comonadic }
-
-  let zap_to_ceil { comonadic; monadic } =
-    let monadic = Monadic.zap_to_ceil monadic in
-    let comonadic = Comonadic.zap_to_ceil comonadic in
-    merge { monadic; comonadic }
-
-  let zap_to_legacy { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy monadic in
-    let comonadic = Comonadic.zap_to_legacy comonadic in
-    merge { monadic; comonadic }
-
-  (** This is about partially applying [A -> B -> C] to [A] and getting [B ->
-    C]. [comonadic] and [monadic] constutute the mode of [A], and we need to
-    give the lower bound mode of [B -> C]. *)
-  let close_over { comonadic; monadic } =
-    let comonadic = Comonadic.disallow_right comonadic in
-    (* The comonadic of the returned function is constrained by the monadic of the closed argument via the dualizing morphism. *)
-    let comonadic1 = monadic_to_comonadic_min monadic in
-    (* It's also constrained by the comonadic of the closed argument. *)
-    let comonadic = Comonadic.join [comonadic; comonadic1] in
-    (* The returned function crosses all monadic axes that we know of
-       (uniqueness/contention). *)
-    let monadic = Monadic.disallow_right Monadic.min in
-    { comonadic; monadic }
-
-  (** Similar to above, but we are given the mode of [A -> B -> C], and need to
-      give the lower bound mode of [B -> C]. *)
-  let partial_apply { comonadic; _ } =
-    (* The returned function crosses all monadic axes that we know of. *)
-    let monadic = Monadic.disallow_right Monadic.min in
-    let comonadic = Comonadic.disallow_right comonadic in
-    { comonadic; monadic }
-
-  module List = struct
-    type nonrec 'd t = 'd t list
-
-    include Magic_allow_disallow (struct
-      type (_, _, 'd) sided = 'd t constraint 'd = 'l * 'r
-
-      let allow_left l = List.map allow_left l
-
-      let allow_right l = List.map allow_right l
-
-      let disallow_left l = List.map disallow_left l
-
-      let disallow_right l = List.map disallow_right l
-    end)
-  end
-end
+module Value = Mode (Regionality)
+module Alloc = Mode (Locality)
 
 module Const = struct
   let alloc_as_value ({ areality; linearity; uniqueness } : Alloc.Const.t) :

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1284,7 +1284,7 @@ let tree_of_modes modes =
   let diff = Mode.Alloc.Const.diff modes Mode.Alloc.Const.legacy in
   (* The mapping passed to [tree_of_mode] must cover all non-legacy modes *)
   let l = [
-    tree_of_mode diff.locality [Mode.Locality.Const.Local, Omd_local];
+    tree_of_mode diff.areality [Mode.Locality.Const.Local, Omd_local];
     tree_of_mode diff.linearity [Mode.Linearity.Const.Once, Omd_once];
     tree_of_mode diff.uniqueness [Mode.Uniqueness.Const.Unique, Omd_unique]]
   in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -8761,7 +8761,7 @@ and type_mode_expr
     submode ~loc ~env ~reason:Other (Value.of_const min) expected_mode;
     let expected_mode = mode_coerce (Value.of_const max) expected_mode in
     let expected_mode =
-      match modes.locality with
+      match modes.areality with
       | Some Local -> mode_strictly_local expected_mode
       | _ -> expected_mode
     in

--- a/ocaml/typing/typemode.ml
+++ b/ocaml/typing/typemode.ml
@@ -20,8 +20,8 @@ let transl_mode_annots modes =
         (* CR zqian: We should interpret other mode names (global, shared, once)
            as well. We can't do that yet because of the CR below. *)
         | "local" -> (
-          match acc.locality with
-          | None -> { acc with locality = Some Local }
+          match acc.areality with
+          | None -> { acc with areality = Some Local }
           | Some _ -> raise (Error (loc, Duplicated_mode Areality)))
         | "unique" -> (
           match acc.uniqueness with


### PR DESCRIPTION
The `Value` and `Alloc` modules in mode.ml seemed very similar. It was not hard to combine them, losing almost 400 lines of code.

Review: @riaqn.