### PR TITLE
Fix call kinds in apply

### DIFF
--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -855,8 +855,7 @@ let simplify_direct_function_call ~simplify_expr dacc apply
 let rebuild_function_call_where_callee's_type_unavailable apply call_kind
     ~use_id ~exn_cont_use_id uacc ~after_rebuild =
   let apply =
-    Apply.with_call_kind apply call_kind
-    |> Simplify_common.update_exn_continuation_extra_args uacc ~exn_cont_use_id
+    Simplify_common.update_exn_continuation_extra_args uacc ~exn_cont_use_id
   in
   let apply =
     Apply.with_inlined_attribute apply
@@ -912,6 +911,7 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
          which function it is. *)
       Call_kind.indirect_function_call_known_arity apply_alloc_mode
   in
+  let apply = Apply_expr.with_call_kind apply call_kind in
   let dacc =
     record_free_names_of_apply_as_used ~use_id ~exn_cont_use_id dacc apply
   in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -852,8 +852,8 @@ let simplify_direct_function_call ~simplify_expr dacc apply
            with %d arguments: %a"
           num_params provided_num_args Apply.print apply
 
-let rebuild_function_call_where_callee's_type_unavailable apply call_kind
-    ~use_id ~exn_cont_use_id uacc ~after_rebuild =
+let rebuild_function_call_where_callee's_type_unavailable apply ~use_id
+    ~exn_cont_use_id uacc ~after_rebuild =
   let apply =
     Simplify_common.update_exn_continuation_extra_args uacc ~exn_cont_use_id
       apply
@@ -918,8 +918,8 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
   in
   down_to_up dacc
     ~rebuild:
-      (rebuild_function_call_where_callee's_type_unavailable apply call_kind
-         ~use_id ~exn_cont_use_id)
+      (rebuild_function_call_where_callee's_type_unavailable apply ~use_id
+         ~exn_cont_use_id)
 
 let simplify_function_call ~simplify_expr dacc apply ~callee_ty
     (call : Call_kind.Function_call.t) ~apply_alloc_mode ~down_to_up =

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -856,6 +856,7 @@ let rebuild_function_call_where_callee's_type_unavailable apply call_kind
     ~use_id ~exn_cont_use_id uacc ~after_rebuild =
   let apply =
     Simplify_common.update_exn_continuation_extra_args uacc ~exn_cont_use_id
+      apply
   in
   let apply =
     Apply.with_inlined_attribute apply


### PR DESCRIPTION
This fix is split off from #2295 . With @Ekdohibs we're still trying to find out what kind of bug was triggered, but in any case, the fix seems sound to me: it makes the computation during `record_free_names_of_apply_as_used` more precise and accurate.