### PR TITLE
Revert "Fix for missing stub inlining in classic mode"

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2220,7 +2220,9 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
   in
   let inlining_decision =
     if Flambda_features.classic_mode ()
-    then Inlining.definition_inlining_decision inline cost_metrics ~stub
+    then Inlining.definition_inlining_decision inline cost_metrics
+    else if stub
+    then Function_decl_inlining_decision_type.Stub
     else Function_decl_inlining_decision_type.Not_yet_decided
   in
   let loopify : Loopify_attribute.t =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -121,21 +121,16 @@ module Inlining = struct
     let magic_scale_constant = 20. in
     int_of_float (inline_threshold *. magic_scale_constant)
 
-  let definition_inlining_decision inline cost_metrics ~stub =
+  let definition_inlining_decision inline cost_metrics =
     let inline_threshold = threshold () in
     let code_size = Cost_metrics.size cost_metrics in
     match (inline : Inline_attribute.t) with
     | Never_inline ->
       Function_decl_inlining_decision_type.Never_inline_attribute
-    | Always_inline -> Function_decl_inlining_decision_type.Attribute_inline
-    | Available_inline ->
-      if stub
-      then Function_decl_inlining_decision_type.Stub
-      else Function_decl_inlining_decision_type.Attribute_inline
+    | Always_inline | Available_inline ->
+      Function_decl_inlining_decision_type.Attribute_inline
     | Unroll _ | Default_inline ->
-      if stub
-      then Function_decl_inlining_decision_type.Stub
-      else if Code_size.to_int code_size <= inline_threshold
+      if Code_size.to_int code_size <= inline_threshold
       then
         Function_decl_inlining_decision_type.Small_function
           { size = code_size;
@@ -426,10 +421,9 @@ module Acc = struct
                 Inlining.definition_inlining_decision
                   (Code_metadata.inline metadata)
                   (Code_metadata.cost_metrics metadata)
-                  ~stub:(Code_metadata.stub metadata)
               with
-              | Attribute_inline | Small_function _ | Stub -> approx
-              | Not_yet_decided | Never_inline_attribute | Recursive
+              | Attribute_inline | Small_function _ -> approx
+              | Not_yet_decided | Never_inline_attribute | Stub | Recursive
               | Function_body_too_large _ | Speculatively_inlinable _
               | Functor _ ->
                 Value_approximation.Closure_approximation

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -100,7 +100,6 @@ module Inlining : sig
   val definition_inlining_decision :
     Inline_attribute.t ->
     Cost_metrics.t ->
-    stub:bool ->
     Function_decl_inlining_decision_type.t
 end
 


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#2545

Increases artifact sizes. Reverting for now to further investigate.