### PR TITLE
Non-null objects and misc

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -60,10 +60,10 @@ let f: ('a : void) -> 'b = fun x -> x # baz
 Line 1, characters 36-37:
 1 | let f: ('a : void) -> 'b = fun x -> x # baz
                                         ^
-Error: Object types must have layout value.
+Error: Object types must have layout non_null_value.
        The layout of the type of this expression is void, because
          of the annotation on the type variable 'a.
-       But the layout of the type of this expression must overlap with value, because
+       But the layout of the type of this expression must overlap with non_null_value, because
          it's the type of an object.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts-non-null-value/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-non-null-value/basics.ml
@@ -288,15 +288,7 @@ let _ = id_non_null_value (lazy 3)
 ;;
 
 [%%expect{|
-Line 1, characters 26-34:
-1 | let _ = id_non_null_value (lazy 3)
-                              ^^^^^^^^
-Error: This expression has type 'a lazy_t
-       but an expression was expected of type ('b : non_null_value)
-       The layout of 'a lazy_t is value, because
-         it is the primitive value type lazy_t.
-       But the layout of 'a lazy_t must be a sublayout of non_null_value, because
-         of the definition of id_non_null_value at line 3, characters 4-21.
+- : int lazy_t = lazy 3
 |}]
 
 (* Unboxed types are not values, so they are not non-null. *)

--- a/ocaml/testsuite/tests/typing-layouts-non-null-value/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-non-null-value/basics.ml
@@ -264,22 +264,11 @@ let _ = id_non_null_value (module M1 : S1)
 module type S1 = sig val bar : float# -> int end
 - : (module S1) = <module>
 |}]
-
-(* CR layouts v3.0: objects should be non-null. *)
-
 let _ = id_non_null_value (object val foo = () end)
 ;;
 
 [%%expect{|
-Line 1, characters 26-51:
-1 | let _ = id_non_null_value (object val foo = () end)
-                              ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type <  > but an expression was expected of type
-         ('a : non_null_value)
-       The layout of <  > is value, because
-         it's the type of an object.
-       But the layout of <  > must be a sublayout of non_null_value, because
-         of the definition of id_non_null_value at line 3, characters 4-21.
+- : <  > = <obj>
 |}]
 
 (* CR layouts v3.0: [lazy_t] should be non-null. *)

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -871,10 +871,10 @@ end;;
 Line 5, characters 4-7:
 5 |     t.v # baz11
         ^^^
-Error: Object types must have layout value.
+Error: Object types must have layout non_null_value.
        The layout of the type of this expression is void, because
          of the definition of t at line 2, characters 2-42.
-       But the layout of the type of this expression must overlap with value, because
+       But the layout of the type of this expression must overlap with non_null_value, because
          it's the type of an object.
 |}]
 

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2114,9 +2114,9 @@ let rec estimate_type_jkind env ty =
   | Tvar { jkind } -> TyVar (jkind, ty)
   | Tarrow _ -> Jkind (non_null_value ~why:Arrow)
   | Ttuple _ -> Jkind (non_null_value ~why:Tuple)
-  | Tobject _ -> Jkind (value ~why:Object)
-  | Tfield _ -> Jkind (value ~why:Tfield)
-  | Tnil -> Jkind (value ~why:Tnil)
+  | Tobject _ -> Jkind (non_null_value ~why:Object)
+  | Tfield _ -> Jkind (non_null_value ~why:Tfield)
+  | Tnil -> Jkind (non_null_value ~why:Tnil)
   | (Tlink _ | Tsubst _) -> assert false
   | Tunivar { jkind } -> Jkind jkind
   | Tpoly (ty, _) -> estimate_type_jkind env ty
@@ -4223,7 +4223,7 @@ let filter_method env name ty =
       let scope = get_scope ty in
       let ty', ty_meth = object_type ~level ~scope in
       begin match
-        constrain_type_jkind env ty (Jkind.value ~why:Object)
+        constrain_type_jkind env ty (Jkind.non_null_value ~why:Object)
       with
       | Ok _ -> ()
       | Error err -> raise (Filter_method_failed (Not_a_value err))
@@ -4522,7 +4522,7 @@ let generalize_class_signature_spine env sign =
   (* But keep levels correct on the type of self *)
   Meths.iter
     (fun _ (_, _, ty) ->
-       unify_var env (newvar (Jkind.value ~why:Object)) ty)
+       unify_var env (newvar (Jkind.value ~why:Object_field)) ty)
     meths;
   sign.csig_meths <- new_meths
 
@@ -5815,7 +5815,7 @@ let rec build_subtype env (visited : transient_expr list)
       else (t, Unchanged)
   | Tnil ->
       if posi then
-        let v = newvar (Jkind.value ~why:Tnil) in
+        let v = newvar (Jkind.non_null_value ~why:Tnil) in
         (v, Changed)
       else begin
         warn := true;

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -943,7 +943,6 @@ end = struct
   let format_value_creation_reason ppf : value_creation_reason -> _ = function
     | Tuple_element -> fprintf ppf "it's the type of a tuple element"
     | Probe -> format_with_notify_js ppf "it's a probe"
-    | Object -> fprintf ppf "it's the type of an object"
     | Instance_variable -> fprintf ppf "it's the type of an instance variable"
     | Object_field -> fprintf ppf "it's the type of an object field"
     | Class_field -> fprintf ppf "it's the type of a class field"
@@ -954,12 +953,6 @@ end = struct
         (format_position ~arity position)
         !printtyp_path parent_path
     | Row_variable -> format_with_notify_js ppf "it's a row variable"
-    | Tfield ->
-      format_with_notify_js ppf
-        "it's an internal Tfield type (you shouldn't see this)"
-    | Tnil ->
-      format_with_notify_js ppf
-        "it's an internal Tnil type (you shouldn't see this)"
     | Separability_check ->
       fprintf ppf "the check that a type is definitely not `float`"
     | Univar ->
@@ -1017,6 +1010,13 @@ end = struct
         (format_position ~arity position)
         !printtyp_path parent_path
         (Legacy.string_of_const Non_null_value)
+    | Object -> fprintf ppf "it's the type of an object"
+    | Tfield ->
+      format_with_notify_js ppf
+        "it's an internal Tfield type (you shouldn't see this)"
+    | Tnil ->
+      format_with_notify_js ppf
+        "it's an internal Tnil type (you shouldn't see this)"
 
   let format_float64_creation_reason ppf : float64_creation_reason -> _ =
     function
@@ -1381,7 +1381,6 @@ module Debug_printers = struct
   let value_creation_reason ppf : value_creation_reason -> _ = function
     | Tuple_element -> fprintf ppf "Tuple_element"
     | Probe -> fprintf ppf "Probe"
-    | Object -> fprintf ppf "Object"
     | Instance_variable -> fprintf ppf "Instance_variable"
     | Object_field -> fprintf ppf "Object_field"
     | Class_field -> fprintf ppf "Class_field"
@@ -1390,8 +1389,6 @@ module Debug_printers = struct
       fprintf ppf "Type_argument (pos %d, arity %d) of %a" position arity
         !printtyp_path parent_path
     | Row_variable -> fprintf ppf "Row_variable"
-    | Tfield -> fprintf ppf "Tfield"
-    | Tnil -> fprintf ppf "Tnil"
     | Separability_check -> fprintf ppf "Separability_check"
     | Univar -> fprintf ppf "Univar"
     | Polymorphic_variant_field -> fprintf ppf "Polymorphic_variant_field"
@@ -1421,6 +1418,9 @@ module Debug_printers = struct
     | Type_argument { parent_path; position; arity } ->
       fprintf ppf "Type_argument (pos %d, arity %d) of %a" position arity
         !printtyp_path parent_path
+    | Object -> fprintf ppf "Object"
+    | Tnil -> fprintf ppf "Tnil"
+    | Tfield -> fprintf ppf "Tfield"
 
   let float64_creation_reason ppf : float64_creation_reason -> _ = function
     | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -941,8 +941,6 @@ end = struct
       fprintf ppf "the check that a type is definitely not `float`"
 
   let format_value_creation_reason ppf : value_creation_reason -> _ = function
-    | Class_let_binding ->
-      fprintf ppf "it's the type of a let-bound variable in a class expression"
     | Tuple_element -> fprintf ppf "it's the type of a tuple element"
     | Probe -> format_with_notify_js ppf "it's a probe"
     | Object -> fprintf ppf "it's the type of an object"
@@ -1381,7 +1379,6 @@ module Debug_printers = struct
     | Separability_check -> fprintf ppf "Separability_check"
 
   let value_creation_reason ppf : value_creation_reason -> _ = function
-    | Class_let_binding -> fprintf ppf "Class_let_binding"
     | Tuple_element -> fprintf ppf "Tuple_element"
     | Probe -> fprintf ppf "Probe"
     | Object -> fprintf ppf "Object"

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -171,7 +171,6 @@ module History = struct
     | With_error_message of string * annotation_context
 
   type value_creation_reason =
-    | Class_let_binding
     | Tuple_element
     | Probe
     | Object

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -173,7 +173,6 @@ module History = struct
   type value_creation_reason =
     | Tuple_element
     | Probe
-    | Object
     | Instance_variable
     | Object_field
     | Class_field
@@ -185,8 +184,6 @@ module History = struct
         }
     (* [position] is 1-indexed *)
     | Row_variable
-    | Tfield
-    | Tnil
     | Separability_check
     | Univar
     | Polymorphic_variant_field
@@ -217,7 +214,10 @@ module History = struct
           position : int;
           arity : int
         }
-  (* [position] is 1-indexed *)
+    (* [position] is 1-indexed *)
+    | Object
+    | Tfield
+    | Tnil
 
   type immediate_creation_reason =
     | Empty_record

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -339,7 +339,6 @@ let build_initial_env add_type add_extension empty_env =
   |> add_type1 ident_lazy_t
        ~variance:Variance.covariant
        ~separability:Separability.Ind
-       ~jkind:(Jkind.value ~why:(Primitive ident_lazy_t))
   |> add_type1 ident_list
        ~variance:Variance.covariant
        ~separability:Separability.Ind

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1566,7 +1566,7 @@ let rec approx_declaration cl =
       approx_declaration cl
   | Pcl_constraint (cl, _) ->
       approx_declaration cl
-  | _ -> Ctype.newvar (Jkind.value ~why:Object)
+  | _ -> Ctype.newvar (Jkind.non_null_value ~why:Object)
 
 let rec approx_description ct =
   match ct.pcty_desc with
@@ -1582,7 +1582,7 @@ let rec approx_description ct =
       let arrow_desc = l, Mode.Alloc.legacy, Mode.Alloc.legacy in
       Ctype.newty
         (Tarrow (arrow_desc, arg, approx_description ct, commu_ok))
-  | _ -> Ctype.newvar (Jkind.value ~why:Object)
+  | _ -> Ctype.newvar (Jkind.non_null_value ~why:Object)
 
 (*******************************)
 
@@ -1593,12 +1593,12 @@ let temp_abbrev loc id arity uid =
       Type_argument {parent_path = Path.Pident id; position = i; arity})
     ) :: !params
   done;
-  let ty = Ctype.newobj (Ctype.newvar (Jkind.value ~why:Object)) in
+  let ty = Ctype.newobj (Ctype.newvar (Jkind.non_null_value ~why:Object)) in
   let ty_td =
       {type_params = !params;
        type_arity = arity;
        type_kind = Type_abstract Abstract_def;
-       type_jkind = Jkind.value ~why:Object;
+       type_jkind = Jkind.non_null_value ~why:Object;
        type_jkind_annotation = None;
        type_private = Public;
        type_manifest = Some ty;
@@ -1829,7 +1829,7 @@ let class_infos define_class kind
      type_params = obj_params;
      type_arity = arity;
      type_kind = Type_abstract Abstract_def;
-     type_jkind = Jkind.value ~why:Object;
+     type_jkind = Jkind.non_null_value ~why:Object;
      type_jkind_annotation = None;
      type_private = Public;
      type_manifest = Some obj_ty;

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -2904,7 +2904,7 @@ let type_self_pattern env spat =
   let open Ast_helper in
   let spat = Pat.mk(Ppat_alias (spat, mknoloc "selfpat-*")) in
   let tps = create_type_pat_state Modules_rejected in
-  let nv = newvar (Jkind.value ~why:Object) in
+  let nv = newvar (Jkind.non_null_value ~why:Object) in
   let alloc_mode = simple_pat_mode Value.legacy in
   let pat =
     type_pat tps Value ~no_existentials:In_self_pattern ~alloc_mode
@@ -9828,7 +9828,8 @@ let report_error ~loc env = function
     ) ()
   | Not_a_value (err, explanation) ->
     Location.error_of_printer ~loc (fun ppf () ->
-      fprintf ppf "Object types must have layout value.@ %a"
+      fprintf ppf "Object types must have layout %s.@ %a"
+        (Jkind.string_of_const Non_null_value)
         (Jkind.Violation.report_with_name ~name:"the type of this expression")
         err;
       report_type_expected_explanation_opt explanation ppf)


### PR DESCRIPTION
Mark `lazy_t` as non-null: we have not figured out the runtime interactions between `lazy_t` and `or_null` yet, but this should be our design goal for backward compatibility.

Remove `Class_let_binding` from the list of value creation reasons -- it is never used.

Make objects non-null. To achieve this, I also move `Tfield` and `Tnil` to `non_null_value_creation_reason`.

`generalize_class_signature_spine` in `ctype.ml` had this code for checking class methods:

```
  (* But keep levels correct on the type of self *)
  Meths.iter
    (fun _ (_, _, ty) ->
       unify_var env (newvar (Jkind.value ~why:Object)) ty)
    meths;
  sign.csig_meths <- new_meths
  ```
I had to change `~why:` to `Object_fields` to let objects have nullable fields. I assume `Object_fields` was intended all along.