### PR TITLE
Fix `--enable-dev`

### DIFF
--- a/ocaml/otherlibs/systhreads4/byte/dune
+++ b/ocaml/otherlibs/systhreads4/byte/dune
@@ -1,19 +1,21 @@
 (copy_files# ../*.{c,h,ml,mli})
 
 (library
-  (name threads)
-  (modes byte)
-  (wrapped false)
-  ; FIXME Fix warning 27
+ (name threads)
+ (modes byte)
+ (wrapped false)
+ ; FIXME Fix warning 27 and -no-strict-sequence
+ (flags
+  (:standard -no-strict-sequence -g -bin-annot -safe-string -w -27))
+ (ocamlopt_flags
+  (:include %{project_root}/ocamlopt_flags.sexp))
+ (libraries unix)
+ (library_flags -linkall)
+ (c_library_flags -lpthread)
+ (foreign_stubs
+  (language c)
+  (names st_stubs)
   (flags
-   (:standard -g -bin-annot -safe-string -w -27))
-  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
-  (libraries unix)
-  (library_flags -linkall)
-  (c_library_flags -lpthread)
-  (foreign_stubs
-    (language c)
-    (names st_stubs)
-    (flags ((:include %{project_root}/oc_cflags.sexp)
-            (:include %{project_root}/sharedlib_cflags.sexp)
-            (:include %{project_root}/oc_cppflags.sexp)))))
+   ((:include %{project_root}/oc_cflags.sexp)
+    (:include %{project_root}/sharedlib_cflags.sexp)
+    (:include %{project_root}/oc_cppflags.sexp)))))

--- a/ocaml/otherlibs/systhreads4/native/dune
+++ b/ocaml/otherlibs/systhreads4/native/dune
@@ -1,20 +1,22 @@
 (copy_files# ../*.{c,h,ml,mli})
 
 (library
-  (name threadsnat)
-  (modes native)
-  (wrapped false)
-  ; FIXME Fix warning 27
+ (name threadsnat)
+ (modes native)
+ (wrapped false)
+ ; FIXME Fix warning 27 and -no-strict-sequence
+ (flags
+  (:standard -no-strict-sequence -g -bin-annot -safe-string -w -27))
+ (ocamlopt_flags
+  (:include %{project_root}/ocamlopt_flags.sexp))
+ (libraries unix)
+ (library_flags -linkall)
+ (c_library_flags -lpthread)
+ (foreign_stubs
+  (language c)
+  (names st_stubs)
   (flags
-   (:standard -g -bin-annot -safe-string -w -27))
-  (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
-  (libraries unix)
-  (library_flags -linkall)
-  (c_library_flags -lpthread)
-  (foreign_stubs
-    (language c)
-    (names st_stubs)
-    (flags ((-DNATIVE_CODE)
-            (:include %{project_root}/oc_cflags.sexp)
-            (:include %{project_root}/sharedlib_cflags.sexp)
-            (:include %{project_root}/oc_cppflags.sexp)))))
+   ((-DNATIVE_CODE)
+    (:include %{project_root}/oc_cflags.sexp)
+    (:include %{project_root}/sharedlib_cflags.sexp)
+    (:include %{project_root}/oc_cppflags.sexp)))))


### PR DESCRIPTION
Fix compilation of `systhreads4` with `--enable-dev` set. The dev build profile includes the `-strict-sequence` flag by default, which we disable with `-no-strict-sequence`.

Tested manually with `--enable-dev`.

Also reformat the dune file to be consistent with VSCode formatting.