### PR TITLE
Fix labeled tuple pattern location in parser, again.

### DIFF
--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -3529,10 +3529,12 @@ pattern_no_exn:
       { let loc = $loc(label) in
         Some label, mkpatvar ~loc label }
   | TILDE LPAREN label = LIDENT COLON cty = core_type RPAREN %prec COMMA
-      { let loc = $loc(label) in
-        let pat = mkpatvar ~loc label in
-        Some label, mkpat_opt_constraint ~loc pat (Some cty) }
+      { let lbl_loc = $loc(label) in
+        let pat_loc = $startpos($2), $endpos in
+        let pat = mkpatvar ~loc:lbl_loc label in
+        Some label, mkpat_opt_constraint ~loc:pat_loc pat (Some cty) }
 
+(* If changing this, don't forget to change its copy just above. *)
 %inline labeled_tuple_pat_element_noprec(self):
   | self { None, $1 }
   | LABEL simple_pattern


### PR DESCRIPTION
#2399 fixed a bug with the locations of non-initial components of labeled tuple patterns when they are punned and have type annotations.  This fixes the same bug again, in the other copy of the pattern parser for labeled tuples.  Why are there two copies?  Boring reasons to do with limitations of menhir.  I've added a comment to hopefully prevent this kind of mistake in the future.