### PR TITLE
Add a dev-mode CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ jobs:
             config: --enable-middle-end=flambda2 --enable-runtime5
             os: ubuntu-latest
 
+          - name: flambda2_dev
+            config: --enable-middle-end=flambda2 --enable-dev
+            os: ubuntu-latest
+
           - name: flambda2_debug_runtime5
             config: --enable-middle-end=flambda2 --enable-runtime5
             os: ubuntu-latest


### PR DESCRIPTION
Adds a CI action that builds the compiler and runs tests with `--enable-dev`.

This checks that a PR doesn't break our local build configuration.