### PR TITLE
Fix `tests/` with `--enable-dev`

### DIFF
--- a/tests/backend/caml_apply_split_max_arity/t.ml
+++ b/tests/backend/caml_apply_split_max_arity/t.ml
@@ -19,7 +19,7 @@ let split_with_tailcall ?x1:_ ?x2:_ ?x3:_ ?x4:_ ?x5:_ ?x6:_ ?x7:_ ?x8:_ ?x9:_ ?x
   = ()
 ;;
 
-let go x =
+let _go x =
   let (_ : _) = Some x in
   (Sys.opaque_identity split_with_tailcall) ()
 ;;

--- a/tests/simd/arrays.ml
+++ b/tests/simd/arrays.ml
@@ -1,5 +1,6 @@
-
 open Stdlib
+
+[@@@ocaml.warning "-37-32-35"]
 
 external int8x16_of_int64s : int64 -> int64 -> int8x16 = "" "vec128_of_int64s" [@@noalloc] [@@unboxed]
 external int8x16_low_int64 : int8x16 -> int64 = "" "vec128_low_int64" [@@noalloc] [@@unboxed]

--- a/tests/simd/arrays.ml
+++ b/tests/simd/arrays.ml
@@ -1,6 +1,6 @@
 open Stdlib
 
-[@@@ocaml.warning "-37-32-35"]
+[@@@ocaml.warning "-unused-value-declaration"]
 
 external int8x16_of_int64s : int64 -> int64 -> int8x16 = "" "vec128_of_int64s" [@@noalloc] [@@unboxed]
 external int8x16_low_int64 : int8x16 -> int64 = "" "vec128_low_int64" [@@noalloc] [@@unboxed]

--- a/tests/simd/consts.ml
+++ b/tests/simd/consts.ml
@@ -16,7 +16,6 @@ let eqi lv hv l h =
 ;;
 
 let eqf lv hv l h =
-    let open Float in
     if l <> lv then Printf.printf "%f <> %f\n" l lv;
     if h <> hv then Printf.printf "%f <> %f\n" h hv
 ;;

--- a/tests/simd/ops.ml
+++ b/tests/simd/ops.ml
@@ -1,5 +1,7 @@
 open Stdlib
 
+[@@@ocaml.warning "-37-32-35"]
+
 let failmsg = ref (fun () -> ())
 
 let eq lv hv l h =
@@ -21,10 +23,15 @@ let eqi lv hv l h =
 ;;
 
 let eqf lv hv l h =
-    let open Float in
     if l <> lv then Printf.printf "%f <> %f\n" l lv;
     if h <> hv then Printf.printf "%f <> %f\n" h hv;
     if l <> lv || h <> hv then !failmsg ()
+;;
+
+let eqf' lv l =
+    let fail = lv <> l && not (Float.is_nan lv && Float.is_nan l) in
+    if fail then Printf.printf "%f <> %f\n" l lv;
+    if fail then !failmsg ()
 ;;
 
 external int64x2_of_int64s : int64 -> int64 -> int64x2 = "caml_vec128_unreachable" "vec128_of_int64s" [@@noalloc] [@@unboxed]
@@ -424,10 +431,10 @@ module Float64 = struct
             [@@noalloc] [@@builtin]
 
         let () =
-            check_floats (fun l r -> eqf (max l r) (c_max l r));
-            check_floats (fun l r -> eqf (min l r) (c_min l r));
-            check_floats (fun l _ -> eqf (sqrt l) (c_sqrt l));
-            check_floats (fun l _ -> eqf (round 0x8 l) (c_round l))
+            check_floats (fun l r -> eqf' (max l r) (c_max l r));
+            check_floats (fun l r -> eqf' (min l r) (c_min l r));
+            check_floats (fun l _ -> eqf' (sqrt l) (c_sqrt l));
+            check_floats (fun l _ -> eqf' (round 0x8 l) (c_round l))
         ;;
     end
 end

--- a/tests/simd/ops.ml
+++ b/tests/simd/ops.ml
@@ -1,6 +1,6 @@
 open Stdlib
 
-[@@@ocaml.warning "-37-32-35"]
+[@@@ocaml.warning "-unused-value-declaration"]
 
 let failmsg = ref (fun () -> ())
 
@@ -371,7 +371,7 @@ module Float32 = struct
         f maxv maxv;
         f minv minv;
         f maxv minv;
-        for i = 0 to 100_000 do
+        for _ = 0 to 100_000 do
             let f0 = Random.int32 Int32.max_int in
             let f1 = Random.int32 Int32.max_int in
             f (if Random.bool () then f0 else Int32.neg f0)
@@ -415,7 +415,7 @@ module Float64 = struct
         f max_float max_float;
         f min_float min_float;
         f max_float min_float;
-        for i = 0 to 100_000 do
+        for _ = 0 to 100_000 do
             let f0 = Random.int64 Int64.max_int in
             let f1 = Random.int64 Int64.max_int in
             f (if Random.bool () then Int64.float_of_bits f0 else Int64.(neg f0 |> float_of_bits))
@@ -456,7 +456,7 @@ module Int64s = struct
         f max_int max_int;
         f min_int min_int;
         f max_int min_int;
-        for i = 0 to 100_000 do
+        for _ = 0 to 100_000 do
             let i0 = Random.int64 Int64.max_int in
             let i1 = Random.int64 Int64.max_int in
             f (if Random.bool () then i0 else Int64.neg i0)
@@ -500,7 +500,7 @@ module Int32s = struct
         f max_int max_int;
         f min_int min_int;
         f max_int min_int;
-        for i = 0 to 100_000 do
+        for _ = 0 to 100_000 do
             let i0 = Random.int32 Int32.max_int in
             let i1 = Random.int32 Int32.max_int in
             f (if Random.bool () then i0 else Int32.neg i0)
@@ -606,7 +606,7 @@ module Int16 = struct
         f max_int max_int;
         f min_int min_int;
         f max_int min_int;
-        for i = 0 to 100_000 do
+        for _ = 0 to 100_000 do
             let i0 = Random.int 0x10000 in
             let i1 = Random.int 0x10000 in
             f (if Random.bool () then i0 else (-i0))

--- a/tests/simd/scalar_ops.ml
+++ b/tests/simd/scalar_ops.ml
@@ -1,5 +1,5 @@
 
-[@@@ocaml.warning "-37-32-35"]
+[@@@ocaml.warning "-unused-value-declaration"]
 
 external int64x2_of_int64s : int64 -> int64 -> int64x2 = "caml_vec128_unreachable" "vec128_of_int64s" [@@noalloc] [@@unboxed]
 external int64x2_low_int64 : int64x2 -> int64 = "caml_vec128_unreachable" "vec128_low_int64" [@@noalloc] [@@unboxed]
@@ -79,7 +79,7 @@ module Int = struct
       eqi (f minus_one) (g minus_one);
       eqi (f max_int) (g max_int);
       eqi (f min_int) (g min_int);
-      for i = 0 to 100_000 do
+      for _ = 0 to 100_000 do
           let i = Random.full_int max_int in
           let i = if Random.bool () then i else neg i in
           eqi (f i) (g i)
@@ -173,7 +173,7 @@ module Int64 = struct
       eqi (f minus_one) (g minus_one);
       eqi (f max_int) (g max_int);
       eqi (f min_int) (g min_int);
-      for i = 0 to 100_000 do
+      for _ = 0 to 100_000 do
           let i = Random.int64 max_int in
           let i = if Random.bool () then i else neg i in
           if not nz || i <> 0L then eqi (f i) (g i);
@@ -252,7 +252,7 @@ module Int32 = struct
       eqi (f minus_one) (g minus_one);
       eqi (f max_int) (g max_int);
       eqi (f min_int) (g min_int);
-      for i = 0 to 100_000 do
+      for _ = 0 to 100_000 do
           let i = Random.int32 max_int in
           let i = if Random.bool () then i else neg i in
           if not nz || i <> 0l then eqi (f i) (g i);

--- a/tests/simd/scalar_ops.ml
+++ b/tests/simd/scalar_ops.ml
@@ -1,4 +1,6 @@
 
+[@@@ocaml.warning "-37-32-35"]
+
 external int64x2_of_int64s : int64 -> int64 -> int64x2 = "caml_vec128_unreachable" "vec128_of_int64s" [@@noalloc] [@@unboxed]
 external int64x2_low_int64 : int64x2 -> int64 = "caml_vec128_unreachable" "vec128_low_int64" [@@noalloc] [@@unboxed]
 external int64x2_high_int64 : int64x2 -> int64 = "caml_vec128_unreachable" "vec128_high_int64" [@@noalloc] [@@unboxed]

--- a/tests/small_numbers/float32.ml
+++ b/tests/small_numbers/float32.ml
@@ -1,6 +1,6 @@
 open Stdlib
 
-[@@@ocaml.warning "-37-32-35"]
+[@@@ocaml.warning "-unused-constructor"]
 
 let eq l r =
   if l <> r then Printf.printf "%d <> %d\n" l r
@@ -127,7 +127,7 @@ module CFloat32 = struct
       f maxv maxv;
       f minv minv;
       f maxv minv;
-      for i = 0 to 100_000 do
+      for _ = 0 to 100_000 do
           let f0 = Random.int32 Int32.max_int in
           let f1 = Random.int32 Int32.max_int in
           f ((if Random.bool () then f0 else Int32.neg f0) |> Int32.float_of_bits |> Beta.Float32.of_float)
@@ -149,7 +149,7 @@ module Float64 = struct
     f nan;
     f max_float;
     f min_float;
-    for i = 0 to 100_000 do
+    for _ = 0 to 100_000 do
         let v = Random.int64 Int64.max_int in
         f ((if Random.bool () then v else Int64.neg v) |> Int64.float_of_bits)
     done
@@ -165,7 +165,7 @@ module Int = struct
     f minus_one;
     f max_int;
     f min_int;
-    for i = 0 to 100_000 do
+    for _ = 0 to 100_000 do
         let i = Random.int64 Int64.max_int |> Int64.to_int in
         f (if Random.bool () then i else Int.neg i)
     done

--- a/tests/small_numbers/float32.ml
+++ b/tests/small_numbers/float32.ml
@@ -1,5 +1,7 @@
 open Stdlib
 
+[@@@ocaml.warning "-37-32-35"]
+
 let eq l r =
   if l <> r then Printf.printf "%d <> %d\n" l r
 ;;

--- a/tests/small_numbers/float32_builtin.ml
+++ b/tests/small_numbers/float32_builtin.ml
@@ -1,6 +1,7 @@
 open Stdlib
 
-[@@@ocaml.warning "-37-32-35"]
+[@@@ocaml.warning "-unused-constructor"]
+[@@@ocaml.warning "-unused-value-declaration"]
 
 let eq l r =
   if l <> r then Printf.printf "%d <> %d\n" l r
@@ -127,7 +128,7 @@ module CFloat32 = struct
       f maxv maxv;
       f minv minv;
       f maxv minv;
-      for i = 0 to 100_000 do
+      for _ = 0 to 100_000 do
           let f0 = Random.int32 Int32.max_int in
           let f1 = Random.int32 Int32.max_int in
           f ((if Random.bool () then f0 else Int32.neg f0) |> Int32.float_of_bits |> Float32.of_float)
@@ -149,7 +150,7 @@ module Float64 = struct
     f nan;
     f max_float;
     f min_float;
-    for i = 0 to 100_000 do
+    for _ = 0 to 100_000 do
         let v = Random.int64 Int64.max_int in
         f ((if Random.bool () then v else Int64.neg v) |> Int64.float_of_bits)
     done
@@ -165,7 +166,7 @@ module Int = struct
     f minus_one;
     f max_int;
     f min_int;
-    for i = 0 to 100_000 do
+    for _ = 0 to 100_000 do
         let i = Random.int64 Int64.max_int |> Int64.to_int in
         f (if Random.bool () then i else Int.neg i)
     done

--- a/tests/small_numbers/float32_builtin.ml
+++ b/tests/small_numbers/float32_builtin.ml
@@ -1,5 +1,7 @@
 open Stdlib
 
+[@@@ocaml.warning "-37-32-35"]
+
 let eq l r =
   if l <> r then Printf.printf "%d <> %d\n" l r
 ;;
@@ -206,13 +208,13 @@ let () = (* Compare *)
     CFloat32.check_float32s (fun f1 f2 ->
       let no_nan = (not (CFloat32.is_nan f1)) && (not (CFloat32.is_nan f2)) in
       if no_nan then (
-        (match Float32.compare f1 f2 with
+        (match compare f1 f2 with
         | -1 -> assert (CFloat32.lt f1 f2)
         | 0 -> assert (CFloat32.eq f1 f2)
         | 1 -> assert (CFloat32.gt f1 f2)
         | _ -> assert false);
         let f2, f1 = f1, f2 in
-        (match Float32.compare f1 f2 with
+        (match compare f1 f2 with
         | -1 -> assert (CFloat32.lt f1 f2)
         | 0 -> assert (CFloat32.eq f1 f2)
         | 1 -> assert (CFloat32.gt f1 f2)
@@ -225,16 +227,16 @@ let () = (* Compare *)
         assert (CFloat32.ngt f1 f2);
         assert (CFloat32.nge f1 f2);
         if CFloat32.is_nan f1 && CFloat32.is_nan f2 then (
-          assert (Float32.compare f1 f2 = 0)
+          assert (compare f1 f2 = 0)
         );
         if CFloat32.is_nan f1 && not (CFloat32.is_nan f2) then (
-          assert (Float32.compare f1 f2 = -1);
-          assert (Float32.compare f2 f1 = 1)
+          assert (compare f1 f2 = -1);
+          assert (compare f2 f1 = 1)
         );
         let f2, f1 = f1, f2 in
         if CFloat32.is_nan f1 && not (CFloat32.is_nan f2) then (
-          assert (Float32.compare f1 f2 = -1);
-          assert (Float32.compare f2 f1 = 1)
+          assert (compare f1 f2 = -1);
+          assert (compare f2 f1 = 1)
         )
       )
     )

--- a/tests/small_numbers/float32_lib.ml
+++ b/tests/small_numbers/float32_lib.ml
@@ -1,4 +1,6 @@
 
+[@@@ocaml.warning "-37-32-35"]
+
 (* Tests for the float32 otherlib  *)
 
 module F32 = Beta.Float32

--- a/tests/small_numbers/float32_lib.ml
+++ b/tests/small_numbers/float32_lib.ml
@@ -1,5 +1,5 @@
 
-[@@@ocaml.warning "-37-32-35"]
+[@@@ocaml.warning "-unused-value-declaration"]
 
 (* Tests for the float32 otherlib  *)
 
@@ -135,7 +135,7 @@ module CF32 = struct
       f maxv maxv;
       f minv minv;
       f maxv minv;
-      for i = 0 to 100_000 do
+      for _ = 0 to 100_000 do
           let f0 = Random.int32 Int32.max_int in
           let f1 = Random.int32 Int32.max_int in
           f ((if Random.bool () then f0 else Int32.neg f0) |> Int32.float_of_bits |> Beta.Float32.of_float)

--- a/tests/small_numbers/float32_u_lib.ml
+++ b/tests/small_numbers/float32_u_lib.ml
@@ -1,5 +1,5 @@
 
-[@@@ocaml.warning "-37-32-35"]
+[@@@ocaml.warning "-unused-value-declaration"]
 
 (* Tests for the float32 otherlib  *)
 
@@ -140,7 +140,7 @@ module CF32 = struct
       f maxv maxv;
       f minv minv;
       f maxv minv;
-      for i = 0 to 100_000 do
+      for _ = 0 to 100_000 do
           let f0 = Random.int32 Int32.max_int in
           let f1 = Random.int32 Int32.max_int in
           f ((if Random.bool () then f0 else Int32.neg f0) |> Int32.float_of_bits |> Beta.Float32.of_float)

--- a/tests/small_numbers/float32_u_lib.ml
+++ b/tests/small_numbers/float32_u_lib.ml
@@ -1,4 +1,6 @@
 
+[@@@ocaml.warning "-37-32-35"]
+
 (* Tests for the float32 otherlib  *)
 
 module F32 = Beta.Float32_u


### PR DESCRIPTION
Configuring with `--enable-dev` turns on strict sequence and various compiler warnings, causing these tests to fail.