### PR TITLE
Add [Deleted_code] case for code ids in set of closures.

### DIFF
--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -44,6 +44,8 @@ val infix_header : int -> nativeint
 
 val black_custom_header : size:int -> nativeint
 
+val pack_closure_info : arity:int -> startenv:int -> is_last:bool -> nativeint
+
 (** Closure info for a closure of given arity and distance to environment *)
 val closure_info : arity:arity -> startenv:int -> is_last:bool -> nativeint
 

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -252,7 +252,12 @@ let subst_primitive env (p : Flambda_primitive.t) : Flambda_primitive.t =
     Unary (subst_unary_primitive env unary_primitive, subst_simple env arg)
   | _ -> p
 
-let subst_func_decl env code_id = subst_code_id env code_id
+let subst_func_decl env
+    (code_id : Function_declarations.code_id_in_function_declaration) :
+    Function_declarations.code_id_in_function_declaration =
+  match code_id with
+  | Deleted -> Deleted
+  | Code_id code_id -> Code_id (subst_code_id env code_id)
 
 let subst_func_decls env decls =
   Function_declarations.funs_in_order decls
@@ -708,10 +713,17 @@ let primitives env prim1 prim2 : Flambda_primitive.t Comparison.t =
   | _, _ -> Different { approximant = subst_primitive env prim1 }
 
 (* Returns unit because the approximant isn't used by sets_of_closures *)
-let function_decls env code_id1 code_id2 : unit Comparison.t =
-  if code_ids env code_id1 code_id2 |> Comparison.is_equivalent
-  then Equivalent
-  else Different { approximant = () }
+let function_decls env
+    (fun_decl1 : Function_declarations.code_id_in_function_declaration)
+    (fun_decl2 : Function_declarations.code_id_in_function_declaration) :
+    unit Comparison.t =
+  match fun_decl1, fun_decl2 with
+  | Deleted, Deleted -> Equivalent
+  | Code_id code_id1, Code_id code_id2 ->
+    if code_ids env code_id1 code_id2 |> Comparison.is_equivalent
+    then Equivalent
+    else Different { approximant = () }
+  | Deleted, Code_id _ | Code_id _, Deleted -> Different { approximant = () }
 
 (** Match up equal elements in two lists and iterate through both of them, using
     [f] analogously to [Map.S.merge] *)
@@ -772,10 +784,27 @@ let sets_of_closures env set1 set2 : Set_of_closures.t Comparison.t =
   in
   let function_slots_and_fun_decls_by_code_id set =
     let map = Function_declarations.funs (Set_of_closures.function_decls set) in
-    Function_slot.Map.bindings map
-    |> List.map (fun (function_slot, code_id) ->
-           subst_code_id env code_id, (function_slot, code_id))
-    |> Code_id.Map.of_list
+    let function_slot_map, deleted_function_slot_set =
+      Function_slot.Map.bindings map
+      |> List.partition_map
+           (fun
+             ( function_slot,
+               (code_id : Function_declarations.code_id_in_function_declaration)
+             )
+           ->
+             match code_id with
+             | Deleted -> Right function_slot
+             | Code_id code_id0 ->
+               Left (subst_code_id env code_id0, (function_slot, code_id)))
+    in
+    ( Code_id.Map.of_list function_slot_map,
+      Function_slot.Set.of_list deleted_function_slot_set )
+  in
+  let function_slot_map1, deleted_function_slot_set1 =
+    function_slots_and_fun_decls_by_code_id set1
+  in
+  let function_slot_map2, deleted_function_slot_set2 =
+    function_slots_and_fun_decls_by_code_id set2
   in
   (* Using merge here as a map version of [List.iter2]; always returning None
    * means the returned map is always empty, so this shouldn't waste much *)
@@ -794,9 +823,13 @@ let sets_of_closures env set1 set2 : Set_of_closures.t Comparison.t =
           | Equivalent -> ()
           | Different _ -> ok := false));
         None)
-      (function_slots_and_fun_decls_by_code_id set1)
-      (function_slots_and_fun_decls_by_code_id set2)
+      function_slot_map1 function_slot_map2
   in
+  (* Trying to find a mapping between the deleted function_slots is not easy, so
+     we simply say the sets are equal if they have the same cardinality *)
+  if Function_slot.Set.cardinal deleted_function_slot_set1
+     <> Function_slot.Set.cardinal deleted_function_slot_set2
+  then ok := false;
   if !ok
   then Equivalent
   else Different { approximant = subst_set_of_closures env set1 }

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2489,6 +2489,9 @@ let close_functions acc external_env ~current_region function_declarations =
   let acc = Acc.with_free_names Name_occurrences.empty acc in
   let funs =
     function_code_ids_in_order |> List.rev |> Function_slot.Lmap.of_list
+    |> Function_slot.Lmap.map
+         (fun code_id : Function_declarations.code_id_in_function_declaration ->
+           Code_id code_id)
   in
   let function_decls = Function_declarations.create funs in
   let value_slots =

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -531,7 +531,11 @@ let set_of_closures env fun_decls value_slots alloc =
       function_slot, code_id
     in
     List.map translate_fun_decl fun_decls
-    |> Function_slot.Lmap.of_list |> Function_declarations.create
+    |> Function_slot.Lmap.of_list
+    |> Function_slot.Lmap.map
+         (fun code_id : Function_declarations.code_id_in_function_declaration ->
+           Code_id code_id)
+    |> Function_declarations.create
   in
   let value_slots = Option.value value_slots ~default:[] in
   let value_slots : Simple.t Value_slot.Map.t =

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -674,7 +674,7 @@ let set_of_closures env sc =
       (Set_of_closures.function_decls sc
       |> Function_declarations.funs_in_order
       |> Function_slot.Lmap.map (function
-           | Function_declarations.Deleted -> Misc.fatal_error "todo"
+           | Function_declarations.Deleted _ -> Misc.fatal_error "todo"
            | Function_declarations.Code_id code_id -> code_id)
       |> Function_slot.Lmap.bindings)
   in

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -672,7 +672,11 @@ let set_of_closures env sc =
       (fun (function_slot, fun_decl) ->
         function_declaration env fun_decl function_slot alloc)
       (Set_of_closures.function_decls sc
-      |> Function_declarations.funs_in_order |> Function_slot.Lmap.bindings)
+      |> Function_declarations.funs_in_order
+      |> Function_slot.Lmap.map (function
+           | Function_declarations.Deleted -> Misc.fatal_error "todo"
+           | Function_declarations.Code_id code_id -> code_id)
+      |> Function_slot.Lmap.bindings)
   in
   let elts = value_slots env (Set_of_closures.value_slots sc) in
   let elts = match elts with [] -> None | _ -> Some elts in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -645,7 +645,9 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         in
         let function_decls =
           Function_declarations.create
-            (Function_slot.Lmap.singleton wrapper_function_slot code_id)
+            (Function_slot.Lmap.singleton wrapper_function_slot
+               (Code_id code_id
+                 : Function_declarations.code_id_in_function_declaration))
         in
         let value_slots =
           List.filter_map

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -543,12 +543,12 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
            function_slot
            (old_code_id : Function_declarations.code_id_in_function_declaration) ->
         match old_code_id with
-        | Deleted ->
+        | Deleted _ ->
           ( ( result_code_ids_to_never_delete_this_set,
               Function_slot.Map.add function_slot Or_unknown_or_bottom.Unknown
                 fun_types,
               outer_dacc ),
-            Function_declarations.Deleted )
+            old_code_id )
         | Code_id old_code_id ->
           let code_id, outer_dacc, code_ids_to_never_delete_this_set =
             simplify_function context ~outer_dacc function_slot old_code_id
@@ -581,7 +581,7 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
            (code_id : Function_declarations.code_id_in_function_declaration)
            code_ids ->
         match code_id with
-        | Deleted -> code_ids
+        | Deleted _ -> code_ids
         | Code_id code_id -> Code_id.Set.add code_id code_ids)
       all_function_decls_in_set Code_id.Set.empty
   in

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -540,33 +540,49 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
         all_function_decls_in_set ) =
     Function_slot.Lmap.fold_left_map
       (fun (result_code_ids_to_never_delete_this_set, fun_types, outer_dacc)
-           function_slot old_code_id ->
-        let code_id, outer_dacc, code_ids_to_never_delete_this_set =
-          simplify_function context ~outer_dacc function_slot old_code_id
-            ~closure_bound_names_inside_function:closure_bound_names_inside
-        in
-        let function_type =
-          let rec_info =
-            (* This is the intrinsic type of the function as seen outside its
-               own scope, so its [Rec_info] needs to say its depth is zero *)
-            T.this_rec_info Rec_info_expr.initial
+           function_slot
+           (old_code_id : Function_declarations.code_id_in_function_declaration) ->
+        match old_code_id with
+        | Deleted ->
+          ( ( result_code_ids_to_never_delete_this_set,
+              Function_slot.Map.add function_slot Or_unknown_or_bottom.Unknown
+                fun_types,
+              outer_dacc ),
+            Function_declarations.Deleted )
+        | Code_id old_code_id ->
+          let code_id, outer_dacc, code_ids_to_never_delete_this_set =
+            simplify_function context ~outer_dacc function_slot old_code_id
+              ~closure_bound_names_inside_function:closure_bound_names_inside
           in
-          C.function_decl_type code_id ~rec_info
-        in
-        let fun_types =
-          Function_slot.Map.add function_slot function_type fun_types
-        in
-        let code_ids_to_never_delete_this_set =
-          Code_id.Set.union code_ids_to_never_delete_this_set
-            result_code_ids_to_never_delete_this_set
-        in
-        (code_ids_to_never_delete_this_set, fun_types, outer_dacc), code_id)
+          let function_type =
+            let rec_info =
+              (* This is the intrinsic type of the function as seen outside its
+                 own scope, so its [Rec_info] needs to say its depth is zero *)
+              T.this_rec_info Rec_info_expr.initial
+            in
+            C.function_decl_type code_id ~rec_info
+          in
+          let fun_types =
+            Function_slot.Map.add function_slot function_type fun_types
+          in
+          let code_ids_to_never_delete_this_set =
+            Code_id.Set.union code_ids_to_never_delete_this_set
+              result_code_ids_to_never_delete_this_set
+          in
+          ( (code_ids_to_never_delete_this_set, fun_types, outer_dacc),
+            (Code_id code_id
+              : Function_declarations.code_id_in_function_declaration) ))
       (Code_id.Set.empty, Function_slot.Map.empty, outer_dacc)
       all_function_decls_in_set
   in
   let code_ids_to_remember_this_set =
     Function_slot.Lmap.fold
-      (fun _function_slot code_id code_ids -> Code_id.Set.add code_id code_ids)
+      (fun _function_slot
+           (code_id : Function_declarations.code_id_in_function_declaration)
+           code_ids ->
+        match code_id with
+        | Deleted -> code_ids
+        | Code_id code_id -> Code_id.Set.add code_id code_ids)
       all_function_decls_in_set Code_id.Set.empty
   in
   let dacc =

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
@@ -113,7 +113,7 @@ let compute_closure_types_inside_functions ~denv ~all_sets_of_closures
                  (old_code_id :
                    Function_declarations.code_id_in_function_declaration) ->
               match old_code_id with
-              | Deleted -> Or_unknown_or_bottom.Unknown
+              | Deleted _ -> Or_unknown_or_bottom.Unknown
               | Code_id old_code_id ->
                 let code_or_metadata = DE.find_code_exn denv old_code_id in
                 let new_code_id =
@@ -216,7 +216,7 @@ let compute_old_to_new_code_ids_all_sets denv ~all_sets_of_closures =
                Function_declarations.code_id_in_function_declaration)
              old_to_new_code_ids ->
           match old_code_id with
-          | Deleted -> old_to_new_code_ids
+          | Deleted _ -> old_to_new_code_ids
           | Code_id old_code_id ->
             let code =
               try DE.find_code_exn denv old_code_id

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
@@ -109,40 +109,45 @@ let compute_closure_types_inside_functions ~denv ~all_sets_of_closures
         let function_decls = Set_of_closures.function_decls set_of_closures in
         let all_function_slots_in_set =
           Function_slot.Map.mapi
-            (fun function_slot old_code_id ->
-              let code_or_metadata = DE.find_code_exn denv old_code_id in
-              let new_code_id =
-                (* The types of the functions involved should reference the
-                   _new_ code IDs (where such exist), so that direct recursive
-                   calls can be compiled straight to the new code. *)
-                if Code_or_metadata.code_present code_or_metadata
-                   && not
-                        (Code_metadata.stub
-                           (Code_or_metadata.code_metadata code_or_metadata))
-                then Code_id.Map.find old_code_id old_to_new_code_ids_all_sets
-                else old_code_id
-              in
-              let rec_info =
-                (* From inside their own bodies, every function in the set
-                   currently being defined has an unknown recursion depth *)
-                T.unknown K.rec_info
-              in
-              let code_metadata =
-                code_or_metadata |> Code_or_metadata.code_metadata
-              in
-              let absolute_history, _relative_history =
-                DE.inlining_history_tracker denv
-                |> Inlining_history.Tracker.fundecl
-                     ~dbg:(Code_metadata.dbg code_metadata)
-                     ~function_relative_history:
-                       (Code_metadata.relative_history code_metadata)
-                     ~name:(Function_slot.name function_slot)
-              in
-              Inlining_report.record_decision_at_function_definition
-                ~absolute_history ~code_metadata ~pass:Before_simplify
-                ~are_rebuilding_terms:(DE.are_rebuilding_terms denv)
-                (Code_metadata.inlining_decision code_metadata);
-              function_decl_type old_code_id ~new_code_id ~rec_info)
+            (fun function_slot
+                 (old_code_id :
+                   Function_declarations.code_id_in_function_declaration) ->
+              match old_code_id with
+              | Deleted -> Or_unknown_or_bottom.Unknown
+              | Code_id old_code_id ->
+                let code_or_metadata = DE.find_code_exn denv old_code_id in
+                let new_code_id =
+                  (* The types of the functions involved should reference the
+                     _new_ code IDs (where such exist), so that direct recursive
+                     calls can be compiled straight to the new code. *)
+                  if Code_or_metadata.code_present code_or_metadata
+                     && not
+                          (Code_metadata.stub
+                             (Code_or_metadata.code_metadata code_or_metadata))
+                  then Code_id.Map.find old_code_id old_to_new_code_ids_all_sets
+                  else old_code_id
+                in
+                let rec_info =
+                  (* From inside their own bodies, every function in the set
+                     currently being defined has an unknown recursion depth *)
+                  T.unknown K.rec_info
+                in
+                let code_metadata =
+                  code_or_metadata |> Code_or_metadata.code_metadata
+                in
+                let absolute_history, _relative_history =
+                  DE.inlining_history_tracker denv
+                  |> Inlining_history.Tracker.fundecl
+                       ~dbg:(Code_metadata.dbg code_metadata)
+                       ~function_relative_history:
+                         (Code_metadata.relative_history code_metadata)
+                       ~name:(Function_slot.name function_slot)
+                in
+                Inlining_report.record_decision_at_function_definition
+                  ~absolute_history ~code_metadata ~pass:Before_simplify
+                  ~are_rebuilding_terms:(DE.are_rebuilding_terms denv)
+                  (Code_metadata.inlining_decision code_metadata);
+                function_decl_type old_code_id ~new_code_id ~rec_info)
             (Function_declarations.funs function_decls)
         in
         Function_slot.Map.mapi
@@ -206,18 +211,25 @@ let compute_old_to_new_code_ids_all_sets denv ~all_sets_of_closures =
     (fun old_to_new_code_ids_all_sets set_of_closures ->
       let function_decls = Set_of_closures.function_decls set_of_closures in
       Function_slot.Map.fold
-        (fun _ old_code_id old_to_new_code_ids ->
-          let code =
-            try DE.find_code_exn denv old_code_id
-            with Not_found ->
-              Misc.fatal_errorf "Missing code for %a" Code_id.print old_code_id
-          in
-          if Code_or_metadata.code_present code
-             && not (Code_metadata.stub (Code_or_metadata.code_metadata code))
-          then
-            let new_code_id = Code_id.rename old_code_id in
-            Code_id.Map.add old_code_id new_code_id old_to_new_code_ids
-          else old_to_new_code_ids)
+        (fun _
+             (old_code_id :
+               Function_declarations.code_id_in_function_declaration)
+             old_to_new_code_ids ->
+          match old_code_id with
+          | Deleted -> old_to_new_code_ids
+          | Code_id old_code_id ->
+            let code =
+              try DE.find_code_exn denv old_code_id
+              with Not_found ->
+                Misc.fatal_errorf "Missing code for %a" Code_id.print
+                  old_code_id
+            in
+            if Code_or_metadata.code_present code
+               && not (Code_metadata.stub (Code_or_metadata.code_metadata code))
+            then
+              let new_code_id = Code_id.rename old_code_id in
+              Code_id.Map.add old_code_id new_code_id old_to_new_code_ids
+            else old_to_new_code_ids)
         (Function_declarations.funs function_decls)
         old_to_new_code_ids_all_sets)
     Code_id.Map.empty all_sets_of_closures

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -752,7 +752,8 @@ end = struct
 
   (* Create slots (and create the cross-referencing). *)
 
-  let create_function_slot set state get_code_metadata function_slot (code_id : Function_declarations.code_id_in_function_declaration) =
+  let create_function_slot set state get_code_metadata function_slot
+      (code_id : Function_declarations.code_id_in_function_declaration) =
     if Compilation_unit.is_current
          (Function_slot.get_compilation_unit function_slot)
     then (

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -752,14 +752,14 @@ end = struct
 
   (* Create slots (and create the cross-referencing). *)
 
-  let create_function_slot set state get_code_metadata function_slot code_id =
+  let create_function_slot set state get_code_metadata function_slot (code_id : Function_declarations.code_id_in_function_declaration) =
     if Compilation_unit.is_current
          (Function_slot.get_compilation_unit function_slot)
     then (
       let size =
         match code_id with
-        | None -> 2
-        | Some code_id ->
+        | Deleted { function_slot_size } -> function_slot_size
+        | Code_id code_id ->
           let code_metadata = get_code_metadata code_id in
           let module CM = Code_metadata in
           let is_tupled = CM.is_tupled code_metadata in
@@ -889,11 +889,7 @@ end = struct
     state.sets_of_closures <- set :: state.sets_of_closures;
     (* Fill closure slots *)
     Function_slot.Map.iter
-      (fun function_slot
-           (code_id : Function_declarations.code_id_in_function_declaration) ->
-        let code_id =
-          match code_id with Deleted -> None | Code_id code_id -> Some code_id
-        in
+      (fun function_slot code_id ->
         let s =
           match
             Function_slot.Map.find_opt function_slot state.function_slots

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -158,10 +158,18 @@ module Layout = struct
     (* Make sure there's a slot at offset 0 *)
     if Numeric_types.Int.Map.mem 0 acc
     then acc
-    else
+    else (
+      if Numeric_types.Int.Map.mem 1 acc
+      then
+        Misc.fatal_errorf
+          "[order_function_slots]: a slots exists at offset 1, no room to \
+           insert a dummy function slot.@\n\
+           Slots: %a@."
+          (Numeric_types.Int.Map.print print_slot)
+          acc;
       Numeric_types.Int.Map.add 0
         (Dummy_function_slot { last_function_slot = false })
-        acc
+        acc)
 
   let mark_last_function_slot map =
     match Numeric_types.Int.Map.max_binding map with

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -112,6 +112,7 @@ module Layout = struct
           function_slot : Function_slot.t;
           last_function_slot : bool
         }
+    | Dummy_function_slot of { last_function_slot : bool }
 
   type t =
     { startenv : words;
@@ -128,6 +129,9 @@ module Layout = struct
       Format.fprintf fmt "function_slot%s(%d) %a"
         (if last_function_slot then "[last]" else "")
         size Function_slot.print function_slot
+    | Dummy_function_slot { last_function_slot } ->
+      Format.fprintf fmt "dummy_function_slot%s"
+        (if last_function_slot then "[last]" else "")
 
   let print fmt l =
     Format.fprintf fmt "@[<v>startenv: %d;@ " l.startenv;
@@ -137,24 +141,37 @@ module Layout = struct
     Format.fprintf fmt "@]"
 
   let order_function_slots env l acc =
-    Function_slot.Lmap.fold
-      (fun function_slot _ acc ->
-        match EO.function_slot_offset env function_slot with
-        | Some Dead_function_slot -> acc
-        | Some (Live_function_slot { size; offset }) ->
-          Numeric_types.Int.Map.add offset
-            (Function_slot { size; function_slot; last_function_slot = false })
-            acc
-        | None ->
-          Misc.fatal_errorf "No function_slot offset for %a" Function_slot.print
-            function_slot)
-      l acc
+    let acc =
+      Function_slot.Lmap.fold
+        (fun function_slot _ acc ->
+          match EO.function_slot_offset env function_slot with
+          | Some Dead_function_slot -> acc
+          | Some (Live_function_slot { size; offset }) ->
+            Numeric_types.Int.Map.add offset
+              (Function_slot { size; function_slot; last_function_slot = false })
+              acc
+          | None ->
+            Misc.fatal_errorf "No function_slot offset for %a"
+              Function_slot.print function_slot)
+        l acc
+    in
+    (* Make sure there's a slot at offset 0 *)
+    if Numeric_types.Int.Map.mem 0 acc
+    then acc
+    else
+      Numeric_types.Int.Map.add 0
+        (Dummy_function_slot { last_function_slot = false })
+        acc
 
   let mark_last_function_slot map =
     match Numeric_types.Int.Map.max_binding map with
     | offset, Function_slot slot ->
       Numeric_types.Int.Map.add offset
         (Function_slot { slot with last_function_slot = true })
+        map
+    | offset, Dummy_function_slot _ ->
+      Numeric_types.Int.Map.add offset
+        (Dummy_function_slot { last_function_slot = true })
         map
     | _, (Value_slot _ | Infix_header) ->
       Misc.fatal_errorf
@@ -189,12 +206,15 @@ module Layout = struct
        when scanning the block. Thus, if we see a function slot, we check that
        then the environment has not started yet (i.e. we have not seen any value
        slots). *)
-    | Function_slot _ when offset = 0 ->
+    | (Dummy_function_slot _ | Function_slot _) when offset = 0 ->
       assert (match acc_slots with [] -> true | _ :: _ -> false);
       assert (Option.is_none startenv);
       (* see comment above *)
       let acc_slots = [0, slot] in
       startenv, acc_slots
+    | Dummy_function_slot _ ->
+      (* dummy function slots should only appear at offset 0 *)
+      assert false
     | Function_slot _ ->
       assert (Option.is_none startenv);
       (* see comment above *)
@@ -238,6 +258,7 @@ module Layout = struct
       | Some i, _ -> i, false
       | None, [] -> 0, true (* will raise a fatal_error later *)
       | None, (offset, Function_slot { size; _ }) :: _ -> offset + size, true
+      | None, (offset, Dummy_function_slot _) :: _ -> offset + 2, true
       | None, (offset, Value_slot { is_scanned = false; size; _ }) :: _ ->
         offset + size, false
       | None, (_, Infix_header) :: _ ->
@@ -257,8 +278,12 @@ module Layout = struct
        slot at offset 0. *)
     let res = { startenv; slots; empty_env } in
     match slots with
-    | (0, Function_slot _) :: _ -> res
-    | [] | (_, (Function_slot _ | Infix_header | Value_slot _)) :: _ ->
+    | (0, (Function_slot _ | Dummy_function_slot _)) :: _ -> res
+    | []
+    | ( _,
+        (Function_slot _ | Infix_header | Value_slot _ | Dummy_function_slot _)
+      )
+      :: _ ->
       Misc.fatal_errorf
         "Sets of closures must start with a function slot at offset 0:@\n%a"
         print res
@@ -724,12 +749,15 @@ end = struct
          (Function_slot.get_compilation_unit function_slot)
     then (
       let size =
-        let code_metadata = get_code_metadata code_id in
-        let module CM = Code_metadata in
-        let is_tupled = CM.is_tupled code_metadata in
-        let params_arity = CM.params_arity code_metadata in
-        let arity = Flambda_arity.num_params params_arity in
-        if (arity = 0 || arity = 1) && not is_tupled then 2 else 3
+        match code_id with
+        | None -> 2
+        | Some code_id ->
+          let code_metadata = get_code_metadata code_id in
+          let module CM = Code_metadata in
+          let is_tupled = CM.is_tupled code_metadata in
+          let params_arity = CM.params_arity code_metadata in
+          let arity = Flambda_arity.num_params params_arity in
+          if (arity = 0 || arity = 1) && not is_tupled then 2 else 3
       in
       let s = create_slot ~size (Function_slot function_slot) Unassigned in
       add_function_slot state function_slot s;
@@ -853,7 +881,11 @@ end = struct
     state.sets_of_closures <- set :: state.sets_of_closures;
     (* Fill closure slots *)
     Function_slot.Map.iter
-      (fun function_slot code_id ->
+      (fun function_slot
+           (code_id : Function_declarations.code_id_in_function_declaration) ->
+        let code_id =
+          match code_id with Deleted -> None | Code_id code_id -> Some code_id
+        in
         let s =
           match
             Function_slot.Map.find_opt function_slot state.function_slots

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -137,18 +137,18 @@ module Layout = struct
     Format.fprintf fmt "@]"
 
   let order_function_slots env l acc =
-      Function_slot.Lmap.fold
-        (fun function_slot _ acc ->
-          match EO.function_slot_offset env function_slot with
-          | Some Dead_function_slot -> acc
-          | Some (Live_function_slot { size; offset }) ->
-            Numeric_types.Int.Map.add offset
-              (Function_slot { size; function_slot; last_function_slot = false })
-              acc
-          | None ->
-            Misc.fatal_errorf "No function_slot offset for %a"
-              Function_slot.print function_slot)
-        l acc
+    Function_slot.Lmap.fold
+      (fun function_slot _ acc ->
+        match EO.function_slot_offset env function_slot with
+        | Some Dead_function_slot -> acc
+        | Some (Live_function_slot { size; offset }) ->
+          Numeric_types.Int.Map.add offset
+            (Function_slot { size; function_slot; last_function_slot = false })
+            acc
+        | None ->
+          Misc.fatal_errorf "No function_slot offset for %a" Function_slot.print
+            function_slot)
+      l acc
 
   let mark_last_function_slot map =
     match Numeric_types.Int.Map.max_binding map with
@@ -258,11 +258,7 @@ module Layout = struct
     let res = { startenv; slots; empty_env } in
     match slots with
     | (0, Function_slot _) :: _ -> res
-    | []
-    | ( _,
-        (Function_slot _ | Infix_header | Value_slot _)
-      )
-      :: _ ->
+    | [] | (_, (Function_slot _ | Infix_header | Value_slot _)) :: _ ->
       Misc.fatal_errorf
         "Sets of closures must start with a function slot at offset 0:@\n%a"
         print res

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -159,10 +159,11 @@ module Layout = struct
     if Numeric_types.Int.Map.mem 0 acc
     then acc
     else (
+      (* Dummy function slots have size 2, so make sure there is room for it. *)
       if Numeric_types.Int.Map.mem 1 acc
       then
         Misc.fatal_errorf
-          "[order_function_slots]: a slots exists at offset 1, no room to \
+          "[order_function_slots]: a slot exists at offset 1, no room to \
            insert a dummy function slot.@\n\
            Slots: %a@."
           (Numeric_types.Int.Map.print print_slot)
@@ -221,8 +222,10 @@ module Layout = struct
       let acc_slots = [0, slot] in
       startenv, acc_slots
     | Dummy_function_slot _ ->
-      (* dummy function slots should only appear at offset 0 *)
-      assert false
+      Misc.fatal_errorf
+        "Dummy function slots should only appear at offset 0, but one was \
+         found at offset %d@."
+        offset
     | Function_slot _ ->
       assert (Option.is_none startenv);
       (* see comment above *)

--- a/middle_end/flambda2/simplify_shared/slot_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.mli
@@ -91,6 +91,7 @@ module Layout : sig
           function_slot : Function_slot.t;
           last_function_slot : bool
         }
+    | Dummy_function_slot of { last_function_slot : bool }
   (**)
 
   (** Alias for complete layouts. The list is sorted according to offsets (in

--- a/middle_end/flambda2/simplify_shared/slot_offsets.mli
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.mli
@@ -91,7 +91,6 @@ module Layout : sig
           function_slot : Function_slot.t;
           last_function_slot : bool
         }
-    | Dummy_function_slot of { last_function_slot : bool }
   (**)
 
   (** Alias for complete layouts. The list is sorted according to offsets (in

--- a/middle_end/flambda2/terms/cost_metrics.ml
+++ b/middle_end/flambda2/terms/cost_metrics.ml
@@ -74,7 +74,7 @@ let set_of_closures ~find_code_characteristics set_of_closures =
            (metrics, num_words) ->
         match code_id with
         | Deleted { function_slot_size } ->
-          metrics, Stdlib.( + ) num_words function_slot_size (* XXX *)
+          metrics, Stdlib.( + ) num_words function_slot_size
         | Code_id code_id ->
           let { cost_metrics; params_arity } =
             find_code_characteristics code_id

--- a/middle_end/flambda2/terms/cost_metrics.ml
+++ b/middle_end/flambda2/terms/cost_metrics.ml
@@ -73,7 +73,7 @@ let set_of_closures ~find_code_characteristics set_of_closures =
       (fun _ (code_id : Function_declarations.code_id_in_function_declaration)
            (metrics, num_words) ->
         match code_id with
-        | Deleted -> metrics, num_words
+        | Deleted { function_slot_size } -> metrics, Stdlib.(+) num_words function_slot_size (* XXX *)
         | Code_id code_id ->
           let { cost_metrics; params_arity } =
             find_code_characteristics code_id

--- a/middle_end/flambda2/terms/cost_metrics.ml
+++ b/middle_end/flambda2/terms/cost_metrics.ml
@@ -70,13 +70,17 @@ let set_of_closures ~find_code_characteristics set_of_closures =
   in
   let cost_metrics, num_words =
     Function_slot.Map.fold
-      (fun _ code_id (metrics, num_words) ->
-        let { cost_metrics; params_arity } =
-          find_code_characteristics code_id
-        in
-        ( metrics + cost_metrics,
-          (* CR poechsel: valid until OCaml 4.12, as for named_size *)
-          Stdlib.( + ) num_words (if params_arity <= 1 then 2 else 3) ))
+      (fun _ (code_id : Function_declarations.code_id_in_function_declaration)
+           (metrics, num_words) ->
+        match code_id with
+        | Deleted -> metrics, num_words
+        | Code_id code_id ->
+          let { cost_metrics; params_arity } =
+            find_code_characteristics code_id
+          in
+          ( metrics + cost_metrics,
+            (* CR poechsel: valid until OCaml 4.12, as for named_size *)
+            Stdlib.( + ) num_words (if params_arity <= 1 then 2 else 3) ))
       funs (zero, num_clos_vars)
   in
   let alloc_size =

--- a/middle_end/flambda2/terms/cost_metrics.ml
+++ b/middle_end/flambda2/terms/cost_metrics.ml
@@ -73,7 +73,8 @@ let set_of_closures ~find_code_characteristics set_of_closures =
       (fun _ (code_id : Function_declarations.code_id_in_function_declaration)
            (metrics, num_words) ->
         match code_id with
-        | Deleted { function_slot_size } -> metrics, Stdlib.(+) num_words function_slot_size (* XXX *)
+        | Deleted { function_slot_size } ->
+          metrics, Stdlib.( + ) num_words function_slot_size (* XXX *)
         | Code_id code_id ->
           let { cost_metrics; params_arity } =
             find_code_characteristics code_id

--- a/middle_end/flambda2/terms/function_declarations.ml
+++ b/middle_end/flambda2/terms/function_declarations.ml
@@ -15,7 +15,7 @@
 (**************************************************************************)
 
 type code_id_in_function_declaration =
-  | Deleted of { function_slot_size: int }
+  | Deleted of { function_slot_size : int }
   | Code_id of Code_id.t
 
 type t =
@@ -87,7 +87,9 @@ let compare { funs = funs1; _ } { funs = funs2; _ } =
   Function_slot.Map.compare
     (fun code_id1 code_id2 ->
       match code_id1, code_id2 with
-      | Deleted { function_slot_size = size1 }, Deleted { function_slot_size = size2 } -> Int.compare size1 size2
+      | ( Deleted { function_slot_size = size1 },
+          Deleted { function_slot_size = size2 } ) ->
+        Int.compare size1 size2
       | Deleted _, Code_id _ -> -1
       | Code_id _, Deleted _ -> 1
       | Code_id code_id1, Code_id code_id2 -> Code_id.compare code_id1 code_id2)

--- a/middle_end/flambda2/terms/function_declarations.mli
+++ b/middle_end/flambda2/terms/function_declarations.mli
@@ -23,7 +23,7 @@ include Expr_std.S with type t := t
 include Contains_ids.S with type t := t
 
 type code_id_in_function_declaration =
-  | Deleted
+  | Deleted of { function_slot_size : int }
   | Code_id of Code_id.t
 
 val empty : t

--- a/middle_end/flambda2/terms/function_declarations.mli
+++ b/middle_end/flambda2/terms/function_declarations.mli
@@ -22,26 +22,31 @@ include Expr_std.S with type t := t
 
 include Contains_ids.S with type t := t
 
+type code_id_in_function_declaration =
+  | Deleted
+  | Code_id of Code_id.t
+
 val empty : t
 
 val is_empty : t -> bool
 
 (** Create a set of function declarations in the given order. *)
-val create : Code_id.t Function_slot.Lmap.t -> t
+val create : code_id_in_function_declaration Function_slot.Lmap.t -> t
 
 (** The function(s) defined by the set of function declarations, indexed by
     function slot. *)
-val funs : t -> Code_id.t Function_slot.Map.t
+val funs : t -> code_id_in_function_declaration Function_slot.Map.t
 
 (** The function(s) defined by the set of function declarations, in the order
     originally given. *)
-val funs_in_order : t -> Code_id.t Function_slot.Lmap.t
+val funs_in_order : t -> code_id_in_function_declaration Function_slot.Lmap.t
 
 (** [find f t] raises [Not_found] if [f] is not in [t]. *)
-val find : t -> Function_slot.t -> Code_id.t
+val find : t -> Function_slot.t -> code_id_in_function_declaration
 
 val binds_function_slot : t -> Function_slot.t -> bool
 
 val compare : t -> t -> int
 
-val filter : t -> f:(Function_slot.t -> Code_id.t -> bool) -> t
+val filter :
+  t -> f:(Function_slot.t -> code_id_in_function_declaration -> bool) -> t

--- a/middle_end/flambda2/terms/set_of_closures.mli
+++ b/middle_end/flambda2/terms/set_of_closures.mli
@@ -42,6 +42,11 @@ val is_closed : t -> bool
 val alloc_mode : t -> Alloc_mode.For_allocations.t
 
 val filter_function_declarations :
-  t -> f:(Function_slot.t -> Code_id.t -> bool) -> t
+  t ->
+  f:
+    (Function_slot.t ->
+    Function_declarations.code_id_in_function_declaration ->
+    bool) ->
+  t
 
 include Container_types.S with type t := t

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -111,7 +111,7 @@ module Make_layout_filler (P : sig
 end) : sig
   val fill_layout :
     for_static_sets option ->
-    Code_id.t Function_slot.Map.t ->
+    Function_declarations.code_id_in_function_declaration Function_slot.Map.t ->
     Debuginfo.t ->
     startenv:int ->
     Simple.t Value_slot.Map.t ->
@@ -203,17 +203,23 @@ end = struct
         res,
         eff,
         updates )
-    | Function_slot { size; function_slot; last_function_slot } -> (
-      let code_id = Function_slot.Map.find function_slot decls in
-      let code_symbol =
-        R.symbol_of_code_id res code_id ~currently_in_inlined_body:false
-      in
-      let (kind, params_ty, result_ty), closure_code_pointers, dbg =
-        get_func_decl_params_arity env code_id
-      in
+    | Dummy_function_slot { last_function_slot } ->
       let closure_info =
-        C.closure_info' ~arity:(kind, params_ty)
+        C.closure_info'
+          ~arity:(Curried { nlocal = 0 }, [()])
           ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
+      in
+      ( P.int ~dbg closure_info :: P.int ~dbg 0n :: acc,
+        Backend_var.Set.empty,
+        slot_offset + 2,
+        env,
+        res,
+        Ece.pure,
+        updates )
+    | Function_slot { size; function_slot; last_function_slot } -> (
+      let code_id =
+        (Function_slot.Map.find function_slot decls
+          : Function_declarations.code_id_in_function_declaration)
       in
       let acc =
         match for_static_sets with
@@ -224,40 +230,79 @@ end = struct
           in
           List.rev_append (P.define_symbol (R.symbol res function_symbol)) acc
       in
-      (* We build here the **reverse** list of fields for the function slot *)
-      match closure_code_pointers with
-      | Full_application_only ->
-        if size <> 2
-        then
-          Misc.fatal_errorf
-            "fill_slot: Function slot %a is of size %d, but it is used to \
-             store code ID %a which is classified as Full_application_only (so \
-             the expected size is 2)"
-            Function_slot.print function_slot size Code_id.print code_id;
-        let acc =
-          P.int ~dbg closure_info :: P.term_of_symbol ~dbg code_symbol :: acc
+      match code_id with
+      | Code_id code_id -> (
+        let code_symbol =
+          R.symbol_of_code_id res ~currently_in_inlined_body:false code_id
         in
-        ( acc,
-          Backend_var.Set.empty,
-          slot_offset + size,
-          env,
-          res,
-          Ece.pure,
-          updates )
-      | Full_and_partial_application ->
-        if size <> 3
-        then
-          Misc.fatal_errorf
-            "fill_slot: Function slot %a is of size %d, but it is used to \
-             store code ID %a which is classified as \
-             Full_and_partial_application (so the expected size is 3)"
-            Function_slot.print function_slot size Code_id.print code_id;
+        let (kind, params_ty, result_ty), closure_code_pointers, dbg =
+          get_func_decl_params_arity env code_id
+        in
+        let closure_info =
+          C.closure_info' ~arity:(kind, params_ty)
+            ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
+        in
+        (* We build here the **reverse** list of fields for the function slot *)
+        match closure_code_pointers with
+        | Full_application_only ->
+          if size < 2
+          then
+            Misc.fatal_errorf
+              "fill_slot: Function slot %a is of size %d, but it is used to \
+               store code ID %a which is classified as Full_application_only \
+               (so the expected size is 2)"
+              Function_slot.print function_slot size Code_id.print code_id;
+          let acc =
+            P.int ~dbg closure_info :: P.term_of_symbol ~dbg code_symbol :: acc
+          in
+          let acc =
+            if size > 2
+            then (
+              assert (size = 3);
+              P.int ~dbg 0n :: acc)
+            else acc
+          in
+          ( acc,
+            Backend_var.Set.empty,
+            slot_offset + size,
+            env,
+            res,
+            Ece.pure,
+            updates )
+        | Full_and_partial_application ->
+          if size <> 3
+          then
+            Misc.fatal_errorf
+              "fill_slot: Function slot %a is of size %d, but it is used to \
+               store code ID %a which is classified as \
+               Full_and_partial_application (so the expected size is 3)"
+              Function_slot.print function_slot size Code_id.print code_id;
+          let acc =
+            P.term_of_symbol ~dbg code_symbol
+            :: P.int ~dbg closure_info
+            :: P.term_of_symbol ~dbg
+                 (C.curry_function_sym kind params_ty result_ty)
+            :: acc
+          in
+          ( acc,
+            Backend_var.Set.empty,
+            slot_offset + size,
+            env,
+            res,
+            Ece.pure,
+            updates ))
+      | Deleted ->
+        let closure_info =
+          C.closure_info'
+            ~arity:(Curried { nlocal = 0 }, if size = 2 then [()] else [(); ()])
+            ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
+        in
         let acc =
-          P.term_of_symbol ~dbg code_symbol
-          :: P.int ~dbg closure_info
-          :: P.term_of_symbol ~dbg
-               (C.curry_function_sym kind params_ty result_ty)
-          :: acc
+          match size with
+          | 2 -> P.int ~dbg closure_info :: P.int ~dbg 0n :: acc
+          | 3 ->
+            P.int ~dbg 0n :: P.int ~dbg closure_info :: P.int ~dbg 0n :: acc
+          | _ -> assert false
         in
         ( acc,
           Backend_var.Set.empty,
@@ -456,6 +501,12 @@ let debuginfo_for_set_of_closures env set =
   let code_ids_in_set =
     Set_of_closures.function_decls set
     |> Function_declarations.funs |> Function_slot.Map.data
+    |> List.filter_map
+         (fun (code_id : Function_declarations.code_id_in_function_declaration)
+         ->
+           match code_id with
+           | Deleted -> None
+           | Code_id code_id -> Some code_id)
   in
   let dbg =
     List.map
@@ -480,7 +531,7 @@ let let_static_set_of_closures0 env res closure_symbols
         (fun (offset, (layout_slot : Slot_offsets.Layout.slot)) ->
           match layout_slot with
           | Function_slot { function_slot; _ } -> Some (offset, function_slot)
-          | Infix_header | Value_slot _ -> None)
+          | Infix_header | Value_slot _ | Dummy_function_slot _ -> None)
         layout.slots
     with
     | Some (function_slot_offset, function_slot) -> (

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -279,8 +279,8 @@ end = struct
              deleted of size %d"
             Function_slot.print function_slot size function_slot_size;
         let closure_info =
-          C.closure_info'
-            ~arity:(Curried { nlocal = 0 }, if size = 2 then [()] else [(); ()])
+          C.pack_closure_info
+            ~arity:(if size = 2 then 1 else 2)
             ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
         in
         let acc =

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -245,7 +245,7 @@ end = struct
         (* We build here the **reverse** list of fields for the function slot *)
         match closure_code_pointers with
         | Full_application_only ->
-          if size < 2
+          if size <> 2
           then
             Misc.fatal_errorf
               "fill_slot: Function slot %a is of size %d, but it is used to \
@@ -254,13 +254,6 @@ end = struct
               Function_slot.print function_slot size Code_id.print code_id;
           let acc =
             P.int ~dbg closure_info :: P.term_of_symbol ~dbg code_symbol :: acc
-          in
-          let acc =
-            if size > 2
-            then (
-              assert (size = 3);
-              P.int ~dbg 0n :: acc)
-            else acc
           in
           ( acc,
             Backend_var.Set.empty,

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -292,8 +292,12 @@ end = struct
             Ece.pure,
             updates ))
       | Deleted { function_slot_size } ->
-        if size <> function_slot_size then
-          Misc.fatal_errorf "fill_slot: Function slot %a is of size %d, but it is said to be deleted of size %d" Function_slot.print function_slot size function_slot_size;
+        if size <> function_slot_size
+        then
+          Misc.fatal_errorf
+            "fill_slot: Function slot %a is of size %d, but it is said to be \
+             deleted of size %d"
+            Function_slot.print function_slot size function_slot_size;
         let closure_info =
           C.closure_info'
             ~arity:(Curried { nlocal = 0 }, if size = 2 then [()] else [(); ()])

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -203,19 +203,6 @@ end = struct
         res,
         eff,
         updates )
-    | Dummy_function_slot { last_function_slot } ->
-      let closure_info =
-        C.closure_info'
-          ~arity:(Curried { nlocal = 0 }, [()])
-          ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
-      in
-      ( P.int ~dbg closure_info :: P.int ~dbg 0n :: acc,
-        Backend_var.Set.empty,
-        slot_offset + 2,
-        env,
-        res,
-        Ece.pure,
-        updates )
     | Function_slot { size; function_slot; last_function_slot } -> (
       let code_id =
         (Function_slot.Map.find function_slot decls
@@ -530,7 +517,7 @@ let let_static_set_of_closures0 env res closure_symbols
         (fun (offset, (layout_slot : Slot_offsets.Layout.slot)) ->
           match layout_slot with
           | Function_slot { function_slot; _ } -> Some (offset, function_slot)
-          | Infix_header | Value_slot _ | Dummy_function_slot _ -> None)
+          | Infix_header | Value_slot _ -> None)
         layout.slots
     with
     | Some (function_slot_offset, function_slot) -> (

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -291,7 +291,9 @@ end = struct
             res,
             Ece.pure,
             updates ))
-      | Deleted ->
+      | Deleted { function_slot_size } ->
+        if size <> function_slot_size then
+          Misc.fatal_errorf "fill_slot: Function slot %a is of size %d, but it is said to be deleted of size %d" Function_slot.print function_slot size function_slot_size;
         let closure_info =
           C.closure_info'
             ~arity:(Curried { nlocal = 0 }, if size = 2 then [()] else [(); ()])
@@ -505,7 +507,7 @@ let debuginfo_for_set_of_closures env set =
          (fun (code_id : Function_declarations.code_id_in_function_declaration)
          ->
            match code_id with
-           | Deleted -> None
+           | Deleted _ -> None
            | Code_id code_id -> Some code_id)
   in
   let dbg =


### PR DESCRIPTION
This is a prerequisite for #2213. It adds a way to specify that some code ids in a set of closures have been deleted, and the closure therefore does not need a code pointer (but the function slot is still used for projections, and the closure still exists). For now, we do not change the layout and simply put a zero instead of the code id; in the future we can make slot_offsets share the slot as much as possible.