### PR TITLE
Cancel running CI if new commits are pushed to a pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,3 +226,6 @@ jobs:
       if: matrix.check_arch == true
       run: |
         PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH make check_all_arches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true


### PR DESCRIPTION
So that we don't have to wait too long for the CI to run.
See https://docs.github.com/en/actions/using-jobs/using-concurrency.