### PR TITLE
Remove leftover reference in Slot_offsets

### DIFF
--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -1146,11 +1146,11 @@ let add_offsets_from_function l1 ~from_function:l2 =
   List.rev_append l2 l1
 
 let finalize_offsets ~get_code_metadata ~used_slots l =
-  let state = ref (Greedy.create_initial_state ()) in
+  let state = Greedy.create_initial_state () in
   Misc.try_finally
     (fun () ->
-      List.iter (Greedy.create_slots_for_set !state ~get_code_metadata) l;
-      Greedy.finalize ~used_slots !state)
+      List.iter (Greedy.create_slots_for_set state ~get_code_metadata) l;
+      Greedy.finalize ~used_slots state)
     ~always:(fun () ->
       if Flambda_features.dump_slot_offsets ()
-      then Format.eprintf "%a@." Greedy.print !state)
+      then Format.eprintf "%a@." Greedy.print state)


### PR DESCRIPTION
Apparently #700 (and #706) removed all assignments to a reference but left the reference itself; this PR removes it (the state itself is mutable, and updated by the relevant functions).