### PR TITLE
Eliminate fallthrough blocks at the end of Cfgize

### DIFF
--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -845,6 +845,8 @@ let fundecl :
      terminator simplification. *)
   Profile.record ~accumulate:true "optimizations"
     (fun () ->
+      if simplify_terminators
+      then Eliminate_fallthrough_blocks.run cfg_with_layout;
       if simplify_terminators then Merge_straightline_blocks.run cfg_with_layout;
       Eliminate_dead_code.run_dead_block cfg_with_layout;
       if simplify_terminators then Simplify_terminator.run cfg)


### PR DESCRIPTION
This PR enables an existing pass `Eliminate_fallthrough_blocks` to run at the end of `Cfgize`.  This is minor improvement to code generation (avoid an unnecessary branch) at the cost of increased compilation time. A follow up PR will clean it up to reduce the overhead.  