### PR TITLE
Mode crossing for unboxed integers

### DIFF
--- a/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
@@ -197,11 +197,7 @@ val float_u_escape : unit -> float# = <fun>
 let int64_u_escape () = let local_ x : int64# = #314L in x
 
 [%%expect{|
-Line 1, characters 57-58:
-1 | let int64_u_escape () = let local_ x : int64# = #314L in x
-                                                             ^
-Error: This value escapes its region.
-  Hint: Cannot return a local value without an "exclave_" annotation.
+val int64_u_escape : unit -> int64# = <fun>
 |}]
 
 let hidden_float_u_escape () =
@@ -370,10 +366,7 @@ val float_u_duplicate : unit -> float# = <fun>
 let int64_u_duplicate () = let once_ x : int64# = #314L in Int64_u.id x
 
 [%%expect{|
-Line 1, characters 70-71:
-1 | let int64_u_duplicate () = let once_ x : int64# = #314L in Int64_u.id x
-                                                                          ^
-Error: This value is once but expected to be many.
+val int64_u_duplicate : unit -> int64# = <fun>
 |}]
 
 let hidden_float_u_duplicate () =
@@ -582,6 +575,7 @@ Line 1, characters 66-67:
 
 let int64_u_unshare () = let x : int64# = #314L in Int64_u.ignore x; Int64_u.unique x
 
+(* CR layouts v2.8: this should succeed *)
 [%%expect{|
 Line 1, characters 84-85:
 1 | let int64_u_unshare () = let x : int64# = #314L in Int64_u.ignore x; Int64_u.unique x

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -161,20 +161,28 @@ val immediate64 : why:immediate64_creation_reason -> t
 (** We know for sure that values of types of this jkind are always immediate *)
 val immediate : why:immediate_creation_reason -> t
 
-(** This is the jkind of unboxed 64-bit floats.  They have sort Float64. *)
+(** This is the jkind of unboxed 64-bit floats.  They have sort
+    Float64. Mode-crosses. *)
 val float64 : why:float64_creation_reason -> t
 
-(** This is the jkind of unboxed 32-bit floats.  They have sort Float32. *)
+(** This is the jkind of unboxed 32-bit floats.  They have sort
+    Float32. Mode-crosses. *)
 val float32 : why:float32_creation_reason -> t
 
-(** This is the jkind of unboxed native-sized integers. They have sort Word. *)
+(** This is the jkind of unboxed native-sized integers. They have sort
+    Word. Does not mode-cross. *)
 val word : why:word_creation_reason -> t
 
-(** This is the jkind of unboxed 32-bit integers. They have sort Bits32. *)
+(** This is the jkind of unboxed 32-bit integers. They have sort Bits32. Does
+    not mode-cross. *)
 val bits32 : why:bits32_creation_reason -> t
 
-(** This is the jkind of unboxed 64-bit integers. They have sort Bits64. *)
+(** This is the jkind of unboxed 64-bit integers. They have sort Bits64. Does
+    not mode-cross. *)
 val bits64 : why:bits64_creation_reason -> t
+
+(** Take an existing [t] and add an ability to mode-cross along all the axes. *)
+val add_mode_crossing : t -> t
 
 (******************************)
 (* construction *)

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -397,13 +397,13 @@ let build_initial_env add_type add_extension empty_env =
        ~jkind:(Jkind.float64 ~why:(Primitive ident_unboxed_float))
        ~jkind_annotation:Float64
   |> add_type ident_unboxed_nativeint
-       ~jkind:(Jkind.word ~why:(Primitive ident_unboxed_nativeint))
+       ~jkind:(Jkind.add_mode_crossing (Jkind.word ~why:(Primitive ident_unboxed_nativeint)))
        ~jkind_annotation:Word
   |> add_type ident_unboxed_int32
-       ~jkind:(Jkind.bits32 ~why:(Primitive ident_unboxed_int32))
+       ~jkind:(Jkind.add_mode_crossing (Jkind.bits32 ~why:(Primitive ident_unboxed_int32)))
        ~jkind_annotation:Bits32
   |> add_type ident_unboxed_int64
-       ~jkind:(Jkind.bits64 ~why:(Primitive ident_unboxed_int64))
+       ~jkind:(Jkind.add_mode_crossing (Jkind.bits64 ~why:(Primitive ident_unboxed_int64)))
        ~jkind_annotation:Bits64
   |> add_type1 ident_or_null
        ~variance:Variance.covariant


### PR DESCRIPTION
Mode-crossing uniqueness doesn't work, but it doesn't for `int` either (at least, not as I've tested it). This is an independent bug which I claim should not hold up this PR.