### PR TITLE
Add Assert_mixed_block_layout_v1 macro

### DIFF
--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -540,6 +540,14 @@ CAMLextern value caml_atom(tag_t);
 
 CAMLextern value caml_set_oo_id(value obj);
 
+/* Users write this to assert that the ensuing C code is sensitive
+   to the current layout of mixed blocks in a way that's subject
+   to change in future compiler releases. We'll bump the version
+   number when we make a breaking change. For example, we currently
+   don't pack int32's efficiently, and we will want to someday.
+ */
+#define Assert_mixed_block_layout_v1 _Static_assert(1, "")
+
 /* Header for out-of-heap blocks. */
 
 #define Caml_out_of_heap_header_with_reserved(wosize, tag, reserved)   \

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -545,6 +545,14 @@ CAMLextern value caml_set_oo_id(value obj);
    to change in future compiler releases. We'll bump the version
    number when we make a breaking change. For example, we currently
    don't pack int32's efficiently, and we will want to someday.
+
+   Users can write:
+
+   Assert_mixed_block_layout_v1;
+
+   (Hack: we define using _Static_assert rather than just an empty
+   definition so that users can write a semicolon, which is treated
+   better by C formatters.)
  */
 #define Assert_mixed_block_layout_v1 _Static_assert(1, "")
 

--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -521,6 +521,22 @@ extern value caml_global_data;
 
 CAMLextern value caml_set_oo_id(value obj);
 
+/* Users write this to assert that the ensuing C code is sensitive
+   to the current layout of mixed blocks in a way that's subject
+   to change in future compiler releases. We'll bump the version
+   number when we make a breaking change. For example, we currently
+   don't pack int32's efficiently, and we will want to someday.
+
+   Users can write:
+
+   Assert_mixed_block_layout_v1;
+
+   (Hack: we define using _Static_assert rather than just an empty
+   definition so that users can write a semicolon, which is treated
+   better by C formatters.)
+ */
+#define Assert_mixed_block_layout_v1 _Static_assert(1, "")
+
 /* Header for out-of-heap blocks. */
 
 #define Caml_out_of_heap_header(wosize, tag)                                  \


### PR DESCRIPTION
Define a macro that user code can write to assert that the surrounding C code is sensitive to the layout of mixed blocks (in a way that may change in a future release).