### PR TITLE
Unboxed records may be null

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-non-null-value/arguments.ml
+++ b/ocaml/testsuite/tests/typing-layouts-non-null-value/arguments.ml
@@ -143,35 +143,12 @@ end = struct
 end
 
 [%%expect{|
-Lines 6-11, characters 6-3:
- 6 | ......struct
- 7 |   type 'a t = { v : 'a } [@@unboxed]
- 8 |
- 9 |   let box v = { v }
-10 |   let unbox { v } = v
-11 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           type 'a t = { v : 'a; } [@@unboxed]
-           val box : 'a -> 'a t
-           val unbox : ('a : non_null_value). 'a t -> 'a
-         end
-       is not included in
-         sig
-           type 'a t = { v : 'a; } [@@unboxed]
-           val box : 'a -> 'a t
-           val unbox : 'a t -> 'a
-         end
-       Values do not match:
-         val unbox : ('a : non_null_value). 'a t -> 'a
-       is not included in
-         val unbox : 'a t -> 'a
-       The type 'a t -> 'a is not compatible with the type 'b t -> 'b
-       The layout of 'a is value, because
-         of the definition of unbox at line 5, characters 2-24.
-       But the layout of 'a must be a sublayout of non_null_value, because
-         of the definition of unbox at line 10, characters 12-21.
+module M2 :
+  sig
+    type 'a t = { v : 'a; } [@@unboxed]
+    val box : 'a -> 'a t
+    val unbox : 'a t -> 'a
+  end
 |}]
 
 module M3 : sig

--- a/ocaml/testsuite/tests/typing-layouts-non-null-value/arguments.ml
+++ b/ocaml/testsuite/tests/typing-layouts-non-null-value/arguments.ml
@@ -127,3 +127,70 @@ let _ = my_id4 (Fake_or_null.some 4)
 - : int Fake_or_null.t = <abstr>
 - : int Fake_or_null.t = <abstr>
 |}]
+
+(* Check behavior of type arguments and unboxed annotations. *)
+
+module M2 : sig
+  type 'a t = { v : 'a } [@@unboxed]
+
+  val box : 'a -> 'a t
+  val unbox : 'a t -> 'a
+end = struct
+  type 'a t = { v : 'a } [@@unboxed]
+
+  let box v = { v }
+  let unbox { v } = v
+end
+
+[%%expect{|
+Lines 6-11, characters 6-3:
+ 6 | ......struct
+ 7 |   type 'a t = { v : 'a } [@@unboxed]
+ 8 |
+ 9 |   let box v = { v }
+10 |   let unbox { v } = v
+11 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type 'a t = { v : 'a; } [@@unboxed]
+           val box : 'a -> 'a t
+           val unbox : ('a : non_null_value). 'a t -> 'a
+         end
+       is not included in
+         sig
+           type 'a t = { v : 'a; } [@@unboxed]
+           val box : 'a -> 'a t
+           val unbox : 'a t -> 'a
+         end
+       Values do not match:
+         val unbox : ('a : non_null_value). 'a t -> 'a
+       is not included in
+         val unbox : 'a t -> 'a
+       The type 'a t -> 'a is not compatible with the type 'b t -> 'b
+       The layout of 'a is value, because
+         of the definition of unbox at line 5, characters 2-24.
+       But the layout of 'a must be a sublayout of non_null_value, because
+         of the definition of unbox at line 10, characters 12-21.
+|}]
+
+module M3 : sig
+  type 'a t = V of 'a [@@unboxed]
+
+  val box : 'a -> 'a t
+  val unbox : 'a t -> 'a
+end = struct
+  type 'a t = V of 'a [@@unboxed]
+
+  let box v = V v
+  let unbox (V v) = v
+end
+
+[%%expect{|
+module M3 :
+  sig
+    type 'a t = V of 'a [@@unboxed]
+    val box : 'a -> 'a t
+    val unbox : 'a t -> 'a
+  end
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -693,15 +693,15 @@ module M9_4 = struct
     | ({vur_void = _},i) -> i
 end;;
 [%%expect {|
-Line 4, characters 8-16:
+Line 4, characters 7-21:
 4 |     | ({vur_void = _},i) -> i
-            ^^^^^^^^
-Error: The record field vur_void belongs to the type void_unboxed_record
-       but is mixed here with fields of type ('a : non_null_value)
+           ^^^^^^^^^^^^^^
+Error: This pattern matches values of type void_unboxed_record
+       but a pattern was expected which matches values of type ('a : value)
        The layout of void_unboxed_record is void, because
          of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of non_null_value, because
-         it's a boxed record type.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_5 = struct

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -2669,7 +2669,9 @@ and type_pat_aux
             let ty = generic_instance expected_ty in
             Some (p0, p, is_principal expected_ty), ty
         | Maybe_a_record_type ->
-          None, newvar (Jkind.non_null_value ~why:Boxed_record)
+          (* We can't assume that the jkind of a record type is [non_null_value]
+             because of unboxed records. *)
+          None, newvar (Jkind.any ~why:Dummy_jkind)
         | Not_a_record_type ->
           let error = Wrong_expected_kind(Record, Pattern, expected_ty) in
           raise (Error (loc, !env, error))


### PR DESCRIPTION
`type_pat_aux` in `typecore.ml` assumes that the layout of a record type is always `non_null_value`. This is only true for boxed records. Since we can't tell if the record is boxed yet at this point, assume layout `any`.

Add a test for this: before the change, the first of these tests failed.

This slightly changes some typechecking around void unboxed records, but it does not seem to be problematic.