### PR TITLE
Remove access to old size macros

### DIFF
--- a/ocaml/otherlibs/str/strstubs.c
+++ b/ocaml/otherlibs/str/strstubs.c
@@ -13,6 +13,8 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
+
 #include <string.h>
 #include <ctype.h>
 #include <caml/mlvalues.h>

--- a/ocaml/otherlibs/unix/setgroups.c
+++ b/ocaml/otherlibs/unix/setgroups.c
@@ -13,6 +13,8 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
+
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -130,7 +130,7 @@ mixed blocks. In the upstream compiler, R is set with the
 
 #define Tag_hd(hd) ((tag_t) ((hd) & HEADER_TAG_MASK))
 #define Hd_with_tag(hd, tag) (((hd) &~ HEADER_TAG_MASK) | (tag))
-#define Wosize_hd(hd) ((mlsize_t) (((hd) & HEADER_WOSIZE_MASK) \
+#define Allocated_wosize_hd(hd) ((mlsize_t) (((hd) & HEADER_WOSIZE_MASK) \
                                      >> HEADER_WOSIZE_SHIFT))
 
 /* A "clean" header, without reserved or color bits. */
@@ -192,7 +192,7 @@ Caml_inline mlsize_t Scannable_wosize_hd_native(header_t hd) {
   return
     Is_mixed_block_reserved(res)
     ? Mixed_block_scannable_wosize_reserved_native(res)
-    : Wosize_hd(hd);
+    : Allocated_wosize_hd(hd);
 }
 
 /* Bytecode versions of mixed block macros.
@@ -203,8 +203,8 @@ Caml_inline mlsize_t Scannable_wosize_hd_native(header_t hd) {
    in the header bits.
 */
 
-#define Scannable_wosize_hd_byte(hd)  (Wosize_hd (hd))
-#define Scannable_wosize_val_byte(val) (Wosize_hd (Hd_val (val)))
+#define Scannable_wosize_hd_byte(hd)  (Allocated_wosize_hd (hd))
+#define Scannable_wosize_val_byte(val) (Allocated_wosize_hd (Hd_val (val)))
 Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
                                                     mlsize_t size) {
   (void)res;
@@ -252,16 +252,6 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
 #define Num_tags (1ull << HEADER_TAG_BITS)
 #define Max_wosize ((1ull << HEADER_WOSIZE_BITS) - 1ull)
 
-// Note that Wosize_val and the other macros that read headers will not
-// be optimized by common subexpression elimination, because of the
-// atomic header loads.  It is best to bind the results of such macros
-// to variables if they will be tested repeatedly, e.g. as the end condition
-// in a for-loop.
-
-#define Wosize_val(val) (Wosize_hd (Hd_val (val)))
-#define Wosize_op(op) (Wosize_val (op))
-#define Wosize_bp(bp) (Wosize_val (bp))
-#define Wosize_hp(hp) (Wosize_hd (Hd_hp (hp)))
 #define Whsize_wosize(sz) ((sz) + 1)
 #define Wosize_whsize(sz) ((sz) - 1)
 #define Wosize_bhsize(sz) ((sz) / sizeof (value) - 1)
@@ -269,16 +259,56 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
 #define Wsize_bsize(sz) ((sz) / sizeof (value))
 #define Bhsize_wosize(sz) (Bsize_wsize (Whsize_wosize (sz)))
 #define Bhsize_bosize(sz) ((sz) + sizeof (header_t))
-#define Bosize_val(val) (Bsize_wsize (Wosize_val (val)))
-#define Bosize_op(op) (Bosize_val (Val_op (op)))
-#define Bosize_bp(bp) (Bosize_val (Val_bp (bp)))
-#define Bosize_hd(hd) (Bsize_wsize (Wosize_hd (hd)))
-#define Whsize_hp(hp) (Whsize_wosize (Wosize_hp (hp)))
-#define Whsize_val(val) (Whsize_hp (Hp_val (val)))
-#define Whsize_bp(bp) (Whsize_val (Val_bp (bp)))
-#define Whsize_hd(hd) (Whsize_wosize (Wosize_hd (hd)))
-#define Bhsize_hp(hp) (Bsize_wsize (Whsize_hp (hp)))
-#define Bhsize_hd(hd) (Bsize_wsize (Whsize_hd (hd)))
+
+/* Note that Allocated_wosize_val and the other macros that read headers will not
+   be optimized by common subexpression elimination, because of the
+   atomic header loads.  It is best to bind the results of such macros
+   to variables if they will be tested repeatedly, e.g. as the end condition
+   in a for-loop.
+*/
+
+/* We rename the size macros to [Allocated_...] internally so that we're forced
+   to think about whether imported code needs to updated for mixed blocks,
+   which have separate notions of scannable size and total size of
+   an object, even for scannable tags. We call an object's size
+   (including possibly non-scannable fields) its "allocated" size
+   to document the fact that you shouldn't scan fields on the
+   basis of this size alone.
+ */
+
+#define Allocated_wosize_val(val) (Allocated_wosize_hd (Hd_val (val)))
+#define Allocated_wosize_op(op) (Allocated_wosize_val (op))
+#define Allocated_wosize_bp(bp) (Allocated_wosize_val (bp))
+#define Allocated_wosize_hp(hp) (Allocated_wosize_hd (Hd_hp (hp)))
+#define Allocated_bosize_val(val) (Bsize_wsize (Allocated_wosize_val (val)))
+#define Allocated_bosize_op(op) (Allocated_bosize_val (Val_op (op)))
+#define Allocated_bosize_bp(bp) (Allocated_bosize_val (Val_bp (bp)))
+#define Allocated_bosize_hd(hd) (Bsize_wsize (Allocated_wosize_hd (hd)))
+#define Allocated_whsize_hp(hp) (Whsize_wosize (Allocated_wosize_hp (hp)))
+#define Allocated_whsize_val(val) (Allocated_whsize_hp (Hp_val (val)))
+#define Allocated_whsize_bp(bp) (Allocated_whsize_val (Val_bp (bp)))
+#define Allocated_whsize_hd(hd) (Whsize_wosize (Allocated_wosize_hd (hd)))
+#define Allocated_bhsize_hp(hp) (Bsize_wsize (Allocated_whsize_hp (hp)))
+#define Allocated_bhsize_hd(hd) (Bsize_wsize (Allocated_whsize_hd (hd)))
+
+/* CR nroberts: Soon, we'd like to only define these macros if CAML_INTERNALS
+   is defined. This allows us to ban the old names in user code.
+*/
+#define Wosize_hd(hd)   Allocated_wosize_hd(hd)
+#define Wosize_val(val) Allocated_wosize_val(val)
+#define Wosize_op(op)   Allocated_wosize_op(op)
+#define Wosize_bp(bp)   Allocated_wosize_bp(bp)
+#define Wosize_hp(hp)   Allocated_wosize_hp(hp)
+#define Bosize_val(val) Allocated_bosize_val(val)
+#define Bosize_op(op)   Allocated_bosize_op(op)
+#define Bosize_bp(bp)   Allocated_bosize_bp(bp)
+#define Bosize_hd(hd)   Allocated_bosize_hd(hd)
+#define Whsize_hp(hp)   Allocated_whsize_hp(hp)
+#define Whsize_val(val) Allocated_whsize_val(val)
+#define Whsize_bp(bp)   Allocated_whsize_bp(bp)
+#define Whsize_hd(hd)   Allocated_whsize_hd(hd)
+#define Bhsize_hp(hp)   Allocated_bhsize_hp(hp)
+#define Bhsize_hd(hd)   Allocated_bhsize_hd(hd)
 
 #define Reserved_val(val) (Reserved_hd (Hd_val (val)))
 
@@ -333,7 +363,7 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
    with tag Closure_tag (see compact.c). */
 
 #define Infix_tag 249
-#define Infix_offset_hd(hd) (Bosize_hd(hd))
+#define Infix_offset_hd(hd) (Allocated_bosize_hd(hd))
 #define Infix_offset_val(v) Infix_offset_hd(Hd_val(v))
 
 /* Another special case: objects */

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -290,6 +290,15 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
 #define Allocated_bhsize_hp(hp) (Bsize_wsize (Allocated_whsize_hp (hp)))
 #define Allocated_bhsize_hd(hd) (Bsize_wsize (Allocated_whsize_hd (hd)))
 
+  /* User code should define [Define_upstream_macros_for_accessing_block_size]
+     to document that the author is explicitly acknowledging that the code
+     has been vetted to not improperly interpret the allocated size of a mixed
+     block as its scannable size.
+
+     Typically, it is encouraged to use the new names so that any new code that's
+     added is also vetted, but there are some cases where it's much more
+     convenient to define the [Define_*] macro.
+  */
 #if defined(CAML_INTERNALS) || \
     defined(Define_upstream_macros_for_accessing_block_size)
 #define Wosize_hd(hd)   Allocated_wosize_hd(hd)

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -267,14 +267,13 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
    in a for-loop.
 */
 
-/* We rename the size macros to [Allocated_...] internally so that we're forced
-   to think about whether imported code needs to updated for mixed blocks,
-   which have separate notions of scannable size and total size of
-   an object, even for scannable tags. We call an object's size
-   (including possibly non-scannable fields) its "allocated" size
-   to document the fact that you shouldn't scan fields on the
-   basis of this size alone.
- */
+/* Jane Street: We rename the size macros to [Allocated_...] internally so that
+   we're forced to think about whether imported code needs to updated for mixed
+   blocks, which have separate notions of scannable size and total size of an
+   object, even for scannable tags. We call an object's size (including possibly
+   non-scannable fields) its "allocated" size to document the fact that you
+   shouldn't scan fields on the basis of this size alone.
+*/
 
 #define Allocated_wosize_val(val) (Allocated_wosize_hd (Hd_val (val)))
 #define Allocated_wosize_op(op) (Allocated_wosize_val (op))
@@ -291,9 +290,8 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
 #define Allocated_bhsize_hp(hp) (Bsize_wsize (Allocated_whsize_hp (hp)))
 #define Allocated_bhsize_hd(hd) (Bsize_wsize (Allocated_whsize_hd (hd)))
 
-/* CR nroberts: Soon, we'd like to only define these macros if CAML_INTERNALS
-   is defined. This allows us to ban the old names in user code.
-*/
+#if defined(CAML_INTERNALS) || \
+    defined(Define_upstream_macros_for_accessing_block_size)
 #define Wosize_hd(hd)   Allocated_wosize_hd(hd)
 #define Wosize_val(val) Allocated_wosize_val(val)
 #define Wosize_op(op)   Allocated_wosize_op(op)
@@ -309,6 +307,7 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
 #define Whsize_hd(hd)   Allocated_whsize_hd(hd)
 #define Bhsize_hp(hp)   Allocated_bhsize_hp(hp)
 #define Bhsize_hd(hd)   Allocated_bhsize_hd(hd)
+#endif // CAML_INTERNALS || Define_upstream_macros_for_accessing_block_size
 
 #define Reserved_val(val) (Reserved_hd (Hd_val (val)))
 

--- a/ocaml/runtime/clambda_checks.c
+++ b/ocaml/runtime/clambda_checks.c
@@ -14,6 +14,8 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
+
 /* Runtime checks to try to catch errors in code generation.
    See flambda_to_clambda.ml for more information. */
 

--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -275,6 +275,15 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
 #define Allocated_bhsize_hp(hp) (Bsize_wsize (Allocated_whsize_hp (hp)))
 #define Allocated_bhsize_hd(hd) (Bsize_wsize (Allocated_whsize_hd (hd)))
 
+/* User code should define [Define_upstream_macros_for_accessing_block_size]
+   to document that the author is explicitly acknowledging that the code
+   has been vetted to not improperly interpret the allocated size of a mixed
+   block as its scannable size.
+
+   Typically, it is encouraged to use the new names so that any new code that's
+   added is also vetted, but there are some cases where it's much more
+   convenient to define the [Define_*] macro.
+ */
 #if defined(CAML_INTERNALS) || \
     defined(Define_upstream_macros_for_accessing_block_size)
 #define Wosize_hd(hd)   Allocated_wosize_hd(hd)

--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -255,9 +255,9 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
 /* Jane Street: We rename the size macros to [Allocated_...] internally so that
    we're forced to think about whether imported code needs to updated for mixed
    blocks, which have separate notions of scannable size and total size of an
-   object, even for scannable tags. We call an object's size (including
-   possibly non-scannable fields) its "allocated" size to document the fact
-   that you shouldn't scan fields on the basis of this size alone.
+   object, even for scannable tags. We call an object's size (including possibly
+   non-scannable fields) its "allocated" size to document the fact that you
+   shouldn't scan fields on the basis of this size alone.
  */
 
 #define Allocated_wosize_val(val) (Allocated_wosize_hd (Hd_val (val)))
@@ -275,9 +275,8 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
 #define Allocated_bhsize_hp(hp) (Bsize_wsize (Allocated_whsize_hp (hp)))
 #define Allocated_bhsize_hd(hd) (Bsize_wsize (Allocated_whsize_hd (hd)))
 
-/* CR nroberts: Soon, we'd like to only define these macros if CAML_INTERNALS
-   is defined. This allows us to ban the old names in user code.
-*/
+#if defined(CAML_INTERNALS) || \
+    defined(Define_upstream_macros_for_accessing_block_size)
 #define Wosize_hd(hd)   Allocated_wosize_hd(hd)
 #define Wosize_val(val) Allocated_wosize_val(val)
 #define Wosize_op(op)   Allocated_wosize_op(op)
@@ -293,6 +292,7 @@ Caml_inline mlsize_t Scannable_wosize_reserved_byte(reserved_t res,
 #define Whsize_hd(hd)   Allocated_whsize_hd(hd)
 #define Bhsize_hp(hp)   Allocated_bhsize_hp(hp)
 #define Bhsize_hd(hd)   Allocated_bhsize_hd(hd)
+#endif // CAML_INTERNALS || Define_upstream_macros_for_accessing_block_size
 
 #define Scannable_wosize_hp(hp) (Scannable_wosize_hd (Hd_hp (hp)))
 

--- a/ocaml/runtime4/clambda_checks.c
+++ b/ocaml/runtime4/clambda_checks.c
@@ -14,6 +14,8 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
+
 /* Runtime checks to try to catch errors in code generation.
    See flambda_to_clambda.ml for more information. */
 


### PR DESCRIPTION
Stop allowing use of the `*size*` family of macros. User code should instead use `Allocated_*size*`. This helps us be more confident that users will be notified if importing code that interprets a block's allocated size as its scannable size.

There are two exceptions:

- User code can explicitly request the old naming of macros by defining a magic macro. This makes some user code much easier to update. (It's encouraged to use the new names, as this will also force people to think about new code they import in the future.)
- The compiler distribution itself uses the `*size*` family of macros. This avoids some renaming churn in the compiler which could introduce the possibility of merge conflicts. A counterargument is: well, we should be confident that the compiler code has been vetted in the same way. (My preference is to rely on testing here.) I'm open to rethinking this, but my starting point is that it's better to avoid the merge conflicts.

Once #2653 is merged and user code is updated, we can merge this.