### PR TITLE
Fix `--enable-dev` in runtime 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ jobs:
             config: --enable-middle-end=flambda2 --enable-dev
             os: ubuntu-latest
 
+          - name: flambda2_dev_runtime5
+            config: --enable-middle-end=flambda2 --enable-dev --enable-runtime5
+            os: ubuntu-latest
+
           - name: flambda2_debug_runtime5
             config: --enable-middle-end=flambda2 --enable-runtime5
             os: ubuntu-latest

--- a/ocaml/otherlibs/systhreads/byte/dune
+++ b/ocaml/otherlibs/systhreads/byte/dune
@@ -6,9 +6,9 @@
  (name threads)
  (modes byte)
  (wrapped false)
- ; FIXME Fix warning 27
+ ; FIXME Fix warning 27 and -no-strict-sequence
  (flags
-  (:standard -g -bin-annot -w -27))
+  (:standard -no-strict-sequence -g -bin-annot -w -27))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
  (libraries unix)

--- a/ocaml/otherlibs/systhreads/native/dune
+++ b/ocaml/otherlibs/systhreads/native/dune
@@ -6,9 +6,9 @@
  (name threadsnat)
  (modes native)
  (wrapped false)
- ; FIXME Fix warning 27
+ ; FIXME Fix warning 27 and -no-strict-sequence
  (flags
-  (:standard -g -bin-annot -w -27))
+  (:standard -no-strict-sequence -g -bin-annot -w -27))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
  (libraries unix)


### PR DESCRIPTION
Mirrors #2635 , but for `systhreads` instead of only `systhreads4`. Also, add a CI job for checking that `--enable-dev` works with runtime 5. (#2639 was just for runtime 4.) 