### PR TITLE
Refactor `check_representable` in `typedecl.ml`

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -614,14 +614,7 @@ Error: Layout void is more experimental than allowed by the enabled layouts exte
 
 type ('a : any) any4 = Any4 of 'a
 [%%expect{|
-Line 1, characters 23-33:
-1 | type ('a : any) any4 = Any4 of 'a
-                           ^^^^^^^^^^
-Error: Constructor argument types must have a representable layout.
-       The layout of 'a is any, because
-         of the annotation on 'a in the declaration of the type any4.
-       But the layout of 'a must be representable, because
-         it's the type of a constructor field.
+type 'a any4 = Any4 of 'a
 |}];;
 
 (************************************************************)


### PR DESCRIPTION
Call `check_representable` before type variables in record and variant declarations get generalized. This will allow us to initialize more type variables to `any` in later PRs. `Ctype.type_sort` will now lower their layouts to sort variables instead of raising an error. Note that we now only call `Jkind.Sort.get_default_value` if `allow_unboxed = false`, since we might actually default sort variables now.

Call `check_representable` in `transl_labels` and `transl_types_gf`, instead of  `update_` functions. `allow_unboxed` is set to `false` for variants and records with `[@@unboxed]` annotations, and for inlined records. It is set to `true` otherwise.

We now accept `type ('a : any) any4 = Any4 of 'a`, lowering `'a` to `value`. This is confusing, however @goldfirere says that this is in line with existing OCaml behavior.