### PR TITLE
Disable partial inlining for runtime/str.c

### DIFF
--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -1019,6 +1019,10 @@ $(DEPDIR)/$(RUNTIME_DIR)/%.npic.$(D): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
 # https://www.intel.co.uk/content/www/uk/en/support/articles/000055650/processors.html
 $(RUNTIME_DIR)/major_gc.%.$(O): OC_CFLAGS += $(INTEL_JCC_BUG_CFLAGS)
 
+# Partial inlining on (at least) caml_string_compare seems to produce
+# worse code.
+$(RUNTIME_DIR)/str.%.$(O): OC_CFLAGS += -fno-partial-inlining
+
 ## Compilation of runtime C files
 
 # The COMPILE_C_FILE macro below receives as argument the pattern

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -1021,7 +1021,7 @@ $(RUNTIME_DIR)/major_gc.%.$(O): OC_CFLAGS += $(INTEL_JCC_BUG_CFLAGS)
 
 # Partial inlining on (at least) caml_string_compare seems to produce
 # worse code.
-$(RUNTIME_DIR)/str.%.$(O): OC_CFLAGS += -fno-partial-inlining
+$(RUNTIME_DIR)/str.%.$(O): OC_CFLAGS += $(NO_PARTIAL_INLINING_CFLAGS)
 
 ## Compilation of runtime C files
 

--- a/ocaml/Makefile.config.in
+++ b/ocaml/Makefile.config.in
@@ -219,6 +219,7 @@ WITH_PROFINFO=@profinfo@
 PROFINFO_WIDTH=@profinfo_width@
 HEADER_RESERVED_BITS=@reserved_header_bits@
 CUSTOM_OPS_STRUCT_SIZE=@custom_ops_struct_size@
+NO_PARTIAL_INLINING_CFLAGS=@no_partial_inlining_cflags@
 LIBUNWIND_AVAILABLE=@libunwind_available@
 LIBUNWIND_INCLUDE_FLAGS=@libunwind_include_flags@
 LIBUNWIND_LINK_FLAGS=@libunwind_link_flags@

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -751,6 +751,7 @@ flambda2
 flambda
 cpp_mangling
 frame_pointers
+no_partial_inlining_cflags
 custom_ops_struct_size
 profinfo_width
 profinfo
@@ -3360,6 +3361,7 @@ OCAML_VERSION_SHORT=5.1
 
 
  # TODO: rename this variable
+
 
 
 
@@ -15590,6 +15592,7 @@ fi ;; #(
      ;;
 esac
 
+# Disabling of stack checks is only supported on amd64.
 if test x"$enable_stack_checks" = xyes
 then :
   printf "%s\n" "#define STACK_CHECKS_ENABLED 1" >>confdefs.h
@@ -19673,6 +19676,14 @@ then :
 
 fi
 
+# Only gcc supports -fno-partial-inlining
+case $ocaml_cv_cc_vendor in #(
+  gcc-*) :
+    no_partial_inlining_cflags="-fno-partial-inlining" ;; #(
+  *) :
+    no_partial_inlining_cflags="" ;;
+esac
+
 printf "%s\n" "#define CUSTOM_OPS_STRUCT_SIZE $custom_ops_struct_size" >>confdefs.h
 
 
@@ -22455,3 +22466,5 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 printf "%s\n" "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
+
+

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -219,6 +219,7 @@ AC_SUBST([reserved_header_bits])
 AC_SUBST([profinfo])
 AC_SUBST([profinfo_width])
 AC_SUBST([custom_ops_struct_size])
+AC_SUBST([no_partial_inlining_cflags])
 AC_SUBST([frame_pointers])
 AC_SUBST([cpp_mangling])
 AC_SUBST([flambda])
@@ -2220,6 +2221,12 @@ OCAML_MMAP_SUPPORTS_HUGE_PAGES
 AC_DEFINE_UNQUOTED([HEADER_RESERVED_BITS], [$reserved_header_bits])
 AC_DEFINE_UNQUOTED([PROFINFO_WIDTH], [$profinfo_width])
 AS_IF([$profinfo], [AC_DEFINE([WITH_PROFINFO])])
+
+# Only gcc supports -fno-partial-inlining
+AS_CASE([$ocaml_cv_cc_vendor],
+  [gcc-*],
+    [no_partial_inlining_cflags="-fno-partial-inlining"],
+  [no_partial_inlining_cflags=""])
 
 AC_DEFINE_UNQUOTED([CUSTOM_OPS_STRUCT_SIZE], [$custom_ops_struct_size])
 


### PR DESCRIPTION
Partial inlining seems to be producing worse code on x86-64 for `caml_string_compare` (and maybe other functions too)?  This PR disables it, just for `str.c` in the initial instance.