### PR TITLE
Implement `Nullability` axis for jkinds

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-or-null/array.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/array.ml
@@ -1,0 +1,24 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+(* CR layouts v3.0: array type arguments should be [any_non_null]: *)
+
+type t_any : any
+
+type should_fail = t_any array
+
+[%%expect{|
+type t_any : any
+type should_fail = t_any array
+|}]
+
+type t_value_or_null : value_or_null
+
+type should_fail = t_value_or_null array
+
+[%%expect{|
+type t_value_or_null : value_or_null
+type should_fail = t_value_or_null array
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -460,3 +460,43 @@ Error: Signature mismatch:
        But the layout of the first must be a sublayout of bits64, because
          of the definition of t at line 1, characters 51-66.
 |}]
+
+(* The meet of [any_non_null] and [value_or_null] is [value] *)
+
+type (_, _) two
+
+type ('a : any) t1 = ('a id_any_non_null, 'a id_value_or_null) two
+
+type should_work = t_value t1
+
+[%%expect{|
+type (_, _) two
+type 'a t1 = ('a id_any_non_null, 'a id_value_or_null) two
+type should_work = t_value t1
+|}]
+
+type should_fail = t_value_or_null t1
+
+[%%expect{|
+Line 1, characters 19-34:
+1 | type should_fail = t_value_or_null t1
+                       ^^^^^^^^^^^^^^^
+Error: This type t_value_or_null should be an instance of type ('a : value)
+       The layout of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the layout of t_value_or_null must be a sublayout of value, because
+         of the definition of t1 at line 3, characters 0-66.
+|}]
+
+type should_fail = t_any_non_null t1
+
+[%%expect{|
+Line 1, characters 19-33:
+1 | type should_fail = t_any_non_null t1
+                       ^^^^^^^^^^^^^^
+Error: This type t_any_non_null should be an instance of type ('a : value)
+       The layout of t_any_non_null is any_non_null, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of value, because
+         of the definition of t1 at line 3, characters 0-66.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -61,8 +61,6 @@ Error: This type signature for x is not a value type.
          it's the type of something stored in a module structure.
 |}]
 
-(* This is ok for some reason *)
-
 module type S2 = sig
   val f : unit -> t_any
   val g : unit -> t_any_non_null

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -188,14 +188,35 @@ module M :
 type t = t_any id_any_non_null
 
 [%%expect{|
-type t = t_any id_any_non_null
+Line 1, characters 9-14:
+1 | type t = t_any id_any_non_null
+             ^^^^^
+Error: This type t_any should be an instance of type ('a : any_non_null)
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be a sublayout of any_non_null, because
+         of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
 module M (X : sig type t : any end) : sig type t : any_non_null end = X
 
 [%%expect{|
-module M :
-  functor (X : sig type t : any end) -> sig type t : any_non_null end
+Line 1, characters 70-71:
+1 | module M (X : sig type t : any end) : sig type t : any_non_null end = X
+                                                                          ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = X.t end
+       is not included in
+         sig type t : any_non_null end
+       Type declarations do not match:
+         type t = X.t
+       is not included in
+         type t : any_non_null
+       The layout of the first is any, because
+         of the definition of t at line 1, characters 18-30.
+       But the layout of the first must be a sublayout of any_non_null, because
+         of the definition of t at line 1, characters 42-63.
 |}]
 
 (* [value_or_null] is not a subtype of [value] *)

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -1,0 +1,235 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+type t_any : any
+type t_any_non_null : any_non_null
+type t_value_or_null : value_or_null
+type t_value : value
+
+[%%expect{|
+type t_any : any
+type t_any_non_null : any_non_null
+type t_value_or_null : value_or_null
+type t_value : value
+|}]
+
+(* [any_non_null] is not representable *)
+let f (x : t_any_non_null) = x
+
+[%%expect{|
+Line 1, characters 6-26:
+1 | let f (x : t_any_non_null) = x
+          ^^^^^^^^^^^^^^^^^^^^
+Error: This pattern matches values of type t_any_non_null
+       but a pattern was expected which matches values of type
+         ('a : '_representable_layout_1)
+       The layout of t_any_non_null is any_non_null, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable, because
+         we must know concretely how to pass a function argument.
+|}]
+
+type t = { x : t_any_non_null }
+
+[%%expect{|
+Line 1, characters 11-29:
+1 | type t = { x : t_any_non_null }
+               ^^^^^^^^^^^^^^^^^^
+Error: Record element types must have a representable layout.
+       The layout of t_any_non_null is any_non_null, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable, because
+         it is the type of record field x.
+|}]
+
+module type S1 = sig
+  val x : t_any_non_null
+end
+
+[%%expect{|
+Line 2, characters 10-24:
+2 |   val x : t_any_non_null
+              ^^^^^^^^^^^^^^
+Error: This type signature for x is not a value type.
+       The layout of type t_any_non_null is any_non_null, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of type t_any_non_null must be a sublayout of value, because
+         it's the type of something stored in a module structure.
+|}]
+
+(* This is ok for some reason *)
+
+module type S2 = sig
+  val f : unit -> t_any
+  val g : unit -> t_any_non_null
+end
+
+[%%expect{|
+module type S2 = sig val f : unit -> t_any val g : unit -> t_any_non_null end
+|}]
+
+module M2 (X : S2) = struct
+  let g () = X.g ()
+end
+
+[%%expect{|
+Line 2, characters 13-19:
+2 |   let g () = X.g ()
+                 ^^^^^^
+Error: This expression has type t_any_non_null
+       but an expression was expected of type ('a : '_representable_layout_2)
+       The layout of t_any_non_null is any_non_null, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable, because
+         we must know concretely how to return a function result.
+|}]
+
+(* CR layouts v3.0: [value_or_null] should be representable *)
+
+let f (x : t_value_or_null) = x
+
+[%%expect{|
+Line 1, characters 6-27:
+1 | let f (x : t_value_or_null) = x
+          ^^^^^^^^^^^^^^^^^^^^^
+Error: This pattern matches values of type t_value_or_null
+       but a pattern was expected which matches values of type ('a : value)
+       The layout of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the layout of t_value_or_null must be a sublayout of value, because
+         we must know concretely how to pass a function argument, defaulted to layout value.
+|}]
+
+type t = { x : t_value_or_null }
+
+[%%expect {|
+Line 1, characters 11-30:
+1 | type t = { x : t_value_or_null }
+               ^^^^^^^^^^^^^^^^^^^
+Error: Record element types must have a representable layout.
+       The layout of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the layout of t_value_or_null must be a sublayout of value, because
+         it is the type of record field x, defaulted to layout value.
+|}]
+
+module type S1 = sig
+  val x : t_value_or_null
+end
+
+[%%expect {|
+Line 2, characters 10-25:
+2 |   val x : t_value_or_null
+              ^^^^^^^^^^^^^^^
+Error: This type signature for x is not a value type.
+       The layout of type t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the layout of type t_value_or_null must be a sublayout of value, because
+         it's the type of something stored in a module structure.
+|}]
+
+module type S2 = sig
+  val f : unit -> t_value_or_null
+end
+
+[%%expect {|
+module type S2 = sig val f : unit -> t_value_or_null end
+|}]
+
+module M2 (X : S2) = struct
+  let f () = X.f ()
+end
+
+[%%expect{|
+Line 2, characters 13-19:
+2 |   let f () = X.f ()
+                 ^^^^^^
+Error: This expression has type t_value_or_null
+       but an expression was expected of type ('a : value)
+       The layout of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the layout of t_value_or_null must be a sublayout of value, because
+         we must know concretely how to return a function result, defaulted to layout value.
+|}]
+
+type ('a : any) id_any = 'a
+type ('a : any_non_null) id_any_non_null = 'a
+type ('a : value_or_null) id_value_or_null = 'a
+type ('a : value) id_value = 'a
+type ('a : bits64) id_bits64 = 'a
+
+[%%expect{|
+type ('a : any) id_any = 'a
+type ('a : any_non_null) id_any_non_null = 'a
+type ('a : value_or_null) id_value_or_null = 'a
+type 'a id_value = 'a
+type ('a : bits64) id_bits64 = 'a
+|}]
+
+(* [any_non_null] is a subtype of [any] *)
+
+type t = t_any_non_null id_any
+
+[%%expect{|
+type t = t_any_non_null id_any
+|}]
+
+module M (X : sig type t : any_non_null end) : sig type t : any end = X
+
+[%%expect{|
+module M :
+  functor (X : sig type t : any_non_null end) -> sig type t : any end
+|}]
+
+(* CR layouts v3.0: [any] should not be a subtype of [any_non_null] *)
+
+type t = t_any id_any_non_null
+
+[%%expect{|
+type t = t_any id_any_non_null
+|}]
+
+module M (X : sig type t : any end) : sig type t : any_non_null end = X
+
+[%%expect{|
+module M :
+  functor (X : sig type t : any end) -> sig type t : any_non_null end
+|}]
+
+(* [value_or_null] is not a subtype of [value] *)
+
+type t = t_value_or_null id_value
+
+[%%expect{|
+Line 1, characters 9-24:
+1 | type t = t_value_or_null id_value
+             ^^^^^^^^^^^^^^^
+Error: This type t_value_or_null should be an instance of type ('a : value)
+       The layout of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the layout of t_value_or_null must be a sublayout of value, because
+         of the definition of id_value at line 4, characters 0-31.
+|}]
+
+module M (X : sig type t : value_or_null end) : sig type t : value end = X
+
+[%%expect{|
+Line 1, characters 73-74:
+1 | module M (X : sig type t : value_or_null end) : sig type t : value end = X
+                                                                             ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = X.t end
+       is not included in
+         sig type t : value end
+       Type declarations do not match:
+         type t = X.t
+       is not included in
+         type t : value
+       The layout of the first is value_or_null, because
+         of the definition of t at line 1, characters 18-40.
+       But the layout of the first must be a sublayout of value, because
+         of the definition of t at line 1, characters 52-66.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -1,0 +1,164 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+type t_value_or_null : value_or_null
+type ('a : value_or_null) id_value_or_null = 'a
+
+
+[%%expect{|
+type t_value_or_null : value_or_null
+type ('a : value_or_null) id_value_or_null = 'a
+|}]
+
+(* CR layouts v3.0: sort variables in functions should start as [Or_null]. *)
+
+type 'a should_accept_or_null = 'a id_value_or_null
+
+type should_work = t_value_or_null should_accept_or_null
+
+[%%expect{|
+type 'a should_accept_or_null = 'a id_value_or_null
+Line 3, characters 19-34:
+3 | type should_work = t_value_or_null should_accept_or_null
+                       ^^^^^^^^^^^^^^^
+Error: This type t_value_or_null should be an instance of type ('a : value)
+       The layout of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the layout of t_value_or_null must be a sublayout of value, because
+         of the definition of should_accept_or_null at line 1, characters 0-51.
+|}]
+
+let should_work (x : t_value_or_null) = x
+
+[%%expect{|
+Line 1, characters 16-37:
+1 | let should_work (x : t_value_or_null) = x
+                    ^^^^^^^^^^^^^^^^^^^^^
+Error: This pattern matches values of type t_value_or_null
+       but a pattern was expected which matches values of type ('a : value)
+       The layout of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the layout of t_value_or_null must be a sublayout of value, because
+         we must know concretely how to pass a function argument, defaulted to layout value.
+|}]
+
+module type S = sig
+  val should_work : 'a -> unit
+end
+
+module M (X : S) : sig
+  val should_work : ('a : value_or_null) . 'a -> unit
+end = X
+
+[%%expect{|
+module type S = sig val should_work : 'a -> unit end
+Line 7, characters 6-7:
+7 | end = X
+          ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val should_work : 'a -> unit end
+       is not included in
+         sig val should_work : ('a : value_or_null). 'a -> unit end
+       Values do not match:
+         val should_work : 'a -> unit
+       is not included in
+         val should_work : ('a : value_or_null). 'a -> unit
+       The type 'a -> unit is not compatible with the type 'b -> unit
+       The layout of 'a is value_or_null, because
+         of the definition of should_work at line 6, characters 2-53.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of should_work at line 2, characters 2-30.
+|}]
+
+(* Type parameters should default to [value] for fully abstract types *)
+
+module M (X : sig type 'a t end) : sig type ('a : value_or_null) t end = X
+
+[%%expect{|
+Line 1, characters 73-74:
+1 | module M (X : sig type 'a t end) : sig type ('a : value_or_null) t end = X
+                                                                             ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a X.t end
+       is not included in
+         sig type ('a : value_or_null) t end
+       Type declarations do not match:
+         type 'a t = 'a X.t
+       is not included in
+         type ('a : value_or_null) t
+       Their parameters differ:
+       The type ('a : value) is not equal to the type ('a0 : value_or_null)
+       because their layouts are different.
+|}]
+
+(* CR layouts v3.0: type parameters should default to [any] for abstract types
+   with equalities. *)
+
+module type S = sig
+  type 'a t = 'a
+
+  type t2 = t_value_or_null t
+end
+
+[%%expect{|
+Line 4, characters 12-27:
+4 |   type t2 = t_value_or_null t
+                ^^^^^^^^^^^^^^^
+Error: This type t_value_or_null should be an instance of type ('a : value)
+       The layout of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the layout of t_value_or_null must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-16.
+|}]
+
+(* CR layouts v3.0: the sublayout check should accept this for backwards
+   compatibility. *)
+
+module M : sig
+  type 'a t
+end = struct
+  type ('a : value_or_null) t = 'a
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a : value_or_null) t = 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a : value_or_null) t = 'a end
+       is not included in
+         sig type 'a t end
+       Type declarations do not match:
+         type ('a : value_or_null) t = 'a
+       is not included in
+         type 'a t
+       Their parameters differ:
+       The type ('a : value_or_null) is not equal to the type ('a0 : value)
+       because their layouts are different.
+|}]
+
+(* CR layouts v3.0: type parameters should default to [any] for
+   non-abstract types. *)
+
+module type S = sig
+  type 'a t = Value of 'a
+
+  type t2 = t_value_or_null t
+end
+
+[%%expect{|
+Line 4, characters 12-27:
+4 |   type t2 = t_value_or_null t
+                ^^^^^^^^^^^^^^^
+Error: This type t_value_or_null should be an instance of type ('a : value)
+       The layout of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the layout of t_value_or_null must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-25.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -32,6 +32,26 @@ Error: Layout void is more experimental than allowed by the enabled layouts exte
        You must enable -extension layouts_alpha to use this feature.
 |}]
 
+type t_any_non_null : any_non_null;;
+
+[%%expect{|
+Line 1, characters 22-34:
+1 | type t_any_non_null : any_non_null;;
+                          ^^^^^^^^^^^^
+Error: Layout any_non_null is more experimental than allowed by the enabled layouts extension.
+       You must enable -extension layouts_alpha to use this feature.
+|}]
+
+type t_value_or_null : value_or_null;;
+
+[%%expect{|
+Line 1, characters 23-36:
+1 | type t_value_or_null : value_or_null;;
+                           ^^^^^^^^^^^^^
+Error: Layout value_or_null is more experimental than allowed by the enabled layouts extension.
+       You must enable -extension layouts_alpha to use this feature.
+|}]
+
 (***************************************)
 (* Test 1: annotation on type variable *)
 

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -31,6 +31,26 @@ Error: Layout void is more experimental than allowed by the enabled layouts exte
        You must enable -extension layouts_alpha to use this feature.
 |}];;
 
+type t_any_non_null : any_non_null;;
+
+[%%expect{|
+Line 1, characters 22-34:
+1 | type t_any_non_null : any_non_null;;
+                          ^^^^^^^^^^^^
+Error: Layout any_non_null is more experimental than allowed by the enabled layouts extension.
+       You must enable -extension layouts_alpha to use this feature.
+|}]
+
+type t_value_or_null : value_or_null;;
+
+[%%expect{|
+Line 1, characters 23-36:
+1 | type t_value_or_null : value_or_null;;
+                           ^^^^^^^^^^^^^
+Error: Layout value_or_null is more experimental than allowed by the enabled layouts extension.
+       You must enable -extension layouts_alpha to use this feature.
+|}]
+
 (******************************************************************)
 (* Test 1: Allow non-representable function args/returns in types *)
 

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -9,6 +9,8 @@ type t_imm   : immediate
 type t_imm64 : immediate64
 type t_float64 : float64
 type t_void  : void
+type t_any_non_null : any_non_null;;
+type t_value_or_null : value_or_null;;
 
 type void_variant = VV of t_void
 type void_record = {vr_void : t_void; vr_int : int}
@@ -21,6 +23,8 @@ type t_imm : immediate
 type t_imm64 : immediate64
 type t_float64 : float64
 type t_void : void
+type t_any_non_null : any_non_null
+type t_value_or_null : value_or_null
 type void_variant = VV of t_void
 type void_record = { vr_void : t_void; vr_int : int; }
 type void_unboxed_record = { vur_void : t_void; } [@@unboxed]

--- a/ocaml/toplevel/genprintval.ml
+++ b/ocaml/toplevel/genprintval.ml
@@ -251,13 +251,13 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
     let get_and_default_jkind_for_printing jkind =
       match Jkind.get_default_value jkind with
-      (* CR layouts v3.0: [Value] should probably require special
+      (* CR layouts v3.0: [Value_or_null] should probably require special
          printing to avoid descending into NULL. (This module uses
          lots of unsafe Obj features.)
       *)
-      | Immediate64 | Immediate | Value -> Print_as_value
+      | Immediate64 | Immediate | Value | Value_or_null -> Print_as_value
       | Void -> Print_as "<void>"
-      | Any -> Print_as "<any>"
+      | Any | Any_non_null -> Print_as "<any>"
       | Float64 | Float32 | Bits32 | Bits64 | Word -> Print_as "<abstr>"
 
     let outval_of_value max_steps max_depth check_depth env obj ty =

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -1657,6 +1657,10 @@ let instance_prim_layout (desc : Primitive.description) ty =
   then ty, None
   else
   let new_sort_and_jkind = ref None in
+  (* CR layouts v3.0: the sort variable created here should inherit
+     the nullability of the original jkind with layout [Any].
+     This is ok while sort variables are restricted to [Non_null],
+     but we should implement the correct logic afterwards. *)
   let get_jkind () =
     (* CR layouts v2.8: This should replace only the layout component of the
        jkind. It's possible that we might want a primitive that accepts a

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1336,6 +1336,7 @@ let combine_histories reason lhs rhs =
     | Not_le ->
       rhs.history
       (* CR layouts: this will be wrong if we ever have a non-trivial meet in the layout lattice *)
+      (* CR layouts v3.0: we do now: [any_non_null /\ value_or_null = value]. Fix this. *)
     | Equal ->
       if score_reason lhs.history >= score_reason rhs.history
       then lhs.history

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -50,6 +50,14 @@ module Externality : sig
   val le : t -> t -> bool
 end
 
+module Nullability : sig
+  type t = Jkind_types.Nullability.t =
+    | Non_null (* can't be null *)
+    | Or_null (* can be null *)
+
+  val le : t -> t -> bool
+end
+
 module Sort : Jkind_intf.Sort with type const = Jkind_types.Sort.const
 
 type sort = Sort.t

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -127,6 +127,8 @@ end
     the type checker when we know a jkind has no variables *)
 type const = Jkind_types.const =
   | Any
+  | Any_non_null
+  | Value_or_null
   | Value
   | Void
   | Immediate64
@@ -149,8 +151,14 @@ val equal_const : const -> const -> bool
     [any]. *)
 val any : why:any_creation_reason -> t
 
+(** This is the jkind of any non-null values *)
+val any_non_null : why:any_non_null_creation_reason -> t
+
 (** Value of types of this jkind are not retained at all at runtime *)
 val void : why:void_creation_reason -> t
+
+(** This is the jkind of normal ocaml values or null pointers *)
+val value_or_null : why:value_or_null_creation_reason -> t
 
 (** This is the jkind of normal ocaml values *)
 val value : why:value_creation_reason -> t

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -170,6 +170,9 @@ module History = struct
     | Type_wildcard of Location.t
     | With_error_message of string * annotation_context
 
+  (* CR layouts v3: make new creation reasons *)
+  type value_or_null_creation_reason = |
+
   type value_creation_reason =
     | Class_let_binding
     | Tuple_element
@@ -235,6 +238,9 @@ module History = struct
     | Unification_var
     | Array_type_argument
 
+  (* CR layouts v3: make new creation reasons *)
+  type any_non_null_creation_reason = |
+
   type float64_creation_reason = Primitive of Ident.t
 
   type float32_creation_reason = Primitive of Ident.t
@@ -248,11 +254,13 @@ module History = struct
   type creation_reason =
     | Annotated of annotation_context * Location.t
     | Missing_cmi of Path.t
+    | Value_or_null_creation of value_or_null_creation_reason
     | Value_creation of value_creation_reason
     | Immediate_creation of immediate_creation_reason
     | Immediate64_creation of immediate64_creation_reason
     | Void_creation of void_creation_reason
     | Any_creation of any_creation_reason
+    | Any_non_null_creation of any_non_null_creation_reason
     | Float64_creation of float64_creation_reason
     | Float32_creation of float32_creation_reason
     | Word_creation of word_creation_reason

--- a/ocaml/typing/jkind_types.ml
+++ b/ocaml/typing/jkind_types.ml
@@ -321,13 +321,20 @@ module Externality = struct
     | Internal
 end
 
+module Nullability = struct
+  type t =
+    | Non_null
+    | Or_null
+end
+
 module Modes = Mode.Alloc.Const
 
 module Jkind_desc = struct
   type 'type_expr t =
     { layout : 'type_expr Layout.t;
       modes_upper_bounds : Modes.t;
-      externality_upper_bound : Externality.t
+      externality_upper_bound : Externality.t;
+      nullability_upper_bound : Nullability.t
     }
 end
 

--- a/ocaml/typing/jkind_types.ml
+++ b/ocaml/typing/jkind_types.ml
@@ -362,6 +362,8 @@ type 'type_expr t =
 
 type const =
   | Any
+  | Any_non_null
+  | Value_or_null
   | Value
   | Void
   | Immediate64

--- a/ocaml/typing/jkind_types.mli
+++ b/ocaml/typing/jkind_types.mli
@@ -93,13 +93,20 @@ module Externality : sig
     | Internal
 end
 
+module Nullability : sig
+  type t =
+    | Non_null
+    | Or_null
+end
+
 module Modes = Mode.Alloc.Const
 
 module Jkind_desc : sig
   type 'type_expr t =
     { layout : 'type_expr Layout.t;
       modes_upper_bounds : Modes.t;
-      externality_upper_bound : Externality.t
+      externality_upper_bound : Externality.t;
+      nullability_upper_bound : Nullability.t
     }
 end
 

--- a/ocaml/typing/jkind_types.mli
+++ b/ocaml/typing/jkind_types.mli
@@ -112,6 +112,8 @@ end
 
 type const =
   | Any
+  | Any_non_null
+  | Value_or_null
   | Value
   | Void
   | Immediate64

--- a/ocaml/typing/subst.ml
+++ b/ocaml/typing/subst.ml
@@ -96,7 +96,9 @@ let with_additional_action (config : additional_action_config) s =
     | Prepare_for_saving ->
         let reason = Jkind.Imported in
         let any = Jkind.of_const Any ~why:reason in
+        let any_non_null = Jkind.of_const Any_non_null ~why:reason in
         let void = Jkind.of_const Void ~why:reason in
+        let value_or_null = Jkind.of_const Value_or_null ~why:reason in
         let value = Jkind.of_const Value ~why:reason in
         let immediate = Jkind.of_const Immediate ~why:reason in
         let immediate64 = Jkind.of_const Immediate64 ~why:reason in
@@ -108,7 +110,9 @@ let with_additional_action (config : additional_action_config) s =
         let prepare_jkind loc lay =
           match Jkind.get lay with
           | Const Any -> any
+          | Const Any_non_null -> any_non_null
           | Const Void -> void
+          | Const Value_or_null -> value_or_null
           | Const Value -> value
           | Const Immediate -> immediate
           | Const Immediate64 -> immediate64

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2798,7 +2798,11 @@ let has_ty_var_with_layout_any env ty =
     (Ctype.free_variables ty)
 
 let unexpected_layout_any_check prim env cty ty =
+<<<<<<< HEAD
   if Primitive.prim_can_contain_layout_any prim ||
+=======
+  if Primitive.prim_can_contain_jkind_any prim ||
+>>>>>>> 76dc96606 (Fixes)
      prim.prim_is_layout_poly then ()
   else
   if has_ty_var_with_layout_any env ty then
@@ -2851,9 +2855,14 @@ let unexpected_layout_any_check prim env cty ty =
       point to the source of the mistake which is, in fact, the external
       declaration.
 
+<<<<<<< HEAD
       For this reason, we have [unexpected_layout_any_check].  It's here to
       point out this type of mistake early and suggest the use of
       [@layout_poly].
+=======
+      For this reason, we have [unexpected_layout_any_check].  It's here to point
+      out this type of mistake early and suggest the use of [@layout_poly].
+>>>>>>> 76dc96606 (Fixes)
 
       An exception is raised if any of these checks fails. *)
 let error_if_containing_unexpected_jkind prim env cty ty =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2798,11 +2798,7 @@ let has_ty_var_with_layout_any env ty =
     (Ctype.free_variables ty)
 
 let unexpected_layout_any_check prim env cty ty =
-<<<<<<< HEAD
   if Primitive.prim_can_contain_layout_any prim ||
-=======
-  if Primitive.prim_can_contain_jkind_any prim ||
->>>>>>> 76dc96606 (Fixes)
      prim.prim_is_layout_poly then ()
   else
   if has_ty_var_with_layout_any env ty then

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1250,6 +1250,7 @@ module Element_repr = struct
          flambda2 to unbox for 32 bit platforms.
       *)
       | Immediate64 -> Value_element
+      | Value_or_null -> Value_element
       | Value -> Value_element
       | Immediate -> Imm_element
       | Float64 -> Unboxed_element Float64
@@ -1258,7 +1259,7 @@ module Element_repr = struct
       | Bits32 -> Unboxed_element Bits32
       | Bits64 -> Unboxed_element Bits64
       | Void -> Element_without_runtime_component { loc; ty }
-      | Any ->
+      | Any | Any_non_null ->
           Misc.fatal_error "Element_repr.classify: unexpected Any"
 
   let unboxed_to_flat : unboxed_element -> flat_element = function

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2851,14 +2851,9 @@ let unexpected_layout_any_check prim env cty ty =
       point to the source of the mistake which is, in fact, the external
       declaration.
 
-<<<<<<< HEAD
       For this reason, we have [unexpected_layout_any_check].  It's here to
       point out this type of mistake early and suggest the use of
       [@layout_poly].
-=======
-      For this reason, we have [unexpected_layout_any_check].  It's here to point
-      out this type of mistake early and suggest the use of [@layout_poly].
->>>>>>> 76dc96606 (Fixes)
 
       An exception is raised if any of these checks fails. *)
 let error_if_containing_unexpected_jkind prim env cty ty =

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -235,11 +235,11 @@ let bigarray_type_kind_and_layout env typ =
 
 let value_kind_of_value_jkind jkind =
   match Jkind.get_default_value jkind with
-  | Value -> Pgenval
+  | Value_or_null | Value -> Pgenval
   | Immediate -> Pintval
   | Immediate64 ->
     if !Clflags.native_code && Sys.word_size = 64 then Pintval else Pgenval
-  | Any | Void | Float64 | Float32 | Word | Bits32 | Bits64 -> assert false
+  | Any | Any_non_null | Void | Float64 | Float32 | Word | Bits32 | Bits64 -> assert false
 
 (* [value_kind] has a pre-condition that it is only called on values.  With the
    current set of sort restrictions, there are two reasons this invariant may


### PR DESCRIPTION
Implement `Nullability` axis for jkinds, ordered `Non_null < Or_null`.

Implement two new legacy jkinds: `value_or_null` and `any_non_null`. The first will be used for `'a or_null`, while the second will be the jkind of array type parameters.

Mark sort variables as always `Non_null` for now. This is incorrect, but setting it to `Or_null` requires a lot of changes to the typing algorithm.

Split `Jkind.has_layout_any` from `Jkind.is_any` and handle existing callsites.

Test the new jkinds.