### PR TITLE
Make float32 NaN quiet

### DIFF
--- a/ocaml/otherlibs/stdlib_beta/float32.ml
+++ b/ocaml/otherlibs/stdlib_beta/float32.ml
@@ -71,7 +71,7 @@ let one = 1.s
 let minus_one = -1.s
 let infinity = float32_of_bits 0x7f800000l
 let neg_infinity = float32_of_bits 0xff800000l
-let nan = float32_of_bits 0x7f800001l
+let nan = float32_of_bits 0x7fc00001l
 let is_finite (x : t) = sub x x = 0.s
 let is_infinite (x : t) = div 1.s x = 0.s
 let is_nan (x : t) = x <> x

--- a/ocaml/otherlibs/stdlib_beta/float32.ml
+++ b/ocaml/otherlibs/stdlib_beta/float32.ml
@@ -71,7 +71,9 @@ let one = 1.s
 let minus_one = -1.s
 let infinity = float32_of_bits 0x7f800000l
 let neg_infinity = float32_of_bits 0xff800000l
-let nan = float32_of_bits 0x7fc00001l
+let quiet_nan = float32_of_bits 0x7fc00001l
+let signaling_nan = float32_of_bits 0x7f800001l
+let nan = quiet_nan
 let is_finite (x : t) = sub x x = 0.s
 let is_infinite (x : t) = div 1.s x = 0.s
 let is_nan (x : t) = x <> x

--- a/ocaml/otherlibs/stdlib_beta/float32.mli
+++ b/ocaml/otherlibs/stdlib_beta/float32.mli
@@ -128,7 +128,16 @@ val nan : t
     argument returns [nan] as result, unless otherwise specified in
     IEEE 754 standard.  As for floating-point comparisons,
     [=], [<], [<=], [>] and [>=] return [false] and [<>] returns [true]
-    if one or both of their arguments is [nan]. *)
+    if one or both of their arguments is [nan].
+
+    Equivalent to [quiet_nan]. *)
+
+val signaling_nan : t
+(** Signaling NaN. The corresponding signals do not raise OCaml exception,
+    but the value can be useful for interoperability with C libraries. *)
+
+val quiet_nan : t
+(** Quiet NaN. *)
 
 val pi : t
 (** The constant pi. *)

--- a/tests/small_numbers/float32_lib.ml
+++ b/tests/small_numbers/float32_lib.ml
@@ -204,10 +204,9 @@ let () =
 ;;
 
 let () =
-  (* In glibc 2.25+, powf(nan, zero) returns one only if the nan is non-signaling. *)
+  (* In glibc 2.25+, powf(nan, zero) returns one if the nan is non-signaling. *)
   bit_eq (F32.pow F32.nan F32.zero) F32.one;
   bit_eq (F32.pow F32.quiet_nan F32.zero) F32.one;
-  assert (F32.is_nan (F32.pow F32.signaling_nan F32.zero));
 ;;
 
 let () =

--- a/tests/small_numbers/float32_lib.ml
+++ b/tests/small_numbers/float32_lib.ml
@@ -204,6 +204,13 @@ let () =
 ;;
 
 let () =
+  (* In glibc 2.25+, powf(nan, zero) returns one only if the nan is non-signaling. *)
+  bit_eq (F32.pow F32.nan F32.zero) F32.one;
+  bit_eq (F32.pow F32.quiet_nan F32.zero) F32.one;
+  assert (F32.is_nan (F32.pow F32.signaling_nan F32.zero));
+;;
+
+let () =
   CF32.check_float32s (fun f1 f2 ->
     bit_eq (F32.add f1 f2) (CF32.add f1 f2);
     bit_eq (F32.sub f1 f2) (CF32.sub f1 f2);


### PR DESCRIPTION
See https://github.com/ocaml/ocaml/issues/10862 
We need to use a non-signaling NaN value (top mantissa bit set) in order for glibc >=2.25 `powf(nan, 0)` to return `1` instead of another NaN.