### PR TITLE
Fix a "bug" in `Ctype.constrain_type_jkind`

### DIFF
--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -1658,6 +1658,9 @@ let instance_prim_layout (desc : Primitive.description) ty =
   else
   let new_sort_and_jkind = ref None in
   let get_jkind () =
+    (* CR layouts v2.8: This should replace only the layout component of the
+       jkind. It's possible that we might want a primitive that accepts a
+       mode-crossing, layout-polymorphic parameter. *)
     match !new_sort_and_jkind with
     | Some (_, jkind) ->
       jkind

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -1675,10 +1675,10 @@ let instance_prim_layout (desc : Primitive.description) ty =
          from an outer scope *)
       if level = generic_level && try_mark_node ty then begin
         begin match get_desc ty with
-        | Tvar ({ jkind; _ } as r) when Jkind.is_any jkind ->
+        | Tvar ({ jkind; _ } as r) when Jkind.has_layout_any jkind ->
           For_copy.redirect_desc copy_scope ty
             (Tvar {r with jkind = get_jkind ()})
-        | Tunivar ({ jkind; _ } as r) when Jkind.is_any jkind ->
+        | Tunivar ({ jkind; _ } as r) when Jkind.has_layout_any jkind ->
           For_copy.redirect_desc copy_scope ty
             (Tunivar {r with jkind = get_jkind ()})
         | _ -> ()
@@ -2205,7 +2205,7 @@ let constrain_type_jkind ~fixed env ty jkind =
 let constrain_type_jkind ~fixed env ty jkind =
   (* An optimization to avoid doing any work if we're checking against
      any. *)
-  if Jkind.is_any jkind then Ok ()
+  if Jkind.is_max jkind then Ok ()
   else constrain_type_jkind ~fixed env ty jkind
 
 let check_type_jkind env ty jkind =

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1232,7 +1232,12 @@ let is_void_defaulting = function
   | { jkind = { layout = Sort s; _ }; _ } -> Sort.is_void_defaulting s
   | _ -> false
 
-let is_any jkind = match jkind.jkind.layout with Any -> true | _ -> false
+(* This doesn't do any mutation because mutating a sort variable can't make it
+   any, and modal upper bounds are constant. *)
+let is_max jkind = sub any_dummy_jkind jkind
+
+let has_layout_any jkind =
+  match jkind.jkind.layout with Any -> true | _ -> false
 
 (*********************************)
 (* debugging *)

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -346,8 +346,12 @@ val sub_or_error : t -> t -> (unit, Violation.t) result
 (** Like [sub], but returns the subjkind with an updated history. *)
 val sub_with_history : t -> t -> (t, Violation.t) result
 
-(** Checks to see whether a jkind is any. Never does any mutation. *)
-val is_any : t -> bool
+(** Checks to see whether a jkind is the maximum jkind. Never does any
+    mutation. *)
+val is_max : t -> bool
+
+(** Checks to see whether a jkind is has layout. Never does any mutation. *)
+val has_layout_any : t -> bool
 
 (*********************************)
 (* debugging *)

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -700,7 +700,7 @@ let prim_has_valid_reprs ~loc prim =
     raise (Error (loc,
             Invalid_native_repr_for_primitive (prim.prim_name)))
 
-let prim_can_contain_jkind_any prim =
+let prim_can_contain_layout_any prim =
   match prim.prim_name with
   | "%array_length"
   | "%array_safe_get"

--- a/ocaml/typing/primitive.mli
+++ b/ocaml/typing/primitive.mli
@@ -119,10 +119,10 @@ val native_name_is_external : description -> bool
     fails. *)
 val prim_has_valid_reprs : loc:Location.t -> description -> unit
 
-(** Check if a primitive can have jkind [any] anywhere within its type
+(** Check if a primitive can have layout [any] anywhere within its type
     declaration. Returns [false] for built-in primitives that inspect
     the layout of type parameters ([%array_length] for example). *)
-val prim_can_contain_jkind_any : description -> bool
+val prim_can_contain_layout_any : description -> bool
 
 type error =
   | Old_style_float_with_native_repr_attribute

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -171,7 +171,7 @@ type error =
   | Nonrec_gadt
   | Invalid_private_row_declaration of type_expr
   | Local_not_enabled
-  | Unexpected_jkind_any_in_primitive of string
+  | Unexpected_layout_any_in_primitive of string
   | Useless_layout_poly
   | Modalities_on_value_description
   | Zero_alloc_attr_unsupported of Builtin_attributes.zero_alloc_attribute


### PR DESCRIPTION
This fixes a bug that I believe is currently unreachable but will soon not be.  Here's the bug:

```ocaml
let constrain_type_jkind ~fixed env ty jkind =
  (* An optimization to avoid doing any work if we're checking against
     any. *)
  if Jkind.is_any jkind then Ok ()
  else constrain_type_jkind ~fixed env ty jkind
```

The issue is that `is_any` only checks whether the layout is any, and the layout isn't the only part of a jkind, so knowing the layout is any is insufficient to skip the call to `constrain_type_jkind`.

I don't think this bug is reachable because we haven't given the user any way to ask for weird jkinds like `any mod ...`, and because the compiler also never constructs such a jkind.

I've fixed this by:
* Splitting `Jkind.is_any` into two functions: `Jkind.is_max` and `Jkind.has_layout_any`.
* Updating all call sites to use the appropriate one.
* Adjusting some documentation and function names accordingly.
