### PR TITLE
Remove unnecessary regions for %int_as_pointer

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3086,7 +3086,7 @@ let curry_function (kind, arity, return) =
 
 type unary_primitive = expression -> Debuginfo.t -> expression
 
-let int_as_pointer arg dbg = Cop (Caddi, [arg; Cconst_int (-1, dbg)], dbg)
+let int_as_pointer arg dbg = Cop (Cadda, [arg; Cconst_int (-1, dbg)], dbg)
 (* always a pointer outside the heap *)
 
 let raise_prim raise_kind arg dbg =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3086,7 +3086,7 @@ let curry_function (kind, arity, return) =
 
 type unary_primitive = expression -> Debuginfo.t -> expression
 
-let int_as_pointer arg dbg = Cop (Cadda, [arg; Cconst_int (-1, dbg)], dbg)
+let int_as_pointer arg dbg = Cop (Caddi, [arg; Cconst_int (-1, dbg)], dbg)
 (* always a pointer outside the heap *)
 
 let raise_prim raise_kind arg dbg =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -365,6 +365,7 @@ type unary_primitive =
   (* CR gbury: Invariant check: 0 < dimension <= 3 *)
   | String_length of string_or_bytes
   | Int_as_pointer of Alloc_mode.For_allocations.t
+      (** In terms of regions, [Int_as_pointer] is like a zero-sized stack allocation. *)
   | Opaque_identity of
       { middle_end_only : bool;
         kind : Flambda_kind.t

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -56,7 +56,7 @@ type 'env trans_prim =
     unary :
       ( 'env,
         Flambda_primitive.unary_primitive,
-        Cmm.expression -> prim_res )
+        Simple.t * Cmm.expression -> prim_res )
       prim_helper;
     binary :
       ( 'env,
@@ -225,6 +225,7 @@ val simple : Cmm.expression -> free_vars -> simple bound_expr
 val splittable_primitive :
   Debuginfo.t ->
   Flambda_primitive.Without_args.t ->
+  Simple.t list ->
   expr_with_info list ->
   complex bound_expr
 
@@ -260,6 +261,8 @@ val add_alias :
   alias_of:Variable.t ->
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   t * To_cmm_result.t
+
+val resolve_alias : t -> Variable.t -> Variable.t
 
 (** Try and inline an Flambda variable using the delayed let-bindings. *)
 val inline_variable :

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -140,7 +140,11 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
   in
   let return_ty = C.extended_machtype_of_return_arity return_arity in
   match Apply.call_kind apply with
-  | Function { function_call = Direct code_id; alloc_mode = _ } -> (
+  | Function { function_call = Direct code_id; alloc_mode } -> (
+    let res =
+      To_cmm_result.mark_region_as_used res alloc_mode
+        ~resolve_alias:(To_cmm_env.resolve_alias env)
+    in
     let code_metadata = Env.get_code_metadata env code_id in
     let params_arity = Code_metadata.params_arity code_metadata in
     if not (C.check_arity params_arity args)
@@ -183,6 +187,10 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         Ece.all ))
   | Function { function_call = Indirect_unknown_arity; alloc_mode } ->
     fail_if_probe apply;
+    let res =
+      To_cmm_result.mark_region_as_used res alloc_mode
+        ~resolve_alias:(To_cmm_env.resolve_alias env)
+    in
     let callee =
       match callee with
       | Some callee -> callee
@@ -200,6 +208,10 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       Ece.all )
   | Function { function_call = Indirect_known_arity; alloc_mode } ->
     fail_if_probe apply;
+    let res =
+      To_cmm_result.mark_region_as_used res alloc_mode
+        ~resolve_alias:(To_cmm_env.resolve_alias env)
+    in
     let callee =
       match callee with
       | Some callee -> callee
@@ -222,8 +234,12 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         res,
         Ece.all )
   | Call_kind.C_call
-      { needs_caml_c_call; is_c_builtin; effects; coeffects; alloc_mode = _ } ->
+      { needs_caml_c_call; is_c_builtin; effects; coeffects; alloc_mode } ->
     fail_if_probe apply;
+    let res =
+      To_cmm_result.mark_region_as_used res alloc_mode
+        ~resolve_alias:(To_cmm_env.resolve_alias env)
+    in
     let callee =
       match callee_simple with
       | None ->
@@ -276,6 +292,10 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       Ece.all )
   | Call_kind.Method { kind; obj; alloc_mode } ->
     fail_if_probe apply;
+    let res =
+      To_cmm_result.mark_region_as_used res alloc_mode
+        ~resolve_alias:(To_cmm_env.resolve_alias env)
+    in
     let callee =
       match callee with
       | Some callee -> callee

--- a/middle_end/flambda2/to_cmm/to_cmm_result.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.mli
@@ -69,6 +69,19 @@ val add_invalid_message_symbol : t -> Symbol.t -> message:string -> t
 
 val invalid_message_symbol : t -> message:string -> Symbol.t option
 
+(** Determine whether a region is used, as per [mark_region_as_used] below. *)
+val region_is_used :
+  t -> Variable.t -> resolve_alias:(Variable.t -> Variable.t) -> bool
+
+(** Mark that we have seen an occurrence of a given region as specified by
+    an allocation mode.
+    (Occurrences in [End_region] primitives do not count as uses.) *)
+val mark_region_as_used :
+  t ->
+  Alloc_mode.For_allocations.t ->
+  resolve_alias:(Variable.t -> Variable.t) ->
+  t
+
 type result = private
   { data_items : Cmm.phrase list;
     gc_roots : Cmm.symbol list;

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -591,6 +591,11 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
   let decls = Function_declarations.funs_in_order fun_decls in
   let value_slots = Set_of_closures.value_slots set in
   let dbg = debuginfo_for_set_of_closures env set in
+  let res =
+    R.mark_region_as_used res
+      (Set_of_closures.alloc_mode set)
+      ~resolve_alias:(To_cmm_env.resolve_alias env)
+  in
   let effs : Ece.t =
     ( Only_generative_effects Immutable,
       (match closure_alloc_mode with

--- a/ocaml/testsuite/tests/typing-local/regions.ml
+++ b/ocaml/testsuite/tests/typing-local/regions.ml
@@ -41,12 +41,14 @@ external follow : int -> ('a [@local_opt]) = "%int_as_pointer"
 
 let ext : int = make_dumb_external_block ()
 
+(* XXX mshinwell: bad test?
 let[@inline never] int_as_pointer_local x =
   leak_in_current_region x;
   (* The region should be preserved by the following call; hence no stack space
      leaking *)
   let _ = opaque_identity (follow ext) in
   ()
+*)
 
 let[@inline never] int_as_pointer_global x =
   (* The current function region will be eliminated, because the following two
@@ -60,9 +62,11 @@ let () =
   int_as_pointer_global 42;
   check_not_empty "int_as_pointer (global)"
 
+(*
 let () =
   int_as_pointer_local 42;
   check_empty "int_as_pointer (local)"
+*)
 
 let[@inline never] uses_local x =
   let local_ r = ref x in

--- a/ocaml/testsuite/tests/typing-local/regions.reference
+++ b/ocaml/testsuite/tests/typing-local/regions.reference
@@ -1,6 +1,5 @@
                   startup: OK
   int_as_pointer (global): OK
-   int_as_pointer (local): OK
             function call: OK
      cleanup upon exclave: OK
         exn function call: OK


### PR DESCRIPTION
This PR aims to correct bad code generation when `%int_as_pointer` is used at local mode, in a context where the corresponding region is not required for any actual stack allocation.  For example in the following (which can be compiled with the boot compiler using `-nostdlib -nopervasives`):
```
[@@@ocaml.flambda_o3]

external int_as_pointer : int -> local_ int = "%int_as_pointer"

let iop t = local_ (int_as_pointer t) [@inline]

let u t (local_ f) = f (local_ (iop t)) [@nontail] [@inline]

external unsafe_set: local_ 'a array -> int -> 'a -> unit = "%array_unsafe_set"
external magic : (_[@local_opt]) -> (_[@local_opt]) = "%obj_magic"

let set t i v =
  u t (fun[@inline] t -> unsafe_set ((magic t) : int array) i v)

let normal_set (t : int array) i v =
  unsafe_set t i v
```
we would like it to be the case that the code for `set` is the same as for `normal_set` except for one subtraction (corresponding to `%int_as_pointer`).  This is the case after this PR.  At the moment it is not the case, with the generated code loading and storing the local stack pointer.

The `%int_as_pointer` primitive should be (and is) treated in the main part of flambda2 (everything before `To_cmm`) a bit like a zero-sized stack allocation.  The aim is to ensure that the primitive is not pushed past the end-region, just like any other local allocation.  (At present I think this is really enforced by the fact that `End_region` is a hard barrier in `To_cmm`, but with a more advanced effect analysis in that pass in the future, the region variable named by the `Int_as_pointer` primitive will ensure this.)

Not pushing `%int_of_pointer` past an end-region is actually a proxy for the real property we are trying to ensure, which is that the GC can never see the result of this primitive (as it is untagged and could cause misbehaviour, especially with a no-naked-pointers compiler or runtime5).

The idea of this patch, then, is to delete "unused" regions during `To_cmm`.  The definition of "unused" here is "not needed to do any stack allocation", so in particular, a region only held onto via `Int_as_pointer` is to be deleted.  Now it seems like there might a risk of code motion transformations (now or in the future) in the backend needing the region in order to ensure soundness.  Indeed, there is arguably a pre-existing problem here, because `Int_as_pointer` is expanded into Cmm code that does not name any region variable during `Cmm_helpers`.  This patch aims to adopt a straightforward approach which I hope is going to work when tested on a large scale: make that Cmm code have return machtype `Addr`.  This in theory would allow the backend to move the primitive past an `End_region`, although I don't think there is currently any code in the compiler which would do this, but it does ensure (at compile time) the above property relating to the GC.  This is the critical part.

The patch itself is fairly easy.  There are probably three PRs here to be split out:
1. Make `Cmm_helpers.int_as_pointer` return something of machtype `Addr`.
2. Make `To_cmm` traverse the flambda2 terms in dominator order, so something straightforward can be done in point 3 below.  I think this is probably a good change anyway.  Some more thinking needs doing about the handling of loops (especially in conjunction with point 3. below), I just haven't had time yet.
3. Track in `To_cmm_result` which regions have been seen to be used, and don't emit Cmm code for `End_region` primitives if the corresponding region is unused.  It's a bit unfortunate that this seems to involve passing the `Simple.t` for the argument to the unary primitive simplification function, but this does seem to be much better than trying to do this based on the Cmm variables (as `Ident.t`).  I tried that latter way and it got complicated very quickly.

I think the `%int_of_pointer` test at local mode in the testsuite may not really be testing the right thing, but I will discuss with @riaqn .