### PR TITLE
Minor cleanup of kind checking in ctype

### DIFF
--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -701,6 +701,9 @@ let get_modal_upper_bounds jk = jk.jkind.modes_upper_bounds
 
 let get_externality_upper_bound jk = jk.jkind.externality_upper_bound
 
+let set_externality_upper_bound jk externality_upper_bound =
+  { jk with jkind = { jk.jkind with externality_upper_bound } }
+
 (*********************************)
 (* pretty printing *)
 

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -279,6 +279,10 @@ val get_modal_upper_bounds : t -> Mode.Alloc.Const.t
 (** Gets the maximum mode on the externality axis for types of this jkind. *)
 val get_externality_upper_bound : t -> Externality.t
 
+(** Computes a jkind that is the same as the input but with an updated maximum
+    mode for the externality axis *)
+val set_externality_upper_bound : t -> Externality.t -> t
+
 (*********************************)
 (* pretty printing *)
 


### PR DESCRIPTION
This simplifies `type_jkind_sub` to just take a jkind to check against, rather than a higher-order parameter telling it what check it should do.  The reason for the previous approach was to allow this function to be used for general kind checking (where the higher order parameter compared two jkinds) or just externality checking (where the higher order parameter compared just the externalities of the kinds).

That complexity is unnecessary - externality checking can be implemented as general kind checking with the appropriate kind (`any mod <externality>`).  And this has benefits: in the short term, it means only one function (`check_type_jkind`) needs to understand the somewhat complicated result type of `type_jkind_sub`.  And in the medium term it will simplify the implementation of product layouts, where `type_jkind_sub` wants to traverse the layout deeply.

(This is orthogonal to #2676 and looking quickly the small jkind edit here doesn't overlap with that PR so it shouldn't cause a conflict)