### PR TITLE
Fix warning 34 (unused type declaration) for locally-abstract types

### DIFF
--- a/ocaml/testsuite/tests/typing-warnings/unused_types.ml
+++ b/ocaml/testsuite/tests/typing-warnings/unused_types.ml
@@ -535,14 +535,19 @@ module Unused_field_disable_one_warning : sig end
 
 let u (type unused) = ()
 [%%expect {|
+Line 1, characters 12-18:
+1 | let u (type unused) = ()
+                ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val u : unit = ()
 |}]
 
 let u = fun (type unused) -> ()
 [%%expect {|
-Line 1, characters 8-31:
+Line 1, characters 18-24:
 1 | let u = fun (type unused) -> ()
-            ^^^^^^^^^^^^^^^^^^^^^^^
+                      ^^^^^^
 Warning 34 [unused-type-declaration]: unused type unused.
 
 val u : unit = ()
@@ -550,21 +555,41 @@ val u : unit = ()
 
 let f (type unused) x = x
 [%%expect {|
+Line 1, characters 12-18:
+1 | let f (type unused) x = x
+                ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val f : 'a -> 'a = <fun>
 |}]
 
 let f = fun (type unused) x -> x
 [%%expect {|
+Line 1, characters 18-24:
+1 | let f = fun (type unused) x -> x
+                      ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val f : 'a -> 'a = <fun>
 |}]
 
 let f (type used unused) (x : used) = x
 [%%expect {|
+Line 1, characters 17-23:
+1 | let f (type used unused) (x : used) = x
+                     ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val f : 'used -> 'used = <fun>
 |}]
 
 let f = fun (type used unused) (x : used) -> x
 
 [%%expect{|
+Line 1, characters 23-29:
+1 | let f = fun (type used unused) (x : used) -> x
+                           ^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
 val f : 'used -> 'used = <fun>
 |}]

--- a/ocaml/testsuite/tests/typing-warnings/unused_types.ml
+++ b/ocaml/testsuite/tests/typing-warnings/unused_types.ml
@@ -530,3 +530,41 @@ Warning 69 [unused-field]: unused record field b.
 
 module Unused_field_disable_one_warning : sig end
 |}]
+
+(* Locally abstract types *)
+
+let u (type unused) = ()
+[%%expect {|
+val u : unit = ()
+|}]
+
+let u = fun (type unused) -> ()
+[%%expect {|
+Line 1, characters 8-31:
+1 | let u = fun (type unused) -> ()
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 34 [unused-type-declaration]: unused type unused.
+
+val u : unit = ()
+|}]
+
+let f (type unused) x = x
+[%%expect {|
+val f : 'a -> 'a = <fun>
+|}]
+
+let f = fun (type unused) x -> x
+[%%expect {|
+val f : 'a -> 'a = <fun>
+|}]
+
+let f (type used unused) (x : used) = x
+[%%expect {|
+val f : 'used -> 'used = <fun>
+|}]
+
+let f = fun (type used unused) (x : used) -> x
+
+[%%expect{|
+val f : 'used -> 'used = <fun>
+|}]


### PR DESCRIPTION
Fix a bug introduced in #1548: we unintentionally stopped warning on some unused locally-abstract types. Add a test to ensure this doesn't happen again in the future.

The bug exists upstream too.

The source of the bug is that the "unused X" check in `env.ml` does not run if the location is marked as ghost. #1548 makes more `Pexp_newtypes` ghost. (I think they should be marked ghost: the range of text indicated by the location in the source program is not something that can be called a "newtype expression", and this is the usual criteria we use. But the fact of the matter is that the compiler uses ghostiness as a proxy for other properties, and sometimes there is a sharp edge like this one.)

The fix I take is to use the identifier's location (which is never ghost) for purposes of this check, not the `Pexp_newtype`'s location.

**Review**: the first commit adds a regression test with bad old output, and the second commit fixes the bug and updates the test output.