### PR TITLE
Float32 min/max/rounding intrinsics

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1086,6 +1086,13 @@ let emit_simd_instr op i =
   | CLMUL (Clmul_64 n) -> I.pclmulqdq (X86_dsl.int n) (arg i 1) (res i 0)
   | BMI2 Extract_64 -> I.pext (arg i 1) (arg i 0) (res i 0)
   | BMI2 Deposit_64 -> I.pdep (arg i 1) (arg i 0) (res i 0)
+  | SSE Round_current_f32_i64 -> I.cvtss2si (arg i 0) (res i 0)
+  | SSE Sqrt_scalar_f32 ->
+    if arg i 0 <> res i 0 then
+      I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
+    I.sqrtss (arg i 0) (res i 0)
+  | SSE Max_scalar_f32 -> I.maxss (arg i 1) (res i 0)
+  | SSE Min_scalar_f32 -> I.minss (arg i 1) (res i 0)
   | SSE (Cmp_f32 n) -> I.cmpps n (arg i 1) (res i 0)
   | SSE Add_f32 -> I.addps (arg i 1) (res i 0)
   | SSE Sub_f32 -> I.subps (arg i 1) (res i 0)
@@ -1109,10 +1116,6 @@ let emit_simd_instr op i =
     if arg i 0 <> res i 0 then
       I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
     I.sqrtsd (arg i 0) (res i 0)
-  | SSE2 Sqrt_scalar_f32 ->
-    if arg i 0 <> res i 0 then
-      I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
-    I.sqrtss (arg i 0) (res i 0)
   | SSE2 Sqrt_f64 -> I.sqrtpd (arg i 0) (res i 0)
   | SSE2 Add_i8 -> I.paddb (arg i 1) (res i 0)
   | SSE2 Add_i16 -> I.paddw (arg i 1) (res i 0)
@@ -1271,6 +1274,10 @@ let emit_simd_instr op i =
     if arg i 0 <> res i 0 then
       I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
     I.roundsd n (arg i 0) (res i 0)
+  | SSE41 (Round_scalar_f32 n) ->
+    if arg i 0 <> res i 0 then
+      I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
+    I.roundss n (arg i 0) (res i 0)
   | SSE41 (Round_f64 n) -> I.roundpd n (arg i 0) (res i 0)
   | SSE41 (Round_f32 n) -> I.roundps n (arg i 0) (res i 0)
   | SSE41 (Multi_sad_unsigned_i8 n) -> I.mpsadbw (X86_dsl.int n) (arg i 1) (res i 0)

--- a/backend/amd64/simd_proc.ml
+++ b/backend/amd64/simd_proc.ml
@@ -39,10 +39,12 @@ let register_behavior_clmul = function Clmul_64 _ -> R_RM_to_fst
 let register_behavior_bmi2 = function Extract_64 | Deposit_64 -> R_RM_to_R
 
 let register_behavior_sse = function
-  | Cmp_f32 _ | Add_f32 | Sub_f32 | Mul_f32 | Div_f32 | Max_f32 | Min_f32
-  | Interleave_low_32 | Interleave_high_32 | Shuffle_32 _ ->
+  | Min_scalar_f32 | Max_scalar_f32 | Cmp_f32 _ | Add_f32 | Sub_f32 | Mul_f32
+  | Div_f32 | Max_f32 | Min_f32 | Interleave_low_32 | Interleave_high_32
+  | Shuffle_32 _ ->
     R_RM_to_fst
-  | Rcp_f32 | Sqrt_f32 | Rsqrt_f32 -> RM_to_R
+  | Round_current_f32_i64 | Sqrt_scalar_f32 | Rcp_f32 | Sqrt_f32 | Rsqrt_f32 ->
+    RM_to_R
   | Interleave_low_32_regs | High_64_to_low_64 | Low_64_to_high_64 -> R_R_to_fst
   | Movemask_32 -> R_to_R
 
@@ -64,7 +66,7 @@ let register_behavior_sse2 = function
     R_RM_to_fst
   | Shuffle_high_16 _ | Shuffle_low_16 _ | I32_to_f64 | I32_to_f32 | F64_to_i32
   | Round_current_f64_i64 | F64_to_f32 | F32_to_i32 | F32_to_f64 | Sqrt_f64
-  | Sqrt_scalar_f64 | Sqrt_scalar_f32 ->
+  | Sqrt_scalar_f64 ->
     RM_to_R
   | SLLi_i16 _ | SLLi_i32 _ | SLLi_i64 _ | SRLi_i16 _ | SRLi_i32 _ | SRLi_i64 _
   | SRAi_i16 _ | SRAi_i32 _ | Shift_left_bytes _ | Shift_right_bytes _ ->
@@ -91,7 +93,8 @@ let register_behavior_sse41 = function
     R_RM_to_fst
   | I8_sx_i16 | I8_sx_i32 | I8_sx_i64 | I16_sx_i32 | I16_sx_i64 | I32_sx_i64
   | I8_zx_i16 | I8_zx_i32 | I8_zx_i64 | I16_zx_i32 | I16_zx_i64 | I32_zx_i64
-  | Round_f64 _ | Round_f32 _ | Minpos_unsigned_i16 | Round_scalar_f64 _ ->
+  | Round_f64 _ | Round_f32 _ | Minpos_unsigned_i16 | Round_scalar_f64 _
+  | Round_scalar_f32 _ ->
     RM_to_R
   | Blendv_8 | Blendv_32 | Blendv_64 -> R_RM_xmm0_to_fst
   | Extract_i64 _ | Extract_i32 _ -> R_to_RM

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -338,9 +338,16 @@ let select_operation_sse41 op args =
       let i, args = extract_constant args ~max:15 op in
       Some (Round_f64 (float_rounding_of_int i), args)
     | "caml_sse41_float64_round" ->
+      (* CR-someday mslater: the following CR also applies here, but this
+         builtin is not exposed by any of the stdlib libraries. *)
       let i, args = extract_constant args ~max:15 op in
       Some (Round_scalar_f64 (float_rounding_of_int i), args)
     | "caml_sse41_float32_round" ->
+      (* CR-someday mslater: this builtin is exposed by float32.ml, so must
+         actually be cross-platform. Currently, non-amd64 architectures will
+         fall back to a C implementation. If we want the arm64 backend to
+         specialize it, we should redefine the constant mapping from the amd64
+         values to a new sum type. *)
       let i, args = extract_constant args ~max:15 op in
       Some (Round_scalar_f32 (float_rounding_of_int i), args)
     | "caml_sse41_int8x16_max" -> Some (Max_i8, args)

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -78,6 +78,10 @@ let select_operation_bmi2 op args =
 
 let select_operation_sse op args =
   match op with
+  | "caml_sse_float32_sqrt" | "sqrtf" -> Some (Sqrt_scalar_f32, args)
+  | "caml_sse_float32_max" -> Some (Max_scalar_f32, args)
+  | "caml_sse_float32_min" -> Some (Min_scalar_f32, args)
+  | "caml_sse_cast_float32_int64" -> Some (Round_current_f32_i64, args)
   | "caml_sse_float32x4_cmp" ->
     let i, args = extract_constant args ~max:7 op in
     Some (Cmp_f32 (float_condition_of_int i), args)
@@ -103,7 +107,6 @@ let select_operation_sse op args =
 let select_operation_sse2 op args =
   match op with
   | "caml_sse2_float64_sqrt" | "sqrt" -> Some (Sqrt_scalar_f64, args)
-  | "caml_sse2_float32_sqrt" | "sqrtf" -> Some (Sqrt_scalar_f32, args)
   | "caml_sse2_float64_max" -> Some (Max_scalar_f64, args)
   | "caml_sse2_float64_min" -> Some (Min_scalar_f64, args)
   | "caml_sse2_cast_float64_int64" -> Some (Round_current_f64_i64, args)
@@ -337,6 +340,9 @@ let select_operation_sse41 op args =
     | "caml_sse41_float64_round" ->
       let i, args = extract_constant args ~max:15 op in
       Some (Round_scalar_f64 (float_rounding_of_int i), args)
+    | "caml_sse41_float32_round" ->
+      let i, args = extract_constant args ~max:15 op in
+      Some (Round_scalar_f32 (float_rounding_of_int i), args)
     | "caml_sse41_int8x16_max" -> Some (Max_i8, args)
     | "caml_sse41_int32x4_max" -> Some (Max_i32, args)
     | "caml_sse41_int16x8_max_unsigned" -> Some (Max_unsigned_i16, args)

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -413,6 +413,10 @@ let transl_builtin name args dbg typ_res =
     Some (Cop (Creinterpret_cast Float32_of_int32, args, dbg))
   | "caml_float32_to_bits" ->
     Some (Cop (Creinterpret_cast Int32_of_float32, args, dbg))
+  | "caml_float32_to_int64" ->
+    Some (Cop (Cstatic_cast (Int_of_float Float32), args, dbg))
+  | "caml_float32_of_int64" ->
+    Some (Cop (Cstatic_cast (Float_of_int Float32), args, dbg))
   | "caml_int_clz_tagged_to_untagged" ->
     (* The tag does not change the number of leading zeros. The advantage of
        keeping the tag is it guarantees that, on x86-64, the input to the BSR

--- a/backend/x86_ast.mli
+++ b/backend/x86_ast.mli
@@ -109,6 +109,8 @@ type arg =
   | Mem64_RIP of data_type * string * int
 
 type sse_instruction =
+  | MINSS of arg * arg
+  | MAXSS of arg * arg
   | CMPPS of float_condition * arg * arg
   | SHUFPS of arg * arg * arg
   | ADDPS of arg * arg
@@ -280,6 +282,7 @@ type sse41_instruction =
   | PMINUD of arg * arg
   | ROUNDPD of rounding * arg * arg
   | ROUNDPS of rounding * arg * arg
+  | ROUNDSS of rounding * arg * arg
   | MPSADBW of arg * arg * arg
   | PHMINPOSUW of arg * arg
   | PMULLD of arg * arg

--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -205,6 +205,8 @@ module I = struct
   let andps x y = emit (ANDPS (x, y))
   let cmpss i x y = emit (CMPSS (i, x, y))
 
+  let minss x y = emit (SSE (MINSS (x, y)))
+  let maxss x y = emit (SSE (MAXSS (x, y)))
   let cmpps i x y = emit (SSE (CMPPS (i, x, y)))
   let shufps i x y = emit (SSE (SHUFPS (i, x, y)))
   let addps x y = emit (SSE (ADDPS (x, y)))
@@ -372,6 +374,7 @@ module I = struct
   let pminud x y = emit (SSE41 (PMINUD (x, y)))
   let roundpd i x y = emit (SSE41 (ROUNDPD (i, x, y)))
   let roundps i x y = emit (SSE41 (ROUNDPS (i, x, y)))
+  let roundss i x y = emit (SSE41 (ROUNDSS (i, x, y)))
   let mpsadbw i x y = emit (SSE41 (MPSADBW (i, x, y)))
   let phminposuw x y = emit (SSE41 (PHMINPOSUW (x, y)))
   let pmulld x y = emit (SSE41 (PMULLD (x, y)))

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -200,6 +200,8 @@ module I : sig
 
   (* Float32 arithmetic *)
 
+  val minss: arg -> arg -> unit
+  val maxss: arg -> arg -> unit
   val addss: arg -> arg -> unit
   val subss: arg -> arg -> unit
   val mulss: arg -> arg -> unit
@@ -388,6 +390,7 @@ module I : sig
   val pminud: arg -> arg -> unit
   val roundpd: rounding -> arg -> arg -> unit
   val roundps: rounding -> arg -> arg -> unit
+  val roundss: rounding -> arg -> arg -> unit
   val mpsadbw: arg -> arg -> arg -> unit
   val phminposuw: arg -> arg -> unit
   val pmulld: arg -> arg -> unit

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -219,6 +219,8 @@ let print_instr b = function
   | XORPS (arg1, arg2) -> i2 b "xorps" arg1 arg2
   | ANDPS (arg1, arg2) -> i2 b "andps" arg1 arg2
   | CMPSS (cmp, arg1, arg2) -> i2 b ("cmp" ^ string_of_float_condition cmp ^ "ss") arg1 arg2
+  | SSE MINSS (arg1, arg2) -> i2 b "minss" arg1 arg2
+  | SSE MAXSS (arg1, arg2) -> i2 b "maxss" arg1 arg2
   | SSE CMPPS (cmp, arg1, arg2) -> i2 b ("cmp" ^ string_of_float_condition cmp ^ "ps") arg1 arg2
   | SSE SHUFPS (shuf, arg1, arg2) -> i3 b "shufps" shuf arg1 arg2
   | SSE ADDPS (arg1, arg2) -> i2 b "addps" arg1 arg2
@@ -382,6 +384,7 @@ let print_instr b = function
   | SSE41 PMINUD (arg1, arg2) -> i2 b "pminud" arg1 arg2
   | SSE41 ROUNDPD (rd, arg1, arg2) -> i3 b "roundpd" (imm_of_rounding rd) arg1 arg2
   | SSE41 ROUNDPS (rd, arg1, arg2) -> i3 b "roundps" (imm_of_rounding rd) arg1 arg2
+  | SSE41 ROUNDSS (rd, arg1, arg2) -> i3 b "roundss" (imm_of_rounding rd) arg1 arg2
   | SSE41 MPSADBW (n, arg1, arg2) -> i3 b "mpsadbw" n arg1 arg2
   | SSE41 PHMINPOSUW (arg1, arg2) -> i2 b "phminposuw" arg1 arg2
   | SSE41 PMULLD (arg1, arg2) -> i2 b "pmulld" arg1 arg2

--- a/backend/x86_masm.ml
+++ b/backend/x86_masm.ml
@@ -221,6 +221,8 @@ let print_instr b = function
   | CMPSS (cmp, arg1, arg2) -> i2 b ("cmp" ^ string_of_float_condition cmp ^ "ss") arg1 arg2
   | SSE CMPPS (cmp, arg1, arg2) -> i2 b ("cmp" ^ string_of_float_condition cmp ^ "ps") arg1 arg2
   | SSE SHUFPS (shuf, arg1, arg2) -> i3 b "shufps" shuf arg1 arg2
+  | SSE MINSS (arg1, arg2) -> i2 b "minss" arg1 arg2
+  | SSE MAXSS (arg1, arg2) -> i2 b "maxss" arg1 arg2
   | SSE ADDPS (arg1, arg2) -> i2 b "addps" arg1 arg2
   | SSE SUBPS (arg1, arg2) -> i2 b "subps" arg1 arg2
   | SSE MULPS (arg1, arg2) -> i2 b "mulps" arg1 arg2
@@ -382,6 +384,7 @@ let print_instr b = function
   | SSE41 PMINUD (arg1, arg2) -> i2 b "pminud" arg1 arg2
   | SSE41 ROUNDPD (rd, arg1, arg2) -> i3 b "roundpd" (imm_of_rounding rd) arg1 arg2
   | SSE41 ROUNDPS (rd, arg1, arg2) -> i3 b "roundps" (imm_of_rounding rd) arg1 arg2
+  | SSE41 ROUNDSS (rd, arg1, arg2) -> i3 b "roundss" (imm_of_rounding rd) arg1 arg2
   | SSE41 MPSADBW (n, arg1, arg2) -> i3 b "mpsadbw" n arg1 arg2
   | SSE41 PHMINPOSUW (arg1, arg2) -> i2 b "phminposuw" arg1 arg2
   | SSE41 PMULLD (arg1, arg2) -> i2 b "pmulld" arg1 arg2

--- a/ocaml/otherlibs/stdlib_beta/float32.ml
+++ b/ocaml/otherlibs/stdlib_beta/float32.ml
@@ -246,6 +246,16 @@ let[@inline] max (x : t) (y : t) =
   else if is_nan y then y
   else x
 
+module With_weird_nan_behavior = struct
+  external min : t -> t -> t
+    = "caml_sse_float32_min_bytecode" "caml_sse_float32_min"
+    [@@noalloc] [@@unboxed] [@@builtin]
+
+  external max : t -> t -> t
+    = "caml_sse_float32_max_bytecode" "caml_sse_float32_max"
+    [@@noalloc] [@@unboxed] [@@builtin]
+end
+
 let[@inline] min_max (x : t) (y : t) =
   if is_nan x || is_nan y then (nan, nan)
   else if y > x || ((not (sign_bit y)) && sign_bit x) then (x, y)
@@ -266,6 +276,19 @@ let[@inline] min_max_num (x : t) (y : t) =
   else if is_nan y then (x, x)
   else if y > x || ((not (sign_bit y)) && sign_bit x) then (x, y)
   else (y, x)
+
+external iround_half_to_even : t -> int64
+  = "caml_sse_cast_float32_int64_bytecode" "caml_sse_cast_float32_int64"
+  [@@noalloc] [@@unboxed] [@@builtin]
+
+external round_intrinsic : (int[@untagged]) -> (t[@unboxed]) -> (t[@unboxed])
+  = "caml_sse41_float32_round_bytecode" "caml_sse41_float32_round"
+  [@@noalloc] [@@builtin]
+
+let[@inline] round_half_to_even x = round_intrinsic 0xC x
+let[@inline] round_down x = round_intrinsic 0x9 x
+let[@inline] round_up x = round_intrinsic 0xA x
+let[@inline] round_towards_zero x = round_intrinsic 0xB x
 
 external seeded_hash_param : int -> int -> int -> 'a -> int = "caml_hash_exn"
   [@@noalloc]

--- a/ocaml/otherlibs/stdlib_beta/float32.ml
+++ b/ocaml/otherlibs/stdlib_beta/float32.ml
@@ -285,10 +285,15 @@ external round_intrinsic : (int[@untagged]) -> (t[@unboxed]) -> (t[@unboxed])
   = "caml_sse41_float32_round_bytecode" "caml_sse41_float32_round"
   [@@noalloc] [@@builtin]
 
-let[@inline] round_half_to_even x = round_intrinsic 0xC x
-let[@inline] round_down x = round_intrinsic 0x9 x
-let[@inline] round_up x = round_intrinsic 0xA x
-let[@inline] round_towards_zero x = round_intrinsic 0xB x
+(* On amd64, these constants also imply _MM_FROUND_NO_EXC (suppress exceptions). *)
+let round_neg_inf = 0x9
+let round_pos_inf = 0xA
+let round_zero = 0xB
+let round_current_mode = 0xC
+let[@inline] round_half_to_even x = round_intrinsic round_current_mode x
+let[@inline] round_down x = round_intrinsic round_neg_inf x
+let[@inline] round_up x = round_intrinsic round_pos_inf x
+let[@inline] round_towards_zero x = round_intrinsic round_zero x
 
 external seeded_hash_param : int -> int -> int -> 'a -> int = "caml_hash_exn"
   [@@noalloc]

--- a/ocaml/otherlibs/stdlib_beta/float32.ml
+++ b/ocaml/otherlibs/stdlib_beta/float32.ml
@@ -87,6 +87,14 @@ external to_int : (t[@local_opt]) -> int = "%intoffloat32"
 external of_float : (float[@local_opt]) -> t = "%float32offloat"
 external to_float : (t[@local_opt]) -> float = "%floatoffloat32"
 
+external of_int64 : (int64[@local_opt]) -> t
+  = "caml_float32_of_int64_bytecode" "caml_float32_of_int64"
+  [@@unboxed] [@@noalloc] [@@builtin]
+
+external to_int64 : (t[@local_opt]) -> int64
+  = "caml_float32_to_int64_bytecode" "caml_float32_to_int64"
+  [@@unboxed] [@@noalloc] [@@builtin]
+
 external of_bits : (int32[@local_opt]) -> t
   = "caml_float32_of_bits_bytecode" "caml_float32_of_bits"
   [@@unboxed] [@@noalloc] [@@builtin]

--- a/ocaml/otherlibs/stdlib_beta/float32.mli
+++ b/ocaml/otherlibs/stdlib_beta/float32.mli
@@ -183,7 +183,8 @@ external to_int : (t[@local_opt]) -> int = "%intoffloat32"
 external of_int64 : (int64[@local_opt]) -> t
   = "caml_float32_of_int64_bytecode" "caml_float32_of_int64"
   [@@unboxed] [@@noalloc] [@@builtin]
-(** Convert the given 64-bit integer to the nearest representable 32-bit float. *)
+(** Convert the given 64-bit integer to the nearest representable 32-bit float.
+    The amd64 flambda-backend compiler translates this call to CVTSI2SS. *)
 
 external to_int64 : (t[@local_opt]) -> int64
   = "caml_float32_to_int64_bytecode" "caml_float32_to_int64"
@@ -192,7 +193,8 @@ external to_int64 : (t[@local_opt]) -> int64
     discarding the fractional part (truncate towards 0).
     If the truncated floating-point number is outside the range
     \[{!Int64.min_int}, {!Int64.max_int}\], no exception is raised, and
-    an unspecified, platform-dependent integer is returned. *)
+    an unspecified, platform-dependent integer is returned.
+    The amd64 flambda-backend compiler translates this call to CVTTSS2SI. *)
 
 external of_bits : (int32[@local_opt]) -> t
   = "caml_float32_of_bits_bytecode" "caml_float32_of_bits"

--- a/ocaml/otherlibs/stdlib_beta/float32.mli
+++ b/ocaml/otherlibs/stdlib_beta/float32.mli
@@ -374,17 +374,14 @@ external erfc : t -> t = "caml_erfc_float32_bytecode" "erfcf"
 external trunc : t -> t = "caml_trunc_float32_bytecode" "truncf"
   [@@unboxed] [@@noalloc]
 (** [trunc x] rounds [x] to the nearest integer whose absolute value is
-   less than or equal to [x]. *)
+    less than or equal to [x]. *)
 
 external round : t -> t = "caml_round_float32_bytecode" "roundf"
   [@@unboxed] [@@noalloc]
 (** [round x] rounds [x] to the nearest integer with ties (fractional
-   values of 0.5s) rounded away from zero, regardless of the current
-   rounding direction.  If [x] is an integer, [+0.s], [-0.s], [nan], or
-   infinite, [x] itself is returned.
-
-   On 64-bit mingw-w64, this function may be emulated owing to a bug in the
-   C runtime library (CRT) on this platform. *)
+    values of 0.5s) rounded away from zero, regardless of the current
+    rounding direction.  If [x] is an integer, [+0.s], [-0.s], [nan], or
+    infinite, [x] itself is returned. *)
 
 external ceil : t -> t = "caml_ceil_float32_bytecode" "ceilf"
   [@@unboxed] [@@noalloc]
@@ -461,6 +458,24 @@ val max : t -> t -> t
 (** [max x y] returns the maximum of [x] and [y].  It returns [nan]
    when [x] or [y] is [nan].  Moreover [max (-0.s) (+0.s) = +0.s] *)
 
+module With_weird_nan_behavior : sig
+  external min : t -> t -> t
+    = "caml_sse_float32_min_bytecode" "caml_sse_float32_min"
+    [@@noalloc] [@@unboxed] [@@builtin]
+  (** [min x y] returns the minimum of [x] and [y].
+      If either [x] or [y] is [nan], [y] is returned.
+      If both [x] and [y] equal zero, [y] is returned.
+      The amd64 flambda-backend compiler translates this call to MINSS. *)
+
+  external max : t -> t -> t
+    = "caml_sse_float32_max_bytecode" "caml_sse_float32_max"
+    [@@noalloc] [@@unboxed] [@@builtin]
+  (** [max x y] returns the maximum of [x] and [y].  It returns [x]
+      If either [x] or [y] is [nan], [y] is returned.
+      If both [x] and [y] equal zero, [y] is returned.
+      The amd64 flambda-backend compiler translates this call to MAXSS. *)
+end
+
 val min_max : t -> t -> t * t
 (** [min_max x y] is [(min x y, max x y)], just more efficient. *)
 
@@ -478,6 +493,34 @@ val min_max_num : t -> t -> t * t
 (** [min_max_num x y] is [(min_num x y, max_num x y)], just more
    efficient.  Note that in particular [min_max_num x nan = (x, x)]
    and [min_max_num nan y = (y, y)]. *)
+
+external iround_half_to_even : t -> int64
+  = "caml_sse_cast_float32_int64_bytecode" "caml_sse_cast_float32_int64"
+  [@@noalloc] [@@unboxed] [@@builtin]
+(** Rounds a [float32] to an [int64] using the current rounding mode. The default
+    rounding mode is "round half to even", and we expect that no program will
+    change the rounding mode.
+    If the argument is NaN or infinite or if the rounded value cannot be
+    represented, then the result is unspecified.
+    The amd64 flambda-backend compiler translates this call to CVTSS2SI. *)
+
+val round_half_to_even : t -> t
+(** Rounds a [float32] to an integer [float32] using the current rounding
+    mode.  The default rounding mode is "round half to even", and we
+    expect that no program will change the rounding mode.
+    The amd64 flambda-backend compiler translates this call to ROUNDSS. *)
+
+val round_down : t -> t
+(** Rounds a [float32] down to the next integer [float32] toward negative infinity.
+    The amd64 flambda-backend compiler translates this call to ROUNDSS.*)
+
+val round_up : t -> t
+(** Rounds a [float32] up to the next integer [float32] toward positive infinity.
+    The amd64 flambda-backend compiler translates this call to ROUNDSS.*)
+
+val round_towards_zero : t -> t
+(** Rounds a [float32] to the next integer [float32] toward zero.
+    The amd64 flambda-backend compiler translates this call to ROUNDSS.*)
 
 val seeded_hash : int -> t -> int
 (** A seeded hash function for floats, with the same output value as

--- a/ocaml/otherlibs/stdlib_beta/float32.mli
+++ b/ocaml/otherlibs/stdlib_beta/float32.mli
@@ -470,7 +470,7 @@ module With_weird_nan_behavior : sig
   external max : t -> t -> t
     = "caml_sse_float32_max_bytecode" "caml_sse_float32_max"
     [@@noalloc] [@@unboxed] [@@builtin]
-  (** [max x y] returns the maximum of [x] and [y].  It returns [x]
+  (** [max x y] returns the maximum of [x] and [y].
       If either [x] or [y] is [nan], [y] is returned.
       If both [x] and [y] equal zero, [y] is returned.
       The amd64 flambda-backend compiler translates this call to MAXSS. *)

--- a/ocaml/otherlibs/stdlib_beta/float32.mli
+++ b/ocaml/otherlibs/stdlib_beta/float32.mli
@@ -180,6 +180,20 @@ external to_int : (t[@local_opt]) -> int = "%intoffloat32"
     The result is unspecified if the argument is [nan] or falls outside the
     range of representable integers. *)
 
+external of_int64 : (int64[@local_opt]) -> t
+  = "caml_float32_of_int64_bytecode" "caml_float32_of_int64"
+  [@@unboxed] [@@noalloc] [@@builtin]
+(** Convert the given 64-bit integer to the nearest representable 32-bit float. *)
+
+external to_int64 : (t[@local_opt]) -> int64
+  = "caml_float32_to_int64_bytecode" "caml_float32_to_int64"
+  [@@unboxed] [@@noalloc] [@@builtin]
+(** Convert the given 32-bit float to a 64-bit integer,
+    discarding the fractional part (truncate towards 0).
+    If the truncated floating-point number is outside the range
+    \[{!Int64.min_int}, {!Int64.max_int}\], no exception is raised, and
+    an unspecified, platform-dependent integer is returned. *)
+
 external of_bits : (int32[@local_opt]) -> t
   = "caml_float32_of_bits_bytecode" "caml_float32_of_bits"
   [@@unboxed] [@@noalloc] [@@builtin]

--- a/ocaml/otherlibs/stdlib_beta/float32_u.ml
+++ b/ocaml/otherlibs/stdlib_beta/float32_u.ml
@@ -26,6 +26,10 @@ external box_int32 : int32# -> (int32[@local_opt]) = "%box_int32"
 
 external unbox_int32 : (int32[@local_opt]) -> int32# = "%unbox_int32"
 
+external box_int64 : int64# -> (int64[@local_opt]) = "%box_int64"
+
+external unbox_int64 : (int64[@local_opt]) -> int64# = "%unbox_int64"
+
 external to_float32 : t -> (float32[@local_opt]) = "%box_float32"
 
 external of_float32 : (float32[@local_opt]) -> t = "%unbox_float32"
@@ -82,6 +86,9 @@ let[@inline always] of_int x = of_float32 (Float32.of_int x)
 
 let[@inline always] to_int x = Float32.to_int (to_float32 x)
 
+let[@inline always] of_int64 x = of_float32 (Float32.of_int64 (box_int64 x))
+
+let[@inline always] to_int64 x = unbox_int64 (Float32.to_int64 (to_float32 x))
 let[@inline always] of_float x = of_float32 (Float32.of_float (box_float x))
 
 let[@inline always] to_float x = unbox_float (Float32.to_float (to_float32 x))

--- a/ocaml/otherlibs/stdlib_beta/float32_u.ml
+++ b/ocaml/otherlibs/stdlib_beta/float32_u.ml
@@ -184,6 +184,22 @@ let[@inline always] min x y = of_float32 (Float32.min (to_float32 x) (to_float32
 
 let[@inline always] max x y = of_float32 (Float32.max (to_float32 x) (to_float32 y))
 
+module With_weird_nan_behavior = struct
+  let[@inline always] min x y = of_float32 (Float32.With_weird_nan_behavior.min (to_float32 x) (to_float32 y))
+
+  let[@inline always] max x y = of_float32 (Float32.With_weird_nan_behavior.max (to_float32 x) (to_float32 y))
+end
+
 let[@inline always] min_num x y = of_float32 (Float32.min_num (to_float32 x) (to_float32 y))
 
 let[@inline always] max_num x y = of_float32 (Float32.max_num (to_float32 x) (to_float32 y))
+
+let iround_half_to_even x = unbox_int64 (Float32.iround_half_to_even (to_float32 x))
+
+let round_half_to_even x = of_float32 (Float32.round_half_to_even (to_float32 x))
+
+let round_down x = of_float32 (Float32.round_down (to_float32 x))
+
+let round_up x = of_float32 (Float32.round_up (to_float32 x))
+
+let round_towards_zero x = of_float32 (Float32.round_towards_zero (to_float32 x))

--- a/ocaml/otherlibs/stdlib_beta/float32_u.mli
+++ b/ocaml/otherlibs/stdlib_beta/float32_u.mli
@@ -134,6 +134,16 @@ val to_int : t -> int
     The result is unspecified if the argument is [nan] or falls outside the
     range of representable integers. *)
 
+val of_int64 : int64# -> t
+(** Convert the given 64-bit integer to the nearest representable 32-bit float. *)
+
+val to_int64 : t -> int64#
+(** Convert the given 32-bit float to a 64-bit integer,
+    discarding the fractional part (truncate towards 0).
+    If the truncated floating-point number is outside the range
+    \[{!Int64.min_int}, {!Int64.max_int}\], no exception is raised, and
+    an unspecified, platform-dependent integer is returned. *)
+
 val of_float : float# -> t
 (** Convert a 64-bit float to the nearest 32-bit float. *)
 

--- a/ocaml/otherlibs/stdlib_beta/float32_u.mli
+++ b/ocaml/otherlibs/stdlib_beta/float32_u.mli
@@ -372,7 +372,7 @@ module With_weird_nan_behavior : sig
         The amd64 flambda-backend compiler translates this call to MINSS. *)
 
     val max : t -> t -> t
-    (** [max x y] returns the maximum of [x] and [y].  It returns [x]
+    (** [max x y] returns the maximum of [x] and [y].
         If either [x] or [y] is [nan], [y] is returned.
         If both [x] and [y] equal zero, [y] is returned.
         The amd64 flambda-backend compiler translates this call to MAXSS. *)

--- a/ocaml/otherlibs/stdlib_beta/float32_u.mli
+++ b/ocaml/otherlibs/stdlib_beta/float32_u.mli
@@ -364,6 +364,20 @@ val max : t -> t -> t
 (** [max x y] returns the maximum of [x] and [y].  It returns [nan]
     when [x] or [y] is [nan].  Moreover [max #-0.s #+0.s = #+0.s] *)
 
+module With_weird_nan_behavior : sig
+    val min : t -> t -> t
+    (** [min x y] returns the minimum of [x] and [y].
+        If either [x] or [y] is [nan], [y] is returned.
+        If both [x] and [y] equal zero, [y] is returned.
+        The amd64 flambda-backend compiler translates this call to MINSS. *)
+
+    val max : t -> t -> t
+    (** [max x y] returns the maximum of [x] and [y].  It returns [x]
+        If either [x] or [y] is [nan], [y] is returned.
+        If both [x] and [y] equal zero, [y] is returned.
+        The amd64 flambda-backend compiler translates this call to MAXSS. *)
+end
+
 val min_num : t -> t -> t
 (** [min_num x y] returns the minimum of [x] and [y] treating [nan] as
     missing values.  If both [x] and [y] are [nan], [nan] is returned.
@@ -373,6 +387,32 @@ val max_num : t -> t -> t
 (** [max_num x y] returns the maximum of [x] and [y] treating [nan] as
     missing values.  If both [x] and [y] are [nan] [nan] is returned.
     Moreover [max_num #-0.s #+0.s = #+0.s] *)
+
+val iround_half_to_even : t -> int64#
+(** Rounds a [float32#] to an [int64#] using the current rounding mode. The default
+    rounding mode is "round half to even", and we expect that no program will
+    change the rounding mode.
+    If the argument is NaN or infinite or if the rounded value cannot be
+    represented, then the result is unspecified.
+    The amd64 flambda-backend compiler translates this call to CVTSS2SI. *)
+
+val round_half_to_even : t -> t
+(** Rounds a [float32#] to an integer [float32#] using the current rounding
+    mode.  The default rounding mode is "round half to even", and we
+    expect that no program will change the rounding mode.
+    The amd64 flambda-backend compiler translates this call to ROUNDSS. *)
+
+val round_down : t -> t
+(** Rounds a [float32#] down to the next integer [float32#] toward negative infinity.
+    The amd64 flambda-backend compiler translates this call to ROUNDSS.*)
+
+val round_up : t -> t
+(** Rounds a [float32#] up to the next integer [float32#] toward positive infinity.
+    The amd64 flambda-backend compiler translates this call to ROUNDSS.*)
+
+val round_towards_zero : t -> t
+(** Rounds a [float32#] to the next integer [float32#] toward zero.
+    The amd64 flambda-backend compiler translates this call to ROUNDSS.*)
 
 (* CR layouts v5: add back hash when we deal with the ad-hoc polymorphic
    functions. *)

--- a/ocaml/runtime/float32.c
+++ b/ocaml/runtime/float32.c
@@ -309,6 +309,51 @@ CAMLprim value caml_ldexp_float32_bytecode(value f, value i)
   return caml_copy_float32(caml_ldexp_float32(Float32_val(f), Int_val(i)));
 }
 
+float caml_sse_float32_min(float x, float y) {
+  return x < y ? x : y;
+}
+
+CAMLprim value caml_sse_float32_min_bytecode(value x, value y) {
+  return caml_copy_float32(caml_sse_float32_min(Float32_val(x), Float32_val(y)));
+}
+
+float caml_sse_float32_max(float x, float y) {
+  return x > y ? x : y;
+}
+
+CAMLprim value caml_sse_float32_max_bytecode(value x, value y) {
+  return caml_copy_float32(caml_sse_float32_max(Float32_val(x), Float32_val(y)));
+}
+
+int64_t caml_sse_cast_float32_int64(float f)
+{
+  return llrintf(f);
+}
+
+CAMLprim value caml_sse_cast_float32_int64_bytecode(value f)
+{
+  return caml_copy_int64(caml_sse_cast_float32_int64(Float32_val(f)));
+}
+
+#define ROUND_NEG_INF 0x9
+#define ROUND_POS_INF 0xA
+#define ROUND_ZERO 0xB
+#define ROUND_CURRENT 0xC
+
+float caml_sse41_float32_round(int mode, float f) {
+  switch(mode) {
+  case ROUND_NEG_INF: return floorf(f);
+  case ROUND_POS_INF: return ceilf(f);
+  case ROUND_ZERO:    return truncf(f);
+  case ROUND_CURRENT: return rintf(f);
+  default: caml_fatal_error("Unknown rounding mode.");
+  }
+}
+
+value caml_sse41_float32_round_bytecode(value mode, value f) {
+  return caml_copy_float32(caml_sse41_float32_round(Int_val(mode), Float32_val(f)));
+}
+
 enum { FP_normal, FP_subnormal, FP_zero, FP_infinite, FP_nan };
 
 value caml_classify_float32(float vf)

--- a/ocaml/runtime/float32.c
+++ b/ocaml/runtime/float32.c
@@ -350,7 +350,7 @@ float caml_sse41_float32_round(int mode, float f) {
   }
 }
 
-value caml_sse41_float32_round_bytecode(value mode, value f) {
+CAMLprim value caml_sse41_float32_round_bytecode(value mode, value f) {
   return caml_copy_float32(caml_sse41_float32_round(Int_val(mode), Float32_val(f)));
 }
 

--- a/ocaml/runtime/float32.c
+++ b/ocaml/runtime/float32.c
@@ -314,7 +314,7 @@ float caml_sse_float32_min(float x, float y) {
 }
 
 CAMLprim value caml_sse_float32_min_bytecode(value x, value y) {
-  return caml_copy_float32(caml_sse_float32_min(Float32_val(x), Float32_val(y)));
+  return Float32_val(x) < Float32_val(y) ? x : y;
 }
 
 float caml_sse_float32_max(float x, float y) {
@@ -322,7 +322,7 @@ float caml_sse_float32_max(float x, float y) {
 }
 
 CAMLprim value caml_sse_float32_max_bytecode(value x, value y) {
-  return caml_copy_float32(caml_sse_float32_max(Float32_val(x), Float32_val(y)));
+  return Float32_val(x) > Float32_val(y) ? x : y;
 }
 
 int64_t caml_sse_cast_float32_int64(float f)

--- a/ocaml/runtime/float32.c
+++ b/ocaml/runtime/float32.c
@@ -259,6 +259,22 @@ CAMLprim value caml_fma_float32_bytecode(value f, value g, value h)
   return caml_copy_float32(fmaf(Float32_val(f), Float32_val(g), Float32_val(h)));
 }
 
+float caml_float32_of_int64(int64_t i) {
+  return (float)i;
+}
+
+CAMLprim value caml_float32_of_int64_bytecode(value i) {
+  return caml_copy_float32(caml_float32_of_int64(Int64_val(i)));
+}
+
+int64_t caml_float32_to_int64(float f) {
+  return (int64_t)f;
+}
+
+CAMLprim value caml_float32_to_int64_bytecode(value f) {
+  return caml_copy_int64(caml_float32_to_int64(Float32_val(f)));
+}
+
 float caml_float32_of_bits(int32_t bits)
 {
   union { float f; int32_t i; } u;

--- a/ocaml/runtime4/float32.c
+++ b/ocaml/runtime4/float32.c
@@ -309,6 +309,51 @@ CAMLprim value caml_ldexp_float32_bytecode(value f, value i)
   return caml_copy_float32(caml_ldexp_float32(Float32_val(f), Int_val(i)));
 }
 
+float caml_sse_float32_min(float x, float y) {
+  return x < y ? x : y;
+}
+
+CAMLprim value caml_sse_float32_min_bytecode(value x, value y) {
+  return caml_copy_float32(caml_sse_float32_min(Float32_val(x), Float32_val(y)));
+}
+
+float caml_sse_float32_max(float x, float y) {
+  return x > y ? x : y;
+}
+
+CAMLprim value caml_sse_float32_max_bytecode(value x, value y) {
+  return caml_copy_float32(caml_sse_float32_max(Float32_val(x), Float32_val(y)));
+}
+
+int64_t caml_sse_cast_float32_int64(float f)
+{
+  return llrintf(f);
+}
+
+CAMLprim value caml_sse_cast_float32_int64_bytecode(value f)
+{
+  return caml_copy_int64(caml_sse_cast_float32_int64(Float32_val(f)));
+}
+
+#define ROUND_NEG_INF 0x9
+#define ROUND_POS_INF 0xA
+#define ROUND_ZERO 0xB
+#define ROUND_CURRENT 0xC
+
+float caml_sse41_float32_round(int mode, float f) {
+  switch(mode) {
+  case ROUND_NEG_INF: return floorf(f);
+  case ROUND_POS_INF: return ceilf(f);
+  case ROUND_ZERO:    return truncf(f);
+  case ROUND_CURRENT: return rintf(f);
+  default: caml_fatal_error("Unknown rounding mode.");
+  }
+}
+
+value caml_sse41_float32_round_bytecode(value mode, value f) {
+  return caml_copy_float32(caml_sse41_float32_round(Int_val(mode), Float32_val(f)));
+}
+
 enum { FP_normal, FP_subnormal, FP_zero, FP_infinite, FP_nan };
 
 value caml_classify_float32(float vf)

--- a/ocaml/runtime4/float32.c
+++ b/ocaml/runtime4/float32.c
@@ -350,7 +350,7 @@ float caml_sse41_float32_round(int mode, float f) {
   }
 }
 
-value caml_sse41_float32_round_bytecode(value mode, value f) {
+CAMLprim value caml_sse41_float32_round_bytecode(value mode, value f) {
   return caml_copy_float32(caml_sse41_float32_round(Int_val(mode), Float32_val(f)));
 }
 

--- a/ocaml/runtime4/float32.c
+++ b/ocaml/runtime4/float32.c
@@ -314,7 +314,7 @@ float caml_sse_float32_min(float x, float y) {
 }
 
 CAMLprim value caml_sse_float32_min_bytecode(value x, value y) {
-  return caml_copy_float32(caml_sse_float32_min(Float32_val(x), Float32_val(y)));
+  return Float32_val(x) < Float32_val(y) ? x : y;
 }
 
 float caml_sse_float32_max(float x, float y) {
@@ -322,7 +322,7 @@ float caml_sse_float32_max(float x, float y) {
 }
 
 CAMLprim value caml_sse_float32_max_bytecode(value x, value y) {
-  return caml_copy_float32(caml_sse_float32_max(Float32_val(x), Float32_val(y)));
+  return Float32_val(x) > Float32_val(y) ? x : y;
 }
 
 int64_t caml_sse_cast_float32_int64(float f)

--- a/ocaml/runtime4/float32.c
+++ b/ocaml/runtime4/float32.c
@@ -259,6 +259,22 @@ CAMLprim value caml_fma_float32_bytecode(value f, value g, value h)
   return caml_copy_float32(fmaf(Float32_val(f), Float32_val(g), Float32_val(h)));
 }
 
+float caml_float32_of_int64(int64_t i) {
+  return (float)i;
+}
+
+CAMLprim value caml_float32_of_int64_bytecode(value i) {
+  return caml_copy_float32(caml_float32_of_int64(Int64_val(i)));
+}
+
+int64_t caml_float32_to_int64(float f) {
+  return (int64_t)f;
+}
+
+CAMLprim value caml_float32_to_int64_bytecode(value f) {
+  return caml_copy_int64(caml_float32_to_int64(Float32_val(f)));
+}
+
 float caml_float32_of_bits(int32_t bits)
 {
   union { float f; int32_t i; } u;

--- a/tests/small_numbers/float32_lib.ml
+++ b/tests/small_numbers/float32_lib.ml
@@ -249,6 +249,7 @@ let () =
     bit_eq (F32.round_up f) (CF32.ceil f);
     bit_eq (F32.round_down f) (CF32.floor f);
     bit_eq (F32.round_half_to_even f) (CF32.round_current f);
+    (* Returns int64, so can compare directly. *)
     assert ((F32.iround_half_to_even f) = (CF32.iround_current f));
   )
 ;;

--- a/tests/small_numbers/float32_lib.ml
+++ b/tests/small_numbers/float32_lib.ml
@@ -363,8 +363,8 @@ let () =
   );
   for _ = 0 to 100_000 do
     let i = if Random.bool () then Random.full_int Int.max_int else Int.neg (Random.full_int Int.max_int) in
-    let i64 = if Random.bool () then Random.int64 Int64.max_int else Int64.neg (Random.int64 Int64.max_int) in
     let f = if Random.bool () then Random.float Float.max_float else Float.neg (Random.float Float.max_float) in
+    let i64 = if Random.bool () then Random.int64 Int64.max_int else Int64.neg (Random.int64 Int64.max_int) in
     bit_eq (F32.of_int i) (CF32.of_int i);
     bit_eq (F32.of_int64 i64) (CF32.of_int64 i64);
     bit_eq (F32.of_float f) (CF32.of_float f);

--- a/tests/small_numbers/float32_lib.ml
+++ b/tests/small_numbers/float32_lib.ml
@@ -11,9 +11,11 @@ module CF32 = struct
   external to_bits : (t [@unboxed]) -> (int32 [@unboxed]) = "float32_bits_to_int_boxed" "float32_bits_to_int" [@@noalloc]
 
   external of_int : (int [@untagged]) -> (t [@unboxed]) = "float32_of_int_boxed" "float32_of_int" [@@noalloc]
+  external of_int64 : (int64 [@unboxed]) -> (t [@unboxed]) = "float32_of_int64_boxed" "float32_of_int64" [@@noalloc]
   external of_float : (float [@unboxed]) -> (t [@unboxed]) = "float32_of_float_boxed" "float32_of_float" [@@noalloc]
 
   external to_int : (t [@unboxed]) -> (int [@untagged]) = "float32_to_int_boxed" "float32_to_int" [@@noalloc]
+  external to_int64 : (t [@unboxed]) -> (int64 [@unboxed]) = "float32_to_int64_boxed" "float32_to_int64" [@@noalloc]
   external to_float : (t [@unboxed]) -> (float [@unboxed]) = "float32_to_float_boxed" "float32_to_float" [@@noalloc]
 
   external zero : unit -> (t [@unboxed]) = "float32_zero_boxed" "float32_zero" [@@noalloc]
@@ -339,13 +341,16 @@ let () =
   );
   CF32.check_float32s (fun f _ ->
     assert (F32.to_int f = CF32.to_int f);
+    assert (F32.to_int64 f = CF32.to_int64 f);
     if CF32.is_nan f then assert (Float.is_nan (F32.to_float f))
     else assert (F32.to_float f = CF32.to_float f)
   );
   for _ = 0 to 100_000 do
     let i = if Random.bool () then Random.full_int Int.max_int else Int.neg (Random.full_int Int.max_int) in
     let f = if Random.bool () then Random.float Float.max_float else Float.neg (Random.float Float.max_float) in
+    let i64 = if Random.bool () then Random.int64 Int64.max_int else Int64.neg (Random.int64 Int64.max_int) in
     bit_eq (F32.of_int i) (CF32.of_int i);
+    bit_eq (F32.of_int64 i64) (CF32.of_int64 i64);
     bit_eq (F32.of_float f) (CF32.of_float f);
   done
 ;;

--- a/tests/small_numbers/float32_lib.ml
+++ b/tests/small_numbers/float32_lib.ml
@@ -102,10 +102,15 @@ module CF32 = struct
 
   external min : t -> t -> t = "float32_min_boxed"
   external max : t -> t -> t = "float32_max_boxed"
+  external min_weird : t -> t -> t = "float32_min_weird_boxed"
+  external max_weird : t -> t -> t = "float32_max_weird_boxed"
   external min_num : t -> t -> t = "float32_min_num_boxed"
   external max_num : t -> t -> t = "float32_max_num_boxed"
   external min_max : t -> t -> t * t = "float32_min_max_boxed"
   external min_max_num : t -> t -> t * t = "float32_min_max_num_boxed"
+
+  external round_current : t -> t = "float32_round_current_boxed"
+  external iround_current : t -> int64 = "float32_iround_current_boxed"
 
   external compare : t -> t -> int = "float32_compare_boxed" [@@noalloc]
   let equal x y = compare x y = 0
@@ -230,10 +235,21 @@ let () =
     bit_eq (F32.copy_sign f1 f2) (CF32.copy_sign f1 f2);
     bit_eq (F32.min f1 f2) (CF32.min f1 f2);
     bit_eq (F32.max f1 f2) (CF32.max f1 f2);
+    bit_eq (F32.With_weird_nan_behavior.min f1 f2) (CF32.min_weird f1 f2);
+    bit_eq (F32.With_weird_nan_behavior.max f1 f2) (CF32.max_weird f1 f2);
     bit_eq (F32.min_num f1 f2) (CF32.min_num f1 f2);
     bit_eq (F32.max_num f1 f2) (CF32.max_num f1 f2);
     assert((F32.compare f1 f2) = (CF32.compare f1 f2));
     assert((F32.equal f1 f2) = (CF32.equal f1 f2));
+  )
+;;
+
+let () =
+  CF32.check_float32s (fun f _ ->
+    bit_eq (F32.round_up f) (CF32.ceil f);
+    bit_eq (F32.round_down f) (CF32.floor f);
+    bit_eq (F32.round_half_to_even f) (CF32.round_current f);
+    assert ((F32.iround_half_to_even f) = (CF32.iround_current f));
   )
 ;;
 
@@ -347,8 +363,8 @@ let () =
   );
   for _ = 0 to 100_000 do
     let i = if Random.bool () then Random.full_int Int.max_int else Int.neg (Random.full_int Int.max_int) in
-    let f = if Random.bool () then Random.float Float.max_float else Float.neg (Random.float Float.max_float) in
     let i64 = if Random.bool () then Random.int64 Int64.max_int else Int64.neg (Random.int64 Int64.max_int) in
+    let f = if Random.bool () then Random.float Float.max_float else Float.neg (Random.float Float.max_float) in
     bit_eq (F32.of_int i) (CF32.of_int i);
     bit_eq (F32.of_int64 i64) (CF32.of_int64 i64);
     bit_eq (F32.of_float f) (CF32.of_float f);

--- a/tests/small_numbers/float32_u_lib.ml
+++ b/tests/small_numbers/float32_u_lib.ml
@@ -227,6 +227,8 @@ let () =
     bit_eq (F32.copy_sign u1 u2) (CF32.copy_sign f1 f2);
     bit_eq (F32.min u1 u2) (CF32.min f1 f2);
     bit_eq (F32.max u1 u2) (CF32.max f1 f2);
+    bit_eq (F32.With_weird_nan_behavior.min u1 u2) (CF32.min_weird f1 f2);
+    bit_eq (F32.With_weird_nan_behavior.max u1 u2) (CF32.max_weird f1 f2);
     bit_eq (F32.min_num u1 u2) (CF32.min_num f1 f2);
     bit_eq (F32.max_num u1 u2) (CF32.max_num f1 f2);
     assert((F32.compare u1 u2) = (CF32.compare f1 f2));

--- a/tests/small_numbers/float32_u_lib.ml
+++ b/tests/small_numbers/float32_u_lib.ml
@@ -242,6 +242,7 @@ let () =
     bit_eq (F32.round_up u) (CF32.ceil f);
     bit_eq (F32.round_down u) (CF32.floor f);
     bit_eq (F32.round_half_to_even u) (CF32.round_current f);
+    (* Returns int64, so can compare directly. *)
     assert (box_int64 (F32.iround_half_to_even u) = (CF32.iround_current f));
   )
 ;;

--- a/tests/small_numbers/float32_u_lib.ml
+++ b/tests/small_numbers/float32_u_lib.ml
@@ -7,6 +7,8 @@ module F32 = Beta.Float32_u
 
 external box_int32 : int32# -> (int32[@local_opt]) = "%box_int32"
 external unbox_int32 : (int32[@local_opt]) -> int32# = "%unbox_int32"
+external box_int64 : int64# -> (int64[@local_opt]) = "%box_int64"
+external unbox_int64 : (int64[@local_opt]) -> int64# = "%unbox_int64"
 external box_float : float# -> (float[@local_opt]) = "%box_float"
 external unbox_float : (float[@local_opt]) -> float# = "%unbox_float"
 
@@ -16,9 +18,11 @@ module CF32 = struct
   external to_bits : (t [@unboxed]) -> (int32 [@unboxed]) = "float32_bits_to_int_boxed" "float32_bits_to_int" [@@noalloc]
 
   external of_int : (int [@untagged]) -> (t [@unboxed]) = "float32_of_int_boxed" "float32_of_int" [@@noalloc]
+  external of_int64 : (int64 [@unboxed]) -> (t [@unboxed]) = "float32_of_int64_boxed" "float32_of_int64" [@@noalloc]
   external of_float : (float [@unboxed]) -> (t [@unboxed]) = "float32_of_float_boxed" "float32_of_float" [@@noalloc]
 
   external to_int : (t [@unboxed]) -> (int [@untagged]) = "float32_to_int_boxed" "float32_to_int" [@@noalloc]
+  external to_int64 : (t [@unboxed]) -> (int64 [@unboxed]) = "float32_to_int64_boxed" "float32_to_int64" [@@noalloc]
   external to_float : (t [@unboxed]) -> (float [@unboxed]) = "float32_to_float_boxed" "float32_to_float" [@@noalloc]
 
   external zero : unit -> (t [@unboxed]) = "float32_zero_boxed" "float32_zero" [@@noalloc]
@@ -267,13 +271,16 @@ let () =
   CF32.check_float32s (fun f _ ->
     let u = F32.of_float32 f in
     assert (F32.to_int u = CF32.to_int f);
+    assert (box_int64 (F32.to_int64 u) = CF32.to_int64 f);
     if CF32.is_nan f then assert (Float.is_nan (box_float (F32.to_float u)))
     else assert (box_float (F32.to_float u) = CF32.to_float f)
   );
   for _ = 0 to 100_000 do
     let i = if Random.bool () then Random.full_int Int.max_int else Int.neg (Random.full_int Int.max_int) in
+    let i64 = if Random.bool () then Random.int64 Int64.max_int else Int64.neg (Random.int64 Int64.max_int) in
     let f = if Random.bool () then Random.float Float.max_float else Float.neg (Random.float Float.max_float) in
     bit_eq (F32.of_int i) (CF32.of_int i);
+    bit_eq (F32.of_int64 (unbox_int64 i64)) (CF32.of_int64 i64);
     bit_eq (F32.of_float (unbox_float f)) (CF32.of_float f);
   done
 ;;

--- a/tests/small_numbers/float32_u_lib.ml
+++ b/tests/small_numbers/float32_u_lib.ml
@@ -109,10 +109,15 @@ module CF32 = struct
 
   external min : t -> t -> t = "float32_min_boxed"
   external max : t -> t -> t = "float32_max_boxed"
+  external min_weird : t -> t -> t = "float32_min_weird_boxed"
+  external max_weird : t -> t -> t = "float32_max_weird_boxed"
   external min_num : t -> t -> t = "float32_min_num_boxed"
   external max_num : t -> t -> t = "float32_max_num_boxed"
   external min_max : t -> t -> t * t = "float32_min_max_boxed"
   external min_max_num : t -> t -> t * t = "float32_min_max_num_boxed"
+
+  external round_current : t -> t = "float32_round_current_boxed"
+  external iround_current : t -> int64 = "float32_iround_current_boxed"
 
   external compare : t -> t -> int = "float32_compare_boxed" [@@noalloc]
   let equal x y = compare x y = 0
@@ -226,6 +231,16 @@ let () =
     bit_eq (F32.max_num u1 u2) (CF32.max_num f1 f2);
     assert((F32.compare u1 u2) = (CF32.compare f1 f2));
     assert((F32.equal u1 u2) = (CF32.equal f1 f2));
+  )
+;;
+
+let () =
+  CF32.check_float32s (fun f _ ->
+    let u = F32.of_float32 f in
+    bit_eq (F32.round_up u) (CF32.ceil f);
+    bit_eq (F32.round_down u) (CF32.floor f);
+    bit_eq (F32.round_half_to_even u) (CF32.round_current f);
+    assert (box_int64 (F32.iround_half_to_even u) = (CF32.iround_current f));
   )
 ;;
 

--- a/tests/small_numbers/stubs.c
+++ b/tests/small_numbers/stubs.c
@@ -192,6 +192,20 @@ value float32_max_boxed(value l, value r)
     return caml_copy_float32(fmaxf(f, g));
 }
 
+value float32_min_weird_boxed(value l, value r)
+{
+    float f = Float32_val(l);
+    float g = Float32_val(r);
+    return caml_copy_float32(f < g ? f : g);
+}
+
+value float32_max_weird_boxed(value l, value r)
+{
+    float f = Float32_val(l);
+    float g = Float32_val(r);
+    return caml_copy_float32(f > g ? f : g);
+}
+
 value float32_min_num_boxed(value l, value r)
 {
     float f = Float32_val(l);
@@ -311,4 +325,14 @@ value float32_classify(float f)
 value float32_classify_boxed(value f)
 {
     return float32_classify(Float32_val(f));
+}
+
+value float32_round_current_boxed(value f)
+{
+    return caml_copy_float32(rintf(Float32_val(f)));
+}
+
+value float32_iround_current_boxed(value f)
+{
+    return caml_copy_int64(llrintf(Float32_val(f)));
 }

--- a/tests/small_numbers/stubs.c
+++ b/tests/small_numbers/stubs.c
@@ -7,8 +7,10 @@
 
 int32_t float32_bits_to_int(float f) { return *(int32_t *)&f; }
 float float32_of_int(intnat i) { return (float)i; }
+float float32_of_int64(int64_t i) { return (float)i; }
 float float32_of_float(double d) { return (float)d; }
 intnat float32_to_int(float f) { return (intnat)f; }
+int64_t float32_to_int64(float f) { return (int64_t)f; }
 double float32_to_float(float f) { return (double)f; }
 float float32_zero(value unit) { return 0.0f; }
 float float32_neg_zero(value unit) { return -0.0f; }


### PR DESCRIPTION
Adds intrinsics for `MINSS`,`MAXSS`,`ROUNDSS`, reaching parity with float64.

Note that while `Ocaml_intrinsics` also provides `round_nearest`, the float32 library does not. 
This is because we can't easily provide a cross-platform C implementation of round-half-to-even.
Instead, users should use `round_half_to_even` (respective of the current rounding mode).

Tests have been added to `float32_lib.ml` and `float32_u_lib.ml`.

p.s. moves `Sqrt_scalar_f32` from `SSE2` to `SSE`, where it belongs.