### PR TITLE
Stop using exceptions for control flow in `camlinternalOO`

### DIFF
--- a/ocaml/stdlib/camlinternalOO.ml
+++ b/ocaml/stdlib/camlinternalOO.ml
@@ -295,9 +295,7 @@ let new_methods_variables table meths vals =
   res
 
 let get_variable table name =
-  match Vars.find_opt name table.vars with
-  | Some x -> x
-  | None -> assert false
+  try Vars.find name table.vars with Not_found -> assert false
 
 let get_variables table names =
   Array.map (get_variable table) names

--- a/ocaml/stdlib/camlinternalOO.ml
+++ b/ocaml/stdlib/camlinternalOO.ml
@@ -200,8 +200,9 @@ let set_method table label element =
     table.hidden_meths <- (label, element) :: table.hidden_meths
 
 let get_method table label =
-  try List.assoc label table.hidden_meths
-  with Not_found -> table.methods.(label)
+  match List.assoc_opt label table.hidden_meths with
+  | Some x -> x
+  | None -> table.methods.(label)
 
 let to_list arr =
   if arr == Obj.magic 0 then [] else Array.to_list arr
@@ -228,7 +229,9 @@ let narrow table vars virt_meths concr_meths =
        by_name := Meths.add met label !by_name;
        by_label :=
           Labs.add label
-            (try Labs.find label table.methods_by_label with Not_found -> true)
+            (match Labs.find_opt label table.methods_by_label with
+             | Some x -> x
+             | None -> true)
             !by_label)
     concr_meths concr_meth_labs;
   List.iter2
@@ -269,8 +272,9 @@ let new_slot table =
   index
 
 let new_variable table name =
-  try Vars.find name table.vars
-  with Not_found ->
+  match Vars.find_opt name table.vars with
+  | Some x -> x
+  | None ->
     let index = new_slot table in
     if name <> "" then table.vars <- Vars.add name index table.vars;
     index
@@ -291,7 +295,9 @@ let new_methods_variables table meths vals =
   res
 
 let get_variable table name =
-  try Vars.find name table.vars with Not_found -> assert false
+  match Vars.find_opt name table.vars with
+  | Some x -> x
+  | None -> assert false
 
 let get_variables table names =
   Array.map (get_variable table) names


### PR DESCRIPTION
We have some evidence that doing this will speed up uses of the object system in JSOO.

I don't see a compelling reason to use exceptions in `ocaml/stdlib/camlinternalOO.ml`, and think using options is fine. I don't think this will affect bytecode or native compilation meaningfully. Perhaps this will add some more short-lived allocations for uses of the object system, but I don't think it's meaningfully more, judging from the surrounding code.