### PR TITLE
Add comment about structured constants for mixed blocks

### DIFF
--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -542,6 +542,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                     let shape = transl_mixed_product_shape shape in
                     Some (Const_mixed_block(runtime_tag, shape, constants))
                   else
+                    (* CR layouts v5.9: Structured constants for mixed blocks should
+                       be supported in bytecode. See symtable.ml for the difficulty.
+                    *)
                     None
               | Constructor_uniform_value ->
                   Some (Const_block(runtime_tag, constants)))


### PR DESCRIPTION
**Notes for reviewer:**
  * This PR is stacked on top of #2533, and should not be merged before that PR.
  * The first commit is #2533, but squashed, and the second commit is this PR.

Implement structured constants for mixed blocks in native code.

This PR both changes flambda2 to handle constant mixed blocks as static constants, and changes translation to start identifying constant mixed blocks as such. 

@mshinwell is reviewing the flambda2 parts. @ccasin , please review `translcore.ml` and the tests.