### PR TITLE
Implicit braces in ocamltest trees

### DIFF
--- a/ocaml/ocamltest/tsl_parser.mly
+++ b/ocaml/ocamltest/tsl_parser.mly
@@ -55,6 +55,7 @@ node:
 tree_list:
 | { [] }
 | tree tree_list { $1 :: $2 }
+| statement statement_list tree_list { [ Ast ($1 :: $2, $3) ] }
 
 tree:
 | LEFT_BRACE node RIGHT_BRACE { $2 }

--- a/ocaml/testsuite/tests/tool-ocamltest/tsl_nesting.ml
+++ b/ocaml/testsuite/tests/tool-ocamltest/tsl_nesting.ml
@@ -1,0 +1,36 @@
+(* TEST
+
+ set x = "a";
+ set expected = "a";
+ script = "bash -c 'if [[ $x != $expected ]]; then exit 1; fi'";
+ script;
+ {
+  expected = "a";
+  script;
+ }{
+  x = "b";
+  expected = "b";
+  script;
+ }{
+  expected = "a";
+  script;
+ }
+ expected = "a";
+ script;
+ x = "c";
+ expected = "c";
+ script;
+ {
+  expected = "c";
+  script;
+ }{
+  x = "d";
+  expected = "d";
+  script;
+ }{
+  expected = "c";
+  script;
+ }
+ expected = "c";
+ script;
+*)


### PR DESCRIPTION
The new tree syntax for ocamltest greatly improves the common case where several test cases are sequentially composed, each depending on the last. We can now write such tests as

```
test1;
test2;
test3;
test4;
...
test27;
```

without increasing the indentation level. This makes sense because these tests are not “nested” in any meaningful sense, any more than consecutive statements in imperative code are nested. Practically speaking, the great advantage is that we can now add `test1a` between `test1` and `test2` without increasing indentation (or other markers of nested-ness).

Unfortunately, this only works if `test1a` belongs in the sequence with the other tests. But it might be completely independent: for example, it might check an error case that is only meaningful after `test1` but has no bearing on the other tests. In that case, we have three unpalatable options:

1. Write it in the sequence anyway. This obscures the structure of the test cases and causes the entire rest of the sequence to be skipped if `test1a` fails.
2. Indent _every test in the sequence after `test1a`_ and risk emotional damage the next time you try to rebase.
3. Add braces around every test in the sequence after `test1a` but don't indent, then try to invent a convention that will help you keep the formatting straight.

The annoying thing here is that `test4` is _still_ not meaningfully “more nested” than `test1`. It just happens that there's an extra branch jutting out of the sequence somewhere between `test1` and `test4`, and the syntax makes that everyone's problem.

My proposed syntax is this:

```
test1;
{
 test1a;
}
test2;
test3;
test4;
...
test27;
```

This is exactly as if we'd put braces around everything from `test2` to `test27`, but it once again expresses that this is simply a sequence of tests in a chain. It's just that now there are some tests that branch off from the sequence.