### PR TITLE
Advise against new bytecode instructions

### DIFF
--- a/ocaml/runtime/caml/instruct.h
+++ b/ocaml/runtime/caml/instruct.h
@@ -63,6 +63,15 @@ enum instructions {
   GETSTRINGCHAR,
   PERFORM, RESUME, RESUMETERM, REPERFORMTERM,
   MAKE_FAUX_MIXEDBLOCK,
+  /* Think carefully before adding a new bytecode instruction. In general,
+     this makes the flambda-backend compiler less compatible with the
+     OCaml ecosystem. Projects may need to be patched to build with
+     flambda-backend.
+
+     We added the [MAKE_FAUX_MIXEDBLOCK] instruction without making this
+     consideration and it has turned out OK, but we might want to reverse
+     this decision if we run into difficulty in the future.
+   */
 FIRST_UNIMPLEMENTED_OP};
 
 #endif /* CAML_INTERNALS */

--- a/ocaml/runtime/caml/instruct.h
+++ b/ocaml/runtime/caml/instruct.h
@@ -63,16 +63,16 @@ enum instructions {
   GETSTRINGCHAR,
   PERFORM, RESUME, RESUMETERM, REPERFORMTERM,
   MAKE_FAUX_MIXEDBLOCK,
-  /* Think carefully before adding a new bytecode instruction. In general,
-     this makes the flambda-backend compiler less compatible with the
-     OCaml ecosystem. Projects may need to be patched to build with
-     flambda-backend.
-
-     We added the [MAKE_FAUX_MIXEDBLOCK] instruction without making this
-     consideration and it has turned out OK, but we might want to reverse
-     this decision if we run into difficulty in the future.
-   */
 FIRST_UNIMPLEMENTED_OP};
+
+// Think carefully before adding a new bytecode instruction. In general,
+// this makes the flambda-backend compiler less compatible with the
+// OCaml ecosystem. Projects may need to be patched to build with
+// flambda-backend.
+//
+// We added the [MAKE_FAUX_MIXEDBLOCK] instruction without making this
+// consideration and it has turned out OK, but we might want to reverse
+// this decision if we run into difficulty in the future.
 
 #endif /* CAML_INTERNALS */
 

--- a/ocaml/runtime4/caml/instruct.h
+++ b/ocaml/runtime4/caml/instruct.h
@@ -62,6 +62,15 @@ enum instructions {
   RERAISE, RAISE_NOTRACE,
   GETSTRINGCHAR,
   MAKE_FAUX_MIXEDBLOCK,
+  /* Think carefully before adding a new bytecode instruction. In general,
+     this makes the flambda-backend compiler less compatible with the
+     OCaml ecosystem. Projects may need to be patched to build with
+     flambda-backend.
+
+     We added the [MAKE_FAUX_MIXEDBLOCK] instruction without making this
+     consideration and it has turned out OK, but we might want to reverse
+     this decision if we run into difficulty in the future.
+  */
 FIRST_UNIMPLEMENTED_OP};
 
 #endif /* CAML_INTERNALS */

--- a/ocaml/runtime4/caml/instruct.h
+++ b/ocaml/runtime4/caml/instruct.h
@@ -62,16 +62,16 @@ enum instructions {
   RERAISE, RAISE_NOTRACE,
   GETSTRINGCHAR,
   MAKE_FAUX_MIXEDBLOCK,
-  /* Think carefully before adding a new bytecode instruction. In general,
-     this makes the flambda-backend compiler less compatible with the
-     OCaml ecosystem. Projects may need to be patched to build with
-     flambda-backend.
-
-     We added the [MAKE_FAUX_MIXEDBLOCK] instruction without making this
-     consideration and it has turned out OK, but we might want to reverse
-     this decision if we run into difficulty in the future.
-  */
 FIRST_UNIMPLEMENTED_OP};
+
+// Think carefully before adding a new bytecode instruction. In general,
+// this makes the flambda-backend compiler less compatible with the
+// OCaml ecosystem. Projects may need to be patched to build with
+// flambda-backend.
+//
+// We added the [MAKE_FAUX_MIXEDBLOCK] instruction without making this
+// consideration and it has turned out OK, but we might want to reverse
+// this decision if we run into difficulty in the future.
 
 #endif /* CAML_INTERNALS */
 


### PR DESCRIPTION
Add a comment that urges caution when adding a new bytecode instruction. (It's not impossible &mdash; we've done it &mdash; but it shouldn't be done lightly.)