### PR TITLE
Restore missing `.h` files to `caml` directory of runtime 5's installed compiler

### DIFF
--- a/ocaml/otherlibs/runtime_events/dune
+++ b/ocaml/otherlibs/runtime_events/dune
@@ -44,7 +44,7 @@
     (.runtime_events.objs/byte/runtime_events.cmi as runtime_events/runtime_events.cmi)
     (.runtime_events.objs/byte/runtime_events.cmt as runtime_events/runtime_events.cmt)
     (.runtime_events.objs/byte/runtime_events.cmti as runtime_events/runtime_events.cmti)
-    (runtime_events_consumer.h as runtime_events_consumer.h)
+    (runtime_events_consumer.h as caml/runtime_events_consumer.h)
     (META as runtime_events/META)
   )
   (section lib)

--- a/ocaml/runtime/caml/dune
+++ b/ocaml/runtime/caml/dune
@@ -76,6 +76,7 @@
     (intext.h as caml/intext.h)
     (io.h as caml/io.h)
     (lf_skiplist.h as caml/lf_skiplist.h)
+    (jumptbl.h as caml/jumptbl.h)
     (m.h as caml/m.h)
     (major_gc.h as caml/major_gc.h)
     (md5.h as caml/md5.h)

--- a/ocaml/runtime/caml/dune
+++ b/ocaml/runtime/caml/dune
@@ -22,6 +22,16 @@
             sed -n -e '/^  /s/ \\([A-Z]\\)/ \\&\\&lbl_\\1/gp' -e '/^}/q'"))))
 
 (rule
+  (targets opnames.h)
+  (deps instruct.h ../../Makefile
+   ../../Makefile.common
+   ../../Makefile.config
+   ../../Makefile.build_config
+   ../../Makefile.config_if_required
+  )
+  (action (run make -s -C ../.. COMPUTE_DEPS=false runtime/caml/opnames.h)))
+
+(rule
  (targets version.h)
  (mode    fallback)
  (action
@@ -74,6 +84,7 @@
     (minor_gc.h as caml/minor_gc.h)
     (misc.h as caml/misc.h)
     (mlvalues.h as caml/mlvalues.h)
+    (opnames.h as caml/opnames.h)
     (osdeps.h as caml/osdeps.h)
     (platform.h as caml/platform.h)
     (prims.h as caml/prims.h)


### PR DESCRIPTION
Restore these `.h` files to `caml` in runtime 5:
  * `opnames.h`
  * `jumptbl.h`
  * `runtime_events_consumer.h` (this was being put in the wrong place: the parent directory of `caml`)

I believe these were unintentionally dropped/misplaced in the runtime 5 merge.

The build rule to generate `opnames.h` is copied and adapted from runtime 4.

Testing: I diffed the `caml` directory of flambda-backend's runtime 5 with 5.1.0 on opam. Now the only differences are header files we added: `float32.h` and `simd.h`.