### PR TITLE
Expose float32 mask symbols

### DIFF
--- a/ocaml/runtime/amd64.S
+++ b/ocaml/runtime/amd64.S
@@ -1123,6 +1123,14 @@ G(caml_negf_mask):
         .align  SIXTEEN_ALIGN
 G(caml_absf_mask):
         .quad   0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF
+        .globl  G(caml_negf32_mask)
+        .align  SIXTEEN_ALIGN
+G(caml_negf32_mask):
+        .quad   0x80000000, 0
+        .globl  G(caml_absf32_mask)
+        .align  SIXTEEN_ALIGN
+G(caml_absf32_mask):
+        .quad   0xFFFFFFFF7FFFFFFFL, 0xFFFFFFFFFFFFFFFF
 
 #if defined(SYS_linux)
     /* Mark stack as non-executable, PR#4564 */

--- a/ocaml/runtime/amd64nt.asm
+++ b/ocaml/runtime/amd64nt.asm
@@ -452,4 +452,14 @@ caml_negf_mask LABEL QWORD
 caml_absf_mask LABEL QWORD
         QWORD   7FFFFFFFFFFFFFFFH, 0FFFFFFFFFFFFFFFFH
 
+        PUBLIC  caml_negf32_mask
+        ALIGN   16
+caml_negf32_mask LABEL QWORD
+        QWORD   80000000H, 0
+
+        PUBLIC  caml_absf32_mask
+        ALIGN   16
+caml_absf32_mask LABEL QWORD
+        QWORD   FFFFFFFF7FFFFFFFH, 0FFFFFFFFFFFFFFFFH
+
         END

--- a/ocaml/runtime4/amd64.S
+++ b/ocaml/runtime4/amd64.S
@@ -791,6 +791,14 @@ G(caml_negf_mask):
         .align  SIXTEEN_ALIGN
 G(caml_absf_mask):
         .quad   0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF
+        .globl  G(caml_negf32_mask)
+        .align  SIXTEEN_ALIGN
+G(caml_negf32_mask):
+        .quad   0x80000000, 0
+        .globl  G(caml_absf32_mask)
+        .align  SIXTEEN_ALIGN
+G(caml_absf32_mask):
+        .quad   0xFFFFFFFF7FFFFFFFL, 0xFFFFFFFFFFFFFFFF
 
 #if defined(SYS_linux)
     /* Mark stack as non-executable, PR#4564 */

--- a/ocaml/runtime4/amd64nt.asm
+++ b/ocaml/runtime4/amd64nt.asm
@@ -453,4 +453,14 @@ caml_negf_mask LABEL QWORD
 caml_absf_mask LABEL QWORD
         QWORD   7FFFFFFFFFFFFFFFH, 0FFFFFFFFFFFFFFFFH
 
+        PUBLIC  caml_negf32_mask
+        ALIGN   16
+caml_negf32_mask LABEL QWORD
+        QWORD   80000000H, 0
+
+        PUBLIC  caml_absf32_mask
+        ALIGN   16
+caml_absf32_mask LABEL QWORD
+        QWORD   FFFFFFFF7FFFFFFFH, 0FFFFFFFFFFFFFFFFH
+
         END

--- a/tests/simd/arrays.ml
+++ b/tests/simd/arrays.ml
@@ -1,6 +1,7 @@
 open Stdlib
 
 [@@@ocaml.warning "-unused-value-declaration"]
+[@@@ocaml.warning "-unused-module"]
 
 external int8x16_of_int64s : int64 -> int64 -> int8x16 = "" "vec128_of_int64s" [@@noalloc] [@@unboxed]
 external int8x16_low_int64 : int8x16 -> int64 = "" "vec128_low_int64" [@@noalloc] [@@unboxed]

--- a/tests/simd/consts.ml
+++ b/tests/simd/consts.ml
@@ -1,5 +1,7 @@
 open Stdlib
 
+[@@@ocaml.warning "-unused-module"]
+
 let eq lv hv l h =
     if l <> lv then Printf.printf "%016Lx <> %016Lx\n" lv l;
     if h <> hv then Printf.printf "%016Lx <> %016Lx\n" hv h

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -98,6 +98,8 @@
   (:standard -extension simd -nodynlink)))
 
 (rule
+ (enabled_if
+  (= %{context_name} "main"))
  (targets
   basic_nodynlink.out
   ops_nodynlink.out
@@ -128,6 +130,10 @@
 
 (rule
  (alias runtest)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (= %{architecture} amd64)))
  (action
   (progn
    (diff empty.expected basic_nodynlink.out)

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -1,9 +1,3 @@
-(env
- (_
-  ; FIXME Fix warnings or suppress them more finely
-  (flags
-   (:standard -w -32-33-35-60))))
-
 ; Helpers
 
 (library
@@ -28,7 +22,7 @@
  (libraries simd_test_helpers)
  (foreign_archives stubs)
  (ocamlopt_flags
-  (:standard -extension simd -dump-into-file -dsel)))
+  (:standard -extension simd)))
 
 (rule
  (enabled_if
@@ -66,6 +60,81 @@
    (diff empty.expected arrays.out)
    (diff empty.expected scalar_ops.out)
    (diff empty.expected consts.out))))
+
+; Tests with nodynlink
+
+(rule
+ (targets
+  basic_nodynlink.ml
+  ops_nodynlink.ml
+  consts_nodynlink.ml
+  arrays_nodynlink.ml
+  scalar_ops_nodynlink.ml)
+ (deps basic.ml ops.ml consts.ml scalar_ops.ml)
+ (action
+  (progn
+   (copy basic.ml basic_nodynlink.ml)
+   (copy ops.ml ops_nodynlink.ml)
+   (copy consts.ml consts_nodynlink.ml)
+   (copy arrays.ml arrays_nodynlink.ml)
+   (copy scalar_ops.ml scalar_ops_nodynlink.ml))))
+
+(executables
+ (names
+  basic_nodynlink
+  ops_nodynlink
+  consts_nodynlink
+  arrays_nodynlink
+  scalar_ops_nodynlink)
+ (modules
+  basic_nodynlink
+  ops_nodynlink
+  consts_nodynlink
+  arrays_nodynlink
+  scalar_ops_nodynlink)
+ (libraries simd_test_helpers)
+ (foreign_archives stubs)
+ (ocamlopt_flags
+  (:standard -extension simd -nodynlink)))
+
+(rule
+ (targets
+  basic_nodynlink.out
+  ops_nodynlink.out
+  arrays_nodynlink.out
+  scalar_ops_nodynlink.out)
+ (deps
+  basic_nodynlink.exe
+  ops_nodynlink.exe
+  arrays_nodynlink.exe
+  scalar_ops_nodynlink.exe)
+ (action
+  (progn
+   (with-outputs-to
+    basic_nodynlink.out
+    (run ./basic_nodynlink.exe))
+   (with-outputs-to
+    ops_nodynlink.out
+    (run ./ops_nodynlink.exe))
+   (with-outputs-to
+    arrays_nodynlink.out
+    (run ./arrays_nodynlink.exe))
+   (with-outputs-to
+    scalar_ops_nodynlink.out
+    (run ./scalar_ops_nodynlink.exe))
+   (with-outputs-to
+    consts_nodynlink.out
+    (run ./consts_nodynlink.exe)))))
+
+(rule
+ (alias runtest)
+ (action
+  (progn
+   (diff empty.expected basic_nodynlink.out)
+   (diff empty.expected ops_nodynlink.out)
+   (diff empty.expected arrays_nodynlink.out)
+   (diff empty.expected scalar_ops_nodynlink.out)
+   (diff empty.expected consts_nodynlink.out))))
 
 ; Tests with probes / internal assembler - not supported on macOS
 

--- a/tests/simd/ops.ml
+++ b/tests/simd/ops.ml
@@ -1,6 +1,7 @@
 open Stdlib
 
 [@@@ocaml.warning "-unused-value-declaration"]
+[@@@ocaml.warning "-unused-module"]
 
 let failmsg = ref (fun () -> ())
 

--- a/tests/simd/scalar_ops.ml
+++ b/tests/simd/scalar_ops.ml
@@ -1,5 +1,6 @@
 
 [@@@ocaml.warning "-unused-value-declaration"]
+[@@@ocaml.warning "-unused-module"]
 
 external int64x2_of_int64s : int64 -> int64 -> int64x2 = "caml_vec128_unreachable" "vec128_of_int64s" [@@noalloc] [@@unboxed]
 external int64x2_low_int64 : int64x2 -> int64 = "caml_vec128_unreachable" "vec128_low_int64" [@@noalloc] [@@unboxed]

--- a/tests/small_numbers/dune
+++ b/tests/small_numbers/dune
@@ -14,9 +14,6 @@
  (modules float32_builtin float32_lib float32_u_lib)
  (libraries beta)
  (foreign_archives stubs)
- ; FIXME Fix warnings
- (flags
-  (:standard -w -27-32-35-37))
  (ocamlopt_flags
   (:standard -extension-universe beta)))
 
@@ -47,6 +44,63 @@
    (diff empty.expected float32_lib.out)
    (diff empty.expected float32_u_lib.out))))
 
+; Tests with nodynlink
+
+(rule
+ (targets
+  float32_builtin_nodynlink.ml
+  float32_lib_nodynlink.ml
+  float32_u_lib_nodynlink.ml)
+ (deps float32_builtin.ml float32_lib.ml float32_u_lib.ml)
+ (action
+  (progn
+   (copy float32_builtin.ml float32_builtin_nodynlink.ml)
+   (copy float32_lib.ml float32_lib_nodynlink.ml)
+   (copy float32_u_lib.ml float32_u_lib_nodynlink.ml))))
+
+(executables
+ (names
+  float32_builtin_nodynlink
+  float32_lib_nodynlink
+  float32_u_lib_nodynlink)
+ (modules
+  float32_builtin_nodynlink
+  float32_lib_nodynlink
+  float32_u_lib_nodynlink)
+ (libraries beta)
+ (foreign_archives stubs)
+ (ocamlopt_flags
+  (:standard -extension-universe beta -nodynlink)))
+
+(rule
+ (targets
+  float32_builtin_nodynlink.out
+  float32_lib_nodynlink.out
+  float32_u_lib_nodynlink.out)
+ (deps
+  float32_builtin_nodynlink.exe
+  float32_lib_nodynlink.exe
+  float32_u_lib_nodynlink.exe)
+ (action
+  (progn
+   (with-outputs-to
+    float32_builtin_nodynlink.out
+    (run ./float32_builtin_nodynlink.exe))
+   (with-outputs-to
+    float32_lib_nodynlink.out
+    (run ./float32_lib_nodynlink.exe))
+   (with-outputs-to
+    float32_u_lib_nodynlink.out
+    (run ./float32_u_lib_nodynlink.exe)))))
+
+(rule
+ (alias runtest)
+ (action
+  (progn
+   (diff empty.expected float32_builtin_nodynlink.out)
+   (diff empty.expected float32_lib_nodynlink.out)
+   (diff empty.expected float32_u_lib_nodynlink.out))))
+
 ; Tests with internal assembler - not supported on macOS
 
 (rule
@@ -71,9 +125,6 @@
  (enabled_if
   (<> %{system} macosx))
  (foreign_archives stubs)
- ; FIXME Fix warnings
- (flags
-  (:standard -w -27-32-35-37))
  (ocamlopt_flags
   (:standard -extension-universe beta -internal-assembler)))
 

--- a/tests/small_numbers/dune
+++ b/tests/small_numbers/dune
@@ -73,6 +73,8 @@
   (:standard -extension-universe beta -nodynlink)))
 
 (rule
+ (enabled_if
+  (= %{context_name} "main"))
  (targets
   float32_builtin_nodynlink.out
   float32_lib_nodynlink.out
@@ -95,6 +97,8 @@
 
 (rule
  (alias runtest)
+ (enabled_if
+  (= %{context_name} "main"))
  (action
   (progn
    (diff empty.expected float32_builtin_nodynlink.out)


### PR DESCRIPTION
Adds `caml_negf32_mask` and `caml_absf32_mask` to the `amd64` runtime assembly files.
This was required to compile float32 code using `-nodynlink`.

The float32 and SIMD tests have been updated to also run with `-nodynlink`, and some warnings were cleaned up.