### PR TITLE
Fix unsound modes in typecore

### DIFF
--- a/ocaml/testsuite/tests/typing-modes/class.ml
+++ b/ocaml/testsuite/tests/typing-modes/class.ml
@@ -172,3 +172,25 @@ Line 3, characters 17-20:
                      ^^^
 Error: This value is nonportable but expected to be portable.
 |}]
+
+let foo () =
+    let x = object end in
+    portable_use x
+[%%expect{|
+Line 3, characters 17-18:
+3 |     portable_use x
+                     ^
+Error: This value is nonportable but expected to be portable.
+|}]
+
+class cla = object
+    method m =
+        let o = {< >} in
+        portable_use o
+end
+[%%expect{|
+Line 4, characters 21-22:
+4 |         portable_use o
+                         ^
+Error: This value is nonportable but expected to be portable.
+|}]

--- a/ocaml/testsuite/tests/typing-modes/lazy.ml
+++ b/ocaml/testsuite/tests/typing-modes/lazy.ml
@@ -6,9 +6,11 @@
 let u =
     let _x @ portable = lazy "hello" in
     ()
-(* CR zqian: this should fail. *)
 [%%expect{|
-val u : unit = ()
+Line 2, characters 24-36:
+2 |     let _x @ portable = lazy "hello" in
+                            ^^^^^^^^^^^^
+Error: This value is nonportable but expected to be portable.
 |}]
 
 (* lazy body is legacy *)

--- a/ocaml/testsuite/tests/typing-modes/letop.ml
+++ b/ocaml/testsuite/tests/typing-modes/letop.ml
@@ -1,0 +1,95 @@
+(* TEST
+    expect;
+*)
+
+let portable_use : _ @ portable -> unit = fun _ -> ()
+
+let ( let* ) o f =
+  match o with
+  | None -> None
+  | Some x -> f x
+
+let ( and* ) a b =
+  match a, b with
+  | Some a, Some b -> Some (a, b)
+  | _ -> None
+
+[%%expect{|
+val portable_use : 'a @ portable -> unit = <fun>
+val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option = <fun>
+val ( and* ) : 'a option -> 'b option -> ('a * 'b) option = <fun>
+|}]
+
+(* bindings are required to be legacy *)
+let foo () =
+    let* a = local_ "hello" in
+    ()
+[%%expect{|
+Line 2, characters 13-27:
+2 |     let* a = local_ "hello" in
+                 ^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+let foo () =
+    let* a = Some "hello"
+    and* b = local_ "hello" in
+    ()
+[%%expect{|
+Line 3, characters 13-27:
+3 |     and* b = local_ "hello" in
+                 ^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+(* Bindings are avialable as legacy *)
+let foo () =
+    let* a = Some (fun x -> x)
+    and* b = Some (fun x -> x) in
+    portable_use a
+[%%expect{|
+Line 4, characters 17-18:
+4 |     portable_use a
+                     ^
+Error: This value is nonportable but expected to be portable.
+|}]
+
+let foo () =
+    let* a = Some (fun x -> x)
+    and* b = Some (fun x -> x) in
+    portable_use b
+[%%expect{|
+Line 4, characters 17-18:
+4 |     portable_use b
+                     ^
+Error: This value is nonportable but expected to be portable.
+|}]
+
+(* Body required to be legacy *)
+let foo () =
+    let _ =
+        let* a = Some (fun x -> x) in
+        local_ "hello"
+    in
+    ()
+[%%expect{|
+Line 4, characters 8-22:
+4 |         local_ "hello"
+            ^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+(* The whole letop is available as legacy *)
+let foo () =
+    portable_use (
+        let* a = Some (fun x -> x) in
+        fun x -> x
+    )
+[%%expect{|
+Lines 2-5, characters 17-5:
+2 | .................(
+3 |         let* a = Some (fun x -> x) in
+4 |         fun x -> x
+5 |     )
+Error: This value is nonportable but expected to be portable.
+|}]

--- a/ocaml/testsuite/tests/typing-modes/module.ml
+++ b/ocaml/testsuite/tests/typing-modes/module.ml
@@ -117,9 +117,11 @@ val u : unit = ()
 
 (* first class modules are produced at legacy *)
 let x = ((module M : SL) : _ @@ portable)
-(* CR zqian: this should fail *)
 [%%expect{|
-val x : (module SL) = <module>
+Line 1, characters 9-24:
+1 | let x = ((module M : SL) : _ @@ portable)
+             ^^^^^^^^^^^^^^^
+Error: This value is nonportable but expected to be portable.
 |}]
 
 (* first class modules are consumed at legacy *)

--- a/ocaml/testsuite/tests/typing-unique/unique_analysis.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique_analysis.ml
@@ -555,62 +555,6 @@ let foo () =
 val foo : unit -> unit = <fun>
 |}]
 
-
-(* testing Tpat_lazy *)
-let foo () =
-  match lazy (unique_ "hello") with
-  | (lazy y) as x -> ignore (shared_id x)
-[%%expect{|
-val foo : unit -> unit = <fun>
-|}]
-
-
-let foo () =
-match lazy (unique_ "hello") with
-| (lazy y) as x -> ignore (unique_id x)
-
-[%%expect{|
-Line 3, characters 37-38:
-3 | | (lazy y) as x -> ignore (unique_id x)
-                                         ^
-Error: This value is used here as unique, but it has already been used:
-Line 3, characters 2-10:
-3 | | (lazy y) as x -> ignore (unique_id x)
-      ^^^^^^^^
-
-|}]
-
-type 'a r_lazy = {x_lazy : 'a Lazy.t; y : string}
-
-let foo () =
-  match {x_lazy = lazy (unique_ "hello"); y = "world"} with
-  | {x_lazy = lazy y} as r -> ignore (unique_id r.x_lazy)
-[%%expect{|
-type 'a r_lazy = { x_lazy : 'a Lazy.t; y : string; }
-Line 5, characters 48-56:
-5 |   | {x_lazy = lazy y} as r -> ignore (unique_id r.x_lazy)
-                                                    ^^^^^^^^
-Error: This value is used here as unique, but it has already been used:
-Line 5, characters 14-20:
-5 |   | {x_lazy = lazy y} as r -> ignore (unique_id r.x_lazy)
-                  ^^^^^^
-
-|}]
-
-let foo () =
-  match {x_lazy = lazy (unique_ "hello"); y = "world"} with
-  | {x_lazy = lazy y} as r -> ignore (shared_id r.x_lazy)
-[%%expect{|
-val foo : unit -> unit = <fun>
-|}]
-
-let foo () =
-  match {x_lazy = lazy (unique_ "hello"); y = "world"} with
-  | {x_lazy = lazy y} as r -> ignore (unique_id r.y)
-[%%expect{|
-val foo : unit -> unit = <fun>
-|}]
-
 (* Testing modalities in records *)
 type r_shared = {x : string; y : string @@ shared many}
 [%%expect{|


### PR DESCRIPTION
This PR fixes several unsoundness in modes in `typecore.ml`.

In particular, we treat `lazy` more coarsely than before: `lazy body` will always be `legacy` and we require `body` to be `legacy`. This trivializes some tests in uniqueness analysis, which we now remove. The code in `uniqueness_analysis.ml` treating `Tpat_lazy` and `Texp_lazy` doesn't need change. 