### PR TITLE
Fix signal_handler_run_in_c_thread test

### DIFF
--- a/ocaml/testsuite/tests/lib-threads/signal_handler_run_in_c_thread_stubs.c
+++ b/ocaml/testsuite/tests/lib-threads/signal_handler_run_in_c_thread_stubs.c
@@ -4,10 +4,14 @@
 
 static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+static int thread_started = 0;
 
 static void* in_thread(void* unused)
 {
-  (void) pthread_cond_signal(&cond);
+  pthread_mutex_lock(&mutex);
+  thread_started = 1;
+  pthread_cond_signal(&cond);
+  pthread_mutex_unlock(&mutex);
   /* Signal to be received in this thread by the OCaml signal handler */
   while (1);
 }
@@ -16,7 +20,11 @@ value test_signal_handler_run_in_c_thread(value unit)
 {
   pthread_t thread;
   pthread_create(&thread, NULL, &in_thread, NULL);
-  pthread_cond_wait(&cond, &mutex);
+  pthread_mutex_lock(&mutex);
+  while (!thread_started) {
+    pthread_cond_wait(&cond, &mutex);
+  }
+  pthread_mutex_unlock(&mutex);
   pthread_kill(thread, SIGUSR1);
   return Val_unit;
 }


### PR DESCRIPTION
The C code of the `signal_handler_run_in_c_thread` test was broken in various ways (calling pthread_cond_wait without holding the corresponding mutex, race condition between wait and signal, no looping around wait), and deadlocked approx once every 1k runs. This patch fixes these issues, and the test then passed 200k times on my machine.