### PR TITLE
Join: only generate alias types to older variables

### DIFF
--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -599,7 +599,7 @@ let mem_simple ?min_name_mode t simple =
     ~name:(fun name ~coercion:_ -> mem ?min_name_mode t name)
     ~const:(fun _ -> true)
 
-let alias_is_bound_before t ~bound_name ~alias =
+let alias_is_bound_strictly_earlier t ~bound_name ~alias =
   let time_of_name =
     binding_time_and_mode t bound_name
     |> Binding_time.With_name_mode.binding_time

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -600,8 +600,14 @@ let mem_simple ?min_name_mode t simple =
     ~const:(fun _ -> true)
 
 let alias_is_bound_before t ~bound_name ~alias =
-  let time_of_name = binding_time_and_mode t bound_name |> Binding_time.With_name_mode.binding_time in
-  let time_of_alias = binding_time_and_mode_of_simple t alias |> Binding_time.With_name_mode.binding_time in
+  let time_of_name =
+    binding_time_and_mode t bound_name
+    |> Binding_time.With_name_mode.binding_time
+  in
+  let time_of_alias =
+    binding_time_and_mode_of_simple t alias
+    |> Binding_time.With_name_mode.binding_time
+  in
   Binding_time.strictly_earlier time_of_alias ~than:time_of_name
 
 let with_current_level t ~current_level = { t with current_level }

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -599,6 +599,11 @@ let mem_simple ?min_name_mode t simple =
     ~name:(fun name ~coercion:_ -> mem ?min_name_mode t name)
     ~const:(fun _ -> true)
 
+let alias_is_bound_before t ~bound_name ~alias =
+  let time_of_name = binding_time_and_mode t bound_name |> Binding_time.With_name_mode.binding_time in
+  let time_of_alias = binding_time_and_mode_of_simple t alias |> Binding_time.With_name_mode.binding_time in
+  Binding_time.strictly_earlier time_of_alias ~than:time_of_name
+
 let with_current_level t ~current_level = { t with current_level }
 
 let with_current_level_and_next_binding_time t ~current_level next_binding_time

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -169,7 +169,8 @@ val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool
 
 val mem_simple : ?min_name_mode:Name_mode.t -> t -> Simple.t -> bool
 
-val alias_is_bound_before : t -> bound_name:Name.t -> alias:Simple.t -> bool
+val alias_is_bound_strictly_earlier :
+  t -> bound_name:Name.t -> alias:Simple.t -> bool
 
 (* CR vlaviron: If the underlying level in the extension defines several
    variables, then there is no guarantee that the binding order in the result

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -169,6 +169,8 @@ val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool
 
 val mem_simple : ?min_name_mode:Name_mode.t -> t -> Simple.t -> bool
 
+val alias_is_bound_before : t -> bound_name:Name.t -> alias:Simple.t -> bool
+
 (* CR vlaviron: If the underlying level in the extension defines several
    variables, then there is no guarantee that the binding order in the result
    will match the binding order used to create the level. If they don't match,

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -1337,15 +1337,17 @@ and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
     match bound_name with
     | None -> shared_aliases
     | Some bound_name ->
-      (* We only return one type for each name, so we have to decide whether
-         to return an alias or an expanded head.
-         Usually we prefer aliases, because we hope that the alias itself
-         will have a concrete equation anyway, but we must be careful to
-         ensure that we don't return aliases to self (obviously wrong)
-         or, if two variables [x] and [y] alias each other, redundant equations
-         [x : (= y)] and [y : (= x)]. *)
+      (* We only return one type for each name, so we have to decide whether to
+         return an alias or an expanded head. Usually we prefer aliases, because
+         we hope that the alias itself will have a concrete equation anyway, but
+         we must be careful to ensure that we don't return aliases to self
+         (obviously wrong) or, if two variables [x] and [y] alias each other,
+         redundant equations [x : (= y)] and [y : (= x)]. *)
       Aliases.Alias_set.filter
-        ~f:(fun alias -> TE.alias_is_bound_before (Join_env.target_join_env env) ~bound_name ~alias)
+        ~f:(fun alias ->
+          TE.alias_is_bound_before
+            (Join_env.target_join_env env)
+            ~bound_name ~alias)
         shared_aliases
   in
   let unknown () : _ Or_unknown.t =

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -1345,7 +1345,7 @@ and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
          redundant equations [x : (= y)] and [y : (= x)]. *)
       Aliases.Alias_set.filter
         ~f:(fun alias ->
-          TE.alias_is_bound_before
+          TE.alias_is_bound_strictly_earlier
             (Join_env.target_join_env env)
             ~bound_name ~alias)
         shared_aliases

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -1337,11 +1337,15 @@ and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
     match bound_name with
     | None -> shared_aliases
     | Some bound_name ->
-      (* This ensures that we're not creating an alias to a different simple
-         that is just bound_name with different coercion. Such an alias is
-         forbidden. *)
+      (* We only return one type for each name, so we have to decide whether
+         to return an alias or an expanded head.
+         Usually we prefer aliases, because we hope that the alias itself
+         will have a concrete equation anyway, but we must be careful to
+         ensure that we don't return aliases to self (obviously wrong)
+         or, if two variables [x] and [y] alias each other, redundant equations
+         [x : (= y)] and [y : (= x)]. *)
       Aliases.Alias_set.filter
-        ~f:(fun simple -> not (Simple.same simple (Simple.name bound_name)))
+        ~f:(fun alias -> TE.alias_is_bound_before (Join_env.target_join_env env) ~bound_name ~alias)
         shared_aliases
   in
   let unknown () : _ Or_unknown.t =

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -1105,7 +1105,7 @@ and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
          redundant equations [x : (= y)] and [y : (= x)]. *)
       Aliases.Alias_set.filter
         ~f:(fun alias ->
-          TE.alias_is_bound_before
+          TE.alias_is_bound_strictly_earlier
             (Join_env.target_join_env env)
             ~bound_name ~alias)
         shared_aliases

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -1097,11 +1097,15 @@ and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
     match bound_name with
     | None -> shared_aliases
     | Some bound_name ->
-      (* This ensures that we're not creating an alias to a different simple
-         that is just bound_name with different coercion. Such an alias is
-         forbidden. *)
+      (* We only return one type for each name, so we have to decide whether
+         to return an alias or an expanded head.
+         Usually we prefer aliases, because we hope that the alias itself
+         will have a concrete equation anyway, but we must be careful to
+         ensure that we don't return aliases to self (obviously wrong)
+         or, if two variables [x] and [y] alias each other, redundant equations
+         [x : (= y)] and [y : (= x)]. *)
       Aliases.Alias_set.filter
-        ~f:(fun simple -> not (Simple.same simple (Simple.name bound_name)))
+        ~f:(fun alias -> TE.alias_is_bound_before (Join_env.target_join_env env) ~bound_name ~alias)
         shared_aliases
   in
   let unknown () : _ Or_unknown.t =

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -1097,15 +1097,17 @@ and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
     match bound_name with
     | None -> shared_aliases
     | Some bound_name ->
-      (* We only return one type for each name, so we have to decide whether
-         to return an alias or an expanded head.
-         Usually we prefer aliases, because we hope that the alias itself
-         will have a concrete equation anyway, but we must be careful to
-         ensure that we don't return aliases to self (obviously wrong)
-         or, if two variables [x] and [y] alias each other, redundant equations
-         [x : (= y)] and [y : (= x)]. *)
+      (* We only return one type for each name, so we have to decide whether to
+         return an alias or an expanded head. Usually we prefer aliases, because
+         we hope that the alias itself will have a concrete equation anyway, but
+         we must be careful to ensure that we don't return aliases to self
+         (obviously wrong) or, if two variables [x] and [y] alias each other,
+         redundant equations [x : (= y)] and [y : (= x)]. *)
       Aliases.Alias_set.filter
-        ~f:(fun alias -> TE.alias_is_bound_before (Join_env.target_join_env env) ~bound_name ~alias)
+        ~f:(fun alias ->
+          TE.alias_is_bound_before
+            (Join_env.target_join_env env)
+            ~bound_name ~alias)
         shared_aliases
   in
   let unknown () : _ Or_unknown.t =

--- a/ocaml/testsuite/tests/flambda/alias_in_join.ml
+++ b/ocaml/testsuite/tests/flambda/alias_in_join.ml
@@ -1,0 +1,52 @@
+(* TEST
+ native;
+*)
+
+(* This test checks for an issue when joining two branches in flambda2.
+   It is only relevant at higher optimisation levels. *)
+[@@@ocaml.flambda_o3]
+
+(* Original example extracted from real code.
+   Triggers the bug when CSE equations on parameters are propagated. *)
+let[@inline] m (x : float) y =
+  if x > y then x else y
+
+let[@inline] foo x c n =
+  if x then c +. n else c -. n
+
+let[@inline] g a b n x b' =
+  let c = m a b in
+  let d = foo x c n in  (* d is the boxed float that should be removed *)
+  if b' then m 0. d else d
+
+let[@opaque] h a b n x b' p =
+  let r = g a b n x b' in
+  p /. r
+
+(* Simplified example triggering the bug without CSE *)
+let[@opaque] f x y z =
+  let[@local] k a b =
+    a +. b
+  in
+  if x then
+    let arg = y -. z in k arg arg
+  else
+    let arg = z -. y in k arg arg
+
+(* Both examples are supposed to allocate a single float at the end *)
+let check_cost =
+  let x = Gc.allocated_bytes () in
+  let y = Gc.allocated_bytes () in
+  y -. x
+
+let check_alloc f =
+  let before = Gc.allocated_bytes () in
+  ignore (f ());
+  let after = Gc.allocated_bytes () in
+  (* A single float allocation should consume 16 bytes *)
+  assert (after -. before = check_cost +. 16.)
+
+let () =
+  check_alloc (fun () -> h 0. 1. 2. true false 3.);
+  check_alloc (fun () -> f true 0. 1.);
+  ()


### PR DESCRIPTION
This ensures that we don't forget to join head types when several parameters are all aliases of each other without a common alias in the environment at fork

This problem starts appearing very frequently after #2628, and was causing a number of allocations to be kept because the absence of a head type made unboxing fail.

Here is an example that doesn't involve #2628:
```ocaml
let f x y z =
  let[@local] k a b =
    a +. b
  in
  if x then
    let arg = y -. z in k arg arg
  else
    let arg = z -. y in k arg arg
```
With this PR, `a` and `b` are unboxed properly and the result contains a single allocation at the end. We still keep both variables though, I'll see if I can fix that too but I think this PR should be merged anyway (assuming it doesn't cause any regressions).