### PR TITLE
Simply Env.lookup for module and class

### DIFF
--- a/ocaml/toplevel/topdirs.ml
+++ b/ocaml/toplevel/topdirs.ml
@@ -573,7 +573,7 @@ let secretly_the_same_path env path1 path2 =
 let () =
   reg_show_prim "show_module"
     (fun env loc id lid ->
-       let path, md, _, _ = Env.lookup_module ~loc lid env in
+       let path, md, _ = Env.lookup_module ~loc lid env in
        let id = match path with
          | Pident id -> id
          | _ -> id
@@ -624,7 +624,7 @@ let () =
 let () =
   reg_show_prim "show_class"
     (fun env loc id lid ->
-       let _path, desc_class, _, _ = Env.lookup_class ~loc lid env in
+       let _path, desc_class, _ = Env.lookup_class ~loc lid env in
        let _path, desc_cltype = Env.lookup_cltype ~loc lid env in
        let _path, typedcl = Env.lookup_type ~loc lid env in
        [

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -3552,12 +3552,14 @@ let find_cltype_index id env = find_index_tbl id env.cltypes
 (* Ordinary lookup functions *)
 
 let lookup_module_path ?(use=true) ?(lock=use) ~loc ~load lid env =
-  let path, vmode = lookup_module_path ~errors:true ~use ~lock ~loc ~load lid env in
-  path, vmode.mode, vmode.context
+  let path, vmode =
+    lookup_module_path ~errors:true ~use ~lock ~loc ~load lid env
+  in
+  path, vmode.mode
 
 let lookup_module ?(use=true) ?(lock=use) ~loc lid env =
-  let path, md, vmode = lookup_module ~errors:true ~use ~lock ~loc lid env in
-  path, md, vmode.mode, vmode.context
+  let path, desc, vmode = lookup_module ~errors:true ~use ~lock ~loc lid env in
+  path, desc, vmode.mode
 
 let lookup_value ?(use=true) ~loc lid env =
   lookup_value ~errors:true ~use ~loc lid env
@@ -3572,8 +3574,8 @@ let lookup_modtype_path ?(use=true) ~loc lid env =
   fst (lookup_modtype_lazy ~errors:true ~use ~loc lid env)
 
 let lookup_class ?(use=true) ~loc lid env =
-  let path, cld, vmode = lookup_class ~errors:true ~use ~loc lid env in
-  path, cld, vmode.mode, vmode.context
+  let path, desc, vmode = lookup_class ~errors:true ~use ~loc lid env in
+  path, desc, vmode.mode
 
 let lookup_cltype ?(use=true) ~loc lid env =
   lookup_cltype ~errors:true ~use ~loc lid env

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -254,20 +254,20 @@ val lookup_type:
   Path.t * type_declaration
 val lookup_module:
   ?use:bool -> ?lock:bool -> loc:Location.t -> Longident.t -> t ->
-  Path.t * module_declaration * Mode.Value.l * shared_context option
+  Path.t * module_declaration * Mode.Value.l
 val lookup_modtype:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * modtype_declaration
 val lookup_class:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
-  Path.t * class_declaration * Mode.Value.l * shared_context option
+  Path.t * class_declaration * Mode.Value.l
 val lookup_cltype:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * class_type_declaration
 
 val lookup_module_path:
   ?use:bool -> ?lock:bool -> loc:Location.t -> load:bool -> Longident.t -> t ->
-    Path.t * Mode.Value.l * shared_context option
+    Path.t * Mode.Value.l
 val lookup_modtype_path:
   ?use:bool -> loc:Location.t -> Longident.t -> t -> Path.t
 

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1133,7 +1133,7 @@ and class_expr cl_num val_env met_env virt self_scope scl =
 and class_expr_aux cl_num val_env met_env virt self_scope scl =
   match scl.pcl_desc with
   | Pcl_constr (lid, styl) ->
-      let (path, decl, mode, _) =
+      let (path, decl, mode) =
         Env.lookup_class ~loc:scl.pcl_loc lid.txt val_env
       in
       Mode.Value.submode_exn mode Mode.Value.legacy;

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -6005,7 +6005,7 @@ and type_expect_
         exp_env = env }
   | Pexp_new cl ->
       submode ~loc ~env Value.legacy expected_mode;
-      let (cl_path, cl_decl, cl_mode, _) =
+      let (cl_path, cl_decl, cl_mode) =
         Env.lookup_class ~loc:cl.loc cl.txt env
       in
       Value.submode_exn cl_mode Value.legacy;

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -194,7 +194,7 @@ let extract_sig_functor_open funct_body env loc mty sig_acc =
 (* Compute the environment after opening a module *)
 
 let type_open_ ?used_slot ?toplevel ovf env loc lid =
-  let path, _, _ =
+  let path, _ =
     Env.lookup_module_path ~lock:false ~load:true ~loc:lid.loc lid.txt env
   in
   match Env.open_signature ~loc ?used_slot ?toplevel ovf path env with
@@ -926,7 +926,7 @@ let rec approx_modtype env smty =
       in
       Mty_ident path
   | Pmty_alias lid ->
-      let path, _, _ =
+      let path, _ =
         Env.lookup_module_path ~use:false ~load:false
           ~loc:smty.pmty_loc lid.txt env
       in
@@ -979,7 +979,7 @@ let rec approx_modtype env smty =
 and approx_modtype_jane_syntax env = function
   | Jane_syntax.Module_type.Jmty_strengthen { mty = smty; mod_id } ->
     let mty = approx_modtype env smty in
-    let path, _, _ =
+    let path, _ =
       (* CR-someday: potentially improve error message for strengthening with
          a mutually recursive module. *)
       Env.lookup_module_path ~use:false ~load:false
@@ -1039,7 +1039,7 @@ and approx_sig env ssg =
           Sig_module(id, pres, md, Trec_not, Exported) :: approx_sig newenv srem
       | Psig_modsubst pms ->
           let scope = Ctype.create_scope () in
-          let _, md, _, _ =
+          let _, md, _ =
             Env.lookup_module ~use:false ~loc:pms.pms_manifest.loc
                pms.pms_manifest.txt env
           in
@@ -1447,7 +1447,7 @@ let transl_modtype_longident loc env lid =
   Env.lookup_modtype_path ~loc lid env
 
 let transl_module_alias loc env lid =
-  let path, _, _ = Env.lookup_module_path ~lock:false ~load:false ~loc lid env in
+  let path, _ = Env.lookup_module_path ~lock:false ~load:false ~loc lid env in
   path
 
 let mkmty desc typ env loc attrs =
@@ -1545,7 +1545,7 @@ and transl_modtype_aux env smty =
 and transl_modtype_jane_syntax_aux ~loc env = function
   | Jane_syntax.Module_type.Jmty_strengthen { mty ; mod_id } ->
       let tmty = transl_modtype_aux env mty in
-      let path, md, _, _ =
+      let path, md, _ =
         Env.lookup_module ~use:false ~loc:mod_id.loc mod_id.txt env
       in
       let aliasable = not (Env.is_functor_arg path env) in
@@ -1569,10 +1569,10 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
     | Pwith_type (l,decl) ->l , With_type decl
     | Pwith_typesubst (l,decl) ->l , With_typesubst decl
     | Pwith_module (l,l') ->
-        let path, md, _, _ = Env.lookup_module ~lock:false ~loc l'.txt env in
+        let path, md, _ = Env.lookup_module ~lock:false ~loc l'.txt env in
         l , With_module {lid=l';path;md; remove_aliases}
     | Pwith_modsubst (l,l') ->
-        let path, md', _, _ = Env.lookup_module ~lock:false ~loc l'.txt env in
+        let path, md', _ = Env.lookup_module ~lock:false ~loc l'.txt env in
         l , With_modsubst (l',path,md')
     | Pwith_modtype (l,smty) ->
         let mty = transl_modtype env smty in
@@ -1757,7 +1757,7 @@ and transl_signature env (sg : Parsetree.signature) =
         sig_item, tsg, newenv
     | Psig_modsubst pms ->
         let scope = Ctype.create_scope () in
-        let path, md, _, _ =
+        let path, md, _ =
           Env.lookup_module ~loc:pms.pms_manifest.loc ~lock:false
             pms.pms_manifest.txt env
         in
@@ -2390,7 +2390,7 @@ let rec type_module ?(alias=false) sttn funct_body anchor env smod =
 and type_module_aux ~alias sttn funct_body anchor env smod =
   match smod.pmod_desc with
     Pmod_ident lid ->
-      let path, mode, _ =
+      let path, mode =
         Env.lookup_module_path ~load:(not alias) ~loc:smod.pmod_loc lid.txt env
       in
       Mode.Value.submode_exn mode Mode.Value.legacy;
@@ -3214,7 +3214,7 @@ let type_module_type_of env smod =
   let tmty =
     match smod.pmod_desc with
     | Pmod_ident lid -> (* turn off strengthening in this case *)
-        let path, md, _, _ =
+        let path, md, _ =
           Env.lookup_module ~lock:false ~loc:smod.pmod_loc lid.txt env
         in
           { mod_desc = Tmod_ident (path, lid);


### PR DESCRIPTION
#2431 enriches modules and classes with modes. However, it over-complicates `Env.lookup_module` and siblings. In particular, it doesn't need to return `closure_context` for mode error hints. This PR removes that.