### PR TITLE
Deduplicate back edges

### DIFF
--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -11,7 +11,9 @@ end
 
 module EdgeMap : Map.S with type key = Edge.t
 
-val compute_back_edges : Cfg.t -> Cfg_dominators.t -> Edge.t list
+module EdgeSet : Set.S with type elt = Edge.t
+
+val compute_back_edges : Cfg.t -> Cfg_dominators.t -> EdgeSet.t
 
 type loop = Label.Set.t
 (* Blocks in a loop; if a node is part of several/nested loops, it will appear
@@ -23,7 +25,7 @@ val compute_loop_of_back_edge : Cfg.t -> Edge.t -> loop
 type loops = loop EdgeMap.t
 (* Map from back edge to loop. *)
 
-val compute_loops_of_back_edges : Cfg.t -> Edge.t list -> loops
+val compute_loops_of_back_edges : Cfg.t -> EdgeSet.t -> loops
 (* Assumes the passed edges are back edges. *)
 
 type header_map = loop list Label.Map.t
@@ -37,7 +39,7 @@ type loop_depths = int Label.Map.t
 val compute_loop_depths : Cfg.t -> header_map -> loop_depths
 
 type t = private
-  { back_edges : Edge.t list;
+  { back_edges : EdgeSet.t;
     loops : loops;
     header_map : header_map;
     loop_depths : loop_depths

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -191,12 +191,12 @@ let potentially_recursive_tailcall :
 let instr_cfg_with_layout :
     Cfg_with_layout.t ->
     block_needs_poll:PolledLoopsAnalysis.domain Label.Tbl.t ->
-    back_edges:Cfg_loop_infos.Edge.t list ->
+    back_edges:Cfg_loop_infos.EdgeSet.t ->
     bool =
  fun cfg_with_layout ~block_needs_poll ~back_edges ->
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  List.fold_left back_edges ~init:false
-    ~f:(fun added_poll { Cfg_loop_infos.Edge.src; dst } ->
+  Cfg_loop_infos.EdgeSet.fold
+    (fun { Cfg_loop_infos.Edge.src; dst } added_poll ->
       let needs_poll =
         match Label.Tbl.find_opt block_needs_poll dst with
         | None -> assert false
@@ -237,6 +237,7 @@ let instr_cfg_with_layout :
           ());
         true)
       else added_poll)
+    back_edges false
 
 type polling_points = (polling_point * Debuginfo.t) list
 


### PR DESCRIPTION
It does not really make a difference right now,
but I don't think there are any reasons to have
duplicates in the collection of back edges.

This pull request thus simply changes this
collection from `Edge.t` to `EdgeSet.t`.