### PR TITLE
zero_alloc: cleanup attributes in Lambda

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1880,8 +1880,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
         (Poll_attribute.from_lambda (Function_decl.poll_attribute decl))
       ~zero_alloc_attribute:
         (Zero_alloc_attribute.from_lambda
-           (Function_decl.zero_alloc_attribute decl)
-           (Debuginfo.Scoped_location.to_location (Function_decl.loc decl)))
+           (Function_decl.zero_alloc_attribute decl))
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~is_opaque:false ~recursive ~newer_version_of:None ~cost_metrics
       ~inlining_arguments:(Inlining_arguments.create ~round:0)
@@ -2249,8 +2248,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
         (Poll_attribute.from_lambda (Function_decl.poll_attribute decl))
       ~zero_alloc_attribute:
         (Zero_alloc_attribute.from_lambda
-           (Function_decl.zero_alloc_attribute decl)
-           (Debuginfo.Scoped_location.to_location (Function_decl.loc decl)))
+           (Function_decl.zero_alloc_attribute decl))
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~is_opaque:(Function_decl.is_opaque decl)
       ~recursive ~newer_version_of:None ~cost_metrics
@@ -2379,7 +2377,6 @@ let close_functions acc external_env ~current_region function_declarations =
         let zero_alloc_attribute =
           Zero_alloc_attribute.from_lambda
             (Function_decl.zero_alloc_attribute decl)
-            (Debuginfo.Scoped_location.to_location (Function_decl.loc decl))
         in
         let cost_metrics = Cost_metrics.zero in
         let dbg = Debuginfo.from_location (Function_decl.loc decl) in

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -925,7 +925,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
             ~first_complex_local_param:(Flambda_arity.num_params params_arity)
             ~result_arity ~result_types:Unknown ~result_mode
             ~contains_no_escaping_local_allocs:false ~stub:false ~inline
-            ~zero_alloc_attribute:Default_check
+            ~zero_alloc_attribute:Default_zero_alloc
               (* CR gyorsh: should [check] be set properly? *)
             ~is_a_functor:false ~is_opaque:false ~recursive
             ~cost_metrics (* CR poechsel: grab inlining arguments from fexpr. *)

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -631,7 +631,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
                 (Code_metadata.contains_no_escaping_local_allocs
                    callee's_code_metadata)
               ~stub:true ~inline:Default_inline ~poll_attribute:Default
-              ~zero_alloc_attribute:Zero_alloc_attribute.Default_check
+              ~zero_alloc_attribute:Zero_alloc_attribute.Default_zero_alloc
               ~is_a_functor:false ~is_opaque:false ~recursive
               ~cost_metrics:cost_metrics_of_body
               ~inlining_arguments:(DE.inlining_arguments (DA.denv dacc))

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -511,7 +511,7 @@ let simplify_function context ~outer_dacc function_slot code_id
     let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
     let never_delete =
       match Code_metadata.zero_alloc_attribute code_metadata with
-      | Default_check -> !Clflags.zero_alloc_check_assert_all
+      | Default_check -> false
       | Assume _ -> false
       | Check _ -> true
     in

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -511,7 +511,7 @@ let simplify_function context ~outer_dacc function_slot code_id
     let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
     let never_delete =
       match Code_metadata.zero_alloc_attribute code_metadata with
-      | Default_check -> false
+      | Default_zero_alloc -> false
       | Assume _ -> false
       | Check _ -> true
     in

--- a/middle_end/flambda2/terms/zero_alloc_attribute.ml
+++ b/middle_end/flambda2/terms/zero_alloc_attribute.ml
@@ -10,22 +10,22 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t =
-  | Default_check
+type t = Lambda.zero_alloc_attribute =
+  | Default_zero_alloc
+  | Check of
+      { strict : bool;
+        loc : Location.t
+      }
   | Assume of
       { strict : bool;
         never_returns_normally : bool;
         never_raises : bool;
         loc : Location.t
       }
-  | Check of
-      { strict : bool;
-        loc : Location.t
-      }
 
 let print ppf t =
   match t with
-  | Default_check -> ()
+  | Default_zero_alloc -> ()
   | Assume { strict; never_returns_normally; never_raises; loc = _ } ->
     Format.fprintf ppf "@[assume_zero_alloc%s%s%s@]"
       (if strict then "_strict" else "")
@@ -35,17 +35,11 @@ let print ppf t =
     Format.fprintf ppf "@[assert_zero_alloc%s@]"
       (if strict then "_strict" else "")
 
-let from_lambda : Lambda.zero_alloc_attribute -> t =
- fun a ->
-  match a with
-  | Default_zero_alloc -> Default_check
-  | Assume { strict; never_returns_normally; never_raises; loc } ->
-    Assume { strict; never_returns_normally; never_raises; loc }
-  | Check { strict; loc } -> Check { strict; loc }
+let from_lambda : Lambda.zero_alloc_attribute -> t = Fun.id
 
 let equal x y =
   match x, y with
-  | Default_check, Default_check -> true
+  | Default_zero_alloc, Default_zero_alloc -> true
   | Check { strict = s1; loc = loc1 }, Check { strict = s2; loc = loc2 } ->
     Bool.equal s1 s2 && Location.compare loc1 loc2 = 0
   | ( Assume
@@ -62,8 +56,8 @@ let equal x y =
         } ) ->
     Bool.equal s1 s2 && Bool.equal n1 n2 && Bool.equal r1 r2
     && Location.compare loc1 loc2 = 0
-  | (Default_check | Check _ | Assume _), _ -> false
+  | (Default_zero_alloc | Check _ | Assume _), _ -> false
 
 let is_default : t -> bool = function
-  | Default_check -> true
+  | Default_zero_alloc -> true
   | Check _ | Assume _ -> false

--- a/middle_end/flambda2/terms/zero_alloc_attribute.ml
+++ b/middle_end/flambda2/terms/zero_alloc_attribute.ml
@@ -35,21 +35,14 @@ let print ppf t =
     Format.fprintf ppf "@[assert_zero_alloc%s@]"
       (if strict then "_strict" else "")
 
-let from_lambda : Lambda.zero_alloc_attribute -> Location.t -> t =
- fun a loc ->
+let from_lambda : Lambda.zero_alloc_attribute -> t =
+ fun a ->
   match a with
-  | Default_zero_alloc ->
-    if !Clflags.zero_alloc_check_assert_all
-       && Builtin_attributes.is_zero_alloc_check_enabled ~opt:false
-    then Check { strict = false; loc }
-    else Default_check
-  | Ignore_assert_all -> Default_check
-  | Assume { strict; never_returns_normally; never_raises; loc; arity = _ } ->
+  | Default_zero_alloc -> Default_check
+  | Assume { strict; never_returns_normally; never_raises; loc; } ->
     Assume { strict; never_returns_normally; never_raises; loc }
-  | Check { strict; opt; loc; arity = _ } ->
-    if Builtin_attributes.is_zero_alloc_check_enabled ~opt
-    then Check { strict; loc }
-    else Default_check
+  | Check { strict; loc; } ->
+    Check { strict; loc }
 
 let equal x y =
   match x, y with

--- a/middle_end/flambda2/terms/zero_alloc_attribute.ml
+++ b/middle_end/flambda2/terms/zero_alloc_attribute.ml
@@ -39,10 +39,9 @@ let from_lambda : Lambda.zero_alloc_attribute -> t =
  fun a ->
   match a with
   | Default_zero_alloc -> Default_check
-  | Assume { strict; never_returns_normally; never_raises; loc; } ->
+  | Assume { strict; never_returns_normally; never_raises; loc } ->
     Assume { strict; never_returns_normally; never_raises; loc }
-  | Check { strict; loc; } ->
-    Check { strict; loc }
+  | Check { strict; loc } -> Check { strict; loc }
 
 let equal x y =
   match x, y with

--- a/middle_end/flambda2/terms/zero_alloc_attribute.mli
+++ b/middle_end/flambda2/terms/zero_alloc_attribute.mli
@@ -10,16 +10,16 @@
 (*                                                                        *)
 (**************************************************************************)
 (** [@zero_alloc ...] annotations on function declaration (not call sites) *)
-type t =
-  | Default_check
+type t = Lambda.zero_alloc_attribute =
+  | Default_zero_alloc
+  | Check of
+      { strict : bool;
+        loc : Location.t
+      }
   | Assume of
       { strict : bool;
         never_returns_normally : bool;
         never_raises : bool;
-        loc : Location.t
-      }
-  | Check of
-      { strict : bool;
         loc : Location.t
       }
 

--- a/middle_end/flambda2/terms/zero_alloc_attribute.mli
+++ b/middle_end/flambda2/terms/zero_alloc_attribute.mli
@@ -29,4 +29,4 @@ val equal : t -> t -> bool
 
 val is_default : t -> bool
 
-val from_lambda : Lambda.zero_alloc_attribute -> Location.t -> t
+val from_lambda : Lambda.zero_alloc_attribute -> t

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -351,7 +351,7 @@ end)
 
 let transl_check_attrib : Zero_alloc_attribute.t -> Cmm.codegen_option list =
   function
-  | Default_check -> []
+  | Default_zero_alloc -> []
   | Assume { strict; never_returns_normally; never_raises; loc } ->
     [Assume_zero_alloc { strict; never_returns_normally; never_raises; loc }]
   | Check { strict; loc } -> [Check_zero_alloc { strict; loc }]

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -634,18 +634,14 @@ type poll_attribute =
   | Error_poll (* [@poll error] *)
   | Default_poll (* no [@poll] attribute *)
 
-type zero_alloc_attribute = Builtin_attributes.zero_alloc_attribute =
+type zero_alloc_attribute =
   | Default_zero_alloc
-  | Ignore_assert_all
   | Check of { strict: bool;
-               opt: bool;
-               arity: int;
                loc: Location.t;
              }
   | Assume of { strict: bool;
                 never_returns_normally: bool;
                 never_raises: bool;
-                arity: int;
                 loc: Location.t;
               }
 
@@ -925,7 +921,7 @@ let default_function_attribute = {
 }
 
 let default_stub_attribute =
-  { default_function_attribute with stub = true; zero_alloc = Ignore_assert_all }
+  { default_function_attribute with stub = true; zero_alloc = Default_zero_alloc }
 
 let default_param_attribute = { unbox_param = false }
 

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -510,23 +510,19 @@ type poll_attribute =
   | Error_poll (* [@poll error] *)
   | Default_poll (* no [@poll] attribute *)
 
-type zero_alloc_attribute = Builtin_attributes.zero_alloc_attribute =
+type zero_alloc_attribute =
   | Default_zero_alloc
-  | Ignore_assert_all
   | Check of { strict: bool;
                (* [strict=true] property holds on all paths.
                   [strict=false] if the function returns normally,
                   then the property holds (but property violations on
                   exceptional returns or divering loops are ignored).
                   This definition may not be applicable to new properties. *)
-               opt: bool;
-               arity: int;
                loc: Location.t;
              }
   | Assume of { strict: bool;
                 never_returns_normally: bool;
                 never_raises: bool;
-                arity: int;
                 loc: Location.t;
               }
 

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -939,15 +939,12 @@ let name_of_primitive = function
 let zero_alloc_attribute ppf check =
   match check with
   | Default_zero_alloc -> ()
-  | Ignore_assert_all ->
-    fprintf ppf "ignore assert all zero_alloc@ "
   | Assume {strict; never_returns_normally; loc = _} ->
     fprintf ppf "assume_zero_alloc%s%s@ "
       (if strict then "_strict" else "")
       (if never_returns_normally then "_never_returns_normally" else "")
-  | Check {strict; loc = _; opt} ->
-    fprintf ppf "assert_zero_alloc%s%s@ "
-      (if opt then "_opt" else "")
+  | Check {strict; loc = _; } ->
+    fprintf ppf "assert_zero_alloc%s@ "
       (if strict then "_strict" else "")
 
 let function_attribute ppf t =

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1608,6 +1608,21 @@ and transl_function ~in_new_scope ~scopes e params body
            ~mode ~return_sort ~return_mode
            ~scopes e.exp_loc repr ~region params body)
   in
+  let zero_alloc : Lambda.zero_alloc_attribute =
+    match (zero_alloc : Builtin_attributes.zero_alloc_attribute) with
+    | Default_zero_alloc ->
+      if !Clflags.zero_alloc_check_assert_all &&
+         Builtin_attributes.is_zero_alloc_check_enabled ~opt:false
+      then Check { strict = false; loc = e.exp_loc }
+      else Default_zero_alloc
+    | Check { strict; opt; arity = _; loc } ->
+      if Builtin_attributes.is_zero_alloc_check_enabled ~opt
+      then Check { strict; loc }
+      else Default_zero_alloc
+    | Assume { strict; never_returns_normally; never_raises; loc; arity = _; } ->
+      Assume { strict; never_returns_normally; never_raises; loc }
+    | Ignore_assert_all -> Default_zero_alloc
+  in
   let attr =
     { function_attribute_disallowing_arity_fusion with zero_alloc }
   in

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -162,7 +162,7 @@ and apply_coercion_result loc strict funct params args cc_res =
              ~return:Lambda.layout_module
              ~attr:{ default_function_attribute with
                         is_a_functor = true;
-                        zero_alloc = Ignore_assert_all;
+                        zero_alloc = Default_zero_alloc;
                         stub = true; }
              ~loc
              ~mode:alloc_heap
@@ -572,7 +572,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
       loop = Never_loop;
       is_a_functor = true;
       is_opaque = false;
-      zero_alloc = Ignore_assert_all;
+      zero_alloc = Default_zero_alloc;
       stub = false;
       tmc_candidate = false;
       may_fuse_arity = true;

--- a/ocaml/testsuite/tests/functors/functors.compilers.reference
+++ b/ocaml/testsuite/tests/functors/functors.compilers.reference
@@ -1,16 +1,14 @@
 (setglobal Functors!
   (let
     (O =
-       (function {nlocal = 0} X is_a_functor always_inline
-         ignore assert all zero_alloc never_loop
+       (function {nlocal = 0} X is_a_functor always_inline never_loop
          (let
            (cow =
               (function {nlocal = 0} x[int] : int (apply (field_imm 0 X) x))
             sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
            (makeblock 0 cow sheep)))
      F =
-       (function {nlocal = 0} X Y is_a_functor always_inline
-         ignore assert all zero_alloc never_loop
+       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
          (let
            (cow =
               (function {nlocal = 0} x[int] : int
@@ -18,8 +16,7 @@
             sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
            (makeblock 0 cow sheep)))
      F1 =
-       (function {nlocal = 0} X Y is_a_functor always_inline
-         ignore assert all zero_alloc never_loop
+       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
          (let
            (cow =
               (function {nlocal = 0} x[int] : int
@@ -27,8 +24,7 @@
             sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
            (makeblock 0 sheep)))
      F2 =
-       (function {nlocal = 0} X Y is_a_functor always_inline
-         ignore assert all zero_alloc never_loop
+       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
          (let
            (X =a (makeblock 0 (field_imm 1 X))
             Y =a (makeblock 0 (field_imm 1 Y))
@@ -40,8 +36,7 @@
      M =
        (let
          (F =
-            (function {nlocal = 0} X Y is_a_functor always_inline
-              ignore assert all zero_alloc never_loop
+            (function {nlocal = 0} X Y is_a_functor always_inline never_loop
               (let
                 (cow =
                    (function {nlocal = 0} x[int] : int
@@ -51,7 +46,6 @@
                 (makeblock 0 cow sheep))))
          (makeblock 0
            (function {nlocal = 0} funarg funarg is_a_functor stub
-             ignore assert all zero_alloc
              (let
                (let =
                   (apply F (makeblock 0 (field_imm 1 funarg))

--- a/ocaml/testsuite/tests/translprim/array_spec.heap.flat.reference
+++ b/ocaml/testsuite/tests/translprim/array_spec.heap.flat.reference
@@ -27,80 +27,64 @@
         (array.unsafe_set[gen indexed by int] a 0 x))
       (let
         (eta_gen_len =
-           (function {nlocal = 0} prim[genarray] stub
-             ignore assert all zero_alloc : int (array.length[gen] prim))
+           (function {nlocal = 0} prim[genarray] stub : int
+             (array.length[gen] prim))
          eta_gen_safe_get =
            (function {nlocal = 0} prim[genarray] prim[int] stub
-             ignore assert all zero_alloc
              (array.get[gen indexed by int] prim prim))
          eta_gen_unsafe_get =
            (function {nlocal = 0} prim[genarray] prim[int] stub
-             ignore assert all zero_alloc
              (array.unsafe_get[gen indexed by int] prim prim))
          eta_gen_safe_set =
-           (function {nlocal = 0} prim[genarray] prim[int] prim stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[genarray] prim[int] prim stub : int
              (array.set[gen indexed by int] prim prim prim))
          eta_gen_unsafe_set =
-           (function {nlocal = 0} prim[genarray] prim[int] prim stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[genarray] prim[int] prim stub : int
              (array.unsafe_set[gen indexed by int] prim prim prim))
          eta_int_len =
-           (function {nlocal = 0} prim[intarray] stub
-             ignore assert all zero_alloc : int (array.length[int] prim))
+           (function {nlocal = 0} prim[intarray] stub : int
+             (array.length[int] prim))
          eta_int_safe_get =
-           (function {nlocal = 0} prim[intarray] prim[int] stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[intarray] prim[int] stub : int
              (array.get[int indexed by int] prim prim))
          eta_int_unsafe_get =
-           (function {nlocal = 0} prim[intarray] prim[int] stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[intarray] prim[int] stub : int
              (array.unsafe_get[int indexed by int] prim prim))
          eta_int_safe_set =
            (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-             ignore assert all zero_alloc : int
-             (array.set[int indexed by int] prim prim prim))
+             : int (array.set[int indexed by int] prim prim prim))
          eta_int_unsafe_set =
            (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-             ignore assert all zero_alloc : int
-             (array.unsafe_set[int indexed by int] prim prim prim))
+             : int (array.unsafe_set[int indexed by int] prim prim prim))
          eta_float_len =
-           (function {nlocal = 0} prim[floatarray] stub
-             ignore assert all zero_alloc : int (array.length[float] prim))
+           (function {nlocal = 0} prim[floatarray] stub : int
+             (array.length[float] prim))
          eta_float_safe_get =
-           (function {nlocal = 0} prim[floatarray] prim[int] stub
-             ignore assert all zero_alloc : float
+           (function {nlocal = 0} prim[floatarray] prim[int] stub : float
              (array.get[float indexed by int] prim prim))
          eta_float_unsafe_get =
-           (function {nlocal = 0} prim[floatarray] prim[int] stub
-             ignore assert all zero_alloc : float
+           (function {nlocal = 0} prim[floatarray] prim[int] stub : float
              (array.unsafe_get[float indexed by int] prim prim))
          eta_float_safe_set =
            (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-             ignore assert all zero_alloc : int
-             (array.set[float indexed by int] prim prim prim))
+             : int (array.set[float indexed by int] prim prim prim))
          eta_float_unsafe_set =
            (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-             ignore assert all zero_alloc : int
-             (array.unsafe_set[float indexed by int] prim prim prim))
+             : int (array.unsafe_set[float indexed by int] prim prim prim))
          eta_addr_len =
-           (function {nlocal = 0} prim[addrarray] stub
-             ignore assert all zero_alloc : int (array.length[addr] prim))
+           (function {nlocal = 0} prim[addrarray] stub : int
+             (array.length[addr] prim))
          eta_addr_safe_get =
            (function {nlocal = 0} prim[addrarray] prim[int] stub
-             ignore assert all zero_alloc
              (array.get[addr indexed by int] prim prim))
          eta_addr_unsafe_get =
            (function {nlocal = 0} prim[addrarray] prim[int] stub
-             ignore assert all zero_alloc
              (array.unsafe_get[addr indexed by int] prim prim))
          eta_addr_safe_set =
-           (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
              (array.set[addr indexed by int] prim prim prim))
          eta_addr_unsafe_set =
-           (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
              (array.unsafe_set[addr indexed by int] prim prim prim)))
         (makeblock 0 int_a float_a addr_a eta_gen_len eta_gen_safe_get
           eta_gen_unsafe_get eta_gen_safe_set eta_gen_unsafe_set eta_int_len

--- a/ocaml/testsuite/tests/translprim/array_spec.stack.flat.reference
+++ b/ocaml/testsuite/tests/translprim/array_spec.stack.flat.reference
@@ -27,80 +27,64 @@
         (array.unsafe_set[gen indexed by int] a 0 x))
       (let
         (eta_gen_len =
-           (function {nlocal = 0} prim[genarray] stub
-             ignore assert all zero_alloc : int (array.length[gen] prim))
+           (function {nlocal = 0} prim[genarray] stub : int
+             (array.length[gen] prim))
          eta_gen_safe_get =
            (function {nlocal = 0} prim[genarray] prim[int] stub
-             ignore assert all zero_alloc
              (array.get[gen indexed by int] prim prim))
          eta_gen_unsafe_get =
            (function {nlocal = 0} prim[genarray] prim[int] stub
-             ignore assert all zero_alloc
              (array.unsafe_get[gen indexed by int] prim prim))
          eta_gen_safe_set =
-           (function {nlocal = 0} prim[genarray] prim[int] prim stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[genarray] prim[int] prim stub : int
              (array.set[gen indexed by int] prim prim prim))
          eta_gen_unsafe_set =
-           (function {nlocal = 0} prim[genarray] prim[int] prim stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[genarray] prim[int] prim stub : int
              (array.unsafe_set[gen indexed by int] prim prim prim))
          eta_int_len =
-           (function {nlocal = 0} prim[intarray] stub
-             ignore assert all zero_alloc : int (array.length[int] prim))
+           (function {nlocal = 0} prim[intarray] stub : int
+             (array.length[int] prim))
          eta_int_safe_get =
-           (function {nlocal = 0} prim[intarray] prim[int] stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[intarray] prim[int] stub : int
              (array.get[int indexed by int] prim prim))
          eta_int_unsafe_get =
-           (function {nlocal = 0} prim[intarray] prim[int] stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[intarray] prim[int] stub : int
              (array.unsafe_get[int indexed by int] prim prim))
          eta_int_safe_set =
            (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-             ignore assert all zero_alloc : int
-             (array.set[int indexed by int] prim prim prim))
+             : int (array.set[int indexed by int] prim prim prim))
          eta_int_unsafe_set =
            (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-             ignore assert all zero_alloc : int
-             (array.unsafe_set[int indexed by int] prim prim prim))
+             : int (array.unsafe_set[int indexed by int] prim prim prim))
          eta_float_len =
-           (function {nlocal = 0} prim[floatarray] stub
-             ignore assert all zero_alloc : int (array.length[float] prim))
+           (function {nlocal = 0} prim[floatarray] stub : int
+             (array.length[float] prim))
          eta_float_safe_get =
-           (function {nlocal = 0} prim[floatarray] prim[int] stub
-             ignore assert all zero_alloc : float
+           (function {nlocal = 0} prim[floatarray] prim[int] stub : float
              (array.get[float indexed by int] prim prim))
          eta_float_unsafe_get =
-           (function {nlocal = 0} prim[floatarray] prim[int] stub
-             ignore assert all zero_alloc : float
+           (function {nlocal = 0} prim[floatarray] prim[int] stub : float
              (array.unsafe_get[float indexed by int] prim prim))
          eta_float_safe_set =
            (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-             ignore assert all zero_alloc : int
-             (array.set[float indexed by int] prim prim prim))
+             : int (array.set[float indexed by int] prim prim prim))
          eta_float_unsafe_set =
            (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-             ignore assert all zero_alloc : int
-             (array.unsafe_set[float indexed by int] prim prim prim))
+             : int (array.unsafe_set[float indexed by int] prim prim prim))
          eta_addr_len =
-           (function {nlocal = 0} prim[addrarray] stub
-             ignore assert all zero_alloc : int (array.length[addr] prim))
+           (function {nlocal = 0} prim[addrarray] stub : int
+             (array.length[addr] prim))
          eta_addr_safe_get =
            (function {nlocal = 0} prim[addrarray] prim[int] stub
-             ignore assert all zero_alloc
              (array.get[addr indexed by int] prim prim))
          eta_addr_unsafe_get =
            (function {nlocal = 0} prim[addrarray] prim[int] stub
-             ignore assert all zero_alloc
              (array.unsafe_get[addr indexed by int] prim prim))
          eta_addr_safe_set =
-           (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
              (array.set[addr indexed by int] prim prim prim))
          eta_addr_unsafe_set =
-           (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-             ignore assert all zero_alloc : int
+           (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
              (array.unsafe_set[addr indexed by int] prim prim prim)))
         (makeblock 0 int_a float_a addr_a eta_gen_len eta_gen_safe_get
           eta_gen_unsafe_get eta_gen_safe_set eta_gen_unsafe_set eta_int_len

--- a/ocaml/testsuite/tests/translprim/comparison_table.heap.reference
+++ b/ocaml/testsuite/tests/translprim/comparison_table.heap.reference
@@ -101,195 +101,172 @@
        (function {nlocal = 0} x[nativeint] y[nativeint] : int
          (Nativeint.>= x y))
      eta_gen_cmp =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_compare prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_compare prim prim))
      eta_int_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (compare_ints prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int
+         (compare_ints prim prim))
      eta_bool_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (compare_ints prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int
+         (compare_ints prim prim))
      eta_intlike_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (compare_ints prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int
+         (compare_ints prim prim))
      eta_float_cmp =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (compare_floats float prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (compare_floats float prim prim))
      eta_string_cmp =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_compare prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_compare prim prim))
      eta_int32_cmp =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (compare_bints int32 prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (compare_bints int32 prim prim))
      eta_int64_cmp =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (compare_bints int64 prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (compare_bints int64 prim prim))
      eta_nativeint_cmp =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (compare_bints nativeint prim prim))
      eta_gen_eq =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_equal prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_equal prim prim))
      eta_int_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (== prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
      eta_bool_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (== prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
      eta_intlike_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (== prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
      eta_float_eq =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.== prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.== prim prim))
      eta_string_eq =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_equal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_equal prim prim))
      eta_int32_eq =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.== prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.== prim prim))
      eta_int64_eq =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.== prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.== prim prim))
      eta_nativeint_eq =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.== prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.== prim prim))
      eta_gen_ne =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_notequal prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_notequal prim prim))
      eta_int_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (!= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
      eta_bool_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (!= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
      eta_intlike_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (!= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
      eta_float_ne =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.!= prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.!= prim prim))
      eta_string_ne =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_notequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_notequal prim prim))
      eta_int32_ne =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.!= prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.!= prim prim))
      eta_int64_ne =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.!= prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.!= prim prim))
      eta_nativeint_ne =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.!= prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.!= prim prim))
      eta_gen_lt =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_lessthan prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_lessthan prim prim))
      eta_int_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (< prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
      eta_bool_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (< prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
      eta_intlike_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (< prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
      eta_float_lt =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.< prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.< prim prim))
      eta_string_lt =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_lessthan prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_lessthan prim prim))
      eta_int32_lt =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.< prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.< prim prim))
      eta_int64_lt =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.< prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.< prim prim))
      eta_nativeint_lt =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.< prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.< prim prim))
      eta_gen_gt =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_greaterthan prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_greaterthan prim prim))
      eta_int_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (> prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_bool_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (> prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_intlike_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (> prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_float_gt =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.> prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.> prim prim))
      eta_string_gt =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_greaterthan prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_greaterthan prim prim))
      eta_int32_gt =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.> prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.> prim prim))
      eta_int64_gt =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.> prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.> prim prim))
      eta_nativeint_gt =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.> prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.> prim prim))
      eta_gen_le =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_lessequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_lessequal prim prim))
      eta_int_le =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (<= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_bool_le =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (<= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_intlike_le =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (<= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_float_le =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.<= prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.<= prim prim))
      eta_string_le =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_lessequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_lessequal prim prim))
      eta_int32_le =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.<= prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.<= prim prim))
      eta_int64_le =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.<= prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.<= prim prim))
      eta_nativeint_le =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.<= prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.<= prim prim))
      eta_gen_ge =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_greaterequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_greaterequal prim prim))
      eta_int_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (>= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_bool_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (>= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_intlike_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (>= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_float_ge =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.>= prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.>= prim prim))
      eta_string_ge =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_greaterequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_greaterequal prim prim))
      eta_int32_ge =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.>= prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.>= prim prim))
      eta_int64_ge =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.>= prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.>= prim prim))
      eta_nativeint_ge =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.>= prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.>= prim prim))
      int_vec =[(consts (0))
                (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
        [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]

--- a/ocaml/testsuite/tests/translprim/comparison_table.stack.reference
+++ b/ocaml/testsuite/tests/translprim/comparison_table.stack.reference
@@ -101,195 +101,172 @@
        (function {nlocal = 0} x[nativeint] y[nativeint] : int
          (Nativeint.>= x y))
      eta_gen_cmp =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_compare prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_compare prim prim))
      eta_int_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (compare_ints prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int
+         (compare_ints prim prim))
      eta_bool_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (compare_ints prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int
+         (compare_ints prim prim))
      eta_intlike_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (compare_ints prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int
+         (compare_ints prim prim))
      eta_float_cmp =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (compare_floats float prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (compare_floats float prim prim))
      eta_string_cmp =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_compare prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_compare prim prim))
      eta_int32_cmp =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (compare_bints int32 prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (compare_bints int32 prim prim))
      eta_int64_cmp =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (compare_bints int64 prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (compare_bints int64 prim prim))
      eta_nativeint_cmp =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
          (compare_bints nativeint prim prim))
      eta_gen_eq =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_equal prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_equal prim prim))
      eta_int_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (== prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
      eta_bool_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (== prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
      eta_intlike_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (== prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
      eta_float_eq =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.== prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.== prim prim))
      eta_string_eq =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_equal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_equal prim prim))
      eta_int32_eq =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.== prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.== prim prim))
      eta_int64_eq =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.== prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.== prim prim))
      eta_nativeint_eq =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.== prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.== prim prim))
      eta_gen_ne =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_notequal prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_notequal prim prim))
      eta_int_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (!= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
      eta_bool_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (!= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
      eta_intlike_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (!= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
      eta_float_ne =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.!= prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.!= prim prim))
      eta_string_ne =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_notequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_notequal prim prim))
      eta_int32_ne =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.!= prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.!= prim prim))
      eta_int64_ne =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.!= prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.!= prim prim))
      eta_nativeint_ne =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.!= prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.!= prim prim))
      eta_gen_lt =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_lessthan prim prim))
+       (function {nlocal = 0} prim prim stub : int (caml_lessthan prim prim))
      eta_int_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (< prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
      eta_bool_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (< prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
      eta_intlike_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (< prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
      eta_float_lt =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.< prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.< prim prim))
      eta_string_lt =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_lessthan prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_lessthan prim prim))
      eta_int32_lt =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.< prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.< prim prim))
      eta_int64_lt =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.< prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.< prim prim))
      eta_nativeint_lt =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.< prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.< prim prim))
      eta_gen_gt =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_greaterthan prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_greaterthan prim prim))
      eta_int_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (> prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_bool_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (> prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_intlike_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (> prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
      eta_float_gt =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.> prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.> prim prim))
      eta_string_gt =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_greaterthan prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_greaterthan prim prim))
      eta_int32_gt =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.> prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.> prim prim))
      eta_int64_gt =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.> prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.> prim prim))
      eta_nativeint_gt =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.> prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.> prim prim))
      eta_gen_le =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_lessequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_lessequal prim prim))
      eta_int_le =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (<= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_bool_le =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (<= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_intlike_le =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (<= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
      eta_float_le =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.<= prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.<= prim prim))
      eta_string_le =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_lessequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_lessequal prim prim))
      eta_int32_le =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.<= prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.<= prim prim))
      eta_int64_le =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.<= prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.<= prim prim))
      eta_nativeint_le =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.<= prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.<= prim prim))
      eta_gen_ge =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_greaterequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_greaterequal prim prim))
      eta_int_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (>= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_bool_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (>= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_intlike_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub
-         ignore assert all zero_alloc : int (>= prim prim))
+       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
      eta_float_ge =
-       (function {nlocal = 0} prim[float] prim[float] stub
-         ignore assert all zero_alloc : int (Float.>= prim prim))
+       (function {nlocal = 0} prim[float] prim[float] stub : int
+         (Float.>= prim prim))
      eta_string_ge =
-       (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-         : int (caml_string_greaterequal prim prim))
+       (function {nlocal = 0} prim prim stub : int
+         (caml_string_greaterequal prim prim))
      eta_int32_ge =
-       (function {nlocal = 0} prim[int32] prim[int32] stub
-         ignore assert all zero_alloc : int (Int32.>= prim prim))
+       (function {nlocal = 0} prim[int32] prim[int32] stub : int
+         (Int32.>= prim prim))
      eta_int64_ge =
-       (function {nlocal = 0} prim[int64] prim[int64] stub
-         ignore assert all zero_alloc : int (Int64.>= prim prim))
+       (function {nlocal = 0} prim[int64] prim[int64] stub : int
+         (Int64.>= prim prim))
      eta_nativeint_ge =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-         ignore assert all zero_alloc : int (Nativeint.>= prim prim))
+       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+         (Nativeint.>= prim prim))
      int_vec =[(consts (0))
                (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
        [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]

--- a/ocaml/testsuite/tests/translprim/module_coercion.compilers.flat.reference
+++ b/ocaml/testsuite/tests/translprim/module_coercion.compilers.flat.reference
@@ -2,178 +2,146 @@
   (let (M = (makeblock 0))
     (makeblock 0 M
       (makeblock 0
-        (function {nlocal = 0} prim[intarray] stub
-          ignore assert all zero_alloc : int (array.length[int] prim))
-        (function {nlocal = 0} prim[intarray] prim[int] stub
-          ignore assert all zero_alloc : int
+        (function {nlocal = 0} prim[intarray] stub : int
+          (array.length[int] prim))
+        (function {nlocal = 0} prim[intarray] prim[int] stub : int
           (array.get[int indexed by int] prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] stub
-          ignore assert all zero_alloc : int
+        (function {nlocal = 0} prim[intarray] prim[int] stub : int
           (array.unsafe_get[int indexed by int] prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-          ignore assert all zero_alloc : int
+        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
           (array.set[int indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-          ignore assert all zero_alloc : int
+        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
           (array.unsafe_set[int indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub
-          ignore assert all zero_alloc : int (compare_ints prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub
-          ignore assert all zero_alloc : int (== prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub
-          ignore assert all zero_alloc : int (!= prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub
-          ignore assert all zero_alloc : int (< prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub
-          ignore assert all zero_alloc : int (> prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub
-          ignore assert all zero_alloc : int (<= prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub
-          ignore assert all zero_alloc : int (>= prim prim)))
+        (function {nlocal = 0} prim[int] prim[int] stub : int
+          (compare_ints prim prim))
+        (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
+        (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
+        (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
+        (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
+        (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
+        (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim)))
       (makeblock 0
-        (function {nlocal = 0} prim[floatarray] stub
-          ignore assert all zero_alloc : int (array.length[float] prim))
-        (function {nlocal = 0} prim[floatarray] prim[int] stub
-          ignore assert all zero_alloc : float
+        (function {nlocal = 0} prim[floatarray] stub : int
+          (array.length[float] prim))
+        (function {nlocal = 0} prim[floatarray] prim[int] stub : float
           (array.get[float indexed by int] prim prim))
-        (function {nlocal = 0} prim[floatarray] prim[int] stub
-          ignore assert all zero_alloc : float
+        (function {nlocal = 0} prim[floatarray] prim[int] stub : float
           (array.unsafe_get[float indexed by int] prim prim))
         (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-          ignore assert all zero_alloc : int
-          (array.set[float indexed by int] prim prim prim))
+          : int (array.set[float indexed by int] prim prim prim))
         (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-          ignore assert all zero_alloc : int
-          (array.unsafe_set[float indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int
+          : int (array.unsafe_set[float indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[float] prim[float] stub : int
           (compare_floats float prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.== prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.!= prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.< prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.> prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.<= prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.>= prim prim)))
+        (function {nlocal = 0} prim[float] prim[float] stub : int
+          (Float.== prim prim))
+        (function {nlocal = 0} prim[float] prim[float] stub : int
+          (Float.!= prim prim))
+        (function {nlocal = 0} prim[float] prim[float] stub : int
+          (Float.< prim prim))
+        (function {nlocal = 0} prim[float] prim[float] stub : int
+          (Float.> prim prim))
+        (function {nlocal = 0} prim[float] prim[float] stub : int
+          (Float.<= prim prim))
+        (function {nlocal = 0} prim[float] prim[float] stub : int
+          (Float.>= prim prim)))
       (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          ignore assert all zero_alloc : int (array.length[addr] prim))
+        (function {nlocal = 0} prim[addrarray] stub : int
+          (array.length[addr] prim))
         (function {nlocal = 0} prim[addrarray] prim[int] stub
-          ignore assert all zero_alloc
           (array.get[addr indexed by int] prim prim))
         (function {nlocal = 0} prim[addrarray] prim[int] stub
-          ignore assert all zero_alloc
           (array.unsafe_get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-          ignore assert all zero_alloc : int
+        (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
           (array.set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-          ignore assert all zero_alloc : int
+        (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
           (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-          : int (caml_string_compare prim prim))
-        (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-          : int (caml_string_equal prim prim))
-        (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-          : int (caml_string_notequal prim prim))
-        (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-          : int (caml_string_lessthan prim prim))
-        (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-          : int (caml_string_greaterthan prim prim))
-        (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-          : int (caml_string_lessequal prim prim))
-        (function {nlocal = 0} prim prim stub ignore assert all zero_alloc
-          : int (caml_string_greaterequal prim prim)))
+        (function {nlocal = 0} prim prim stub : int
+          (caml_string_compare prim prim))
+        (function {nlocal = 0} prim prim stub : int
+          (caml_string_equal prim prim))
+        (function {nlocal = 0} prim prim stub : int
+          (caml_string_notequal prim prim))
+        (function {nlocal = 0} prim prim stub : int
+          (caml_string_lessthan prim prim))
+        (function {nlocal = 0} prim prim stub : int
+          (caml_string_greaterthan prim prim))
+        (function {nlocal = 0} prim prim stub : int
+          (caml_string_lessequal prim prim))
+        (function {nlocal = 0} prim prim stub : int
+          (caml_string_greaterequal prim prim)))
       (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          ignore assert all zero_alloc : int (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          ignore assert all zero_alloc : int32
+        (function {nlocal = 0} prim[addrarray] stub : int
+          (array.length[addr] prim))
+        (function {nlocal = 0} prim[addrarray] prim[int] stub : int32
           (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          ignore assert all zero_alloc : int32
+        (function {nlocal = 0} prim[addrarray] prim[int] stub : int32
           (array.unsafe_get[addr indexed by int] prim prim))
         (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
-          ignore assert all zero_alloc : int
-          (array.set[addr indexed by int] prim prim prim))
+          : int (array.set[addr indexed by int] prim prim prim))
         (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
-          ignore assert all zero_alloc : int
-          (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          ignore assert all zero_alloc : int (compare_bints int32 prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          ignore assert all zero_alloc : int (Int32.== prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          ignore assert all zero_alloc : int (Int32.!= prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          ignore assert all zero_alloc : int (Int32.< prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          ignore assert all zero_alloc : int (Int32.> prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          ignore assert all zero_alloc : int (Int32.<= prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          ignore assert all zero_alloc : int (Int32.>= prim prim)))
+          : int (array.unsafe_set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[int32] prim[int32] stub : int
+          (compare_bints int32 prim prim))
+        (function {nlocal = 0} prim[int32] prim[int32] stub : int
+          (Int32.== prim prim))
+        (function {nlocal = 0} prim[int32] prim[int32] stub : int
+          (Int32.!= prim prim))
+        (function {nlocal = 0} prim[int32] prim[int32] stub : int
+          (Int32.< prim prim))
+        (function {nlocal = 0} prim[int32] prim[int32] stub : int
+          (Int32.> prim prim))
+        (function {nlocal = 0} prim[int32] prim[int32] stub : int
+          (Int32.<= prim prim))
+        (function {nlocal = 0} prim[int32] prim[int32] stub : int
+          (Int32.>= prim prim)))
       (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          ignore assert all zero_alloc : int (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          ignore assert all zero_alloc : int64
+        (function {nlocal = 0} prim[addrarray] stub : int
+          (array.length[addr] prim))
+        (function {nlocal = 0} prim[addrarray] prim[int] stub : int64
           (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          ignore assert all zero_alloc : int64
+        (function {nlocal = 0} prim[addrarray] prim[int] stub : int64
           (array.unsafe_get[addr indexed by int] prim prim))
         (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
-          ignore assert all zero_alloc : int
-          (array.set[addr indexed by int] prim prim prim))
+          : int (array.set[addr indexed by int] prim prim prim))
         (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
-          ignore assert all zero_alloc : int
-          (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          ignore assert all zero_alloc : int (compare_bints int64 prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          ignore assert all zero_alloc : int (Int64.== prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          ignore assert all zero_alloc : int (Int64.!= prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          ignore assert all zero_alloc : int (Int64.< prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          ignore assert all zero_alloc : int (Int64.> prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          ignore assert all zero_alloc : int (Int64.<= prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          ignore assert all zero_alloc : int (Int64.>= prim prim)))
+          : int (array.unsafe_set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[int64] prim[int64] stub : int
+          (compare_bints int64 prim prim))
+        (function {nlocal = 0} prim[int64] prim[int64] stub : int
+          (Int64.== prim prim))
+        (function {nlocal = 0} prim[int64] prim[int64] stub : int
+          (Int64.!= prim prim))
+        (function {nlocal = 0} prim[int64] prim[int64] stub : int
+          (Int64.< prim prim))
+        (function {nlocal = 0} prim[int64] prim[int64] stub : int
+          (Int64.> prim prim))
+        (function {nlocal = 0} prim[int64] prim[int64] stub : int
+          (Int64.<= prim prim))
+        (function {nlocal = 0} prim[int64] prim[int64] stub : int
+          (Int64.>= prim prim)))
       (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          ignore assert all zero_alloc : int (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          ignore assert all zero_alloc : nativeint
+        (function {nlocal = 0} prim[addrarray] stub : int
+          (array.length[addr] prim))
+        (function {nlocal = 0} prim[addrarray] prim[int] stub : nativeint
           (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          ignore assert all zero_alloc : nativeint
+        (function {nlocal = 0} prim[addrarray] prim[int] stub : nativeint
           (array.unsafe_get[addr indexed by int] prim prim))
         (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint] stub
-          ignore assert all zero_alloc : int
-          (array.set[addr indexed by int] prim prim prim))
+          : int (array.set[addr indexed by int] prim prim prim))
         (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint] stub
-          ignore assert all zero_alloc : int
-          (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          ignore assert all zero_alloc : int
+          : int (array.unsafe_set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
           (compare_bints nativeint prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          ignore assert all zero_alloc : int (Nativeint.== prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          ignore assert all zero_alloc : int (Nativeint.!= prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          ignore assert all zero_alloc : int (Nativeint.< prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          ignore assert all zero_alloc : int (Nativeint.> prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          ignore assert all zero_alloc : int (Nativeint.<= prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          ignore assert all zero_alloc : int (Nativeint.>= prim prim))))))
+        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+          (Nativeint.== prim prim))
+        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+          (Nativeint.!= prim prim))
+        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+          (Nativeint.< prim prim))
+        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+          (Nativeint.> prim prim))
+        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+          (Nativeint.<= prim prim))
+        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
+          (Nativeint.>= prim prim))))))


### PR DESCRIPTION
Remove `Ignore_assert_all` and `opt` from Lambda onwards, now that all the decisions about top-level `[@@@zero_alloc all]` can be made before Lambda (see also https://github.com/ocaml-flambda/flambda-backend/pull/2687). This is refactoring only that should not change behavior. Best reviewed with patdiff.