### PR TITLE
Jkind Error Messages

### DIFF
--- a/ocaml/compilerlibs/Makefile.compilerlibs
+++ b/ocaml/compilerlibs/Makefile.compilerlibs
@@ -91,9 +91,9 @@ TYPING = \
   typing/shape.cmo \
   typing/zero_alloc.cmo \
   typing/types.cmo \
-  typing/jkind.cmo \
   typing/btype.cmo \
   typing/oprint.cmo \
+  typing/jkind.cmo \
   typing/subst.cmo \
   typing/predef.cmo \
   typing/datarepr.cmo \

--- a/ocaml/otherlibs/dynlink/Makefile
+++ b/ocaml/otherlibs/dynlink/Makefile
@@ -123,6 +123,7 @@ COMPILERLIBS_SOURCES=\
   typing/primitive.ml \
   typing/zero_alloc.ml \
   typing/types.ml \
+  typing/oprint.ml \
   typing/jkind.ml \
   typing/typedtree.ml \
   typing/btype.ml \

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -389,6 +389,7 @@
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Types.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Attr_helper.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Primitive.cmo
+      .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Oprint.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Jkind.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Btype.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Subst.cmo
@@ -473,6 +474,7 @@
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Types.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Attr_helper.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Primitive.cmx
+      .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Oprint.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Jkind.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Btype.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Subst.cmx

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -96,6 +96,7 @@
     primitive
     zero_alloc
     types
+    oprint
     jkind
     value_rec_types
     btype
@@ -194,6 +195,7 @@
 (copy_files ../../typing/jkind.ml)
 (copy_files ../../typing/jkind_intf.ml)
 (copy_files ../../typing/jkind_types.ml)
+(copy_files ../../typing/oprint.ml)
 (copy_files ../../typing/primitive.ml)
 (copy_files ../../typing/shape.ml)
 (copy_files ../../typing/solver.ml)
@@ -264,6 +266,7 @@
 (copy_files ../../typing/jkind.mli)
 (copy_files ../../typing/jkind_intf.mli)
 (copy_files ../../typing/jkind_types.mli)
+(copy_files ../../typing/oprint.mli)
 (copy_files ../../typing/primitive.mli)
 (copy_files ../../typing/shape.mli)
 (copy_files ../../typing/solver.mli)

--- a/ocaml/testsuite/tests/hidden_includes/missing_cmi_layout.ocamlc.reference
+++ b/ocaml/testsuite/tests/hidden_includes/missing_cmi_layout.ocamlc.reference
@@ -2,9 +2,9 @@ File "libc/c2.ml", line 1, characters 12-15:
 1 | let x = B.f B.x
                 ^^^
 Error: Function arguments and returns must be representable.
-       The layout of A.t is any
-         because the .cmi file for A.t is missing.
-       But the layout of A.t must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of A.t is any, because
+         the .cmi file for A.t is missing.
+       But the layout of A.t must be representable, because
+         we must know concretely how to pass a function argument.
        No .cmi file found containing A.t.
        Hint: Adding "a" to your dependencies might help.

--- a/ocaml/testsuite/tests/hidden_includes/missing_cmi_layout.ocamlc.reference
+++ b/ocaml/testsuite/tests/hidden_includes/missing_cmi_layout.ocamlc.reference
@@ -2,9 +2,9 @@ File "libc/c2.ml", line 1, characters 12-15:
 1 | let x = B.f B.x
                 ^^^
 Error: Function arguments and returns must be representable.
-       The layout of A.t is any, because
-         the .cmi file for A.t is missing.
-       But the layout of A.t must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of A.t is any
+         because the .cmi file for A.t is missing.
+       But the layout of A.t must be representable
+         because we must know concretely how to pass a function argument.
        No .cmi file found containing A.t.
        Hint: Adding "a" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -143,9 +143,9 @@ end;;
 Line 2, characters 2-31:
 2 |   type t = string [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type string is value, because
+Error: The kind of type string is value, because
          it is the primitive value type string.
-       But the layout of type string must be a sublayout of immediate, because
+       But the kind of type string must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-31.
 |}];;
 (* CR layouts v2.9: The "of the definition of t ..." part is not great and it
@@ -160,9 +160,9 @@ end;;
 Line 2, characters 2-41:
 2 |   type t = Foo of int | Bar [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of immediate, because
          of the annotation on the declaration of the type t.
 |}];;
 
@@ -174,9 +174,9 @@ end;;
 Line 2, characters 2-38:
 2 |   type t = { foo : int } [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of immediate, because
          of the annotation on the declaration of the type t.
 |}];;
 
@@ -189,9 +189,9 @@ end;;
 Line 3, characters 2-26:
 3 |   type s = t [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of t at line 2, characters 2-8.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of immediate, because
          of the definition of s at line 3, characters 2-26.
 |}];;
 
@@ -213,9 +213,9 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          it is the primitive value type string.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 1, characters 15-35.
 |}];;
 
@@ -231,9 +231,9 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          it is the primitive value type string.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 1, characters 20-40.
 |}];;
 
@@ -248,9 +248,9 @@ Error: Modules do not match: sig type t = string end is not included in
        type t = string
      is not included in
        type t : immediate
-     The layout of the first is value, because
+     The kind of the first is value, because
        it is the primitive value type string.
-     But the layout of the first must be a sublayout of immediate, because
+     But the kind of the first must be a subkind of immediate, because
        of the definition of t at line 1, characters 20-40.
 |}];;
 
@@ -263,9 +263,9 @@ end;;
 Line 2, characters 2-26:
 2 |   type t = s [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type s is value, because
+Error: The kind of type s is value, because
          it is the primitive value type string.
-       But the layout of type s must be a sublayout of immediate, because
+       But the kind of type s must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-26.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -143,10 +143,10 @@ end;;
 Line 2, characters 2-31:
 2 |   type t = string [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type string is value
-         because it is the primitive value type string.
-       But the kind of type string must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-31.
+Error: The kind of type string is value, because
+         it is the primitive value type string.
+       But the kind of type string must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-31.
 |}];;
 (* CR layouts v2.9: The "of the definition of t ..." part is not great and it
    should only refer to definitions that type check. Fixing it will involve
@@ -160,10 +160,10 @@ end;;
 Line 2, characters 2-41:
 2 |   type t = Foo of int | Bar [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of immediate
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of immediate, because
+         of the annotation on the declaration of the type t.
 |}];;
 
 (* Cannot directly declare a non-immediate type as immediate (record) *)
@@ -174,10 +174,10 @@ end;;
 Line 2, characters 2-38:
 2 |   type t = { foo : int } [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of immediate
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of immediate, because
+         of the annotation on the declaration of the type t.
 |}];;
 
 (* Not guaranteed that t is immediate, so this is an invalid declaration *)
@@ -189,10 +189,10 @@ end;;
 Line 3, characters 2-26:
 3 |   type s = t [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because of the definition of t at line 2, characters 2-8.
-       But the kind of type t must be a subkind of immediate
-         because of the definition of s at line 3, characters 2-26.
+Error: The kind of type t is value, because
+         of the definition of t at line 2, characters 2-8.
+       But the kind of type t must be a subkind of immediate, because
+         of the definition of s at line 3, characters 2-26.
 |}];;
 
 (* Can't ascribe to an immediate type signature with a non-immediate type *)
@@ -213,10 +213,10 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value
-         because it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate
-         because of the definition of t at line 1, characters 15-35.
+       The kind of the first is value, because
+         it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate, because
+         of the definition of t at line 1, characters 15-35.
 |}];;
 
 (* Same as above but with explicit signature *)
@@ -231,10 +231,10 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value
-         because it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate
-         because of the definition of t at line 1, characters 20-40.
+       The kind of the first is value, because
+         it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate, because
+         of the definition of t at line 1, characters 20-40.
 |}];;
 
 module FM_invalid = F (struct type t = string end);;
@@ -248,10 +248,10 @@ Error: Modules do not match: sig type t = string end is not included in
        type t = string
      is not included in
        type t : immediate
-     The kind of the first is value
-       because it is the primitive value type string.
-     But the kind of the first must be a subkind of immediate
-       because of the definition of t at line 1, characters 20-40.
+     The kind of the first is value, because
+       it is the primitive value type string.
+     But the kind of the first must be a subkind of immediate, because
+       of the definition of t at line 1, characters 20-40.
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)
@@ -263,10 +263,10 @@ end;;
 Line 2, characters 2-26:
 2 |   type t = s [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type s is value
-         because it is the primitive value type string.
-       But the kind of type s must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-26.
+Error: The kind of type s is value, because
+         it is the primitive value type string.
+       But the kind of type s must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-26.
 |}];;
 
 

--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -143,9 +143,9 @@ end;;
 Line 2, characters 2-31:
 2 |   type t = string [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type string is value, because
+Error: The layout of type string is value, because
          it is the primitive value type string.
-       But the kind of type string must be a subkind of immediate, because
+       But the layout of type string must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-31.
 |}];;
 (* CR layouts v2.9: The "of the definition of t ..." part is not great and it
@@ -160,9 +160,9 @@ end;;
 Line 2, characters 2-41:
 2 |   type t = Foo of int | Bar [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of immediate, because
+       But the layout of type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
 |}];;
 
@@ -174,9 +174,9 @@ end;;
 Line 2, characters 2-38:
 2 |   type t = { foo : int } [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of immediate, because
+       But the layout of type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
 |}];;
 
@@ -189,9 +189,9 @@ end;;
 Line 3, characters 2-26:
 3 |   type s = t [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          of the definition of t at line 2, characters 2-8.
-       But the kind of type t must be a subkind of immediate, because
+       But the layout of type t must be a sublayout of immediate, because
          of the definition of s at line 3, characters 2-26.
 |}];;
 
@@ -213,9 +213,9 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
+       The layout of the first is value, because
          it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
+       But the layout of the first must be a sublayout of immediate, because
          of the definition of t at line 1, characters 15-35.
 |}];;
 
@@ -231,9 +231,9 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
+       The layout of the first is value, because
          it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
+       But the layout of the first must be a sublayout of immediate, because
          of the definition of t at line 1, characters 20-40.
 |}];;
 
@@ -248,9 +248,9 @@ Error: Modules do not match: sig type t = string end is not included in
        type t = string
      is not included in
        type t : immediate
-     The kind of the first is value, because
+     The layout of the first is value, because
        it is the primitive value type string.
-     But the kind of the first must be a subkind of immediate, because
+     But the layout of the first must be a sublayout of immediate, because
        of the definition of t at line 1, characters 20-40.
 |}];;
 
@@ -263,9 +263,9 @@ end;;
 Line 2, characters 2-26:
 2 |   type t = s [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type s is value, because
+Error: The layout of type s is value, because
          it is the primitive value type string.
-       But the kind of type s must be a subkind of immediate, because
+       But the layout of type s must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-26.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -143,10 +143,10 @@ end;;
 Line 2, characters 2-31:
 2 |   type t = string [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type string is value, because
-         it is the primitive value type string.
-       But the kind of type string must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-31.
+Error: The kind of type string is value
+         because it is the primitive value type string.
+       But the kind of type string must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-31.
 |}];;
 (* CR layouts v2.9: The "of the definition of t ..." part is not great and it
    should only refer to definitions that type check. Fixing it will involve
@@ -160,10 +160,10 @@ end;;
 Line 2, characters 2-41:
 2 |   type t = Foo of int | Bar [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of immediate, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of immediate
+         because of the annotation on the declaration of the type t.
 |}];;
 
 (* Cannot directly declare a non-immediate type as immediate (record) *)
@@ -174,10 +174,10 @@ end;;
 Line 2, characters 2-38:
 2 |   type t = { foo : int } [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of immediate, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of immediate
+         because of the annotation on the declaration of the type t.
 |}];;
 
 (* Not guaranteed that t is immediate, so this is an invalid declaration *)
@@ -189,10 +189,10 @@ end;;
 Line 3, characters 2-26:
 3 |   type s = t [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of t at line 2, characters 2-8.
-       But the kind of type t must be a subkind of immediate, because
-         of the definition of s at line 3, characters 2-26.
+Error: The kind of type t is value
+         because of the definition of t at line 2, characters 2-8.
+       But the kind of type t must be a subkind of immediate
+         because of the definition of s at line 3, characters 2-26.
 |}];;
 
 (* Can't ascribe to an immediate type signature with a non-immediate type *)
@@ -213,10 +213,10 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
-         it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
-         of the definition of t at line 1, characters 15-35.
+       The kind of the first is value
+         because it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate
+         because of the definition of t at line 1, characters 15-35.
 |}];;
 
 (* Same as above but with explicit signature *)
@@ -231,10 +231,10 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
-         it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
-         of the definition of t at line 1, characters 20-40.
+       The kind of the first is value
+         because it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate
+         because of the definition of t at line 1, characters 20-40.
 |}];;
 
 module FM_invalid = F (struct type t = string end);;
@@ -248,10 +248,10 @@ Error: Modules do not match: sig type t = string end is not included in
        type t = string
      is not included in
        type t : immediate
-     The kind of the first is value, because
-       it is the primitive value type string.
-     But the kind of the first must be a subkind of immediate, because
-       of the definition of t at line 1, characters 20-40.
+     The kind of the first is value
+       because it is the primitive value type string.
+     But the kind of the first must be a subkind of immediate
+       because of the definition of t at line 1, characters 20-40.
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)
@@ -263,10 +263,10 @@ end;;
 Line 2, characters 2-26:
 2 |   type t = s [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type s is value, because
-         it is the primitive value type string.
-       But the kind of type s must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-26.
+Error: The kind of type s is value
+         because it is the primitive value type string.
+       But the kind of type s must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-26.
 |}];;
 
 

--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
@@ -91,10 +91,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type float# array
        but an expression was expected of type 'a array
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f (x : float# array) = Array.length x
@@ -104,10 +104,10 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type float# array
        but an expression was expected of type 'a array
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 (*****************************************************************)
@@ -144,10 +144,10 @@ Line 2, characters 23-30:
 2 | let d (x : 'a array) = get x 0
                            ^^^^^^^
 Error: A representable layout is required here.
-       The layout of 'a is any, because
-         of the definition of d at line 2, characters 6-30.
-       But the layout of 'a must be representable, because
-         it's the type of an array element.
+       The layout of 'a is any
+         because of the definition of d at line 2, characters 6-30.
+       But the layout of 'a must be representable
+         because it's the type of an array element.
 |}];;
 
 external get : int32# array -> int -> float = "%floatarray_safe_get"
@@ -257,10 +257,10 @@ Line 11, characters 79-82:
                                                                                     ^^^
 Error: This expression has type int64# but an expression was expected of type
          ('a : bits32)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of bits32, because
-         of the definition of get_third at lines 4-7, characters 16-23.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of bits32
+         because of the definition of get_third at lines 4-7, characters 16-23.
 |}]
 
 module M6_2 = struct
@@ -282,10 +282,10 @@ Line 9, characters 24-35:
                             ^^^^^^^^^^^
 Error: This expression has type ('a : float64)
        but an expression was expected of type int32#
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of float64, because
-         of the definition of arr at line 6, characters 12-16.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of float64
+         because of the definition of arr at line 6, characters 12-16.
 |}]
 
 (*********************)

--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
@@ -91,10 +91,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type float# array
        but an expression was expected of type 'a array
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f (x : float# array) = Array.length x
@@ -104,10 +104,10 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type float# array
        but an expression was expected of type 'a array
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 (*****************************************************************)
@@ -144,10 +144,10 @@ Line 2, characters 23-30:
 2 | let d (x : 'a array) = get x 0
                            ^^^^^^^
 Error: A representable layout is required here.
-       The layout of 'a is any
-         because of the definition of d at line 2, characters 6-30.
-       But the layout of 'a must be representable
-         because it's the type of an array element.
+       The layout of 'a is any, because
+         of the definition of d at line 2, characters 6-30.
+       But the layout of 'a must be representable, because
+         it's the type of an array element.
 |}];;
 
 external get : int32# array -> int -> float = "%floatarray_safe_get"
@@ -257,10 +257,10 @@ Line 11, characters 79-82:
                                                                                     ^^^
 Error: This expression has type int64# but an expression was expected of type
          ('a : bits32)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of bits32
-         because of the definition of get_third at lines 4-7, characters 16-23.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of bits32, because
+         of the definition of get_third at lines 4-7, characters 16-23.
 |}]
 
 module M6_2 = struct
@@ -282,10 +282,10 @@ Line 9, characters 24-35:
                             ^^^^^^^^^^^
 Error: This expression has type ('a : float64)
        but an expression was expected of type int32#
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of float64
-         because of the definition of arr at line 6, characters 12-16.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of float64, because
+         of the definition of arr at line 6, characters 12-16.
 |}]
 
 (*********************)

--- a/ocaml/testsuite/tests/typing-layouts-arrays/exp_and_pat_failing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/exp_and_pat_failing.ml
@@ -52,8 +52,8 @@ Line 25, characters 13-29:
                   ^^^^^^^^^^^^^^^^
 Error: This expression has type Float_u.t = float#
        but an expression was expected of type ('a : value)
-       The layout of Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Float_u.t must be a sublayout of value, because
-         it's the element type of array comprehension.
+       The layout of Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Float_u.t must be a sublayout of value
+         because it's the element type of array comprehension.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-arrays/exp_and_pat_failing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/exp_and_pat_failing.ml
@@ -52,8 +52,8 @@ Line 25, characters 13-29:
                   ^^^^^^^^^^^^^^^^
 Error: This expression has type Float_u.t = float#
        but an expression was expected of type ('a : value)
-       The layout of Float_u.t is float64
-         because it is the primitive float64 type float#.
-       But the layout of Float_u.t must be a sublayout of value
-         because it's the element type of array comprehension.
+       The layout of Float_u.t is float64, because
+         it is the primitive float64 type float#.
+       But the layout of Float_u.t must be a sublayout of value, because
+         it's the element type of array comprehension.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -118,10 +118,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_bits32_id) = x, false;;
@@ -131,10 +131,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits32_id is bits32
-         because of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a t_bits32_id is bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : int32#) = x, false;;
@@ -144,10 +144,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_bits32 * string;;
@@ -156,10 +156,10 @@ Line 1, characters 12-20:
 1 | type t4_4 = t_bits32 * string;;
                 ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * int32#;;
@@ -168,10 +168,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * int32#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : bits32) t4_6 = 'a * 'a
@@ -180,10 +180,10 @@ Line 1, characters 26-28:
 1 | type ('a : bits32) t4_6 = 'a * 'a
                               ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32
-         because of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -193,10 +193,10 @@ Line 1, characters 31-33:
 1 | type ('a : bits32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits32)
-       The layout of 'a is bits32
-         because of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (*********************************************************)
@@ -284,10 +284,10 @@ Line 1, characters 31-39:
 1 | module type S6_1 = sig val x : t_bits32 end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of type t_bits32 must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of type t_bits32 must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_bits32_id end
@@ -296,10 +296,10 @@ Line 1, characters 31-45:
 1 | module type S6_2 = sig val x : 'a t_bits32_id end
                                    ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_bits32_id is bits32
-         because of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of type 'a t_bits32_id must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type 'a t_bits32_id is bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of type 'a t_bits32_id must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : int32# end
@@ -308,10 +308,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : int32# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of type int32# must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of type int32# must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -324,10 +324,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_bits32_id) = `A x;;
@@ -337,10 +337,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits32_id is bits32
-         because of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       The layout of 'a t_bits32_id is bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : int32#) = `A x;;
@@ -350,10 +350,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_bits32 ];;
@@ -362,10 +362,10 @@ Line 1, characters 20-28:
 1 | type f7_4 = [ `A of t_bits32 ];;
                         ^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : bits32) f7_5 = [ `A of 'a ];;
@@ -374,10 +374,10 @@ Line 1, characters 34-36:
 1 | type ('a : bits32) f7_5 = [ `A of 'a ];;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32
-         because of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -402,10 +402,10 @@ Line 1, characters 20-38:
                         ^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_bits32_id ());;
@@ -415,10 +415,10 @@ Line 1, characters 20-41:
                         ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits32_id is bits32
-         because of the definition of make_t_bits32_id at line 2, characters 21-55.
-       But the layout of 'a t_bits32_id must overlap with value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_bits32_id is bits32, because
+         of the definition of make_t_bits32_id at line 2, characters 21-55.
+       But the layout of 'a t_bits32_id must overlap with value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_int32u ());;
@@ -428,10 +428,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -570,10 +570,10 @@ Line 1, characters 15-27:
 1 | type t12_1 = < x : t_bits32 >;;
                    ^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : bits32) t12_2 = < x : 'a >;;
@@ -582,10 +582,10 @@ Line 1, characters 33-35:
 1 | type ('a : bits32) t12_2 = < x : 'a >;;
                                      ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32
-         because of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value
-         because it's the type of an object field.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_bits32 = assert false end;;
@@ -595,10 +595,10 @@ Line 1, characters 21-55:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_bits32 but is expected to have type
          ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -609,10 +609,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_bits32_id -> 'a t_bits32_id = assert false
                  ^^
 Error: This type ('a : bits32) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits32
-         because of the definition of t_bits32_id at line 2, characters 0-35.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
 |}];;
 
 class c12_5 = object val x : t_bits32 = assert false end;;
@@ -621,10 +621,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_bits32 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of x must be a sublayout of value
-         because it's the type of a class field.
+       The layout of x is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : int32# end;;
@@ -633,10 +633,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : int32# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type int32# but is expected to have type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's the type of an object field.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : int32# end
@@ -645,10 +645,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : int32# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of x must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of x is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -659,10 +659,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_bits32_id -> 'a t_bits32_id
               ^^
 Error: This type ('a : bits32) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits32
-         because of the definition of t_bits32_id at line 2, characters 0-35.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -698,10 +698,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_bits32
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_bits32) (m2 : t_bits32) = object
@@ -715,10 +715,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -734,10 +734,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_bits32) = compare x x;;
@@ -747,10 +747,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_bits32) = Marshal.to_bytes x;;
@@ -760,10 +760,10 @@ Line 1, characters 44-45:
                                                 ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_bits32) = Hashtbl.hash x;;
@@ -773,8 +773,8 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -118,10 +118,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_bits32_id) = x, false;;
@@ -131,10 +131,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits32_id is bits32, because
-         of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a t_bits32_id is bits32
+         because of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : int32#) = x, false;;
@@ -144,10 +144,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_bits32 * string;;
@@ -156,10 +156,10 @@ Line 1, characters 12-20:
 1 | type t4_4 = t_bits32 * string;;
                 ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * int32#;;
@@ -168,10 +168,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * int32#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type ('a : bits32) t4_6 = 'a * 'a
@@ -180,10 +180,10 @@ Line 1, characters 26-28:
 1 | type ('a : bits32) t4_6 = 'a * 'a
                               ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -193,10 +193,10 @@ Line 1, characters 31-33:
 1 | type ('a : bits32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}]
 
 (*********************************************************)
@@ -284,10 +284,10 @@ Line 1, characters 31-39:
 1 | module type S6_1 = sig val x : t_bits32 end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of type t_bits32 must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of type t_bits32 must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_bits32_id end
@@ -296,10 +296,10 @@ Line 1, characters 31-45:
 1 | module type S6_2 = sig val x : 'a t_bits32_id end
                                    ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_bits32_id is bits32, because
-         of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of type 'a t_bits32_id must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type 'a t_bits32_id is bits32
+         because of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of type 'a t_bits32_id must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : int32# end
@@ -308,10 +308,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : int32# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of type int32# must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of type int32# must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 
@@ -324,10 +324,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_bits32_id) = `A x;;
@@ -337,10 +337,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits32_id is bits32, because
-         of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a t_bits32_id is bits32
+         because of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : int32#) = `A x;;
@@ -350,10 +350,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_bits32 ];;
@@ -362,10 +362,10 @@ Line 1, characters 20-28:
 1 | type f7_4 = [ `A of t_bits32 ];;
                         ^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : bits32) f7_5 = [ `A of 'a ];;
@@ -374,10 +374,10 @@ Line 1, characters 34-36:
 1 | type ('a : bits32) f7_5 = [ `A of 'a ];;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -402,10 +402,10 @@ Line 1, characters 20-38:
                         ^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_bits32_id ());;
@@ -415,10 +415,10 @@ Line 1, characters 20-41:
                         ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits32_id is bits32, because
-         of the definition of make_t_bits32_id at line 2, characters 21-55.
-       But the layout of 'a t_bits32_id must overlap with value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_bits32_id is bits32
+         because of the definition of make_t_bits32_id at line 2, characters 21-55.
+       But the layout of 'a t_bits32_id must overlap with value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_int32u ());;
@@ -428,10 +428,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -570,10 +570,10 @@ Line 1, characters 15-27:
 1 | type t12_1 = < x : t_bits32 >;;
                    ^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 type ('a : bits32) t12_2 = < x : 'a >;;
@@ -582,10 +582,10 @@ Line 1, characters 33-35:
 1 | type ('a : bits32) t12_2 = < x : 'a >;;
                                      ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value
+         because it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_bits32 = assert false end;;
@@ -595,10 +595,10 @@ Line 1, characters 21-55:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_bits32 but is expected to have type
          ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -609,10 +609,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_bits32_id -> 'a t_bits32_id = assert false
                  ^^
 Error: This type ('a : bits32) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits32, because
-         of the definition of t_bits32_id at line 2, characters 0-35.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits32
+         because of the definition of t_bits32_id at line 2, characters 0-35.
 |}];;
 
 class c12_5 = object val x : t_bits32 = assert false end;;
@@ -621,10 +621,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_bits32 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of x must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of x is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of x must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : int32# end;;
@@ -633,10 +633,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : int32# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type int32# but is expected to have type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : int32# end
@@ -645,10 +645,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : int32# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of x must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of x is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of x must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -659,10 +659,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_bits32_id -> 'a t_bits32_id
               ^^
 Error: This type ('a : bits32) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits32, because
-         of the definition of t_bits32_id at line 2, characters 0-35.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits32
+         because of the definition of t_bits32_id at line 2, characters 0-35.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -698,10 +698,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_bits32
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_bits32) (m2 : t_bits32) = object
@@ -715,10 +715,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -734,10 +734,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_bits32) = compare x x;;
@@ -747,10 +747,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_bits32) = Marshal.to_bytes x;;
@@ -760,10 +760,10 @@ Line 1, characters 44-45:
                                                 ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_bits32) = Hashtbl.hash x;;
@@ -773,8 +773,8 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits32/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/parsing.ml
@@ -34,10 +34,10 @@ Line 1, characters 9-15:
 1 | type t = int32# list;;
              ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let f (_ : int32# list) = ();;
@@ -46,10 +46,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int32# list) = ();;
                ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C of int32# list;;
@@ -58,10 +58,10 @@ Line 1, characters 14-20:
 1 | type t = C of int32# list;;
                   ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C : int32# list -> t;;
@@ -70,10 +70,10 @@ Line 1, characters 13-19:
 1 | type t = C : int32# list -> t;;
                  ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* Syntax: int32#c
@@ -92,10 +92,10 @@ Line 1, characters 9-15:
 1 | type t = int32#c;;
              ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int32#c) = ();;
@@ -104,10 +104,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int32#c) = ();;
                ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of int32#c;;
@@ -116,10 +116,10 @@ Line 1, characters 14-20:
 1 | type t = C of int32#c;;
                   ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : int32#c -> t;;
@@ -128,10 +128,10 @@ Line 1, characters 13-19:
 1 | type t = C : int32#c -> t;;
                  ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int32# c
@@ -143,10 +143,10 @@ Line 1, characters 9-15:
 1 | type t = int32# c;;
              ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int32# c) = ();;
@@ -155,10 +155,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int32# c) = ();;
                ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of int32# c;;
@@ -167,10 +167,10 @@ Line 1, characters 14-20:
 1 | type t = C of int32# c;;
                   ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : int32# c -> t;;
@@ -179,10 +179,10 @@ Line 1, characters 13-19:
 1 | type t = C : int32# c -> t;;
                  ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int32 #c

--- a/ocaml/testsuite/tests/typing-layouts-bits32/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/parsing.ml
@@ -34,10 +34,10 @@ Line 1, characters 9-15:
 1 | type t = int32# list;;
              ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let f (_ : int32# list) = ();;
@@ -46,10 +46,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int32# list) = ();;
                ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 type t = C of int32# list;;
@@ -58,10 +58,10 @@ Line 1, characters 14-20:
 1 | type t = C of int32# list;;
                   ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 type t = C : int32# list -> t;;
@@ -70,10 +70,10 @@ Line 1, characters 13-19:
 1 | type t = C : int32# list -> t;;
                  ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (* Syntax: int32#c
@@ -92,10 +92,10 @@ Line 1, characters 9-15:
 1 | type t = int32#c;;
              ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int32#c) = ();;
@@ -104,10 +104,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int32#c) = ();;
                ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C of int32#c;;
@@ -116,10 +116,10 @@ Line 1, characters 14-20:
 1 | type t = C of int32#c;;
                   ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C : int32#c -> t;;
@@ -128,10 +128,10 @@ Line 1, characters 13-19:
 1 | type t = C : int32#c -> t;;
                  ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int32# c
@@ -143,10 +143,10 @@ Line 1, characters 9-15:
 1 | type t = int32# c;;
              ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int32# c) = ();;
@@ -155,10 +155,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int32# c) = ();;
                ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C of int32# c;;
@@ -167,10 +167,10 @@ Line 1, characters 14-20:
 1 | type t = C of int32# c;;
                   ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C : int32# c -> t;;
@@ -179,10 +179,10 @@ Line 1, characters 13-19:
 1 | type t = C : int32# c -> t;;
                  ^^^^^^
 Error: This type int32# should be an instance of type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int32 #c

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -118,10 +118,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_bits64_id) = x, false;;
@@ -131,10 +131,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits64_id is bits64
-         because of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a t_bits64_id is bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : int64#) = x, false;;
@@ -144,10 +144,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_bits64 * string;;
@@ -156,10 +156,10 @@ Line 1, characters 12-20:
 1 | type t4_4 = t_bits64 * string;;
                 ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * int64#;;
@@ -168,10 +168,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * int64#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : bits64) t4_6 = 'a * 'a
@@ -180,10 +180,10 @@ Line 1, characters 26-28:
 1 | type ('a : bits64) t4_6 = 'a * 'a
                               ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       The layout of 'a is bits64
-         because of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -193,10 +193,10 @@ Line 1, characters 31-33:
 1 | type ('a : bits64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits64)
-       The layout of 'a is bits64
-         because of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -284,10 +284,10 @@ Line 1, characters 31-39:
 1 | module type S6_1 = sig val x : t_bits64 end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of type t_bits64 must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of type t_bits64 must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_bits64_id end
@@ -296,10 +296,10 @@ Line 1, characters 31-45:
 1 | module type S6_2 = sig val x : 'a t_bits64_id end
                                    ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_bits64_id is bits64
-         because of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of type 'a t_bits64_id must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type 'a t_bits64_id is bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of type 'a t_bits64_id must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : int64# end
@@ -308,10 +308,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : int64# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of type int64# must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of type int64# must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -324,10 +324,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_bits64_id) = `A x;;
@@ -337,10 +337,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits64_id is bits64
-         because of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       The layout of 'a t_bits64_id is bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : int64#) = `A x;;
@@ -350,10 +350,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_bits64 ];;
@@ -362,10 +362,10 @@ Line 1, characters 20-28:
 1 | type f7_4 = [ `A of t_bits64 ];;
                         ^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : bits64) f7_5 = [ `A of 'a ];;
@@ -374,10 +374,10 @@ Line 1, characters 34-36:
 1 | type ('a : bits64) f7_5 = [ `A of 'a ];;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       The layout of 'a is bits64
-         because of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -402,10 +402,10 @@ Line 1, characters 20-38:
                         ^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_bits64_id ());;
@@ -415,10 +415,10 @@ Line 1, characters 20-41:
                         ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits64_id is bits64
-         because of the definition of make_t_bits64_id at line 2, characters 21-55.
-       But the layout of 'a t_bits64_id must overlap with value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_bits64_id is bits64, because
+         of the definition of make_t_bits64_id at line 2, characters 21-55.
+       But the layout of 'a t_bits64_id must overlap with value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_int64u ());;
@@ -428,10 +428,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -572,10 +572,10 @@ Line 1, characters 15-27:
 1 | type t12_1 = < x : t_bits64 >;;
                    ^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : bits64) t12_2 = < x : 'a >;;
@@ -584,10 +584,10 @@ Line 1, characters 33-35:
 1 | type ('a : bits64) t12_2 = < x : 'a >;;
                                      ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       The layout of 'a is bits64
-         because of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value
-         because it's the type of an object field.
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_bits64 = assert false end;;
@@ -597,10 +597,10 @@ Line 1, characters 21-55:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_bits64 but is expected to have type
          ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -611,10 +611,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_bits64_id -> 'a t_bits64_id = assert false
                  ^^
 Error: This type ('a : bits64) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits64
-         because of the definition of t_bits64_id at line 2, characters 0-35.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
 |}];;
 
 class c12_5 = object val x : t_bits64 = assert false end;;
@@ -623,10 +623,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_bits64 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of x must be a sublayout of value
-         because it's the type of a class field.
+       The layout of x is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : int64# end;;
@@ -635,10 +635,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : int64# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type int64# but is expected to have type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's the type of an object field.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : int64# end
@@ -647,10 +647,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : int64# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of x must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of x is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -661,10 +661,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_bits64_id -> 'a t_bits64_id
               ^^
 Error: This type ('a : bits64) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits64
-         because of the definition of t_bits64_id at line 2, characters 0-35.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -700,10 +700,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_bits64
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_bits64) (m2 : t_bits64) = object
@@ -717,10 +717,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -736,10 +736,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_bits64) = compare x x;;
@@ -749,10 +749,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_bits64) = Marshal.to_bytes x;;
@@ -762,10 +762,10 @@ Line 1, characters 44-45:
                                                 ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_bits64) = Hashtbl.hash x;;
@@ -775,8 +775,8 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -118,10 +118,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_bits64_id) = x, false;;
@@ -131,10 +131,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits64_id is bits64, because
-         of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a t_bits64_id is bits64
+         because of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : int64#) = x, false;;
@@ -144,10 +144,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_bits64 * string;;
@@ -156,10 +156,10 @@ Line 1, characters 12-20:
 1 | type t4_4 = t_bits64 * string;;
                 ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * int64#;;
@@ -168,10 +168,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * int64#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type ('a : bits64) t4_6 = 'a * 'a
@@ -180,10 +180,10 @@ Line 1, characters 26-28:
 1 | type ('a : bits64) t4_6 = 'a * 'a
                               ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       The layout of 'a is bits64, because
-         of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is bits64
+         because of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -193,10 +193,10 @@ Line 1, characters 31-33:
 1 | type ('a : bits64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits64)
-       The layout of 'a is bits64, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is bits64
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -284,10 +284,10 @@ Line 1, characters 31-39:
 1 | module type S6_1 = sig val x : t_bits64 end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of type t_bits64 must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of type t_bits64 must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_bits64_id end
@@ -296,10 +296,10 @@ Line 1, characters 31-45:
 1 | module type S6_2 = sig val x : 'a t_bits64_id end
                                    ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_bits64_id is bits64, because
-         of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of type 'a t_bits64_id must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type 'a t_bits64_id is bits64
+         because of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of type 'a t_bits64_id must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : int64# end
@@ -308,10 +308,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : int64# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of type int64# must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of type int64# must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 
@@ -324,10 +324,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_bits64_id) = `A x;;
@@ -337,10 +337,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits64_id is bits64, because
-         of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a t_bits64_id is bits64
+         because of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : int64#) = `A x;;
@@ -350,10 +350,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_bits64 ];;
@@ -362,10 +362,10 @@ Line 1, characters 20-28:
 1 | type f7_4 = [ `A of t_bits64 ];;
                         ^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : bits64) f7_5 = [ `A of 'a ];;
@@ -374,10 +374,10 @@ Line 1, characters 34-36:
 1 | type ('a : bits64) f7_5 = [ `A of 'a ];;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       The layout of 'a is bits64, because
-         of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a is bits64
+         because of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -402,10 +402,10 @@ Line 1, characters 20-38:
                         ^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_bits64_id ());;
@@ -415,10 +415,10 @@ Line 1, characters 20-41:
                         ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_bits64_id is bits64, because
-         of the definition of make_t_bits64_id at line 2, characters 21-55.
-       But the layout of 'a t_bits64_id must overlap with value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_bits64_id is bits64
+         because of the definition of make_t_bits64_id at line 2, characters 21-55.
+       But the layout of 'a t_bits64_id must overlap with value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_int64u ());;
@@ -428,10 +428,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -572,10 +572,10 @@ Line 1, characters 15-27:
 1 | type t12_1 = < x : t_bits64 >;;
                    ^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 type ('a : bits64) t12_2 = < x : 'a >;;
@@ -584,10 +584,10 @@ Line 1, characters 33-35:
 1 | type ('a : bits64) t12_2 = < x : 'a >;;
                                      ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       The layout of 'a is bits64, because
-         of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a is bits64
+         because of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value
+         because it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_bits64 = assert false end;;
@@ -597,10 +597,10 @@ Line 1, characters 21-55:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_bits64 but is expected to have type
          ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -611,10 +611,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_bits64_id -> 'a t_bits64_id = assert false
                  ^^
 Error: This type ('a : bits64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits64, because
-         of the definition of t_bits64_id at line 2, characters 0-35.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits64
+         because of the definition of t_bits64_id at line 2, characters 0-35.
 |}];;
 
 class c12_5 = object val x : t_bits64 = assert false end;;
@@ -623,10 +623,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_bits64 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of x must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of x is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of x must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : int64# end;;
@@ -635,10 +635,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : int64# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type int64# but is expected to have type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : int64# end
@@ -647,10 +647,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : int64# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of x must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of x is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of x must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -661,10 +661,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_bits64_id -> 'a t_bits64_id
               ^^
 Error: This type ('a : bits64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits64, because
-         of the definition of t_bits64_id at line 2, characters 0-35.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits64
+         because of the definition of t_bits64_id at line 2, characters 0-35.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -700,10 +700,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_bits64
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_bits64) (m2 : t_bits64) = object
@@ -717,10 +717,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -736,10 +736,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_bits64) = compare x x;;
@@ -749,10 +749,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_bits64) = Marshal.to_bytes x;;
@@ -762,10 +762,10 @@ Line 1, characters 44-45:
                                                 ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_bits64) = Hashtbl.hash x;;
@@ -775,8 +775,8 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/parsing.ml
@@ -34,10 +34,10 @@ Line 1, characters 9-15:
 1 | type t = int64# list;;
              ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let f (_ : int64# list) = ();;
@@ -46,10 +46,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int64# list) = ();;
                ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C of int64# list;;
@@ -58,10 +58,10 @@ Line 1, characters 14-20:
 1 | type t = C of int64# list;;
                   ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C : int64# list -> t;;
@@ -70,10 +70,10 @@ Line 1, characters 13-19:
 1 | type t = C : int64# list -> t;;
                  ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* Syntax: int64#c
@@ -92,10 +92,10 @@ Line 1, characters 9-15:
 1 | type t = int64#c;;
              ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int64#c) = ();;
@@ -104,10 +104,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int64#c) = ();;
                ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of int64#c;;
@@ -116,10 +116,10 @@ Line 1, characters 14-20:
 1 | type t = C of int64#c;;
                   ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : int64#c -> t;;
@@ -128,10 +128,10 @@ Line 1, characters 13-19:
 1 | type t = C : int64#c -> t;;
                  ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int64# c
@@ -143,10 +143,10 @@ Line 1, characters 9-15:
 1 | type t = int64# c;;
              ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int64# c) = ();;
@@ -155,10 +155,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int64# c) = ();;
                ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of int64# c;;
@@ -167,10 +167,10 @@ Line 1, characters 14-20:
 1 | type t = C of int64# c;;
                   ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : int64# c -> t;;
@@ -179,10 +179,10 @@ Line 1, characters 13-19:
 1 | type t = C : int64# c -> t;;
                  ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int64 #c

--- a/ocaml/testsuite/tests/typing-layouts-bits64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/parsing.ml
@@ -34,10 +34,10 @@ Line 1, characters 9-15:
 1 | type t = int64# list;;
              ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let f (_ : int64# list) = ();;
@@ -46,10 +46,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int64# list) = ();;
                ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 type t = C of int64# list;;
@@ -58,10 +58,10 @@ Line 1, characters 14-20:
 1 | type t = C of int64# list;;
                   ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 type t = C : int64# list -> t;;
@@ -70,10 +70,10 @@ Line 1, characters 13-19:
 1 | type t = C : int64# list -> t;;
                  ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (* Syntax: int64#c
@@ -92,10 +92,10 @@ Line 1, characters 9-15:
 1 | type t = int64#c;;
              ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int64#c) = ();;
@@ -104,10 +104,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int64#c) = ();;
                ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C of int64#c;;
@@ -116,10 +116,10 @@ Line 1, characters 14-20:
 1 | type t = C of int64#c;;
                   ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C : int64#c -> t;;
@@ -128,10 +128,10 @@ Line 1, characters 13-19:
 1 | type t = C : int64#c -> t;;
                  ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int64# c
@@ -143,10 +143,10 @@ Line 1, characters 9-15:
 1 | type t = int64# c;;
              ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 let f (_ : int64# c) = ();;
@@ -155,10 +155,10 @@ Line 1, characters 11-17:
 1 | let f (_ : int64# c) = ();;
                ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C of int64# c;;
@@ -167,10 +167,10 @@ Line 1, characters 14-20:
 1 | type t = C of int64# c;;
                   ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C : int64# c -> t;;
@@ -179,10 +179,10 @@ Line 1, characters 13-19:
 1 | type t = C : int64# c -> t;;
                  ^^^^^^
 Error: This type int64# should be an instance of type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: int64 #c

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/annots.ml
@@ -19,10 +19,10 @@ Line 5, characters 8-14:
             ^^^^^^
 Error: This type t_void = ('a : void) should be an instance of type
          ('b : value)
-       The layout of t_void is void, because
-         of the annotation on the declaration of the type t_void.
-       But the layout of t_void must overlap with value, because
-         of the definition of value at line 1, characters 0-30.
+       The layout of t_void is void
+         because of the annotation on the declaration of the type t_void.
+       But the layout of t_void must overlap with value
+         because of the definition of value at line 1, characters 0-30.
 |}]
 
 (* Type_parameter *)
@@ -33,10 +33,10 @@ Line 1, characters 21-23:
 1 | type ('a : void) t = 'a value
                          ^^
 Error: This type ('a : value) should be an instance of type ('a0 : void)
-       The layout of 'a is void, because
-         of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with value, because
-         of the definition of value at line 1, characters 0-30.
+       The layout of 'a is void
+         because of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value
+         because of the definition of value at line 1, characters 0-30.
 |}]
 
 (* Newtype_declaration *)
@@ -47,10 +47,10 @@ Line 1, characters 26-27:
 1 | let f (type a : void) (x: a value) = x
                               ^
 Error: This type a should be an instance of type ('a : value)
-       The layout of a is void, because
-         of the annotation on the abstract type declaration for a.
-       But the layout of a must be a sublayout of value, because
-         of the definition of value at line 1, characters 0-30.
+       The layout of a is void
+         because of the annotation on the abstract type declaration for a.
+       But the layout of a must be a sublayout of value
+         because of the definition of value at line 1, characters 0-30.
 |}]
 
 (* Constructor_type_parameter *)
@@ -61,10 +61,10 @@ Line 1, characters 28-30:
 1 | type _ g = A : ('a: void) . 'a value -> unit g
                                 ^^
 Error: This type ('a : void) should be an instance of type ('b : value)
-       The layout of 'a is void, because
-         of the annotation on a in the declaration of constructor A.
-       But the layout of 'a must overlap with value, because
-         of the definition of value at line 1, characters 0-30.
+       The layout of 'a is void
+         because of the annotation on a in the declaration of constructor A.
+       But the layout of 'a must overlap with value
+         because of the definition of value at line 1, characters 0-30.
 |}]
 
 (* Univar *)
@@ -75,10 +75,10 @@ Line 1, characters 27-29:
 1 | let f : ('a : void). 'a -> 'a value = assert false
                                ^^
 Error: This type ('a : void) should be an instance of type ('b : value)
-       The layout of 'a is void, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must overlap with value, because
-         of the definition of value at line 1, characters 0-30.
+       The layout of 'a is void
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must overlap with value
+         because of the definition of value at line 1, characters 0-30.
 |}]
 
 (* Type_variable *)
@@ -90,10 +90,10 @@ Line 1, characters 9-33:
              ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type 'a -> int
        but is used as an instance of type ('b : void)
-       The layout of 'a -> int is value, because
-         it's a function type.
-       But the layout of 'a -> int must be a sublayout of void, because
-         of the annotation on the type variable 'b.
+       The layout of 'a -> int is value
+         because it's a function type.
+       But the layout of 'a -> int must be a sublayout of void
+         because of the annotation on the type variable 'b.
 |}]
 
 (* Type_wildcard *)
@@ -104,8 +104,8 @@ Line 1, characters 27-31:
 1 | type t = 'a -> int as (_ : void)
                                ^^^^
 Error: Bad layout annotation:
-         The layout of 'a -> int is value, because
-           it's a function type.
-         But the layout of 'a -> int must be a sublayout of void, because
-           of the annotation on the wildcard _ at line 1, characters 27-31.
+         The layout of 'a -> int is value
+           because it's a function type.
+         But the layout of 'a -> int must be a sublayout of void
+           because of the annotation on the wildcard _ at line 1, characters 27-31.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/annots.ml
@@ -19,10 +19,10 @@ Line 5, characters 8-14:
             ^^^^^^
 Error: This type t_void = ('a : void) should be an instance of type
          ('b : value)
-       The layout of t_void is void
-         because of the annotation on the declaration of the type t_void.
-       But the layout of t_void must overlap with value
-         because of the definition of value at line 1, characters 0-30.
+       The layout of t_void is void, because
+         of the annotation on the declaration of the type t_void.
+       But the layout of t_void must overlap with value, because
+         of the definition of value at line 1, characters 0-30.
 |}]
 
 (* Type_parameter *)
@@ -33,10 +33,10 @@ Line 1, characters 21-23:
 1 | type ('a : void) t = 'a value
                          ^^
 Error: This type ('a : value) should be an instance of type ('a0 : void)
-       The layout of 'a is void
-         because of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with value
-         because of the definition of value at line 1, characters 0-30.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value, because
+         of the definition of value at line 1, characters 0-30.
 |}]
 
 (* Newtype_declaration *)
@@ -47,10 +47,10 @@ Line 1, characters 26-27:
 1 | let f (type a : void) (x: a value) = x
                               ^
 Error: This type a should be an instance of type ('a : value)
-       The layout of a is void
-         because of the annotation on the abstract type declaration for a.
-       But the layout of a must be a sublayout of value
-         because of the definition of value at line 1, characters 0-30.
+       The layout of a is void, because
+         of the annotation on the abstract type declaration for a.
+       But the layout of a must be a sublayout of value, because
+         of the definition of value at line 1, characters 0-30.
 |}]
 
 (* Constructor_type_parameter *)
@@ -61,10 +61,10 @@ Line 1, characters 28-30:
 1 | type _ g = A : ('a: void) . 'a value -> unit g
                                 ^^
 Error: This type ('a : void) should be an instance of type ('b : value)
-       The layout of 'a is void
-         because of the annotation on a in the declaration of constructor A.
-       But the layout of 'a must overlap with value
-         because of the definition of value at line 1, characters 0-30.
+       The layout of 'a is void, because
+         of the annotation on a in the declaration of constructor A.
+       But the layout of 'a must overlap with value, because
+         of the definition of value at line 1, characters 0-30.
 |}]
 
 (* Univar *)
@@ -75,10 +75,10 @@ Line 1, characters 27-29:
 1 | let f : ('a : void). 'a -> 'a value = assert false
                                ^^
 Error: This type ('a : void) should be an instance of type ('b : value)
-       The layout of 'a is void
-         because of the annotation on the universal variable 'a.
-       But the layout of 'a must overlap with value
-         because of the definition of value at line 1, characters 0-30.
+       The layout of 'a is void, because
+         of the annotation on the universal variable 'a.
+       But the layout of 'a must overlap with value, because
+         of the definition of value at line 1, characters 0-30.
 |}]
 
 (* Type_variable *)
@@ -90,10 +90,10 @@ Line 1, characters 9-33:
              ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type 'a -> int
        but is used as an instance of type ('b : void)
-       The layout of 'a -> int is value
-         because it's a function type.
-       But the layout of 'a -> int must be a sublayout of void
-         because of the annotation on the type variable 'b.
+       The layout of 'a -> int is value, because
+         it's a function type.
+       But the layout of 'a -> int must be a sublayout of void, because
+         of the annotation on the type variable 'b.
 |}]
 
 (* Type_wildcard *)
@@ -104,8 +104,8 @@ Line 1, characters 27-31:
 1 | type t = 'a -> int as (_ : void)
                                ^^^^
 Error: Bad layout annotation:
-         The layout of 'a -> int is value
-           because it's a function type.
-         But the layout of 'a -> int must be a sublayout of void
-           because of the annotation on the wildcard _ at line 1, characters 27-31.
+         The layout of 'a -> int is value, because
+           it's a function type.
+         But the layout of 'a -> int must be a sublayout of void, because
+           of the annotation on the wildcard _ at line 1, characters 27-31.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi.ml
@@ -19,10 +19,10 @@ Line 1, characters 30-44:
 1 | let f = Any_missing_cmi_lib.f (assert false)
                                   ^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Any_missing_cmi_lib2.t is any, because
-         the .cmi file for Any_missing_cmi_lib2.t is missing.
-       But the layout of Any_missing_cmi_lib2.t must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of Any_missing_cmi_lib2.t is any
+         because the .cmi file for Any_missing_cmi_lib2.t is missing.
+       But the layout of Any_missing_cmi_lib2.t must be representable
+         because we must know concretely how to pass a function argument.
        No .cmi file found containing Any_missing_cmi_lib2.t.
        Hint: Adding "any_missing_cmi_lib2" to your dependencies might help.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/any_missing_cmi.ml
@@ -19,10 +19,10 @@ Line 1, characters 30-44:
 1 | let f = Any_missing_cmi_lib.f (assert false)
                                   ^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Any_missing_cmi_lib2.t is any
-         because the .cmi file for Any_missing_cmi_lib2.t is missing.
-       But the layout of Any_missing_cmi_lib2.t must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of Any_missing_cmi_lib2.t is any, because
+         the .cmi file for Any_missing_cmi_lib2.t is missing.
+       But the layout of Any_missing_cmi_lib2.t must be representable, because
+         we must know concretely how to pass a function argument.
        No .cmi file found containing Any_missing_cmi_lib2.t.
        Hint: Adding "any_missing_cmi_lib2" to your dependencies might help.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete.ml
@@ -20,10 +20,10 @@ Line 5, characters 15-37:
                    ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_1)
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable, because
-         a value of this type is matched against a pattern.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable
+         because a value of this type is matched against a pattern.
 |}]
 
 (* Constructor_declaration *)
@@ -34,10 +34,10 @@ Line 1, characters 9-19:
 1 | type t = A of t_any
              ^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}]
 
 (* Label_declaration *)
@@ -48,10 +48,10 @@ Line 1, characters 10-18:
 1 | type t = {a: t_any}
               ^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field a.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field a.
 |}]
 
 (* Unannotated_type_parameter *)
@@ -64,10 +64,10 @@ Line 2, characters 9-14:
              ^^^^^
 Error: This type t_any should be an instance of type
          ('a : '_representable_layout_2)
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable, because
-         it instantiates an unannotated type parameter of t.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable
+         because it instantiates an unannotated type parameter of t.
 |}]
 
 (* Record_projection *)
@@ -86,10 +86,10 @@ Line 1, characters 4-5:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_3)
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a variable bound by a `let`.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a variable bound by a `let`.
 |}]
 
 (* Function_argument *)
@@ -102,10 +102,10 @@ Line 1, characters 6-16:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_4)
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable
+         because we must know concretely how to pass a function argument.
 |}]
 
 (* Function_result *)
@@ -117,10 +117,10 @@ Line 1, characters 18-30:
                       ^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_5)
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable, because
-         we must know concretely how to return a function result.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable
+         because we must know concretely how to return a function result.
 |}]
 
 (* Structure_item_expression *)
@@ -136,10 +136,10 @@ Line 1, characters 14-19:
 1 | external eq : t_any -> 'a -> bool = "%equal"
                   ^^^^^
 Error: Types in an external must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 (* Shadowed by Function_argument *)
 
@@ -150,10 +150,10 @@ Line 1, characters 26-31:
 1 | external eq : 'a -> 'a -> t_any = "%equal"
                               ^^^^^
 Error: Types in an external must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of the result of an external declaration.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of the result of an external declaration.
 |}]
 (* Shadowed by Function_result *)
 
@@ -172,8 +172,8 @@ Line 1, characters 9-21:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_6)
        because it is in the left-hand side of a sequence
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a statement.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a statement.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete.ml
@@ -20,10 +20,10 @@ Line 5, characters 15-37:
                    ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_1)
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable
-         because a value of this type is matched against a pattern.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         a value of this type is matched against a pattern.
 |}]
 
 (* Constructor_declaration *)
@@ -34,10 +34,10 @@ Line 1, characters 9-19:
 1 | type t = A of t_any
              ^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}]
 
 (* Label_declaration *)
@@ -48,10 +48,10 @@ Line 1, characters 10-18:
 1 | type t = {a: t_any}
               ^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field a.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field a.
 |}]
 
 (* Unannotated_type_parameter *)
@@ -64,10 +64,10 @@ Line 2, characters 9-14:
              ^^^^^
 Error: This type t_any should be an instance of type
          ('a : '_representable_layout_2)
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable
-         because it instantiates an unannotated type parameter of t.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it instantiates an unannotated type parameter of t.
 |}]
 
 (* Record_projection *)
@@ -86,10 +86,10 @@ Line 1, characters 4-5:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_3)
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a variable bound by a `let`.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a variable bound by a `let`.
 |}]
 
 (* Function_argument *)
@@ -102,10 +102,10 @@ Line 1, characters 6-16:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_4)
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         we must know concretely how to pass a function argument.
 |}]
 
 (* Function_result *)
@@ -117,10 +117,10 @@ Line 1, characters 18-30:
                       ^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_5)
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable
-         because we must know concretely how to return a function result.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         we must know concretely how to return a function result.
 |}]
 
 (* Structure_item_expression *)
@@ -136,10 +136,10 @@ Line 1, characters 14-19:
 1 | external eq : t_any -> 'a -> bool = "%equal"
                   ^^^^^
 Error: Types in an external must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of an argument in an external declaration.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of an argument in an external declaration.
 |}]
 (* Shadowed by Function_argument *)
 
@@ -150,10 +150,10 @@ Line 1, characters 26-31:
 1 | external eq : 'a -> 'a -> t_any = "%equal"
                               ^^^^^
 Error: Types in an external must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of the result of an external declaration.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of the result of an external declaration.
 |}]
 (* Shadowed by Function_result *)
 
@@ -172,8 +172,8 @@ Line 1, characters 9-21:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_6)
        because it is in the left-hand side of a sequence
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a statement.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_struct_item_expr.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_struct_item_expr.compilers.reference
@@ -4,8 +4,8 @@ Line 1, characters 0-22:
     ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_1)
-       The layout of t_any is any
-         because of the definition of t_any at line 6, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of an expression in a structure.
+       The layout of t_any is any, because
+         of the definition of t_any at line 6, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of an expression in a structure.
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_struct_item_expr.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete_struct_item_expr.compilers.reference
@@ -4,8 +4,8 @@ Line 1, characters 0-22:
     ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_1)
-       The layout of t_any is any, because
-         of the definition of t_any at line 6, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of an expression in a structure.
+       The layout of t_any is any
+         because of the definition of t_any at line 6, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of an expression in a structure.
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/float64.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/float64.ml
@@ -14,8 +14,8 @@ Line 1, characters 34-35:
                                       ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because of the annotation on the type variable 'a.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the type variable 'a.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/float64.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/float64.ml
@@ -14,8 +14,8 @@ Line 1, characters 34-35:
                                       ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         of the annotation on the type variable 'a.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because of the annotation on the type variable 'a.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
@@ -3,7 +3,7 @@ File "gadt_existential.ml", line 13, characters 61-62:
                                                                   ^
 Error: This expression has type a but an expression was expected of type
          'a t = ('a : void)
-       The layout of a is value, because
-         it's an unannotated existential type variable.
-       But the layout of a must be a sublayout of void, because
-         of the definition of f at file "gadt_existential.ml", line 10, characters 6-17.
+       The layout of a is value
+         because it's an unannotated existential type variable.
+       But the layout of a must be a sublayout of void
+         because of the definition of f at file "gadt_existential.ml", line 10, characters 6-17.

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/gadt_existential.compilers.reference
@@ -3,7 +3,7 @@ File "gadt_existential.ml", line 13, characters 61-62:
                                                                   ^
 Error: This expression has type a but an expression was expected of type
          'a t = ('a : void)
-       The layout of a is value
-         because it's an unannotated existential type variable.
-       But the layout of a must be a sublayout of void
-         because of the definition of f at file "gadt_existential.ml", line 10, characters 6-17.
+       The layout of a is value, because
+         it's an unannotated existential type variable.
+       But the layout of a must be a sublayout of void, because
+         of the definition of f at file "gadt_existential.ml", line 10, characters 6-17.

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/immediate.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/immediate.ml
@@ -28,10 +28,10 @@ Line 3, characters 21-22:
                          ^
 Error: This expression has type v = unit
        but an expression was expected of type 'a t = ('a : void)
-       The layout of unit is value
-         because it's an enumeration variant type (all constructors are constant).
-       But the layout of unit must be a sublayout of void
-         because of the definition of t at line 1, characters 0-22.
+       The layout of unit is value, because
+         it's an enumeration variant type (all constructors are constant).
+       But the layout of unit must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
 |}]
 
 (* Primitive *)
@@ -44,10 +44,10 @@ Line 2, characters 23-24:
                            ^
 Error: This expression has type int but an expression was expected of type
          'a t = ('a : void)
-       The layout of int is value
-         because it is the primitive immediate type int.
-       But the layout of int must be a sublayout of void
-         because of the definition of t at line 1, characters 0-22.
+       The layout of int is value, because
+         it is the primitive immediate type int.
+       But the layout of int must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
 |}];;
 
 (* Immediate_polymorphic_variant *)
@@ -60,9 +60,9 @@ Line 2, characters 29-30:
                                  ^
 Error: This expression has type [ `A | `B ]
        but an expression was expected of type 'a t = ('a : void)
-       The layout of [ `A | `B ] is value
-         because it's an enumeration variant type (all constructors are constant).
-       But the layout of [ `A | `B ] must be a sublayout of void
-         because of the definition of t at line 1, characters 0-22.
+       The layout of [ `A | `B ] is value, because
+         it's an enumeration variant type (all constructors are constant).
+       But the layout of [ `A | `B ] must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/immediate.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/immediate.ml
@@ -28,7 +28,7 @@ Line 3, characters 21-22:
                          ^
 Error: This expression has type v = unit
        but an expression was expected of type 'a t = ('a : void)
-       The layout of unit is immediate, because
+       The layout of unit is value, because
          it's an enumeration variant type (all constructors are constant).
        But the layout of unit must be a sublayout of void, because
          of the definition of t at line 1, characters 0-22.
@@ -44,7 +44,7 @@ Line 2, characters 23-24:
                            ^
 Error: This expression has type int but an expression was expected of type
          'a t = ('a : void)
-       The layout of int is immediate, because
+       The layout of int is value, because
          it is the primitive immediate type int.
        But the layout of int must be a sublayout of void, because
          of the definition of t at line 1, characters 0-22.
@@ -60,7 +60,7 @@ Line 2, characters 29-30:
                                  ^
 Error: This expression has type [ `A | `B ]
        but an expression was expected of type 'a t = ('a : void)
-       The layout of [ `A | `B ] is immediate, because
+       The layout of [ `A | `B ] is value, because
          it's an enumeration variant type (all constructors are constant).
        But the layout of [ `A | `B ] must be a sublayout of void, because
          of the definition of t at line 1, characters 0-22.

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/immediate.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/immediate.ml
@@ -28,10 +28,10 @@ Line 3, characters 21-22:
                          ^
 Error: This expression has type v = unit
        but an expression was expected of type 'a t = ('a : void)
-       The layout of unit is value, because
-         it's an enumeration variant type (all constructors are constant).
-       But the layout of unit must be a sublayout of void, because
-         of the definition of t at line 1, characters 0-22.
+       The layout of unit is value
+         because it's an enumeration variant type (all constructors are constant).
+       But the layout of unit must be a sublayout of void
+         because of the definition of t at line 1, characters 0-22.
 |}]
 
 (* Primitive *)
@@ -44,10 +44,10 @@ Line 2, characters 23-24:
                            ^
 Error: This expression has type int but an expression was expected of type
          'a t = ('a : void)
-       The layout of int is value, because
-         it is the primitive immediate type int.
-       But the layout of int must be a sublayout of void, because
-         of the definition of t at line 1, characters 0-22.
+       The layout of int is value
+         because it is the primitive immediate type int.
+       But the layout of int must be a sublayout of void
+         because of the definition of t at line 1, characters 0-22.
 |}];;
 
 (* Immediate_polymorphic_variant *)
@@ -60,9 +60,9 @@ Line 2, characters 29-30:
                                  ^
 Error: This expression has type [ `A | `B ]
        but an expression was expected of type 'a t = ('a : void)
-       The layout of [ `A | `B ] is value, because
-         it's an enumeration variant type (all constructors are constant).
-       But the layout of [ `A | `B ] must be a sublayout of void, because
-         of the definition of t at line 1, characters 0-22.
+       The layout of [ `A | `B ] is value
+         because it's an enumeration variant type (all constructors are constant).
+       But the layout of [ `A | `B ] must be a sublayout of void
+         because of the definition of t at line 1, characters 0-22.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -27,10 +27,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_void but an expression was expected of type
          'a A.t = ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of A.t has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of A.t has this layout.
 |}]
 
 type t = t_void A.t
@@ -40,10 +40,10 @@ Line 1, characters 9-15:
 1 | type t = t_void A.t
              ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of A.t has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of A.t has this layout.
 |}]
 
 
@@ -55,10 +55,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_void but an expression was expected of type
          'a B.t = ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of B.t has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of B.t has this layout.
 |}]
 
 type t = t_void B.t
@@ -68,10 +68,10 @@ Line 1, characters 9-15:
 1 | type t = t_void B.t
              ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of B.t has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of B.t has this layout.
 |}]
 
 let f (x : t_void): ('a, 'b) A.t2 = x
@@ -82,10 +82,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type t_void but an expression was expected of type
          ('a, 'b) A.t2 = ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the 1st type argument of A.t2 has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the 1st type argument of A.t2 has this layout.
 |}]
 
 type t = (t_void, t_value) A.t2
@@ -95,10 +95,10 @@ Line 1, characters 10-16:
 1 | type t = (t_void, t_value) A.t2
               ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the 1st type argument of A.t2 has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the 1st type argument of A.t2 has this layout.
 |}]
 
 type t = (t_value, t_void, t_void, t_void, t_void) A.t5
@@ -108,10 +108,10 @@ Line 1, characters 19-25:
 1 | type t = (t_value, t_void, t_void, t_void, t_void) A.t5
                        ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the 2nd type argument of A.t5 has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the 2nd type argument of A.t5 has this layout.
 |}]
 
 type t = (t_value, t_value, t_void, t_void, t_void) A.t5
@@ -121,10 +121,10 @@ Line 1, characters 28-34:
 1 | type t = (t_value, t_value, t_void, t_void, t_void) A.t5
                                 ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the 3rd type argument of A.t5 has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the 3rd type argument of A.t5 has this layout.
 |}]
 
 type t = (t_value, t_value, t_value, t_void, t_void) A.t5
@@ -134,10 +134,10 @@ Line 1, characters 37-43:
 1 | type t = (t_value, t_value, t_value, t_void, t_void) A.t5
                                          ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the 4th type argument of A.t5 has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the 4th type argument of A.t5 has this layout.
 |}]
 
 
@@ -148,10 +148,10 @@ Line 1, characters 46-52:
 1 | type t = (t_value, t_value, t_value, t_value, t_void) A.t5
                                                   ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the 5th type argument of A.t5 has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the 5th type argument of A.t5 has this layout.
 |}]
 
 let f (x: t_void) = A.f x
@@ -172,10 +172,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}]
 
 type ('a : value) t_v = 'a
@@ -194,10 +194,10 @@ Line 5, characters 20-44:
                         ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_vv = ('a : void)
        but an expression was expected of type 'b t_v = ('b : value)
-       The layout of 'a is value, because
-         of the definition of f2 at line 4, characters 9-10.
-       But the layout of 'a must overlap with void, because
-         of the definition of t_vv at line 2, characters 0-26.
+       The layout of 'a is value
+         because of the definition of f2 at line 4, characters 9-10.
+       But the layout of 'a must overlap with void
+         because of the definition of t_vv at line 2, characters 0-26.
 |}]
 
 type ('a : value) t_v = 'a
@@ -217,10 +217,10 @@ Line 6, characters 19-43:
                        ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_v2 = ('a : void)
        but an expression was expected of type 'b t_v = ('b : value)
-       The layout of 'a is value, because
-         of the definition of f at line 4, characters 6-19.
-       But the layout of 'a must overlap with void, because
-         of the definition of t_v2 at line 3, characters 0-22.
+       The layout of 'a is value
+         because of the definition of f at line 4, characters 6-19.
+       But the layout of 'a must overlap with void
+         because of the definition of t_v2 at line 3, characters 0-22.
 |}]
 
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -27,10 +27,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_void but an expression was expected of type
          'a A.t = ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of A.t has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of A.t has this layout.
 |}]
 
 type t = t_void A.t
@@ -40,10 +40,10 @@ Line 1, characters 9-15:
 1 | type t = t_void A.t
              ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of A.t has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of A.t has this layout.
 |}]
 
 
@@ -55,10 +55,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_void but an expression was expected of type
          'a B.t = ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of B.t has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of B.t has this layout.
 |}]
 
 type t = t_void B.t
@@ -68,10 +68,10 @@ Line 1, characters 9-15:
 1 | type t = t_void B.t
              ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of B.t has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of B.t has this layout.
 |}]
 
 let f (x : t_void): ('a, 'b) A.t2 = x
@@ -82,10 +82,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type t_void but an expression was expected of type
          ('a, 'b) A.t2 = ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the 1st type argument of A.t2 has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 1st type argument of A.t2 has this layout.
 |}]
 
 type t = (t_void, t_value) A.t2
@@ -95,10 +95,10 @@ Line 1, characters 10-16:
 1 | type t = (t_void, t_value) A.t2
               ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the 1st type argument of A.t2 has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 1st type argument of A.t2 has this layout.
 |}]
 
 type t = (t_value, t_void, t_void, t_void, t_void) A.t5
@@ -108,10 +108,10 @@ Line 1, characters 19-25:
 1 | type t = (t_value, t_void, t_void, t_void, t_void) A.t5
                        ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the 2nd type argument of A.t5 has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 2nd type argument of A.t5 has this layout.
 |}]
 
 type t = (t_value, t_value, t_void, t_void, t_void) A.t5
@@ -121,10 +121,10 @@ Line 1, characters 28-34:
 1 | type t = (t_value, t_value, t_void, t_void, t_void) A.t5
                                 ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the 3rd type argument of A.t5 has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 3rd type argument of A.t5 has this layout.
 |}]
 
 type t = (t_value, t_value, t_value, t_void, t_void) A.t5
@@ -134,10 +134,10 @@ Line 1, characters 37-43:
 1 | type t = (t_value, t_value, t_value, t_void, t_void) A.t5
                                          ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the 4th type argument of A.t5 has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 4th type argument of A.t5 has this layout.
 |}]
 
 
@@ -148,10 +148,10 @@ Line 1, characters 46-52:
 1 | type t = (t_value, t_value, t_value, t_value, t_void) A.t5
                                                   ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the 5th type argument of A.t5 has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the 5th type argument of A.t5 has this layout.
 |}]
 
 let f (x: t_void) = A.f x
@@ -172,10 +172,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}]
 
 type ('a : value) t_v = 'a
@@ -194,10 +194,10 @@ Line 5, characters 20-44:
                         ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_vv = ('a : void)
        but an expression was expected of type 'b t_v = ('b : value)
-       The layout of 'a is value
-         because of the definition of f2 at line 4, characters 9-10.
-       But the layout of 'a must overlap with void
-         because of the definition of t_vv at line 2, characters 0-26.
+       The layout of 'a is value, because
+         of the definition of f2 at line 4, characters 9-10.
+       But the layout of 'a must overlap with void, because
+         of the definition of t_vv at line 2, characters 0-26.
 |}]
 
 type ('a : value) t_v = 'a
@@ -217,10 +217,10 @@ Line 6, characters 19-43:
                        ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_v2 = ('a : void)
        but an expression was expected of type 'b t_v = ('b : value)
-       The layout of 'a is value
-         because of the definition of f at line 4, characters 6-19.
-       But the layout of 'a must overlap with void
-         because of the definition of t_v2 at line 3, characters 0-22.
+       The layout of 'a is value, because
+         of the definition of f at line 4, characters 6-19.
+       But the layout of 'a must overlap with void, because
+         of the definition of t_v2 at line 3, characters 0-22.
 |}]
 
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -45,10 +45,10 @@ Line 1, characters 9-14:
 1 | type t = t_any * t_any
              ^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 (* Probe *)
@@ -61,10 +61,10 @@ Line 1, characters 36-37:
 1 | let f: ('a : void) -> 'b = fun x -> x # baz
                                         ^
 Error: Object types must have layout value.
-       The layout of the type of this expression is void, because
-         of the annotation on the type variable 'a.
-       But the layout of the type of this expression must overlap with value, because
-         it's the type of an object.
+       The layout of the type of this expression is void
+         because of the annotation on the type variable 'a.
+       But the layout of the type of this expression must overlap with value
+         because it's the type of an object.
 |}];;
 
 (* Instance_variable *)
@@ -79,10 +79,10 @@ Line 4, characters 6-22:
 4 |       val baz : t_void
           ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of baz is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of baz must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of baz is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of baz must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 (* Object_field *)
@@ -93,10 +93,10 @@ Line 1, characters 18-25:
                       ^^^^^^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 (* Class_field *)
@@ -109,10 +109,10 @@ Line 3, characters 8-11:
 3 |     val bar: t_void = assert false
             ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of bar must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of bar is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of bar must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 (* Boxed_record *)
@@ -121,10 +121,10 @@ type r : void = {a:string}
 Line 1, characters 0-26:
 1 | type r : void = {a:string}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type r is value, because
-         it's a boxed record type.
-       But the layout of type r must be a sublayout of void, because
-         of the annotation on the declaration of the type r.
+Error: The layout of type r is value
+         because it's a boxed record type.
+       But the layout of type r must be a sublayout of void
+         because of the annotation on the declaration of the type r.
 |}];;
 
 (* Boxed_variant *)
@@ -133,10 +133,10 @@ type v : void = A of t_value
 Line 1, characters 0-28:
 1 | type v : void = A of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type v is value, because
-         it's a boxed variant type.
-       But the layout of type v must be a sublayout of void, because
-         of the annotation on the declaration of the type v.
+Error: The layout of type v is value
+         because it's a boxed variant type.
+       But the layout of type v must be a sublayout of void
+         because of the annotation on the declaration of the type v.
 |}];;
 
 (* Extensible_variant *)
@@ -145,10 +145,10 @@ type attr : void = ..
 Line 1, characters 0-21:
 1 | type attr : void = ..
     ^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type attr is value, because
-         it's an extensible variant type.
-       But the layout of type attr must be a sublayout of void, because
-         of the annotation on the declaration of the type attr.
+Error: The layout of type attr is value
+         because it's an extensible variant type.
+       But the layout of type attr must be a sublayout of void
+         because of the annotation on the declaration of the type attr.
 |}]
 
 (* Primitive *)
@@ -159,10 +159,10 @@ Line 1, characters 40-45:
                                             ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : void)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of void, because
-         of the annotation on the type variable 'a.
+       The layout of string is value
+         because it is the primitive value type string.
+       But the layout of string must be a sublayout of void
+         because of the annotation on the type variable 'a.
 |}];;
 
 (* Type_argument *)
@@ -173,10 +173,10 @@ Line 1, characters 21-22:
                          ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (* Tuple *)
@@ -187,10 +187,10 @@ Line 1, characters 40-45:
                                             ^^^^^
 Error: This expression has type 'b * 'c
        but an expression was expected of type ('a : void)
-       The layout of 'a * 'b is value, because
-         it's a tuple type.
-       But the layout of 'a * 'b must be a sublayout of void, because
-         of the annotation on the type variable 'a.
+       The layout of 'a * 'b is value
+         because it's a tuple type.
+       But the layout of 'a * 'b must be a sublayout of void
+         because of the annotation on the type variable 'a.
 |}];;
 
 (* Row_variable *)
@@ -206,10 +206,10 @@ Line 2, characters 36-37:
                                         ^
 Error: This expression has type [ `A of int | `B ]
        but an expression was expected of type 'a t = ('a : void)
-       The layout of [ `A of int | `B ] is value, because
-         it's a polymorphic variant type.
-       But the layout of [ `A of int | `B ] must be a sublayout of void, because
-         of the definition of t at line 1, characters 0-22.
+       The layout of [ `A of int | `B ] is value
+         because it's a polymorphic variant type.
+       But the layout of [ `A of int | `B ] must be a sublayout of void
+         because of the definition of t at line 1, characters 0-22.
 |}]
 
 (* Arrow *)
@@ -222,10 +222,10 @@ Line 2, characters 31-32:
                                    ^
 Error: This expression has type int -> int
        but an expression was expected of type 'a t = ('a : void)
-       The layout of int -> int is value, because
-         it's a function type.
-       But the layout of int -> int must be a sublayout of void, because
-         of the definition of t at line 1, characters 0-22.
+       The layout of int -> int is value
+         because it's a function type.
+       But the layout of int -> int must be a sublayout of void
+         because of the definition of t at line 1, characters 0-22.
 |}]
 
 (* Tfield *)
@@ -248,10 +248,10 @@ Line 4, characters 17-39:
                      ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type (module X_int)
        but an expression was expected of type 'a t = ('a : void)
-       The layout of (module X_int) is value, because
-         it's a first-class module type.
-       But the layout of (module X_int) must be a sublayout of void, because
-         of the definition of t at line 1, characters 0-22.
+       The layout of (module X_int) is value
+         because it's a first-class module type.
+       But the layout of (module X_int) must be a sublayout of void
+         because of the definition of t at line 1, characters 0-22.
 |}]
 
 (* Separability_check *)
@@ -265,10 +265,10 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type ('a : value)
        but an expression was expected of type ('b : void)
-       The layout of 'b is void, because
-         of the annotation on the type variable 'b.
-       But the layout of 'b must overlap with value, because
-         it is or unifies with an unannotated universal variable.
+       The layout of 'b is void
+         because of the annotation on the type variable 'b.
+       But the layout of 'b must overlap with value
+         because it is or unifies with an unannotated universal variable.
 |}];;
 
 (* Polymorphic_variant_field *)
@@ -279,10 +279,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (* Default_type_jkind *)
@@ -292,10 +292,10 @@ Line 1, characters 49-54:
 1 | type ('a : immediate) t2 = {a: 'a} and t3 = t t2 and t
                                                      ^^^^^
 Error:
-       The kind of t is value, because
-         an abstract type has the value kind by default.
-       But the kind of t must be a subkind of immediate, because
-         of the annotation on 'a in the declaration of the type t2.
+       The kind of t is value
+         because an abstract type has the value kind by default.
+       But the kind of t must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t2.
 |}];;
 
 (* Float_record_field *)
@@ -313,10 +313,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the element type of array comprehension.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the element type of array comprehension.
 |}];;
 
 (* Lazy_expression *)
@@ -327,10 +327,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a lazy expression.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a lazy expression.
 |}];;
 
 (* Class_type_argument *)
@@ -347,10 +347,10 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with void, because
-         of the definition of t at line 2, characters 2-20.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void
+         because of the definition of t at line 2, characters 2-20.
 |}];;
 
 (* Class_term_argument *)
@@ -362,10 +362,10 @@ Line 1, characters 10-25:
               ^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a term-level argument to a class constructor.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a term-level argument to a class constructor.
 |}];;
 
 (* Structure_element *)
@@ -375,10 +375,10 @@ Line 1, characters 28-34:
 1 | module type S = sig val x : t_void end
                                 ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of type t_void must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of type t_void must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 (* Debug_printer_argument *)
@@ -405,10 +405,10 @@ Line 2, characters 20-22:
 2 |   val f = fun () -> m1
                         ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (* Unknown *)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -292,9 +292,9 @@ Line 1, characters 49-54:
 1 | type ('a : immediate) t2 = {a: 'a} and t3 = t t2 and t
                                                      ^^^^^
 Error:
-       The layout of t is value, because
-         an abstract type has the value layout by default.
-       But the layout of t must be a sublayout of immediate, because
+       The kind of t is value, because
+         an abstract type has the value kind by default.
+       But the kind of t must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t2.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -292,9 +292,9 @@ Line 1, characters 49-54:
 1 | type ('a : immediate) t2 = {a: 'a} and t3 = t t2 and t
                                                      ^^^^^
 Error:
-       The kind of t is value, because
-         an abstract type has the value kind by default.
-       But the kind of t must be a subkind of immediate, because
+       The layout of t is value, because
+         an abstract type has the value layout by default.
+       But the layout of t must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t2.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -45,10 +45,10 @@ Line 1, characters 9-14:
 1 | type t = t_any * t_any
              ^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 (* Probe *)
@@ -61,10 +61,10 @@ Line 1, characters 36-37:
 1 | let f: ('a : void) -> 'b = fun x -> x # baz
                                         ^
 Error: Object types must have layout value.
-       The layout of the type of this expression is void
-         because of the annotation on the type variable 'a.
-       But the layout of the type of this expression must overlap with value
-         because it's the type of an object.
+       The layout of the type of this expression is void, because
+         of the annotation on the type variable 'a.
+       But the layout of the type of this expression must overlap with value, because
+         it's the type of an object.
 |}];;
 
 (* Instance_variable *)
@@ -79,10 +79,10 @@ Line 4, characters 6-22:
 4 |       val baz : t_void
           ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of baz is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of baz must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of baz is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of baz must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 (* Object_field *)
@@ -93,10 +93,10 @@ Line 1, characters 18-25:
                       ^^^^^^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 (* Class_field *)
@@ -109,10 +109,10 @@ Line 3, characters 8-11:
 3 |     val bar: t_void = assert false
             ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of bar must be a sublayout of value
-         because it's the type of a class field.
+       The layout of bar is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of bar must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 (* Boxed_record *)
@@ -121,10 +121,10 @@ type r : void = {a:string}
 Line 1, characters 0-26:
 1 | type r : void = {a:string}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type r is value
-         because it's a boxed record type.
-       But the layout of type r must be a sublayout of void
-         because of the annotation on the declaration of the type r.
+Error: The layout of type r is value, because
+         it's a boxed record type.
+       But the layout of type r must be a sublayout of void, because
+         of the annotation on the declaration of the type r.
 |}];;
 
 (* Boxed_variant *)
@@ -133,10 +133,10 @@ type v : void = A of t_value
 Line 1, characters 0-28:
 1 | type v : void = A of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type v is value
-         because it's a boxed variant type.
-       But the layout of type v must be a sublayout of void
-         because of the annotation on the declaration of the type v.
+Error: The layout of type v is value, because
+         it's a boxed variant type.
+       But the layout of type v must be a sublayout of void, because
+         of the annotation on the declaration of the type v.
 |}];;
 
 (* Extensible_variant *)
@@ -145,10 +145,10 @@ type attr : void = ..
 Line 1, characters 0-21:
 1 | type attr : void = ..
     ^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type attr is value
-         because it's an extensible variant type.
-       But the layout of type attr must be a sublayout of void
-         because of the annotation on the declaration of the type attr.
+Error: The layout of type attr is value, because
+         it's an extensible variant type.
+       But the layout of type attr must be a sublayout of void, because
+         of the annotation on the declaration of the type attr.
 |}]
 
 (* Primitive *)
@@ -159,10 +159,10 @@ Line 1, characters 40-45:
                                             ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : void)
-       The layout of string is value
-         because it is the primitive value type string.
-       But the layout of string must be a sublayout of void
-         because of the annotation on the type variable 'a.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of void, because
+         of the annotation on the type variable 'a.
 |}];;
 
 (* Type_argument *)
@@ -173,10 +173,10 @@ Line 1, characters 21-22:
                          ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* Tuple *)
@@ -187,10 +187,10 @@ Line 1, characters 40-45:
                                             ^^^^^
 Error: This expression has type 'b * 'c
        but an expression was expected of type ('a : void)
-       The layout of 'a * 'b is value
-         because it's a tuple type.
-       But the layout of 'a * 'b must be a sublayout of void
-         because of the annotation on the type variable 'a.
+       The layout of 'a * 'b is value, because
+         it's a tuple type.
+       But the layout of 'a * 'b must be a sublayout of void, because
+         of the annotation on the type variable 'a.
 |}];;
 
 (* Row_variable *)
@@ -206,10 +206,10 @@ Line 2, characters 36-37:
                                         ^
 Error: This expression has type [ `A of int | `B ]
        but an expression was expected of type 'a t = ('a : void)
-       The layout of [ `A of int | `B ] is value
-         because it's a polymorphic variant type.
-       But the layout of [ `A of int | `B ] must be a sublayout of void
-         because of the definition of t at line 1, characters 0-22.
+       The layout of [ `A of int | `B ] is value, because
+         it's a polymorphic variant type.
+       But the layout of [ `A of int | `B ] must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
 |}]
 
 (* Arrow *)
@@ -222,10 +222,10 @@ Line 2, characters 31-32:
                                    ^
 Error: This expression has type int -> int
        but an expression was expected of type 'a t = ('a : void)
-       The layout of int -> int is value
-         because it's a function type.
-       But the layout of int -> int must be a sublayout of void
-         because of the definition of t at line 1, characters 0-22.
+       The layout of int -> int is value, because
+         it's a function type.
+       But the layout of int -> int must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
 |}]
 
 (* Tfield *)
@@ -248,10 +248,10 @@ Line 4, characters 17-39:
                      ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type (module X_int)
        but an expression was expected of type 'a t = ('a : void)
-       The layout of (module X_int) is value
-         because it's a first-class module type.
-       But the layout of (module X_int) must be a sublayout of void
-         because of the definition of t at line 1, characters 0-22.
+       The layout of (module X_int) is value, because
+         it's a first-class module type.
+       But the layout of (module X_int) must be a sublayout of void, because
+         of the definition of t at line 1, characters 0-22.
 |}]
 
 (* Separability_check *)
@@ -265,10 +265,10 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type ('a : value)
        but an expression was expected of type ('b : void)
-       The layout of 'b is void
-         because of the annotation on the type variable 'b.
-       But the layout of 'b must overlap with value
-         because it is or unifies with an unannotated universal variable.
+       The layout of 'b is void, because
+         of the annotation on the type variable 'b.
+       But the layout of 'b must overlap with value, because
+         it is or unifies with an unannotated universal variable.
 |}];;
 
 (* Polymorphic_variant_field *)
@@ -279,10 +279,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 (* Default_type_jkind *)
@@ -292,10 +292,10 @@ Line 1, characters 49-54:
 1 | type ('a : immediate) t2 = {a: 'a} and t3 = t t2 and t
                                                      ^^^^^
 Error:
-       The kind of t is value
-         because an abstract type has the value kind by default.
-       But the kind of t must be a subkind of immediate
-         because of the annotation on 'a in the declaration of the type t2.
+       The kind of t is value, because
+         an abstract type has the value kind by default.
+       But the kind of t must be a subkind of immediate, because
+         of the annotation on 'a in the declaration of the type t2.
 |}];;
 
 (* Float_record_field *)
@@ -313,10 +313,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the element type of array comprehension.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the element type of array comprehension.
 |}];;
 
 (* Lazy_expression *)
@@ -327,10 +327,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a lazy expression.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a lazy expression.
 |}];;
 
 (* Class_type_argument *)
@@ -347,10 +347,10 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with void
-         because of the definition of t at line 2, characters 2-20.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 (* Class_term_argument *)
@@ -362,10 +362,10 @@ Line 1, characters 10-25:
               ^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a term-level argument to a class constructor.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a term-level argument to a class constructor.
 |}];;
 
 (* Structure_element *)
@@ -375,10 +375,10 @@ Line 1, characters 28-34:
 1 | module type S = sig val x : t_void end
                                 ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of type t_void must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of type t_void must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 (* Debug_printer_argument *)
@@ -405,10 +405,10 @@ Line 2, characters 20-22:
 2 |   val f = fun () -> m1
                         ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (* Unknown *)

--- a/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
@@ -113,10 +113,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_float32_id) = x, false;;
@@ -126,10 +126,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_float32_id = ('a : float32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float32_id is float32
-         because of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of 'a t_float32_id must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a t_float32_id is float32, because
+         of the definition of t_float32_id at line 2, characters 0-37.
+       But the layout of 'a t_float32_id must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : float32#) = x, false;;
@@ -139,10 +139,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type float32#
        but an expression was expected of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_float32 * string;;
@@ -151,10 +151,10 @@ Line 1, characters 12-21:
 1 | type t4_4 = t_float32 * string;;
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * float32#;;
@@ -163,10 +163,10 @@ Line 1, characters 18-26:
 1 | type t4_5 = int * float32#;;
                       ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : float32) t4_6 = 'a * 'a
@@ -175,10 +175,10 @@ Line 1, characters 27-29:
 1 | type ('a : float32) t4_6 = 'a * 'a
                                ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float32)
-       The layout of 'a is float32
-         because of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is float32, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -188,10 +188,10 @@ Line 1, characters 32-34:
 1 | type ('a : float32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float32)
-       The layout of 'a is float32
-         because of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is float32, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (*****************************************)
@@ -264,10 +264,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float32
-           because of the definition of t_float32_id at line 2, characters 0-37.
-         But the layout of 'a must overlap with value
-           because it instantiates an unannotated type parameter of t5_11,
+         The layout of 'a is float32, because
+           of the definition of t_float32_id at line 2, characters 0-37.
+         But the layout of 'a must overlap with value, because
+           it instantiates an unannotated type parameter of t5_11,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -303,10 +303,10 @@ Line 1, characters 31-40:
 1 | module type S6_1 = sig val x : t_float32 end
                                    ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of type t_float32 must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of type t_float32 must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_float32_id end
@@ -315,10 +315,10 @@ Line 1, characters 31-46:
 1 | module type S6_2 = sig val x : 'a t_float32_id end
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_float32_id is float32
-         because of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of type 'a t_float32_id must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type 'a t_float32_id is float32, because
+         of the definition of t_float32_id at line 2, characters 0-37.
+       But the layout of type 'a t_float32_id must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : float32# end
@@ -327,10 +327,10 @@ Line 1, characters 31-39:
 1 | module type S6_3 = sig val x : float32# end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of type float32# must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of type float32# must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -343,10 +343,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_float32_id) = `A x;;
@@ -356,10 +356,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type 'a t_float32_id = ('a : float32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float32_id is float32
-         because of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of 'a t_float32_id must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       The layout of 'a t_float32_id is float32, because
+         of the definition of t_float32_id at line 2, characters 0-37.
+       But the layout of 'a t_float32_id must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : float32#) = `A x;;
@@ -369,10 +369,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type float32#
        but an expression was expected of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_float32 ];;
@@ -381,10 +381,10 @@ Line 1, characters 20-29:
 1 | type f7_4 = [ `A of t_float32 ];;
                         ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : float32) f7_5 = [ `A of 'a ];;
@@ -393,10 +393,10 @@ Line 1, characters 35-37:
 1 | type ('a : float32) f7_5 = [ `A of 'a ];;
                                        ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float32)
-       The layout of 'a is float32
-         because of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       The layout of 'a is float32, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -421,10 +421,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_float32_id ());;
@@ -434,10 +434,10 @@ Line 1, characters 20-42:
                         ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_float32_id = ('a : float32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float32_id is float32
-         because of the definition of make_t_float32_id at line 2, characters 22-57.
-       But the layout of 'a t_float32_id must overlap with value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_float32_id is float32, because
+         of the definition of make_t_float32_id at line 2, characters 22-57.
+       But the layout of 'a t_float32_id must overlap with value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -447,10 +447,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type float32#
        but an expression was expected of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -615,10 +615,10 @@ Line 1, characters 15-28:
 1 | type t12_1 = < x : t_float32 >;;
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : float32) t12_2 = < x : 'a >;;
@@ -627,10 +627,10 @@ Line 1, characters 34-36:
 1 | type ('a : float32) t12_2 = < x : 'a >;;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float32)
-       The layout of 'a is float32
-         because of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value
-         because it's the type of an object field.
+       The layout of 'a is float32, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_float32 = assert false end;;
@@ -640,10 +640,10 @@ Line 1, characters 21-56:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_float32 but is expected to have type
          ('a : value)
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -654,10 +654,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_float32_id -> 'a t_float32_id = assert false
                  ^^
 Error: This type ('a : float32) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float32
-         because of the definition of t_float32_id at line 2, characters 0-37.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float32, because
+         of the definition of t_float32_id at line 2, characters 0-37.
 |}];;
 
 class c12_5 = object val x : t_float32 = assert false end;;
@@ -666,10 +666,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_float32 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of x must be a sublayout of value
-         because it's the type of a class field.
+       The layout of x is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : float32# end;;
@@ -679,10 +679,10 @@ Line 1, characters 26-45:
                               ^^^^^^^^^^^^^^^^^^^
 Error: The method x has type float32# but is expected to have type
          ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's the type of an object field.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : float32# end
@@ -691,10 +691,10 @@ Line 1, characters 26-42:
 1 | class type c12_7 = object val x : float32# end
                               ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float32
-         because it is the primitive float32 type float32#.
-       But the layout of x must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of x is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -705,10 +705,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_float32_id -> 'a t_float32_id
               ^^
 Error: This type ('a : float32) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float32
-         because of the definition of t_float32_id at line 2, characters 0-37.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float32, because
+         of the definition of t_float32_id at line 2, characters 0-37.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -744,10 +744,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float32
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_float32) (m2 : t_float32) = object
@@ -761,10 +761,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -780,10 +780,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_float32) = compare x x;;
@@ -793,10 +793,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_float32) = Marshal.to_bytes x;;
@@ -806,10 +806,10 @@ Line 1, characters 45-46:
                                                  ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_float32) = Hashtbl.hash x;;
@@ -819,10 +819,10 @@ Line 1, characters 41-42:
                                              ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32
-         because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_float32 is float32, because
+         of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 (***********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
@@ -113,10 +113,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_float32_id) = x, false;;
@@ -126,10 +126,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_float32_id = ('a : float32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float32_id is float32, because
-         of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of 'a t_float32_id must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a t_float32_id is float32
+         because of the definition of t_float32_id at line 2, characters 0-37.
+       But the layout of 'a t_float32_id must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : float32#) = x, false;;
@@ -139,10 +139,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type float32#
        but an expression was expected of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_float32 * string;;
@@ -151,10 +151,10 @@ Line 1, characters 12-21:
 1 | type t4_4 = t_float32 * string;;
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * float32#;;
@@ -163,10 +163,10 @@ Line 1, characters 18-26:
 1 | type t4_5 = int * float32#;;
                       ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type ('a : float32) t4_6 = 'a * 'a
@@ -175,10 +175,10 @@ Line 1, characters 27-29:
 1 | type ('a : float32) t4_6 = 'a * 'a
                                ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float32)
-       The layout of 'a is float32, because
-         of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is float32
+         because of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -188,10 +188,10 @@ Line 1, characters 32-34:
 1 | type ('a : float32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float32)
-       The layout of 'a is float32, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is float32
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}]
 
 (*****************************************)
@@ -264,10 +264,11 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float32, because
-           of the definition of t_float32_id at line 2, characters 0-37.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t5_11, defaulted to layout value.
+         The layout of 'a is float32
+           because of the definition of t_float32_id at line 2, characters 0-37.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t5_11,
+           defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;
@@ -302,10 +303,10 @@ Line 1, characters 31-40:
 1 | module type S6_1 = sig val x : t_float32 end
                                    ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of type t_float32 must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of type t_float32 must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_float32_id end
@@ -314,10 +315,10 @@ Line 1, characters 31-46:
 1 | module type S6_2 = sig val x : 'a t_float32_id end
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_float32_id is float32, because
-         of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of type 'a t_float32_id must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type 'a t_float32_id is float32
+         because of the definition of t_float32_id at line 2, characters 0-37.
+       But the layout of type 'a t_float32_id must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : float32# end
@@ -326,10 +327,10 @@ Line 1, characters 31-39:
 1 | module type S6_3 = sig val x : float32# end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of type float32# must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of type float32# must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 
@@ -342,10 +343,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_float32_id) = `A x;;
@@ -355,10 +356,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type 'a t_float32_id = ('a : float32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float32_id is float32, because
-         of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of 'a t_float32_id must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a t_float32_id is float32
+         because of the definition of t_float32_id at line 2, characters 0-37.
+       But the layout of 'a t_float32_id must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : float32#) = `A x;;
@@ -368,10 +369,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type float32#
        but an expression was expected of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_float32 ];;
@@ -380,10 +381,10 @@ Line 1, characters 20-29:
 1 | type f7_4 = [ `A of t_float32 ];;
                         ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : float32) f7_5 = [ `A of 'a ];;
@@ -392,10 +393,10 @@ Line 1, characters 35-37:
 1 | type ('a : float32) f7_5 = [ `A of 'a ];;
                                        ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float32)
-       The layout of 'a is float32, because
-         of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a is float32
+         because of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -420,10 +421,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_float32_id ());;
@@ -433,10 +434,10 @@ Line 1, characters 20-42:
                         ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_float32_id = ('a : float32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float32_id is float32, because
-         of the definition of make_t_float32_id at line 2, characters 22-57.
-       But the layout of 'a t_float32_id must overlap with value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_float32_id is float32
+         because of the definition of make_t_float32_id at line 2, characters 22-57.
+       But the layout of 'a t_float32_id must overlap with value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -446,10 +447,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type float32#
        but an expression was expected of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -614,10 +615,10 @@ Line 1, characters 15-28:
 1 | type t12_1 = < x : t_float32 >;;
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 type ('a : float32) t12_2 = < x : 'a >;;
@@ -626,10 +627,10 @@ Line 1, characters 34-36:
 1 | type ('a : float32) t12_2 = < x : 'a >;;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float32)
-       The layout of 'a is float32, because
-         of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a is float32
+         because of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value
+         because it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_float32 = assert false end;;
@@ -639,10 +640,10 @@ Line 1, characters 21-56:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_float32 but is expected to have type
          ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -653,10 +654,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_float32_id -> 'a t_float32_id = assert false
                  ^^
 Error: This type ('a : float32) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float32, because
-         of the definition of t_float32_id at line 2, characters 0-37.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float32
+         because of the definition of t_float32_id at line 2, characters 0-37.
 |}];;
 
 class c12_5 = object val x : t_float32 = assert false end;;
@@ -665,10 +666,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_float32 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of x must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of x is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of x must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : float32# end;;
@@ -678,10 +679,10 @@ Line 1, characters 26-45:
                               ^^^^^^^^^^^^^^^^^^^
 Error: The method x has type float32# but is expected to have type
          ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : float32# end
@@ -690,10 +691,10 @@ Line 1, characters 26-42:
 1 | class type c12_7 = object val x : float32# end
                               ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of x must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of x is float32
+         because it is the primitive float32 type float32#.
+       But the layout of x must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -704,10 +705,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_float32_id -> 'a t_float32_id
               ^^
 Error: This type ('a : float32) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float32, because
-         of the definition of t_float32_id at line 2, characters 0-37.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float32
+         because of the definition of t_float32_id at line 2, characters 0-37.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -743,10 +744,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float32
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_float32) (m2 : t_float32) = object
@@ -760,10 +761,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -779,10 +780,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_float32) = compare x x;;
@@ -792,10 +793,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_float32) = Marshal.to_bytes x;;
@@ -805,10 +806,10 @@ Line 1, characters 45-46:
                                                  ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_float32) = Hashtbl.hash x;;
@@ -818,10 +819,10 @@ Line 1, characters 41-42:
                                              ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 (***********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
@@ -113,10 +113,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_float32_id) = x, false;;
@@ -126,10 +126,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_float32_id = ('a : float32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float32_id is float32, because
-         of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of 'a t_float32_id must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a t_float32_id is float32
+         because of the definition of t_float32_id at line 2, characters 0-37.
+       But the layout of 'a t_float32_id must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : float32#) = x, false;;
@@ -139,10 +139,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type float32#
        but an expression was expected of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_float32 * string;;
@@ -151,10 +151,10 @@ Line 1, characters 12-21:
 1 | type t4_4 = t_float32 * string;;
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * float32#;;
@@ -163,10 +163,10 @@ Line 1, characters 18-26:
 1 | type t4_5 = int * float32#;;
                       ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type ('a : float32) t4_6 = 'a * 'a
@@ -175,10 +175,10 @@ Line 1, characters 27-29:
 1 | type ('a : float32) t4_6 = 'a * 'a
                                ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float32)
-       The layout of 'a is float32, because
-         of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is float32
+         because of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -188,10 +188,10 @@ Line 1, characters 32-34:
 1 | type ('a : float32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float32)
-       The layout of 'a is float32, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is float32
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}]
 
 (*****************************************)
@@ -264,10 +264,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float32, because
-           of the definition of t_float32_id at line 2, characters 0-37.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t5_11,
+         The layout of 'a is float32
+           because of the definition of t_float32_id at line 2, characters 0-37.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t5_11,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -303,10 +303,10 @@ Line 1, characters 31-40:
 1 | module type S6_1 = sig val x : t_float32 end
                                    ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of type t_float32 must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of type t_float32 must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_float32_id end
@@ -315,10 +315,10 @@ Line 1, characters 31-46:
 1 | module type S6_2 = sig val x : 'a t_float32_id end
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_float32_id is float32, because
-         of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of type 'a t_float32_id must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type 'a t_float32_id is float32
+         because of the definition of t_float32_id at line 2, characters 0-37.
+       But the layout of type 'a t_float32_id must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : float32# end
@@ -327,10 +327,10 @@ Line 1, characters 31-39:
 1 | module type S6_3 = sig val x : float32# end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of type float32# must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of type float32# must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 
@@ -343,10 +343,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_float32_id) = `A x;;
@@ -356,10 +356,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type 'a t_float32_id = ('a : float32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float32_id is float32, because
-         of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of 'a t_float32_id must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a t_float32_id is float32
+         because of the definition of t_float32_id at line 2, characters 0-37.
+       But the layout of 'a t_float32_id must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : float32#) = `A x;;
@@ -369,10 +369,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type float32#
        but an expression was expected of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_float32 ];;
@@ -381,10 +381,10 @@ Line 1, characters 20-29:
 1 | type f7_4 = [ `A of t_float32 ];;
                         ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : float32) f7_5 = [ `A of 'a ];;
@@ -393,10 +393,10 @@ Line 1, characters 35-37:
 1 | type ('a : float32) f7_5 = [ `A of 'a ];;
                                        ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float32)
-       The layout of 'a is float32, because
-         of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a is float32
+         because of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -421,10 +421,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_float32_id ());;
@@ -434,10 +434,10 @@ Line 1, characters 20-42:
                         ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_float32_id = ('a : float32)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float32_id is float32, because
-         of the definition of make_t_float32_id at line 2, characters 22-57.
-       But the layout of 'a t_float32_id must overlap with value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_float32_id is float32
+         because of the definition of make_t_float32_id at line 2, characters 22-57.
+       But the layout of 'a t_float32_id must overlap with value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -447,10 +447,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type float32#
        but an expression was expected of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -615,10 +615,10 @@ Line 1, characters 15-28:
 1 | type t12_1 = < x : t_float32 >;;
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 type ('a : float32) t12_2 = < x : 'a >;;
@@ -627,10 +627,10 @@ Line 1, characters 34-36:
 1 | type ('a : float32) t12_2 = < x : 'a >;;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float32)
-       The layout of 'a is float32, because
-         of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a is float32
+         because of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value
+         because it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_float32 = assert false end;;
@@ -640,10 +640,10 @@ Line 1, characters 21-56:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_float32 but is expected to have type
          ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -654,10 +654,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_float32_id -> 'a t_float32_id = assert false
                  ^^
 Error: This type ('a : float32) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float32, because
-         of the definition of t_float32_id at line 2, characters 0-37.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float32
+         because of the definition of t_float32_id at line 2, characters 0-37.
 |}];;
 
 class c12_5 = object val x : t_float32 = assert false end;;
@@ -666,10 +666,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_float32 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of x must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of x is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of x must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : float32# end;;
@@ -679,10 +679,10 @@ Line 1, characters 26-45:
                               ^^^^^^^^^^^^^^^^^^^
 Error: The method x has type float32# but is expected to have type
          ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : float32# end
@@ -691,10 +691,10 @@ Line 1, characters 26-42:
 1 | class type c12_7 = object val x : float32# end
                               ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of x must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of x is float32
+         because it is the primitive float32 type float32#.
+       But the layout of x must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -705,10 +705,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_float32_id -> 'a t_float32_id
               ^^
 Error: This type ('a : float32) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float32, because
-         of the definition of t_float32_id at line 2, characters 0-37.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float32
+         because of the definition of t_float32_id at line 2, characters 0-37.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -744,10 +744,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float32
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_float32) (m2 : t_float32) = object
@@ -761,10 +761,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -780,10 +780,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_float32) = compare x x;;
@@ -793,10 +793,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_float32) = Marshal.to_bytes x;;
@@ -806,10 +806,10 @@ Line 1, characters 45-46:
                                                  ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_float32) = Hashtbl.hash x;;
@@ -819,10 +819,10 @@ Line 1, characters 41-42:
                                              ^
 Error: This expression has type t_float32
        but an expression was expected of type ('a : value)
-       The layout of t_float32 is float32, because
-         of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float32 is float32
+         because of the definition of t_float32 at line 1, characters 0-24.
+       But the layout of t_float32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 (***********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float32/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float32/parsing.ml
@@ -38,10 +38,10 @@ Line 1, characters 9-17:
 1 | type t = float32# list;;
              ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let f (_ : float32# list) = ();;
@@ -50,10 +50,10 @@ Line 1, characters 11-19:
 1 | let f (_ : float32# list) = ();;
                ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C of float32# list;;
@@ -62,10 +62,10 @@ Line 1, characters 14-22:
 1 | type t = C of float32# list;;
                   ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C : float32# list -> t;;
@@ -74,10 +74,10 @@ Line 1, characters 13-21:
 1 | type t = C : float32# list -> t;;
                  ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* Syntax: float32#c
@@ -96,10 +96,10 @@ Line 1, characters 9-17:
 1 | type t = float32#c;;
              ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : float32#c) = ();;
@@ -108,10 +108,10 @@ Line 1, characters 11-19:
 1 | let f (_ : float32#c) = ();;
                ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of float32#c;;
@@ -120,10 +120,10 @@ Line 1, characters 14-22:
 1 | type t = C of float32#c;;
                   ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : float32#c -> t;;
@@ -132,10 +132,10 @@ Line 1, characters 13-21:
 1 | type t = C : float32#c -> t;;
                  ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: float32# c
@@ -147,10 +147,10 @@ Line 1, characters 9-17:
 1 | type t = float32# c;;
              ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : float32# c) = ();;
@@ -159,10 +159,10 @@ Line 1, characters 11-19:
 1 | let f (_ : float32# c) = ();;
                ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of float32# c;;
@@ -171,10 +171,10 @@ Line 1, characters 14-22:
 1 | type t = C of float32# c;;
                   ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : float32# c -> t;;
@@ -183,10 +183,10 @@ Line 1, characters 13-21:
 1 | type t = C : float32# c -> t;;
                  ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32
-         because it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float32# is float32, because
+         it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: float32 #c

--- a/ocaml/testsuite/tests/typing-layouts-float32/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float32/parsing.ml
@@ -38,10 +38,10 @@ Line 1, characters 9-17:
 1 | type t = float32# list;;
              ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let f (_ : float32# list) = ();;
@@ -50,10 +50,10 @@ Line 1, characters 11-19:
 1 | let f (_ : float32# list) = ();;
                ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 type t = C of float32# list;;
@@ -62,10 +62,10 @@ Line 1, characters 14-22:
 1 | type t = C of float32# list;;
                   ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 type t = C : float32# list -> t;;
@@ -74,10 +74,10 @@ Line 1, characters 13-21:
 1 | type t = C : float32# list -> t;;
                  ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (* Syntax: float32#c
@@ -96,10 +96,10 @@ Line 1, characters 9-17:
 1 | type t = float32#c;;
              ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 let f (_ : float32#c) = ();;
@@ -108,10 +108,10 @@ Line 1, characters 11-19:
 1 | let f (_ : float32#c) = ();;
                ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C of float32#c;;
@@ -120,10 +120,10 @@ Line 1, characters 14-22:
 1 | type t = C of float32#c;;
                   ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C : float32#c -> t;;
@@ -132,10 +132,10 @@ Line 1, characters 13-21:
 1 | type t = C : float32#c -> t;;
                  ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: float32# c
@@ -147,10 +147,10 @@ Line 1, characters 9-17:
 1 | type t = float32# c;;
              ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 let f (_ : float32# c) = ();;
@@ -159,10 +159,10 @@ Line 1, characters 11-19:
 1 | let f (_ : float32# c) = ();;
                ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C of float32# c;;
@@ -171,10 +171,10 @@ Line 1, characters 14-22:
 1 | type t = C of float32# c;;
                   ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C : float32# c -> t;;
@@ -183,10 +183,10 @@ Line 1, characters 13-21:
 1 | type t = C : float32# c -> t;;
                  ^^^^^^^^
 Error: This type float32# should be an instance of type ('a : value)
-       The layout of float32# is float32, because
-         it is the primitive float32 type float32#.
-       But the layout of float32# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float32# is float32
+         because it is the primitive float32 type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: float32 #c

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -113,10 +113,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_float64_id) = x, false;;
@@ -126,10 +126,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float64_id is float64
-         because of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of 'a t_float64_id must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a t_float64_id is float64, because
+         of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of 'a t_float64_id must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : float#) = x, false;;
@@ -139,10 +139,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_float64 * string;;
@@ -151,10 +151,10 @@ Line 1, characters 12-21:
 1 | type t4_4 = t_float64 * string;;
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * float#;;
@@ -163,10 +163,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * float#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : float64) t4_6 = 'a * 'a
@@ -175,10 +175,10 @@ Line 1, characters 27-29:
 1 | type ('a : float64) t4_6 = 'a * 'a
                                ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64
-         because of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -188,10 +188,10 @@ Line 1, characters 32-34:
 1 | type ('a : float64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float64)
-       The layout of 'a is float64
-         because of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (*****************************************)
@@ -269,10 +269,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64
-           because of the definition of t_float64_id at line 2, characters 0-37.
-         But the layout of 'a must overlap with value
-           because it instantiates an unannotated type parameter of t5_11,
+         The layout of 'a is float64, because
+           of the definition of t_float64_id at line 2, characters 0-37.
+         But the layout of 'a must overlap with value, because
+           it instantiates an unannotated type parameter of t5_11,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -308,10 +308,10 @@ Line 1, characters 31-40:
 1 | module type S6_1 = sig val x : t_float64 end
                                    ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of type t_float64 must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_float64_id end
@@ -320,10 +320,10 @@ Line 1, characters 31-46:
 1 | module type S6_2 = sig val x : 'a t_float64_id end
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_float64_id is float64
-         because of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of type 'a t_float64_id must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type 'a t_float64_id is float64, because
+         of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of type 'a t_float64_id must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : float# end
@@ -332,10 +332,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : float# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of type float# must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of type float# must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -348,10 +348,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_float64_id) = `A x;;
@@ -361,10 +361,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float64_id is float64
-         because of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of 'a t_float64_id must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       The layout of 'a t_float64_id is float64, because
+         of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of 'a t_float64_id must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : float#) = `A x;;
@@ -374,10 +374,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_float64 ];;
@@ -386,10 +386,10 @@ Line 1, characters 20-29:
 1 | type f7_4 = [ `A of t_float64 ];;
                         ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : float64) f7_5 = [ `A of 'a ];;
@@ -398,10 +398,10 @@ Line 1, characters 35-37:
 1 | type ('a : float64) f7_5 = [ `A of 'a ];;
                                        ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64
-         because of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -426,10 +426,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -439,10 +439,10 @@ Line 1, characters 20-42:
                         ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float64_id is float64
-         because of the definition of make_t_float64_id at line 2, characters 22-57.
-       But the layout of 'a t_float64_id must overlap with value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_float64_id is float64, because
+         of the definition of make_t_float64_id at line 2, characters 22-57.
+       But the layout of 'a t_float64_id must overlap with value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -452,10 +452,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -624,10 +624,10 @@ Line 1, characters 15-28:
 1 | type t12_1 = < x : t_float64 >;;
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : float64) t12_2 = < x : 'a >;;
@@ -636,10 +636,10 @@ Line 1, characters 34-36:
 1 | type ('a : float64) t12_2 = < x : 'a >;;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64
-         because of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value
-         because it's the type of an object field.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_float64 = assert false end;;
@@ -649,10 +649,10 @@ Line 1, characters 21-56:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_float64 but is expected to have type
          ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -663,10 +663,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_float64_id -> 'a t_float64_id = assert false
                  ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64
-         because of the definition of t_float64_id at line 2, characters 0-37.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t_float64_id at line 2, characters 0-37.
 |}];;
 
 class c12_5 = object val x : t_float64 = assert false end;;
@@ -675,10 +675,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_float64 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of x must be a sublayout of value
-         because it's the type of a class field.
+       The layout of x is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : float# end;;
@@ -687,10 +687,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : float# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type float# but is expected to have type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's the type of an object field.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : float# end
@@ -699,10 +699,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : float# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float64
-         because it is the primitive float64 type float#.
-       But the layout of x must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of x is float64, because
+         it is the primitive float64 type float#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -713,10 +713,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_float64_id -> 'a t_float64_id
               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64
-         because of the definition of t_float64_id at line 2, characters 0-37.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t_float64_id at line 2, characters 0-37.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -752,10 +752,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_float64) (m2 : t_float64) = object
@@ -769,10 +769,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -788,10 +788,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_float64) = compare x x;;
@@ -801,10 +801,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_float64) = Marshal.to_bytes x;;
@@ -814,10 +814,10 @@ Line 1, characters 45-46:
                                                  ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_float64) = Hashtbl.hash x;;
@@ -827,10 +827,10 @@ Line 1, characters 41-42:
                                              ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 (***********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -113,10 +113,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_float64_id) = x, false;;
@@ -126,10 +126,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float64_id is float64, because
-         of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of 'a t_float64_id must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a t_float64_id is float64
+         because of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of 'a t_float64_id must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : float#) = x, false;;
@@ -139,10 +139,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_float64 * string;;
@@ -151,10 +151,10 @@ Line 1, characters 12-21:
 1 | type t4_4 = t_float64 * string;;
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * float#;;
@@ -163,10 +163,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * float#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type ('a : float64) t4_6 = 'a * 'a
@@ -175,10 +175,10 @@ Line 1, characters 27-29:
 1 | type ('a : float64) t4_6 = 'a * 'a
                                ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -188,10 +188,10 @@ Line 1, characters 32-34:
 1 | type ('a : float64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}]
 
 (*****************************************)
@@ -269,10 +269,11 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64, because
-           of the definition of t_float64_id at line 2, characters 0-37.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t5_11, defaulted to layout value.
+         The layout of 'a is float64
+           because of the definition of t_float64_id at line 2, characters 0-37.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t5_11,
+           defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;
@@ -307,10 +308,10 @@ Line 1, characters 31-40:
 1 | module type S6_1 = sig val x : t_float64 end
                                    ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of type t_float64 must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_float64_id end
@@ -319,10 +320,10 @@ Line 1, characters 31-46:
 1 | module type S6_2 = sig val x : 'a t_float64_id end
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_float64_id is float64, because
-         of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of type 'a t_float64_id must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type 'a t_float64_id is float64
+         because of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of type 'a t_float64_id must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : float# end
@@ -331,10 +332,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : float# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of type float# must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of type float# must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 
@@ -347,10 +348,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_float64_id) = `A x;;
@@ -360,10 +361,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float64_id is float64, because
-         of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of 'a t_float64_id must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a t_float64_id is float64
+         because of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of 'a t_float64_id must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : float#) = `A x;;
@@ -373,10 +374,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_float64 ];;
@@ -385,10 +386,10 @@ Line 1, characters 20-29:
 1 | type f7_4 = [ `A of t_float64 ];;
                         ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : float64) f7_5 = [ `A of 'a ];;
@@ -397,10 +398,10 @@ Line 1, characters 35-37:
 1 | type ('a : float64) f7_5 = [ `A of 'a ];;
                                        ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -425,10 +426,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -438,10 +439,10 @@ Line 1, characters 20-42:
                         ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float64_id is float64, because
-         of the definition of make_t_float64_id at line 2, characters 22-57.
-       But the layout of 'a t_float64_id must overlap with value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_float64_id is float64
+         because of the definition of make_t_float64_id at line 2, characters 22-57.
+       But the layout of 'a t_float64_id must overlap with value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -451,10 +452,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -623,10 +624,10 @@ Line 1, characters 15-28:
 1 | type t12_1 = < x : t_float64 >;;
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 type ('a : float64) t12_2 = < x : 'a >;;
@@ -635,10 +636,10 @@ Line 1, characters 34-36:
 1 | type ('a : float64) t12_2 = < x : 'a >;;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value
+         because it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_float64 = assert false end;;
@@ -648,10 +649,10 @@ Line 1, characters 21-56:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_float64 but is expected to have type
          ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -662,10 +663,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_float64_id -> 'a t_float64_id = assert false
                  ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64, because
-         of the definition of t_float64_id at line 2, characters 0-37.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64
+         because of the definition of t_float64_id at line 2, characters 0-37.
 |}];;
 
 class c12_5 = object val x : t_float64 = assert false end;;
@@ -674,10 +675,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_float64 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of x must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of x is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of x must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : float# end;;
@@ -686,10 +687,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : float# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type float# but is expected to have type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : float# end
@@ -698,10 +699,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : float# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float64, because
-         it is the primitive float64 type float#.
-       But the layout of x must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of x is float64
+         because it is the primitive float64 type float#.
+       But the layout of x must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -712,10 +713,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_float64_id -> 'a t_float64_id
               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64, because
-         of the definition of t_float64_id at line 2, characters 0-37.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64
+         because of the definition of t_float64_id at line 2, characters 0-37.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -751,10 +752,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_float64) (m2 : t_float64) = object
@@ -768,10 +769,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -787,10 +788,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_float64) = compare x x;;
@@ -800,10 +801,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_float64) = Marshal.to_bytes x;;
@@ -813,10 +814,10 @@ Line 1, characters 45-46:
                                                  ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_float64) = Hashtbl.hash x;;
@@ -826,10 +827,10 @@ Line 1, characters 41-42:
                                              ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 (***********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -113,10 +113,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_float64_id) = x, false;;
@@ -126,10 +126,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float64_id is float64, because
-         of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of 'a t_float64_id must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a t_float64_id is float64
+         because of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of 'a t_float64_id must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : float#) = x, false;;
@@ -139,10 +139,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_float64 * string;;
@@ -151,10 +151,10 @@ Line 1, characters 12-21:
 1 | type t4_4 = t_float64 * string;;
                 ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * float#;;
@@ -163,10 +163,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * float#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type ('a : float64) t4_6 = 'a * 'a
@@ -175,10 +175,10 @@ Line 1, characters 27-29:
 1 | type ('a : float64) t4_6 = 'a * 'a
                                ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -188,10 +188,10 @@ Line 1, characters 32-34:
 1 | type ('a : float64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}]
 
 (*****************************************)
@@ -269,10 +269,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64, because
-           of the definition of t_float64_id at line 2, characters 0-37.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t5_11,
+         The layout of 'a is float64
+           because of the definition of t_float64_id at line 2, characters 0-37.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t5_11,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -308,10 +308,10 @@ Line 1, characters 31-40:
 1 | module type S6_1 = sig val x : t_float64 end
                                    ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of type t_float64 must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_float64_id end
@@ -320,10 +320,10 @@ Line 1, characters 31-46:
 1 | module type S6_2 = sig val x : 'a t_float64_id end
                                    ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_float64_id is float64, because
-         of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of type 'a t_float64_id must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type 'a t_float64_id is float64
+         because of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of type 'a t_float64_id must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : float# end
@@ -332,10 +332,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : float# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of type float# must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of type float# must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 
@@ -348,10 +348,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_float64_id) = `A x;;
@@ -361,10 +361,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float64_id is float64, because
-         of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of 'a t_float64_id must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a t_float64_id is float64
+         because of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of 'a t_float64_id must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : float#) = `A x;;
@@ -374,10 +374,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_float64 ];;
@@ -386,10 +386,10 @@ Line 1, characters 20-29:
 1 | type f7_4 = [ `A of t_float64 ];;
                         ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : float64) f7_5 = [ `A of 'a ];;
@@ -398,10 +398,10 @@ Line 1, characters 35-37:
 1 | type ('a : float64) f7_5 = [ `A of 'a ];;
                                        ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -426,10 +426,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_float64_id ());;
@@ -439,10 +439,10 @@ Line 1, characters 20-42:
                         ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_float64_id = ('a : float64)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_float64_id is float64, because
-         of the definition of make_t_float64_id at line 2, characters 22-57.
-       But the layout of 'a t_float64_id must overlap with value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_float64_id is float64
+         because of the definition of make_t_float64_id at line 2, characters 22-57.
+       But the layout of 'a t_float64_id must overlap with value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_floatu ());;
@@ -452,10 +452,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -624,10 +624,10 @@ Line 1, characters 15-28:
 1 | type t12_1 = < x : t_float64 >;;
                    ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 type ('a : float64) t12_2 = < x : 'a >;;
@@ -636,10 +636,10 @@ Line 1, characters 34-36:
 1 | type ('a : float64) t12_2 = < x : 'a >;;
                                       ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value
+         because it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_float64 = assert false end;;
@@ -649,10 +649,10 @@ Line 1, characters 21-56:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_float64 but is expected to have type
          ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -663,10 +663,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_float64_id -> 'a t_float64_id = assert false
                  ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64, because
-         of the definition of t_float64_id at line 2, characters 0-37.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64
+         because of the definition of t_float64_id at line 2, characters 0-37.
 |}];;
 
 class c12_5 = object val x : t_float64 = assert false end;;
@@ -675,10 +675,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_float64 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of x must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of x is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of x must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : float# end;;
@@ -687,10 +687,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : float# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type float# but is expected to have type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : float# end
@@ -699,10 +699,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : float# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is float64, because
-         it is the primitive float64 type float#.
-       But the layout of x must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of x is float64
+         because it is the primitive float64 type float#.
+       But the layout of x must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -713,10 +713,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_float64_id -> 'a t_float64_id
               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64, because
-         of the definition of t_float64_id at line 2, characters 0-37.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64
+         because of the definition of t_float64_id at line 2, characters 0-37.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -752,10 +752,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_float64) (m2 : t_float64) = object
@@ -769,10 +769,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -788,10 +788,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_float64) = compare x x;;
@@ -801,10 +801,10 @@ Line 1, characters 36-37:
                                         ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_float64) = Marshal.to_bytes x;;
@@ -814,10 +814,10 @@ Line 1, characters 45-46:
                                                  ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_float64) = Hashtbl.hash x;;
@@ -827,10 +827,10 @@ Line 1, characters 41-42:
                                              ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 1, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 (***********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -30,10 +30,10 @@ Line 1, characters 9-15:
 1 | type t = float# list;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let f (_ : float# list) = ();;
@@ -42,10 +42,10 @@ Line 1, characters 11-17:
 1 | let f (_ : float# list) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C of float# list;;
@@ -54,10 +54,10 @@ Line 1, characters 14-20:
 1 | type t = C of float# list;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C : float# list -> t;;
@@ -66,10 +66,10 @@ Line 1, characters 13-19:
 1 | type t = C : float# list -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* Syntax: float#c
@@ -88,10 +88,10 @@ Line 1, characters 9-15:
 1 | type t = float#c;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : float#c) = ();;
@@ -100,10 +100,10 @@ Line 1, characters 11-17:
 1 | let f (_ : float#c) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of float#c;;
@@ -112,10 +112,10 @@ Line 1, characters 14-20:
 1 | type t = C of float#c;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : float#c -> t;;
@@ -124,10 +124,10 @@ Line 1, characters 13-19:
 1 | type t = C : float#c -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: float# c
@@ -139,10 +139,10 @@ Line 1, characters 9-15:
 1 | type t = float# c;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : float# c) = ();;
@@ -151,10 +151,10 @@ Line 1, characters 11-17:
 1 | let f (_ : float# c) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of float# c;;
@@ -163,10 +163,10 @@ Line 1, characters 14-20:
 1 | type t = C of float# c;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : float# c -> t;;
@@ -175,10 +175,10 @@ Line 1, characters 13-19:
 1 | type t = C : float# c -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: float #c

--- a/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/parsing.ml
@@ -30,10 +30,10 @@ Line 1, characters 9-15:
 1 | type t = float# list;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let f (_ : float# list) = ();;
@@ -42,10 +42,10 @@ Line 1, characters 11-17:
 1 | let f (_ : float# list) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 type t = C of float# list;;
@@ -54,10 +54,10 @@ Line 1, characters 14-20:
 1 | type t = C of float# list;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 type t = C : float# list -> t;;
@@ -66,10 +66,10 @@ Line 1, characters 13-19:
 1 | type t = C : float# list -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (* Syntax: float#c
@@ -88,10 +88,10 @@ Line 1, characters 9-15:
 1 | type t = float#c;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 let f (_ : float#c) = ();;
@@ -100,10 +100,10 @@ Line 1, characters 11-17:
 1 | let f (_ : float#c) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C of float#c;;
@@ -112,10 +112,10 @@ Line 1, characters 14-20:
 1 | type t = C of float#c;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C : float#c -> t;;
@@ -124,10 +124,10 @@ Line 1, characters 13-19:
 1 | type t = C : float#c -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: float# c
@@ -139,10 +139,10 @@ Line 1, characters 9-15:
 1 | type t = float# c;;
              ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 let f (_ : float# c) = ();;
@@ -151,10 +151,10 @@ Line 1, characters 11-17:
 1 | let f (_ : float# c) = ();;
                ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C of float# c;;
@@ -163,10 +163,10 @@ Line 1, characters 14-20:
 1 | type t = C of float# c;;
                   ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C : float# c -> t;;
@@ -175,10 +175,10 @@ Line 1, characters 13-19:
 1 | type t = C : float# c -> t;;
                  ^^^^^^
 Error: This type float# should be an instance of type ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: float #c

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
@@ -3,7 +3,7 @@ File "insert.ml", line 5, characters 47-48:
                                                    ^
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
-       The layout of t_void is void
-         because of the definition of t_void at file "insert.ml", line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_void is void, because
+         of the definition of t_void at file "insert.ml", line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         of layout requirements from an imported definition.

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
@@ -3,7 +3,7 @@ File "insert.ml", line 5, characters 47-48:
                                                    ^
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
-       The layout of t_void is void, because
-         of the definition of t_void at file "insert.ml", line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_void is void
+         because of the definition of t_void at file "insert.ml", line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because of layout requirements from an imported definition.

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
@@ -3,7 +3,7 @@ File "insert_extensible.ml", line 5, characters 58-59:
                                                               ^
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
-       The layout of t_void is void, because
-         of the definition of t_void at file "insert_extensible.ml", line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_void is void
+         because of the definition of t_void at file "insert_extensible.ml", line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because of layout requirements from an imported definition.

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
@@ -3,7 +3,7 @@ File "insert_extensible.ml", line 5, characters 58-59:
                                                               ^
 Error: This expression has type t_void -> unit
        but an expression was expected of type 'a -> unit
-       The layout of t_void is void
-         because of the definition of t_void at file "insert_extensible.ml", line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_void is void, because
+         of the definition of t_void at file "insert_extensible.ml", line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         of layout requirements from an imported definition.

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -44,10 +44,10 @@ Line 1, characters 12-19:
                 ^^^^^^^
 Error: This type B.b_value = A.a_value should be an instance of type
          ('a : immediate)
-       The kind of B.b_value is value
-         because the .cmi file for A.a_value is missing.
-       But the kind of B.b_value must be a subkind of immediate
-         because of the definition of imm_arg at line 3, characters 0-29.
+       The kind of B.b_value is value, because
+         the .cmi file for A.a_value is missing.
+       But the kind of B.b_value must be a subkind of immediate, because
+         of the definition of imm_arg at line 3, characters 0-29.
        No .cmi file found containing A.a_value.
        Hint: Adding "a" to your dependencies might help.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -44,9 +44,9 @@ Line 1, characters 12-19:
                 ^^^^^^^
 Error: This type B.b_value = A.a_value should be an instance of type
          ('a : immediate)
-       The layout of B.b_value is value, because
+       The kind of B.b_value is value, because
          the .cmi file for A.a_value is missing.
-       But the layout of B.b_value must be a sublayout of immediate, because
+       But the kind of B.b_value must be a subkind of immediate, because
          of the definition of imm_arg at line 3, characters 0-29.
        No .cmi file found containing A.a_value.
        Hint: Adding "a" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -44,10 +44,10 @@ Line 1, characters 12-19:
                 ^^^^^^^
 Error: This type B.b_value = A.a_value should be an instance of type
          ('a : immediate)
-       The kind of B.b_value is value, because
-         the .cmi file for A.a_value is missing.
-       But the kind of B.b_value must be a subkind of immediate, because
-         of the definition of imm_arg at line 3, characters 0-29.
+       The kind of B.b_value is value
+         because the .cmi file for A.a_value is missing.
+       But the kind of B.b_value must be a subkind of immediate
+         because of the definition of imm_arg at line 3, characters 0-29.
        No .cmi file found containing A.a_value.
        Hint: Adding "a" to your dependencies might help.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -44,9 +44,9 @@ Line 1, characters 12-19:
                 ^^^^^^^
 Error: This type B.b_value = A.a_value should be an instance of type
          ('a : immediate)
-       The kind of B.b_value is value, because
+       The layout of B.b_value is value, because
          the .cmi file for A.a_value is missing.
-       But the kind of B.b_value must be a subkind of immediate, because
+       But the layout of B.b_value must be a sublayout of immediate, because
          of the definition of imm_arg at line 3, characters 0-29.
        No .cmi file found containing A.a_value.
        Hint: Adding "a" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
@@ -23,10 +23,10 @@ Line 1, characters 40-54:
 1 | let f0 (g : Function_b.fun_t) = g ~arg1:(assert false)
                                             ^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any
-         because the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -38,10 +38,10 @@ Line 1, characters 34-36:
 1 | let f1 (g : Function_b.fun_t) = g ()
                                       ^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any
-         because the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -53,10 +53,10 @@ Line 1, characters 28-56:
 1 | let f2 : Function_b.fun_t = fun ~arg1:_ ~arg2 () -> arg2
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any
-         because the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -68,10 +68,10 @@ Line 1, characters 31-53:
 1 | let f3 : Function_b.return_t = fun () -> assert false
                                    ^^^^^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any
-         because the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable
-         because we must know concretely how to return a function result.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         we must know concretely how to return a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -85,10 +85,10 @@ Line 2, characters 12-28:
 2 | let x1 = f4 Function_b.f_opt
                 ^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any
-         because the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -102,10 +102,10 @@ Line 2, characters 12-30:
 2 | let x2 = f5 Function_b.f_opt_2
                 ^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any
-         because the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable
-         because we must know concretely how to return a function result.
+       The layout of Function_a.t is any, because
+         the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable, because
+         we must know concretely how to return a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/function_arg.ml
@@ -23,10 +23,10 @@ Line 1, characters 40-54:
 1 | let f0 (g : Function_b.fun_t) = g ~arg1:(assert false)
                                             ^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any, because
-         the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of Function_a.t is any
+         because the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable
+         because we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -38,10 +38,10 @@ Line 1, characters 34-36:
 1 | let f1 (g : Function_b.fun_t) = g ()
                                       ^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any, because
-         the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of Function_a.t is any
+         because the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable
+         because we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -53,10 +53,10 @@ Line 1, characters 28-56:
 1 | let f2 : Function_b.fun_t = fun ~arg1:_ ~arg2 () -> arg2
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any, because
-         the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of Function_a.t is any
+         because the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable
+         because we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -68,10 +68,10 @@ Line 1, characters 31-53:
 1 | let f3 : Function_b.return_t = fun () -> assert false
                                    ^^^^^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any, because
-         the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable, because
-         we must know concretely how to return a function result.
+       The layout of Function_a.t is any
+         because the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable
+         because we must know concretely how to return a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -85,10 +85,10 @@ Line 2, characters 12-28:
 2 | let x1 = f4 Function_b.f_opt
                 ^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any, because
-         the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of Function_a.t is any
+         because the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable
+         because we must know concretely how to pass a function argument.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]
@@ -102,10 +102,10 @@ Line 2, characters 12-30:
 2 | let x2 = f5 Function_b.f_opt_2
                 ^^^^^^^^^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of Function_a.t is any, because
-         the .cmi file for Function_a.t is missing.
-       But the layout of Function_a.t must be representable, because
-         we must know concretely how to return a function result.
+       The layout of Function_a.t is any
+         because the .cmi file for Function_a.t is missing.
+       But the layout of Function_a.t must be representable
+         because we must know concretely how to return a function result.
        No .cmi file found containing Function_a.t.
        Hint: Adding "function_a" to your dependencies might help.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -27,10 +27,10 @@ Line 1, characters 6-26:
 Error: This pattern matches values of type t_any_non_null
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_1)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable
+         because we must know concretely how to pass a function argument.
 |}]
 
 type t = { x : t_any_non_null }
@@ -40,10 +40,10 @@ Line 1, characters 11-29:
 1 | type t = { x : t_any_non_null }
                ^^^^^^^^^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be representable, because
-         it is the type of record field x.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable
+         because it is the type of record field x.
 |}]
 
 module type S1 = sig
@@ -55,10 +55,10 @@ Line 2, characters 10-24:
 2 |   val x : t_any_non_null
               ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of type t_any_non_null must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of type t_any_non_null must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}]
 
 module type S2 = sig
@@ -80,10 +80,10 @@ Line 2, characters 13-19:
                  ^^^^^^
 Error: This expression has type t_any_non_null
        but an expression was expected of type ('a : '_representable_layout_2)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be representable, because
-         we must know concretely how to return a function result.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable
+         because we must know concretely how to return a function result.
 |}]
 
 (* CR layouts v3.0: [value_or_null] should be representable *)
@@ -96,10 +96,11 @@ Line 1, characters 6-27:
           ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         we must know concretely how to pass a function argument, defaulted to kind value.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because we must know concretely how to pass a function argument,
+         defaulted to kind value.
 |}]
 
 type t = { x : t_value_or_null }
@@ -109,10 +110,11 @@ Line 1, characters 11-30:
 1 | type t = { x : t_value_or_null }
                ^^^^^^^^^^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         it is the type of record field x, defaulted to kind value.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because it is the type of record field x,
+         defaulted to kind value.
 |}]
 
 module type S1 = sig
@@ -124,10 +126,10 @@ Line 2, characters 10-25:
 2 |   val x : t_value_or_null
               ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The kind of type t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of type t_value_or_null must be a subkind of value, because
-         it's the type of something stored in a module structure.
+       The kind of type t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of type t_value_or_null must be a subkind of value
+         because it's the type of something stored in a module structure.
 |}]
 
 module type S2 = sig
@@ -148,10 +150,11 @@ Line 2, characters 13-19:
                  ^^^^^^
 Error: This expression has type t_value_or_null
        but an expression was expected of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         we must know concretely how to return a function result, defaulted to kind value.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because we must know concretely how to return a function result,
+         defaulted to kind value.
 |}]
 
 type ('a : any) id_any = 'a
@@ -192,10 +195,10 @@ Line 1, characters 9-14:
 1 | type t = t_any id_any_non_null
              ^^^^^
 Error: This type t_any should be an instance of type ('a : any_non_null)
-       The kind of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the kind of t_any must be a subkind of any_non_null, because
-         of the definition of id_any_non_null at line 2, characters 0-45.
+       The kind of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the kind of t_any must be a subkind of any_non_null
+         because of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
 module M (X : sig type t : any end) : sig type t : any_non_null end = X
@@ -213,10 +216,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The kind of the first is any, because
-         of the definition of t at line 1, characters 18-30.
-       But the kind of the first must be a subkind of any_non_null, because
-         of the definition of t at line 1, characters 42-63.
+       The kind of the first is any
+         because of the definition of t at line 1, characters 18-30.
+       But the kind of the first must be a subkind of any_non_null
+         because of the definition of t at line 1, characters 42-63.
 |}]
 
 (* [value] is a sublayout of [value_or_null] *)
@@ -243,10 +246,10 @@ Line 1, characters 9-24:
 1 | type t = t_value_or_null id_value
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of id_value at line 4, characters 0-31.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of id_value at line 4, characters 0-31.
 |}]
 
 module M (X : sig type t : value_or_null end) : sig type t : value end = X
@@ -264,10 +267,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value
-       The kind of the first is value_or_null, because
-         of the definition of t at line 1, characters 18-40.
-       But the kind of the first must be a subkind of value, because
-         of the definition of t at line 1, characters 52-66.
+       The kind of the first is value_or_null
+         because of the definition of t at line 1, characters 18-40.
+       But the kind of the first must be a subkind of value
+         because of the definition of t at line 1, characters 52-66.
 |}]
 
 (* [value] is a sublayout of [any_non_null] *)
@@ -295,10 +298,10 @@ Line 1, characters 9-24:
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type
          ('a : any_non_null)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of any_non_null, because
-         of the definition of id_any_non_null at line 2, characters 0-45.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of any_non_null
+         because of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
 module M (X : sig type t : value_or_null end) : sig type t : any_non_null end = X
@@ -316,10 +319,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The kind of the first is value_or_null, because
-         of the definition of t at line 1, characters 18-40.
-       But the kind of the first must be a subkind of any_non_null, because
-         of the definition of t at line 1, characters 52-73.
+       The kind of the first is value_or_null
+         because of the definition of t at line 1, characters 18-40.
+       But the kind of the first must be a subkind of any_non_null
+         because of the definition of t at line 1, characters 52-73.
 |}]
 
 (* [value_or_null] is a sublayout of [any] *)
@@ -361,10 +364,10 @@ Line 1, characters 9-23:
 1 | type t = t_any_non_null id_value
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : value)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of value, because
-         of the definition of id_value at line 4, characters 0-31.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of value
+         because of the definition of id_value at line 4, characters 0-31.
 |}]
 
 module M (X : sig type t : any_non_null end) : sig type t : value end = X
@@ -382,10 +385,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value
-       The layout of the first is any, because
-         of the definition of t at line 1, characters 18-39.
-       But the layout of the first must be a sublayout of value, because
-         of the definition of t at line 1, characters 51-65.
+       The layout of the first is any
+         because of the definition of t at line 1, characters 18-39.
+       But the layout of the first must be a sublayout of value
+         because of the definition of t at line 1, characters 51-65.
 |}]
 
 (* [any_non_null] is not a sublayout of [value_or_null] *)
@@ -398,10 +401,10 @@ Line 1, characters 9-23:
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type
          ('a : value_or_null)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of value, because
-         of the definition of id_value_or_null at line 3, characters 0-47.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of value
+         because of the definition of id_value_or_null at line 3, characters 0-47.
 |}]
 
 module M (X : sig type t : any_non_null end) : sig type t : value_or_null end = X
@@ -419,10 +422,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value_or_null
-       The layout of the first is any, because
-         of the definition of t at line 1, characters 18-39.
-       But the layout of the first must be a sublayout of value, because
-         of the definition of t at line 1, characters 51-73.
+       The layout of the first is any
+         because of the definition of t at line 1, characters 18-39.
+       But the layout of the first must be a sublayout of value
+         because of the definition of t at line 1, characters 51-73.
 |}]
 
 (* [any_non_null] is not a sublayout of [bits64] (and presumably similar jkinds) *)
@@ -434,10 +437,10 @@ Line 1, characters 9-23:
 1 | type t = t_any_non_null id_bits64
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : bits64)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of bits64, because
-         of the definition of id_bits64 at line 5, characters 0-33.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of bits64
+         because of the definition of id_bits64 at line 5, characters 0-33.
 |}]
 
 module M (X : sig type t : any_non_null end) : sig type t : bits64 end = X
@@ -455,10 +458,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : bits64
-       The layout of the first is any, because
-         of the definition of t at line 1, characters 18-39.
-       But the layout of the first must be a sublayout of bits64, because
-         of the definition of t at line 1, characters 51-66.
+       The layout of the first is any
+         because of the definition of t at line 1, characters 18-39.
+       But the layout of the first must be a sublayout of bits64
+         because of the definition of t at line 1, characters 51-66.
 |}]
 
 (* The meet of [any_non_null] and [value_or_null] is [value] *)
@@ -482,10 +485,10 @@ Line 1, characters 19-34:
 1 | type should_fail = t_value_or_null t1
                        ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of t1 at line 3, characters 0-66.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of t1 at line 3, characters 0-66.
 |}]
 
 type should_fail = t_any_non_null t1
@@ -495,8 +498,8 @@ Line 1, characters 19-33:
 1 | type should_fail = t_any_non_null t1
                        ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : value)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of value, because
-         of the definition of t1 at line 3, characters 0-66.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of value
+         because of the definition of t1 at line 3, characters 0-66.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -27,7 +27,7 @@ Line 1, characters 6-26:
 Error: This pattern matches values of type t_any_non_null
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_1)
-       The layout of t_any_non_null is any_non_null, because
+       The layout of t_any_non_null is any, because
          of the definition of t_any_non_null at line 2, characters 0-34.
        But the layout of t_any_non_null must be representable, because
          we must know concretely how to pass a function argument.
@@ -40,7 +40,7 @@ Line 1, characters 11-29:
 1 | type t = { x : t_any_non_null }
                ^^^^^^^^^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any_non_null is any_non_null, because
+       The layout of t_any_non_null is any, because
          of the definition of t_any_non_null at line 2, characters 0-34.
        But the layout of t_any_non_null must be representable, because
          it is the type of record field x.
@@ -55,7 +55,7 @@ Line 2, characters 10-24:
 2 |   val x : t_any_non_null
               ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_any_non_null is any_non_null, because
+       The layout of type t_any_non_null is any, because
          of the definition of t_any_non_null at line 2, characters 0-34.
        But the layout of type t_any_non_null must be a sublayout of value, because
          it's the type of something stored in a module structure.
@@ -80,7 +80,7 @@ Line 2, characters 13-19:
                  ^^^^^^
 Error: This expression has type t_any_non_null
        but an expression was expected of type ('a : '_representable_layout_2)
-       The layout of t_any_non_null is any_non_null, because
+       The layout of t_any_non_null is any, because
          of the definition of t_any_non_null at line 2, characters 0-34.
        But the layout of t_any_non_null must be representable, because
          we must know concretely how to return a function result.
@@ -96,10 +96,10 @@ Line 1, characters 6-27:
           ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
-         we must know concretely how to pass a function argument, defaulted to layout value.
+       But the kind of t_value_or_null must be a subkind of value, because
+         we must know concretely how to pass a function argument, defaulted to kind value.
 |}]
 
 type t = { x : t_value_or_null }
@@ -109,10 +109,10 @@ Line 1, characters 11-30:
 1 | type t = { x : t_value_or_null }
                ^^^^^^^^^^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
-         it is the type of record field x, defaulted to layout value.
+       But the kind of t_value_or_null must be a subkind of value, because
+         it is the type of record field x, defaulted to kind value.
 |}]
 
 module type S1 = sig
@@ -124,9 +124,9 @@ Line 2, characters 10-25:
 2 |   val x : t_value_or_null
               ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_value_or_null is value_or_null, because
+       The kind of type t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of type t_value_or_null must be a sublayout of value, because
+       But the kind of type t_value_or_null must be a subkind of value, because
          it's the type of something stored in a module structure.
 |}]
 
@@ -148,10 +148,10 @@ Line 2, characters 13-19:
                  ^^^^^^
 Error: This expression has type t_value_or_null
        but an expression was expected of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
-         we must know concretely how to return a function result, defaulted to layout value.
+       But the kind of t_value_or_null must be a subkind of value, because
+         we must know concretely how to return a function result, defaulted to kind value.
 |}]
 
 type ('a : any) id_any = 'a
@@ -192,9 +192,9 @@ Line 1, characters 9-14:
 1 | type t = t_any id_any_non_null
              ^^^^^
 Error: This type t_any should be an instance of type ('a : any_non_null)
-       The layout of t_any is any, because
+       The kind of t_any is any, because
          of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be a sublayout of any_non_null, because
+       But the kind of t_any must be a subkind of any_non_null, because
          of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
@@ -213,9 +213,9 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The layout of the first is any, because
+       The kind of the first is any, because
          of the definition of t at line 1, characters 18-30.
-       But the layout of the first must be a sublayout of any_non_null, because
+       But the kind of the first must be a subkind of any_non_null, because
          of the definition of t at line 1, characters 42-63.
 |}]
 
@@ -243,9 +243,9 @@ Line 1, characters 9-24:
 1 | type t = t_value_or_null id_value
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of id_value at line 4, characters 0-31.
 |}]
 
@@ -264,9 +264,9 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value
-       The layout of the first is value_or_null, because
+       The kind of the first is value_or_null, because
          of the definition of t at line 1, characters 18-40.
-       But the layout of the first must be a sublayout of value, because
+       But the kind of the first must be a subkind of value, because
          of the definition of t at line 1, characters 52-66.
 |}]
 
@@ -295,9 +295,9 @@ Line 1, characters 9-24:
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type
          ('a : any_non_null)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of any_non_null, because
+       But the kind of t_value_or_null must be a subkind of any_non_null, because
          of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
@@ -316,9 +316,9 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The layout of the first is value_or_null, because
+       The kind of the first is value_or_null, because
          of the definition of t at line 1, characters 18-40.
-       But the layout of the first must be a sublayout of any_non_null, because
+       But the kind of the first must be a subkind of any_non_null, because
          of the definition of t at line 1, characters 52-73.
 |}]
 
@@ -361,7 +361,7 @@ Line 1, characters 9-23:
 1 | type t = t_any_non_null id_value
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : value)
-       The layout of t_any_non_null is any_non_null, because
+       The layout of t_any_non_null is any, because
          of the definition of t_any_non_null at line 2, characters 0-34.
        But the layout of t_any_non_null must be a sublayout of value, because
          of the definition of id_value at line 4, characters 0-31.
@@ -382,7 +382,7 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value
-       The layout of the first is any_non_null, because
+       The layout of the first is any, because
          of the definition of t at line 1, characters 18-39.
        But the layout of the first must be a sublayout of value, because
          of the definition of t at line 1, characters 51-65.
@@ -398,9 +398,9 @@ Line 1, characters 9-23:
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type
          ('a : value_or_null)
-       The layout of t_any_non_null is any_non_null, because
+       The layout of t_any_non_null is any, because
          of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of value_or_null, because
+       But the layout of t_any_non_null must be a sublayout of value, because
          of the definition of id_value_or_null at line 3, characters 0-47.
 |}]
 
@@ -419,9 +419,9 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value_or_null
-       The layout of the first is any_non_null, because
+       The layout of the first is any, because
          of the definition of t at line 1, characters 18-39.
-       But the layout of the first must be a sublayout of value_or_null, because
+       But the layout of the first must be a sublayout of value, because
          of the definition of t at line 1, characters 51-73.
 |}]
 
@@ -434,7 +434,7 @@ Line 1, characters 9-23:
 1 | type t = t_any_non_null id_bits64
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : bits64)
-       The layout of t_any_non_null is any_non_null, because
+       The layout of t_any_non_null is any, because
          of the definition of t_any_non_null at line 2, characters 0-34.
        But the layout of t_any_non_null must be a sublayout of bits64, because
          of the definition of id_bits64 at line 5, characters 0-33.
@@ -455,7 +455,7 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : bits64
-       The layout of the first is any_non_null, because
+       The layout of the first is any, because
          of the definition of t at line 1, characters 18-39.
        But the layout of the first must be a sublayout of bits64, because
          of the definition of t at line 1, characters 51-66.
@@ -482,9 +482,9 @@ Line 1, characters 19-34:
 1 | type should_fail = t_value_or_null t1
                        ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of t1 at line 3, characters 0-66.
 |}]
 
@@ -495,7 +495,7 @@ Line 1, characters 19-33:
 1 | type should_fail = t_any_non_null t1
                        ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : value)
-       The layout of t_any_non_null is any_non_null, because
+       The layout of t_any_non_null is any, because
          of the definition of t_any_non_null at line 2, characters 0-34.
        But the layout of t_any_non_null must be a sublayout of value, because
          of the definition of t1 at line 3, characters 0-66.

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -27,10 +27,10 @@ Line 1, characters 6-26:
 Error: This pattern matches values of type t_any_non_null
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_1)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable
+         because we must know concretely how to pass a function argument.
 |}]
 
 type t = { x : t_any_non_null }
@@ -40,10 +40,10 @@ Line 1, characters 11-29:
 1 | type t = { x : t_any_non_null }
                ^^^^^^^^^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be representable, because
-         it is the type of record field x.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable
+         because it is the type of record field x.
 |}]
 
 module type S1 = sig
@@ -55,10 +55,10 @@ Line 2, characters 10-24:
 2 |   val x : t_any_non_null
               ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of type t_any_non_null must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of type t_any_non_null must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}]
 
 module type S2 = sig
@@ -80,10 +80,10 @@ Line 2, characters 13-19:
                  ^^^^^^
 Error: This expression has type t_any_non_null
        but an expression was expected of type ('a : '_representable_layout_2)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be representable, because
-         we must know concretely how to return a function result.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable
+         because we must know concretely how to return a function result.
 |}]
 
 (* CR layouts v3.0: [value_or_null] should be representable *)
@@ -96,10 +96,10 @@ Line 1, characters 6-27:
           ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         we must know concretely how to pass a function argument,
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because we must know concretely how to pass a function argument,
          defaulted to kind value.
 |}]
 
@@ -110,10 +110,10 @@ Line 1, characters 11-30:
 1 | type t = { x : t_value_or_null }
                ^^^^^^^^^^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         it is the type of record field x,
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because it is the type of record field x,
          defaulted to kind value.
 |}]
 
@@ -126,10 +126,10 @@ Line 2, characters 10-25:
 2 |   val x : t_value_or_null
               ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The kind of type t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of type t_value_or_null must be a subkind of value, because
-         it's the type of something stored in a module structure.
+       The kind of type t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of type t_value_or_null must be a subkind of value
+         because it's the type of something stored in a module structure.
 |}]
 
 module type S2 = sig
@@ -150,10 +150,10 @@ Line 2, characters 13-19:
                  ^^^^^^
 Error: This expression has type t_value_or_null
        but an expression was expected of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         we must know concretely how to return a function result,
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because we must know concretely how to return a function result,
          defaulted to kind value.
 |}]
 
@@ -195,10 +195,10 @@ Line 1, characters 9-14:
 1 | type t = t_any id_any_non_null
              ^^^^^
 Error: This type t_any should be an instance of type ('a : any_non_null)
-       The kind of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the kind of t_any must be a subkind of any_non_null, because
-         of the definition of id_any_non_null at line 2, characters 0-45.
+       The kind of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the kind of t_any must be a subkind of any_non_null
+         because of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
 module M (X : sig type t : any end) : sig type t : any_non_null end = X
@@ -216,10 +216,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The kind of the first is any, because
-         of the definition of t at line 1, characters 18-30.
-       But the kind of the first must be a subkind of any_non_null, because
-         of the definition of t at line 1, characters 42-63.
+       The kind of the first is any
+         because of the definition of t at line 1, characters 18-30.
+       But the kind of the first must be a subkind of any_non_null
+         because of the definition of t at line 1, characters 42-63.
 |}]
 
 (* [value] is a sublayout of [value_or_null] *)
@@ -246,10 +246,10 @@ Line 1, characters 9-24:
 1 | type t = t_value_or_null id_value
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of id_value at line 4, characters 0-31.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of id_value at line 4, characters 0-31.
 |}]
 
 module M (X : sig type t : value_or_null end) : sig type t : value end = X
@@ -267,10 +267,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value
-       The kind of the first is value_or_null, because
-         of the definition of t at line 1, characters 18-40.
-       But the kind of the first must be a subkind of value, because
-         of the definition of t at line 1, characters 52-66.
+       The kind of the first is value_or_null
+         because of the definition of t at line 1, characters 18-40.
+       But the kind of the first must be a subkind of value
+         because of the definition of t at line 1, characters 52-66.
 |}]
 
 (* [value] is a sublayout of [any_non_null] *)
@@ -298,10 +298,10 @@ Line 1, characters 9-24:
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type
          ('a : any_non_null)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of any_non_null, because
-         of the definition of id_any_non_null at line 2, characters 0-45.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of any_non_null
+         because of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
 module M (X : sig type t : value_or_null end) : sig type t : any_non_null end = X
@@ -319,10 +319,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The kind of the first is value_or_null, because
-         of the definition of t at line 1, characters 18-40.
-       But the kind of the first must be a subkind of any_non_null, because
-         of the definition of t at line 1, characters 52-73.
+       The kind of the first is value_or_null
+         because of the definition of t at line 1, characters 18-40.
+       But the kind of the first must be a subkind of any_non_null
+         because of the definition of t at line 1, characters 52-73.
 |}]
 
 (* [value_or_null] is a sublayout of [any] *)
@@ -364,10 +364,10 @@ Line 1, characters 9-23:
 1 | type t = t_any_non_null id_value
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : value)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of value, because
-         of the definition of id_value at line 4, characters 0-31.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of value
+         because of the definition of id_value at line 4, characters 0-31.
 |}]
 
 module M (X : sig type t : any_non_null end) : sig type t : value end = X
@@ -385,10 +385,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value
-       The layout of the first is any, because
-         of the definition of t at line 1, characters 18-39.
-       But the layout of the first must be a sublayout of value, because
-         of the definition of t at line 1, characters 51-65.
+       The layout of the first is any
+         because of the definition of t at line 1, characters 18-39.
+       But the layout of the first must be a sublayout of value
+         because of the definition of t at line 1, characters 51-65.
 |}]
 
 (* [any_non_null] is not a sublayout of [value_or_null] *)
@@ -401,10 +401,10 @@ Line 1, characters 9-23:
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type
          ('a : value_or_null)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of value, because
-         of the definition of id_value_or_null at line 3, characters 0-47.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of value
+         because of the definition of id_value_or_null at line 3, characters 0-47.
 |}]
 
 module M (X : sig type t : any_non_null end) : sig type t : value_or_null end = X
@@ -422,10 +422,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value_or_null
-       The layout of the first is any, because
-         of the definition of t at line 1, characters 18-39.
-       But the layout of the first must be a sublayout of value, because
-         of the definition of t at line 1, characters 51-73.
+       The layout of the first is any
+         because of the definition of t at line 1, characters 18-39.
+       But the layout of the first must be a sublayout of value
+         because of the definition of t at line 1, characters 51-73.
 |}]
 
 (* [any_non_null] is not a sublayout of [bits64] (and presumably similar jkinds) *)
@@ -437,10 +437,10 @@ Line 1, characters 9-23:
 1 | type t = t_any_non_null id_bits64
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : bits64)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of bits64, because
-         of the definition of id_bits64 at line 5, characters 0-33.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of bits64
+         because of the definition of id_bits64 at line 5, characters 0-33.
 |}]
 
 module M (X : sig type t : any_non_null end) : sig type t : bits64 end = X
@@ -458,10 +458,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : bits64
-       The layout of the first is any, because
-         of the definition of t at line 1, characters 18-39.
-       But the layout of the first must be a sublayout of bits64, because
-         of the definition of t at line 1, characters 51-66.
+       The layout of the first is any
+         because of the definition of t at line 1, characters 18-39.
+       But the layout of the first must be a sublayout of bits64
+         because of the definition of t at line 1, characters 51-66.
 |}]
 
 (* The meet of [any_non_null] and [value_or_null] is [value] *)
@@ -485,10 +485,10 @@ Line 1, characters 19-34:
 1 | type should_fail = t_value_or_null t1
                        ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of t1 at line 3, characters 0-66.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of t1 at line 3, characters 0-66.
 |}]
 
 type should_fail = t_any_non_null t1
@@ -498,8 +498,8 @@ Line 1, characters 19-33:
 1 | type should_fail = t_any_non_null t1
                        ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : value)
-       The layout of t_any_non_null is any, because
-         of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of value, because
-         of the definition of t1 at line 3, characters 0-66.
+       The layout of t_any_non_null is any
+         because of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of value
+         because of the definition of t1 at line 3, characters 0-66.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -96,11 +96,11 @@ Line 1, characters 6-27:
           ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          we must know concretely how to pass a function argument,
-         defaulted to kind value.
+         defaulted to layout value.
 |}]
 
 type t = { x : t_value_or_null }
@@ -110,11 +110,11 @@ Line 1, characters 11-30:
 1 | type t = { x : t_value_or_null }
                ^^^^^^^^^^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          it is the type of record field x,
-         defaulted to kind value.
+         defaulted to layout value.
 |}]
 
 module type S1 = sig
@@ -126,9 +126,9 @@ Line 2, characters 10-25:
 2 |   val x : t_value_or_null
               ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The kind of type t_value_or_null is value_or_null, because
+       The layout of type t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of type t_value_or_null must be a subkind of value, because
+       But the layout of type t_value_or_null must be a sublayout of value, because
          it's the type of something stored in a module structure.
 |}]
 
@@ -150,11 +150,11 @@ Line 2, characters 13-19:
                  ^^^^^^
 Error: This expression has type t_value_or_null
        but an expression was expected of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          we must know concretely how to return a function result,
-         defaulted to kind value.
+         defaulted to layout value.
 |}]
 
 type ('a : any) id_any = 'a
@@ -195,9 +195,9 @@ Line 1, characters 9-14:
 1 | type t = t_any id_any_non_null
              ^^^^^
 Error: This type t_any should be an instance of type ('a : any_non_null)
-       The kind of t_any is any, because
+       The layout of t_any is any, because
          of the definition of t_any at line 1, characters 0-16.
-       But the kind of t_any must be a subkind of any_non_null, because
+       But the layout of t_any must be a sublayout of any_non_null, because
          of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
@@ -216,9 +216,9 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The kind of the first is any, because
+       The layout of the first is any, because
          of the definition of t at line 1, characters 18-30.
-       But the kind of the first must be a subkind of any_non_null, because
+       But the layout of the first must be a sublayout of any_non_null, because
          of the definition of t at line 1, characters 42-63.
 |}]
 
@@ -246,9 +246,9 @@ Line 1, characters 9-24:
 1 | type t = t_value_or_null id_value
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          of the definition of id_value at line 4, characters 0-31.
 |}]
 
@@ -267,9 +267,9 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value
-       The kind of the first is value_or_null, because
+       The layout of the first is value_or_null, because
          of the definition of t at line 1, characters 18-40.
-       But the kind of the first must be a subkind of value, because
+       But the layout of the first must be a sublayout of value, because
          of the definition of t at line 1, characters 52-66.
 |}]
 
@@ -298,9 +298,9 @@ Line 1, characters 9-24:
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type
          ('a : any_non_null)
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of any_non_null, because
+       But the layout of t_value_or_null must be a sublayout of any_non_null, because
          of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
@@ -319,9 +319,9 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The kind of the first is value_or_null, because
+       The layout of the first is value_or_null, because
          of the definition of t at line 1, characters 18-40.
-       But the kind of the first must be a subkind of any_non_null, because
+       But the layout of the first must be a sublayout of any_non_null, because
          of the definition of t at line 1, characters 52-73.
 |}]
 
@@ -485,9 +485,9 @@ Line 1, characters 19-34:
 1 | type should_fail = t_value_or_null t1
                        ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          of the definition of t1 at line 3, characters 0-66.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -27,10 +27,10 @@ Line 1, characters 6-26:
 Error: This pattern matches values of type t_any_non_null
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_1)
-       The layout of t_any_non_null is any
-         because of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of t_any_non_null is any, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable, because
+         we must know concretely how to pass a function argument.
 |}]
 
 type t = { x : t_any_non_null }
@@ -40,10 +40,10 @@ Line 1, characters 11-29:
 1 | type t = { x : t_any_non_null }
                ^^^^^^^^^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any_non_null is any
-         because of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be representable
-         because it is the type of record field x.
+       The layout of t_any_non_null is any, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable, because
+         it is the type of record field x.
 |}]
 
 module type S1 = sig
@@ -55,10 +55,10 @@ Line 2, characters 10-24:
 2 |   val x : t_any_non_null
               ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_any_non_null is any
-         because of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of type t_any_non_null must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_any_non_null is any, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of type t_any_non_null must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}]
 
 module type S2 = sig
@@ -80,10 +80,10 @@ Line 2, characters 13-19:
                  ^^^^^^
 Error: This expression has type t_any_non_null
        but an expression was expected of type ('a : '_representable_layout_2)
-       The layout of t_any_non_null is any
-         because of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be representable
-         because we must know concretely how to return a function result.
+       The layout of t_any_non_null is any, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be representable, because
+         we must know concretely how to return a function result.
 |}]
 
 (* CR layouts v3.0: [value_or_null] should be representable *)
@@ -96,10 +96,10 @@ Line 1, characters 6-27:
           ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because we must know concretely how to pass a function argument,
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         we must know concretely how to pass a function argument,
          defaulted to kind value.
 |}]
 
@@ -110,10 +110,10 @@ Line 1, characters 11-30:
 1 | type t = { x : t_value_or_null }
                ^^^^^^^^^^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because it is the type of record field x,
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         it is the type of record field x,
          defaulted to kind value.
 |}]
 
@@ -126,10 +126,10 @@ Line 2, characters 10-25:
 2 |   val x : t_value_or_null
               ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The kind of type t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of type t_value_or_null must be a subkind of value
-         because it's the type of something stored in a module structure.
+       The kind of type t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of type t_value_or_null must be a subkind of value, because
+         it's the type of something stored in a module structure.
 |}]
 
 module type S2 = sig
@@ -150,10 +150,10 @@ Line 2, characters 13-19:
                  ^^^^^^
 Error: This expression has type t_value_or_null
        but an expression was expected of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because we must know concretely how to return a function result,
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         we must know concretely how to return a function result,
          defaulted to kind value.
 |}]
 
@@ -195,10 +195,10 @@ Line 1, characters 9-14:
 1 | type t = t_any id_any_non_null
              ^^^^^
 Error: This type t_any should be an instance of type ('a : any_non_null)
-       The kind of t_any is any
-         because of the definition of t_any at line 1, characters 0-16.
-       But the kind of t_any must be a subkind of any_non_null
-         because of the definition of id_any_non_null at line 2, characters 0-45.
+       The kind of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the kind of t_any must be a subkind of any_non_null, because
+         of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
 module M (X : sig type t : any end) : sig type t : any_non_null end = X
@@ -216,10 +216,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The kind of the first is any
-         because of the definition of t at line 1, characters 18-30.
-       But the kind of the first must be a subkind of any_non_null
-         because of the definition of t at line 1, characters 42-63.
+       The kind of the first is any, because
+         of the definition of t at line 1, characters 18-30.
+       But the kind of the first must be a subkind of any_non_null, because
+         of the definition of t at line 1, characters 42-63.
 |}]
 
 (* [value] is a sublayout of [value_or_null] *)
@@ -246,10 +246,10 @@ Line 1, characters 9-24:
 1 | type t = t_value_or_null id_value
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because of the definition of id_value at line 4, characters 0-31.
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         of the definition of id_value at line 4, characters 0-31.
 |}]
 
 module M (X : sig type t : value_or_null end) : sig type t : value end = X
@@ -267,10 +267,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value
-       The kind of the first is value_or_null
-         because of the definition of t at line 1, characters 18-40.
-       But the kind of the first must be a subkind of value
-         because of the definition of t at line 1, characters 52-66.
+       The kind of the first is value_or_null, because
+         of the definition of t at line 1, characters 18-40.
+       But the kind of the first must be a subkind of value, because
+         of the definition of t at line 1, characters 52-66.
 |}]
 
 (* [value] is a sublayout of [any_non_null] *)
@@ -298,10 +298,10 @@ Line 1, characters 9-24:
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type
          ('a : any_non_null)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of any_non_null
-         because of the definition of id_any_non_null at line 2, characters 0-45.
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of any_non_null, because
+         of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
 module M (X : sig type t : value_or_null end) : sig type t : any_non_null end = X
@@ -319,10 +319,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The kind of the first is value_or_null
-         because of the definition of t at line 1, characters 18-40.
-       But the kind of the first must be a subkind of any_non_null
-         because of the definition of t at line 1, characters 52-73.
+       The kind of the first is value_or_null, because
+         of the definition of t at line 1, characters 18-40.
+       But the kind of the first must be a subkind of any_non_null, because
+         of the definition of t at line 1, characters 52-73.
 |}]
 
 (* [value_or_null] is a sublayout of [any] *)
@@ -364,10 +364,10 @@ Line 1, characters 9-23:
 1 | type t = t_any_non_null id_value
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : value)
-       The layout of t_any_non_null is any
-         because of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of value
-         because of the definition of id_value at line 4, characters 0-31.
+       The layout of t_any_non_null is any, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of value, because
+         of the definition of id_value at line 4, characters 0-31.
 |}]
 
 module M (X : sig type t : any_non_null end) : sig type t : value end = X
@@ -385,10 +385,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value
-       The layout of the first is any
-         because of the definition of t at line 1, characters 18-39.
-       But the layout of the first must be a sublayout of value
-         because of the definition of t at line 1, characters 51-65.
+       The layout of the first is any, because
+         of the definition of t at line 1, characters 18-39.
+       But the layout of the first must be a sublayout of value, because
+         of the definition of t at line 1, characters 51-65.
 |}]
 
 (* [any_non_null] is not a sublayout of [value_or_null] *)
@@ -401,10 +401,10 @@ Line 1, characters 9-23:
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type
          ('a : value_or_null)
-       The layout of t_any_non_null is any
-         because of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of value
-         because of the definition of id_value_or_null at line 3, characters 0-47.
+       The layout of t_any_non_null is any, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of value, because
+         of the definition of id_value_or_null at line 3, characters 0-47.
 |}]
 
 module M (X : sig type t : any_non_null end) : sig type t : value_or_null end = X
@@ -422,10 +422,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value_or_null
-       The layout of the first is any
-         because of the definition of t at line 1, characters 18-39.
-       But the layout of the first must be a sublayout of value
-         because of the definition of t at line 1, characters 51-73.
+       The layout of the first is any, because
+         of the definition of t at line 1, characters 18-39.
+       But the layout of the first must be a sublayout of value, because
+         of the definition of t at line 1, characters 51-73.
 |}]
 
 (* [any_non_null] is not a sublayout of [bits64] (and presumably similar jkinds) *)
@@ -437,10 +437,10 @@ Line 1, characters 9-23:
 1 | type t = t_any_non_null id_bits64
              ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : bits64)
-       The layout of t_any_non_null is any
-         because of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of bits64
-         because of the definition of id_bits64 at line 5, characters 0-33.
+       The layout of t_any_non_null is any, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of bits64, because
+         of the definition of id_bits64 at line 5, characters 0-33.
 |}]
 
 module M (X : sig type t : any_non_null end) : sig type t : bits64 end = X
@@ -458,10 +458,10 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : bits64
-       The layout of the first is any
-         because of the definition of t at line 1, characters 18-39.
-       But the layout of the first must be a sublayout of bits64
-         because of the definition of t at line 1, characters 51-66.
+       The layout of the first is any, because
+         of the definition of t at line 1, characters 18-39.
+       But the layout of the first must be a sublayout of bits64, because
+         of the definition of t at line 1, characters 51-66.
 |}]
 
 (* The meet of [any_non_null] and [value_or_null] is [value] *)
@@ -485,10 +485,10 @@ Line 1, characters 19-34:
 1 | type should_fail = t_value_or_null t1
                        ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because of the definition of t1 at line 3, characters 0-66.
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 3, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         of the definition of t1 at line 3, characters 0-66.
 |}]
 
 type should_fail = t_any_non_null t1
@@ -498,8 +498,8 @@ Line 1, characters 19-33:
 1 | type should_fail = t_any_non_null t1
                        ^^^^^^^^^^^^^^
 Error: This type t_any_non_null should be an instance of type ('a : value)
-       The layout of t_any_non_null is any
-         because of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of t_any_non_null must be a sublayout of value
-         because of the definition of t1 at line 3, characters 0-66.
+       The layout of t_any_non_null is any, because
+         of the definition of t_any_non_null at line 2, characters 0-34.
+       But the layout of t_any_non_null must be a sublayout of value, because
+         of the definition of t1 at line 3, characters 0-66.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -96,11 +96,11 @@ Line 1, characters 6-27:
           ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          we must know concretely how to pass a function argument,
-         defaulted to layout value.
+         defaulted to kind value.
 |}]
 
 type t = { x : t_value_or_null }
@@ -110,11 +110,11 @@ Line 1, characters 11-30:
 1 | type t = { x : t_value_or_null }
                ^^^^^^^^^^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          it is the type of record field x,
-         defaulted to layout value.
+         defaulted to kind value.
 |}]
 
 module type S1 = sig
@@ -126,9 +126,9 @@ Line 2, characters 10-25:
 2 |   val x : t_value_or_null
               ^^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_value_or_null is value_or_null, because
+       The kind of type t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of type t_value_or_null must be a sublayout of value, because
+       But the kind of type t_value_or_null must be a subkind of value, because
          it's the type of something stored in a module structure.
 |}]
 
@@ -150,11 +150,11 @@ Line 2, characters 13-19:
                  ^^^^^^
 Error: This expression has type t_value_or_null
        but an expression was expected of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          we must know concretely how to return a function result,
-         defaulted to layout value.
+         defaulted to kind value.
 |}]
 
 type ('a : any) id_any = 'a
@@ -195,9 +195,9 @@ Line 1, characters 9-14:
 1 | type t = t_any id_any_non_null
              ^^^^^
 Error: This type t_any should be an instance of type ('a : any_non_null)
-       The layout of t_any is any, because
+       The kind of t_any is any, because
          of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be a sublayout of any_non_null, because
+       But the kind of t_any must be a subkind of any_non_null, because
          of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
@@ -216,9 +216,9 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The layout of the first is any, because
+       The kind of the first is any, because
          of the definition of t at line 1, characters 18-30.
-       But the layout of the first must be a sublayout of any_non_null, because
+       But the kind of the first must be a subkind of any_non_null, because
          of the definition of t at line 1, characters 42-63.
 |}]
 
@@ -246,9 +246,9 @@ Line 1, characters 9-24:
 1 | type t = t_value_or_null id_value
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of id_value at line 4, characters 0-31.
 |}]
 
@@ -267,9 +267,9 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : value
-       The layout of the first is value_or_null, because
+       The kind of the first is value_or_null, because
          of the definition of t at line 1, characters 18-40.
-       But the layout of the first must be a sublayout of value, because
+       But the kind of the first must be a subkind of value, because
          of the definition of t at line 1, characters 52-66.
 |}]
 
@@ -298,9 +298,9 @@ Line 1, characters 9-24:
              ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type
          ('a : any_non_null)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of any_non_null, because
+       But the kind of t_value_or_null must be a subkind of any_non_null, because
          of the definition of id_any_non_null at line 2, characters 0-45.
 |}]
 
@@ -319,9 +319,9 @@ Error: Signature mismatch:
          type t = X.t
        is not included in
          type t : any_non_null
-       The layout of the first is value_or_null, because
+       The kind of the first is value_or_null, because
          of the definition of t at line 1, characters 18-40.
-       But the layout of the first must be a sublayout of any_non_null, because
+       But the kind of the first must be a subkind of any_non_null, because
          of the definition of t at line 1, characters 52-73.
 |}]
 
@@ -485,9 +485,9 @@ Line 1, characters 19-34:
 1 | type should_fail = t_value_or_null t1
                        ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 3, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of t1 at line 3, characters 0-66.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -24,10 +24,10 @@ Line 3, characters 23-38:
 3 | type should_not_work = t_value_or_null should_not_accept_or_null
                            ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of should_not_accept_or_null at line 1, characters 0-55.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of should_not_accept_or_null at line 1, characters 0-55.
 |}]
 
 (* CR layouts v3.0: [value_or_null] types should be accepted for
@@ -41,10 +41,11 @@ Line 1, characters 16-37:
                     ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         we must know concretely how to pass a function argument, defaulted to kind value.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because we must know concretely how to pass a function argument,
+         defaulted to kind value.
 |}]
 
 (* Type variables in function definitions default to [value]. *)
@@ -72,10 +73,10 @@ Error: Signature mismatch:
        is not included in
          val should_not_work : ('a : value_or_null). 'a -> unit
        The type 'a -> unit is not compatible with the type 'b -> unit
-       The kind of 'a is value_or_null, because
-         of the definition of should_not_work at line 6, characters 2-57.
-       But the kind of 'a must be a subkind of value, because
-         of the definition of should_not_work at line 2, characters 2-34.
+       The kind of 'a is value_or_null
+         because of the definition of should_not_work at line 6, characters 2-57.
+       But the kind of 'a must be a subkind of value
+         because of the definition of should_not_work at line 2, characters 2-34.
 |}]
 
 (* Type parameters default to [value] for fully abstract types *)
@@ -113,10 +114,10 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of t at line 2, characters 2-16.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of t at line 2, characters 2-16.
 |}]
 
 (* CR layouts v3.0: the sublayout check should accept this for backwards
@@ -160,10 +161,10 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of t at line 2, characters 2-25.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of t at line 2, characters 2-25.
 |}]
 
 (* Rigid type variables default to [value]. *)
@@ -189,10 +190,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
-         of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value, because
-         of the definition of f at line 4, characters 8-28.
+       The kind of 'a is value_or_null
+         because of the definition of f at line 2, characters 2-40.
+       But the kind of 'a must be a subkind of value
+         because of the definition of f at line 4, characters 8-28.
 |}]
 
 module M : sig
@@ -216,10 +217,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
-         of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value, because
-         of the definition of f at line 4, characters 6-7.
+       The kind of 'a is value_or_null
+         because of the definition of f at line 2, characters 2-40.
+       But the kind of 'a must be a subkind of value
+         because of the definition of f at line 4, characters 6-7.
 |}]
 
 
@@ -244,10 +245,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
-         of the definition of f at line 2, characters 2-41.
-       But the kind of 'a must be a subkind of value, because
-         of the definition of f at line 4, characters 6-7.
+       The kind of 'a is value_or_null
+         because of the definition of f at line 2, characters 2-41.
+       But the kind of 'a must be a subkind of value
+         because of the definition of f at line 4, characters 6-7.
 |}]
 
 (* CR layouts v3.0: this should work. *)
@@ -273,10 +274,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
-         of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value, because
-         of the definition of f at line 4, characters 8-13.
+       The kind of 'a is value_or_null
+         because of the definition of f at line 2, characters 2-40.
+       But the kind of 'a must be a subkind of value
+         because of the definition of f at line 4, characters 8-13.
 |}]
 
 (* CR layouts v3.0: annotations on non-rigid type variables are upper bounds.
@@ -343,10 +344,10 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of constrained at line 1, characters 0-49.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of constrained at line 1, characters 0-49.
 |}]
 
 type succeeds = (int dummy) constrained
@@ -372,8 +373,8 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained'
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of constrained' at lines 1-2, characters 0-44.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of constrained' at lines 1-2, characters 0-44.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -24,10 +24,10 @@ Line 3, characters 23-38:
 3 | type should_not_work = t_value_or_null should_not_accept_or_null
                            ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of should_not_accept_or_null at line 1, characters 0-55.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of should_not_accept_or_null at line 1, characters 0-55.
 |}]
 
 (* CR layouts v3.0: [value_or_null] types should be accepted for
@@ -41,10 +41,10 @@ Line 1, characters 16-37:
                     ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         we must know concretely how to pass a function argument,
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because we must know concretely how to pass a function argument,
          defaulted to kind value.
 |}]
 
@@ -73,10 +73,10 @@ Error: Signature mismatch:
        is not included in
          val should_not_work : ('a : value_or_null). 'a -> unit
        The type 'a -> unit is not compatible with the type 'b -> unit
-       The kind of 'a is value_or_null, because
-         of the definition of should_not_work at line 6, characters 2-57.
-       But the kind of 'a must be a subkind of value, because
-         of the definition of should_not_work at line 2, characters 2-34.
+       The kind of 'a is value_or_null
+         because of the definition of should_not_work at line 6, characters 2-57.
+       But the kind of 'a must be a subkind of value
+         because of the definition of should_not_work at line 2, characters 2-34.
 |}]
 
 (* Type parameters default to [value] for fully abstract types *)
@@ -114,10 +114,10 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of t at line 2, characters 2-16.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of t at line 2, characters 2-16.
 |}]
 
 (* CR layouts v3.0: the sublayout check should accept this for backwards
@@ -161,10 +161,10 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of t at line 2, characters 2-25.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of t at line 2, characters 2-25.
 |}]
 
 (* Rigid type variables default to [value]. *)
@@ -190,10 +190,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
-         of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value, because
-         of the definition of f at line 4, characters 8-28.
+       The kind of 'a is value_or_null
+         because of the definition of f at line 2, characters 2-40.
+       But the kind of 'a must be a subkind of value
+         because of the definition of f at line 4, characters 8-28.
 |}]
 
 module M : sig
@@ -217,10 +217,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
-         of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value, because
-         of the definition of f at line 4, characters 6-7.
+       The kind of 'a is value_or_null
+         because of the definition of f at line 2, characters 2-40.
+       But the kind of 'a must be a subkind of value
+         because of the definition of f at line 4, characters 6-7.
 |}]
 
 
@@ -245,10 +245,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
-         of the definition of f at line 2, characters 2-41.
-       But the kind of 'a must be a subkind of value, because
-         of the definition of f at line 4, characters 6-7.
+       The kind of 'a is value_or_null
+         because of the definition of f at line 2, characters 2-41.
+       But the kind of 'a must be a subkind of value
+         because of the definition of f at line 4, characters 6-7.
 |}]
 
 (* CR layouts v3.0: this should work. *)
@@ -274,10 +274,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
-         of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value, because
-         of the definition of f at line 4, characters 8-13.
+       The kind of 'a is value_or_null
+         because of the definition of f at line 2, characters 2-40.
+       But the kind of 'a must be a subkind of value
+         because of the definition of f at line 4, characters 8-13.
 |}]
 
 (* CR layouts v3.0: annotations on non-rigid type variables are upper bounds.
@@ -344,10 +344,10 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of constrained at line 1, characters 0-49.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of constrained at line 1, characters 0-49.
 |}]
 
 type succeeds = (int dummy) constrained
@@ -373,8 +373,8 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained'
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The kind of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
-         of the definition of constrained' at lines 1-2, characters 0-44.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value
+         because of the definition of constrained' at lines 1-2, characters 0-44.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -24,10 +24,10 @@ Line 3, characters 23-38:
 3 | type should_not_work = t_value_or_null should_not_accept_or_null
                            ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because of the definition of should_not_accept_or_null at line 1, characters 0-55.
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         of the definition of should_not_accept_or_null at line 1, characters 0-55.
 |}]
 
 (* CR layouts v3.0: [value_or_null] types should be accepted for
@@ -41,10 +41,10 @@ Line 1, characters 16-37:
                     ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because we must know concretely how to pass a function argument,
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         we must know concretely how to pass a function argument,
          defaulted to kind value.
 |}]
 
@@ -73,10 +73,10 @@ Error: Signature mismatch:
        is not included in
          val should_not_work : ('a : value_or_null). 'a -> unit
        The type 'a -> unit is not compatible with the type 'b -> unit
-       The kind of 'a is value_or_null
-         because of the definition of should_not_work at line 6, characters 2-57.
-       But the kind of 'a must be a subkind of value
-         because of the definition of should_not_work at line 2, characters 2-34.
+       The kind of 'a is value_or_null, because
+         of the definition of should_not_work at line 6, characters 2-57.
+       But the kind of 'a must be a subkind of value, because
+         of the definition of should_not_work at line 2, characters 2-34.
 |}]
 
 (* Type parameters default to [value] for fully abstract types *)
@@ -114,10 +114,10 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because of the definition of t at line 2, characters 2-16.
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         of the definition of t at line 2, characters 2-16.
 |}]
 
 (* CR layouts v3.0: the sublayout check should accept this for backwards
@@ -161,10 +161,10 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because of the definition of t at line 2, characters 2-25.
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         of the definition of t at line 2, characters 2-25.
 |}]
 
 (* Rigid type variables default to [value]. *)
@@ -190,10 +190,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null
-         because of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value
-         because of the definition of f at line 4, characters 8-28.
+       The kind of 'a is value_or_null, because
+         of the definition of f at line 2, characters 2-40.
+       But the kind of 'a must be a subkind of value, because
+         of the definition of f at line 4, characters 8-28.
 |}]
 
 module M : sig
@@ -217,10 +217,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null
-         because of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value
-         because of the definition of f at line 4, characters 6-7.
+       The kind of 'a is value_or_null, because
+         of the definition of f at line 2, characters 2-40.
+       But the kind of 'a must be a subkind of value, because
+         of the definition of f at line 4, characters 6-7.
 |}]
 
 
@@ -245,10 +245,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null
-         because of the definition of f at line 2, characters 2-41.
-       But the kind of 'a must be a subkind of value
-         because of the definition of f at line 4, characters 6-7.
+       The kind of 'a is value_or_null, because
+         of the definition of f at line 2, characters 2-41.
+       But the kind of 'a must be a subkind of value, because
+         of the definition of f at line 4, characters 6-7.
 |}]
 
 (* CR layouts v3.0: this should work. *)
@@ -274,10 +274,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null
-         because of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value
-         because of the definition of f at line 4, characters 8-13.
+       The kind of 'a is value_or_null, because
+         of the definition of f at line 2, characters 2-40.
+       But the kind of 'a must be a subkind of value, because
+         of the definition of f at line 4, characters 8-13.
 |}]
 
 (* CR layouts v3.0: annotations on non-rigid type variables are upper bounds.
@@ -344,10 +344,10 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because of the definition of constrained at line 1, characters 0-49.
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         of the definition of constrained at line 1, characters 0-49.
 |}]
 
 type succeeds = (int dummy) constrained
@@ -373,8 +373,8 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained'
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because of the definition of constrained' at lines 1-2, characters 0-44.
+       The kind of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of value, because
+         of the definition of constrained' at lines 1-2, characters 0-44.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -24,9 +24,9 @@ Line 3, characters 23-38:
 3 | type should_not_work = t_value_or_null should_not_accept_or_null
                            ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of should_not_accept_or_null at line 1, characters 0-55.
 |}]
 
@@ -41,10 +41,10 @@ Line 1, characters 16-37:
                     ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
-         we must know concretely how to pass a function argument, defaulted to layout value.
+       But the kind of t_value_or_null must be a subkind of value, because
+         we must know concretely how to pass a function argument, defaulted to kind value.
 |}]
 
 (* Type variables in function definitions default to [value]. *)
@@ -72,9 +72,9 @@ Error: Signature mismatch:
        is not included in
          val should_not_work : ('a : value_or_null). 'a -> unit
        The type 'a -> unit is not compatible with the type 'b -> unit
-       The layout of 'a is value_or_null, because
+       The kind of 'a is value_or_null, because
          of the definition of should_not_work at line 6, characters 2-57.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value, because
          of the definition of should_not_work at line 2, characters 2-34.
 |}]
 
@@ -113,9 +113,9 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of t at line 2, characters 2-16.
 |}]
 
@@ -160,9 +160,9 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of t at line 2, characters 2-25.
 |}]
 
@@ -189,9 +189,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is value_or_null, because
+       The kind of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-40.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value, because
          of the definition of f at line 4, characters 8-28.
 |}]
 
@@ -216,9 +216,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is value_or_null, because
+       The kind of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-40.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value, because
          of the definition of f at line 4, characters 6-7.
 |}]
 
@@ -244,9 +244,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is value_or_null, because
+       The kind of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-41.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value, because
          of the definition of f at line 4, characters 6-7.
 |}]
 
@@ -273,9 +273,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is value_or_null, because
+       The kind of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-40.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value, because
          of the definition of f at line 4, characters 8-13.
 |}]
 
@@ -343,9 +343,9 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of constrained at line 1, characters 0-49.
 |}]
 
@@ -372,8 +372,8 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained'
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of constrained' at lines 1-2, characters 0-44.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -24,9 +24,9 @@ Line 3, characters 23-38:
 3 | type should_not_work = t_value_or_null should_not_accept_or_null
                            ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          of the definition of should_not_accept_or_null at line 1, characters 0-55.
 |}]
 
@@ -41,11 +41,11 @@ Line 1, characters 16-37:
                     ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          we must know concretely how to pass a function argument,
-         defaulted to kind value.
+         defaulted to layout value.
 |}]
 
 (* Type variables in function definitions default to [value]. *)
@@ -73,9 +73,9 @@ Error: Signature mismatch:
        is not included in
          val should_not_work : ('a : value_or_null). 'a -> unit
        The type 'a -> unit is not compatible with the type 'b -> unit
-       The kind of 'a is value_or_null, because
+       The layout of 'a is value_or_null, because
          of the definition of should_not_work at line 6, characters 2-57.
-       But the kind of 'a must be a subkind of value, because
+       But the layout of 'a must be a sublayout of value, because
          of the definition of should_not_work at line 2, characters 2-34.
 |}]
 
@@ -114,9 +114,9 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          of the definition of t at line 2, characters 2-16.
 |}]
 
@@ -161,9 +161,9 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          of the definition of t at line 2, characters 2-25.
 |}]
 
@@ -190,9 +190,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
+       The layout of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value, because
+       But the layout of 'a must be a sublayout of value, because
          of the definition of f at line 4, characters 8-28.
 |}]
 
@@ -217,9 +217,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
+       The layout of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value, because
+       But the layout of 'a must be a sublayout of value, because
          of the definition of f at line 4, characters 6-7.
 |}]
 
@@ -245,9 +245,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
+       The layout of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-41.
-       But the kind of 'a must be a subkind of value, because
+       But the layout of 'a must be a sublayout of value, because
          of the definition of f at line 4, characters 6-7.
 |}]
 
@@ -274,9 +274,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null, because
+       The layout of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value, because
+       But the layout of 'a must be a sublayout of value, because
          of the definition of f at line 4, characters 8-13.
 |}]
 
@@ -344,9 +344,9 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          of the definition of constrained at line 1, characters 0-49.
 |}]
 
@@ -373,8 +373,8 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained'
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The kind of t_value_or_null is value_or_null, because
+       The layout of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value, because
+       But the layout of t_value_or_null must be a sublayout of value, because
          of the definition of constrained' at lines 1-2, characters 0-44.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -24,9 +24,9 @@ Line 3, characters 23-38:
 3 | type should_not_work = t_value_or_null should_not_accept_or_null
                            ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of should_not_accept_or_null at line 1, characters 0-55.
 |}]
 
@@ -41,11 +41,11 @@ Line 1, characters 16-37:
                     ^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type t_value_or_null
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          we must know concretely how to pass a function argument,
-         defaulted to layout value.
+         defaulted to kind value.
 |}]
 
 (* Type variables in function definitions default to [value]. *)
@@ -73,9 +73,9 @@ Error: Signature mismatch:
        is not included in
          val should_not_work : ('a : value_or_null). 'a -> unit
        The type 'a -> unit is not compatible with the type 'b -> unit
-       The layout of 'a is value_or_null, because
+       The kind of 'a is value_or_null, because
          of the definition of should_not_work at line 6, characters 2-57.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value, because
          of the definition of should_not_work at line 2, characters 2-34.
 |}]
 
@@ -114,9 +114,9 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of t at line 2, characters 2-16.
 |}]
 
@@ -161,9 +161,9 @@ Line 4, characters 12-27:
 4 |   type t2 = t_value_or_null t
                 ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type ('a : value)
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of t at line 2, characters 2-25.
 |}]
 
@@ -190,9 +190,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is value_or_null, because
+       The kind of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-40.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value, because
          of the definition of f at line 4, characters 8-28.
 |}]
 
@@ -217,9 +217,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is value_or_null, because
+       The kind of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-40.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value, because
          of the definition of f at line 4, characters 6-7.
 |}]
 
@@ -245,9 +245,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is value_or_null, because
+       The kind of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-41.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value, because
          of the definition of f at line 4, characters 6-7.
 |}]
 
@@ -274,9 +274,9 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is value_or_null, because
+       The kind of 'a is value_or_null, because
          of the definition of f at line 2, characters 2-40.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value, because
          of the definition of f at line 4, characters 8-13.
 |}]
 
@@ -344,9 +344,9 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of constrained at line 1, characters 0-49.
 |}]
 
@@ -373,8 +373,8 @@ Line 1, characters 14-35:
 1 | type fails = (t_value_or_null dummy) constrained'
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type t_value_or_null dummy should be an instance of type 'a dummy
-       The layout of t_value_or_null is value_or_null, because
+       The kind of t_value_or_null is value_or_null, because
          of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of value, because
+       But the kind of t_value_or_null must be a subkind of value, because
          of the definition of constrained' at lines 1-2, characters 0-44.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-word/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics.ml
@@ -118,10 +118,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_word_id) = x, false;;
@@ -131,10 +131,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_word_id is word
-         because of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a t_word_id is word, because
+         of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : nativeint#) = x, false;;
@@ -144,10 +144,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_word * string;;
@@ -156,10 +156,10 @@ Line 1, characters 12-18:
 1 | type t4_4 = t_word * string;;
                 ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * nativeint#;;
@@ -168,10 +168,10 @@ Line 1, characters 18-28:
 1 | type t4_5 = int * nativeint#;;
                       ^^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : word) t4_6 = 'a * 'a
@@ -180,10 +180,10 @@ Line 1, characters 24-26:
 1 | type ('a : word) t4_6 = 'a * 'a
                             ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       The layout of 'a is word
-         because of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -193,10 +193,10 @@ Line 1, characters 29-31:
 1 | type ('a : word, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                  ^^
 Error: This type ('b : value) should be an instance of type ('a : word)
-       The layout of 'a is word
-         because of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -283,10 +283,10 @@ Line 1, characters 31-37:
 1 | module type S6_1 = sig val x : t_word end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of type t_word must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of type t_word must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_word_id end
@@ -295,10 +295,10 @@ Line 1, characters 31-43:
 1 | module type S6_2 = sig val x : 'a t_word_id end
                                    ^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_word_id is word
-         because of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of type 'a t_word_id must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type 'a t_word_id is word, because
+         of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of type 'a t_word_id must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : nativeint# end
@@ -307,10 +307,10 @@ Line 1, characters 31-41:
 1 | module type S6_3 = sig val x : nativeint# end
                                    ^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of type nativeint# must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of type nativeint# must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -323,10 +323,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_word_id) = `A x;;
@@ -336,10 +336,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_word_id is word
-         because of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       The layout of 'a t_word_id is word, because
+         of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : nativeint#) = `A x;;
@@ -349,10 +349,10 @@ Line 1, characters 31-32:
                                    ^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_word ];;
@@ -361,10 +361,10 @@ Line 1, characters 20-26:
 1 | type f7_4 = [ `A of t_word ];;
                         ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : word) f7_5 = [ `A of 'a ];;
@@ -373,10 +373,10 @@ Line 1, characters 32-34:
 1 | type ('a : word) f7_5 = [ `A of 'a ];;
                                     ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       The layout of 'a is word
-         because of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -401,10 +401,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_word_id ());;
@@ -414,10 +414,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_word_id is word
-         because of the definition of make_t_word_id at line 2, characters 19-51.
-       But the layout of 'a t_word_id must overlap with value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_word_id is word, because
+         of the definition of make_t_word_id at line 2, characters 19-51.
+       But the layout of 'a t_word_id must overlap with value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_nativeintu ());;
@@ -427,10 +427,10 @@ Line 1, characters 20-40:
                         ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -570,10 +570,10 @@ Line 1, characters 15-25:
 1 | type t12_1 = < x : t_word >;;
                    ^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : word) t12_2 = < x : 'a >;;
@@ -582,10 +582,10 @@ Line 1, characters 31-33:
 1 | type ('a : word) t12_2 = < x : 'a >;;
                                    ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       The layout of 'a is word
-         because of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value
-         because it's the type of an object field.
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_word = assert false end;;
@@ -594,10 +594,10 @@ Line 1, characters 21-53:
 1 | class c12_3 = object method x : t_word = assert false end;;
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_word but is expected to have type ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -608,10 +608,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_word_id -> 'a t_word_id = assert false
                  ^^
 Error: This type ('a : word) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with word
-         because of the definition of t_word_id at line 2, characters 0-31.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with word, because
+         of the definition of t_word_id at line 2, characters 0-31.
 |}];;
 
 class c12_5 = object val x : t_word = assert false end;;
@@ -620,10 +620,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_word = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of x must be a sublayout of value
-         because it's the type of a class field.
+       The layout of x is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : nativeint# end;;
@@ -633,10 +633,10 @@ Line 1, characters 26-47:
                               ^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type nativeint# but is expected to have type
          ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's the type of an object field.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : nativeint# end
@@ -645,10 +645,10 @@ Line 1, characters 26-44:
 1 | class type c12_7 = object val x : nativeint# end
                               ^^^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is word
-         because it is the primitive word type nativeint#.
-       But the layout of x must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of x is word, because
+         it is the primitive word type nativeint#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -659,10 +659,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_word_id -> 'a t_word_id
               ^^
 Error: This type ('a : word) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with word
-         because of the definition of t_word_id at line 2, characters 0-31.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with word, because
+         of the definition of t_word_id at line 2, characters 0-31.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -698,10 +698,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_word
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_word) (m2 : t_word) = object
@@ -715,10 +715,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -734,10 +734,10 @@ Line 1, characters 25-26:
                              ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_word) = compare x x;;
@@ -747,10 +747,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_word) = Marshal.to_bytes x;;
@@ -760,10 +760,10 @@ Line 1, characters 42-43:
                                               ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_word) = Hashtbl.hash x;;
@@ -773,8 +773,8 @@ Line 1, characters 38-39:
                                           ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-word/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics.ml
@@ -118,10 +118,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_word_id) = x, false;;
@@ -131,10 +131,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_word_id is word, because
-         of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a t_word_id is word
+         because of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : nativeint#) = x, false;;
@@ -144,10 +144,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_word * string;;
@@ -156,10 +156,10 @@ Line 1, characters 12-18:
 1 | type t4_4 = t_word * string;;
                 ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * nativeint#;;
@@ -168,10 +168,10 @@ Line 1, characters 18-28:
 1 | type t4_5 = int * nativeint#;;
                       ^^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type ('a : word) t4_6 = 'a * 'a
@@ -180,10 +180,10 @@ Line 1, characters 24-26:
 1 | type ('a : word) t4_6 = 'a * 'a
                             ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       The layout of 'a is word, because
-         of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is word
+         because of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -193,10 +193,10 @@ Line 1, characters 29-31:
 1 | type ('a : word, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                  ^^
 Error: This type ('b : value) should be an instance of type ('a : word)
-       The layout of 'a is word, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is word
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -283,10 +283,10 @@ Line 1, characters 31-37:
 1 | module type S6_1 = sig val x : t_word end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of type t_word must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of type t_word must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_word_id end
@@ -295,10 +295,10 @@ Line 1, characters 31-43:
 1 | module type S6_2 = sig val x : 'a t_word_id end
                                    ^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_word_id is word, because
-         of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of type 'a t_word_id must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type 'a t_word_id is word
+         because of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of type 'a t_word_id must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : nativeint# end
@@ -307,10 +307,10 @@ Line 1, characters 31-41:
 1 | module type S6_3 = sig val x : nativeint# end
                                    ^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of type nativeint# must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of type nativeint# must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 
@@ -323,10 +323,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_word_id) = `A x;;
@@ -336,10 +336,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_word_id is word, because
-         of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a t_word_id is word
+         because of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : nativeint#) = `A x;;
@@ -349,10 +349,10 @@ Line 1, characters 31-32:
                                    ^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_word ];;
@@ -361,10 +361,10 @@ Line 1, characters 20-26:
 1 | type f7_4 = [ `A of t_word ];;
                         ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : word) f7_5 = [ `A of 'a ];;
@@ -373,10 +373,10 @@ Line 1, characters 32-34:
 1 | type ('a : word) f7_5 = [ `A of 'a ];;
                                     ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       The layout of 'a is word, because
-         of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a is word
+         because of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -401,10 +401,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_word_id ());;
@@ -414,10 +414,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value)
-       The layout of 'a t_word_id is word, because
-         of the definition of make_t_word_id at line 2, characters 19-51.
-       But the layout of 'a t_word_id must overlap with value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_word_id is word
+         because of the definition of make_t_word_id at line 2, characters 19-51.
+       But the layout of 'a t_word_id must overlap with value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_nativeintu ());;
@@ -427,10 +427,10 @@ Line 1, characters 20-40:
                         ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -570,10 +570,10 @@ Line 1, characters 15-25:
 1 | type t12_1 = < x : t_word >;;
                    ^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 type ('a : word) t12_2 = < x : 'a >;;
@@ -582,10 +582,10 @@ Line 1, characters 31-33:
 1 | type ('a : word) t12_2 = < x : 'a >;;
                                    ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       The layout of 'a is word, because
-         of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a is word
+         because of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value
+         because it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_word = assert false end;;
@@ -594,10 +594,10 @@ Line 1, characters 21-53:
 1 | class c12_3 = object method x : t_word = assert false end;;
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_word but is expected to have type ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -608,10 +608,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_word_id -> 'a t_word_id = assert false
                  ^^
 Error: This type ('a : word) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with word, because
-         of the definition of t_word_id at line 2, characters 0-31.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with word
+         because of the definition of t_word_id at line 2, characters 0-31.
 |}];;
 
 class c12_5 = object val x : t_word = assert false end;;
@@ -620,10 +620,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_word = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of x must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of x is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of x must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : nativeint# end;;
@@ -633,10 +633,10 @@ Line 1, characters 26-47:
                               ^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type nativeint# but is expected to have type
          ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : nativeint# end
@@ -645,10 +645,10 @@ Line 1, characters 26-44:
 1 | class type c12_7 = object val x : nativeint# end
                               ^^^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is word, because
-         it is the primitive word type nativeint#.
-       But the layout of x must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of x is word
+         because it is the primitive word type nativeint#.
+       But the layout of x must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -659,10 +659,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_word_id -> 'a t_word_id
               ^^
 Error: This type ('a : word) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with word, because
-         of the definition of t_word_id at line 2, characters 0-31.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with word
+         because of the definition of t_word_id at line 2, characters 0-31.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -698,10 +698,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_word
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_word) (m2 : t_word) = object
@@ -715,10 +715,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -734,10 +734,10 @@ Line 1, characters 25-26:
                              ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_word) = compare x x;;
@@ -747,10 +747,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_word) = Marshal.to_bytes x;;
@@ -760,10 +760,10 @@ Line 1, characters 42-43:
                                               ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_word) = Hashtbl.hash x;;
@@ -773,8 +773,8 @@ Line 1, characters 38-39:
                                           ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-word/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/parsing.ml
@@ -34,10 +34,10 @@ Line 1, characters 9-19:
 1 | type t = nativeint# list;;
              ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let f (_ : nativeint# list) = ();;
@@ -46,10 +46,10 @@ Line 1, characters 11-21:
 1 | let f (_ : nativeint# list) = ();;
                ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 type t = C of nativeint# list;;
@@ -58,10 +58,10 @@ Line 1, characters 14-24:
 1 | type t = C of nativeint# list;;
                   ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 type t = C : nativeint# list -> t;;
@@ -70,10 +70,10 @@ Line 1, characters 13-23:
 1 | type t = C : nativeint# list -> t;;
                  ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (* Syntax: nativeint#c
@@ -92,10 +92,10 @@ Line 1, characters 9-19:
 1 | type t = nativeint#c;;
              ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 let f (_ : nativeint#c) = ();;
@@ -104,10 +104,10 @@ Line 1, characters 11-21:
 1 | let f (_ : nativeint#c) = ();;
                ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C of nativeint#c;;
@@ -116,10 +116,10 @@ Line 1, characters 14-24:
 1 | type t = C of nativeint#c;;
                   ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C : nativeint#c -> t;;
@@ -128,10 +128,10 @@ Line 1, characters 13-23:
 1 | type t = C : nativeint#c -> t;;
                  ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: nativeint# c
@@ -143,10 +143,10 @@ Line 1, characters 9-19:
 1 | type t = nativeint# c;;
              ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 let f (_ : nativeint# c) = ();;
@@ -155,10 +155,10 @@ Line 1, characters 11-21:
 1 | let f (_ : nativeint# c) = ();;
                ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C of nativeint# c;;
@@ -167,10 +167,10 @@ Line 1, characters 14-24:
 1 | type t = C of nativeint# c;;
                   ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 type t = C : nativeint# c -> t;;
@@ -179,10 +179,10 @@ Line 1, characters 13-23:
 1 | type t = C : nativeint# c -> t;;
                  ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's a type argument to a class constructor.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: nativeint #c

--- a/ocaml/testsuite/tests/typing-layouts-word/parsing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/parsing.ml
@@ -34,10 +34,10 @@ Line 1, characters 9-19:
 1 | type t = nativeint# list;;
              ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let f (_ : nativeint# list) = ();;
@@ -46,10 +46,10 @@ Line 1, characters 11-21:
 1 | let f (_ : nativeint# list) = ();;
                ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C of nativeint# list;;
@@ -58,10 +58,10 @@ Line 1, characters 14-24:
 1 | type t = C of nativeint# list;;
                   ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 type t = C : nativeint# list -> t;;
@@ -70,10 +70,10 @@ Line 1, characters 13-23:
 1 | type t = C : nativeint# list -> t;;
                  ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* Syntax: nativeint#c
@@ -92,10 +92,10 @@ Line 1, characters 9-19:
 1 | type t = nativeint#c;;
              ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : nativeint#c) = ();;
@@ -104,10 +104,10 @@ Line 1, characters 11-21:
 1 | let f (_ : nativeint#c) = ();;
                ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of nativeint#c;;
@@ -116,10 +116,10 @@ Line 1, characters 14-24:
 1 | type t = C of nativeint#c;;
                   ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : nativeint#c -> t;;
@@ -128,10 +128,10 @@ Line 1, characters 13-23:
 1 | type t = C : nativeint#c -> t;;
                  ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: nativeint# c
@@ -143,10 +143,10 @@ Line 1, characters 9-19:
 1 | type t = nativeint# c;;
              ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 let f (_ : nativeint# c) = ();;
@@ -155,10 +155,10 @@ Line 1, characters 11-21:
 1 | let f (_ : nativeint# c) = ();;
                ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C of nativeint# c;;
@@ -167,10 +167,10 @@ Line 1, characters 14-24:
 1 | type t = C of nativeint# c;;
                   ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 type t = C : nativeint# c -> t;;
@@ -179,10 +179,10 @@ Line 1, characters 13-23:
 1 | type t = C : nativeint# c -> t;;
                  ^^^^^^^^^^
 Error: This type nativeint# should be an instance of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's a type argument to a class constructor.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's a type argument to a class constructor.
 |}];;
 
 (* Syntax: nativeint #c

--- a/ocaml/testsuite/tests/typing-layouts/allow_illegal_crossing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/allow_illegal_crossing.ml
@@ -37,10 +37,10 @@ end
 Line 3, characters 2-44:
 3 |   type b : value mod uncontended = private a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 2, characters 2-8.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 3, characters 2-44.
+Error: The kind of type a is value
+         because of the definition of a at line 2, characters 2-8.
+       But the kind of type a must be a subkind of value mod uncontended
+         because of the definition of b at line 3, characters 2-44.
 |}]
 
 type t : value mod portable uncontended = { a : int; b : int }
@@ -286,10 +286,10 @@ type a
 Line 2, characters 0-37:
 2 | type b : value mod global = private a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-6.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-37.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-6.
+       But the kind of type a must be a subkind of value mod global
+         because of the definition of b at line 2, characters 0-37.
 |}]
 
 type a
@@ -299,10 +299,10 @@ type a
 Line 2, characters 0-35:
 2 | type b : value mod many = private a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-6.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-35.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-6.
+       But the kind of type a must be a subkind of value mod many
+         because of the definition of b at line 2, characters 0-35.
 |}]
 
 type a
@@ -312,10 +312,10 @@ type a
 Line 2, characters 0-37:
 2 | type b : value mod unique = private a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-6.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-37.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-6.
+       But the kind of type a must be a subkind of value mod unique
+         because of the definition of b at line 2, characters 0-37.
 |}]
 
 type a
@@ -325,10 +325,10 @@ type a
 Line 2, characters 0-30:
 2 | type b : immediate = private a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-6.
-       But the layout of type a must be a sublayout of immediate, because
-         of the definition of b at line 2, characters 0-30.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-6.
+       But the kind of type a must be a subkind of immediate
+         because of the definition of b at line 2, characters 0-30.
 |}]
 
 module _ = struct
@@ -339,10 +339,10 @@ end
 Line 3, characters 2-39:
 3 |   type b : value mod global = private a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a/2 is value, because
-         of the definition of a at line 2, characters 2-8.
-       But the layout of type a/2 must be a sublayout of value, because
-         of the definition of b at line 3, characters 2-39.
+Error: The kind of type a/2 is value
+         because of the definition of a at line 2, characters 2-8.
+       But the kind of type a/2 must be a subkind of value mod global
+         because of the definition of b at line 3, characters 2-39.
 |}]
 
 module A : sig
@@ -354,10 +354,10 @@ end
 Line 4, characters 2-42:
 4 |   type t : value mod many = private string
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type string is value, because
-         it is the primitive value type string.
-       But the layout of type string must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-42.
+Error: The kind of type string is value
+         because it is the primitive value type string.
+       But the kind of type string must be a subkind of value mod many
+         because of the definition of t at line 4, characters 2-42.
 |}]
 
 type t : value mod external_ = private string
@@ -365,10 +365,10 @@ type t : value mod external_ = private string
 Line 1, characters 0-45:
 1 | type t : value mod external_ = private string
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type string is value, because
-         it is the primitive value type string.
-       But the layout of type string must be a sublayout of immediate, because
-         of the definition of t at line 1, characters 0-45.
+Error: The kind of type string is value
+         because it is the primitive value type string.
+       But the kind of type string must be a subkind of value mod external_
+         because of the definition of t at line 1, characters 0-45.
 |}]
 
 type t : value mod global = { a : int; b : int }
@@ -376,10 +376,10 @@ type t : value mod global = { a : int; b : int }
 Line 1, characters 0-48:
 1 | type t : value mod global = { a : int; b : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
-         it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type ('a, 'b) t : value mod many = { a : 'a; b : 'b }
@@ -387,10 +387,10 @@ type ('a, 'b) t : value mod many = { a : 'a; b : 'b }
 Line 1, characters 0-53:
 1 | type ('a, 'b) t : value mod many = { a : 'a; b : 'b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
-         it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod many
+         because of the annotation on the declaration of the type t.
 |}]
 
 type a : value mod unique = private b
@@ -399,10 +399,10 @@ and b
 Line 1, characters 0-37:
 1 | type a : value mod unique = private b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type b is value, because
-         an abstract type has the value layout by default.
-       But the layout of type b must be a sublayout of value, because
-         of the definition of a at line 1, characters 0-37.
+Error: The kind of type b is value
+         because an abstract type has the value kind by default.
+       But the kind of type b must be a subkind of value mod unique
+         because of the definition of a at line 1, characters 0-37.
 |}]
 
 type a
@@ -411,10 +411,10 @@ and b : value mod global = private a
 Line 2, characters 0-36:
 2 | and b : value mod global = private a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a/3 is value, because
-         an abstract type has the value layout by default.
-       But the layout of type a/3 must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-36.
+Error: The kind of type a/3 is value
+         because an abstract type has the value kind by default.
+       But the kind of type a/3 must be a subkind of value mod global
+         because of the definition of b at line 2, characters 0-36.
 |}]
 
 module rec A : sig
@@ -431,10 +431,10 @@ end
 Line 4, characters 2-44:
 4 |   type t : value mod external_ = private B.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type B.t is value, because
-         of the definition of t at line 7, characters 2-8.
-       But the layout of type B.t must be a sublayout of immediate, because
-         of the definition of t at line 4, characters 2-44.
+Error: The kind of type B.t is value
+         because of the definition of t at line 7, characters 2-8.
+       But the kind of type B.t must be a subkind of value mod external_
+         because of the definition of t at line 4, characters 2-44.
 |}]
 
 module rec A : sig
@@ -451,10 +451,10 @@ end
 Line 9, characters 2-39:
 9 |   type t : value mod many = private A.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type A.t is value, because
-         of the definition of t at line 2, characters 2-8.
-       But the layout of type A.t must be a sublayout of value, because
-         of the definition of t at line 9, characters 2-39.
+Error: The kind of type A.t is value
+         because of the definition of t at line 2, characters 2-8.
+       But the kind of type A.t must be a subkind of value mod many
+         because of the definition of t at line 9, characters 2-39.
 |}]
 
 (*********************************************************************************)
@@ -479,10 +479,10 @@ Error: Signature mismatch:
          type t = { a : string; }
        is not included in
          type t : value mod portable
-       The layout of the first is value, because
-         of the definition of t at line 4, characters 2-25.
-       But the layout of the first must be a sublayout of value, because
-         of the definition of t at line 2, characters 2-29.
+       The kind of the first is value
+         because of the definition of t at line 4, characters 2-25.
+       But the kind of the first must be a subkind of value mod portable
+         because of the definition of t at line 2, characters 2-29.
 |}]
 
 module A : sig
@@ -497,10 +497,10 @@ Line 6, characters 11-12:
 6 |   type v = t u
                ^
 Error: This type t should be an instance of type ('a : value mod portable)
-       The layout of t is value, because
-         of the definition of t at line 4, characters 2-25.
-       But the layout of t must be a sublayout of value, because
-         of the definition of u at line 5, characters 2-39.
+       The kind of t is value
+         because of the definition of t at line 4, characters 2-25.
+       But the kind of t must be a subkind of value mod portable
+         because of the definition of u at line 5, characters 2-39.
 |}]
 
 module A : sig
@@ -515,10 +515,10 @@ Line 5, characters 42-57:
                                               ^^^^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod portable)
-       The layout of t is value, because
-         of the definition of t at line 4, characters 2-25.
-       But the layout of t must be a sublayout of value, because
-         of the annotation on the wildcard _ at line 5, characters 20-38.
+       The kind of t is value
+         because of the definition of t at line 4, characters 2-25.
+       But the kind of t must be a subkind of value mod portable
+         because of the annotation on the wildcard _ at line 5, characters 20-38.
 |}]
 
 type a
@@ -528,10 +528,10 @@ type a
 Line 2, characters 0-31:
 2 | type b : value mod portable = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-6.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-31.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-6.
+       But the kind of type a must be a subkind of value mod portable
+         because of the definition of b at line 2, characters 0-31.
 |}]
 
 type a = { foo : int; bar : string }
@@ -541,10 +541,10 @@ type a = { foo : int; bar : string; }
 Line 2, characters 0-29:
 2 | type b : any mod portable = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-36.
-       But the layout of type a must be a sublayout of any, because
-         of the definition of b at line 2, characters 0-29.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-36.
+       But the kind of type a must be a subkind of any mod portable
+         because of the definition of b at line 2, characters 0-29.
 |}]
 
 type a = Foo of int | Bar of string
@@ -554,10 +554,10 @@ type a = Foo of int | Bar of string
 Line 2, characters 0-32:
 2 | type b : any mod uncontended = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-35.
-       But the layout of type a must be a sublayout of any, because
-         of the definition of b at line 2, characters 0-32.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-35.
+       But the kind of type a must be a subkind of any mod uncontended
+         because of the definition of b at line 2, characters 0-32.
 |}]
 
 module Foo : sig
@@ -570,10 +570,10 @@ type t : value mod portable = Foo.t
 Line 4, characters 2-38:
 4 |   type t : value mod portable = string
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type string is value, because
-         it is the primitive value type string.
-       But the layout of type string must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-38.
+Error: The kind of type string is value
+         because it is the primitive value type string.
+       But the kind of type string must be a subkind of value mod portable
+         because of the definition of t at line 4, characters 2-38.
 |}]
 
 type a = { foo : string }
@@ -583,10 +583,10 @@ type a = { foo : string; }
 Line 2, characters 0-50:
 2 | type b : value mod portable = a = { foo : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-25.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-50.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-25.
+       But the kind of type a must be a subkind of value mod portable
+         because of the definition of b at line 2, characters 0-50.
 |}]
 
 type a = private { foo : string }
@@ -596,10 +596,10 @@ type a = private { foo : string; }
 Line 2, characters 0-61:
 2 | type b : value mod uncontended = a = private { foo : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-33.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-61.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-33.
+       But the kind of type a must be a subkind of value mod uncontended
+         because of the definition of b at line 2, characters 0-61.
 |}]
 
 type a = Foo of string | Bar
@@ -609,10 +609,10 @@ type a = Foo of string | Bar
 Line 2, characters 0-56:
 2 | type b : value mod uncontended = a = Foo of string | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-28.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-56.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-28.
+       But the kind of type a must be a subkind of value mod uncontended
+         because of the definition of b at line 2, characters 0-56.
 |}]
 
 type a = private Foo of string | Bar
@@ -622,10 +622,10 @@ type a = private Foo of string | Bar
 Line 2, characters 0-61:
 2 | type b : value mod portable = a = private Foo of string | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-36.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-61.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-36.
+       But the kind of type a must be a subkind of value mod portable
+         because of the definition of b at line 2, characters 0-61.
 |}]
 
 type ('a : value mod uncontended) of_uncontended
@@ -637,10 +637,10 @@ Line 2, characters 9-15:
              ^^^^^^
 Error: This type string should be an instance of type
          ('a : value mod uncontended)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
-         of the definition of of_uncontended at line 1, characters 0-48.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of value mod uncontended
+         because of the definition of of_uncontended at line 1, characters 0-48.
 |}]
 
 type ('a : value mod portable) of_portable
@@ -653,10 +653,10 @@ Line 3, characters 9-10:
 3 | type u = t of_portable
              ^
 Error: This type t should be an instance of type ('a : value mod portable)
-       The layout of t is value, because
-         of the definition of t at line 2, characters 0-22.
-       But the layout of t must be a sublayout of value, because
-         of the definition of of_portable at line 1, characters 0-42.
+       The kind of t is value
+         because of the definition of t at line 2, characters 0-22.
+       But the kind of t must be a subkind of value mod portable
+         because of the definition of of_portable at line 1, characters 0-42.
 |}]
 
 let f : ('a : value mod portable). 'a -> 'a = fun x -> x
@@ -668,10 +668,10 @@ Line 2, characters 10-17:
               ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod portable)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
-         of the definition of f at line 1, characters 4-5.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of value mod portable
+         because of the definition of f at line 1, characters 4-5.
 |}]
 
 let f : ('a : value mod uncontended). 'a -> 'a = fun x -> x
@@ -683,10 +683,10 @@ Line 2, characters 10-17:
               ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod uncontended)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
-         of the definition of f at line 1, characters 4-5.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of value mod uncontended
+         because of the definition of f at line 1, characters 4-5.
 |}]
 
 (* immediate types can still cross *)
@@ -707,10 +707,10 @@ Line 1, characters 40-53:
                                             ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod portable)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
-         of the annotation on the wildcard _ at line 1, characters 18-36.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of value mod portable
+         because of the annotation on the wildcard _ at line 1, characters 18-36.
 |}]
 
 type t = { str : string }
@@ -722,10 +722,10 @@ Line 2, characters 45-68:
                                                  ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod uncontended)
-       The layout of t is value, because
-         of the definition of t at line 1, characters 0-25.
-       But the layout of t must be a sublayout of value, because
-         of the annotation on the wildcard _ at line 2, characters 20-41.
+       The kind of t is value
+         because of the definition of t at line 1, characters 0-25.
+       But the kind of t must be a subkind of value mod uncontended
+         because of the annotation on the wildcard _ at line 2, characters 20-41.
 |}]
 
 type t = Foo of string
@@ -737,10 +737,10 @@ Line 2, characters 55-72:
                                                            ^^^^^^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod portable)
-       The layout of t is value, because
-         of the definition of t at line 1, characters 0-22.
-       But the layout of t must be a sublayout of value, because
-         of the annotation on the universal variable 'a.
+       The kind of t is value
+         because of the definition of t at line 1, characters 0-22.
+       But the kind of t must be a subkind of value mod portable
+         because of the annotation on the universal variable 'a.
 |}]
 
 type t = string
@@ -752,10 +752,10 @@ Line 2, characters 39-58:
                                            ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t = string
        but an expression was expected of type ('a : value mod uncontended)
-       The layout of t is value, because
-         it is the primitive value type string.
-       But the layout of t must be a sublayout of value, because
-         of the annotation on the type variable 'a.
+       The kind of t is value
+         because it is the primitive value type string.
+       But the kind of t must be a subkind of value mod uncontended
+         because of the annotation on the type variable 'a.
 |}]
 
 (***************************************)
@@ -768,10 +768,10 @@ type a : word
 Line 2, characters 0-31:
 2 | type b : value mod portable = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is word, because
-         of the definition of a at line 1, characters 0-13.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-31.
+Error: The layout of type a is word
+         because of the definition of a at line 1, characters 0-13.
+       But the layout of type a must be a sublayout of value
+         because of the definition of b at line 2, characters 0-31.
 |}]
 
 type a : bits64
@@ -781,10 +781,10 @@ type a : bits64
 Line 2, characters 0-36:
 2 | type b : float32 mod uncontended = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is bits64, because
-         of the definition of a at line 1, characters 0-15.
-       But the layout of type a must be a sublayout of float32, because
-         of the definition of b at line 2, characters 0-36.
+Error: The layout of type a is bits64
+         because of the definition of a at line 1, characters 0-15.
+       But the layout of type a must be a sublayout of float32
+         because of the definition of b at line 2, characters 0-36.
 |}]
 
 type a : any
@@ -794,10 +794,10 @@ type a : any
 Line 2, characters 0-34:
 2 | type b : value mod uncontended = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is any, because
-         of the definition of a at line 1, characters 0-12.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-34.
+Error: The layout of type a is any
+         because of the definition of a at line 1, characters 0-12.
+       But the layout of type a must be a sublayout of value
+         because of the definition of b at line 2, characters 0-34.
 |}]
 
 (****************************************************************)
@@ -810,10 +810,10 @@ type a
 Line 2, characters 0-31:
 2 | type b : value mod portable = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-6.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-31.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-6.
+       But the kind of type a must be a subkind of value mod portable
+         because of the definition of b at line 2, characters 0-31.
 |}]
 
 type a
@@ -823,10 +823,10 @@ type a
 Line 2, characters 0-34:
 2 | type b : value mod uncontended = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-6.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-34.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-6.
+       But the kind of type a must be a subkind of value mod uncontended
+         because of the definition of b at line 2, characters 0-34.
 |}]
 
 type a
@@ -836,10 +836,10 @@ type a
 Line 2, characters 0-39:
 2 | type b : value mod portable = private a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-6.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-39.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-6.
+       But the kind of type a must be a subkind of value mod portable
+         because of the definition of b at line 2, characters 0-39.
 |}]
 
 type a
@@ -849,10 +849,10 @@ type a
 Line 2, characters 0-42:
 2 | type b : value mod uncontended = private a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-6.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-42.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-6.
+       But the kind of type a must be a subkind of value mod uncontended
+         because of the definition of b at line 2, characters 0-42.
 |}]
 
 type a : word
@@ -862,10 +862,11 @@ type a : word
 Line 2, characters 0-49:
 2 | type b : any mod uncontended portable = private a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is word, because
-         of the definition of a at line 1, characters 0-13.
-       But the layout of type a must be a sublayout of any, because
-         of the definition of b at line 2, characters 0-49.
+Error: The kind of type a is word
+         because of the definition of a at line 1, characters 0-13.
+       But the kind of type a must be a subkind of
+         any mod uncontended portable
+         because of the definition of b at line 2, characters 0-49.
 |}]
 
 type a : value mod global many unique external_
@@ -875,10 +876,10 @@ type a : value mod global many unique external_
 Line 2, characters 0-30:
 2 | type b : immediate = private a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is immediate, because
-         of the definition of a at line 1, characters 0-47.
-       But the layout of type a must be a sublayout of immediate, because
-         of the definition of b at line 2, characters 0-30.
+Error: The kind of type a is value mod global unique many external_
+         because of the definition of a at line 1, characters 0-47.
+       But the kind of type a must be a subkind of immediate
+         because of the definition of b at line 2, characters 0-30.
 |}]
 
 module A : sig
@@ -890,10 +891,10 @@ end
 Line 4, characters 2-46:
 4 |   type t : value mod portable = private string
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type string is value, because
-         it is the primitive value type string.
-       But the layout of type string must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-46.
+Error: The kind of type string is value
+         because it is the primitive value type string.
+       But the kind of type string must be a subkind of value mod portable
+         because of the definition of t at line 4, characters 2-46.
 |}]
 
 type a : value mod portable uncontended = private b
@@ -902,10 +903,11 @@ and b
 Line 1, characters 0-51:
 1 | type a : value mod portable uncontended = private b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type b is value, because
-         an abstract type has the value layout by default.
-       But the layout of type b must be a sublayout of value, because
-         of the definition of a at line 1, characters 0-51.
+Error: The kind of type b is value
+         because an abstract type has the value kind by default.
+       But the kind of type b must be a subkind of
+         value mod uncontended portable
+         because of the definition of a at line 1, characters 0-51.
 |}]
 
 type a
@@ -914,10 +916,11 @@ and b : value mod portable uncontended = a
 Line 2, characters 0-42:
 2 | and b : value mod portable uncontended = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a/2 is value, because
-         an abstract type has the value layout by default.
-       But the layout of type a/2 must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-42.
+Error: The kind of type a/2 is value
+         because an abstract type has the value kind by default.
+       But the kind of type a/2 must be a subkind of
+         value mod uncontended portable
+         because of the definition of b at line 2, characters 0-42.
 |}]
 
 module rec A : sig
@@ -934,10 +937,11 @@ end
 Line 4, characters 2-47:
 4 |   type t : value mod portable uncontended = B.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type B.t is value, because
-         of the definition of t at line 7, characters 2-8.
-       But the layout of type B.t must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-47.
+Error: The kind of type B.t is value
+         because of the definition of t at line 7, characters 2-8.
+       But the kind of type B.t must be a subkind of
+         value mod uncontended portable
+         because of the definition of t at line 4, characters 2-47.
 |}]
 
 module rec A : sig
@@ -954,8 +958,9 @@ end
 Line 9, characters 2-55:
 9 |   type t : value mod portable uncontended = private A.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type A.t is value, because
-         of the definition of t at line 2, characters 2-8.
-       But the layout of type A.t must be a sublayout of value, because
-         of the definition of t at line 9, characters 2-55.
+Error: The kind of type A.t is value
+         because of the definition of t at line 2, characters 2-8.
+       But the kind of type A.t must be a subkind of
+         value mod uncontended portable
+         because of the definition of t at line 9, characters 2-55.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -127,10 +127,10 @@ Line 1, characters 8-29:
             ^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int but is used as an instance of type
          ('a : float64)
-       The layout of int is value
-         because it is the primitive immediate type int.
-       But the layout of int must be a sublayout of float64
-         because of the annotation on the type variable 'a.
+       The layout of int is value, because
+         it is the primitive immediate type int.
+       But the layout of int must be a sublayout of float64, because
+         of the annotation on the type variable 'a.
 |}]
 
 let x : (int as ('a : immediate)) list as ('b : value) = [3;4;5]
@@ -147,10 +147,10 @@ Line 1, characters 8-36:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : immediate)
-       The kind of int list is value
-         because it's a boxed variant type.
-       But the kind of int list must be a subkind of immediate
-         because of the annotation on the type variable 'a.
+       The kind of int list is value, because
+         it's a boxed variant type.
+       But the kind of int list must be a subkind of immediate, because
+         of the annotation on the type variable 'a.
 |}]
 (* CR layouts: error message could be phrased better *)
 
@@ -161,10 +161,10 @@ Line 1, characters 8-43:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : value mod global)
-       The kind of int list is value
-         because it's a boxed variant type.
-       But the kind of int list must be a subkind of value mod global
-         because of the annotation on the type variable 'a.
+       The kind of int list is value, because
+         it's a boxed variant type.
+       But the kind of int list must be a subkind of value mod global, because
+         of the annotation on the type variable 'a.
 |}]
 
 (****************************************)
@@ -290,10 +290,10 @@ Line 1, characters 9-15:
 1 | type t = string t2_imm
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of t2_imm at line 1, characters 0-28.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 type t = string t2_global
@@ -303,10 +303,10 @@ Line 1, characters 9-15:
 1 | type t = string t2_global
              ^^^^^^
 Error: This type string should be an instance of type ('a : value mod global)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of value mod global
-         because of the definition of t2_global at line 8, characters 0-38.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of value mod global, because
+         of the definition of t2_global at line 8, characters 0-38.
 |}]
 
 type u : word
@@ -319,10 +319,10 @@ Line 2, characters 9-10:
              ^
 Error: This type u should be an instance of type
          ('a : word mod many external_)
-       The kind of u is word
-         because of the definition of u at line 1, characters 0-13.
-       But the kind of u must be a subkind of word mod many external_
-         because of the definition of t2_complex at line 10, characters 0-53.
+       The kind of u is word, because
+         of the definition of u at line 1, characters 0-13.
+       But the kind of u must be a subkind of word mod many external_, because
+         of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
 let f : 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -372,8 +372,8 @@ Line 1, characters 8-44:
 1 | let f : ('a : value). 'a t2_imm -> 'a t2_imm = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind immediate
-         because of the definition of t2_imm at line 1, characters 0-28.
+       But it was inferred to have kind immediate, because
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 let f : ('a : value). 'a t2_global -> 'a t2_global = fun x -> x
@@ -383,8 +383,8 @@ Line 1, characters 8-50:
 1 | let f : ('a : value). 'a t2_global -> 'a t2_global = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind value mod global
-         because of the definition of t2_global at line 8, characters 0-38.
+       But it was inferred to have kind value mod global, because
+         of the definition of t2_global at line 8, characters 0-38.
 |}]
 
 let f : ('a : word). 'a t2_complex -> 'a t2_complex = fun x -> x
@@ -394,8 +394,8 @@ Line 1, characters 8-51:
 1 | let f : ('a : word). 'a t2_complex -> 'a t2_complex = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind word.
-       But it was inferred to have kind word mod many external_
-         because of the definition of t2_complex at line 10, characters 0-53.
+       But it was inferred to have kind word mod many external_, because
+         of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
 type 'a t = 'a t2_imm
@@ -490,10 +490,10 @@ Line 1, characters 31-41:
                                    ^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          ('a : any). 'a -> 'a
-       The layout of 'a is any
-         because of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of 'a is any, because
+         of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable, because
+         we must know concretely how to pass a function argument.
 |}]
 (* CR layouts v2.9: This error message is not great. Check later if layout history
    is able to improve it. *)
@@ -546,10 +546,10 @@ Line 1, characters 24-31:
                             ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of r at line 1, characters 0-47.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of r at line 1, characters 0-47.
 |}]
 
 let f { fieldg } = fieldg "hello"
@@ -560,10 +560,10 @@ Line 1, characters 26-33:
                               ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of value mod global
-         because of the definition of rg at line 1, characters 0-56.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of value mod global, because
+         of the definition of rg at line 1, characters 0-56.
 |}]
 
 let f { fieldc } = fieldc "hello"
@@ -574,10 +574,10 @@ Line 1, characters 26-33:
                               ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : word mod many external_)
-       The layout of string is value
-         because it is the primitive value type string.
-       But the layout of string must be a sublayout of word
-         because of the definition of rc at line 1, characters 0-70.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of word, because
+         of the definition of rc at line 1, characters 0-70.
 |}]
 
 let r = { field = fun x -> x }
@@ -612,10 +612,10 @@ Line 2, characters 18-55:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The kind of 'a is value
-         because of the definition of r_value at line 1, characters 0-39.
-       But the kind of 'a must be a subkind of immediate
-         because of the annotation on the abstract type declaration for a.
+       The kind of 'a is value, because
+         of the definition of r_value at line 1, characters 0-39.
+       But the kind of 'a must be a subkind of immediate, because
+         of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
 
@@ -626,10 +626,10 @@ Line 1, characters 18-62:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The kind of 'a is value
-         because of the definition of r_value at line 1, characters 0-39.
-       But the kind of 'a must be a subkind of value mod global
-         because of the annotation on the abstract type declaration for a.
+       The kind of 'a is value, because
+         of the definition of r_value at line 1, characters 0-39.
+       But the kind of 'a must be a subkind of value mod global, because
+         of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
 
@@ -648,10 +648,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value
-           because of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of immediate
-           because of the definition of t_imm at line 1, characters 0-27.
+         The kind of 'a is value, because
+           of the annotation on the universal variable 'a.
+         But the kind of 'a must be a subkind of immediate, because
+           of the definition of t_imm at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -674,10 +674,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value
-           because of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of value mod global
-           because of the definition of t_global at line 1, characters 0-37.
+         The kind of 'a is value, because
+           of the annotation on the universal variable 'a.
+         But the kind of 'a must be a subkind of value mod global, because
+           of the definition of t_global at line 1, characters 0-37.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -696,10 +696,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is word
-           because of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of word mod many external_
-           because of the definition of t_complex at line 1, characters 0-52.
+         The kind of 'a is word, because
+           of the annotation on the universal variable 'a.
+         But the kind of 'a must be a subkind of word mod many external_, because
+           of the definition of t_complex at line 1, characters 0-52.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -746,10 +746,10 @@ Line 1, characters 29-36:
 Error: This pattern matches values of type a
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_1)
-       The layout of a is any
-         because of the annotation on the abstract type declaration for a.
-       But the layout of a must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of a is any, because
+         of the annotation on the abstract type declaration for a.
+       But the layout of a must be representable, because
+         we must know concretely how to pass a function argument.
 |}]
 
 (****************************************)
@@ -792,10 +792,10 @@ Line 1, characters 33-43:
 1 | let f : type (a : any). a -> a = fun x -> x
                                      ^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of a is any
-         because of the annotation on the abstract type declaration for a.
-       But the layout of a must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of a is any, because
+         of the annotation on the abstract type declaration for a.
+       But the layout of a must be representable, because
+         we must know concretely how to pass a function argument.
 |}]
 
 (**************************************************)
@@ -810,8 +810,8 @@ Line 2, characters 10-36:
 2 |   val f : 'a. 'a t2_imm -> 'a t2_imm
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was defaulted to have kind value.
-       But it was inferred to have kind immediate
-         because of the definition of t2_imm at line 1, characters 0-28.
+       But it was inferred to have kind immediate, because
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -821,8 +821,8 @@ Line 1, characters 8-34:
 1 | let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was defaulted to have kind value.
-       But it was inferred to have kind immediate
-         because of the definition of t2_imm at line 1, characters 0-28.
+       But it was inferred to have kind immediate, because
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 (********************************************)
@@ -845,8 +845,8 @@ Line 2, characters 10-46:
 2 |   val f : ('a : value). 'a t2_imm -> 'a t2_imm
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind immediate
-         because of the definition of t2_imm at line 1, characters 0-28.
+       But it was inferred to have kind immediate, because
+         of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 module type S = sig
@@ -858,8 +858,8 @@ Line 2, characters 10-52:
 2 |   val f : ('a : value). 'a t2_global -> 'a t2_global
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind value mod global
-         because of the definition of t2_global at line 8, characters 0-38.
+       But it was inferred to have kind value mod global, because
+         of the definition of t2_global at line 8, characters 0-38.
 |}]
 
 module type S = sig
@@ -872,10 +872,10 @@ Line 2, characters 24-26:
                             ^^
 Error: This type ('a : value) should be an instance of type
          ('b : word mod many external_)
-       The layout of 'a is value
-         because of the annotation on the universal variable 'a.
-       But the layout of 'a must overlap with word
-         because of the definition of t2_complex at line 10, characters 0-53.
+       The layout of 'a is value, because
+         of the annotation on the universal variable 'a.
+       But the layout of 'a must overlap with word, because
+         of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
 module type S = sig
@@ -887,8 +887,8 @@ Line 2, characters 10-53:
 2 |   val f : ('a : word). 'a t2_complex -> 'a t2_complex
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind word.
-       But it was inferred to have kind word mod many external_
-         because of the definition of t2_complex at line 10, characters 0-53.
+       But it was inferred to have kind word mod many external_, because
+         of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
 module type S = sig
@@ -970,10 +970,10 @@ Line 1, characters 43-51:
                                                ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the annotation on the universal variable 'a.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the annotation on the universal variable 'a.
 |}]
 
 let f (x : ('a : value mod global). 'a -> 'a) = x "string"
@@ -984,10 +984,10 @@ Line 1, characters 50-58:
                                                       ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of value mod global
-         because of the annotation on the universal variable 'a.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of value mod global, because
+         of the annotation on the universal variable 'a.
 |}]
 
 (**************************************)
@@ -1015,10 +1015,10 @@ type t : value mod global = { x : int}
 Line 1, characters 0-38:
 1 | type t : value mod global = { x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
    immediate *)
@@ -1028,10 +1028,10 @@ type t : any mod portable = { x : float }
 Line 1, characters 0-41:
 1 | type t : any mod portable = { x : float }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod portable, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
    immediate *)
@@ -1063,10 +1063,10 @@ type t : value mod global = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod unique = { x : t_value }
@@ -1074,10 +1074,10 @@ type t : value mod unique = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod unique = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod unique, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod many = { x : t_value }
@@ -1085,10 +1085,10 @@ type t : value mod many = { x : t_value }
 Line 1, characters 0-41:
 1 | type t : value mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod many, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod portable = { x : t_value }
@@ -1096,10 +1096,10 @@ type t : value mod portable = { x : t_value }
 Line 1, characters 0-45:
 1 | type t : value mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod portable
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod portable, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod uncontended = { x : t_value }
@@ -1107,10 +1107,10 @@ type t : value mod uncontended = { x : t_value }
 Line 1, characters 0-48:
 1 | type t : value mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod uncontended
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod uncontended, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod external_ = { x : t_value }
@@ -1118,10 +1118,10 @@ type t : value mod external_ = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod external_ = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod external_, because
+         of the annotation on the declaration of the type t.
 |}]
 
 (***************************************)
@@ -1144,10 +1144,10 @@ type t : value mod global = Foo of int
 Line 1, characters 0-38:
 1 | type t : value mod global = Foo of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod global, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod portable = Foo of float
@@ -1155,10 +1155,10 @@ type t : any mod portable = Foo of float
 Line 1, characters 0-40:
 1 | type t : any mod portable = Foo of float
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod portable, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t = Foo | Bar
@@ -1210,10 +1210,10 @@ type t : value mod global = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod global = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod global, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod unique = Foo of t_value
@@ -1221,10 +1221,10 @@ type t : value mod unique = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod unique = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod unique
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod unique, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod many = Foo of t_value
@@ -1232,10 +1232,10 @@ type t : value mod many = Foo of t_value
 Line 1, characters 0-40:
 1 | type t : value mod many = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod many, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod portable = Foo of t_value
@@ -1243,10 +1243,10 @@ type t : value mod portable = Foo of t_value
 Line 1, characters 0-44:
 1 | type t : value mod portable = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod portable
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod portable, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod uncontended = Foo of t_value
@@ -1254,10 +1254,10 @@ type t : value mod uncontended = Foo of t_value
 Line 1, characters 0-47:
 1 | type t : value mod uncontended = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod uncontended
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod uncontended, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod external_ = Foo of t_value
@@ -1265,10 +1265,10 @@ type t : value mod external_ = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod external_ = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod external_, because
+         of the annotation on the declaration of the type t.
 |}]
 
 (***************************************)
@@ -1331,10 +1331,10 @@ type t : float64 mod global portable
 Line 2, characters 0-47:
 2 | type u : bits64 mod global portable = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is float64
-         because of the definition of t at line 1, characters 0-36.
-       But the layout of type t must be a sublayout of bits64
-         because of the definition of u at line 2, characters 0-47.
+Error: The layout of type t is float64, because
+         of the definition of t at line 1, characters 0-36.
+       But the layout of type t must be a sublayout of bits64, because
+         of the definition of u at line 2, characters 0-47.
 |}]
 
 type t : word
@@ -1344,10 +1344,10 @@ type t : word
 Line 2, characters 0-36:
 2 | type u : word mod global = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word
-         because of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod global
-         because of the definition of u at line 2, characters 0-36.
+Error: The kind of type t is word, because
+         of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod global, because
+         of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1359,10 +1359,10 @@ type t : word
 Line 2, characters 0-36:
 2 | type u : word mod unique = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word
-         because of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod unique
-         because of the definition of u at line 2, characters 0-36.
+Error: The kind of type t is word, because
+         of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod unique, because
+         of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1374,10 +1374,10 @@ type t : word
 Line 2, characters 0-34:
 2 | type u : word mod many = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word
-         because of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod many
-         because of the definition of u at line 2, characters 0-34.
+Error: The kind of type t is word, because
+         of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod many, because
+         of the definition of u at line 2, characters 0-34.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1389,10 +1389,10 @@ type t : word
 Line 2, characters 0-38:
 2 | type u : word mod portable = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word
-         because of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod portable
-         because of the definition of u at line 2, characters 0-38.
+Error: The kind of type t is word, because
+         of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod portable, because
+         of the definition of u at line 2, characters 0-38.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1404,10 +1404,10 @@ type t : word
 Line 2, characters 0-41:
 2 | type u : word mod uncontended = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word
-         because of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod uncontended
-         because of the definition of u at line 2, characters 0-41.
+Error: The kind of type t is word, because
+         of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod uncontended, because
+         of the definition of u at line 2, characters 0-41.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1419,10 +1419,10 @@ type t : word
 Line 2, characters 0-39:
 2 | type u : word mod external_ = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word
-         because of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod external_
-         because of the definition of u at line 2, characters 0-39.
+Error: The kind of type t is word, because
+         of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod external_, because
+         of the definition of u at line 2, characters 0-39.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1621,10 +1621,10 @@ Line 1, characters 37-53:
                                          ^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The kind of 'a is value
-         because of the annotation on the universal variable 'a.
-       But the kind of 'a must be a subkind of immediate
-         because of the definition of f_imm at line 1, characters 4-9.
+       The kind of 'a is value, because
+         of the annotation on the universal variable 'a.
+       But the kind of 'a must be a subkind of immediate, because
+         of the definition of f_imm at line 1, characters 4-9.
 |}]
 
 type (_ : value) g =

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -163,7 +163,7 @@ Error: This alias is bound to type int list
        but is used as an instance of type ('a : value mod global)
        The layout of int list is value, because
          it's a boxed variant type.
-       But the layout of int list must be a sublayout of value mod global, because
+       But the layout of int list must be a sublayout of value, because
          of the annotation on the type variable 'a.
 |}]
 
@@ -305,7 +305,7 @@ Line 1, characters 9-15:
 Error: This type string should be an instance of type ('a : value mod global)
        The layout of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value mod global, because
+       But the layout of string must be a sublayout of value, because
          of the definition of t2_global at line 8, characters 0-38.
 |}]
 
@@ -321,7 +321,7 @@ Error: This type u should be an instance of type
          ('a : word mod many external_)
        The layout of u is word, because
          of the definition of u at line 1, characters 0-13.
-       But the layout of u must be a sublayout of word mod many external_, because
+       But the layout of u must be a sublayout of word, because
          of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
@@ -383,7 +383,7 @@ Line 1, characters 8-50:
 1 | let f : ('a : value). 'a t2_global -> 'a t2_global = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind value mod global, because
+       But it was inferred to have kind value, because
          of the definition of t2_global at line 8, characters 0-38.
 |}]
 
@@ -394,7 +394,7 @@ Line 1, characters 8-51:
 1 | let f : ('a : word). 'a t2_complex -> 'a t2_complex = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind word.
-       But it was inferred to have kind word mod many external_, because
+       But it was inferred to have kind word, because
          of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
@@ -562,7 +562,7 @@ Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
        The layout of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value mod global, because
+       But the layout of string must be a sublayout of value, because
          of the definition of rg at line 1, characters 0-56.
 |}]
 
@@ -628,7 +628,7 @@ Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
        The layout of 'a is value, because
          of the definition of r_value at line 1, characters 0-39.
-       But the layout of 'a must be a sublayout of value mod global, because
+       But the layout of 'a must be a sublayout of value, because
          of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
@@ -676,7 +676,7 @@ Error: Layout mismatch in final type declaration consistency check.
        message, so we'll say this instead:
          The layout of 'a is value, because
            of the annotation on the universal variable 'a.
-         But the layout of 'a must be a sublayout of value mod global, because
+         But the layout of 'a must be a sublayout of value, because
            of the definition of t_global at line 1, characters 0-37.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -698,7 +698,7 @@ Error: Layout mismatch in final type declaration consistency check.
        message, so we'll say this instead:
          The layout of 'a is word, because
            of the annotation on the universal variable 'a.
-         But the layout of 'a must be a sublayout of word mod many external_, because
+         But the layout of 'a must be a sublayout of word, because
            of the definition of t_complex at line 1, characters 0-52.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -858,7 +858,7 @@ Line 2, characters 10-52:
 2 |   val f : ('a : value). 'a t2_global -> 'a t2_global
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind value mod global, because
+       But it was inferred to have kind value, because
          of the definition of t2_global at line 8, characters 0-38.
 |}]
 
@@ -887,7 +887,7 @@ Line 2, characters 10-53:
 2 |   val f : ('a : word). 'a t2_complex -> 'a t2_complex
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind word.
-       But it was inferred to have kind word mod many external_, because
+       But it was inferred to have kind word, because
          of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
@@ -986,7 +986,7 @@ Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
        The layout of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value mod global, because
+       But the layout of string must be a sublayout of value, because
          of the annotation on the universal variable 'a.
 |}]
 
@@ -1017,7 +1017,7 @@ Line 1, characters 0-38:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod global, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
@@ -1030,7 +1030,7 @@ Line 1, characters 0-41:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod portable, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
@@ -1065,7 +1065,7 @@ Line 1, characters 0-43:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod global, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1076,7 +1076,7 @@ Line 1, characters 0-43:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod unique, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1087,7 +1087,7 @@ Line 1, characters 0-41:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod many, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1098,7 +1098,7 @@ Line 1, characters 0-45:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod portable, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1109,7 +1109,7 @@ Line 1, characters 0-48:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod uncontended, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1120,7 +1120,7 @@ Line 1, characters 0-46:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod external_, because
+       But the layout of type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1146,7 +1146,7 @@ Line 1, characters 0-38:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value mod global, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1157,7 +1157,7 @@ Line 1, characters 0-40:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any mod portable, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1212,7 +1212,7 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value mod global, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1223,7 +1223,7 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value mod unique, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1234,7 +1234,7 @@ Line 1, characters 0-40:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value mod many, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1245,7 +1245,7 @@ Line 1, characters 0-44:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value mod portable, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1256,7 +1256,7 @@ Line 1, characters 0-47:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value mod uncontended, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1267,7 +1267,7 @@ Line 1, characters 0-45:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value mod external_, because
+       But the layout of type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1346,7 +1346,7 @@ Line 2, characters 0-36:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word mod global, because
+       But the layout of type t must be a sublayout of word, because
          of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1361,7 +1361,7 @@ Line 2, characters 0-36:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word mod unique, because
+       But the layout of type t must be a sublayout of word, because
          of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1376,7 +1376,7 @@ Line 2, characters 0-34:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word mod many, because
+       But the layout of type t must be a sublayout of word, because
          of the definition of u at line 2, characters 0-34.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1391,7 +1391,7 @@ Line 2, characters 0-38:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word mod portable, because
+       But the layout of type t must be a sublayout of word, because
          of the definition of u at line 2, characters 0-38.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1406,7 +1406,7 @@ Line 2, characters 0-41:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word mod uncontended, because
+       But the layout of type t must be a sublayout of word, because
          of the definition of u at line 2, characters 0-41.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1421,7 +1421,7 @@ Line 2, characters 0-39:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word mod external_, because
+       But the layout of type t must be a sublayout of word, because
          of the definition of u at line 2, characters 0-39.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -147,9 +147,9 @@ Line 1, characters 8-36:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : immediate)
-       The layout of int list is value, because
+       The kind of int list is value, because
          it's a boxed variant type.
-       But the layout of int list must be a sublayout of immediate, because
+       But the kind of int list must be a subkind of immediate, because
          of the annotation on the type variable 'a.
 |}]
 (* CR layouts: error message could be phrased better *)
@@ -161,9 +161,9 @@ Line 1, characters 8-43:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : value mod global)
-       The layout of int list is value, because
+       The kind of int list is value, because
          it's a boxed variant type.
-       But the layout of int list must be a sublayout of value, because
+       But the kind of int list must be a subkind of value mod global, because
          of the annotation on the type variable 'a.
 |}]
 
@@ -290,9 +290,9 @@ Line 1, characters 9-15:
 1 | type t = string t2_imm
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
@@ -303,9 +303,9 @@ Line 1, characters 9-15:
 1 | type t = string t2_global
              ^^^^^^
 Error: This type string should be an instance of type ('a : value mod global)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
+       But the kind of string must be a subkind of value mod global, because
          of the definition of t2_global at line 8, characters 0-38.
 |}]
 
@@ -319,9 +319,9 @@ Line 2, characters 9-10:
              ^
 Error: This type u should be an instance of type
          ('a : word mod many external_)
-       The layout of u is word, because
+       The kind of u is word, because
          of the definition of u at line 1, characters 0-13.
-       But the layout of u must be a sublayout of word, because
+       But the kind of u must be a subkind of word mod many external_, because
          of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
@@ -383,7 +383,7 @@ Line 1, characters 8-50:
 1 | let f : ('a : value). 'a t2_global -> 'a t2_global = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind value, because
+       But it was inferred to have kind value mod global, because
          of the definition of t2_global at line 8, characters 0-38.
 |}]
 
@@ -394,7 +394,7 @@ Line 1, characters 8-51:
 1 | let f : ('a : word). 'a t2_complex -> 'a t2_complex = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind word.
-       But it was inferred to have kind word, because
+       But it was inferred to have kind word mod many external_, because
          of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
@@ -546,9 +546,9 @@ Line 1, characters 24-31:
                             ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of r at line 1, characters 0-47.
 |}]
 
@@ -560,9 +560,9 @@ Line 1, characters 26-33:
                               ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
+       But the kind of string must be a subkind of value mod global, because
          of the definition of rg at line 1, characters 0-56.
 |}]
 
@@ -612,9 +612,9 @@ Line 2, characters 18-55:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          of the definition of r_value at line 1, characters 0-39.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
@@ -626,9 +626,9 @@ Line 1, characters 18-62:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          of the definition of r_value at line 1, characters 0-39.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value mod global, because
          of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
@@ -648,9 +648,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is value, because
+         The kind of 'a is value, because
            of the annotation on the universal variable 'a.
-         But the layout of 'a must be a sublayout of immediate, because
+         But the kind of 'a must be a subkind of immediate, because
            of the definition of t_imm at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -674,9 +674,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is value, because
+         The kind of 'a is value, because
            of the annotation on the universal variable 'a.
-         But the layout of 'a must be a sublayout of value, because
+         But the kind of 'a must be a subkind of value mod global, because
            of the definition of t_global at line 1, characters 0-37.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -696,9 +696,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is word, because
+         The kind of 'a is word, because
            of the annotation on the universal variable 'a.
-         But the layout of 'a must be a sublayout of word, because
+         But the kind of 'a must be a subkind of word mod many external_, because
            of the definition of t_complex at line 1, characters 0-52.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -858,7 +858,7 @@ Line 2, characters 10-52:
 2 |   val f : ('a : value). 'a t2_global -> 'a t2_global
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind value, because
+       But it was inferred to have kind value mod global, because
          of the definition of t2_global at line 8, characters 0-38.
 |}]
 
@@ -887,7 +887,7 @@ Line 2, characters 10-53:
 2 |   val f : ('a : word). 'a t2_complex -> 'a t2_complex
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind word.
-       But it was inferred to have kind word, because
+       But it was inferred to have kind word mod many external_, because
          of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
@@ -970,9 +970,9 @@ Line 1, characters 43-51:
                                                ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on the universal variable 'a.
 |}]
 
@@ -984,9 +984,9 @@ Line 1, characters 50-58:
                                                       ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
+       But the kind of string must be a subkind of value mod global, because
          of the annotation on the universal variable 'a.
 |}]
 
@@ -1015,9 +1015,9 @@ type t : value mod global = { x : int}
 Line 1, characters 0-38:
 1 | type t : value mod global = { x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
@@ -1028,9 +1028,9 @@ type t : any mod portable = { x : float }
 Line 1, characters 0-41:
 1 | type t : any mod portable = { x : float }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
@@ -1063,9 +1063,9 @@ type t : value mod global = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1074,9 +1074,9 @@ type t : value mod unique = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod unique = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1085,9 +1085,9 @@ type t : value mod many = { x : t_value }
 Line 1, characters 0-41:
 1 | type t : value mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod many, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1096,9 +1096,9 @@ type t : value mod portable = { x : t_value }
 Line 1, characters 0-45:
 1 | type t : value mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1107,9 +1107,9 @@ type t : value mod uncontended = { x : t_value }
 Line 1, characters 0-48:
 1 | type t : value mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1118,9 +1118,9 @@ type t : value mod external_ = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod external_ = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of value mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1144,9 +1144,9 @@ type t : value mod global = Foo of int
 Line 1, characters 0-38:
 1 | type t : value mod global = Foo of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1155,9 +1155,9 @@ type t : any mod portable = Foo of float
 Line 1, characters 0-40:
 1 | type t : any mod portable = Foo of float
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1210,9 +1210,9 @@ type t : value mod global = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod global = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1221,9 +1221,9 @@ type t : value mod unique = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod unique = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1232,9 +1232,9 @@ type t : value mod many = Foo of t_value
 Line 1, characters 0-40:
 1 | type t : value mod many = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod many, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1243,9 +1243,9 @@ type t : value mod portable = Foo of t_value
 Line 1, characters 0-44:
 1 | type t : value mod portable = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1254,9 +1254,9 @@ type t : value mod uncontended = Foo of t_value
 Line 1, characters 0-47:
 1 | type t : value mod uncontended = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1265,9 +1265,9 @@ type t : value mod external_ = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod external_ = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of value mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1344,9 +1344,9 @@ type t : word
 Line 2, characters 0-36:
 2 | type u : word mod global = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod global, because
          of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1359,9 +1359,9 @@ type t : word
 Line 2, characters 0-36:
 2 | type u : word mod unique = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod unique, because
          of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1374,9 +1374,9 @@ type t : word
 Line 2, characters 0-34:
 2 | type u : word mod many = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod many, because
          of the definition of u at line 2, characters 0-34.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1389,9 +1389,9 @@ type t : word
 Line 2, characters 0-38:
 2 | type u : word mod portable = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod portable, because
          of the definition of u at line 2, characters 0-38.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1404,9 +1404,9 @@ type t : word
 Line 2, characters 0-41:
 2 | type u : word mod uncontended = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod uncontended, because
          of the definition of u at line 2, characters 0-41.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1419,9 +1419,9 @@ type t : word
 Line 2, characters 0-39:
 2 | type u : word mod external_ = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod external_, because
          of the definition of u at line 2, characters 0-39.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1621,9 +1621,9 @@ Line 1, characters 37-53:
                                          ^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          of the annotation on the universal variable 'a.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the definition of f_imm at line 1, characters 4-9.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -147,9 +147,9 @@ Line 1, characters 8-36:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : immediate)
-       The kind of int list is value, because
+       The layout of int list is value, because
          it's a boxed variant type.
-       But the kind of int list must be a subkind of immediate, because
+       But the layout of int list must be a sublayout of immediate, because
          of the annotation on the type variable 'a.
 |}]
 (* CR layouts: error message could be phrased better *)
@@ -161,9 +161,9 @@ Line 1, characters 8-43:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : value mod global)
-       The kind of int list is value, because
+       The layout of int list is value, because
          it's a boxed variant type.
-       But the kind of int list must be a subkind of value mod global, because
+       But the layout of int list must be a sublayout of value mod global, because
          of the annotation on the type variable 'a.
 |}]
 
@@ -290,9 +290,9 @@ Line 1, characters 9-15:
 1 | type t = string t2_imm
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
@@ -303,9 +303,9 @@ Line 1, characters 9-15:
 1 | type t = string t2_global
              ^^^^^^
 Error: This type string should be an instance of type ('a : value mod global)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of value mod global, because
+       But the layout of string must be a sublayout of value mod global, because
          of the definition of t2_global at line 8, characters 0-38.
 |}]
 
@@ -319,9 +319,9 @@ Line 2, characters 9-10:
              ^
 Error: This type u should be an instance of type
          ('a : word mod many external_)
-       The kind of u is word, because
+       The layout of u is word, because
          of the definition of u at line 1, characters 0-13.
-       But the kind of u must be a subkind of word mod many external_, because
+       But the layout of u must be a sublayout of word mod many external_, because
          of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
@@ -546,9 +546,9 @@ Line 1, characters 24-31:
                             ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of r at line 1, characters 0-47.
 |}]
 
@@ -560,9 +560,9 @@ Line 1, characters 26-33:
                               ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of value mod global, because
+       But the layout of string must be a sublayout of value mod global, because
          of the definition of rg at line 1, characters 0-56.
 |}]
 
@@ -612,9 +612,9 @@ Line 2, characters 18-55:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The kind of 'a is value, because
+       The layout of 'a is value, because
          of the definition of r_value at line 1, characters 0-39.
-       But the kind of 'a must be a subkind of immediate, because
+       But the layout of 'a must be a sublayout of immediate, because
          of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
@@ -626,9 +626,9 @@ Line 1, characters 18-62:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The kind of 'a is value, because
+       The layout of 'a is value, because
          of the definition of r_value at line 1, characters 0-39.
-       But the kind of 'a must be a subkind of value mod global, because
+       But the layout of 'a must be a sublayout of value mod global, because
          of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
@@ -648,9 +648,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value, because
+         The layout of 'a is value, because
            of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of immediate, because
+         But the layout of 'a must be a sublayout of immediate, because
            of the definition of t_imm at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -674,9 +674,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value, because
+         The layout of 'a is value, because
            of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of value mod global, because
+         But the layout of 'a must be a sublayout of value mod global, because
            of the definition of t_global at line 1, characters 0-37.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -696,9 +696,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is word, because
+         The layout of 'a is word, because
            of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of word mod many external_, because
+         But the layout of 'a must be a sublayout of word mod many external_, because
            of the definition of t_complex at line 1, characters 0-52.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -970,9 +970,9 @@ Line 1, characters 43-51:
                                                ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the annotation on the universal variable 'a.
 |}]
 
@@ -984,9 +984,9 @@ Line 1, characters 50-58:
                                                       ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of value mod global, because
+       But the layout of string must be a sublayout of value mod global, because
          of the annotation on the universal variable 'a.
 |}]
 
@@ -1015,9 +1015,9 @@ type t : value mod global = { x : int}
 Line 1, characters 0-38:
 1 | type t : value mod global = { x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global, because
+       But the layout of type t must be a sublayout of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
@@ -1028,9 +1028,9 @@ type t : any mod portable = { x : float }
 Line 1, characters 0-41:
 1 | type t : any mod portable = { x : float }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod portable, because
+       But the layout of type t must be a sublayout of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
@@ -1063,9 +1063,9 @@ type t : value mod global = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global, because
+       But the layout of type t must be a sublayout of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1074,9 +1074,9 @@ type t : value mod unique = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod unique = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique, because
+       But the layout of type t must be a sublayout of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1085,9 +1085,9 @@ type t : value mod many = { x : t_value }
 Line 1, characters 0-41:
 1 | type t : value mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many, because
+       But the layout of type t must be a sublayout of value mod many, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1096,9 +1096,9 @@ type t : value mod portable = { x : t_value }
 Line 1, characters 0-45:
 1 | type t : value mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod portable, because
+       But the layout of type t must be a sublayout of value mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1107,9 +1107,9 @@ type t : value mod uncontended = { x : t_value }
 Line 1, characters 0-48:
 1 | type t : value mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod uncontended, because
+       But the layout of type t must be a sublayout of value mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1118,9 +1118,9 @@ type t : value mod external_ = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod external_ = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external_, because
+       But the layout of type t must be a sublayout of value mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1144,9 +1144,9 @@ type t : value mod global = Foo of int
 Line 1, characters 0-38:
 1 | type t : value mod global = Foo of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod global, because
+       But the layout of type t must be a sublayout of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1155,9 +1155,9 @@ type t : any mod portable = Foo of float
 Line 1, characters 0-40:
 1 | type t : any mod portable = Foo of float
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod portable, because
+       But the layout of type t must be a sublayout of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1210,9 +1210,9 @@ type t : value mod global = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod global = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod global, because
+       But the layout of type t must be a sublayout of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1221,9 +1221,9 @@ type t : value mod unique = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod unique = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod unique, because
+       But the layout of type t must be a sublayout of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1232,9 +1232,9 @@ type t : value mod many = Foo of t_value
 Line 1, characters 0-40:
 1 | type t : value mod many = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod many, because
+       But the layout of type t must be a sublayout of value mod many, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1243,9 +1243,9 @@ type t : value mod portable = Foo of t_value
 Line 1, characters 0-44:
 1 | type t : value mod portable = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod portable, because
+       But the layout of type t must be a sublayout of value mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1254,9 +1254,9 @@ type t : value mod uncontended = Foo of t_value
 Line 1, characters 0-47:
 1 | type t : value mod uncontended = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod uncontended, because
+       But the layout of type t must be a sublayout of value mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1265,9 +1265,9 @@ type t : value mod external_ = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod external_ = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod external_, because
+       But the layout of type t must be a sublayout of value mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1344,9 +1344,9 @@ type t : word
 Line 2, characters 0-36:
 2 | type u : word mod global = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
+Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod global, because
+       But the layout of type t must be a sublayout of word mod global, because
          of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1359,9 +1359,9 @@ type t : word
 Line 2, characters 0-36:
 2 | type u : word mod unique = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
+Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod unique, because
+       But the layout of type t must be a sublayout of word mod unique, because
          of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1374,9 +1374,9 @@ type t : word
 Line 2, characters 0-34:
 2 | type u : word mod many = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
+Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod many, because
+       But the layout of type t must be a sublayout of word mod many, because
          of the definition of u at line 2, characters 0-34.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1389,9 +1389,9 @@ type t : word
 Line 2, characters 0-38:
 2 | type u : word mod portable = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
+Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod portable, because
+       But the layout of type t must be a sublayout of word mod portable, because
          of the definition of u at line 2, characters 0-38.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1404,9 +1404,9 @@ type t : word
 Line 2, characters 0-41:
 2 | type u : word mod uncontended = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
+Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod uncontended, because
+       But the layout of type t must be a sublayout of word mod uncontended, because
          of the definition of u at line 2, characters 0-41.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1419,9 +1419,9 @@ type t : word
 Line 2, characters 0-39:
 2 | type u : word mod external_ = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
+Error: The layout of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod external_, because
+       But the layout of type t must be a sublayout of word mod external_, because
          of the definition of u at line 2, characters 0-39.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1621,9 +1621,9 @@ Line 1, characters 37-53:
                                          ^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The kind of 'a is value, because
+       The layout of 'a is value, because
          of the annotation on the universal variable 'a.
-       But the kind of 'a must be a subkind of immediate, because
+       But the layout of 'a must be a sublayout of immediate, because
          of the definition of f_imm at line 1, characters 4-9.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -127,10 +127,10 @@ Line 1, characters 8-29:
             ^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int but is used as an instance of type
          ('a : float64)
-       The layout of int is value, because
-         it is the primitive immediate type int.
-       But the layout of int must be a sublayout of float64, because
-         of the annotation on the type variable 'a.
+       The layout of int is value
+         because it is the primitive immediate type int.
+       But the layout of int must be a sublayout of float64
+         because of the annotation on the type variable 'a.
 |}]
 
 let x : (int as ('a : immediate)) list as ('b : value) = [3;4;5]
@@ -147,10 +147,10 @@ Line 1, characters 8-36:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : immediate)
-       The kind of int list is value, because
-         it's a boxed variant type.
-       But the kind of int list must be a subkind of immediate, because
-         of the annotation on the type variable 'a.
+       The kind of int list is value
+         because it's a boxed variant type.
+       But the kind of int list must be a subkind of immediate
+         because of the annotation on the type variable 'a.
 |}]
 (* CR layouts: error message could be phrased better *)
 
@@ -161,10 +161,10 @@ Line 1, characters 8-43:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : value mod global)
-       The kind of int list is value, because
-         it's a boxed variant type.
-       But the kind of int list must be a subkind of value mod global, because
-         of the annotation on the type variable 'a.
+       The kind of int list is value
+         because it's a boxed variant type.
+       But the kind of int list must be a subkind of value mod global
+         because of the annotation on the type variable 'a.
 |}]
 
 (****************************************)
@@ -290,10 +290,10 @@ Line 1, characters 9-15:
 1 | type t = string t2_imm
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of t2_imm at line 1, characters 0-28.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 type t = string t2_global
@@ -303,10 +303,10 @@ Line 1, characters 9-15:
 1 | type t = string t2_global
              ^^^^^^
 Error: This type string should be an instance of type ('a : value mod global)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of value mod global, because
-         of the definition of t2_global at line 8, characters 0-38.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of value mod global
+         because of the definition of t2_global at line 8, characters 0-38.
 |}]
 
 type u : word
@@ -319,10 +319,10 @@ Line 2, characters 9-10:
              ^
 Error: This type u should be an instance of type
          ('a : word mod many external_)
-       The kind of u is word, because
-         of the definition of u at line 1, characters 0-13.
-       But the kind of u must be a subkind of word mod many external_, because
-         of the definition of t2_complex at line 10, characters 0-53.
+       The kind of u is word
+         because of the definition of u at line 1, characters 0-13.
+       But the kind of u must be a subkind of word mod many external_
+         because of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
 let f : 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -372,8 +372,8 @@ Line 1, characters 8-44:
 1 | let f : ('a : value). 'a t2_imm -> 'a t2_imm = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind immediate, because
-         of the definition of t2_imm at line 1, characters 0-28.
+       But it was inferred to have kind immediate
+         because of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 let f : ('a : value). 'a t2_global -> 'a t2_global = fun x -> x
@@ -383,8 +383,8 @@ Line 1, characters 8-50:
 1 | let f : ('a : value). 'a t2_global -> 'a t2_global = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind value mod global, because
-         of the definition of t2_global at line 8, characters 0-38.
+       But it was inferred to have kind value mod global
+         because of the definition of t2_global at line 8, characters 0-38.
 |}]
 
 let f : ('a : word). 'a t2_complex -> 'a t2_complex = fun x -> x
@@ -394,8 +394,8 @@ Line 1, characters 8-51:
 1 | let f : ('a : word). 'a t2_complex -> 'a t2_complex = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind word.
-       But it was inferred to have kind word mod many external_, because
-         of the definition of t2_complex at line 10, characters 0-53.
+       But it was inferred to have kind word mod many external_
+         because of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
 type 'a t = 'a t2_imm
@@ -490,10 +490,10 @@ Line 1, characters 31-41:
                                    ^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          ('a : any). 'a -> 'a
-       The layout of 'a is any, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable
+         because we must know concretely how to pass a function argument.
 |}]
 (* CR layouts v2.9: This error message is not great. Check later if layout history
    is able to improve it. *)
@@ -546,10 +546,10 @@ Line 1, characters 24-31:
                             ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of r at line 1, characters 0-47.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of r at line 1, characters 0-47.
 |}]
 
 let f { fieldg } = fieldg "hello"
@@ -560,10 +560,10 @@ Line 1, characters 26-33:
                               ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of value mod global, because
-         of the definition of rg at line 1, characters 0-56.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of value mod global
+         because of the definition of rg at line 1, characters 0-56.
 |}]
 
 let f { fieldc } = fieldc "hello"
@@ -574,10 +574,10 @@ Line 1, characters 26-33:
                               ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : word mod many external_)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of word, because
-         of the definition of rc at line 1, characters 0-70.
+       The layout of string is value
+         because it is the primitive value type string.
+       But the layout of string must be a sublayout of word
+         because of the definition of rc at line 1, characters 0-70.
 |}]
 
 let r = { field = fun x -> x }
@@ -612,10 +612,10 @@ Line 2, characters 18-55:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The kind of 'a is value, because
-         of the definition of r_value at line 1, characters 0-39.
-       But the kind of 'a must be a subkind of immediate, because
-         of the annotation on the abstract type declaration for a.
+       The kind of 'a is value
+         because of the definition of r_value at line 1, characters 0-39.
+       But the kind of 'a must be a subkind of immediate
+         because of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
 
@@ -626,10 +626,10 @@ Line 1, characters 18-62:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The kind of 'a is value, because
-         of the definition of r_value at line 1, characters 0-39.
-       But the kind of 'a must be a subkind of value mod global, because
-         of the annotation on the abstract type declaration for a.
+       The kind of 'a is value
+         because of the definition of r_value at line 1, characters 0-39.
+       But the kind of 'a must be a subkind of value mod global
+         because of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
 
@@ -648,10 +648,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value, because
-           of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of immediate, because
-           of the definition of t_imm at line 1, characters 0-27.
+         The kind of 'a is value
+           because of the annotation on the universal variable 'a.
+         But the kind of 'a must be a subkind of immediate
+           because of the definition of t_imm at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -674,10 +674,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value, because
-           of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of value mod global, because
-           of the definition of t_global at line 1, characters 0-37.
+         The kind of 'a is value
+           because of the annotation on the universal variable 'a.
+         But the kind of 'a must be a subkind of value mod global
+           because of the definition of t_global at line 1, characters 0-37.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -696,10 +696,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is word, because
-           of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of word mod many external_, because
-           of the definition of t_complex at line 1, characters 0-52.
+         The kind of 'a is word
+           because of the annotation on the universal variable 'a.
+         But the kind of 'a must be a subkind of word mod many external_
+           because of the definition of t_complex at line 1, characters 0-52.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -746,10 +746,10 @@ Line 1, characters 29-36:
 Error: This pattern matches values of type a
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_1)
-       The layout of a is any, because
-         of the annotation on the abstract type declaration for a.
-       But the layout of a must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of a is any
+         because of the annotation on the abstract type declaration for a.
+       But the layout of a must be representable
+         because we must know concretely how to pass a function argument.
 |}]
 
 (****************************************)
@@ -792,10 +792,10 @@ Line 1, characters 33-43:
 1 | let f : type (a : any). a -> a = fun x -> x
                                      ^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of a is any, because
-         of the annotation on the abstract type declaration for a.
-       But the layout of a must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of a is any
+         because of the annotation on the abstract type declaration for a.
+       But the layout of a must be representable
+         because we must know concretely how to pass a function argument.
 |}]
 
 (**************************************************)
@@ -810,8 +810,8 @@ Line 2, characters 10-36:
 2 |   val f : 'a. 'a t2_imm -> 'a t2_imm
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was defaulted to have kind value.
-       But it was inferred to have kind immediate, because
-         of the definition of t2_imm at line 1, characters 0-28.
+       But it was inferred to have kind immediate
+         because of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -821,8 +821,8 @@ Line 1, characters 8-34:
 1 | let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was defaulted to have kind value.
-       But it was inferred to have kind immediate, because
-         of the definition of t2_imm at line 1, characters 0-28.
+       But it was inferred to have kind immediate
+         because of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 (********************************************)
@@ -845,8 +845,8 @@ Line 2, characters 10-46:
 2 |   val f : ('a : value). 'a t2_imm -> 'a t2_imm
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind immediate, because
-         of the definition of t2_imm at line 1, characters 0-28.
+       But it was inferred to have kind immediate
+         because of the definition of t2_imm at line 1, characters 0-28.
 |}]
 
 module type S = sig
@@ -858,8 +858,8 @@ Line 2, characters 10-52:
 2 |   val f : ('a : value). 'a t2_global -> 'a t2_global
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value.
-       But it was inferred to have kind value mod global, because
-         of the definition of t2_global at line 8, characters 0-38.
+       But it was inferred to have kind value mod global
+         because of the definition of t2_global at line 8, characters 0-38.
 |}]
 
 module type S = sig
@@ -872,10 +872,10 @@ Line 2, characters 24-26:
                             ^^
 Error: This type ('a : value) should be an instance of type
          ('b : word mod many external_)
-       The layout of 'a is value, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must overlap with word, because
-         of the definition of t2_complex at line 10, characters 0-53.
+       The layout of 'a is value
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must overlap with word
+         because of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
 module type S = sig
@@ -887,8 +887,8 @@ Line 2, characters 10-53:
 2 |   val f : ('a : word). 'a t2_complex -> 'a t2_complex
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind word.
-       But it was inferred to have kind word mod many external_, because
-         of the definition of t2_complex at line 10, characters 0-53.
+       But it was inferred to have kind word mod many external_
+         because of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
 module type S = sig
@@ -970,10 +970,10 @@ Line 1, characters 43-51:
                                                ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the annotation on the universal variable 'a.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the annotation on the universal variable 'a.
 |}]
 
 let f (x : ('a : value mod global). 'a -> 'a) = x "string"
@@ -984,10 +984,10 @@ Line 1, characters 50-58:
                                                       ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of value mod global, because
-         of the annotation on the universal variable 'a.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of value mod global
+         because of the annotation on the universal variable 'a.
 |}]
 
 (**************************************)
@@ -1015,10 +1015,10 @@ type t : value mod global = { x : int}
 Line 1, characters 0-38:
 1 | type t : value mod global = { x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
    immediate *)
@@ -1028,10 +1028,10 @@ type t : any mod portable = { x : float }
 Line 1, characters 0-41:
 1 | type t : any mod portable = { x : float }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod portable
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
    immediate *)
@@ -1063,10 +1063,10 @@ type t : value mod global = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod unique = { x : t_value }
@@ -1074,10 +1074,10 @@ type t : value mod unique = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod unique = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod many = { x : t_value }
@@ -1085,10 +1085,10 @@ type t : value mod many = { x : t_value }
 Line 1, characters 0-41:
 1 | type t : value mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod many
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod portable = { x : t_value }
@@ -1096,10 +1096,10 @@ type t : value mod portable = { x : t_value }
 Line 1, characters 0-45:
 1 | type t : value mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod uncontended = { x : t_value }
@@ -1107,10 +1107,10 @@ type t : value mod uncontended = { x : t_value }
 Line 1, characters 0-48:
 1 | type t : value mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod external_ = { x : t_value }
@@ -1118,10 +1118,10 @@ type t : value mod external_ = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod external_ = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 
 (***************************************)
@@ -1144,10 +1144,10 @@ type t : value mod global = Foo of int
 Line 1, characters 0-38:
 1 | type t : value mod global = Foo of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod portable = Foo of float
@@ -1155,10 +1155,10 @@ type t : any mod portable = Foo of float
 Line 1, characters 0-40:
 1 | type t : any mod portable = Foo of float
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod portable
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t = Foo | Bar
@@ -1210,10 +1210,10 @@ type t : value mod global = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod global = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod unique = Foo of t_value
@@ -1221,10 +1221,10 @@ type t : value mod unique = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod unique = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod many = Foo of t_value
@@ -1232,10 +1232,10 @@ type t : value mod many = Foo of t_value
 Line 1, characters 0-40:
 1 | type t : value mod many = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod many, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod many
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod portable = Foo of t_value
@@ -1243,10 +1243,10 @@ type t : value mod portable = Foo of t_value
 Line 1, characters 0-44:
 1 | type t : value mod portable = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod uncontended = Foo of t_value
@@ -1254,10 +1254,10 @@ type t : value mod uncontended = Foo of t_value
 Line 1, characters 0-47:
 1 | type t : value mod uncontended = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod external_ = Foo of t_value
@@ -1265,10 +1265,10 @@ type t : value mod external_ = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod external_ = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of value mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of value mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 
 (***************************************)
@@ -1331,10 +1331,10 @@ type t : float64 mod global portable
 Line 2, characters 0-47:
 2 | type u : bits64 mod global portable = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is float64, because
-         of the definition of t at line 1, characters 0-36.
-       But the layout of type t must be a sublayout of bits64, because
-         of the definition of u at line 2, characters 0-47.
+Error: The layout of type t is float64
+         because of the definition of t at line 1, characters 0-36.
+       But the layout of type t must be a sublayout of bits64
+         because of the definition of u at line 2, characters 0-47.
 |}]
 
 type t : word
@@ -1344,10 +1344,10 @@ type t : word
 Line 2, characters 0-36:
 2 | type u : word mod global = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
-         of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod global, because
-         of the definition of u at line 2, characters 0-36.
+Error: The kind of type t is word
+         because of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod global
+         because of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1359,10 +1359,10 @@ type t : word
 Line 2, characters 0-36:
 2 | type u : word mod unique = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
-         of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod unique, because
-         of the definition of u at line 2, characters 0-36.
+Error: The kind of type t is word
+         because of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod unique
+         because of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1374,10 +1374,10 @@ type t : word
 Line 2, characters 0-34:
 2 | type u : word mod many = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
-         of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod many, because
-         of the definition of u at line 2, characters 0-34.
+Error: The kind of type t is word
+         because of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod many
+         because of the definition of u at line 2, characters 0-34.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1389,10 +1389,10 @@ type t : word
 Line 2, characters 0-38:
 2 | type u : word mod portable = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
-         of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod portable, because
-         of the definition of u at line 2, characters 0-38.
+Error: The kind of type t is word
+         because of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod portable
+         because of the definition of u at line 2, characters 0-38.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1404,10 +1404,10 @@ type t : word
 Line 2, characters 0-41:
 2 | type u : word mod uncontended = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
-         of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod uncontended, because
-         of the definition of u at line 2, characters 0-41.
+Error: The kind of type t is word
+         because of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod uncontended
+         because of the definition of u at line 2, characters 0-41.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1419,10 +1419,10 @@ type t : word
 Line 2, characters 0-39:
 2 | type u : word mod external_ = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is word, because
-         of the definition of t at line 1, characters 0-13.
-       But the kind of type t must be a subkind of word mod external_, because
-         of the definition of u at line 2, characters 0-39.
+Error: The kind of type t is word
+         because of the definition of t at line 1, characters 0-13.
+       But the kind of type t must be a subkind of word mod external_
+         because of the definition of u at line 2, characters 0-39.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1621,10 +1621,10 @@ Line 1, characters 37-53:
                                          ^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The kind of 'a is value, because
-         of the annotation on the universal variable 'a.
-       But the kind of 'a must be a subkind of immediate, because
-         of the definition of f_imm at line 1, characters 4-9.
+       The kind of 'a is value
+         because of the annotation on the universal variable 'a.
+       But the kind of 'a must be a subkind of immediate
+         because of the definition of f_imm at line 1, characters 4-9.
 |}]
 
 type (_ : value) g =

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -127,7 +127,7 @@ Line 1, characters 8-29:
             ^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int but is used as an instance of type
          ('a : float64)
-       The layout of int is immediate, because
+       The layout of int is value, because
          it is the primitive immediate type int.
        But the layout of int must be a sublayout of float64, because
          of the annotation on the type variable 'a.
@@ -147,9 +147,9 @@ Line 1, characters 8-36:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : immediate)
-       The layout of int list is value, because
+       The kind of int list is value, because
          it's a boxed variant type.
-       But the layout of int list must be a sublayout of immediate, because
+       But the kind of int list must be a subkind of immediate, because
          of the annotation on the type variable 'a.
 |}]
 (* CR layouts: error message could be phrased better *)
@@ -161,13 +161,11 @@ Line 1, characters 8-43:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type int list
        but is used as an instance of type ('a : value mod global)
-       The layout of int list is value, because
+       The kind of int list is value, because
          it's a boxed variant type.
-       But the layout of int list must be a sublayout of value, because
+       But the kind of int list must be a subkind of value mod global, because
          of the annotation on the type variable 'a.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (****************************************)
 (* Test 2: Annotation on type parameter *)
@@ -292,13 +290,11 @@ Line 1, characters 9-15:
 1 | type t = string t2_imm
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of t2_imm at line 1, characters 0-28.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t = string t2_global
 ;;
@@ -307,13 +303,11 @@ Line 1, characters 9-15:
 1 | type t = string t2_global
              ^^^^^^
 Error: This type string should be an instance of type ('a : value mod global)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
+       But the kind of string must be a subkind of value mod global, because
          of the definition of t2_global at line 8, characters 0-38.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type u : word
 type t = u t2_complex
@@ -325,13 +319,11 @@ Line 2, characters 9-10:
              ^
 Error: This type u should be an instance of type
          ('a : word mod many external_)
-       The layout of u is word, because
+       The kind of u is word, because
          of the definition of u at line 1, characters 0-13.
-       But the layout of u must be a sublayout of word, because
+       But the kind of u must be a subkind of word mod many external_, because
          of the definition of t2_complex at line 10, characters 0-53.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let f : 'a t2_imm -> 'a t2_imm = fun x -> x
 let f : 'a t2_global -> 'a t2_global = fun x -> x
@@ -379,12 +371,10 @@ let f : ('a : value). 'a t2_imm -> 'a t2_imm = fun x -> x
 Line 1, characters 8-44:
 1 | let f : ('a : value). 'a t2_imm -> 'a t2_imm = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was declared to have layout value.
-       But it was inferred to have layout immediate, because
+Error: The universal type variable 'a was declared to have kind value.
+       But it was inferred to have kind immediate, because
          of the definition of t2_imm at line 1, characters 0-28.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let f : ('a : value). 'a t2_global -> 'a t2_global = fun x -> x
 ;;
@@ -392,12 +382,10 @@ let f : ('a : value). 'a t2_global -> 'a t2_global = fun x -> x
 Line 1, characters 8-50:
 1 | let f : ('a : value). 'a t2_global -> 'a t2_global = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was declared to have layout value.
-       But it was inferred to have layout value, because
+Error: The universal type variable 'a was declared to have kind value.
+       But it was inferred to have kind value mod global, because
          of the definition of t2_global at line 8, characters 0-38.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let f : ('a : word). 'a t2_complex -> 'a t2_complex = fun x -> x
 ;;
@@ -405,8 +393,8 @@ let f : ('a : word). 'a t2_complex -> 'a t2_complex = fun x -> x
 Line 1, characters 8-51:
 1 | let f : ('a : word). 'a t2_complex -> 'a t2_complex = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was declared to have layout word.
-       But it was inferred to have layout word, because
+Error: The universal type variable 'a was declared to have kind word.
+       But it was inferred to have kind word mod many external_, because
          of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
@@ -558,13 +546,11 @@ Line 1, characters 24-31:
                             ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of r at line 1, characters 0-47.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let f { fieldg } = fieldg "hello"
 ;;
@@ -574,13 +560,11 @@ Line 1, characters 26-33:
                               ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
+       But the kind of string must be a subkind of value mod global, because
          of the definition of rg at line 1, characters 0-56.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let f { fieldc } = fieldc "hello"
 ;;
@@ -595,8 +579,6 @@ Error: This expression has type string but an expression was expected of type
        But the layout of string must be a sublayout of word, because
          of the definition of rc at line 1, characters 0-70.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let r = { field = fun x -> x }
 let r = { field = Fun.id }
@@ -630,9 +612,9 @@ Line 2, characters 18-55:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          of the definition of r_value at line 1, characters 0-39.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
@@ -644,9 +626,9 @@ Line 1, characters 18-62:
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This field value has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          of the definition of r_value at line 1, characters 0-39.
-       But the layout of 'a must be a sublayout of value, because
+       But the kind of 'a must be a subkind of value mod global, because
          of the annotation on the abstract type declaration for a.
 |}]
 (* CR layouts v1.5: that's a pretty awful error message *)
@@ -666,9 +648,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is value, because
+         The kind of 'a is value, because
            of the annotation on the universal variable 'a.
-         But the layout of 'a must be a sublayout of immediate, because
+         But the kind of 'a must be a subkind of immediate, because
            of the definition of t_imm at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -692,15 +674,13 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is value, because
+         The kind of 'a is value, because
            of the annotation on the universal variable 'a.
-         But the layout of 'a must be a sublayout of value, because
+         But the kind of 'a must be a subkind of value mod global, because
            of the definition of t_global at line 1, characters 0-37.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type ('a : word mod external_ many shared) t_complex
 
@@ -716,15 +696,13 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is word, because
+         The kind of 'a is word, because
            of the annotation on the universal variable 'a.
-         But the layout of 'a must be a sublayout of word, because
+         But the kind of 'a must be a subkind of word mod many external_, because
            of the definition of t_complex at line 1, characters 0-52.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (********************)
 (* Test 5: newtypes *)
@@ -831,12 +809,10 @@ end
 Line 2, characters 10-36:
 2 |   val f : 'a. 'a t2_imm -> 'a t2_imm
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was defaulted to have layout value.
-       But it was inferred to have layout immediate, because
+Error: The universal type variable 'a was defaulted to have kind value.
+       But it was inferred to have kind immediate, because
          of the definition of t2_imm at line 1, characters 0-28.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
 
@@ -844,12 +820,10 @@ let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
 Line 1, characters 8-34:
 1 | let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was defaulted to have layout value.
-       But it was inferred to have layout immediate, because
+Error: The universal type variable 'a was defaulted to have kind value.
+       But it was inferred to have kind immediate, because
          of the definition of t2_imm at line 1, characters 0-28.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (********************************************)
 (* Test 8: Annotation on universal variable *)
@@ -870,12 +844,10 @@ end
 Line 2, characters 10-46:
 2 |   val f : ('a : value). 'a t2_imm -> 'a t2_imm
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was declared to have layout value.
-       But it was inferred to have layout immediate, because
+Error: The universal type variable 'a was declared to have kind value.
+       But it was inferred to have kind immediate, because
          of the definition of t2_imm at line 1, characters 0-28.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 module type S = sig
   val f : ('a : value). 'a t2_global -> 'a t2_global
@@ -885,12 +857,10 @@ end
 Line 2, characters 10-52:
 2 |   val f : ('a : value). 'a t2_global -> 'a t2_global
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was declared to have layout value.
-       But it was inferred to have layout value, because
+Error: The universal type variable 'a was declared to have kind value.
+       But it was inferred to have kind value mod global, because
          of the definition of t2_global at line 8, characters 0-38.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 module type S = sig
   val f : ('a : value). 'a t2_complex -> 'a t2_complex
@@ -916,12 +886,10 @@ end
 Line 2, characters 10-53:
 2 |   val f : ('a : word). 'a t2_complex -> 'a t2_complex
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was declared to have layout word.
-       But it was inferred to have layout word, because
+Error: The universal type variable 'a was declared to have kind word.
+       But it was inferred to have kind word mod many external_, because
          of the definition of t2_complex at line 10, characters 0-53.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 module type S = sig
   val f : 'a t2_imm -> 'a t2_imm
@@ -1002,13 +970,11 @@ Line 1, characters 43-51:
                                                ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on the universal variable 'a.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let f (x : ('a : value mod global). 'a -> 'a) = x "string"
 
@@ -1018,13 +984,11 @@ Line 1, characters 50-58:
                                                       ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
+       But the kind of string must be a subkind of value mod global, because
          of the annotation on the universal variable 'a.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (**************************************)
 (* Test 10: Annotation of record type *)
@@ -1051,9 +1015,9 @@ type t : value mod global = { x : int}
 Line 1, characters 0-38:
 1 | type t : value mod global = { x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
@@ -1064,9 +1028,9 @@ type t : any mod portable = { x : float }
 Line 1, characters 0-41:
 1 | type t : any mod portable = { x : float }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted, because t should be inferred to be
@@ -1099,78 +1063,66 @@ type t : value mod global = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod unique = { x : t_value }
 [%%expect {|
 Line 1, characters 0-43:
 1 | type t : value mod unique = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod many = { x : t_value }
 [%%expect {|
 Line 1, characters 0-41:
 1 | type t : value mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod many, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod portable = { x : t_value }
 [%%expect {|
 Line 1, characters 0-45:
 1 | type t : value mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod portable, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod uncontended = { x : t_value }
 [%%expect {|
 Line 1, characters 0-48:
 1 | type t : value mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod external_ = { x : t_value }
 [%%expect {|
 Line 1, characters 0-46:
 1 | type t : value mod external_ = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of value mod external_, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (***************************************)
 (* Test 11: Annotation of variant type *)
@@ -1192,26 +1144,22 @@ type t : value mod global = Foo of int
 Line 1, characters 0-38:
 1 | type t : value mod global = Foo of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod portable = Foo of float
 [%%expect {|
 Line 1, characters 0-40:
 1 | type t : any mod portable = Foo of float
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t = Foo | Bar
 let f (x : t) : _ as (_ : immediate) = x
@@ -1262,78 +1210,66 @@ type t : value mod global = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod global = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod unique = Foo of t_value
 [%%expect {|
 Line 1, characters 0-42:
 1 | type t : value mod unique = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod many = Foo of t_value
 [%%expect {|
 Line 1, characters 0-40:
 1 | type t : value mod many = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod many, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod portable = Foo of t_value
 [%%expect {|
 Line 1, characters 0-44:
 1 | type t : value mod portable = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod portable, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod uncontended = Foo of t_value
 [%%expect {|
 Line 1, characters 0-47:
 1 | type t : value mod uncontended = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod external_ = Foo of t_value
 [%%expect {|
 Line 1, characters 0-45:
 1 | type t : value mod external_ = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of value mod external_, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (***************************************)
 (* Test 12: Annotation on private type *)
@@ -1400,8 +1336,6 @@ Error: The layout of type t is float64, because
        But the layout of type t must be a sublayout of bits64, because
          of the definition of u at line 2, characters 0-47.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : word
 type u : word mod global = private t
@@ -1410,9 +1344,9 @@ type t : word
 Line 2, characters 0-36:
 2 | type u : word mod global = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod global, because
          of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1425,9 +1359,9 @@ type t : word
 Line 2, characters 0-36:
 2 | type u : word mod unique = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod unique, because
          of the definition of u at line 2, characters 0-36.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1440,9 +1374,9 @@ type t : word
 Line 2, characters 0-34:
 2 | type u : word mod many = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod many, because
          of the definition of u at line 2, characters 0-34.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1455,9 +1389,9 @@ type t : word
 Line 2, characters 0-38:
 2 | type u : word mod portable = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod portable, because
          of the definition of u at line 2, characters 0-38.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1470,9 +1404,9 @@ type t : word
 Line 2, characters 0-41:
 2 | type u : word mod uncontended = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod uncontended, because
          of the definition of u at line 2, characters 0-41.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1485,9 +1419,9 @@ type t : word
 Line 2, characters 0-39:
 2 | type u : word mod external_ = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is word, because
+Error: The kind of type t is word, because
          of the definition of t at line 1, characters 0-13.
-       But the layout of type t must be a sublayout of word, because
+       But the kind of type t must be a subkind of word mod external_, because
          of the definition of u at line 2, characters 0-39.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1687,9 +1621,9 @@ Line 1, characters 37-53:
                                          ^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> 'b which is less general than
          'a. 'a -> 'a
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          of the annotation on the universal variable 'a.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the definition of f_imm at line 1, characters 4-9.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -93,10 +93,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_1) is not compatible with type t
-       The layout of t is any, because
-         of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable, because
-         it instantiates an unannotated type parameter of s.
+       The layout of t is any
+         because of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable
+         because it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -267,10 +267,10 @@ Line 4, characters 72-73:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
-         of the definition of s at line 2, characters 2-55.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because of the definition of s at line 2, characters 2-55.
 |}]
 
 module type S1 = sig
@@ -302,10 +302,10 @@ Line 4, characters 67-68:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
-         of the definition of s at line 2, characters 2-50.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because of the definition of s at line 2, characters 2-50.
 |}]
 
 module M1 = struct
@@ -321,10 +321,10 @@ Line 4, characters 74-75:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
-         of the definition of s at line 2, characters 2-70.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because of the definition of s at line 2, characters 2-70.
 |}]
 
 module M1 = struct
@@ -340,10 +340,10 @@ Line 4, characters 69-70:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
-         of the definition of s at line 2, characters 2-65.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because of the definition of s at line 2, characters 2-65.
 |}]
 
 module type S1 = sig
@@ -357,10 +357,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_2) is not compatible with type t
-       The layout of t is any, because
-         of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable, because
-         it instantiates an unannotated type parameter of s.
+       The layout of t is any
+         because of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable
+         because it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -374,10 +374,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_3) is not compatible with type t
-       The layout of t is any, because
-         of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable, because
-         it instantiates an unannotated type parameter of s.
+       The layout of t is any
+         because of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable
+         because it instantiates an unannotated type parameter of s.
 |}]
 
 let f1 () : t_any = assert false;;
@@ -387,10 +387,10 @@ Line 1, characters 20-32:
                         ^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_4)
-       The layout of t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable, because
-         we must know concretely how to return a function result.
+       The layout of t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable
+         because we must know concretely how to return a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -401,10 +401,10 @@ Line 1, characters 7-18:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_5)
-       The layout of t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable
+         because we must know concretely how to pass a function argument.
 |}];;
 
 (*****************************************************)
@@ -468,10 +468,10 @@ Line 1, characters 27-36:
 1 | module F2 (X : sig val x : t_float64 end) = struct
                                ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of type t_float64 must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 (* CR layouts v5: the test above should be made to work *)
 
@@ -508,10 +508,10 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of imm_id at line 1, characters 0-33.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -531,10 +531,10 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of id_for_imms at line 1, characters 16-35.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -547,10 +547,10 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the annotation on 'a in the declaration of the type t4.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t4.
 |}];;
 
 type s4 = string t4
@@ -561,10 +561,10 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the annotation on 'a in the declaration of the type t4.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type s4 = int t4
@@ -594,10 +594,10 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of s5 is value, because
-         it is the primitive value type string.
-       But the kind of s5 must be a subkind of immediate, because
-         of the annotation on 'a in the declaration of the type t4.
+       The kind of s5 is value
+         because it is the primitive value type string.
+       But the kind of s5 must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type ('a : any) t4 = 'a
@@ -657,10 +657,10 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value, because
-         it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate, because
-         of the definition of t6_imm at line 1, characters 0-42.
+       The kind of 'a is value
+         because it is or unifies with an unannotated universal variable.
+       But the kind of 'a must be a subkind of immediate
+         because of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -673,10 +673,10 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value, because
-         it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate, because
-         of the definition of t6_imm at line 1, characters 0-42.
+       The kind of 'a is value
+         because it is or unifies with an unannotated universal variable.
+       But the kind of 'a must be a subkind of immediate
+         because of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -694,10 +694,10 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The kind of int * int is value, because
-         it's a tuple type.
-       But the kind of int * int must be a subkind of immediate, because
-         of the definition of t7 at line 1, characters 0-37.
+       The kind of int * int is value
+         because it's a tuple type.
+       But the kind of int * int must be a subkind of immediate
+         because of the definition of t7 at line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -713,10 +713,10 @@ Line 2, characters 40-49:
 2 |   type foo1 = [ `Foo1 of int | `Baz1 of t_float64 | `Bar1 of string ];;
                                             ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_2f = struct
@@ -733,10 +733,10 @@ Line 5, characters 16-17:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_3f = struct
@@ -749,10 +749,10 @@ Line 4, characters 13-22:
 4 |   type bad = t_float64 t
                  ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of t at line 2, characters 2-42.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of t at line 2, characters 2-42.
 |}];;
 
 module M8_4f = struct
@@ -764,10 +764,10 @@ Line 2, characters 54-68:
                                                           ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 module type S8_5f = sig
@@ -778,10 +778,10 @@ Line 2, characters 17-26:
 2 |   val x : [`A of t_float64]
                      ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}]
 
 (************************************************)
@@ -796,10 +796,10 @@ Line 2, characters 20-29:
 2 |   type foo1 = int * t_float64 * [ `Foo1 of int | `Bar1 of string ];;
                         ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module M9_2f = struct
@@ -810,10 +810,10 @@ Line 2, characters 31-40:
 2 |   type result = V of (string * t_float64) | I of int
                                    ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module M9_4f = struct
@@ -829,10 +829,10 @@ Line 6, characters 21-22:
                          ^
 Error: This expression has type ('a : value)
        but an expression was expected of type float#
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module M9_5f = struct
@@ -845,10 +845,10 @@ Line 4, characters 13-22:
 4 |   type bad = t_float64 t
                  ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of t at line 2, characters 2-24.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of t at line 2, characters 2-24.
 |}];;
 
 module M9_6f = struct
@@ -860,10 +860,10 @@ Line 2, characters 34-48:
                                       ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module type S9_7f = sig
@@ -874,10 +874,10 @@ Line 2, characters 16-25:
 2 |   val x : int * t_float64
                     ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 (*************************************************)
@@ -917,10 +917,10 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of x at line 8, characters 10-26.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of x at line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -958,10 +958,10 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of x at line 8, characters 10-26.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of x at line 8, characters 10-26.
 |}]
 
 (**********************************************************************)
@@ -993,10 +993,10 @@ Line 5, characters 4-5:
 5 |     x # baz11
         ^
 Error: Object types must have layout value.
-       The layout of the type of this expression is float64, because
-         of the definition of t at line 2, characters 2-28.
-       But the layout of the type of this expression must overlap with value, because
-         it's the type of an object.
+       The layout of the type of this expression is float64
+         because of the definition of t at line 2, characters 2-28.
+       But the layout of the type of this expression must overlap with value
+         because it's the type of an object.
 |}]
 
 module M11_2f = struct
@@ -1010,10 +1010,10 @@ Line 4, characters 19-33:
                        ^^^^^^^^^^^^^^
 Error: This expression has type ('a : value)
        but an expression was expected of type 'b t = ('b : float64)
-       The layout of 'a t is float64, because
-         of the definition of f_id at line 3, characters 11-25.
-       But the layout of 'a t must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a t is float64
+         because of the definition of f_id at line 3, characters 11-25.
+       But the layout of 'a t must overlap with value
+         because it's the type of an object field.
 |}];;
 
 module M11_3f = struct
@@ -1037,10 +1037,10 @@ Line 2, characters 12-25:
 2 |   val x : < l : t_float64 >
                 ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 module M11_5f = struct
@@ -1052,10 +1052,10 @@ Line 3, characters 2-27:
 3 |   and ('a : float64) s = 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'a s is float64, because
-         of the annotation on 'a in the declaration of the type s.
-       But the layout of 'a s must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of 'a s is float64
+         because of the annotation on 'a in the declaration of the type s.
+       But the layout of 'a s must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 module M11_6f = struct
@@ -1067,10 +1067,10 @@ Line 2, characters 36-50:
                                         ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 (*******************************************************************)
@@ -1108,10 +1108,10 @@ Line 5, characters 10-13:
 5 |       val bar = f u
               ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is float64, because
-         of the definition of f at line 2, characters 6-7.
-       But the layout of bar must overlap with value, because
-         it's the type of a class field.
+       The layout of bar is float64
+         because of the definition of f at line 2, characters 6-7.
+       But the layout of bar must overlap with value
+         because it's the type of a class field.
 |}];;
 
 (* Hits the Cfk_virtual case of Pcf_val *)
@@ -1126,10 +1126,10 @@ Line 4, characters 18-21:
 4 |       val virtual bar : t_float64
                       ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of bar must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of bar is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of bar must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 module M12_4f = struct
@@ -1145,10 +1145,10 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64, because
-         of the definition of t at line 2, characters 2-23.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64
+         because of the definition of t at line 2, characters 2-23.
 |}];;
 
 module M12_5f = struct
@@ -1164,10 +1164,10 @@ Line 6, characters 26-28:
 6 |       method void_id (a : 'a t) : 'a t = a
                               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64, because
-         of the definition of t at line 2, characters 2-28.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64
+         because of the definition of t at line 2, characters 2-28.
 |}];;
 
 module type S12_6f = sig
@@ -1184,10 +1184,10 @@ Line 5, characters 4-6:
 5 |     'a t ->
         ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64, because
-         of the definition of t at line 2, characters 2-28.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64
+         because of the definition of t at line 2, characters 2-28.
 |}];;
 
 module type S12_7f = sig
@@ -1201,10 +1201,10 @@ Line 4, characters 6-25:
 4 |       val baz : t_float64
           ^^^^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of baz is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of baz must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of baz is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of baz must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 (*************************************************************************)
@@ -1219,10 +1219,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 Lazy.t;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of Lazy.t has this layout.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of Lazy.t has this layout.
 |}];;
 
 let x13f (v : t_float64) = lazy v;;
@@ -1232,10 +1232,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a lazy expression.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a lazy expression.
 |}];;
 
 let f_id (x : t_float64) = x
@@ -1249,10 +1249,10 @@ Line 4, characters 19-20:
                        ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a lazy expression.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a lazy expression.
 |}];;
 
 (* option *)
@@ -1263,10 +1263,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 option;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of option has layout value.
 |}];;
 
 let x13f (v : t_float64) = Some v;;
@@ -1276,10 +1276,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of option has layout value.
 |}];;
 
 let x13f v =
@@ -1292,10 +1292,10 @@ Line 3, characters 19-20:
                        ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of option has layout value.
 |}];;
 
 (* list *)
@@ -1305,10 +1305,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 list;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let x13 (v : t_float64) = [v];;
@@ -1318,10 +1318,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let x13 v =
@@ -1334,10 +1334,10 @@ Line 3, characters 16-17:
                     ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (* array *)
@@ -1378,10 +1378,10 @@ Line 2, characters 0-21:
 2 | and foo14 = t_float64;;
     ^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of foo14 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of foo14 must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of foo14 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of foo14 must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (****************************************************)
@@ -1534,10 +1534,10 @@ Line 15, characters 4-8:
 Error: This pattern matches values of type (Mf.t_float64, Mf.t_float64) eq
        but a pattern was expected which matches values of type
          (Mf.t_float64, Mf.t_imm) eq
-       The layout of Mf.t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 2-26.
-       But the layout of Mf.t_float64 must overlap with value, because
-         of the definition of t_imm at line 5, characters 2-24.
+       The layout of Mf.t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 2-26.
+       But the layout of Mf.t_float64 must overlap with value
+         because of the definition of t_imm at line 5, characters 2-24.
 |}]
 
 (*****************************************************)
@@ -1568,10 +1568,10 @@ Line 2, characters 15-16:
                    ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of option has layout value.
 |}]
 
 (*********************************************************)
@@ -1711,10 +1711,10 @@ Line 4, characters 9-22:
              ^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}]
 
 (*******************************************)
@@ -1734,10 +1734,10 @@ Line 3, characters 14-29:
                   ^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of eq at line 1, characters 0-41.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of eq at line 1, characters 0-41.
 |}]
 
 (**************************************)
@@ -1760,10 +1760,10 @@ Line 7, characters 28-29:
                                 ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of f at line 2, characters 2-18.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of f at line 2, characters 2-18.
 |}]
 
 (**************************************************)
@@ -1780,10 +1780,11 @@ Line 1, characters 44-46:
 1 | type ('a : float64) poly_var = [`A of int * 'a | `B]
                                                 ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type poly_var.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type
+                                      poly_var.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}]
 
 (*********************************************************)
@@ -1799,10 +1800,10 @@ Line 1, characters 14-40:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}]
 
 (******************************************************)
@@ -1815,10 +1816,10 @@ Line 1, characters 17-22:
 1 | external foo33 : t_any = "foo33";;
                      ^^^^^
 Error: This type signature for foo33 is not a value type.
-       The layout of type t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of type t_any must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of type t_any must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}]
 
 external foo44 : ('a : any). 'a -> unit = "foo44";;
@@ -1828,10 +1829,10 @@ Line 1, characters 29-31:
 1 | external foo44 : ('a : any). 'a -> unit = "foo44";;
                                  ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 external foo55 : ('a : any). unit -> 'a = "foo55";;
@@ -1841,10 +1842,10 @@ Line 1, characters 37-39:
 1 | external foo55 : ('a : any). unit -> 'a = "foo55";;
                                          ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable, because
-         it's the type of the result of an external declaration.
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable
+         because it's the type of the result of an external declaration.
 |}]
 
 (****************************************************)
@@ -1865,10 +1866,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value, because
-           of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of immediate, because
-           of the definition of t2_imm at line 1, characters 0-28.
+         The kind of 'a is value
+           because of the annotation on the universal variable 'a.
+         But the kind of 'a must be a subkind of immediate
+           because of the definition of t2_imm at line 1, characters 0-28.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -1885,10 +1886,10 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value, because
-         it's a function type.
-       But the kind of 'a -> 'b must be a subkind of immediate, because
-         of the definition of t35 at line 1, characters 0-30.
+       The kind of 'a -> 'b is value
+         because it's a function type.
+       But the kind of 'a -> 'b must be a subkind of immediate
+         because of the definition of t35 at line 1, characters 0-30.
 |}]
 
 (**************************************************)
@@ -1907,10 +1908,10 @@ Line 1, characters 10-22:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_6)
        because it is in the left-hand side of a sequence
-       The layout of t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable, because
-         it's the type of a statement.
+       The layout of t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable
+         because it's the type of a statement.
 |}]
 
 let () = while false do (assert false : t_any); done
@@ -1926,10 +1927,10 @@ Line 1, characters 25-37:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_7)
        because it is in the body of a while-loop
-       The layout of t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable, because
-         it's the type of a statement.
+       The layout of t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable
+         because it's the type of a statement.
 |}]
 
 let () = for i = 0 to 0 do (assert false : t_any); done
@@ -1945,10 +1946,10 @@ Line 1, characters 28-40:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_8)
        because it is in the body of a for-loop
-       The layout of t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable, because
-         it's the type of a statement.
+       The layout of t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable
+         because it's the type of a statement.
 |}]
 
 (******************************************************)
@@ -1975,10 +1976,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is any, because
-         of the definition of f at line 2, characters 2-30.
-       But the layout of 'a must be representable, because
-         of the definition of f at line 4, characters 8-13.
+       The layout of 'a is any
+         because of the definition of f at line 2, characters 2-30.
+       But the layout of 'a must be representable
+         because of the definition of f at line 4, characters 8-13.
 |}]
 
 module M1 : sig
@@ -2031,10 +2032,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is any, because
-         of the definition of f at line 2, characters 2-30.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of f at line 6, characters 2-18.
+       The layout of 'a is any
+         because of the definition of f at line 2, characters 2-30.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of f at line 6, characters 2-18.
 |}]
 
 module F (X : S_value) : S_float64 = X
@@ -2053,10 +2054,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : float64). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is float64, because
-         of the definition of f at line 10, characters 2-34.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of f at line 6, characters 2-18.
+       The layout of 'a is float64
+         because of the definition of f at line 10, characters 2-34.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of f at line 6, characters 2-18.
 |}]
 
 module M2 : sig
@@ -2356,10 +2357,10 @@ Line 2, characters 33-34:
                                      ^
 Error: This expression has type t_float64
        but an expression was expected of type 'a t40 = ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of t40 at line 1, characters 0-16.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of t40 at line 1, characters 0-16.
 |}]
 
 (**********************************************************************)
@@ -2374,10 +2375,11 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value, because
-         it instantiates an unannotated type parameter of t2, defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate, because
-         of the annotation on the wildcard _ at line 1, characters 28-37.
+       The kind of 'a t2 is value
+         because it instantiates an unannotated type parameter of t2,
+         defaulted to kind value.
+       But the kind of 'a t2 must be a subkind of immediate
+         because of the annotation on the wildcard _ at line 1, characters 28-37.
 |}]
 
 (* This example is unfortunately rejected as a consequence of the fix for the
@@ -2392,10 +2394,11 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value, because
-         it instantiates an unannotated type parameter of t2, defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate, because
-         of the annotation on the wildcard _ at line 1, characters 27-36.
+       The kind of 'a t2 is value
+         because it instantiates an unannotated type parameter of t2,
+         defaulted to kind value.
+       But the kind of 'a t2 must be a subkind of immediate
+         because of the annotation on the wildcard _ at line 1, characters 27-36.
 |}]
 
 (* This one also unfortunately rejected for the same reason. *)
@@ -2407,10 +2410,11 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value, because
-         it instantiates an unannotated type parameter of t2, defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate, because
-         of the annotation on the wildcard _ at line 1, characters 25-34.
+       The kind of 'a t2 is value
+         because it instantiates an unannotated type parameter of t2,
+         defaulted to kind value.
+       But the kind of 'a t2 must be a subkind of immediate
+         because of the annotation on the wildcard _ at line 1, characters 25-34.
 |}]
 
 (**********************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -93,10 +93,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_1) is not compatible with type t
-       The layout of t is any, because
-         of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable, because
-         it instantiates an unannotated type parameter of s.
+       The layout of t is any
+         because of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable
+         because it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -267,10 +267,10 @@ Line 4, characters 72-73:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
-         of the definition of s at line 2, characters 2-55.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because of the definition of s at line 2, characters 2-55.
 |}]
 
 module type S1 = sig
@@ -302,10 +302,10 @@ Line 4, characters 67-68:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
-         of the definition of s at line 2, characters 2-50.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because of the definition of s at line 2, characters 2-50.
 |}]
 
 module M1 = struct
@@ -321,10 +321,10 @@ Line 4, characters 74-75:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
-         of the definition of s at line 2, characters 2-70.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because of the definition of s at line 2, characters 2-70.
 |}]
 
 module M1 = struct
@@ -340,10 +340,10 @@ Line 4, characters 69-70:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
-         of the definition of s at line 2, characters 2-65.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because of the definition of s at line 2, characters 2-65.
 |}]
 
 module type S1 = sig
@@ -357,10 +357,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_2) is not compatible with type t
-       The layout of t is any, because
-         of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable, because
-         it instantiates an unannotated type parameter of s.
+       The layout of t is any
+         because of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable
+         because it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -374,10 +374,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_3) is not compatible with type t
-       The layout of t is any, because
-         of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable, because
-         it instantiates an unannotated type parameter of s.
+       The layout of t is any
+         because of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable
+         because it instantiates an unannotated type parameter of s.
 |}]
 
 let f1 () : t_any = assert false;;
@@ -387,10 +387,10 @@ Line 1, characters 20-32:
                         ^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_4)
-       The layout of t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable, because
-         we must know concretely how to return a function result.
+       The layout of t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable
+         because we must know concretely how to return a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -401,10 +401,10 @@ Line 1, characters 7-18:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_5)
-       The layout of t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable
+         because we must know concretely how to pass a function argument.
 |}];;
 
 (*****************************************************)
@@ -468,10 +468,10 @@ Line 1, characters 27-36:
 1 | module F2 (X : sig val x : t_float64 end) = struct
                                ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of type t_float64 must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 (* CR layouts v5: the test above should be made to work *)
 
@@ -508,10 +508,10 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of imm_id at line 1, characters 0-33.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -531,10 +531,10 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of id_for_imms at line 1, characters 16-35.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -547,10 +547,10 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the annotation on 'a in the declaration of the type t4.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t4.
 |}];;
 
 type s4 = string t4
@@ -561,10 +561,10 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the annotation on 'a in the declaration of the type t4.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type s4 = int t4
@@ -594,10 +594,10 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of s5 is value, because
-         it is the primitive value type string.
-       But the kind of s5 must be a subkind of immediate, because
-         of the annotation on 'a in the declaration of the type t4.
+       The kind of s5 is value
+         because it is the primitive value type string.
+       But the kind of s5 must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type ('a : any) t4 = 'a
@@ -657,10 +657,10 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value, because
-         it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate, because
-         of the definition of t6_imm at line 1, characters 0-42.
+       The kind of 'a is value
+         because it is or unifies with an unannotated universal variable.
+       But the kind of 'a must be a subkind of immediate
+         because of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -673,10 +673,10 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value, because
-         it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate, because
-         of the definition of t6_imm at line 1, characters 0-42.
+       The kind of 'a is value
+         because it is or unifies with an unannotated universal variable.
+       But the kind of 'a must be a subkind of immediate
+         because of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -694,10 +694,10 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The kind of int * int is value, because
-         it's a tuple type.
-       But the kind of int * int must be a subkind of immediate, because
-         of the definition of t7 at line 1, characters 0-37.
+       The kind of int * int is value
+         because it's a tuple type.
+       But the kind of int * int must be a subkind of immediate
+         because of the definition of t7 at line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -713,10 +713,10 @@ Line 2, characters 40-49:
 2 |   type foo1 = [ `Foo1 of int | `Baz1 of t_float64 | `Bar1 of string ];;
                                             ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_2f = struct
@@ -733,10 +733,10 @@ Line 5, characters 16-17:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_3f = struct
@@ -749,10 +749,10 @@ Line 4, characters 13-22:
 4 |   type bad = t_float64 t
                  ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of t at line 2, characters 2-42.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of t at line 2, characters 2-42.
 |}];;
 
 module M8_4f = struct
@@ -764,10 +764,10 @@ Line 2, characters 54-68:
                                                           ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 module type S8_5f = sig
@@ -778,10 +778,10 @@ Line 2, characters 17-26:
 2 |   val x : [`A of t_float64]
                      ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}]
 
 (************************************************)
@@ -796,10 +796,10 @@ Line 2, characters 20-29:
 2 |   type foo1 = int * t_float64 * [ `Foo1 of int | `Bar1 of string ];;
                         ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module M9_2f = struct
@@ -810,10 +810,10 @@ Line 2, characters 31-40:
 2 |   type result = V of (string * t_float64) | I of int
                                    ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module M9_4f = struct
@@ -829,10 +829,10 @@ Line 6, characters 21-22:
                          ^
 Error: This expression has type ('a : value)
        but an expression was expected of type float#
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module M9_5f = struct
@@ -845,10 +845,10 @@ Line 4, characters 13-22:
 4 |   type bad = t_float64 t
                  ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of t at line 2, characters 2-24.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of t at line 2, characters 2-24.
 |}];;
 
 module M9_6f = struct
@@ -860,10 +860,10 @@ Line 2, characters 34-48:
                                       ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module type S9_7f = sig
@@ -874,10 +874,10 @@ Line 2, characters 16-25:
 2 |   val x : int * t_float64
                     ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 (*************************************************)
@@ -917,10 +917,10 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of x at line 8, characters 10-26.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of x at line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -958,10 +958,10 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of x at line 8, characters 10-26.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of x at line 8, characters 10-26.
 |}]
 
 (**********************************************************************)
@@ -993,10 +993,10 @@ Line 5, characters 4-5:
 5 |     x # baz11
         ^
 Error: Object types must have layout value.
-       The layout of the type of this expression is float64, because
-         of the definition of t at line 2, characters 2-28.
-       But the layout of the type of this expression must overlap with value, because
-         it's the type of an object.
+       The layout of the type of this expression is float64
+         because of the definition of t at line 2, characters 2-28.
+       But the layout of the type of this expression must overlap with value
+         because it's the type of an object.
 |}]
 
 module M11_2f = struct
@@ -1010,10 +1010,10 @@ Line 4, characters 19-33:
                        ^^^^^^^^^^^^^^
 Error: This expression has type ('a : value)
        but an expression was expected of type 'b t = ('b : float64)
-       The layout of 'a t is float64, because
-         of the definition of f_id at line 3, characters 11-25.
-       But the layout of 'a t must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a t is float64
+         because of the definition of f_id at line 3, characters 11-25.
+       But the layout of 'a t must overlap with value
+         because it's the type of an object field.
 |}];;
 
 module M11_3f = struct
@@ -1037,10 +1037,10 @@ Line 2, characters 12-25:
 2 |   val x : < l : t_float64 >
                 ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 module M11_5f = struct
@@ -1052,10 +1052,10 @@ Line 3, characters 2-27:
 3 |   and ('a : float64) s = 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'a s is float64, because
-         of the annotation on 'a in the declaration of the type s.
-       But the layout of 'a s must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of 'a s is float64
+         because of the annotation on 'a in the declaration of the type s.
+       But the layout of 'a s must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 module M11_6f = struct
@@ -1067,10 +1067,10 @@ Line 2, characters 36-50:
                                         ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 (*******************************************************************)
@@ -1108,10 +1108,10 @@ Line 5, characters 10-13:
 5 |       val bar = f u
               ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is float64, because
-         of the definition of f at line 2, characters 6-7.
-       But the layout of bar must overlap with value, because
-         it's the type of a class field.
+       The layout of bar is float64
+         because of the definition of f at line 2, characters 6-7.
+       But the layout of bar must overlap with value
+         because it's the type of a class field.
 |}];;
 
 (* Hits the Cfk_virtual case of Pcf_val *)
@@ -1126,10 +1126,10 @@ Line 4, characters 18-21:
 4 |       val virtual bar : t_float64
                       ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of bar must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of bar is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of bar must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 module M12_4f = struct
@@ -1145,10 +1145,10 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64, because
-         of the definition of t at line 2, characters 2-23.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64
+         because of the definition of t at line 2, characters 2-23.
 |}];;
 
 module M12_5f = struct
@@ -1164,10 +1164,10 @@ Line 6, characters 26-28:
 6 |       method void_id (a : 'a t) : 'a t = a
                               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64, because
-         of the definition of t at line 2, characters 2-28.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64
+         because of the definition of t at line 2, characters 2-28.
 |}];;
 
 module type S12_6f = sig
@@ -1184,10 +1184,10 @@ Line 5, characters 4-6:
 5 |     'a t ->
         ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64, because
-         of the definition of t at line 2, characters 2-28.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64
+         because of the definition of t at line 2, characters 2-28.
 |}];;
 
 module type S12_7f = sig
@@ -1201,10 +1201,10 @@ Line 4, characters 6-25:
 4 |       val baz : t_float64
           ^^^^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of baz is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of baz must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of baz is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of baz must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 (*************************************************************************)
@@ -1219,10 +1219,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 Lazy.t;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of Lazy.t has this layout.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of Lazy.t has this layout.
 |}];;
 
 let x13f (v : t_float64) = lazy v;;
@@ -1232,10 +1232,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a lazy expression.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a lazy expression.
 |}];;
 
 let f_id (x : t_float64) = x
@@ -1249,10 +1249,10 @@ Line 4, characters 19-20:
                        ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a lazy expression.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a lazy expression.
 |}];;
 
 (* option *)
@@ -1263,10 +1263,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 option;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of option has layout value.
 |}];;
 
 let x13f (v : t_float64) = Some v;;
@@ -1276,10 +1276,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of option has layout value.
 |}];;
 
 let x13f v =
@@ -1292,10 +1292,10 @@ Line 3, characters 19-20:
                        ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of option has layout value.
 |}];;
 
 (* list *)
@@ -1305,10 +1305,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 list;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let x13 (v : t_float64) = [v];;
@@ -1318,10 +1318,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let x13 v =
@@ -1334,10 +1334,10 @@ Line 3, characters 16-17:
                     ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (* array *)
@@ -1378,10 +1378,10 @@ Line 2, characters 0-21:
 2 | and foo14 = t_float64;;
     ^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of foo14 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of foo14 must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of foo14 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of foo14 must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (****************************************************)
@@ -1534,10 +1534,10 @@ Line 15, characters 4-8:
 Error: This pattern matches values of type (Mf.t_float64, Mf.t_float64) eq
        but a pattern was expected which matches values of type
          (Mf.t_float64, Mf.t_imm) eq
-       The layout of Mf.t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 2-26.
-       But the layout of Mf.t_float64 must overlap with value, because
-         of the definition of t_imm at line 5, characters 2-24.
+       The layout of Mf.t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 2-26.
+       But the layout of Mf.t_float64 must overlap with value
+         because of the definition of t_imm at line 5, characters 2-24.
 |}]
 
 (*****************************************************)
@@ -1568,10 +1568,10 @@ Line 2, characters 15-16:
                    ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because the type argument of option has layout value.
 |}]
 
 (*********************************************************)
@@ -1711,10 +1711,10 @@ Line 4, characters 9-22:
              ^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}]
 
 (*******************************************)
@@ -1734,10 +1734,10 @@ Line 3, characters 14-29:
                   ^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of eq at line 1, characters 0-41.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of eq at line 1, characters 0-41.
 |}]
 
 (**************************************)
@@ -1760,10 +1760,10 @@ Line 7, characters 28-29:
                                 ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of f at line 2, characters 2-18.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of f at line 2, characters 2-18.
 |}]
 
 (**************************************************)
@@ -1780,10 +1780,11 @@ Line 1, characters 44-46:
 1 | type ('a : float64) poly_var = [`A of int * 'a | `B]
                                                 ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type poly_var.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type
+                                      poly_var.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}]
 
 (*********************************************************)
@@ -1799,10 +1800,10 @@ Line 1, characters 14-40:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}]
 
 (******************************************************)
@@ -1815,10 +1816,10 @@ Line 1, characters 17-22:
 1 | external foo33 : t_any = "foo33";;
                      ^^^^^
 Error: This type signature for foo33 is not a value type.
-       The layout of type t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of type t_any must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of type t_any must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}]
 
 external foo44 : ('a : any). 'a -> unit = "foo44";;
@@ -1828,10 +1829,10 @@ Line 1, characters 29-31:
 1 | external foo44 : ('a : any). 'a -> unit = "foo44";;
                                  ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 external foo55 : ('a : any). unit -> 'a = "foo55";;
@@ -1841,10 +1842,10 @@ Line 1, characters 37-39:
 1 | external foo55 : ('a : any). unit -> 'a = "foo55";;
                                          ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable, because
-         it's the type of the result of an external declaration.
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable
+         because it's the type of the result of an external declaration.
 |}]
 
 (****************************************************)
@@ -1865,10 +1866,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value, because
-           of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of immediate, because
-           of the definition of t2_imm at line 1, characters 0-28.
+         The kind of 'a is value
+           because of the annotation on the universal variable 'a.
+         But the kind of 'a must be a subkind of immediate
+           because of the definition of t2_imm at line 1, characters 0-28.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -1885,10 +1886,10 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value, because
-         it's a function type.
-       But the kind of 'a -> 'b must be a subkind of immediate, because
-         of the definition of t35 at line 1, characters 0-30.
+       The kind of 'a -> 'b is value
+         because it's a function type.
+       But the kind of 'a -> 'b must be a subkind of immediate
+         because of the definition of t35 at line 1, characters 0-30.
 |}]
 
 (**************************************************)
@@ -1907,10 +1908,10 @@ Line 1, characters 10-22:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_6)
        because it is in the left-hand side of a sequence
-       The layout of t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable, because
-         it's the type of a statement.
+       The layout of t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable
+         because it's the type of a statement.
 |}]
 
 let () = while false do (assert false : t_any); done
@@ -1926,10 +1927,10 @@ Line 1, characters 25-37:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_7)
        because it is in the body of a while-loop
-       The layout of t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable, because
-         it's the type of a statement.
+       The layout of t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable
+         because it's the type of a statement.
 |}]
 
 let () = for i = 0 to 0 do (assert false : t_any); done
@@ -1945,10 +1946,10 @@ Line 1, characters 28-40:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_8)
        because it is in the body of a for-loop
-       The layout of t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable, because
-         it's the type of a statement.
+       The layout of t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable
+         because it's the type of a statement.
 |}]
 
 (******************************************************)
@@ -1975,10 +1976,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is any, because
-         of the definition of f at line 2, characters 2-30.
-       But the layout of 'a must be representable, because
-         of the definition of f at line 4, characters 8-13.
+       The layout of 'a is any
+         because of the definition of f at line 2, characters 2-30.
+       But the layout of 'a must be representable
+         because of the definition of f at line 4, characters 8-13.
 |}]
 
 module M1 : sig
@@ -2031,10 +2032,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is any, because
-         of the definition of f at line 2, characters 2-30.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of f at line 6, characters 2-18.
+       The layout of 'a is any
+         because of the definition of f at line 2, characters 2-30.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of f at line 6, characters 2-18.
 |}]
 
 module F (X : S_value) : S_float64 = X
@@ -2053,10 +2054,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : float64). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is float64, because
-         of the definition of f at line 10, characters 2-34.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of f at line 6, characters 2-18.
+       The layout of 'a is float64
+         because of the definition of f at line 10, characters 2-34.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of f at line 6, characters 2-18.
 |}]
 
 module M2 : sig
@@ -2356,10 +2357,10 @@ Line 2, characters 33-34:
                                      ^
 Error: This expression has type t_float64
        but an expression was expected of type 'a t40 = ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         of the definition of t40 at line 1, characters 0-16.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because of the definition of t40 at line 1, characters 0-16.
 |}]
 
 (**********************************************************************)
@@ -2374,11 +2375,11 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value, because
-         it instantiates an unannotated type parameter of t2,
+       The kind of 'a t2 is value
+         because it instantiates an unannotated type parameter of t2,
          defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate, because
-         of the annotation on the wildcard _ at line 1, characters 28-37.
+       But the kind of 'a t2 must be a subkind of immediate
+         because of the annotation on the wildcard _ at line 1, characters 28-37.
 |}]
 
 (* This example is unfortunately rejected as a consequence of the fix for the
@@ -2393,11 +2394,11 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value, because
-         it instantiates an unannotated type parameter of t2,
+       The kind of 'a t2 is value
+         because it instantiates an unannotated type parameter of t2,
          defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate, because
-         of the annotation on the wildcard _ at line 1, characters 27-36.
+       But the kind of 'a t2 must be a subkind of immediate
+         because of the annotation on the wildcard _ at line 1, characters 27-36.
 |}]
 
 (* This one also unfortunately rejected for the same reason. *)
@@ -2409,11 +2410,11 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value, because
-         it instantiates an unannotated type parameter of t2,
+       The kind of 'a t2 is value
+         because it instantiates an unannotated type parameter of t2,
          defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate, because
-         of the annotation on the wildcard _ at line 1, characters 25-34.
+       But the kind of 'a t2 must be a subkind of immediate
+         because of the annotation on the wildcard _ at line 1, characters 25-34.
 |}]
 
 (**********************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -508,9 +508,9 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
@@ -531,9 +531,9 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
@@ -547,9 +547,9 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}];;
 
@@ -561,9 +561,9 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -594,9 +594,9 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The layout of s5 is value, because
+       The kind of s5 is value, because
          it is the primitive value type string.
-       But the layout of s5 must be a sublayout of immediate, because
+       But the kind of s5 must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -657,9 +657,9 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -673,9 +673,9 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -694,9 +694,9 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The layout of int * int is value, because
+       The kind of int * int is value, because
          it's a tuple type.
-       But the layout of int * int must be a sublayout of immediate, because
+       But the kind of int * int must be a subkind of immediate, because
          of the definition of t7 at line 1, characters 0-37.
 |}]
 
@@ -917,9 +917,9 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}];;
 
@@ -958,9 +958,9 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}]
 
@@ -1865,9 +1865,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is value, because
+         The kind of 'a is value, because
            of the annotation on the universal variable 'a.
-         But the layout of 'a must be a sublayout of immediate, because
+         But the kind of 'a must be a subkind of immediate, because
            of the definition of t2_imm at line 1, characters 0-28.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -1885,9 +1885,9 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The layout of 'a -> 'b is value, because
+       The kind of 'a -> 'b is value, because
          it's a function type.
-       But the layout of 'a -> 'b must be a sublayout of immediate, because
+       But the kind of 'a -> 'b must be a subkind of immediate, because
          of the definition of t35 at line 1, characters 0-30.
 |}]
 
@@ -2374,10 +2374,10 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The layout of 'a t2 is value, because
+       The kind of 'a t2 is value, because
          it instantiates an unannotated type parameter of t2,
-         defaulted to layout value.
-       But the layout of 'a t2 must be a sublayout of immediate, because
+         defaulted to kind value.
+       But the kind of 'a t2 must be a subkind of immediate, because
          of the annotation on the wildcard _ at line 1, characters 28-37.
 |}]
 
@@ -2393,10 +2393,10 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The layout of 'a t2 is value, because
+       The kind of 'a t2 is value, because
          it instantiates an unannotated type parameter of t2,
-         defaulted to layout value.
-       But the layout of 'a t2 must be a sublayout of immediate, because
+         defaulted to kind value.
+       But the kind of 'a t2 must be a subkind of immediate, because
          of the annotation on the wildcard _ at line 1, characters 27-36.
 |}]
 
@@ -2409,10 +2409,10 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The layout of 'a t2 is value, because
+       The kind of 'a t2 is value, because
          it instantiates an unannotated type parameter of t2,
-         defaulted to layout value.
-       But the layout of 'a t2 must be a sublayout of immediate, because
+         defaulted to kind value.
+       But the kind of 'a t2 must be a subkind of immediate, because
          of the annotation on the wildcard _ at line 1, characters 25-34.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -93,10 +93,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_1) is not compatible with type t
-       The layout of t is any
-         because of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable
-         because it instantiates an unannotated type parameter of s.
+       The layout of t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable, because
+         it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -267,10 +267,10 @@ Line 4, characters 72-73:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
-         because of the definition of s at line 2, characters 2-55.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
+         it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
+         of the definition of s at line 2, characters 2-55.
 |}]
 
 module type S1 = sig
@@ -302,10 +302,10 @@ Line 4, characters 67-68:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
-         because of the definition of s at line 2, characters 2-50.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
+         it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
+         of the definition of s at line 2, characters 2-50.
 |}]
 
 module M1 = struct
@@ -321,10 +321,10 @@ Line 4, characters 74-75:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
-         because of the definition of s at line 2, characters 2-70.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
+         it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
+         of the definition of s at line 2, characters 2-70.
 |}]
 
 module M1 = struct
@@ -340,10 +340,10 @@ Line 4, characters 69-70:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
-         because of the definition of s at line 2, characters 2-65.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
+         it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
+         of the definition of s at line 2, characters 2-65.
 |}]
 
 module type S1 = sig
@@ -357,10 +357,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_2) is not compatible with type t
-       The layout of t is any
-         because of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable
-         because it instantiates an unannotated type parameter of s.
+       The layout of t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable, because
+         it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -374,10 +374,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_3) is not compatible with type t
-       The layout of t is any
-         because of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable
-         because it instantiates an unannotated type parameter of s.
+       The layout of t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable, because
+         it instantiates an unannotated type parameter of s.
 |}]
 
 let f1 () : t_any = assert false;;
@@ -387,10 +387,10 @@ Line 1, characters 20-32:
                         ^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_4)
-       The layout of t_any is any
-         because of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable
-         because we must know concretely how to return a function result.
+       The layout of t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable, because
+         we must know concretely how to return a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -401,10 +401,10 @@ Line 1, characters 7-18:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_5)
-       The layout of t_any is any
-         because of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable, because
+         we must know concretely how to pass a function argument.
 |}];;
 
 (*****************************************************)
@@ -468,10 +468,10 @@ Line 1, characters 27-36:
 1 | module F2 (X : sig val x : t_float64 end) = struct
                                ^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of type t_float64 must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 (* CR layouts v5: the test above should be made to work *)
 
@@ -508,10 +508,10 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of imm_id at line 1, characters 0-33.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -531,10 +531,10 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of id_for_imms at line 1, characters 16-35.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -547,10 +547,10 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the annotation on 'a in the declaration of the type t4.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}];;
 
 type s4 = string t4
@@ -561,10 +561,10 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the annotation on 'a in the declaration of the type t4.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type s4 = int t4
@@ -594,10 +594,10 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of s5 is value
-         because it is the primitive value type string.
-       But the kind of s5 must be a subkind of immediate
-         because of the annotation on 'a in the declaration of the type t4.
+       The kind of s5 is value, because
+         it is the primitive value type string.
+       But the kind of s5 must be a subkind of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type ('a : any) t4 = 'a
@@ -657,10 +657,10 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value
-         because it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate
-         because of the definition of t6_imm at line 1, characters 0-42.
+       The kind of 'a is value, because
+         it is or unifies with an unannotated universal variable.
+       But the kind of 'a must be a subkind of immediate, because
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -673,10 +673,10 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value
-         because it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate
-         because of the definition of t6_imm at line 1, characters 0-42.
+       The kind of 'a is value, because
+         it is or unifies with an unannotated universal variable.
+       But the kind of 'a must be a subkind of immediate, because
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -694,10 +694,10 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The kind of int * int is value
-         because it's a tuple type.
-       But the kind of int * int must be a subkind of immediate
-         because of the definition of t7 at line 1, characters 0-37.
+       The kind of int * int is value, because
+         it's a tuple type.
+       But the kind of int * int must be a subkind of immediate, because
+         of the definition of t7 at line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -713,10 +713,10 @@ Line 2, characters 40-49:
 2 |   type foo1 = [ `Foo1 of int | `Baz1 of t_float64 | `Bar1 of string ];;
                                             ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_2f = struct
@@ -733,10 +733,10 @@ Line 5, characters 16-17:
 Error: This expression has type ('a : value)
        but an expression was expected of type
          Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive float64 type float#.
-       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64, because
+         it is the primitive float64 type float#.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_3f = struct
@@ -749,10 +749,10 @@ Line 4, characters 13-22:
 4 |   type bad = t_float64 t
                  ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of the definition of t at line 2, characters 2-42.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-42.
 |}];;
 
 module M8_4f = struct
@@ -764,10 +764,10 @@ Line 2, characters 54-68:
                                                           ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 module type S8_5f = sig
@@ -778,10 +778,10 @@ Line 2, characters 17-26:
 2 |   val x : [`A of t_float64]
                      ^^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}]
 
 (************************************************)
@@ -796,10 +796,10 @@ Line 2, characters 20-29:
 2 |   type foo1 = int * t_float64 * [ `Foo1 of int | `Bar1 of string ];;
                         ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_2f = struct
@@ -810,10 +810,10 @@ Line 2, characters 31-40:
 2 |   type result = V of (string * t_float64) | I of int
                                    ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_4f = struct
@@ -829,10 +829,10 @@ Line 6, characters 21-22:
                          ^
 Error: This expression has type ('a : value)
        but an expression was expected of type float#
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_5f = struct
@@ -845,10 +845,10 @@ Line 4, characters 13-22:
 4 |   type bad = t_float64 t
                  ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of the definition of t at line 2, characters 2-24.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-24.
 |}];;
 
 module M9_6f = struct
@@ -860,10 +860,10 @@ Line 2, characters 34-48:
                                       ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module type S9_7f = sig
@@ -874,10 +874,10 @@ Line 2, characters 16-25:
 2 |   val x : int * t_float64
                     ^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 (*************************************************)
@@ -917,10 +917,10 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of x at line 8, characters 10-26.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of x at line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -958,10 +958,10 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of x at line 8, characters 10-26.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of x at line 8, characters 10-26.
 |}]
 
 (**********************************************************************)
@@ -993,10 +993,10 @@ Line 5, characters 4-5:
 5 |     x # baz11
         ^
 Error: Object types must have layout value.
-       The layout of the type of this expression is float64
-         because of the definition of t at line 2, characters 2-28.
-       But the layout of the type of this expression must overlap with value
-         because it's the type of an object.
+       The layout of the type of this expression is float64, because
+         of the definition of t at line 2, characters 2-28.
+       But the layout of the type of this expression must overlap with value, because
+         it's the type of an object.
 |}]
 
 module M11_2f = struct
@@ -1010,10 +1010,10 @@ Line 4, characters 19-33:
                        ^^^^^^^^^^^^^^
 Error: This expression has type ('a : value)
        but an expression was expected of type 'b t = ('b : float64)
-       The layout of 'a t is float64
-         because of the definition of f_id at line 3, characters 11-25.
-       But the layout of 'a t must overlap with value
-         because it's the type of an object field.
+       The layout of 'a t is float64, because
+         of the definition of f_id at line 3, characters 11-25.
+       But the layout of 'a t must overlap with value, because
+         it's the type of an object field.
 |}];;
 
 module M11_3f = struct
@@ -1037,10 +1037,10 @@ Line 2, characters 12-25:
 2 |   val x : < l : t_float64 >
                 ^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 module M11_5f = struct
@@ -1052,10 +1052,10 @@ Line 3, characters 2-27:
 3 |   and ('a : float64) s = 'a
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'a s is float64
-         because of the annotation on 'a in the declaration of the type s.
-       But the layout of 'a s must be a sublayout of value
-         because it's the type of an object field.
+       The layout of 'a s is float64, because
+         of the annotation on 'a in the declaration of the type s.
+       But the layout of 'a s must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 module M11_6f = struct
@@ -1067,10 +1067,10 @@ Line 2, characters 36-50:
                                         ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 (*******************************************************************)
@@ -1108,10 +1108,10 @@ Line 5, characters 10-13:
 5 |       val bar = f u
               ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is float64
-         because of the definition of f at line 2, characters 6-7.
-       But the layout of bar must overlap with value
-         because it's the type of a class field.
+       The layout of bar is float64, because
+         of the definition of f at line 2, characters 6-7.
+       But the layout of bar must overlap with value, because
+         it's the type of a class field.
 |}];;
 
 (* Hits the Cfk_virtual case of Pcf_val *)
@@ -1126,10 +1126,10 @@ Line 4, characters 18-21:
 4 |       val virtual bar : t_float64
                       ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of bar must be a sublayout of value
-         because it's the type of a class field.
+       The layout of bar is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of bar must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 module M12_4f = struct
@@ -1145,10 +1145,10 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64
-         because of the definition of t at line 2, characters 2-23.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t at line 2, characters 2-23.
 |}];;
 
 module M12_5f = struct
@@ -1164,10 +1164,10 @@ Line 6, characters 26-28:
 6 |       method void_id (a : 'a t) : 'a t = a
                               ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64
-         because of the definition of t at line 2, characters 2-28.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t at line 2, characters 2-28.
 |}];;
 
 module type S12_6f = sig
@@ -1184,10 +1184,10 @@ Line 5, characters 4-6:
 5 |     'a t ->
         ^^
 Error: This type ('a : float64) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with float64
-         because of the definition of t at line 2, characters 2-28.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t at line 2, characters 2-28.
 |}];;
 
 module type S12_7f = sig
@@ -1201,10 +1201,10 @@ Line 4, characters 6-25:
 4 |       val baz : t_float64
           ^^^^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of baz is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of baz must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of baz is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of baz must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 (*************************************************************************)
@@ -1219,10 +1219,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 Lazy.t;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because the type argument of Lazy.t has this layout.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of Lazy.t has this layout.
 |}];;
 
 let x13f (v : t_float64) = lazy v;;
@@ -1232,10 +1232,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a lazy expression.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a lazy expression.
 |}];;
 
 let f_id (x : t_float64) = x
@@ -1249,10 +1249,10 @@ Line 4, characters 19-20:
                        ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a lazy expression.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a lazy expression.
 |}];;
 
 (* option *)
@@ -1263,10 +1263,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 option;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because the type argument of option has layout value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 let x13f (v : t_float64) = Some v;;
@@ -1276,10 +1276,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because the type argument of option has layout value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 let x13f v =
@@ -1292,10 +1292,10 @@ Line 3, characters 19-20:
                        ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because the type argument of option has layout value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 (* list *)
@@ -1305,10 +1305,10 @@ Line 1, characters 12-21:
 1 | type t13f = t_float64 list;;
                 ^^^^^^^^^
 Error: This type t_float64 should be an instance of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let x13 (v : t_float64) = [v];;
@@ -1318,10 +1318,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let x13 v =
@@ -1334,10 +1334,10 @@ Line 3, characters 16-17:
                     ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_float64
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* array *)
@@ -1378,10 +1378,10 @@ Line 2, characters 0-21:
 2 | and foo14 = t_float64;;
     ^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of foo14 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of foo14 must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of foo14 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of foo14 must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (****************************************************)
@@ -1534,10 +1534,10 @@ Line 15, characters 4-8:
 Error: This pattern matches values of type (Mf.t_float64, Mf.t_float64) eq
        but a pattern was expected which matches values of type
          (Mf.t_float64, Mf.t_imm) eq
-       The layout of Mf.t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 2-26.
-       But the layout of Mf.t_float64 must overlap with value
-         because of the definition of t_imm at line 5, characters 2-24.
+       The layout of Mf.t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 2-26.
+       But the layout of Mf.t_float64 must overlap with value, because
+         of the definition of t_imm at line 5, characters 2-24.
 |}]
 
 (*****************************************************)
@@ -1568,10 +1568,10 @@ Line 2, characters 15-16:
                    ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because the type argument of option has layout value.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         the type argument of option has layout value.
 |}]
 
 (*********************************************************)
@@ -1711,10 +1711,10 @@ Line 4, characters 9-22:
              ^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}]
 
 (*******************************************)
@@ -1734,10 +1734,10 @@ Line 3, characters 14-29:
                   ^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of the definition of eq at line 1, characters 0-41.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of eq at line 1, characters 0-41.
 |}]
 
 (**************************************)
@@ -1760,10 +1760,10 @@ Line 7, characters 28-29:
                                 ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of the definition of f at line 2, characters 2-18.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of f at line 2, characters 2-18.
 |}]
 
 (**************************************************)
@@ -1780,11 +1780,10 @@ Line 1, characters 44-46:
 1 | type ('a : float64) poly_var = [`A of int * 'a | `B]
                                                 ^^
 Error: This type ('a : value) should be an instance of type ('a0 : float64)
-       The layout of 'a is float64
-         because of the annotation on 'a in the declaration of the type
-                                      poly_var.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type poly_var.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (*********************************************************)
@@ -1800,10 +1799,10 @@ Line 1, characters 14-40:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}]
 
 (******************************************************)
@@ -1816,10 +1815,10 @@ Line 1, characters 17-22:
 1 | external foo33 : t_any = "foo33";;
                      ^^^^^
 Error: This type signature for foo33 is not a value type.
-       The layout of type t_any is any
-         because of the definition of t_any at line 5, characters 0-18.
-       But the layout of type t_any must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of type t_any must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}]
 
 external foo44 : ('a : any). 'a -> unit = "foo44";;
@@ -1829,10 +1828,10 @@ Line 1, characters 29-31:
 1 | external foo44 : ('a : any). 'a -> unit = "foo44";;
                                  ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any
-         because of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable
-         because it's the type of an argument in an external declaration.
+       The layout of 'a is any, because
+         of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable, because
+         it's the type of an argument in an external declaration.
 |}]
 
 external foo55 : ('a : any). unit -> 'a = "foo55";;
@@ -1842,10 +1841,10 @@ Line 1, characters 37-39:
 1 | external foo55 : ('a : any). unit -> 'a = "foo55";;
                                          ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any
-         because of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable
-         because it's the type of the result of an external declaration.
+       The layout of 'a is any, because
+         of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable, because
+         it's the type of the result of an external declaration.
 |}]
 
 (****************************************************)
@@ -1866,10 +1865,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value
-           because of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of immediate
-           because of the definition of t2_imm at line 1, characters 0-28.
+         The kind of 'a is value, because
+           of the annotation on the universal variable 'a.
+         But the kind of 'a must be a subkind of immediate, because
+           of the definition of t2_imm at line 1, characters 0-28.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -1886,10 +1885,10 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value
-         because it's a function type.
-       But the kind of 'a -> 'b must be a subkind of immediate
-         because of the definition of t35 at line 1, characters 0-30.
+       The kind of 'a -> 'b is value, because
+         it's a function type.
+       But the kind of 'a -> 'b must be a subkind of immediate, because
+         of the definition of t35 at line 1, characters 0-30.
 |}]
 
 (**************************************************)
@@ -1908,10 +1907,10 @@ Line 1, characters 10-22:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_6)
        because it is in the left-hand side of a sequence
-       The layout of t_any is any
-         because of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable
-         because it's the type of a statement.
+       The layout of t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 let () = while false do (assert false : t_any); done
@@ -1927,10 +1926,10 @@ Line 1, characters 25-37:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_7)
        because it is in the body of a while-loop
-       The layout of t_any is any
-         because of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable
-         because it's the type of a statement.
+       The layout of t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 let () = for i = 0 to 0 do (assert false : t_any); done
@@ -1946,10 +1945,10 @@ Line 1, characters 28-40:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_8)
        because it is in the body of a for-loop
-       The layout of t_any is any
-         because of the definition of t_any at line 5, characters 0-18.
-       But the layout of t_any must be representable
-         because it's the type of a statement.
+       The layout of t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 (******************************************************)
@@ -1976,10 +1975,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is any
-         because of the definition of f at line 2, characters 2-30.
-       But the layout of 'a must be representable
-         because of the definition of f at line 4, characters 8-13.
+       The layout of 'a is any, because
+         of the definition of f at line 2, characters 2-30.
+       But the layout of 'a must be representable, because
+         of the definition of f at line 4, characters 8-13.
 |}]
 
 module M1 : sig
@@ -2032,10 +2031,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is any
-         because of the definition of f at line 2, characters 2-30.
-       But the layout of 'a must be a sublayout of value
-         because of the definition of f at line 6, characters 2-18.
+       The layout of 'a is any, because
+         of the definition of f at line 2, characters 2-30.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of f at line 6, characters 2-18.
 |}]
 
 module F (X : S_value) : S_float64 = X
@@ -2054,10 +2053,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : float64). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is float64
-         because of the definition of f at line 10, characters 2-34.
-       But the layout of 'a must be a sublayout of value
-         because of the definition of f at line 6, characters 2-18.
+       The layout of 'a is float64, because
+         of the definition of f at line 10, characters 2-34.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of f at line 6, characters 2-18.
 |}]
 
 module M2 : sig
@@ -2357,10 +2356,10 @@ Line 2, characters 33-34:
                                      ^
 Error: This expression has type t_float64
        but an expression was expected of type 'a t40 = ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of the definition of t40 at line 1, characters 0-16.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         of the definition of t40 at line 1, characters 0-16.
 |}]
 
 (**********************************************************************)
@@ -2375,11 +2374,11 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value
-         because it instantiates an unannotated type parameter of t2,
+       The kind of 'a t2 is value, because
+         it instantiates an unannotated type parameter of t2,
          defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate
-         because of the annotation on the wildcard _ at line 1, characters 28-37.
+       But the kind of 'a t2 must be a subkind of immediate, because
+         of the annotation on the wildcard _ at line 1, characters 28-37.
 |}]
 
 (* This example is unfortunately rejected as a consequence of the fix for the
@@ -2394,11 +2393,11 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value
-         because it instantiates an unannotated type parameter of t2,
+       The kind of 'a t2 is value, because
+         it instantiates an unannotated type parameter of t2,
          defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate
-         because of the annotation on the wildcard _ at line 1, characters 27-36.
+       But the kind of 'a t2 must be a subkind of immediate, because
+         of the annotation on the wildcard _ at line 1, characters 27-36.
 |}]
 
 (* This one also unfortunately rejected for the same reason. *)
@@ -2410,11 +2409,11 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value
-         because it instantiates an unannotated type parameter of t2,
+       The kind of 'a t2 is value, because
+         it instantiates an unannotated type parameter of t2,
          defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate
-         because of the annotation on the wildcard _ at line 1, characters 25-34.
+       But the kind of 'a t2 must be a subkind of immediate, because
+         of the annotation on the wildcard _ at line 1, characters 25-34.
 |}]
 
 (**********************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -508,9 +508,9 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
@@ -531,9 +531,9 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
@@ -547,9 +547,9 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}];;
 
@@ -561,9 +561,9 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -594,9 +594,9 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of s5 is value, because
+       The layout of s5 is value, because
          it is the primitive value type string.
-       But the kind of s5 must be a subkind of immediate, because
+       But the layout of s5 must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -657,9 +657,9 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value, because
+       The layout of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate, because
+       But the layout of 'a must be a sublayout of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -673,9 +673,9 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value, because
+       The layout of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate, because
+       But the layout of 'a must be a sublayout of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -694,9 +694,9 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The kind of int * int is value, because
+       The layout of int * int is value, because
          it's a tuple type.
-       But the kind of int * int must be a subkind of immediate, because
+       But the layout of int * int must be a sublayout of immediate, because
          of the definition of t7 at line 1, characters 0-37.
 |}]
 
@@ -917,9 +917,9 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}];;
 
@@ -958,9 +958,9 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}]
 
@@ -1865,9 +1865,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value, because
+         The layout of 'a is value, because
            of the annotation on the universal variable 'a.
-         But the kind of 'a must be a subkind of immediate, because
+         But the layout of 'a must be a sublayout of immediate, because
            of the definition of t2_imm at line 1, characters 0-28.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -1885,9 +1885,9 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value, because
+       The layout of 'a -> 'b is value, because
          it's a function type.
-       But the kind of 'a -> 'b must be a subkind of immediate, because
+       But the layout of 'a -> 'b must be a sublayout of immediate, because
          of the definition of t35 at line 1, characters 0-30.
 |}]
 
@@ -2374,10 +2374,10 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value, because
+       The layout of 'a t2 is value, because
          it instantiates an unannotated type parameter of t2,
-         defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate, because
+         defaulted to layout value.
+       But the layout of 'a t2 must be a sublayout of immediate, because
          of the annotation on the wildcard _ at line 1, characters 28-37.
 |}]
 
@@ -2393,10 +2393,10 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value, because
+       The layout of 'a t2 is value, because
          it instantiates an unannotated type parameter of t2,
-         defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate, because
+         defaulted to layout value.
+       But the layout of 'a t2 must be a sublayout of immediate, because
          of the annotation on the wildcard _ at line 1, characters 27-36.
 |}]
 
@@ -2409,10 +2409,10 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t2 is value, because
+       The layout of 'a t2 is value, because
          it instantiates an unannotated type parameter of t2,
-         defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate, because
+         defaulted to layout value.
+       But the layout of 'a t2 must be a sublayout of immediate, because
          of the annotation on the wildcard _ at line 1, characters 25-34.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -508,9 +508,9 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
@@ -531,9 +531,9 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
@@ -547,9 +547,9 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}];;
 
@@ -561,9 +561,9 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -594,9 +594,9 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The layout of s5 is value, because
+       The kind of s5 is value, because
          it is the primitive value type string.
-       But the layout of s5 must be a sublayout of immediate, because
+       But the kind of s5 must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -657,9 +657,9 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -673,9 +673,9 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -694,9 +694,9 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The layout of int * int is value, because
+       The kind of int * int is value, because
          it's a tuple type.
-       But the layout of int * int must be a sublayout of immediate, because
+       But the kind of int * int must be a subkind of immediate, because
          of the definition of t7 at line 1, characters 0-37.
 |}]
 
@@ -917,9 +917,9 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}];;
 
@@ -958,9 +958,9 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}]
 
@@ -1536,7 +1536,7 @@ Error: This pattern matches values of type (Mf.t_float64, Mf.t_float64) eq
          (Mf.t_float64, Mf.t_imm) eq
        The layout of Mf.t_float64 is float64, because
          of the definition of t_float64 at line 4, characters 2-26.
-       But the layout of Mf.t_float64 must overlap with immediate, because
+       But the layout of Mf.t_float64 must overlap with value, because
          of the definition of t_imm at line 5, characters 2-24.
 |}]
 
@@ -1865,9 +1865,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is value, because
+         The kind of 'a is value, because
            of the annotation on the universal variable 'a.
-         But the layout of 'a must be a sublayout of immediate, because
+         But the kind of 'a must be a subkind of immediate, because
            of the definition of t2_imm at line 1, characters 0-28.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -1885,9 +1885,9 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The layout of 'a -> 'b is value, because
+       The kind of 'a -> 'b is value, because
          it's a function type.
-       But the layout of 'a -> 'b must be a sublayout of immediate, because
+       But the kind of 'a -> 'b must be a subkind of immediate, because
          of the definition of t35 at line 1, characters 0-30.
 |}]
 
@@ -2374,9 +2374,9 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The layout of 'a t2 is value, because
-         it instantiates an unannotated type parameter of t2, defaulted to layout value.
-       But the layout of 'a t2 must be a sublayout of immediate, because
+       The kind of 'a t2 is value, because
+         it instantiates an unannotated type parameter of t2, defaulted to kind value.
+       But the kind of 'a t2 must be a subkind of immediate, because
          of the annotation on the wildcard _ at line 1, characters 28-37.
 |}]
 
@@ -2392,9 +2392,9 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The layout of 'a t2 is value, because
-         it instantiates an unannotated type parameter of t2, defaulted to layout value.
-       But the layout of 'a t2 must be a sublayout of immediate, because
+       The kind of 'a t2 is value, because
+         it instantiates an unannotated type parameter of t2, defaulted to kind value.
+       But the kind of 'a t2 must be a subkind of immediate, because
          of the annotation on the wildcard _ at line 1, characters 27-36.
 |}]
 
@@ -2407,9 +2407,9 @@ Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
 Error:
-       The layout of 'a t2 is value, because
-         it instantiates an unannotated type parameter of t2, defaulted to layout value.
-       But the layout of 'a t2 must be a sublayout of immediate, because
+       The kind of 'a t2 is value, because
+         it instantiates an unannotated type parameter of t2, defaulted to kind value.
+       But the kind of 'a t2 must be a subkind of immediate, because
          of the annotation on the wildcard _ at line 1, characters 25-34.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -246,9 +246,9 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
@@ -269,9 +269,9 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
@@ -285,9 +285,9 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}];;
 
@@ -299,9 +299,9 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -332,9 +332,9 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The layout of s5 is value, because
+       The kind of s5 is value, because
          it is the primitive value type string.
-       But the layout of s5 must be a sublayout of immediate, because
+       But the kind of s5 must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -398,7 +398,7 @@ Line 1, characters 12-15:
 1 | let h5 (x : int void5) = f5 x
                 ^^^
 Error: This type int should be an instance of type ('a : void)
-       The layout of int is immediate, because
+       The layout of int is value, because
          it is the primitive immediate type int.
        But the layout of int must be a sublayout of void, because
          of the definition of void5 at line 1, characters 0-37.
@@ -411,7 +411,7 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type int but an expression was expected of type
          ('a : void)
-       The layout of int is immediate, because
+       The layout of int is value, because
          it is the primitive immediate type int.
        But the layout of int must be a sublayout of void, because
          of the definition of void5 at line 1, characters 0-37.
@@ -452,9 +452,9 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -468,9 +468,9 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -490,9 +490,9 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The layout of int * int is value, because
+       The kind of int * int is value, because
          it's a tuple type.
-       But the layout of int * int must be a sublayout of immediate, because
+       But the kind of int * int must be a subkind of immediate, because
          of the definition of t7 at line 1, characters 0-37.
 |}]
 
@@ -747,9 +747,9 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}];;
 
@@ -788,9 +788,9 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}]
 
@@ -1353,7 +1353,7 @@ Error: This pattern matches values of type (M.t_void, M.t_void) eq
          (M.t_void, M.t_imm) eq
        The layout of M.t_void is void, because
          of the definition of t_void at line 4, characters 2-20.
-       But the layout of M.t_void must overlap with immediate, because
+       But the layout of M.t_void must overlap with value, because
          of the definition of t_imm at line 5, characters 2-24.
 |}]
 
@@ -1796,9 +1796,9 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The layout of 'a -> 'b is value, because
+       The kind of 'a -> 'b is value, because
          it's a function type.
-       But the layout of 'a -> 'b must be a sublayout of immediate, because
+       But the kind of 'a -> 'b must be a subkind of immediate, because
          of the definition of t35 at line 1, characters 0-30.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -246,9 +246,9 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
@@ -269,9 +269,9 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
@@ -285,9 +285,9 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}];;
 
@@ -299,9 +299,9 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -332,9 +332,9 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of s5 is value, because
+       The layout of s5 is value, because
          it is the primitive value type string.
-       But the kind of s5 must be a subkind of immediate, because
+       But the layout of s5 must be a sublayout of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -452,9 +452,9 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value, because
+       The layout of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate, because
+       But the layout of 'a must be a sublayout of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -468,9 +468,9 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value, because
+       The layout of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate, because
+       But the layout of 'a must be a sublayout of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -490,9 +490,9 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The kind of int * int is value, because
+       The layout of int * int is value, because
          it's a tuple type.
-       But the kind of int * int must be a subkind of immediate, because
+       But the layout of int * int must be a sublayout of immediate, because
          of the definition of t7 at line 1, characters 0-37.
 |}]
 
@@ -747,9 +747,9 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}];;
 
@@ -788,9 +788,9 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}]
 
@@ -1796,9 +1796,9 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value, because
+       The layout of 'a -> 'b is value, because
          it's a function type.
-       But the kind of 'a -> 'b must be a subkind of immediate, because
+       But the layout of 'a -> 'b must be a sublayout of immediate, because
          of the definition of t35 at line 1, characters 0-30.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -246,9 +246,9 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
@@ -269,9 +269,9 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
@@ -285,9 +285,9 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}];;
 
@@ -299,9 +299,9 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -332,9 +332,9 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The layout of s5 is value, because
+       The kind of s5 is value, because
          it is the primitive value type string.
-       But the layout of s5 must be a sublayout of immediate, because
+       But the kind of s5 must be a subkind of immediate, because
          of the annotation on 'a in the declaration of the type t4.
 |}]
 
@@ -452,9 +452,9 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -468,9 +468,9 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The layout of 'a is value, because
+       The kind of 'a is value, because
          it is or unifies with an unannotated universal variable.
-       But the layout of 'a must be a sublayout of immediate, because
+       But the kind of 'a must be a subkind of immediate, because
          of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
@@ -490,9 +490,9 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The layout of int * int is value, because
+       The kind of int * int is value, because
          it's a tuple type.
-       But the layout of int * int must be a sublayout of immediate, because
+       But the kind of int * int must be a subkind of immediate, because
          of the definition of t7 at line 1, characters 0-37.
 |}]
 
@@ -747,9 +747,9 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}];;
 
@@ -788,9 +788,9 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of x at line 8, characters 10-26.
 |}]
 
@@ -1796,9 +1796,9 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The layout of 'a -> 'b is value, because
+       The kind of 'a -> 'b is value, because
          it's a function type.
-       But the layout of 'a -> 'b must be a sublayout of immediate, because
+       But the kind of 'a -> 'b must be a subkind of immediate, because
          of the definition of t35 at line 1, characters 0-30.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -75,10 +75,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_1) is not compatible with type t
-       The layout of t is any, because
-         of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable, because
-         it instantiates an unannotated type parameter of s.
+       The layout of t is any
+         because of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable
+         because it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -92,10 +92,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_2) is not compatible with type t
-       The layout of t is any, because
-         of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable, because
-         it instantiates an unannotated type parameter of s.
+       The layout of t is any
+         because of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable
+         because it instantiates an unannotated type parameter of s.
 |}]
 
 let f1 () : t_any = assert false;;
@@ -105,10 +105,10 @@ Line 1, characters 20-32:
                         ^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_3)
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be representable, because
-         we must know concretely how to return a function result.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable
+         because we must know concretely how to return a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -119,10 +119,10 @@ Line 1, characters 7-18:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_4)
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable
+         because we must know concretely how to pass a function argument.
 |}];;
 
 (*****************************************************)
@@ -200,10 +200,10 @@ Line 1, characters 27-33:
 1 | module F2 (X : sig val x : t_void end) = struct
                                ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of type t_void must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of type t_void must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 (* CR layouts v5: the test above should be made to work *)
 
@@ -216,10 +216,10 @@ Line 2, characters 16-44:
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}];;
 
 (**************************************)
@@ -246,10 +246,10 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of imm_id at line 1, characters 0-33.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -269,10 +269,10 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of id_for_imms at line 1, characters 16-35.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -285,10 +285,10 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the annotation on 'a in the declaration of the type t4.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t4.
 |}];;
 
 type s4 = string t4
@@ -299,10 +299,10 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the annotation on 'a in the declaration of the type t4.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type s4 = int t4
@@ -332,10 +332,10 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of s5 is value, because
-         it is the primitive value type string.
-       But the kind of s5 must be a subkind of immediate, because
-         of the annotation on 'a in the declaration of the type t4.
+       The kind of s5 is value
+         because it is the primitive value type string.
+       But the kind of s5 must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type ('a : any) t4 = 'a
@@ -385,10 +385,10 @@ Lines 3-4, characters 33-22:
 4 |   | Void5 x -> Void5 x
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of 'a is void, because
-         of the definition of void5 at line 1, characters 0-37.
-       But the layout of 'a must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of 'a is void
+         because of the definition of void5 at line 1, characters 0-37.
+       But the layout of 'a must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}];;
 
 (* disallowed attempts to use f5 and Void5 on non-voids *)
@@ -398,10 +398,10 @@ Line 1, characters 12-15:
 1 | let h5 (x : int void5) = f5 x
                 ^^^
 Error: This type int should be an instance of type ('a : void)
-       The layout of int is value, because
-         it is the primitive immediate type int.
-       But the layout of int must be a sublayout of void, because
-         of the definition of void5 at line 1, characters 0-37.
+       The layout of int is value
+         because it is the primitive immediate type int.
+       But the layout of int must be a sublayout of void
+         because of the definition of void5 at line 1, characters 0-37.
 |}];;
 
 let h5' (x : int) = Void5 x
@@ -411,10 +411,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type int but an expression was expected of type
          ('a : void)
-       The layout of int is value, because
-         it is the primitive immediate type int.
-       But the layout of int must be a sublayout of void, because
-         of the definition of void5 at line 1, characters 0-37.
+       The layout of int is value
+         because it is the primitive immediate type int.
+       But the layout of int must be a sublayout of void
+         because of the definition of void5 at line 1, characters 0-37.
 |}];;
 
 (* disallowed - tries to return void *)
@@ -452,10 +452,10 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value, because
-         it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate, because
-         of the definition of t6_imm at line 1, characters 0-42.
+       The kind of 'a is value
+         because it is or unifies with an unannotated universal variable.
+       But the kind of 'a must be a subkind of immediate
+         because of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -468,10 +468,10 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value, because
-         it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate, because
-         of the definition of t6_imm at line 1, characters 0-42.
+       The kind of 'a is value
+         because it is or unifies with an unannotated universal variable.
+       But the kind of 'a must be a subkind of immediate
+         because of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -490,10 +490,10 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The kind of int * int is value, because
-         it's a tuple type.
-       But the kind of int * int must be a subkind of immediate, because
-         of the definition of t7 at line 1, characters 0-37.
+       The kind of int * int is value
+         because it's a tuple type.
+       But the kind of int * int must be a subkind of immediate
+         because of the definition of t7 at line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -509,10 +509,10 @@ Line 2, characters 40-46:
 2 |   type foo1 = [ `Foo1 of int | `Baz1 of t_void | `Bar1 of string ];;
                                             ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_2 = struct
@@ -542,10 +542,10 @@ Line 4, characters 13-19:
 4 |   type bad = t_void t
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         of the definition of t at line 2, characters 2-42.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because of the definition of t at line 2, characters 2-42.
 |}];;
 
 module M8_4 = struct
@@ -557,10 +557,10 @@ Line 2, characters 54-78:
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
-       The layout of void_unboxed_record is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of void_unboxed_record is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 module type S8_5 = sig
@@ -571,10 +571,10 @@ Line 2, characters 17-23:
 2 |   val x : [`A of t_void]
                      ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}]
 
 (************************************************)
@@ -589,10 +589,10 @@ Line 2, characters 20-26:
 2 |   type foo1 = int * t_void * [ `Foo1 of int | `Bar1 of string ];;
                         ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module M9_2 = struct
@@ -603,10 +603,10 @@ Line 2, characters 31-50:
 2 |   type result = V of (string * void_unboxed_record) | I of int
                                    ^^^^^^^^^^^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of void_unboxed_record is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of void_unboxed_record is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module M9_3 = struct
@@ -623,10 +623,10 @@ Line 7, characters 13-14:
                  ^
 Error: This expression has type void_unboxed_record
        but an expression was expected of type ('a : value)
-       The layout of void_unboxed_record is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of void_unboxed_record is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module M9_4 = struct
@@ -640,10 +640,10 @@ Line 4, characters 8-16:
             ^^^^^^^^
 Error: The record field vur_void belongs to the type void_unboxed_record
        but is mixed here with fields of type ('a : value)
-       The layout of void_unboxed_record is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value, because
-         it's a boxed record type.
+       The layout of void_unboxed_record is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value
+         because it's a boxed record type.
 |}];;
 
 module M9_5 = struct
@@ -656,10 +656,10 @@ Line 4, characters 13-19:
 4 |   type bad = t_void t
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         of the definition of t at line 2, characters 2-24.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because of the definition of t at line 2, characters 2-24.
 |}];;
 
 module M9_6 = struct
@@ -671,10 +671,10 @@ Line 2, characters 34-58:
                                       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
-       The layout of void_unboxed_record is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of void_unboxed_record is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module type S9_7 = sig
@@ -685,10 +685,10 @@ Line 2, characters 16-22:
 2 |   val x : int * t_void
                     ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 module M9_9 (X : sig
@@ -704,10 +704,10 @@ Line 5, characters 11-23:
                ^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 (*************************************************)
@@ -747,10 +747,10 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of x at line 8, characters 10-26.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of x at line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -788,10 +788,10 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of x at line 8, characters 10-26.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of x at line 8, characters 10-26.
 |}]
 
 (**************************************************************)
@@ -807,10 +807,10 @@ Line 5, characters 4-7:
 5 |     t.v # baz11
         ^^^
 Error: Object types must have layout value.
-       The layout of the type of this expression is void, because
-         of the definition of t at line 2, characters 2-42.
-       But the layout of the type of this expression must overlap with value, because
-         it's the type of an object.
+       The layout of the type of this expression is void
+         because of the definition of t at line 2, characters 2-42.
+       But the layout of the type of this expression must overlap with value
+         because it's the type of an object.
 |}]
 
 module M11_2 = struct
@@ -822,10 +822,10 @@ Line 2, characters 17-30:
                      ^^^^^^^^^^^^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 module M11_3 = struct
@@ -849,10 +849,10 @@ Line 2, characters 12-22:
 2 |   val x : < l : t_void >
                 ^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 module M11_5 = struct
@@ -864,10 +864,10 @@ Line 3, characters 2-24:
 3 |   and ('a : void) s = 'a
       ^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'a s is void, because
-         of the annotation on 'a in the declaration of the type s.
-       But the layout of 'a s must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of 'a s is void
+         because of the annotation on 'a in the declaration of the type s.
+       But the layout of 'a s must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 module M11_6 = struct
@@ -879,10 +879,10 @@ Line 2, characters 36-47:
                                         ^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_void
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 (*******************************************************************)
@@ -916,10 +916,10 @@ Line 4, characters 10-13:
 4 |       val bar = v.vr_void
               ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of bar must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of bar is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of bar must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 (* Hits the Cfk_virtual case of Pcf_val *)
@@ -934,10 +934,10 @@ Line 4, characters 18-21:
 4 |       val virtual bar : t_void
                       ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of bar must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of bar is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of bar must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 module M12_4 = struct
@@ -953,10 +953,10 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with void, because
-         of the definition of t at line 2, characters 2-20.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void
+         because of the definition of t at line 2, characters 2-20.
 |}];;
 
 module M12_5 = struct
@@ -972,10 +972,10 @@ Line 6, characters 29-31:
 6 |       method void_id (A a) : 'a t = a
                                  ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with void, because
-         of the definition of t at line 2, characters 2-30.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void
+         because of the definition of t at line 2, characters 2-30.
 |}];;
 
 module type S12_6 = sig
@@ -992,10 +992,10 @@ Line 5, characters 4-6:
 5 |     'a t ->
         ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with void, because
-         of the definition of t at line 2, characters 2-30.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void
+         because of the definition of t at line 2, characters 2-30.
 |}];;
 
 module type S12_7 = sig
@@ -1009,10 +1009,10 @@ Line 4, characters 6-22:
 4 |       val baz : t_void
           ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of baz is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of baz must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of baz is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of baz must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 (*************************************************************************)
@@ -1025,10 +1025,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void Lazy.t;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of Lazy.t has this layout.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of Lazy.t has this layout.
 |}];;
 
 let x13 (VV v) = lazy v;;
@@ -1038,10 +1038,10 @@ Line 1, characters 22-23:
                           ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of a lazy expression.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of a lazy expression.
 |}];;
 
 let x13 v =
@@ -1053,10 +1053,10 @@ Line 3, characters 17-18:
                      ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of a lazy expression.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of a lazy expression.
 |}];;
 
 (* option *)
@@ -1067,10 +1067,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void option;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of option has layout value.
 |}];;
 
 let x13 (VV v) = Some v;;
@@ -1080,10 +1080,10 @@ Line 1, characters 22-23:
                           ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of option has layout value.
 |}];;
 
 let x13 v =
@@ -1096,10 +1096,10 @@ Line 3, characters 17-18:
                      ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of option has layout value.
 |}];;
 
 (* list *)
@@ -1110,10 +1110,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void list;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let x13 (VV v) = [v];;
@@ -1123,10 +1123,10 @@ Line 1, characters 18-19:
                       ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 let x13 v =
@@ -1139,10 +1139,10 @@ Line 3, characters 14-15:
                   ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (* array *)
@@ -1171,10 +1171,10 @@ Lines 2-4, characters 2-21:
 4 |   | _ -> assert false
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}];;
 
 (****************************************************************************)
@@ -1193,10 +1193,10 @@ Line 2, characters 0-18:
 2 | and foo14 = t_void;;
     ^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of foo14 is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of foo14 must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of foo14 is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of foo14 must be a sublayout of value
+         because the type argument of list has layout value.
 |}];;
 
 (****************************************************)
@@ -1317,10 +1317,10 @@ Lines 6-7, characters 2-20:
 7 |   g (failwith "foo")..
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of 'a is void, because
-         of the definition of r at line 3, characters 0-40.
-       But the layout of 'a must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of 'a is void
+         because of the definition of r at line 3, characters 0-40.
+       But the layout of 'a must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}];;
 
 (********************************************************************)
@@ -1351,10 +1351,10 @@ Line 15, characters 4-8:
 Error: This pattern matches values of type (M.t_void, M.t_void) eq
        but a pattern was expected which matches values of type
          (M.t_void, M.t_imm) eq
-       The layout of M.t_void is void, because
-         of the definition of t_void at line 4, characters 2-20.
-       But the layout of M.t_void must overlap with value, because
-         of the definition of t_imm at line 5, characters 2-24.
+       The layout of M.t_void is void
+         because of the definition of t_void at line 4, characters 2-20.
+       But the layout of M.t_void must overlap with value
+         because of the definition of t_imm at line 5, characters 2-24.
 |}]
 
 (*****************************************************)
@@ -1387,10 +1387,10 @@ Line 2, characters 15-16:
                    ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         the type argument of option has layout value.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because the type argument of option has layout value.
 |}]
 
 (*********************************************************)
@@ -1640,10 +1640,10 @@ Line 4, characters 9-19:
              ^^^^^^^^^^
 Error: This pattern matches values of type t_void
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of a tuple element.
 |}]
 
 let ( let* ) x f = ()
@@ -1662,10 +1662,10 @@ Line 4, characters 9-22:
              ^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it's the type of a tuple element.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}]
 
 
@@ -1688,10 +1688,10 @@ Line 4, characters 16-28:
                     ^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         of the definition of eq at line 2, characters 2-43.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because of the definition of eq at line 2, characters 2-43.
 |}]
 
 (**************************************)
@@ -1717,10 +1717,10 @@ Line 8, characters 27-28:
                                ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         of the definition of f at line 3, characters 4-20.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because of the definition of f at line 3, characters 4-20.
 |}]
 
 (**************************************************)
@@ -1735,10 +1735,11 @@ Line 1, characters 41-43:
 1 | type ('a : void) poly_var = [`A of int * 'a | `B]
                                              ^^
 Error: This type ('a : value) should be an instance of type ('a0 : void)
-       The layout of 'a is void, because
-         of the annotation on 'a in the declaration of the type poly_var.
-       But the layout of 'a must overlap with value, because
-         it's the type of a tuple element.
+       The layout of 'a is void
+         because of the annotation on 'a in the declaration of the type
+                                      poly_var.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}]
 
 (* CR layouts bug: this should be accepted (or maybe we should reject
@@ -1757,10 +1758,10 @@ Line 1, characters 14-37:
                   ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}]
 
 (******************************************************)
@@ -1772,10 +1773,10 @@ Line 1, characters 17-22:
 1 | external foo33 : t_any = "foo33";;
                      ^^^^^
 Error: This type signature for foo33 is not a value type.
-       The layout of type t_any is any, because
-         of the definition of t_any at line 1, characters 0-18.
-       But the layout of type t_any must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_any is any
+         because of the definition of t_any at line 1, characters 0-18.
+       But the layout of type t_any must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}]
 
 
@@ -1796,10 +1797,10 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value, because
-         it's a function type.
-       But the kind of 'a -> 'b must be a subkind of immediate, because
-         of the definition of t35 at line 1, characters 0-30.
+       The kind of 'a -> 'b is value
+         because it's a function type.
+       But the kind of 'a -> 'b must be a subkind of immediate
+         because of the definition of t35 at line 1, characters 0-30.
 |}]
 
 (**************************************************)
@@ -1818,10 +1819,10 @@ Line 1, characters 10-22:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_5)
        because it is in the left-hand side of a sequence
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be representable, because
-         it's the type of a statement.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable
+         because it's the type of a statement.
 |}]
 
 let () = while false do (assert false : t_any); done
@@ -1837,10 +1838,10 @@ Line 1, characters 25-37:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_6)
        because it is in the body of a while-loop
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be representable, because
-         it's the type of a statement.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable
+         because it's the type of a statement.
 |}]
 
 let () = for i = 0 to 0 do (assert false : t_any); done
@@ -1856,10 +1857,10 @@ Line 1, characters 28-40:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_7)
        because it is in the body of a for-loop
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be representable, because
-         it's the type of a statement.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable
+         because it's the type of a statement.
 |}]
 
 (******************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -75,10 +75,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_1) is not compatible with type t
-       The layout of t is any
-         because of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable
-         because it instantiates an unannotated type parameter of s.
+       The layout of t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable, because
+         it instantiates an unannotated type parameter of s.
 |}]
 
 module type S1 = sig
@@ -92,10 +92,10 @@ Line 4, characters 35-41:
                                        ^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : '_representable_layout_2) is not compatible with type t
-       The layout of t is any
-         because of the definition of t at line 2, characters 2-14.
-       But the layout of t must be representable
-         because it instantiates an unannotated type parameter of s.
+       The layout of t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of t must be representable, because
+         it instantiates an unannotated type parameter of s.
 |}]
 
 let f1 () : t_any = assert false;;
@@ -105,10 +105,10 @@ Line 1, characters 20-32:
                         ^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_3)
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be representable
-         because we must know concretely how to return a function result.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable, because
+         we must know concretely how to return a function result.
 |}];;
 
 let f1 (x : t_any) = ();;
@@ -119,10 +119,10 @@ Line 1, characters 7-18:
 Error: This pattern matches values of type t_any
        but a pattern was expected which matches values of type
          ('a : '_representable_layout_4)
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable, because
+         we must know concretely how to pass a function argument.
 |}];;
 
 (*****************************************************)
@@ -200,10 +200,10 @@ Line 1, characters 27-33:
 1 | module F2 (X : sig val x : t_void end) = struct
                                ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of type t_void must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of type t_void must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}];;
 (* CR layouts v5: the test above should be made to work *)
 
@@ -216,10 +216,10 @@ Line 2, characters 16-44:
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}];;
 
 (**************************************)
@@ -246,10 +246,10 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of imm_id at line 1, characters 0-33.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of imm_id at line 1, characters 0-33.
 |}];;
 
 let id_for_imms (x : 'a imm_id) = x
@@ -269,10 +269,10 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of id_for_imms at line 1, characters 16-35.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of id_for_imms at line 1, characters 16-35.
 |}]
 
 (************************************)
@@ -285,10 +285,10 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the annotation on 'a in the declaration of the type t4.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}];;
 
 type s4 = string t4
@@ -299,10 +299,10 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the annotation on 'a in the declaration of the type t4.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type s4 = int t4
@@ -332,10 +332,10 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of s5 is value
-         because it is the primitive value type string.
-       But the kind of s5 must be a subkind of immediate
-         because of the annotation on 'a in the declaration of the type t4.
+       The kind of s5 is value, because
+         it is the primitive value type string.
+       But the kind of s5 must be a subkind of immediate, because
+         of the annotation on 'a in the declaration of the type t4.
 |}]
 
 type ('a : any) t4 = 'a
@@ -385,10 +385,10 @@ Lines 3-4, characters 33-22:
 4 |   | Void5 x -> Void5 x
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of 'a is void
-         because of the definition of void5 at line 1, characters 0-37.
-       But the layout of 'a must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of 'a is void, because
+         of the definition of void5 at line 1, characters 0-37.
+       But the layout of 'a must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}];;
 
 (* disallowed attempts to use f5 and Void5 on non-voids *)
@@ -398,10 +398,10 @@ Line 1, characters 12-15:
 1 | let h5 (x : int void5) = f5 x
                 ^^^
 Error: This type int should be an instance of type ('a : void)
-       The layout of int is value
-         because it is the primitive immediate type int.
-       But the layout of int must be a sublayout of void
-         because of the definition of void5 at line 1, characters 0-37.
+       The layout of int is value, because
+         it is the primitive immediate type int.
+       But the layout of int must be a sublayout of void, because
+         of the definition of void5 at line 1, characters 0-37.
 |}];;
 
 let h5' (x : int) = Void5 x
@@ -411,10 +411,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type int but an expression was expected of type
          ('a : void)
-       The layout of int is value
-         because it is the primitive immediate type int.
-       But the layout of int must be a sublayout of void
-         because of the definition of void5 at line 1, characters 0-37.
+       The layout of int is value, because
+         it is the primitive immediate type int.
+       But the layout of int must be a sublayout of void, because
+         of the definition of void5 at line 1, characters 0-37.
 |}];;
 
 (* disallowed - tries to return void *)
@@ -452,10 +452,10 @@ Line 2, characters 2-32:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value
-         because it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate
-         because of the definition of t6_imm at line 1, characters 0-42.
+       The kind of 'a is value, because
+         it is or unifies with an unannotated universal variable.
+       But the kind of 'a must be a subkind of immediate, because
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 let o6 = object
@@ -468,10 +468,10 @@ Line 3, characters 4-34:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This method has type 'b -> unit which is less general than
          'a. 'a -> unit
-       The kind of 'a is value
-         because it is or unifies with an unannotated universal variable.
-       But the kind of 'a must be a subkind of immediate
-         because of the definition of t6_imm at line 1, characters 0-42.
+       The kind of 'a is value, because
+         it is or unifies with an unannotated universal variable.
+       But the kind of 'a must be a subkind of immediate, because
+         of the definition of t6_imm at line 1, characters 0-42.
 |}];;
 
 (* CR layouts v1.5: add more tests here once you can annotate these types with
@@ -490,10 +490,10 @@ Line 3, characters 12-21:
 3 | type t7' = (int * int) t7;;
                 ^^^^^^^^^
 Error: This type int * int should be an instance of type ('a : immediate)
-       The kind of int * int is value
-         because it's a tuple type.
-       But the kind of int * int must be a subkind of immediate
-         because of the definition of t7 at line 1, characters 0-37.
+       The kind of int * int is value, because
+         it's a tuple type.
+       But the kind of int * int must be a subkind of immediate, because
+         of the definition of t7 at line 1, characters 0-37.
 |}]
 
 (**********************************************************)
@@ -509,10 +509,10 @@ Line 2, characters 40-46:
 2 |   type foo1 = [ `Foo1 of int | `Baz1 of t_void | `Bar1 of string ];;
                                             ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 module M8_2 = struct
@@ -542,10 +542,10 @@ Line 4, characters 13-19:
 4 |   type bad = t_void t
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because of the definition of t at line 2, characters 2-42.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-42.
 |}];;
 
 module M8_4 = struct
@@ -557,10 +557,10 @@ Line 2, characters 54-78:
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
-       The layout of void_unboxed_record is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of void_unboxed_record is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 module type S8_5 = sig
@@ -571,10 +571,10 @@ Line 2, characters 17-23:
 2 |   val x : [`A of t_void]
                      ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}]
 
 (************************************************)
@@ -589,10 +589,10 @@ Line 2, characters 20-26:
 2 |   type foo1 = int * t_void * [ `Foo1 of int | `Bar1 of string ];;
                         ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_2 = struct
@@ -603,10 +603,10 @@ Line 2, characters 31-50:
 2 |   type result = V of (string * void_unboxed_record) | I of int
                                    ^^^^^^^^^^^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of void_unboxed_record is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of void_unboxed_record is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_3 = struct
@@ -623,10 +623,10 @@ Line 7, characters 13-14:
                  ^
 Error: This expression has type void_unboxed_record
        but an expression was expected of type ('a : value)
-       The layout of void_unboxed_record is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of void_unboxed_record is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_4 = struct
@@ -640,10 +640,10 @@ Line 4, characters 8-16:
             ^^^^^^^^
 Error: The record field vur_void belongs to the type void_unboxed_record
        but is mixed here with fields of type ('a : value)
-       The layout of void_unboxed_record is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value
-         because it's a boxed record type.
+       The layout of void_unboxed_record is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's a boxed record type.
 |}];;
 
 module M9_5 = struct
@@ -656,10 +656,10 @@ Line 4, characters 13-19:
 4 |   type bad = t_void t
                  ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because of the definition of t at line 2, characters 2-24.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-24.
 |}];;
 
 module M9_6 = struct
@@ -671,10 +671,10 @@ Line 2, characters 34-58:
                                       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type void_unboxed_record
-       The layout of void_unboxed_record is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of void_unboxed_record is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module type S9_7 = sig
@@ -685,10 +685,10 @@ Line 2, characters 16-22:
 2 |   val x : int * t_void
                     ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 module M9_9 (X : sig
@@ -704,10 +704,10 @@ Line 5, characters 11-23:
                ^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a tuple element.
 |}];;
 
 (*************************************************)
@@ -747,10 +747,10 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of x at line 8, characters 10-26.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of x at line 8, characters 10-26.
 |}];;
 
 (* This hits the second linktype in moregen (requires expansion to see it's a
@@ -788,10 +788,10 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of x at line 8, characters 10-26.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of x at line 8, characters 10-26.
 |}]
 
 (**************************************************************)
@@ -807,10 +807,10 @@ Line 5, characters 4-7:
 5 |     t.v # baz11
         ^^^
 Error: Object types must have layout value.
-       The layout of the type of this expression is void
-         because of the definition of t at line 2, characters 2-42.
-       But the layout of the type of this expression must overlap with value
-         because it's the type of an object.
+       The layout of the type of this expression is void, because
+         of the definition of t at line 2, characters 2-42.
+       But the layout of the type of this expression must overlap with value, because
+         it's the type of an object.
 |}]
 
 module M11_2 = struct
@@ -822,10 +822,10 @@ Line 2, characters 17-30:
                      ^^^^^^^^^^^^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 module M11_3 = struct
@@ -849,10 +849,10 @@ Line 2, characters 12-22:
 2 |   val x : < l : t_void >
                 ^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 module M11_5 = struct
@@ -864,10 +864,10 @@ Line 3, characters 2-24:
 3 |   and ('a : void) s = 'a
       ^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'a s is void
-         because of the annotation on 'a in the declaration of the type s.
-       But the layout of 'a s must be a sublayout of value
-         because it's the type of an object field.
+       The layout of 'a s is void, because
+         of the annotation on 'a in the declaration of the type s.
+       But the layout of 'a s must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 module M11_6 = struct
@@ -879,10 +879,10 @@ Line 2, characters 36-47:
                                         ^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_void
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 (*******************************************************************)
@@ -916,10 +916,10 @@ Line 4, characters 10-13:
 4 |       val bar = v.vr_void
               ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of bar must be a sublayout of value
-         because it's the type of a class field.
+       The layout of bar is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of bar must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 (* Hits the Cfk_virtual case of Pcf_val *)
@@ -934,10 +934,10 @@ Line 4, characters 18-21:
 4 |       val virtual bar : t_void
                       ^^^
 Error: Variables bound in a class must have layout value.
-       The layout of bar is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of bar must be a sublayout of value
-         because it's the type of a class field.
+       The layout of bar is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of bar must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 module M12_4 = struct
@@ -953,10 +953,10 @@ Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with void
-         because of the definition of t at line 2, characters 2-20.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module M12_5 = struct
@@ -972,10 +972,10 @@ Line 6, characters 29-31:
 6 |       method void_id (A a) : 'a t = a
                                  ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with void
-         because of the definition of t at line 2, characters 2-30.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void, because
+         of the definition of t at line 2, characters 2-30.
 |}];;
 
 module type S12_6 = sig
@@ -992,10 +992,10 @@ Line 5, characters 4-6:
 5 |     'a t ->
         ^^
 Error: This type ('a : void) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with void
-         because of the definition of t at line 2, characters 2-30.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with void, because
+         of the definition of t at line 2, characters 2-30.
 |}];;
 
 module type S12_7 = sig
@@ -1009,10 +1009,10 @@ Line 4, characters 6-22:
 4 |       val baz : t_void
           ^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of baz is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of baz must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of baz is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of baz must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 (*************************************************************************)
@@ -1025,10 +1025,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void Lazy.t;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of Lazy.t has this layout.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of Lazy.t has this layout.
 |}];;
 
 let x13 (VV v) = lazy v;;
@@ -1038,10 +1038,10 @@ Line 1, characters 22-23:
                           ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of a lazy expression.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a lazy expression.
 |}];;
 
 let x13 v =
@@ -1053,10 +1053,10 @@ Line 3, characters 17-18:
                      ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of a lazy expression.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a lazy expression.
 |}];;
 
 (* option *)
@@ -1067,10 +1067,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void option;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of option has layout value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 let x13 (VV v) = Some v;;
@@ -1080,10 +1080,10 @@ Line 1, characters 22-23:
                           ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of option has layout value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 let x13 v =
@@ -1096,10 +1096,10 @@ Line 3, characters 17-18:
                      ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of option has layout value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of option has layout value.
 |}];;
 
 (* list *)
@@ -1110,10 +1110,10 @@ Line 1, characters 11-17:
 1 | type t13 = t_void list;;
                ^^^^^^
 Error: This type t_void should be an instance of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let x13 (VV v) = [v];;
@@ -1123,10 +1123,10 @@ Line 1, characters 18-19:
                       ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 let x13 v =
@@ -1139,10 +1139,10 @@ Line 3, characters 14-15:
                   ^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_void
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (* array *)
@@ -1171,10 +1171,10 @@ Lines 2-4, characters 2-21:
 4 |   | _ -> assert false
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}];;
 
 (****************************************************************************)
@@ -1193,10 +1193,10 @@ Line 2, characters 0-18:
 2 | and foo14 = t_void;;
     ^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of foo14 is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of foo14 must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of foo14 is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of foo14 must be a sublayout of value, because
+         the type argument of list has layout value.
 |}];;
 
 (****************************************************)
@@ -1317,10 +1317,10 @@ Lines 6-7, characters 2-20:
 7 |   g (failwith "foo")..
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of 'a is void
-         because of the definition of r at line 3, characters 0-40.
-       But the layout of 'a must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of 'a is void, because
+         of the definition of r at line 3, characters 0-40.
+       But the layout of 'a must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}];;
 
 (********************************************************************)
@@ -1351,10 +1351,10 @@ Line 15, characters 4-8:
 Error: This pattern matches values of type (M.t_void, M.t_void) eq
        but a pattern was expected which matches values of type
          (M.t_void, M.t_imm) eq
-       The layout of M.t_void is void
-         because of the definition of t_void at line 4, characters 2-20.
-       But the layout of M.t_void must overlap with value
-         because of the definition of t_imm at line 5, characters 2-24.
+       The layout of M.t_void is void, because
+         of the definition of t_void at line 4, characters 2-20.
+       But the layout of M.t_void must overlap with value, because
+         of the definition of t_imm at line 5, characters 2-24.
 |}]
 
 (*****************************************************)
@@ -1387,10 +1387,10 @@ Line 2, characters 15-16:
                    ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because the type argument of option has layout value.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         the type argument of option has layout value.
 |}]
 
 (*********************************************************)
@@ -1640,10 +1640,10 @@ Line 4, characters 9-19:
              ^^^^^^^^^^
 Error: This pattern matches values of type t_void
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of a tuple element.
 |}]
 
 let ( let* ) x f = ()
@@ -1662,10 +1662,10 @@ Line 4, characters 9-22:
              ^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
        but a pattern was expected which matches values of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it's the type of a tuple element.
 |}]
 
 
@@ -1688,10 +1688,10 @@ Line 4, characters 16-28:
                     ^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because of the definition of eq at line 2, characters 2-43.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         of the definition of eq at line 2, characters 2-43.
 |}]
 
 (**************************************)
@@ -1717,10 +1717,10 @@ Line 8, characters 27-28:
                                ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because of the definition of f at line 3, characters 4-20.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         of the definition of f at line 3, characters 4-20.
 |}]
 
 (**************************************************)
@@ -1735,11 +1735,10 @@ Line 1, characters 41-43:
 1 | type ('a : void) poly_var = [`A of int * 'a | `B]
                                              ^^
 Error: This type ('a : value) should be an instance of type ('a0 : void)
-       The layout of 'a is void
-         because of the annotation on 'a in the declaration of the type
-                                      poly_var.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type poly_var.
+       But the layout of 'a must overlap with value, because
+         it's the type of a tuple element.
 |}]
 
 (* CR layouts bug: this should be accepted (or maybe we should reject
@@ -1758,10 +1757,10 @@ Line 1, characters 14-37:
                   ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it's the type of the field of a polymorphic variant.
 |}]
 
 (******************************************************)
@@ -1773,10 +1772,10 @@ Line 1, characters 17-22:
 1 | external foo33 : t_any = "foo33";;
                      ^^^^^
 Error: This type signature for foo33 is not a value type.
-       The layout of type t_any is any
-         because of the definition of t_any at line 1, characters 0-18.
-       But the layout of type t_any must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of type t_any must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}]
 
 
@@ -1797,10 +1796,10 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value
-         because it's a function type.
-       But the kind of 'a -> 'b must be a subkind of immediate
-         because of the definition of t35 at line 1, characters 0-30.
+       The kind of 'a -> 'b is value, because
+         it's a function type.
+       But the kind of 'a -> 'b must be a subkind of immediate, because
+         of the definition of t35 at line 1, characters 0-30.
 |}]
 
 (**************************************************)
@@ -1819,10 +1818,10 @@ Line 1, characters 10-22:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_5)
        because it is in the left-hand side of a sequence
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be representable
-         because it's the type of a statement.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 let () = while false do (assert false : t_any); done
@@ -1838,10 +1837,10 @@ Line 1, characters 25-37:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_6)
        because it is in the body of a while-loop
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be representable
-         because it's the type of a statement.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 let () = for i = 0 to 0 do (assert false : t_any); done
@@ -1857,10 +1856,10 @@ Line 1, characters 28-40:
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_7)
        because it is in the body of a for-loop
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be representable
-         because it's the type of a statement.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be representable, because
+         it's the type of a statement.
 |}]
 
 (******************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/datatypes.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes.ml
@@ -339,9 +339,9 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The layout of float is value, because
+       The kind of float is value, because
          it is the primitive value type float.
-       But the layout of float must be a sublayout of immediate, because
+       But the kind of float must be a subkind of immediate, because
          of the definition of s6 at line 2, characters 0-35.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/datatypes.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes.ml
@@ -43,10 +43,10 @@ Line 1, characters 15-31:
 1 | type t2_any1 = T2_any1 of t_any
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t2_any2 = T2_any2 of t_immediate * t_any
@@ -55,10 +55,10 @@ Line 1, characters 15-45:
 1 | type t2_any2 = T2_any2 of t_immediate * t_any
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t2_any3 = T2_any3 of t_any * t_value
@@ -67,10 +67,10 @@ Line 1, characters 15-41:
 1 | type t2_any3 = T2_any3 of t_any * t_value
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type 'a t1_constraint = T1_con of 'a constraint 'a = 'b t1_constraint'
@@ -80,10 +80,10 @@ Line 2, characters 0-29:
 2 | and 'b t1_constraint' = t_any
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'b t1_constraint' is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of 'b t1_constraint' must be representable, because
-         it instantiates an unannotated type parameter of t1_constraint.
+       The layout of 'b t1_constraint' is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of 'b t1_constraint' must be representable
+         because it instantiates an unannotated type parameter of t1_constraint.
 |}]
 
 (******************************************************)
@@ -101,10 +101,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -113,10 +113,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -125,10 +125,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -137,10 +137,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -149,10 +149,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -161,10 +161,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -177,10 +177,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -189,10 +189,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -201,10 +201,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -213,10 +213,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -225,10 +225,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -237,10 +237,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -267,10 +267,10 @@ Line 1, characters 11-24:
 1 | type t5 += T5_7 of t_any
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_8 of t_immediate * t_any
@@ -279,10 +279,10 @@ Line 1, characters 11-38:
 1 | type t5 += T5_8 of t_immediate * t_any
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_9 of t_any * t_value
@@ -291,10 +291,10 @@ Line 1, characters 11-34:
 1 | type t5 += T5_9 of t_any * t_value
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_11 of { x : t_value }
@@ -313,10 +313,10 @@ Line 1, characters 39-48:
 1 | type t5 += T5_17 of { x : t_immediate; y : t_any }
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 (**************************************************************************)
@@ -339,10 +339,10 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The kind of float is value, because
-         it is the primitive value type float.
-       But the kind of float must be a subkind of immediate, because
-         of the definition of s6 at line 2, characters 0-35.
+       The kind of float is value
+         because it is the primitive value type float.
+       But the kind of float must be a subkind of immediate
+         because of the definition of s6 at line 2, characters 0-35.
 |}];;
 
 (*****************************************************)
@@ -391,10 +391,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64, because
-           of the definition of float64_t at line 2, characters 0-29.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t8_5,
+         The layout of 'a is float64
+           because of the definition of float64_t at line 2, characters 0-29.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t8_5,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -456,10 +456,10 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be a sublayout of value, because
-         of the definition of t1 at line 2, characters 2-42.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value
+         because of the definition of t1 at line 2, characters 2-42.
 |}]
 
 module M : sig
@@ -481,10 +481,10 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be a sublayout of value, because
-         of the definition of t1 at line 3, characters 2-41.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value
+         because of the definition of t1 at line 3, characters 2-41.
 |}]
 
 module M : sig
@@ -506,9 +506,9 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be a sublayout of value, because
-         of the definition of t1 at line 3, characters 2-42.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value
+         because of the definition of t1 at line 3, characters 2-42.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/datatypes.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes.ml
@@ -43,10 +43,10 @@ Line 1, characters 15-31:
 1 | type t2_any1 = T2_any1 of t_any
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t2_any2 = T2_any2 of t_immediate * t_any
@@ -55,10 +55,10 @@ Line 1, characters 15-45:
 1 | type t2_any2 = T2_any2 of t_immediate * t_any
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t2_any3 = T2_any3 of t_any * t_value
@@ -67,10 +67,10 @@ Line 1, characters 15-41:
 1 | type t2_any3 = T2_any3 of t_any * t_value
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type 'a t1_constraint = T1_con of 'a constraint 'a = 'b t1_constraint'
@@ -80,10 +80,10 @@ Line 2, characters 0-29:
 2 | and 'b t1_constraint' = t_any
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'b t1_constraint' is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of 'b t1_constraint' must be representable
-         because it instantiates an unannotated type parameter of t1_constraint.
+       The layout of 'b t1_constraint' is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of 'b t1_constraint' must be representable, because
+         it instantiates an unannotated type parameter of t1_constraint.
 |}]
 
 (******************************************************)
@@ -101,10 +101,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -113,10 +113,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field y.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -125,10 +125,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -137,10 +137,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -149,10 +149,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field y.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -161,10 +161,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -177,10 +177,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -189,10 +189,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field y.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -201,10 +201,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -213,10 +213,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -225,10 +225,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field y.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -237,10 +237,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -267,10 +267,10 @@ Line 1, characters 11-24:
 1 | type t5 += T5_7 of t_any
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_8 of t_immediate * t_any
@@ -279,10 +279,10 @@ Line 1, characters 11-38:
 1 | type t5 += T5_8 of t_immediate * t_any
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_9 of t_any * t_value
@@ -291,10 +291,10 @@ Line 1, characters 11-34:
 1 | type t5 += T5_9 of t_any * t_value
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_11 of { x : t_value }
@@ -313,10 +313,10 @@ Line 1, characters 39-48:
 1 | type t5 += T5_17 of { x : t_immediate; y : t_any }
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field y.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 (**************************************************************************)
@@ -339,10 +339,10 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The kind of float is value
-         because it is the primitive value type float.
-       But the kind of float must be a subkind of immediate
-         because of the definition of s6 at line 2, characters 0-35.
+       The kind of float is value, because
+         it is the primitive value type float.
+       But the kind of float must be a subkind of immediate, because
+         of the definition of s6 at line 2, characters 0-35.
 |}];;
 
 (*****************************************************)
@@ -391,10 +391,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64
-           because of the definition of float64_t at line 2, characters 0-29.
-         But the layout of 'a must overlap with value
-           because it instantiates an unannotated type parameter of t8_5,
+         The layout of 'a is float64, because
+           of the definition of float64_t at line 2, characters 0-29.
+         But the layout of 'a must overlap with value, because
+           it instantiates an unannotated type parameter of t8_5,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -456,10 +456,10 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be a sublayout of value
-         because of the definition of t1 at line 2, characters 2-42.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value, because
+         of the definition of t1 at line 2, characters 2-42.
 |}]
 
 module M : sig
@@ -481,10 +481,10 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be a sublayout of value
-         because of the definition of t1 at line 3, characters 2-41.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value, because
+         of the definition of t1 at line 3, characters 2-41.
 |}]
 
 module M : sig
@@ -506,9 +506,9 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be a sublayout of value
-         because of the definition of t1 at line 3, characters 2-42.
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value, because
+         of the definition of t1 at line 3, characters 2-42.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/datatypes.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes.ml
@@ -339,9 +339,9 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The kind of float is value, because
+       The layout of float is value, because
          it is the primitive value type float.
-       But the kind of float must be a subkind of immediate, because
+       But the layout of float must be a sublayout of immediate, because
          of the definition of s6 at line 2, characters 0-35.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/datatypes.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes.ml
@@ -43,10 +43,10 @@ Line 1, characters 15-31:
 1 | type t2_any1 = T2_any1 of t_any
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t2_any2 = T2_any2 of t_immediate * t_any
@@ -55,10 +55,10 @@ Line 1, characters 15-45:
 1 | type t2_any2 = T2_any2 of t_immediate * t_any
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t2_any3 = T2_any3 of t_any * t_value
@@ -67,10 +67,10 @@ Line 1, characters 15-41:
 1 | type t2_any3 = T2_any3 of t_any * t_value
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type 'a t1_constraint = T1_con of 'a constraint 'a = 'b t1_constraint'
@@ -80,10 +80,10 @@ Line 2, characters 0-29:
 2 | and 'b t1_constraint' = t_any
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'b t1_constraint' is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of 'b t1_constraint' must be representable, because
-         it instantiates an unannotated type parameter of t1_constraint.
+       The layout of 'b t1_constraint' is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of 'b t1_constraint' must be representable
+         because it instantiates an unannotated type parameter of t1_constraint.
 |}]
 
 (******************************************************)
@@ -101,10 +101,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -113,10 +113,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -125,10 +125,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -137,10 +137,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -149,10 +149,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -161,10 +161,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -177,10 +177,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -189,10 +189,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -201,10 +201,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -213,10 +213,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -225,10 +225,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -237,10 +237,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -267,10 +267,10 @@ Line 1, characters 11-24:
 1 | type t5 += T5_7 of t_any
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_8 of t_immediate * t_any
@@ -279,10 +279,10 @@ Line 1, characters 11-38:
 1 | type t5 += T5_8 of t_immediate * t_any
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_9 of t_any * t_value
@@ -291,10 +291,10 @@ Line 1, characters 11-34:
 1 | type t5 += T5_9 of t_any * t_value
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_11 of { x : t_value }
@@ -313,10 +313,10 @@ Line 1, characters 39-48:
 1 | type t5 += T5_17 of { x : t_immediate; y : t_any }
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 (**************************************************************************)
@@ -339,10 +339,10 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The kind of float is value, because
-         it is the primitive value type float.
-       But the kind of float must be a subkind of immediate, because
-         of the definition of s6 at line 2, characters 0-35.
+       The kind of float is value
+         because it is the primitive value type float.
+       But the kind of float must be a subkind of immediate
+         because of the definition of s6 at line 2, characters 0-35.
 |}];;
 
 (*****************************************************)
@@ -391,10 +391,11 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64, because
-           of the definition of float64_t at line 2, characters 0-29.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t8_5, defaulted to layout value.
+         The layout of 'a is float64
+           because of the definition of float64_t at line 2, characters 0-29.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t8_5,
+           defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -455,10 +456,10 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be a sublayout of value, because
-         of the definition of t1 at line 2, characters 2-42.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value
+         because of the definition of t1 at line 2, characters 2-42.
 |}]
 
 module M : sig
@@ -480,10 +481,10 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be a sublayout of value, because
-         of the definition of t1 at line 3, characters 2-41.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value
+         because of the definition of t1 at line 3, characters 2-41.
 |}]
 
 module M : sig
@@ -505,9 +506,9 @@ Line 10, characters 10-20:
 10 | type t4 = t_any M.t2 M.t1
                ^^^^^^^^^^
 Error: This type t_any M.t2 should be an instance of type 'a M.t2
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be a sublayout of value, because
-         of the definition of t1 at line 3, characters 2-42.
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be a sublayout of value
+         because of the definition of t1 at line 3, characters 2-42.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -49,10 +49,10 @@ Line 1, characters 15-31:
 1 | type t2_any1 = T2_any1 of t_any
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t2_any2 = T2_any2 of t_immediate * t_any
@@ -61,10 +61,10 @@ Line 1, characters 15-45:
 1 | type t2_any2 = T2_any2 of t_immediate * t_any
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t2_any3 = T2_any3 of t_any * t_value
@@ -73,10 +73,10 @@ Line 1, characters 15-41:
 1 | type t2_any3 = T2_any3 of t_any * t_value
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type 'a t1_constraint = T1_con of 'a constraint 'a = 'b t1_constraint'
@@ -86,10 +86,10 @@ Line 2, characters 0-29:
 2 | and 'b t1_constraint' = t_any
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'b t1_constraint' is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of 'b t1_constraint' must be representable, because
-         it instantiates an unannotated type parameter of t1_constraint.
+       The layout of 'b t1_constraint' is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of 'b t1_constraint' must be representable
+         because it instantiates an unannotated type parameter of t1_constraint.
 |}]
 (* CR layouts errors: this error is blamed on the wrong piece *)
 
@@ -147,10 +147,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -159,10 +159,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -171,10 +171,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -183,10 +183,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -195,10 +195,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -207,10 +207,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -241,10 +241,10 @@ Line 1, characters 11-24:
 1 | type t5 += T5_7 of t_any
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_8 of t_immediate * t_any
@@ -253,10 +253,10 @@ Line 1, characters 11-38:
 1 | type t5 += T5_8 of t_immediate * t_any
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_9 of t_any * t_value
@@ -265,10 +265,10 @@ Line 1, characters 11-34:
 1 | type t5 += T5_9 of t_any * t_value
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_11 of { x : t_value }
@@ -299,10 +299,10 @@ Line 1, characters 39-48:
 1 | type t5 += T5_17 of { x : t_immediate; y : t_any }
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 (**************************************************************************)
@@ -325,10 +325,10 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The kind of float is value, because
-         it is the primitive value type float.
-       But the kind of float must be a subkind of immediate, because
-         of the definition of s6 at line 2, characters 0-35.
+       The kind of float is value
+         because it is the primitive value type float.
+       But the kind of float must be a subkind of immediate
+         because of the definition of s6 at line 2, characters 0-35.
 |}];;
 
 (*****************************************************)
@@ -384,10 +384,11 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is void, because
-           of the definition of void_t at line 1, characters 0-23.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t8_5, defaulted to layout value.
+         The layout of 'a is void
+           because of the definition of void_t at line 1, characters 0-23.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t8_5,
+           defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -406,10 +407,11 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value, because
-           it instantiates an unannotated type parameter of t10, defaulted to kind value.
-         But the kind of 'a must be a subkind of immediate, because
-           of the definition of imm_t at line 1, characters 0-27.
+         The kind of 'a is value
+           because it instantiates an unannotated type parameter of t10,
+           defaulted to kind value.
+         But the kind of 'a must be a subkind of immediate
+           because of the definition of imm_t at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -426,10 +428,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of float# is float64, because
-           it is the primitive float64 type float#.
-         But the layout of float# must be a sublayout of void, because
-           of the annotation on the universal variable 'b.
+         The layout of float# is float64
+           because it is the primitive float64 type float#.
+         But the layout of float# must be a sublayout of void
+           because of the annotation on the universal variable 'b.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -49,10 +49,10 @@ Line 1, characters 15-31:
 1 | type t2_any1 = T2_any1 of t_any
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t2_any2 = T2_any2 of t_immediate * t_any
@@ -61,10 +61,10 @@ Line 1, characters 15-45:
 1 | type t2_any2 = T2_any2 of t_immediate * t_any
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t2_any3 = T2_any3 of t_any * t_value
@@ -73,10 +73,10 @@ Line 1, characters 15-41:
 1 | type t2_any3 = T2_any3 of t_any * t_value
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type 'a t1_constraint = T1_con of 'a constraint 'a = 'b t1_constraint'
@@ -86,10 +86,10 @@ Line 2, characters 0-29:
 2 | and 'b t1_constraint' = t_any
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'b t1_constraint' is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of 'b t1_constraint' must be representable
-         because it instantiates an unannotated type parameter of t1_constraint.
+       The layout of 'b t1_constraint' is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of 'b t1_constraint' must be representable, because
+         it instantiates an unannotated type parameter of t1_constraint.
 |}]
 (* CR layouts errors: this error is blamed on the wrong piece *)
 
@@ -147,10 +147,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -159,10 +159,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field y.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -171,10 +171,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -183,10 +183,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -195,10 +195,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field y.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -207,10 +207,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field x.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -241,10 +241,10 @@ Line 1, characters 11-24:
 1 | type t5 += T5_7 of t_any
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_8 of t_immediate * t_any
@@ -253,10 +253,10 @@ Line 1, characters 11-38:
 1 | type t5 += T5_8 of t_immediate * t_any
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_9 of t_any * t_value
@@ -265,10 +265,10 @@ Line 1, characters 11-34:
 1 | type t5 += T5_9 of t_any * t_value
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the type of a constructor field.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the type of a constructor field.
 |}];;
 
 type t5 += T5_11 of { x : t_value }
@@ -299,10 +299,10 @@ Line 1, characters 39-48:
 1 | type t5 += T5_17 of { x : t_immediate; y : t_any }
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it is the type of record field y.
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it is the type of record field y.
 |}];;
 
 (**************************************************************************)
@@ -325,10 +325,10 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The kind of float is value
-         because it is the primitive value type float.
-       But the kind of float must be a subkind of immediate
-         because of the definition of s6 at line 2, characters 0-35.
+       The kind of float is value, because
+         it is the primitive value type float.
+       But the kind of float must be a subkind of immediate, because
+         of the definition of s6 at line 2, characters 0-35.
 |}];;
 
 (*****************************************************)
@@ -384,10 +384,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is void
-           because of the definition of void_t at line 1, characters 0-23.
-         But the layout of 'a must overlap with value
-           because it instantiates an unannotated type parameter of t8_5,
+         The layout of 'a is void, because
+           of the definition of void_t at line 1, characters 0-23.
+         But the layout of 'a must overlap with value, because
+           it instantiates an unannotated type parameter of t8_5,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -407,11 +407,11 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value
-           because it instantiates an unannotated type parameter of t10,
+         The kind of 'a is value, because
+           it instantiates an unannotated type parameter of t10,
            defaulted to kind value.
-         But the kind of 'a must be a subkind of immediate
-           because of the definition of imm_t at line 1, characters 0-27.
+         But the kind of 'a must be a subkind of immediate, because
+           of the definition of imm_t at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -428,10 +428,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of float# is float64
-           because it is the primitive float64 type float#.
-         But the layout of float# must be a sublayout of void
-           because of the annotation on the universal variable 'b.
+         The layout of float# is float64, because
+           it is the primitive float64 type float#.
+         But the layout of float# must be a sublayout of void, because
+           of the annotation on the universal variable 'b.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -325,9 +325,9 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The layout of float is value, because
+       The kind of float is value, because
          it is the primitive value type float.
-       But the layout of float must be a sublayout of immediate, because
+       But the kind of float must be a subkind of immediate, because
          of the definition of s6 at line 2, characters 0-35.
 |}];;
 
@@ -407,10 +407,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is value, because
+         The kind of 'a is value, because
            it instantiates an unannotated type parameter of t10,
-           defaulted to layout value.
-         But the layout of 'a must be a sublayout of immediate, because
+           defaulted to kind value.
+         But the kind of 'a must be a subkind of immediate, because
            of the definition of imm_t at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -325,9 +325,9 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The kind of float is value, because
+       The layout of float is value, because
          it is the primitive value type float.
-       But the kind of float must be a subkind of immediate, because
+       But the layout of float must be a sublayout of immediate, because
          of the definition of s6 at line 2, characters 0-35.
 |}];;
 
@@ -407,10 +407,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value, because
+         The layout of 'a is value, because
            it instantiates an unannotated type parameter of t10,
-           defaulted to kind value.
-         But the kind of 'a must be a subkind of immediate, because
+           defaulted to layout value.
+         But the layout of 'a must be a sublayout of immediate, because
            of the definition of imm_t at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -325,9 +325,9 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The layout of float is value, because
+       The kind of float is value, because
          it is the primitive value type float.
-       But the layout of float must be a sublayout of immediate, because
+       But the kind of float must be a subkind of immediate, because
          of the definition of s6 at line 2, characters 0-35.
 |}];;
 
@@ -406,9 +406,9 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is value, because
-           it instantiates an unannotated type parameter of t10, defaulted to layout value.
-         But the layout of 'a must be a sublayout of immediate, because
+         The kind of 'a is value, because
+           it instantiates an unannotated type parameter of t10, defaulted to kind value.
+         But the kind of 'a must be a subkind of immediate, because
            of the definition of imm_t at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -49,10 +49,10 @@ Line 1, characters 15-31:
 1 | type t2_any1 = T2_any1 of t_any
                    ^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t2_any2 = T2_any2 of t_immediate * t_any
@@ -61,10 +61,10 @@ Line 1, characters 15-45:
 1 | type t2_any2 = T2_any2 of t_immediate * t_any
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t2_any3 = T2_any3 of t_any * t_value
@@ -73,10 +73,10 @@ Line 1, characters 15-41:
 1 | type t2_any3 = T2_any3 of t_any * t_value
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type 'a t1_constraint = T1_con of 'a constraint 'a = 'b t1_constraint'
@@ -86,10 +86,10 @@ Line 2, characters 0-29:
 2 | and 'b t1_constraint' = t_any
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The layout of 'b t1_constraint' is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of 'b t1_constraint' must be representable, because
-         it instantiates an unannotated type parameter of t1_constraint.
+       The layout of 'b t1_constraint' is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of 'b t1_constraint' must be representable
+         because it instantiates an unannotated type parameter of t1_constraint.
 |}]
 (* CR layouts errors: this error is blamed on the wrong piece *)
 
@@ -147,10 +147,10 @@ Line 1, characters 17-26:
 1 | type t4_any1 = { x : t_any }
                      ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_any2 = { x : t_immediate; y : t_any }
@@ -159,10 +159,10 @@ Line 1, characters 34-43:
 1 | type t4_any2 = { x : t_immediate; y : t_any }
                                       ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_any3 =  { x : t_any; y : t_value }
@@ -171,10 +171,10 @@ Line 1, characters 18-28:
 1 | type t4_any3 =  { x : t_any; y : t_value }
                       ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany1 = C of { x : t_any }
@@ -183,10 +183,10 @@ Line 1, characters 23-32:
 1 | type t4_cany1 = C of { x : t_any }
                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 type t4_cany2 = C of { x : t_immediate; y : t_any }
@@ -195,10 +195,10 @@ Line 1, characters 40-49:
 1 | type t4_cany2 = C of { x : t_immediate; y : t_any }
                                             ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 type t4_cany3 = C of { x : t_any; y : t_value }
@@ -207,10 +207,10 @@ Line 1, characters 23-33:
 1 | type t4_cany3 = C of { x : t_any; y : t_value }
                            ^^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field x.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field x.
 |}];;
 
 (*********************************************************)
@@ -241,10 +241,10 @@ Line 1, characters 11-24:
 1 | type t5 += T5_7 of t_any
                ^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_8 of t_immediate * t_any
@@ -253,10 +253,10 @@ Line 1, characters 11-38:
 1 | type t5 += T5_8 of t_immediate * t_any
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_9 of t_any * t_value
@@ -265,10 +265,10 @@ Line 1, characters 11-34:
 1 | type t5 += T5_9 of t_any * t_value
                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Constructor argument types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the type of a constructor field.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the type of a constructor field.
 |}];;
 
 type t5 += T5_11 of { x : t_value }
@@ -299,10 +299,10 @@ Line 1, characters 39-48:
 1 | type t5 += T5_17 of { x : t_immediate; y : t_any }
                                            ^^^^^^^^^
 Error: Record element types must have a representable layout.
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it is the type of record field y.
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it is the type of record field y.
 |}];;
 
 (**************************************************************************)
@@ -325,10 +325,10 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The kind of float is value, because
-         it is the primitive value type float.
-       But the kind of float must be a subkind of immediate, because
-         of the definition of s6 at line 2, characters 0-35.
+       The kind of float is value
+         because it is the primitive value type float.
+       But the kind of float must be a subkind of immediate
+         because of the definition of s6 at line 2, characters 0-35.
 |}];;
 
 (*****************************************************)
@@ -384,10 +384,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is void, because
-           of the definition of void_t at line 1, characters 0-23.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t8_5,
+         The layout of 'a is void
+           because of the definition of void_t at line 1, characters 0-23.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t8_5,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -407,11 +407,11 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a is value, because
-           it instantiates an unannotated type parameter of t10,
+         The kind of 'a is value
+           because it instantiates an unannotated type parameter of t10,
            defaulted to kind value.
-         But the kind of 'a must be a subkind of immediate, because
-           of the definition of imm_t at line 1, characters 0-27.
+         But the kind of 'a must be a subkind of immediate
+           because of the definition of imm_t at line 1, characters 0-27.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]
@@ -428,10 +428,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of float# is float64, because
-           it is the primitive float64 type float#.
-         But the layout of float# must be a sublayout of void, because
-           of the annotation on the universal variable 'b.
+         The layout of float# is float64
+           because it is the primitive float64 type float#.
+         But the layout of float# must be a sublayout of void
+           because of the annotation on the universal variable 'b.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -232,9 +232,9 @@ Line 1, characters 22-23:
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
        custom message
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the annotation on the wildcard _ at line 1, characters 26-41.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -25,10 +25,10 @@ Line 1, characters 51-52:
                                                        ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         of the annotation on the wildcard _ at line 1, characters 20-31.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because of the annotation on the wildcard _ at line 1, characters 20-31.
 |}]
 
 let f (v: float#): ((_ : value)[@error_message 1]) = v
@@ -44,10 +44,10 @@ Line 1, characters 53-54:
                                                          ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         of the annotation on the wildcard _ at line 1, characters 20-31.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because of the annotation on the wildcard _ at line 1, characters 20-31.
 |}]
 
 (* Ltyp_var { name = None; layout } case *)
@@ -58,10 +58,10 @@ Line 1, characters 68-69:
                                                                         ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         of the annotation on the wildcard _ at line 1, characters 20-31.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because of the annotation on the wildcard _ at line 1, characters 20-31.
          Custom message
 |}]
 
@@ -74,10 +74,10 @@ Line 3, characters 19-20:
                        ^
 Error: This expression has type ('a : value)
        but an expression was expected of type Float_u.t = float#
-       The layout of Float_u.t is float64, because
-         it is the primitive float64 type float#.
-       But the layout of Float_u.t must be a sublayout of value, because
-         of the annotation on the wildcard _ at line 2, characters 15-26.
+       The layout of Float_u.t is float64
+         because it is the primitive float64 type float#.
+       But the layout of Float_u.t must be a sublayout of value
+         because of the annotation on the wildcard _ at line 2, characters 15-26.
          Custom message
 |}]
 
@@ -92,11 +92,11 @@ Line 3, characters 61-63:
 3 |   val f : (('a : value)[@error_message "Custom message"]) -> 'a t
                                                                  ^^
 Error: This type ('a : value) should be an instance of type ('b : float64)
-       The layout of 'a is value, because
-         of the annotation on the type variable 'a.
+       The layout of 'a is value
+         because of the annotation on the type variable 'a.
          Custom message
-       But the layout of 'a must overlap with float64, because
-         of the definition of t at line 2, characters 2-28.
+       But the layout of 'a must overlap with float64
+         because of the definition of t at line 2, characters 2-28.
 |}]
 
 
@@ -112,10 +112,10 @@ Line 3, characters 33-38:
 3 |   val f : 'a -> t -> (t as ('a : value)[@error_message "Custom message"])
                                      ^^^^^
 Error: Bad layout annotation:
-         The layout of t is float64, because
-           of the definition of t at line 2, characters 2-18.
-         But the layout of t must be a sublayout of value, because
-           of the annotation on the type variable 'a.
+         The layout of t is float64
+           because of the definition of t at line 2, characters 2-18.
+         But the layout of t must be a sublayout of value
+           because of the annotation on the type variable 'a.
            Custom message
 |}]
 
@@ -131,10 +131,10 @@ Line 3, characters 16-33:
                     ^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type t but is used as an instance of type
          ('a : value)
-       The layout of t is float64, because
-         of the definition of t at line 2, characters 2-18.
-       But the layout of t must be a sublayout of value, because
-         of the annotation on the type variable 'a.
+       The layout of t is float64
+         because of the definition of t at line 2, characters 2-18.
+       But the layout of t must be a sublayout of value
+         because of the annotation on the type variable 'a.
          Custom message
 |}]
 
@@ -149,10 +149,10 @@ Line 3, characters 26-31:
 3 |   val f : t -> (t as (_ : value)[@error_message "Custom message"])
                               ^^^^^
 Error: Bad layout annotation:
-         The layout of t/2 is float64, because
-           of the definition of t at line 2, characters 2-18.
-         But the layout of t/2 must be a sublayout of value, because
-           of the annotation on the wildcard _ at line 3, characters 26-31.
+         The layout of t/2 is float64
+           because of the definition of t at line 2, characters 2-18.
+         But the layout of t/2 must be a sublayout of value
+           because of the annotation on the wildcard _ at line 3, characters 26-31.
            Custom message
 |}]
 
@@ -232,10 +232,10 @@ Line 1, characters 22-23:
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
        custom message
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the annotation on the wildcard _ at line 1, characters 26-41.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the annotation on the wildcard _ at line 1, characters 26-41.
 |}]
 
 (* Doesn't apply when the mismatch is deep *)

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -25,10 +25,10 @@ Line 1, characters 51-52:
                                                        ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because of the annotation on the wildcard _ at line 1, characters 20-31.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 1, characters 20-31.
 |}]
 
 let f (v: float#): ((_ : value)[@error_message 1]) = v
@@ -44,10 +44,10 @@ Line 1, characters 53-54:
                                                          ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because of the annotation on the wildcard _ at line 1, characters 20-31.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 1, characters 20-31.
 |}]
 
 (* Ltyp_var { name = None; layout } case *)
@@ -58,10 +58,10 @@ Line 1, characters 68-69:
                                                                         ^
 Error: This expression has type float# but an expression was expected of type
          ('a : value)
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because of the annotation on the wildcard _ at line 1, characters 20-31.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 1, characters 20-31.
          Custom message
 |}]
 
@@ -74,10 +74,10 @@ Line 3, characters 19-20:
                        ^
 Error: This expression has type ('a : value)
        but an expression was expected of type Float_u.t = float#
-       The layout of Float_u.t is float64
-         because it is the primitive float64 type float#.
-       But the layout of Float_u.t must be a sublayout of value
-         because of the annotation on the wildcard _ at line 2, characters 15-26.
+       The layout of Float_u.t is float64, because
+         it is the primitive float64 type float#.
+       But the layout of Float_u.t must be a sublayout of value, because
+         of the annotation on the wildcard _ at line 2, characters 15-26.
          Custom message
 |}]
 
@@ -92,11 +92,11 @@ Line 3, characters 61-63:
 3 |   val f : (('a : value)[@error_message "Custom message"]) -> 'a t
                                                                  ^^
 Error: This type ('a : value) should be an instance of type ('b : float64)
-       The layout of 'a is value
-         because of the annotation on the type variable 'a.
+       The layout of 'a is value, because
+         of the annotation on the type variable 'a.
          Custom message
-       But the layout of 'a must overlap with float64
-         because of the definition of t at line 2, characters 2-28.
+       But the layout of 'a must overlap with float64, because
+         of the definition of t at line 2, characters 2-28.
 |}]
 
 
@@ -112,10 +112,10 @@ Line 3, characters 33-38:
 3 |   val f : 'a -> t -> (t as ('a : value)[@error_message "Custom message"])
                                      ^^^^^
 Error: Bad layout annotation:
-         The layout of t is float64
-           because of the definition of t at line 2, characters 2-18.
-         But the layout of t must be a sublayout of value
-           because of the annotation on the type variable 'a.
+         The layout of t is float64, because
+           of the definition of t at line 2, characters 2-18.
+         But the layout of t must be a sublayout of value, because
+           of the annotation on the type variable 'a.
            Custom message
 |}]
 
@@ -131,10 +131,10 @@ Line 3, characters 16-33:
                     ^^^^^^^^^^^^^^^^^
 Error: This alias is bound to type t but is used as an instance of type
          ('a : value)
-       The layout of t is float64
-         because of the definition of t at line 2, characters 2-18.
-       But the layout of t must be a sublayout of value
-         because of the annotation on the type variable 'a.
+       The layout of t is float64, because
+         of the definition of t at line 2, characters 2-18.
+       But the layout of t must be a sublayout of value, because
+         of the annotation on the type variable 'a.
          Custom message
 |}]
 
@@ -149,10 +149,10 @@ Line 3, characters 26-31:
 3 |   val f : t -> (t as (_ : value)[@error_message "Custom message"])
                               ^^^^^
 Error: Bad layout annotation:
-         The layout of t/2 is float64
-           because of the definition of t at line 2, characters 2-18.
-         But the layout of t/2 must be a sublayout of value
-           because of the annotation on the wildcard _ at line 3, characters 26-31.
+         The layout of t/2 is float64, because
+           of the definition of t at line 2, characters 2-18.
+         But the layout of t/2 must be a sublayout of value, because
+           of the annotation on the wildcard _ at line 3, characters 26-31.
            Custom message
 |}]
 
@@ -232,10 +232,10 @@ Line 1, characters 22-23:
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
        custom message
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the annotation on the wildcard _ at line 1, characters 26-41.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the annotation on the wildcard _ at line 1, characters 26-41.
 |}]
 
 (* Doesn't apply when the mismatch is deep *)

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -232,9 +232,9 @@ Line 1, characters 22-23:
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
        custom message
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the annotation on the wildcard _ at line 1, characters 26-41.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -1102,8 +1102,6 @@ Error: The kind of type t is value
        But the kind of type t must be a subkind of any mod external_
          because of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-  mismatch, not a layout mismatch. *)
 
 type t : any mod portable = Foo of bool [@@unboxed]
 let x = (Foo true : _ as (_ : value mod portable uncontended unique))
@@ -1509,10 +1507,10 @@ type 'a t : value mod global = 'a
 Line 1, characters 0-33:
 1 | type 'a t : value mod global = 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type 'a is value, because
-         of the definition of t at line 1, characters 0-33.
-       But the layout of type 'a must be a sublayout of value, because
-         of the definition of t at line 1, characters 0-33.
+Error: The kind of type 'a is value
+         because of the definition of t at line 1, characters 0-33.
+       But the kind of type 'a must be a subkind of value mod global
+         because of the definition of t at line 1, characters 0-33.
 |}]
 (* CR layouts v2.8: this should be accepted; 'a should be inferred to have kind
    value mod global *)
@@ -1522,10 +1520,10 @@ type 'a t : word = 'a
 Line 1, characters 0-21:
 1 | type 'a t : word = 'a
     ^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type 'a is value, because
-         of the definition of t at line 1, characters 0-21.
-       But the layout of type 'a must be a sublayout of word, because
-         of the definition of t at line 1, characters 0-21.
+Error: The layout of type 'a is value
+         because of the definition of t at line 1, characters 0-21.
+       But the layout of type 'a must be a sublayout of word
+         because of the definition of t at line 1, characters 0-21.
 |}]
 (* CR layouts v2.8: this should be accepted; 'a should be inferred to have kind
    word *)
@@ -1545,10 +1543,10 @@ type 'a t : value mod global = private 'a
 Line 1, characters 0-41:
 1 | type 'a t : value mod global = private 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type 'a is value, because
-         of the definition of t at line 1, characters 0-41.
-       But the layout of type 'a must be a sublayout of value, because
-         of the definition of t at line 1, characters 0-41.
+Error: The kind of type 'a is value
+         because of the definition of t at line 1, characters 0-41.
+       But the kind of type 'a must be a subkind of value mod global
+         because of the definition of t at line 1, characters 0-41.
 |}]
 (* CR layouts v2.8: this should be accepted; 'a should be inferred to have kind
   value mod global *)
@@ -1558,10 +1556,10 @@ type 'a t : word = private 'a
 Line 1, characters 0-29:
 1 | type 'a t : word = private 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type 'a is value, because
-         of the definition of t at line 1, characters 0-29.
-       But the layout of type 'a must be a sublayout of word, because
-         of the definition of t at line 1, characters 0-29.
+Error: The layout of type 'a is value
+         because of the definition of t at line 1, characters 0-29.
+       But the layout of type 'a must be a sublayout of word
+         because of the definition of t at line 1, characters 0-29.
 |}]
 (* CR layouts v2.8: this should be accepted; 'a should be inferred to have kind
   word *)
@@ -1571,10 +1569,11 @@ type 'a t : value mod global = Foo of 'a [@@unboxed]
 Line 1, characters 0-52:
 1 | type 'a t : value mod global = Foo of 'a [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
-         it instantiates an unannotated type parameter of t, defaulted to layout value.
-       But the layout of type t must be a sublayout of value, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it instantiates an unannotated type parameter of t,
+         defaulted to kind value.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted; 'a should be inferred to have kind
   value mod global *)
@@ -1584,10 +1583,10 @@ type 'a t : value mod global = { x : 'a }
 Line 1, characters 0-41:
 1 | type 'a t : value mod global = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
-         it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type 'a t : value mod many = { x : 'a }
@@ -1595,8 +1594,8 @@ type 'a t : value mod many = { x : 'a }
 Line 1, characters 0-39:
 1 | type 'a t : value mod many = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
-         it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod many
+         because of the annotation on the declaration of the type t.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -188,13 +188,11 @@ type a : value mod local
 Line 2, characters 0-29:
 2 | type b : value mod global = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
+Error: The kind of type a is value, because
          of the definition of a at line 1, characters 0-24.
-       But the layout of type a must be a sublayout of value, because
+       But the kind of type a must be a subkind of value mod global, because
          of the definition of b at line 2, characters 0-29.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type a : value mod global
 type b : any mod local = a
@@ -230,13 +228,12 @@ type a : value mod global unique once uncontended portable external_
 Line 2, characters 0-73:
 2 | type b : value mod local shared many uncontended nonportable internal = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is immediate, because
+Error: The kind of type a is value mod global unique uncontended portable
+                                       external_, because
          of the definition of a at line 1, characters 0-68.
-       But the layout of type a must be a sublayout of value, because
+       But the kind of type a must be a subkind of value mod many uncontended, because
          of the definition of b at line 2, characters 0-73.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (********************************************************)
 (* Test 3: Abbreviation primitives are properly defined *)
@@ -415,78 +412,66 @@ type t : any mod global = t_value
 Line 1, characters 0-33:
 1 | type t : any mod global = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod global, because
          of the definition of t at line 1, characters 0-33.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod unique = t_value
 [%%expect{|
 Line 1, characters 0-33:
 1 | type t : any mod unique = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod unique, because
          of the definition of t at line 1, characters 0-33.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod many = t_value
 [%%expect{|
 Line 1, characters 0-31:
 1 | type t : any mod many = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod many, because
          of the definition of t at line 1, characters 0-31.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod uncontended = t_value
 [%%expect{|
 Line 1, characters 0-38:
 1 | type t : any mod uncontended = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod uncontended, because
          of the definition of t at line 1, characters 0-38.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod portable = t_value
 [%%expect{|
 Line 1, characters 0-35:
 1 | type t : any mod portable = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod portable, because
          of the definition of t at line 1, characters 0-35.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod external_ = t_value
 [%%expect{|
 Line 1, characters 0-36:
 1 | type t : any mod external_ = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod external_, because
          of the definition of t at line 1, characters 0-36.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type ('a : value mod unique) t = { unique_field : 'a }
 let x = { unique_field = "string" }
@@ -497,13 +482,11 @@ Line 2, characters 25-33:
                              ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod unique)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
+       But the kind of string must be a subkind of value mod unique, because
          of the definition of t at line 1, characters 0-54.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod global
 let g (x : t) : ('a : value mod global) = x
@@ -521,13 +504,11 @@ Line 2, characters 42-43:
                                               ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod global)
-       The layout of t is value, because
+       The kind of t is value mod many, because
          of the definition of t at line 1, characters 0-23.
-       But the layout of t must be a sublayout of value, because
+       But the kind of t must be a subkind of value mod global, because
          of the annotation on the type variable 'a.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod unique
 let f (x : _ as (_ : value mod unique)) = ()
@@ -549,13 +530,11 @@ Line 3, characters 18-19:
                       ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod unique)
-       The layout of t is immediate64, because
+       The kind of t is value mod external64, because
          of the definition of t at line 1, characters 0-29.
-       But the layout of t must be a sublayout of value, because
+       But the kind of t must be a subkind of value mod unique, because
          of the definition of f at line 2, characters 6-44.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 module A : sig
   type t : immediate
@@ -583,13 +562,11 @@ module A : sig type t : value end
 Line 7, characters 0-24:
 7 | type t : immediate = A.t
     ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type A.t is value, because
+Error: The kind of type A.t is value, because
          of the definition of t at line 2, characters 2-16.
-       But the layout of type A.t must be a sublayout of immediate, because
+       But the kind of type A.t must be a subkind of immediate, because
          of the definition of t at line 7, characters 0-24.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value = private int
 let f (x : t) : _ as (_ : value mod global) = x
@@ -714,39 +691,33 @@ type t : any mod global = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod global = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod unique = { x : string }
 [%%expect{|
 Line 1, characters 0-40:
 1 | type t : any mod unique = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod external_ = { x : string }
 [%%expect{|
 Line 1, characters 0-43:
 1 | type t : any mod external_ = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod many = { x : string }
 type t : any mod portable = { x : string }
@@ -755,9 +726,9 @@ type t : any mod uncontended = { x : string }
 Line 1, characters 0-38:
 1 | type t : any mod many = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod many, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
@@ -767,39 +738,33 @@ type t : any mod many = { x : t_value }
 Line 1, characters 0-39:
 1 | type t : any mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod many, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod uncontended = { x : t_value }
 [%%expect{|
 Line 1, characters 0-46:
 1 | type t : any mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod portable = { x : t_value }
 [%%expect{|
 Line 1, characters 0-43:
 1 | type t : any mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type u : immediate
 type t : value mod portable many uncontended = { x : string; y : int; z : u }
@@ -808,9 +773,10 @@ type u : immediate
 Line 2, characters 0-77:
 2 | type t : value mod portable many uncontended = { x : string; y : int; z : u }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod many uncontended
+                                                             portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
@@ -824,13 +790,11 @@ Line 2, characters 43-59:
                                                ^^^^^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod external_)
-       The layout of t is value, because
+       The kind of t is value, because
          of the definition of t at line 1, characters 0-23.
-       But the layout of t must be a sublayout of immediate, because
+       But the kind of t must be a subkind of value mod external_, because
          of the annotation on the wildcard _ at line 2, characters 20-39.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod uncontended = { x : int }
 type t : any mod portable = { x : int }
@@ -839,9 +803,9 @@ type t : any mod many = { x : int }
 Line 1, characters 0-42:
 1 | type t : any mod uncontended = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -851,39 +815,33 @@ type t : any mod global = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod external_ = { x : int }
 [%%expect {|
 Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod unique = { x : int }
 [%%expect {|
 Line 1, characters 0-37:
 1 | type t : any mod unique = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod global = { x : int } [@@unboxed]
 type t : any mod portable = { x : int } [@@unboxed]
@@ -929,78 +887,66 @@ type t : any mod global = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod portable = { x : u } [@@unboxed]
 [%%expect {|
 Line 1, characters 0-49:
 1 | type t : any mod portable = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod uncontended = { x : u } [@@unboxed]
 [%%expect {|
 Line 1, characters 0-52:
 1 | type t : any mod uncontended = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod external_ = { x : u } [@@unboxed]
 [%%expect {|
 Line 1, characters 0-50:
 1 | type t : any mod external_ = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod many = { x : u } [@@unboxed]
 [%%expect {|
 Line 1, characters 0-45:
 1 | type t : any mod many = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod many, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod unique = { x : u } [@@unboxed]
 [%%expect {|
 Line 1, characters 0-47:
 1 | type t : any mod unique = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : value mod global = { x : int } [@@unboxed]
 let f (x : _ as (_ : immediate)) : (_ as (_ : value mod many)) = x.x
@@ -1016,9 +962,9 @@ type ('a : immediate) t : value mod many portable = { mutable x : 'a }
 Line 1, characters 0-70:
 1 | type ('a : immediate) t : value mod many portable = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod many portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1028,65 +974,55 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type ('a : immediate) t : value mod unique = { mutable x : 'a }
 [%%expect {|
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod unique = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
 [%%expect {|
 Line 1, characters 0-68:
 1 | type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 [%%expect {|
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of value mod external_, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 [%%expect {|
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of immediate64, because
+       But the kind of type t must be a subkind of value mod external64, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (*************************************)
 (* Test 6: Mode crossing of variants *)
@@ -1114,9 +1050,9 @@ type t : any mod many = Foo of int | Bar
 Line 1, characters 0-47:
 1 | type t : any mod uncontended = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1126,26 +1062,22 @@ type t : any mod unique = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod unique = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type t : any mod global = Foo of int | Bar
 [%%expect {|
 Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 
 type t : any mod external_ = Foo of int | Bar
@@ -1153,9 +1085,9 @@ type t : any mod external_ = Foo of int | Bar
 Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1189,9 +1121,9 @@ type t : any mod portable = Foo of string [@@unboxed]
 Line 1, characters 0-53:
 1 | type t : any mod portable = Foo of string [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it is the primitive value type string.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1207,9 +1139,11 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-67:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   { x : 'a @@ global portable uncontended many unique } [@@unboxed]
-Error: The layout of type t is value, because
-         it instantiates an unannotated type parameter of t, defaulted to layout value.
-       But the layout of type t must be a sublayout of value, because
+Error: The kind of type t is value, because
+         it instantiates an unannotated type parameter of t, defaulted to kind value.
+       But the kind of type t must be a subkind of value mod global unique
+                                                             many uncontended
+                                                             portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1220,9 +1154,11 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-66:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The layout of type t is value, because
-         it instantiates an unannotated type parameter of t, defaulted to layout value.
-       But the layout of type t must be a sublayout of value, because
+Error: The kind of type t is value, because
+         it instantiates an unannotated type parameter of t, defaulted to kind value.
+       But the kind of type t must be a subkind of value mod global unique
+                                                             many uncontended
+                                                             portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1248,9 +1184,10 @@ type ('a : value mod uncontended many) t : value mod uncontended many unique =
 Lines 1-2, characters 0-34:
 1 | type ('a : value mod uncontended many) t : value mod uncontended many unique =
 2 |   { x : 'a @@ unique } [@@unboxed]
-Error: The layout of type t is value, because
+Error: The kind of type t is value mod many uncontended, because
          of the annotation on 'a in the declaration of the type t.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod unique many
+                                                             uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1261,9 +1198,9 @@ type ('a : value mod external_) t : immediate =
 Lines 1-2, characters 0-66:
 1 | type ('a : value mod external_) t : immediate =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The layout of type t is immediate, because
+Error: The kind of type t is value mod external_, because
          of the annotation on 'a in the declaration of the type t.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of immediate, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1275,9 +1212,9 @@ type 'a t : value mod portable = { x : 'a @@ portable }
 Line 1, characters 0-47:
 1 | type 'a t : value mod many = { x : 'a @@ many }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod many, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1287,26 +1224,22 @@ type 'a t : value mod unique = { x : 'a @@ unique }
 Line 1, characters 0-51:
 1 | type 'a t : value mod unique = { x : 'a @@ unique }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 type 'a t : value mod global = { x : 'a @@ global }
 [%%expect {|
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (*****************************)
 (* Test 8: Kind intersection *)
@@ -1366,12 +1299,10 @@ val x : 'a. ('a : value mod global)
 Line 1, characters 8-35:
 1 | val x : 'a. ('a : value mod global)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was defaulted to have layout value.
-       But it was inferred to have layout value, because
+Error: The universal type variable 'a was defaulted to have kind value.
+       But it was inferred to have kind value mod global, because
          of the annotation on the type variable 'a.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (*****************)
 (* Test 9: GADTs *)
@@ -1442,13 +1373,11 @@ Line 17, characters 6-7:
            ^
 Error: This expression has type a but an expression was expected of type
          ('a : immediate)
-       The layout of a is value, because
+       The kind of a is value, because
          of the annotation on the abstract type declaration for a.
-       But the layout of a must be a sublayout of immediate, because
+       But the kind of a must be a subkind of immediate, because
          of the definition of f at line 16, characters 10-41.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (********************)
 (* Test 10: Objects *)
@@ -1463,13 +1392,11 @@ type t : value mod global = < >
 Line 1, characters 0-31:
 1 | type t : value mod global = < >
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type <  > is value, because
+Error: The kind of type <  > is value, because
          it's the type of an object.
-       But the layout of type <  > must be a sublayout of value, because
+       But the kind of type <  > must be a subkind of value mod global, because
          of the definition of t at line 1, characters 0-31.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let x : (_ as (_ : value)) = object end
 [%%expect{|
@@ -1483,13 +1410,11 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod global)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value, because
+       But the kind of <  > must be a subkind of value mod global, because
          of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let x : (_ as (_ : value mod many)) = object end
 [%%expect {|
@@ -1498,13 +1423,11 @@ Line 1, characters 38-48:
                                           ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod many)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value, because
+       But the kind of <  > must be a subkind of value mod many, because
          of the annotation on the wildcard _ at line 1, characters 19-33.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let x : (_ as (_ : value mod unique)) = object end
 [%%expect {|
@@ -1513,13 +1436,11 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod unique)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value, because
+       But the kind of <  > must be a subkind of value mod unique, because
          of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let x : (_ as (_ : value mod portable)) = object end
 [%%expect {|
@@ -1528,13 +1449,11 @@ Line 1, characters 42-52:
                                               ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod portable)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value, because
+       But the kind of <  > must be a subkind of value mod portable, because
          of the annotation on the wildcard _ at line 1, characters 19-37.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let x : (_ as (_ : value mod uncontended)) = object end
 [%%expect {|
@@ -1543,13 +1462,11 @@ Line 1, characters 45-55:
                                                  ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod uncontended)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value, because
+       But the kind of <  > must be a subkind of value mod uncontended, because
          of the annotation on the wildcard _ at line 1, characters 19-40.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 let x : (_ as (_ : value mod external_)) = object end
 [%%expect {|
@@ -1558,13 +1475,11 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod external_)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of immediate, because
+       But the kind of <  > must be a subkind of value mod external_, because
          of the annotation on the wildcard _ at line 1, characters 19-38.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. *)
 
 (****************************************)
 (* Test 11: Inference of type parameter *)

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -114,10 +114,10 @@ type a : any
 Line 2, characters 0-18:
 2 | type b : value = a
     ^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is any, because
-         of the definition of a at line 1, characters 0-12.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-18.
+Error: The layout of type a is any
+         because of the definition of a at line 1, characters 0-12.
+       But the layout of type a must be a sublayout of value
+         because of the definition of b at line 2, characters 0-18.
 |}]
 
 type a : float32
@@ -141,10 +141,10 @@ type a : any
 Line 2, characters 0-20:
 2 | type b : float32 = a
     ^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is any, because
-         of the definition of a at line 1, characters 0-12.
-       But the layout of type a must be a sublayout of float32, because
-         of the definition of b at line 2, characters 0-20.
+Error: The layout of type a is any
+         because of the definition of a at line 1, characters 0-12.
+       But the layout of type a must be a sublayout of float32
+         because of the definition of b at line 2, characters 0-20.
 |}]
 
 type a : float32
@@ -154,10 +154,10 @@ type a : float32
 Line 2, characters 0-17:
 2 | type b : word = a
     ^^^^^^^^^^^^^^^^^
-Error: The layout of type a is float32, because
-         of the definition of a at line 1, characters 0-16.
-       But the layout of type a must be a sublayout of word, because
-         of the definition of b at line 2, characters 0-17.
+Error: The layout of type a is float32
+         because of the definition of a at line 1, characters 0-16.
+       But the layout of type a must be a sublayout of word
+         because of the definition of b at line 2, characters 0-17.
 |}]
 
 type a : value mod local
@@ -188,10 +188,10 @@ type a : value mod local
 Line 2, characters 0-29:
 2 | type b : value mod global = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type a is value, because
-         of the definition of a at line 1, characters 0-24.
-       But the kind of type a must be a subkind of value mod global, because
-         of the definition of b at line 2, characters 0-29.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-24.
+       But the kind of type a must be a subkind of value mod global
+         because of the definition of b at line 2, characters 0-29.
 |}]
 
 type a : value mod global
@@ -208,10 +208,10 @@ type a : value mod global
 Line 2, characters 0-30:
 2 | type b : float32 mod local = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-25.
-       But the layout of type a must be a sublayout of float32, because
-         of the definition of b at line 2, characters 0-30.
+Error: The layout of type a is value
+         because of the definition of a at line 1, characters 0-25.
+       But the layout of type a must be a sublayout of float32
+         because of the definition of b at line 2, characters 0-30.
 |}]
 
 type a : value mod global unique many uncontended portable external_
@@ -228,11 +228,11 @@ type a : value mod global unique once uncontended portable external_
 Line 2, characters 0-73:
 2 | type b : value mod local shared many uncontended nonportable internal = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type a is value mod global unique uncontended portable
-                                       external_, because
-         of the definition of a at line 1, characters 0-68.
-       But the kind of type a must be a subkind of value mod many uncontended, because
-         of the definition of b at line 2, characters 0-73.
+Error: The kind of type a is
+         value mod global unique uncontended portable external_
+         because of the definition of a at line 1, characters 0-68.
+       But the kind of type a must be a subkind of value mod many uncontended
+         because of the definition of b at line 2, characters 0-73.
 |}]
 
 (********************************************************)
@@ -412,10 +412,10 @@ type t : any mod global = t_value
 Line 1, characters 0-33:
 1 | type t : any mod global = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod global, because
-         of the definition of t at line 1, characters 0-33.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod global
+         because of the definition of t at line 1, characters 0-33.
 |}]
 
 type t : any mod unique = t_value
@@ -423,10 +423,10 @@ type t : any mod unique = t_value
 Line 1, characters 0-33:
 1 | type t : any mod unique = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod unique, because
-         of the definition of t at line 1, characters 0-33.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod unique
+         because of the definition of t at line 1, characters 0-33.
 |}]
 
 type t : any mod many = t_value
@@ -434,10 +434,10 @@ type t : any mod many = t_value
 Line 1, characters 0-31:
 1 | type t : any mod many = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod many, because
-         of the definition of t at line 1, characters 0-31.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod many
+         because of the definition of t at line 1, characters 0-31.
 |}]
 
 type t : any mod uncontended = t_value
@@ -445,10 +445,10 @@ type t : any mod uncontended = t_value
 Line 1, characters 0-38:
 1 | type t : any mod uncontended = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod uncontended, because
-         of the definition of t at line 1, characters 0-38.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod uncontended
+         because of the definition of t at line 1, characters 0-38.
 |}]
 
 type t : any mod portable = t_value
@@ -456,10 +456,10 @@ type t : any mod portable = t_value
 Line 1, characters 0-35:
 1 | type t : any mod portable = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod portable, because
-         of the definition of t at line 1, characters 0-35.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod portable
+         because of the definition of t at line 1, characters 0-35.
 |}]
 
 type t : any mod external_ = t_value
@@ -467,10 +467,10 @@ type t : any mod external_ = t_value
 Line 1, characters 0-36:
 1 | type t : any mod external_ = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod external_, because
-         of the definition of t at line 1, characters 0-36.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod external_
+         because of the definition of t at line 1, characters 0-36.
 |}]
 
 type ('a : value mod unique) t = { unique_field : 'a }
@@ -482,10 +482,10 @@ Line 2, characters 25-33:
                              ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod unique)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of value mod unique, because
-         of the definition of t at line 1, characters 0-54.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of value mod unique
+         because of the definition of t at line 1, characters 0-54.
 |}]
 
 type t : value mod global
@@ -504,10 +504,10 @@ Line 2, characters 42-43:
                                               ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod global)
-       The kind of t is value mod many, because
-         of the definition of t at line 1, characters 0-23.
-       But the kind of t must be a subkind of value mod global, because
-         of the annotation on the type variable 'a.
+       The kind of t is value mod many
+         because of the definition of t at line 1, characters 0-23.
+       But the kind of t must be a subkind of value mod global
+         because of the annotation on the type variable 'a.
 |}]
 
 type t : value mod unique
@@ -530,10 +530,10 @@ Line 3, characters 18-19:
                       ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod unique)
-       The kind of t is value mod external64, because
-         of the definition of t at line 1, characters 0-29.
-       But the kind of t must be a subkind of value mod unique, because
-         of the definition of f at line 2, characters 6-44.
+       The kind of t is value mod external64
+         because of the definition of t at line 1, characters 0-29.
+       But the kind of t must be a subkind of value mod unique
+         because of the definition of f at line 2, characters 6-44.
 |}]
 
 module A : sig
@@ -562,10 +562,10 @@ module A : sig type t : value end
 Line 7, characters 0-24:
 7 | type t : immediate = A.t
     ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type A.t is value, because
-         of the definition of t at line 2, characters 2-16.
-       But the kind of type A.t must be a subkind of immediate, because
-         of the definition of t at line 7, characters 0-24.
+Error: The kind of type A.t is value
+         because of the definition of t at line 2, characters 2-16.
+       But the kind of type A.t must be a subkind of immediate
+         because of the definition of t at line 7, characters 0-24.
 |}]
 
 type t : value = private int
@@ -691,10 +691,10 @@ type t : any mod global = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod global = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod unique = { x : string }
@@ -702,10 +702,10 @@ type t : any mod unique = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod unique = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod external_ = { x : string }
@@ -713,10 +713,10 @@ type t : any mod external_ = { x : string }
 Line 1, characters 0-43:
 1 | type t : any mod external_ = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod many = { x : string }
@@ -726,10 +726,10 @@ type t : any mod uncontended = { x : string }
 Line 1, characters 0-38:
 1 | type t : any mod many = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod many, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod many
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
 
@@ -738,10 +738,10 @@ type t : any mod many = { x : t_value }
 Line 1, characters 0-39:
 1 | type t : any mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod many, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod many
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod uncontended = { x : t_value }
@@ -749,10 +749,10 @@ type t : any mod uncontended = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : any mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod portable = { x : t_value }
@@ -760,10 +760,22 @@ type t : any mod portable = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : any mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod portable
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : any mod many uncontended portable global = { x : t_value }
+[%%expect{|
+Line 1, characters 0-67:
+1 | type t : any mod many uncontended portable global = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of
+         any mod global many uncontended portable
+         because of the annotation on the declaration of the type t.
 |}]
 
 type u : immediate
@@ -773,11 +785,11 @@ type u : immediate
 Line 2, characters 0-77:
 2 | type t : value mod portable many uncontended = { x : string; y : int; z : u }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many uncontended
-                                                             portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of
+         value mod many uncontended portable
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
 
@@ -790,10 +802,10 @@ Line 2, characters 43-59:
                                                ^^^^^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod external_)
-       The kind of t is value, because
-         of the definition of t at line 1, characters 0-23.
-       But the kind of t must be a subkind of value mod external_, because
-         of the annotation on the wildcard _ at line 2, characters 20-39.
+       The kind of t is value
+         because of the definition of t at line 1, characters 0-23.
+       But the kind of t must be a subkind of value mod external_
+         because of the annotation on the wildcard _ at line 2, characters 20-39.
 |}]
 
 type t : any mod uncontended = { x : int }
@@ -803,10 +815,10 @@ type t : any mod many = { x : int }
 Line 1, characters 0-42:
 1 | type t : any mod uncontended = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -815,10 +827,10 @@ type t : any mod global = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod external_ = { x : int }
@@ -826,10 +838,10 @@ type t : any mod external_ = { x : int }
 Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod unique = { x : int }
@@ -837,10 +849,10 @@ type t : any mod unique = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod unique = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod global = { x : int } [@@unboxed]
@@ -887,10 +899,10 @@ type t : any mod global = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod portable = { x : u } [@@unboxed]
@@ -898,10 +910,10 @@ type t : any mod portable = { x : u } [@@unboxed]
 Line 1, characters 0-49:
 1 | type t : any mod portable = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod portable
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod uncontended = { x : u } [@@unboxed]
@@ -909,10 +921,10 @@ type t : any mod uncontended = { x : u } [@@unboxed]
 Line 1, characters 0-52:
 1 | type t : any mod uncontended = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod external_ = { x : u } [@@unboxed]
@@ -920,10 +932,10 @@ type t : any mod external_ = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod external_ = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod many = { x : u } [@@unboxed]
@@ -931,10 +943,10 @@ type t : any mod many = { x : u } [@@unboxed]
 Line 1, characters 0-45:
 1 | type t : any mod many = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod many, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod many
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod unique = { x : u } [@@unboxed]
@@ -942,10 +954,10 @@ type t : any mod unique = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod unique = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod global = { x : int } [@@unboxed]
@@ -962,10 +974,10 @@ type ('a : immediate) t : value mod many portable = { mutable x : 'a }
 Line 1, characters 0-70:
 1 | type ('a : immediate) t : value mod many portable = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod many portable
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -974,10 +986,10 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod unique = { mutable x : 'a }
@@ -985,10 +997,10 @@ type ('a : immediate) t : value mod unique = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod unique = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
@@ -996,10 +1008,10 @@ type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
 Line 1, characters 0-68:
 1 | type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod external_ = { mutable x : 'a }
@@ -1007,10 +1019,10 @@ type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod external64 = { mutable x : 'a }
@@ -1018,10 +1030,10 @@ type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external64, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod external64
+         because of the annotation on the declaration of the type t.
 |}]
 
 (*************************************)
@@ -1050,10 +1062,10 @@ type t : any mod many = Foo of int | Bar
 Line 1, characters 0-47:
 1 | type t : any mod uncontended = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1062,10 +1074,10 @@ type t : any mod unique = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod unique = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod global = Foo of int | Bar
@@ -1073,10 +1085,10 @@ type t : any mod global = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 
@@ -1085,10 +1097,10 @@ type t : any mod external_ = Foo of int | Bar
 Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1121,14 +1133,12 @@ type t : any mod portable = Foo of string [@@unboxed]
 Line 1, characters 0-53:
 1 | type t : any mod portable = Foo of string [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it is the primitive value type string.
-       But the kind of type t must be a subkind of any mod portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it is the primitive value type string.
+       But the kind of type t must be a subkind of any mod portable
+         because of the annotation on the declaration of the type t.
 |}]
-(* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
-   mismatch, not a layout mismatch. But this will be accepted once [string] mode-crosses
-   portability *)
+(* CR layouts v2.8: this should be accepted portability *)
 
 (***********************************************)
 (* Test 7: Inference with modality annotations *)
@@ -1139,12 +1149,12 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-67:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   { x : 'a @@ global portable uncontended many unique } [@@unboxed]
-Error: The kind of type t is value, because
-         it instantiates an unannotated type parameter of t, defaulted to kind value.
-       But the kind of type t must be a subkind of value mod global unique
-                                                             many uncontended
-                                                             portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it instantiates an unannotated type parameter of t,
+         defaulted to kind value.
+       But the kind of type t must be a subkind of
+         value mod global unique many uncontended portable
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1154,12 +1164,12 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-66:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The kind of type t is value, because
-         it instantiates an unannotated type parameter of t, defaulted to kind value.
-       But the kind of type t must be a subkind of value mod global unique
-                                                             many uncontended
-                                                             portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it instantiates an unannotated type parameter of t,
+         defaulted to kind value.
+       But the kind of type t must be a subkind of
+         value mod global unique many uncontended portable
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1184,11 +1194,11 @@ type ('a : value mod uncontended many) t : value mod uncontended many unique =
 Lines 1-2, characters 0-34:
 1 | type ('a : value mod uncontended many) t : value mod uncontended many unique =
 2 |   { x : 'a @@ unique } [@@unboxed]
-Error: The kind of type t is value mod many uncontended, because
-         of the annotation on 'a in the declaration of the type t.
-       But the kind of type t must be a subkind of value mod unique many
-                                                             uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value mod many uncontended
+         because of the annotation on 'a in the declaration of the type t.
+       But the kind of type t must be a subkind of
+         value mod unique many uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1198,10 +1208,10 @@ type ('a : value mod external_) t : immediate =
 Lines 1-2, characters 0-66:
 1 | type ('a : value mod external_) t : immediate =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The kind of type t is value mod external_, because
-         of the annotation on 'a in the declaration of the type t.
-       But the kind of type t must be a subkind of immediate, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value mod external_
+         because of the annotation on 'a in the declaration of the type t.
+       But the kind of type t must be a subkind of immediate
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1212,10 +1222,10 @@ type 'a t : value mod portable = { x : 'a @@ portable }
 Line 1, characters 0-47:
 1 | type 'a t : value mod many = { x : 'a @@ many }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod many
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1224,10 +1234,10 @@ type 'a t : value mod unique = { x : 'a @@ unique }
 Line 1, characters 0-51:
 1 | type 'a t : value mod unique = { x : 'a @@ unique }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type 'a t : value mod global = { x : 'a @@ global }
@@ -1235,10 +1245,10 @@ type 'a t : value mod global = { x : 'a @@ global }
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 (*****************************)
@@ -1267,10 +1277,10 @@ Line 1, characters 23-34:
 1 | type ('a : bits32) t = ('a : word)
                            ^^^^^^^^^^^
 Error: This type ('a : word) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with word, because
-         of the annotation on the type variable 'a.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with word
+         because of the annotation on the type variable 'a.
 |}]
 
 let f : ('a : any mod global unique) -> ('a: any mod uncontended) = fun x -> x
@@ -1288,10 +1298,10 @@ Line 1, characters 29-36:
 1 | let f : ('a : value) -> ('a: float32) = fun x -> x
                                  ^^^^^^^
 Error: Bad layout annotation:
-         The layout of 'a is value, because
-           of the annotation on the type variable 'a.
-         But the layout of 'a must overlap with float32, because
-           of the annotation on the type variable 'a.
+         The layout of 'a is value
+           because of the annotation on the type variable 'a.
+         But the layout of 'a must overlap with float32
+           because of the annotation on the type variable 'a.
 |}]
 
 val x : 'a. ('a : value mod global)
@@ -1300,8 +1310,8 @@ Line 1, characters 8-35:
 1 | val x : 'a. ('a : value mod global)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was defaulted to have kind value.
-       But it was inferred to have kind value mod global, because
-         of the annotation on the type variable 'a.
+       But it was inferred to have kind value mod global
+         because of the annotation on the type variable 'a.
 |}]
 
 (*****************)
@@ -1373,10 +1383,10 @@ Line 17, characters 6-7:
            ^
 Error: This expression has type a but an expression was expected of type
          ('a : immediate)
-       The kind of a is value, because
-         of the annotation on the abstract type declaration for a.
-       But the kind of a must be a subkind of immediate, because
-         of the definition of f at line 16, characters 10-41.
+       The kind of a is value
+         because of the annotation on the abstract type declaration for a.
+       But the kind of a must be a subkind of immediate
+         because of the definition of f at line 16, characters 10-41.
 |}]
 
 (********************)
@@ -1392,10 +1402,10 @@ type t : value mod global = < >
 Line 1, characters 0-31:
 1 | type t : value mod global = < >
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type <  > is value, because
-         it's the type of an object.
-       But the kind of type <  > must be a subkind of value mod global, because
-         of the definition of t at line 1, characters 0-31.
+Error: The kind of type <  > is value
+         because it's the type of an object.
+       But the kind of type <  > must be a subkind of value mod global
+         because of the definition of t at line 1, characters 0-31.
 |}]
 
 let x : (_ as (_ : value)) = object end
@@ -1410,10 +1420,10 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod global)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod global, because
-         of the annotation on the wildcard _ at line 1, characters 19-35.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod global
+         because of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
 let x : (_ as (_ : value mod many)) = object end
@@ -1423,10 +1433,10 @@ Line 1, characters 38-48:
                                           ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod many)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod many, because
-         of the annotation on the wildcard _ at line 1, characters 19-33.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod many
+         because of the annotation on the wildcard _ at line 1, characters 19-33.
 |}]
 
 let x : (_ as (_ : value mod unique)) = object end
@@ -1436,10 +1446,10 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod unique)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod unique, because
-         of the annotation on the wildcard _ at line 1, characters 19-35.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod unique
+         because of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
 let x : (_ as (_ : value mod portable)) = object end
@@ -1449,10 +1459,10 @@ Line 1, characters 42-52:
                                               ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod portable)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod portable, because
-         of the annotation on the wildcard _ at line 1, characters 19-37.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod portable
+         because of the annotation on the wildcard _ at line 1, characters 19-37.
 |}]
 
 let x : (_ as (_ : value mod uncontended)) = object end
@@ -1462,10 +1472,10 @@ Line 1, characters 45-55:
                                                  ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod uncontended)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod uncontended, because
-         of the annotation on the wildcard _ at line 1, characters 19-40.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod uncontended
+         because of the annotation on the wildcard _ at line 1, characters 19-40.
 |}]
 
 let x : (_ as (_ : value mod external_)) = object end
@@ -1475,10 +1485,10 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod external_)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod external_, because
-         of the annotation on the wildcard _ at line 1, characters 19-38.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod external_
+         because of the annotation on the wildcard _ at line 1, characters 19-38.
 |}]
 
 (****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -190,7 +190,7 @@ Line 2, characters 0-29:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type a is value, because
          of the definition of a at line 1, characters 0-24.
-       But the layout of type a must be a sublayout of value mod global, because
+       But the layout of type a must be a sublayout of value, because
          of the definition of b at line 2, characters 0-29.
 |}]
 
@@ -228,11 +228,9 @@ type a : value mod global unique once uncontended portable external_
 Line 2, characters 0-73:
 2 | type b : value mod local shared many uncontended nonportable internal = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is
-         value mod global unique uncontended portable external_, because
+Error: The layout of type a is immediate, because
          of the definition of a at line 1, characters 0-68.
-       But the layout of type a must be a sublayout of
-         value mod many uncontended, because
+       But the layout of type a must be a sublayout of value, because
          of the definition of b at line 2, characters 0-73.
 |}]
 
@@ -415,7 +413,7 @@ Line 1, characters 0-33:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any mod global, because
+       But the layout of type t_value must be a sublayout of any, because
          of the definition of t at line 1, characters 0-33.
 |}]
 
@@ -426,7 +424,7 @@ Line 1, characters 0-33:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any mod unique, because
+       But the layout of type t_value must be a sublayout of any, because
          of the definition of t at line 1, characters 0-33.
 |}]
 
@@ -437,7 +435,7 @@ Line 1, characters 0-31:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any mod many, because
+       But the layout of type t_value must be a sublayout of any, because
          of the definition of t at line 1, characters 0-31.
 |}]
 
@@ -448,8 +446,7 @@ Line 1, characters 0-38:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of
-         any mod uncontended, because
+       But the layout of type t_value must be a sublayout of any, because
          of the definition of t at line 1, characters 0-38.
 |}]
 
@@ -460,7 +457,7 @@ Line 1, characters 0-35:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any mod portable, because
+       But the layout of type t_value must be a sublayout of any, because
          of the definition of t at line 1, characters 0-35.
 |}]
 
@@ -471,8 +468,7 @@ Line 1, characters 0-36:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of
-         any mod external_, because
+       But the layout of type t_value must be a sublayout of any, because
          of the definition of t at line 1, characters 0-36.
 |}]
 
@@ -487,7 +483,7 @@ Error: This expression has type string but an expression was expected of type
          ('a : value mod unique)
        The layout of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value mod unique, because
+       But the layout of string must be a sublayout of value, because
          of the definition of t at line 1, characters 0-54.
 |}]
 
@@ -507,9 +503,9 @@ Line 2, characters 42-43:
                                               ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod global)
-       The layout of t is value mod many, because
+       The layout of t is value, because
          of the definition of t at line 1, characters 0-23.
-       But the layout of t must be a sublayout of value mod global, because
+       But the layout of t must be a sublayout of value, because
          of the annotation on the type variable 'a.
 |}]
 
@@ -533,9 +529,9 @@ Line 3, characters 18-19:
                       ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod unique)
-       The layout of t is value mod external64, because
+       The layout of t is immediate64, because
          of the definition of t at line 1, characters 0-29.
-       But the layout of t must be a sublayout of value mod unique, because
+       But the layout of t must be a sublayout of value, because
          of the definition of f at line 2, characters 6-44.
 |}]
 
@@ -696,7 +692,7 @@ Line 1, characters 0-40:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod global, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -707,7 +703,7 @@ Line 1, characters 0-40:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod unique, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -718,7 +714,7 @@ Line 1, characters 0-43:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod external_, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -731,7 +727,7 @@ Line 1, characters 0-38:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod many, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
@@ -743,7 +739,7 @@ Line 1, characters 0-39:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod many, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -754,7 +750,7 @@ Line 1, characters 0-46:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod uncontended, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -765,7 +761,7 @@ Line 1, characters 0-43:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod portable, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -776,8 +772,7 @@ Line 1, characters 0-67:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of
-         any mod global many uncontended portable, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -790,8 +785,7 @@ Line 2, characters 0-77:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of
-         value mod many uncontended portable, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
@@ -807,7 +801,7 @@ Error: This expression has type t but an expression was expected of type
          ('a : value mod external_)
        The layout of t is value, because
          of the definition of t at line 1, characters 0-23.
-       But the layout of t must be a sublayout of value mod external_, because
+       But the layout of t must be a sublayout of immediate, because
          of the annotation on the wildcard _ at line 2, characters 20-39.
 |}]
 
@@ -820,7 +814,7 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod uncontended, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -832,7 +826,7 @@ Line 1, characters 0-37:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod global, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -843,7 +837,7 @@ Line 1, characters 0-40:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod external_, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -854,7 +848,7 @@ Line 1, characters 0-37:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any mod unique, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -904,7 +898,7 @@ Line 1, characters 0-47:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any mod global, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -915,7 +909,7 @@ Line 1, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any mod portable, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -926,7 +920,7 @@ Line 1, characters 0-52:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any mod uncontended, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -937,7 +931,7 @@ Line 1, characters 0-50:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any mod external_, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -948,7 +942,7 @@ Line 1, characters 0-45:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any mod many, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -959,7 +953,7 @@ Line 1, characters 0-47:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any mod unique, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -979,8 +973,7 @@ Line 1, characters 0-70:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of
-         value mod many portable, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -992,7 +985,7 @@ Line 1, characters 0-63:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod global, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1003,7 +996,7 @@ Line 1, characters 0-63:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod unique, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1014,7 +1007,7 @@ Line 1, characters 0-68:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod uncontended, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1025,7 +1018,7 @@ Line 1, characters 0-66:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod external_, because
+       But the layout of type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1036,7 +1029,7 @@ Line 1, characters 0-67:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod external64, because
+       But the layout of type t must be a sublayout of immediate64, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1068,7 +1061,7 @@ Line 1, characters 0-47:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any mod uncontended, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1080,7 +1073,7 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any mod unique, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1091,7 +1084,7 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any mod global, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1103,7 +1096,7 @@ Line 1, characters 0-45:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any mod external_, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1139,7 +1132,7 @@ Line 1, characters 0-53:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it is the primitive value type string.
-       But the layout of type t must be a sublayout of any mod portable, because
+       But the layout of type t must be a sublayout of any, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted portability *)
@@ -1156,8 +1149,7 @@ Lines 1-2, characters 0-67:
 Error: The layout of type t is value, because
          it instantiates an unannotated type parameter of t,
          defaulted to layout value.
-       But the layout of type t must be a sublayout of
-         value mod global unique many uncontended portable, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1171,8 +1163,7 @@ Lines 1-2, characters 0-66:
 Error: The layout of type t is value, because
          it instantiates an unannotated type parameter of t,
          defaulted to layout value.
-       But the layout of type t must be a sublayout of
-         value mod global unique many uncontended portable, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1198,10 +1189,9 @@ type ('a : value mod uncontended many) t : value mod uncontended many unique =
 Lines 1-2, characters 0-34:
 1 | type ('a : value mod uncontended many) t : value mod uncontended many unique =
 2 |   { x : 'a @@ unique } [@@unboxed]
-Error: The layout of type t is value mod many uncontended, because
+Error: The layout of type t is value, because
          of the annotation on 'a in the declaration of the type t.
-       But the layout of type t must be a sublayout of
-         value mod unique many uncontended, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1212,7 +1202,7 @@ type ('a : value mod external_) t : immediate =
 Lines 1-2, characters 0-66:
 1 | type ('a : value mod external_) t : immediate =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The layout of type t is value mod external_, because
+Error: The layout of type t is immediate, because
          of the annotation on 'a in the declaration of the type t.
        But the layout of type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
@@ -1228,7 +1218,7 @@ Line 1, characters 0-47:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod many, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1240,7 +1230,7 @@ Line 1, characters 0-51:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod unique, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1251,7 +1241,7 @@ Line 1, characters 0-51:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value mod global, because
+       But the layout of type t must be a sublayout of value, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1314,7 +1304,7 @@ Line 1, characters 8-35:
 1 | val x : 'a. ('a : value mod global)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was defaulted to have kind value.
-       But it was inferred to have kind value mod global, because
+       But it was inferred to have kind value, because
          of the annotation on the type variable 'a.
 |}]
 
@@ -1408,7 +1398,7 @@ Line 1, characters 0-31:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type <  > is value, because
          it's the type of an object.
-       But the layout of type <  > must be a sublayout of value mod global, because
+       But the layout of type <  > must be a sublayout of value, because
          of the definition of t at line 1, characters 0-31.
 |}]
 
@@ -1426,7 +1416,7 @@ Error: This expression has type <  > but an expression was expected of type
          ('a : value mod global)
        The layout of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value mod global, because
+       But the layout of <  > must be a sublayout of value, because
          of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
@@ -1439,7 +1429,7 @@ Error: This expression has type <  > but an expression was expected of type
          ('a : value mod many)
        The layout of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value mod many, because
+       But the layout of <  > must be a sublayout of value, because
          of the annotation on the wildcard _ at line 1, characters 19-33.
 |}]
 
@@ -1452,7 +1442,7 @@ Error: This expression has type <  > but an expression was expected of type
          ('a : value mod unique)
        The layout of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value mod unique, because
+       But the layout of <  > must be a sublayout of value, because
          of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
@@ -1465,7 +1455,7 @@ Error: This expression has type <  > but an expression was expected of type
          ('a : value mod portable)
        The layout of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value mod portable, because
+       But the layout of <  > must be a sublayout of value, because
          of the annotation on the wildcard _ at line 1, characters 19-37.
 |}]
 
@@ -1478,7 +1468,7 @@ Error: This expression has type <  > but an expression was expected of type
          ('a : value mod uncontended)
        The layout of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value mod uncontended, because
+       But the layout of <  > must be a sublayout of value, because
          of the annotation on the wildcard _ at line 1, characters 19-40.
 |}]
 
@@ -1491,7 +1481,7 @@ Error: This expression has type <  > but an expression was expected of type
          ('a : value mod external_)
        The layout of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value mod external_, because
+       But the layout of <  > must be a sublayout of immediate, because
          of the annotation on the wildcard _ at line 1, characters 19-38.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -188,9 +188,9 @@ type a : value mod local
 Line 2, characters 0-29:
 2 | type b : value mod global = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
+Error: The kind of type a is value, because
          of the definition of a at line 1, characters 0-24.
-       But the layout of type a must be a sublayout of value, because
+       But the kind of type a must be a subkind of value mod global, because
          of the definition of b at line 2, characters 0-29.
 |}]
 
@@ -228,9 +228,10 @@ type a : value mod global unique once uncontended portable external_
 Line 2, characters 0-73:
 2 | type b : value mod local shared many uncontended nonportable internal = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is immediate, because
+Error: The kind of type a is
+         value mod global unique uncontended portable external_, because
          of the definition of a at line 1, characters 0-68.
-       But the layout of type a must be a sublayout of value, because
+       But the kind of type a must be a subkind of value mod many uncontended, because
          of the definition of b at line 2, characters 0-73.
 |}]
 
@@ -411,9 +412,9 @@ type t : any mod global = t_value
 Line 1, characters 0-33:
 1 | type t : any mod global = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod global, because
          of the definition of t at line 1, characters 0-33.
 |}]
 
@@ -422,9 +423,9 @@ type t : any mod unique = t_value
 Line 1, characters 0-33:
 1 | type t : any mod unique = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod unique, because
          of the definition of t at line 1, characters 0-33.
 |}]
 
@@ -433,9 +434,9 @@ type t : any mod many = t_value
 Line 1, characters 0-31:
 1 | type t : any mod many = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod many, because
          of the definition of t at line 1, characters 0-31.
 |}]
 
@@ -444,9 +445,9 @@ type t : any mod uncontended = t_value
 Line 1, characters 0-38:
 1 | type t : any mod uncontended = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod uncontended, because
          of the definition of t at line 1, characters 0-38.
 |}]
 
@@ -455,9 +456,9 @@ type t : any mod portable = t_value
 Line 1, characters 0-35:
 1 | type t : any mod portable = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod portable, because
          of the definition of t at line 1, characters 0-35.
 |}]
 
@@ -466,9 +467,9 @@ type t : any mod external_ = t_value
 Line 1, characters 0-36:
 1 | type t : any mod external_ = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_value is value, because
+Error: The kind of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the layout of type t_value must be a sublayout of any, because
+       But the kind of type t_value must be a subkind of any mod external_, because
          of the definition of t at line 1, characters 0-36.
 |}]
 
@@ -481,9 +482,9 @@ Line 2, characters 25-33:
                              ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod unique)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of value, because
+       But the kind of string must be a subkind of value mod unique, because
          of the definition of t at line 1, characters 0-54.
 |}]
 
@@ -503,9 +504,9 @@ Line 2, characters 42-43:
                                               ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod global)
-       The layout of t is value, because
+       The kind of t is value mod many, because
          of the definition of t at line 1, characters 0-23.
-       But the layout of t must be a sublayout of value, because
+       But the kind of t must be a subkind of value mod global, because
          of the annotation on the type variable 'a.
 |}]
 
@@ -529,9 +530,9 @@ Line 3, characters 18-19:
                       ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod unique)
-       The layout of t is immediate64, because
+       The kind of t is value mod external64, because
          of the definition of t at line 1, characters 0-29.
-       But the layout of t must be a sublayout of value, because
+       But the kind of t must be a subkind of value mod unique, because
          of the definition of f at line 2, characters 6-44.
 |}]
 
@@ -561,9 +562,9 @@ module A : sig type t : value end
 Line 7, characters 0-24:
 7 | type t : immediate = A.t
     ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type A.t is value, because
+Error: The kind of type A.t is value, because
          of the definition of t at line 2, characters 2-16.
-       But the layout of type A.t must be a sublayout of immediate, because
+       But the kind of type A.t must be a subkind of immediate, because
          of the definition of t at line 7, characters 0-24.
 |}]
 
@@ -690,9 +691,9 @@ type t : any mod global = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod global = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -701,9 +702,9 @@ type t : any mod unique = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod unique = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -712,9 +713,9 @@ type t : any mod external_ = { x : string }
 Line 1, characters 0-43:
 1 | type t : any mod external_ = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -725,9 +726,9 @@ type t : any mod uncontended = { x : string }
 Line 1, characters 0-38:
 1 | type t : any mod many = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod many, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
@@ -737,9 +738,9 @@ type t : any mod many = { x : t_value }
 Line 1, characters 0-39:
 1 | type t : any mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod many, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -748,9 +749,9 @@ type t : any mod uncontended = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : any mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -759,9 +760,9 @@ type t : any mod portable = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : any mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -770,9 +771,10 @@ type t : any mod many uncontended portable global = { x : t_value }
 Line 1, characters 0-67:
 1 | type t : any mod many uncontended portable global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of
+         any mod global many uncontended portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -783,9 +785,10 @@ type u : immediate
 Line 2, characters 0-77:
 2 | type t : value mod portable many uncontended = { x : string; y : int; z : u }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of
+         value mod many uncontended portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
@@ -799,9 +802,9 @@ Line 2, characters 43-59:
                                                ^^^^^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod external_)
-       The layout of t is value, because
+       The kind of t is value, because
          of the definition of t at line 1, characters 0-23.
-       But the layout of t must be a sublayout of immediate, because
+       But the kind of t must be a subkind of value mod external_, because
          of the annotation on the wildcard _ at line 2, characters 20-39.
 |}]
 
@@ -812,9 +815,9 @@ type t : any mod many = { x : int }
 Line 1, characters 0-42:
 1 | type t : any mod uncontended = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -824,9 +827,9 @@ type t : any mod global = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -835,9 +838,9 @@ type t : any mod external_ = { x : int }
 Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -846,9 +849,9 @@ type t : any mod unique = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod unique = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -896,9 +899,9 @@ type t : any mod global = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -907,9 +910,9 @@ type t : any mod portable = { x : u } [@@unboxed]
 Line 1, characters 0-49:
 1 | type t : any mod portable = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -918,9 +921,9 @@ type t : any mod uncontended = { x : u } [@@unboxed]
 Line 1, characters 0-52:
 1 | type t : any mod uncontended = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -929,9 +932,9 @@ type t : any mod external_ = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod external_ = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -940,9 +943,9 @@ type t : any mod many = { x : u } [@@unboxed]
 Line 1, characters 0-45:
 1 | type t : any mod many = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod many, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -951,9 +954,9 @@ type t : any mod unique = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod unique = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -971,9 +974,9 @@ type ('a : immediate) t : value mod many portable = { mutable x : 'a }
 Line 1, characters 0-70:
 1 | type ('a : immediate) t : value mod many portable = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod many portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -983,9 +986,9 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -994,9 +997,9 @@ type ('a : immediate) t : value mod unique = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod unique = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1005,9 +1008,9 @@ type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
 Line 1, characters 0-68:
 1 | type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1016,9 +1019,9 @@ type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of value mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1027,9 +1030,9 @@ type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of immediate64, because
+       But the kind of type t must be a subkind of value mod external64, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1059,9 +1062,9 @@ type t : any mod many = Foo of int | Bar
 Line 1, characters 0-47:
 1 | type t : any mod uncontended = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1071,9 +1074,9 @@ type t : any mod unique = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod unique = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1082,9 +1085,9 @@ type t : any mod global = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1094,9 +1097,9 @@ type t : any mod external_ = Foo of int | Bar
 Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed variant type.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1130,9 +1133,9 @@ type t : any mod portable = Foo of string [@@unboxed]
 Line 1, characters 0-53:
 1 | type t : any mod portable = Foo of string [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it is the primitive value type string.
-       But the layout of type t must be a sublayout of any, because
+       But the kind of type t must be a subkind of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted portability *)
@@ -1146,10 +1149,11 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-67:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   { x : 'a @@ global portable uncontended many unique } [@@unboxed]
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it instantiates an unannotated type parameter of t,
-         defaulted to layout value.
-       But the layout of type t must be a sublayout of value, because
+         defaulted to kind value.
+       But the kind of type t must be a subkind of
+         value mod global unique many uncontended portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1160,10 +1164,11 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-66:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it instantiates an unannotated type parameter of t,
-         defaulted to layout value.
-       But the layout of type t must be a sublayout of value, because
+         defaulted to kind value.
+       But the kind of type t must be a subkind of
+         value mod global unique many uncontended portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1189,9 +1194,10 @@ type ('a : value mod uncontended many) t : value mod uncontended many unique =
 Lines 1-2, characters 0-34:
 1 | type ('a : value mod uncontended many) t : value mod uncontended many unique =
 2 |   { x : 'a @@ unique } [@@unboxed]
-Error: The layout of type t is value, because
+Error: The kind of type t is value mod many uncontended, because
          of the annotation on 'a in the declaration of the type t.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of
+         value mod unique many uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1202,9 +1208,9 @@ type ('a : value mod external_) t : immediate =
 Lines 1-2, characters 0-66:
 1 | type ('a : value mod external_) t : immediate =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The layout of type t is immediate, because
+Error: The kind of type t is value mod external_, because
          of the annotation on 'a in the declaration of the type t.
-       But the layout of type t must be a sublayout of immediate, because
+       But the kind of type t must be a subkind of immediate, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1216,9 +1222,9 @@ type 'a t : value mod portable = { x : 'a @@ portable }
 Line 1, characters 0-47:
 1 | type 'a t : value mod many = { x : 'a @@ many }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod many, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1228,9 +1234,9 @@ type 'a t : value mod unique = { x : 'a @@ unique }
 Line 1, characters 0-51:
 1 | type 'a t : value mod unique = { x : 'a @@ unique }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1239,9 +1245,9 @@ type 'a t : value mod global = { x : 'a @@ global }
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type t is value, because
+Error: The kind of type t is value, because
          it's a boxed record type.
-       But the layout of type t must be a sublayout of value, because
+       But the kind of type t must be a subkind of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1304,7 +1310,7 @@ Line 1, characters 8-35:
 1 | val x : 'a. ('a : value mod global)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was defaulted to have kind value.
-       But it was inferred to have kind value, because
+       But it was inferred to have kind value mod global, because
          of the annotation on the type variable 'a.
 |}]
 
@@ -1377,9 +1383,9 @@ Line 17, characters 6-7:
            ^
 Error: This expression has type a but an expression was expected of type
          ('a : immediate)
-       The layout of a is value, because
+       The kind of a is value, because
          of the annotation on the abstract type declaration for a.
-       But the layout of a must be a sublayout of immediate, because
+       But the kind of a must be a subkind of immediate, because
          of the definition of f at line 16, characters 10-41.
 |}]
 
@@ -1396,9 +1402,9 @@ type t : value mod global = < >
 Line 1, characters 0-31:
 1 | type t : value mod global = < >
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type <  > is value, because
+Error: The kind of type <  > is value, because
          it's the type of an object.
-       But the layout of type <  > must be a sublayout of value, because
+       But the kind of type <  > must be a subkind of value mod global, because
          of the definition of t at line 1, characters 0-31.
 |}]
 
@@ -1414,9 +1420,9 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod global)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value, because
+       But the kind of <  > must be a subkind of value mod global, because
          of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
@@ -1427,9 +1433,9 @@ Line 1, characters 38-48:
                                           ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod many)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value, because
+       But the kind of <  > must be a subkind of value mod many, because
          of the annotation on the wildcard _ at line 1, characters 19-33.
 |}]
 
@@ -1440,9 +1446,9 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod unique)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value, because
+       But the kind of <  > must be a subkind of value mod unique, because
          of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
@@ -1453,9 +1459,9 @@ Line 1, characters 42-52:
                                               ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod portable)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value, because
+       But the kind of <  > must be a subkind of value mod portable, because
          of the annotation on the wildcard _ at line 1, characters 19-37.
 |}]
 
@@ -1466,9 +1472,9 @@ Line 1, characters 45-55:
                                                  ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod uncontended)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of value, because
+       But the kind of <  > must be a subkind of value mod uncontended, because
          of the annotation on the wildcard _ at line 1, characters 19-40.
 |}]
 
@@ -1479,9 +1485,9 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod external_)
-       The layout of <  > is value, because
+       The kind of <  > is value, because
          it's the type of an object.
-       But the layout of <  > must be a sublayout of immediate, because
+       But the kind of <  > must be a subkind of value mod external_, because
          of the annotation on the wildcard _ at line 1, characters 19-38.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -114,10 +114,10 @@ type a : any
 Line 2, characters 0-18:
 2 | type b : value = a
     ^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is any
-         because of the definition of a at line 1, characters 0-12.
-       But the layout of type a must be a sublayout of value
-         because of the definition of b at line 2, characters 0-18.
+Error: The layout of type a is any, because
+         of the definition of a at line 1, characters 0-12.
+       But the layout of type a must be a sublayout of value, because
+         of the definition of b at line 2, characters 0-18.
 |}]
 
 type a : float32
@@ -141,10 +141,10 @@ type a : any
 Line 2, characters 0-20:
 2 | type b : float32 = a
     ^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is any
-         because of the definition of a at line 1, characters 0-12.
-       But the layout of type a must be a sublayout of float32
-         because of the definition of b at line 2, characters 0-20.
+Error: The layout of type a is any, because
+         of the definition of a at line 1, characters 0-12.
+       But the layout of type a must be a sublayout of float32, because
+         of the definition of b at line 2, characters 0-20.
 |}]
 
 type a : float32
@@ -154,10 +154,10 @@ type a : float32
 Line 2, characters 0-17:
 2 | type b : word = a
     ^^^^^^^^^^^^^^^^^
-Error: The layout of type a is float32
-         because of the definition of a at line 1, characters 0-16.
-       But the layout of type a must be a sublayout of word
-         because of the definition of b at line 2, characters 0-17.
+Error: The layout of type a is float32, because
+         of the definition of a at line 1, characters 0-16.
+       But the layout of type a must be a sublayout of word, because
+         of the definition of b at line 2, characters 0-17.
 |}]
 
 type a : value mod local
@@ -188,10 +188,10 @@ type a : value mod local
 Line 2, characters 0-29:
 2 | type b : value mod global = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type a is value
-         because of the definition of a at line 1, characters 0-24.
-       But the kind of type a must be a subkind of value mod global
-         because of the definition of b at line 2, characters 0-29.
+Error: The kind of type a is value, because
+         of the definition of a at line 1, characters 0-24.
+       But the kind of type a must be a subkind of value mod global, because
+         of the definition of b at line 2, characters 0-29.
 |}]
 
 type a : value mod global
@@ -208,10 +208,10 @@ type a : value mod global
 Line 2, characters 0-30:
 2 | type b : float32 mod local = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value
-         because of the definition of a at line 1, characters 0-25.
-       But the layout of type a must be a sublayout of float32
-         because of the definition of b at line 2, characters 0-30.
+Error: The layout of type a is value, because
+         of the definition of a at line 1, characters 0-25.
+       But the layout of type a must be a sublayout of float32, because
+         of the definition of b at line 2, characters 0-30.
 |}]
 
 type a : value mod global unique many uncontended portable external_
@@ -229,10 +229,10 @@ Line 2, characters 0-73:
 2 | type b : value mod local shared many uncontended nonportable internal = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type a is
-         value mod global unique uncontended portable external_
-         because of the definition of a at line 1, characters 0-68.
-       But the kind of type a must be a subkind of value mod many uncontended
-         because of the definition of b at line 2, characters 0-73.
+         value mod global unique uncontended portable external_, because
+         of the definition of a at line 1, characters 0-68.
+       But the kind of type a must be a subkind of value mod many uncontended, because
+         of the definition of b at line 2, characters 0-73.
 |}]
 
 (********************************************************)
@@ -412,10 +412,10 @@ type t : any mod global = t_value
 Line 1, characters 0-33:
 1 | type t : any mod global = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value
-         because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod global
-         because of the definition of t at line 1, characters 0-33.
+Error: The kind of type t_value is value, because
+         of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod global, because
+         of the definition of t at line 1, characters 0-33.
 |}]
 
 type t : any mod unique = t_value
@@ -423,10 +423,10 @@ type t : any mod unique = t_value
 Line 1, characters 0-33:
 1 | type t : any mod unique = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value
-         because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod unique
-         because of the definition of t at line 1, characters 0-33.
+Error: The kind of type t_value is value, because
+         of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod unique, because
+         of the definition of t at line 1, characters 0-33.
 |}]
 
 type t : any mod many = t_value
@@ -434,10 +434,10 @@ type t : any mod many = t_value
 Line 1, characters 0-31:
 1 | type t : any mod many = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value
-         because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod many
-         because of the definition of t at line 1, characters 0-31.
+Error: The kind of type t_value is value, because
+         of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod many, because
+         of the definition of t at line 1, characters 0-31.
 |}]
 
 type t : any mod uncontended = t_value
@@ -445,10 +445,10 @@ type t : any mod uncontended = t_value
 Line 1, characters 0-38:
 1 | type t : any mod uncontended = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value
-         because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod uncontended
-         because of the definition of t at line 1, characters 0-38.
+Error: The kind of type t_value is value, because
+         of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod uncontended, because
+         of the definition of t at line 1, characters 0-38.
 |}]
 
 type t : any mod portable = t_value
@@ -456,10 +456,10 @@ type t : any mod portable = t_value
 Line 1, characters 0-35:
 1 | type t : any mod portable = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value
-         because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod portable
-         because of the definition of t at line 1, characters 0-35.
+Error: The kind of type t_value is value, because
+         of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod portable, because
+         of the definition of t at line 1, characters 0-35.
 |}]
 
 type t : any mod external_ = t_value
@@ -467,10 +467,10 @@ type t : any mod external_ = t_value
 Line 1, characters 0-36:
 1 | type t : any mod external_ = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value
-         because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod external_
-         because of the definition of t at line 1, characters 0-36.
+Error: The kind of type t_value is value, because
+         of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod external_, because
+         of the definition of t at line 1, characters 0-36.
 |}]
 
 type ('a : value mod unique) t = { unique_field : 'a }
@@ -482,10 +482,10 @@ Line 2, characters 25-33:
                              ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod unique)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of value mod unique
-         because of the definition of t at line 1, characters 0-54.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of value mod unique, because
+         of the definition of t at line 1, characters 0-54.
 |}]
 
 type t : value mod global
@@ -504,10 +504,10 @@ Line 2, characters 42-43:
                                               ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod global)
-       The kind of t is value mod many
-         because of the definition of t at line 1, characters 0-23.
-       But the kind of t must be a subkind of value mod global
-         because of the annotation on the type variable 'a.
+       The kind of t is value mod many, because
+         of the definition of t at line 1, characters 0-23.
+       But the kind of t must be a subkind of value mod global, because
+         of the annotation on the type variable 'a.
 |}]
 
 type t : value mod unique
@@ -530,10 +530,10 @@ Line 3, characters 18-19:
                       ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod unique)
-       The kind of t is value mod external64
-         because of the definition of t at line 1, characters 0-29.
-       But the kind of t must be a subkind of value mod unique
-         because of the definition of f at line 2, characters 6-44.
+       The kind of t is value mod external64, because
+         of the definition of t at line 1, characters 0-29.
+       But the kind of t must be a subkind of value mod unique, because
+         of the definition of f at line 2, characters 6-44.
 |}]
 
 module A : sig
@@ -562,10 +562,10 @@ module A : sig type t : value end
 Line 7, characters 0-24:
 7 | type t : immediate = A.t
     ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type A.t is value
-         because of the definition of t at line 2, characters 2-16.
-       But the kind of type A.t must be a subkind of immediate
-         because of the definition of t at line 7, characters 0-24.
+Error: The kind of type A.t is value, because
+         of the definition of t at line 2, characters 2-16.
+       But the kind of type A.t must be a subkind of immediate, because
+         of the definition of t at line 7, characters 0-24.
 |}]
 
 type t : value = private int
@@ -691,10 +691,10 @@ type t : any mod global = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod global = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod global, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod unique = { x : string }
@@ -702,10 +702,10 @@ type t : any mod unique = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod unique = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod unique
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod unique, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod external_ = { x : string }
@@ -713,10 +713,10 @@ type t : any mod external_ = { x : string }
 Line 1, characters 0-43:
 1 | type t : any mod external_ = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod external_, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod many = { x : string }
@@ -726,10 +726,10 @@ type t : any mod uncontended = { x : string }
 Line 1, characters 0-38:
 1 | type t : any mod many = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod many
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod many, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
 
@@ -738,10 +738,10 @@ type t : any mod many = { x : t_value }
 Line 1, characters 0-39:
 1 | type t : any mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod many
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod many, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod uncontended = { x : t_value }
@@ -749,10 +749,10 @@ type t : any mod uncontended = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : any mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod uncontended
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod uncontended, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod portable = { x : t_value }
@@ -760,10 +760,10 @@ type t : any mod portable = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : any mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod portable, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod many uncontended portable global = { x : t_value }
@@ -771,11 +771,11 @@ type t : any mod many uncontended portable global = { x : t_value }
 Line 1, characters 0-67:
 1 | type t : any mod many uncontended portable global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
+Error: The kind of type t is value, because
+         it's a boxed record type.
        But the kind of type t must be a subkind of
-         any mod global many uncontended portable
-         because of the annotation on the declaration of the type t.
+         any mod global many uncontended portable, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type u : immediate
@@ -785,11 +785,11 @@ type u : immediate
 Line 2, characters 0-77:
 2 | type t : value mod portable many uncontended = { x : string; y : int; z : u }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
+Error: The kind of type t is value, because
+         it's a boxed record type.
        But the kind of type t must be a subkind of
-         value mod many uncontended portable
-         because of the annotation on the declaration of the type t.
+         value mod many uncontended portable, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
 
@@ -802,10 +802,10 @@ Line 2, characters 43-59:
                                                ^^^^^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod external_)
-       The kind of t is value
-         because of the definition of t at line 1, characters 0-23.
-       But the kind of t must be a subkind of value mod external_
-         because of the annotation on the wildcard _ at line 2, characters 20-39.
+       The kind of t is value, because
+         of the definition of t at line 1, characters 0-23.
+       But the kind of t must be a subkind of value mod external_, because
+         of the annotation on the wildcard _ at line 2, characters 20-39.
 |}]
 
 type t : any mod uncontended = { x : int }
@@ -815,10 +815,10 @@ type t : any mod many = { x : int }
 Line 1, characters 0-42:
 1 | type t : any mod uncontended = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod uncontended
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod uncontended, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -827,10 +827,10 @@ type t : any mod global = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod global, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod external_ = { x : int }
@@ -838,10 +838,10 @@ type t : any mod external_ = { x : int }
 Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod external_, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod unique = { x : int }
@@ -849,10 +849,10 @@ type t : any mod unique = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod unique = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of any mod unique
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of any mod unique, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod global = { x : int } [@@unboxed]
@@ -899,10 +899,10 @@ type t : any mod global = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod global, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod portable = { x : u } [@@unboxed]
@@ -910,10 +910,10 @@ type t : any mod portable = { x : u } [@@unboxed]
 Line 1, characters 0-49:
 1 | type t : any mod portable = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod portable, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod uncontended = { x : u } [@@unboxed]
@@ -921,10 +921,10 @@ type t : any mod uncontended = { x : u } [@@unboxed]
 Line 1, characters 0-52:
 1 | type t : any mod uncontended = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod uncontended
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod uncontended, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod external_ = { x : u } [@@unboxed]
@@ -932,10 +932,10 @@ type t : any mod external_ = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod external_ = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod external_, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod many = { x : u } [@@unboxed]
@@ -943,10 +943,10 @@ type t : any mod many = { x : u } [@@unboxed]
 Line 1, characters 0-45:
 1 | type t : any mod many = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod many
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod many, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod unique = { x : u } [@@unboxed]
@@ -954,10 +954,10 @@ type t : any mod unique = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod unique = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod unique
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod unique, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod global = { x : int } [@@unboxed]
@@ -974,10 +974,10 @@ type ('a : immediate) t : value mod many portable = { mutable x : 'a }
 Line 1, characters 0-70:
 1 | type ('a : immediate) t : value mod many portable = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many portable
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod many portable, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -986,10 +986,10 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod unique = { mutable x : 'a }
@@ -997,10 +997,10 @@ type ('a : immediate) t : value mod unique = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod unique = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod unique, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
@@ -1008,10 +1008,10 @@ type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
 Line 1, characters 0-68:
 1 | type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod uncontended
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod uncontended, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod external_ = { mutable x : 'a }
@@ -1019,10 +1019,10 @@ type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod external_, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod external64 = { mutable x : 'a }
@@ -1030,10 +1030,10 @@ type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external64
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod external64, because
+         of the annotation on the declaration of the type t.
 |}]
 
 (*************************************)
@@ -1062,10 +1062,10 @@ type t : any mod many = Foo of int | Bar
 Line 1, characters 0-47:
 1 | type t : any mod uncontended = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod uncontended
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod uncontended, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1074,10 +1074,10 @@ type t : any mod unique = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod unique = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod unique
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod unique, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod global = Foo of int | Bar
@@ -1085,10 +1085,10 @@ type t : any mod global = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod global, because
+         of the annotation on the declaration of the type t.
 |}]
 
 
@@ -1097,10 +1097,10 @@ type t : any mod external_ = Foo of int | Bar
 Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod external_, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1133,10 +1133,10 @@ type t : any mod portable = Foo of string [@@unboxed]
 Line 1, characters 0-53:
 1 | type t : any mod portable = Foo of string [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it is the primitive value type string.
-       But the kind of type t must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it is the primitive value type string.
+       But the kind of type t must be a subkind of any mod portable, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted portability *)
 
@@ -1149,12 +1149,12 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-67:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   { x : 'a @@ global portable uncontended many unique } [@@unboxed]
-Error: The kind of type t is value
-         because it instantiates an unannotated type parameter of t,
+Error: The kind of type t is value, because
+         it instantiates an unannotated type parameter of t,
          defaulted to kind value.
        But the kind of type t must be a subkind of
-         value mod global unique many uncontended portable
-         because of the annotation on the declaration of the type t.
+         value mod global unique many uncontended portable, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1164,12 +1164,12 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-66:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The kind of type t is value
-         because it instantiates an unannotated type parameter of t,
+Error: The kind of type t is value, because
+         it instantiates an unannotated type parameter of t,
          defaulted to kind value.
        But the kind of type t must be a subkind of
-         value mod global unique many uncontended portable
-         because of the annotation on the declaration of the type t.
+         value mod global unique many uncontended portable, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1194,11 +1194,11 @@ type ('a : value mod uncontended many) t : value mod uncontended many unique =
 Lines 1-2, characters 0-34:
 1 | type ('a : value mod uncontended many) t : value mod uncontended many unique =
 2 |   { x : 'a @@ unique } [@@unboxed]
-Error: The kind of type t is value mod many uncontended
-         because of the annotation on 'a in the declaration of the type t.
+Error: The kind of type t is value mod many uncontended, because
+         of the annotation on 'a in the declaration of the type t.
        But the kind of type t must be a subkind of
-         value mod unique many uncontended
-         because of the annotation on the declaration of the type t.
+         value mod unique many uncontended, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1208,10 +1208,10 @@ type ('a : value mod external_) t : immediate =
 Lines 1-2, characters 0-66:
 1 | type ('a : value mod external_) t : immediate =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The kind of type t is value mod external_
-         because of the annotation on 'a in the declaration of the type t.
-       But the kind of type t must be a subkind of immediate
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value mod external_, because
+         of the annotation on 'a in the declaration of the type t.
+       But the kind of type t must be a subkind of immediate, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1222,10 +1222,10 @@ type 'a t : value mod portable = { x : 'a @@ portable }
 Line 1, characters 0-47:
 1 | type 'a t : value mod many = { x : 'a @@ many }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod many, because
+         of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1234,10 +1234,10 @@ type 'a t : value mod unique = { x : 'a @@ unique }
 Line 1, characters 0-51:
 1 | type 'a t : value mod unique = { x : 'a @@ unique }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod unique, because
+         of the annotation on the declaration of the type t.
 |}]
 
 type 'a t : value mod global = { x : 'a @@ global }
@@ -1245,10 +1245,10 @@ type 'a t : value mod global = { x : 'a @@ global }
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value
-         because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: The kind of type t is value, because
+         it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global, because
+         of the annotation on the declaration of the type t.
 |}]
 
 (*****************************)
@@ -1277,10 +1277,10 @@ Line 1, characters 23-34:
 1 | type ('a : bits32) t = ('a : word)
                            ^^^^^^^^^^^
 Error: This type ('a : word) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32
-         because of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with word
-         because of the annotation on the type variable 'a.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with word, because
+         of the annotation on the type variable 'a.
 |}]
 
 let f : ('a : any mod global unique) -> ('a: any mod uncontended) = fun x -> x
@@ -1298,10 +1298,10 @@ Line 1, characters 29-36:
 1 | let f : ('a : value) -> ('a: float32) = fun x -> x
                                  ^^^^^^^
 Error: Bad layout annotation:
-         The layout of 'a is value
-           because of the annotation on the type variable 'a.
-         But the layout of 'a must overlap with float32
-           because of the annotation on the type variable 'a.
+         The layout of 'a is value, because
+           of the annotation on the type variable 'a.
+         But the layout of 'a must overlap with float32, because
+           of the annotation on the type variable 'a.
 |}]
 
 val x : 'a. ('a : value mod global)
@@ -1310,8 +1310,8 @@ Line 1, characters 8-35:
 1 | val x : 'a. ('a : value mod global)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was defaulted to have kind value.
-       But it was inferred to have kind value mod global
-         because of the annotation on the type variable 'a.
+       But it was inferred to have kind value mod global, because
+         of the annotation on the type variable 'a.
 |}]
 
 (*****************)
@@ -1383,10 +1383,10 @@ Line 17, characters 6-7:
            ^
 Error: This expression has type a but an expression was expected of type
          ('a : immediate)
-       The kind of a is value
-         because of the annotation on the abstract type declaration for a.
-       But the kind of a must be a subkind of immediate
-         because of the definition of f at line 16, characters 10-41.
+       The kind of a is value, because
+         of the annotation on the abstract type declaration for a.
+       But the kind of a must be a subkind of immediate, because
+         of the definition of f at line 16, characters 10-41.
 |}]
 
 (********************)
@@ -1402,10 +1402,10 @@ type t : value mod global = < >
 Line 1, characters 0-31:
 1 | type t : value mod global = < >
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type <  > is value
-         because it's the type of an object.
-       But the kind of type <  > must be a subkind of value mod global
-         because of the definition of t at line 1, characters 0-31.
+Error: The kind of type <  > is value, because
+         it's the type of an object.
+       But the kind of type <  > must be a subkind of value mod global, because
+         of the definition of t at line 1, characters 0-31.
 |}]
 
 let x : (_ as (_ : value)) = object end
@@ -1420,10 +1420,10 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod global)
-       The kind of <  > is value
-         because it's the type of an object.
-       But the kind of <  > must be a subkind of value mod global
-         because of the annotation on the wildcard _ at line 1, characters 19-35.
+       The kind of <  > is value, because
+         it's the type of an object.
+       But the kind of <  > must be a subkind of value mod global, because
+         of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
 let x : (_ as (_ : value mod many)) = object end
@@ -1433,10 +1433,10 @@ Line 1, characters 38-48:
                                           ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod many)
-       The kind of <  > is value
-         because it's the type of an object.
-       But the kind of <  > must be a subkind of value mod many
-         because of the annotation on the wildcard _ at line 1, characters 19-33.
+       The kind of <  > is value, because
+         it's the type of an object.
+       But the kind of <  > must be a subkind of value mod many, because
+         of the annotation on the wildcard _ at line 1, characters 19-33.
 |}]
 
 let x : (_ as (_ : value mod unique)) = object end
@@ -1446,10 +1446,10 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod unique)
-       The kind of <  > is value
-         because it's the type of an object.
-       But the kind of <  > must be a subkind of value mod unique
-         because of the annotation on the wildcard _ at line 1, characters 19-35.
+       The kind of <  > is value, because
+         it's the type of an object.
+       But the kind of <  > must be a subkind of value mod unique, because
+         of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
 let x : (_ as (_ : value mod portable)) = object end
@@ -1459,10 +1459,10 @@ Line 1, characters 42-52:
                                               ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod portable)
-       The kind of <  > is value
-         because it's the type of an object.
-       But the kind of <  > must be a subkind of value mod portable
-         because of the annotation on the wildcard _ at line 1, characters 19-37.
+       The kind of <  > is value, because
+         it's the type of an object.
+       But the kind of <  > must be a subkind of value mod portable, because
+         of the annotation on the wildcard _ at line 1, characters 19-37.
 |}]
 
 let x : (_ as (_ : value mod uncontended)) = object end
@@ -1472,10 +1472,10 @@ Line 1, characters 45-55:
                                                  ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod uncontended)
-       The kind of <  > is value
-         because it's the type of an object.
-       But the kind of <  > must be a subkind of value mod uncontended
-         because of the annotation on the wildcard _ at line 1, characters 19-40.
+       The kind of <  > is value, because
+         it's the type of an object.
+       But the kind of <  > must be a subkind of value mod uncontended, because
+         of the annotation on the wildcard _ at line 1, characters 19-40.
 |}]
 
 let x : (_ as (_ : value mod external_)) = object end
@@ -1485,10 +1485,10 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod external_)
-       The kind of <  > is value
-         because it's the type of an object.
-       But the kind of <  > must be a subkind of value mod external_
-         because of the annotation on the wildcard _ at line 1, characters 19-38.
+       The kind of <  > is value, because
+         it's the type of an object.
+       But the kind of <  > must be a subkind of value mod external_, because
+         of the annotation on the wildcard _ at line 1, characters 19-38.
 |}]
 
 (****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -114,10 +114,10 @@ type a : any
 Line 2, characters 0-18:
 2 | type b : value = a
     ^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is any, because
-         of the definition of a at line 1, characters 0-12.
-       But the layout of type a must be a sublayout of value, because
-         of the definition of b at line 2, characters 0-18.
+Error: The layout of type a is any
+         because of the definition of a at line 1, characters 0-12.
+       But the layout of type a must be a sublayout of value
+         because of the definition of b at line 2, characters 0-18.
 |}]
 
 type a : float32
@@ -141,10 +141,10 @@ type a : any
 Line 2, characters 0-20:
 2 | type b : float32 = a
     ^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is any, because
-         of the definition of a at line 1, characters 0-12.
-       But the layout of type a must be a sublayout of float32, because
-         of the definition of b at line 2, characters 0-20.
+Error: The layout of type a is any
+         because of the definition of a at line 1, characters 0-12.
+       But the layout of type a must be a sublayout of float32
+         because of the definition of b at line 2, characters 0-20.
 |}]
 
 type a : float32
@@ -154,10 +154,10 @@ type a : float32
 Line 2, characters 0-17:
 2 | type b : word = a
     ^^^^^^^^^^^^^^^^^
-Error: The layout of type a is float32, because
-         of the definition of a at line 1, characters 0-16.
-       But the layout of type a must be a sublayout of word, because
-         of the definition of b at line 2, characters 0-17.
+Error: The layout of type a is float32
+         because of the definition of a at line 1, characters 0-16.
+       But the layout of type a must be a sublayout of word
+         because of the definition of b at line 2, characters 0-17.
 |}]
 
 type a : value mod local
@@ -188,10 +188,10 @@ type a : value mod local
 Line 2, characters 0-29:
 2 | type b : value mod global = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type a is value, because
-         of the definition of a at line 1, characters 0-24.
-       But the kind of type a must be a subkind of value mod global, because
-         of the definition of b at line 2, characters 0-29.
+Error: The kind of type a is value
+         because of the definition of a at line 1, characters 0-24.
+       But the kind of type a must be a subkind of value mod global
+         because of the definition of b at line 2, characters 0-29.
 |}]
 
 type a : value mod global
@@ -208,10 +208,10 @@ type a : value mod global
 Line 2, characters 0-30:
 2 | type b : float32 mod local = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type a is value, because
-         of the definition of a at line 1, characters 0-25.
-       But the layout of type a must be a sublayout of float32, because
-         of the definition of b at line 2, characters 0-30.
+Error: The layout of type a is value
+         because of the definition of a at line 1, characters 0-25.
+       But the layout of type a must be a sublayout of float32
+         because of the definition of b at line 2, characters 0-30.
 |}]
 
 type a : value mod global unique many uncontended portable external_
@@ -229,10 +229,10 @@ Line 2, characters 0-73:
 2 | type b : value mod local shared many uncontended nonportable internal = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type a is
-         value mod global unique uncontended portable external_, because
-         of the definition of a at line 1, characters 0-68.
-       But the kind of type a must be a subkind of value mod many uncontended, because
-         of the definition of b at line 2, characters 0-73.
+         value mod global unique uncontended portable external_
+         because of the definition of a at line 1, characters 0-68.
+       But the kind of type a must be a subkind of value mod many uncontended
+         because of the definition of b at line 2, characters 0-73.
 |}]
 
 (********************************************************)
@@ -412,10 +412,10 @@ type t : any mod global = t_value
 Line 1, characters 0-33:
 1 | type t : any mod global = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod global, because
-         of the definition of t at line 1, characters 0-33.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod global
+         because of the definition of t at line 1, characters 0-33.
 |}]
 
 type t : any mod unique = t_value
@@ -423,10 +423,10 @@ type t : any mod unique = t_value
 Line 1, characters 0-33:
 1 | type t : any mod unique = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod unique, because
-         of the definition of t at line 1, characters 0-33.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod unique
+         because of the definition of t at line 1, characters 0-33.
 |}]
 
 type t : any mod many = t_value
@@ -434,10 +434,10 @@ type t : any mod many = t_value
 Line 1, characters 0-31:
 1 | type t : any mod many = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod many, because
-         of the definition of t at line 1, characters 0-31.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod many
+         because of the definition of t at line 1, characters 0-31.
 |}]
 
 type t : any mod uncontended = t_value
@@ -445,10 +445,10 @@ type t : any mod uncontended = t_value
 Line 1, characters 0-38:
 1 | type t : any mod uncontended = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod uncontended, because
-         of the definition of t at line 1, characters 0-38.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod uncontended
+         because of the definition of t at line 1, characters 0-38.
 |}]
 
 type t : any mod portable = t_value
@@ -456,10 +456,10 @@ type t : any mod portable = t_value
 Line 1, characters 0-35:
 1 | type t : any mod portable = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod portable, because
-         of the definition of t at line 1, characters 0-35.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod portable
+         because of the definition of t at line 1, characters 0-35.
 |}]
 
 type t : any mod external_ = t_value
@@ -467,10 +467,10 @@ type t : any mod external_ = t_value
 Line 1, characters 0-36:
 1 | type t : any mod external_ = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
-         of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod external_, because
-         of the definition of t at line 1, characters 0-36.
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of any mod external_
+         because of the definition of t at line 1, characters 0-36.
 |}]
 
 type ('a : value mod unique) t = { unique_field : 'a }
@@ -482,10 +482,10 @@ Line 2, characters 25-33:
                              ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod unique)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of value mod unique, because
-         of the definition of t at line 1, characters 0-54.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of value mod unique
+         because of the definition of t at line 1, characters 0-54.
 |}]
 
 type t : value mod global
@@ -504,10 +504,10 @@ Line 2, characters 42-43:
                                               ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod global)
-       The kind of t is value mod many, because
-         of the definition of t at line 1, characters 0-23.
-       But the kind of t must be a subkind of value mod global, because
-         of the annotation on the type variable 'a.
+       The kind of t is value mod many
+         because of the definition of t at line 1, characters 0-23.
+       But the kind of t must be a subkind of value mod global
+         because of the annotation on the type variable 'a.
 |}]
 
 type t : value mod unique
@@ -530,10 +530,10 @@ Line 3, characters 18-19:
                       ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod unique)
-       The kind of t is value mod external64, because
-         of the definition of t at line 1, characters 0-29.
-       But the kind of t must be a subkind of value mod unique, because
-         of the definition of f at line 2, characters 6-44.
+       The kind of t is value mod external64
+         because of the definition of t at line 1, characters 0-29.
+       But the kind of t must be a subkind of value mod unique
+         because of the definition of f at line 2, characters 6-44.
 |}]
 
 module A : sig
@@ -562,10 +562,10 @@ module A : sig type t : value end
 Line 7, characters 0-24:
 7 | type t : immediate = A.t
     ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type A.t is value, because
-         of the definition of t at line 2, characters 2-16.
-       But the kind of type A.t must be a subkind of immediate, because
-         of the definition of t at line 7, characters 0-24.
+Error: The kind of type A.t is value
+         because of the definition of t at line 2, characters 2-16.
+       But the kind of type A.t must be a subkind of immediate
+         because of the definition of t at line 7, characters 0-24.
 |}]
 
 type t : value = private int
@@ -691,10 +691,10 @@ type t : any mod global = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod global = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod unique = { x : string }
@@ -702,10 +702,10 @@ type t : any mod unique = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod unique = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod external_ = { x : string }
@@ -713,10 +713,10 @@ type t : any mod external_ = { x : string }
 Line 1, characters 0-43:
 1 | type t : any mod external_ = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod many = { x : string }
@@ -726,10 +726,10 @@ type t : any mod uncontended = { x : string }
 Line 1, characters 0-38:
 1 | type t : any mod many = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod many, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod many
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
 
@@ -738,10 +738,10 @@ type t : any mod many = { x : t_value }
 Line 1, characters 0-39:
 1 | type t : any mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod many, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod many
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod uncontended = { x : t_value }
@@ -749,10 +749,10 @@ type t : any mod uncontended = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : any mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod portable = { x : t_value }
@@ -760,10 +760,10 @@ type t : any mod portable = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : any mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod portable
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod many uncontended portable global = { x : t_value }
@@ -771,11 +771,11 @@ type t : any mod many uncontended portable global = { x : t_value }
 Line 1, characters 0-67:
 1 | type t : any mod many uncontended portable global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
+Error: The kind of type t is value
+         because it's a boxed record type.
        But the kind of type t must be a subkind of
-         any mod global many uncontended portable, because
-         of the annotation on the declaration of the type t.
+         any mod global many uncontended portable
+         because of the annotation on the declaration of the type t.
 |}]
 
 type u : immediate
@@ -785,11 +785,11 @@ type u : immediate
 Line 2, characters 0-77:
 2 | type t : value mod portable many uncontended = { x : string; y : int; z : u }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
+Error: The kind of type t is value
+         because it's a boxed record type.
        But the kind of type t must be a subkind of
-         value mod many uncontended portable, because
-         of the annotation on the declaration of the type t.
+         value mod many uncontended portable
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
 
@@ -802,10 +802,10 @@ Line 2, characters 43-59:
                                                ^^^^^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod external_)
-       The kind of t is value, because
-         of the definition of t at line 1, characters 0-23.
-       But the kind of t must be a subkind of value mod external_, because
-         of the annotation on the wildcard _ at line 2, characters 20-39.
+       The kind of t is value
+         because of the definition of t at line 1, characters 0-23.
+       But the kind of t must be a subkind of value mod external_
+         because of the annotation on the wildcard _ at line 2, characters 20-39.
 |}]
 
 type t : any mod uncontended = { x : int }
@@ -815,10 +815,10 @@ type t : any mod many = { x : int }
 Line 1, characters 0-42:
 1 | type t : any mod uncontended = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -827,10 +827,10 @@ type t : any mod global = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod external_ = { x : int }
@@ -838,10 +838,10 @@ type t : any mod external_ = { x : int }
 Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod unique = { x : int }
@@ -849,10 +849,10 @@ type t : any mod unique = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod unique = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of any mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of any mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod global = { x : int } [@@unboxed]
@@ -899,10 +899,10 @@ type t : any mod global = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod portable = { x : u } [@@unboxed]
@@ -910,10 +910,10 @@ type t : any mod portable = { x : u } [@@unboxed]
 Line 1, characters 0-49:
 1 | type t : any mod portable = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod portable
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod uncontended = { x : u } [@@unboxed]
@@ -921,10 +921,10 @@ type t : any mod uncontended = { x : u } [@@unboxed]
 Line 1, characters 0-52:
 1 | type t : any mod uncontended = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod external_ = { x : u } [@@unboxed]
@@ -932,10 +932,10 @@ type t : any mod external_ = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod external_ = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod many = { x : u } [@@unboxed]
@@ -943,10 +943,10 @@ type t : any mod many = { x : u } [@@unboxed]
 Line 1, characters 0-45:
 1 | type t : any mod many = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod many, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod many
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod unique = { x : u } [@@unboxed]
@@ -954,10 +954,10 @@ type t : any mod unique = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod unique = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because of the definition of u at line 1, characters 0-14.
+       But the kind of type t must be a subkind of any mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : value mod global = { x : int } [@@unboxed]
@@ -974,10 +974,10 @@ type ('a : immediate) t : value mod many portable = { mutable x : 'a }
 Line 1, characters 0-70:
 1 | type ('a : immediate) t : value mod many portable = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod many portable
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -986,10 +986,10 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod unique = { mutable x : 'a }
@@ -997,10 +997,10 @@ type ('a : immediate) t : value mod unique = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod unique = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
@@ -1008,10 +1008,10 @@ type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
 Line 1, characters 0-68:
 1 | type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod external_ = { mutable x : 'a }
@@ -1019,10 +1019,10 @@ type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 
 type ('a : immediate) t : value mod external64 = { mutable x : 'a }
@@ -1030,10 +1030,10 @@ type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external64, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod external64
+         because of the annotation on the declaration of the type t.
 |}]
 
 (*************************************)
@@ -1062,10 +1062,10 @@ type t : any mod many = Foo of int | Bar
 Line 1, characters 0-47:
 1 | type t : any mod uncontended = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod uncontended, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1074,10 +1074,10 @@ type t : any mod unique = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod unique = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod global = Foo of int | Bar
@@ -1085,10 +1085,10 @@ type t : any mod global = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 
@@ -1097,10 +1097,10 @@ type t : any mod external_ = Foo of int | Bar
 Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod external_, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed variant type.
+       But the kind of type t must be a subkind of any mod external_
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
   mismatch, not a layout mismatch. *)
@@ -1133,10 +1133,10 @@ type t : any mod portable = Foo of string [@@unboxed]
 Line 1, characters 0-53:
 1 | type t : any mod portable = Foo of string [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it is the primitive value type string.
-       But the kind of type t must be a subkind of any mod portable, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it is the primitive value type string.
+       But the kind of type t must be a subkind of any mod portable
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted portability *)
 
@@ -1149,12 +1149,12 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-67:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   { x : 'a @@ global portable uncontended many unique } [@@unboxed]
-Error: The kind of type t is value, because
-         it instantiates an unannotated type parameter of t,
+Error: The kind of type t is value
+         because it instantiates an unannotated type parameter of t,
          defaulted to kind value.
        But the kind of type t must be a subkind of
-         value mod global unique many uncontended portable, because
-         of the annotation on the declaration of the type t.
+         value mod global unique many uncontended portable
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1164,12 +1164,12 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-66:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The kind of type t is value, because
-         it instantiates an unannotated type parameter of t,
+Error: The kind of type t is value
+         because it instantiates an unannotated type parameter of t,
          defaulted to kind value.
        But the kind of type t must be a subkind of
-         value mod global unique many uncontended portable, because
-         of the annotation on the declaration of the type t.
+         value mod global unique many uncontended portable
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1194,11 +1194,11 @@ type ('a : value mod uncontended many) t : value mod uncontended many unique =
 Lines 1-2, characters 0-34:
 1 | type ('a : value mod uncontended many) t : value mod uncontended many unique =
 2 |   { x : 'a @@ unique } [@@unboxed]
-Error: The kind of type t is value mod many uncontended, because
-         of the annotation on 'a in the declaration of the type t.
+Error: The kind of type t is value mod many uncontended
+         because of the annotation on 'a in the declaration of the type t.
        But the kind of type t must be a subkind of
-         value mod unique many uncontended, because
-         of the annotation on the declaration of the type t.
+         value mod unique many uncontended
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1208,10 +1208,10 @@ type ('a : value mod external_) t : immediate =
 Lines 1-2, characters 0-66:
 1 | type ('a : value mod external_) t : immediate =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The kind of type t is value mod external_, because
-         of the annotation on 'a in the declaration of the type t.
-       But the kind of type t must be a subkind of immediate, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value mod external_
+         because of the annotation on 'a in the declaration of the type t.
+       But the kind of type t must be a subkind of immediate
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1222,10 +1222,10 @@ type 'a t : value mod portable = { x : 'a @@ portable }
 Line 1, characters 0-47:
 1 | type 'a t : value mod many = { x : 'a @@ many }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod many
+         because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
@@ -1234,10 +1234,10 @@ type 'a t : value mod unique = { x : 'a @@ unique }
 Line 1, characters 0-51:
 1 | type 'a t : value mod unique = { x : 'a @@ unique }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod unique
+         because of the annotation on the declaration of the type t.
 |}]
 
 type 'a t : value mod global = { x : 'a @@ global }
@@ -1245,10 +1245,10 @@ type 'a t : value mod global = { x : 'a @@ global }
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
-         it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global, because
-         of the annotation on the declaration of the type t.
+Error: The kind of type t is value
+         because it's a boxed record type.
+       But the kind of type t must be a subkind of value mod global
+         because of the annotation on the declaration of the type t.
 |}]
 
 (*****************************)
@@ -1277,10 +1277,10 @@ Line 1, characters 23-34:
 1 | type ('a : bits32) t = ('a : word)
                            ^^^^^^^^^^^
 Error: This type ('a : word) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with word, because
-         of the annotation on the type variable 'a.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with word
+         because of the annotation on the type variable 'a.
 |}]
 
 let f : ('a : any mod global unique) -> ('a: any mod uncontended) = fun x -> x
@@ -1298,10 +1298,10 @@ Line 1, characters 29-36:
 1 | let f : ('a : value) -> ('a: float32) = fun x -> x
                                  ^^^^^^^
 Error: Bad layout annotation:
-         The layout of 'a is value, because
-           of the annotation on the type variable 'a.
-         But the layout of 'a must overlap with float32, because
-           of the annotation on the type variable 'a.
+         The layout of 'a is value
+           because of the annotation on the type variable 'a.
+         But the layout of 'a must overlap with float32
+           because of the annotation on the type variable 'a.
 |}]
 
 val x : 'a. ('a : value mod global)
@@ -1310,8 +1310,8 @@ Line 1, characters 8-35:
 1 | val x : 'a. ('a : value mod global)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was defaulted to have kind value.
-       But it was inferred to have kind value mod global, because
-         of the annotation on the type variable 'a.
+       But it was inferred to have kind value mod global
+         because of the annotation on the type variable 'a.
 |}]
 
 (*****************)
@@ -1383,10 +1383,10 @@ Line 17, characters 6-7:
            ^
 Error: This expression has type a but an expression was expected of type
          ('a : immediate)
-       The kind of a is value, because
-         of the annotation on the abstract type declaration for a.
-       But the kind of a must be a subkind of immediate, because
-         of the definition of f at line 16, characters 10-41.
+       The kind of a is value
+         because of the annotation on the abstract type declaration for a.
+       But the kind of a must be a subkind of immediate
+         because of the definition of f at line 16, characters 10-41.
 |}]
 
 (********************)
@@ -1402,10 +1402,10 @@ type t : value mod global = < >
 Line 1, characters 0-31:
 1 | type t : value mod global = < >
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type <  > is value, because
-         it's the type of an object.
-       But the kind of type <  > must be a subkind of value mod global, because
-         of the definition of t at line 1, characters 0-31.
+Error: The kind of type <  > is value
+         because it's the type of an object.
+       But the kind of type <  > must be a subkind of value mod global
+         because of the definition of t at line 1, characters 0-31.
 |}]
 
 let x : (_ as (_ : value)) = object end
@@ -1420,10 +1420,10 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod global)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod global, because
-         of the annotation on the wildcard _ at line 1, characters 19-35.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod global
+         because of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
 let x : (_ as (_ : value mod many)) = object end
@@ -1433,10 +1433,10 @@ Line 1, characters 38-48:
                                           ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod many)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod many, because
-         of the annotation on the wildcard _ at line 1, characters 19-33.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod many
+         because of the annotation on the wildcard _ at line 1, characters 19-33.
 |}]
 
 let x : (_ as (_ : value mod unique)) = object end
@@ -1446,10 +1446,10 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod unique)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod unique, because
-         of the annotation on the wildcard _ at line 1, characters 19-35.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod unique
+         because of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
 let x : (_ as (_ : value mod portable)) = object end
@@ -1459,10 +1459,10 @@ Line 1, characters 42-52:
                                               ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod portable)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod portable, because
-         of the annotation on the wildcard _ at line 1, characters 19-37.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod portable
+         because of the annotation on the wildcard _ at line 1, characters 19-37.
 |}]
 
 let x : (_ as (_ : value mod uncontended)) = object end
@@ -1472,10 +1472,10 @@ Line 1, characters 45-55:
                                                  ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod uncontended)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod uncontended, because
-         of the annotation on the wildcard _ at line 1, characters 19-40.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod uncontended
+         because of the annotation on the wildcard _ at line 1, characters 19-40.
 |}]
 
 let x : (_ as (_ : value mod external_)) = object end
@@ -1485,10 +1485,10 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod external_)
-       The kind of <  > is value, because
-         it's the type of an object.
-       But the kind of <  > must be a subkind of value mod external_, because
-         of the annotation on the wildcard _ at line 1, characters 19-38.
+       The kind of <  > is value
+         because it's the type of an object.
+       But the kind of <  > must be a subkind of value mod external_
+         because of the annotation on the wildcard _ at line 1, characters 19-38.
 |}]
 
 (****************************************)

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -188,9 +188,9 @@ type a : value mod local
 Line 2, characters 0-29:
 2 | type b : value mod global = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type a is value, because
+Error: The layout of type a is value, because
          of the definition of a at line 1, characters 0-24.
-       But the kind of type a must be a subkind of value mod global, because
+       But the layout of type a must be a sublayout of value mod global, because
          of the definition of b at line 2, characters 0-29.
 |}]
 
@@ -228,10 +228,11 @@ type a : value mod global unique once uncontended portable external_
 Line 2, characters 0-73:
 2 | type b : value mod local shared many uncontended nonportable internal = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type a is
+Error: The layout of type a is
          value mod global unique uncontended portable external_, because
          of the definition of a at line 1, characters 0-68.
-       But the kind of type a must be a subkind of value mod many uncontended, because
+       But the layout of type a must be a sublayout of
+         value mod many uncontended, because
          of the definition of b at line 2, characters 0-73.
 |}]
 
@@ -412,9 +413,9 @@ type t : any mod global = t_value
 Line 1, characters 0-33:
 1 | type t : any mod global = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
+Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod global, because
+       But the layout of type t_value must be a sublayout of any mod global, because
          of the definition of t at line 1, characters 0-33.
 |}]
 
@@ -423,9 +424,9 @@ type t : any mod unique = t_value
 Line 1, characters 0-33:
 1 | type t : any mod unique = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
+Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod unique, because
+       But the layout of type t_value must be a sublayout of any mod unique, because
          of the definition of t at line 1, characters 0-33.
 |}]
 
@@ -434,9 +435,9 @@ type t : any mod many = t_value
 Line 1, characters 0-31:
 1 | type t : any mod many = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
+Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod many, because
+       But the layout of type t_value must be a sublayout of any mod many, because
          of the definition of t at line 1, characters 0-31.
 |}]
 
@@ -445,9 +446,10 @@ type t : any mod uncontended = t_value
 Line 1, characters 0-38:
 1 | type t : any mod uncontended = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
+Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod uncontended, because
+       But the layout of type t_value must be a sublayout of
+         any mod uncontended, because
          of the definition of t at line 1, characters 0-38.
 |}]
 
@@ -456,9 +458,9 @@ type t : any mod portable = t_value
 Line 1, characters 0-35:
 1 | type t : any mod portable = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
+Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod portable, because
+       But the layout of type t_value must be a sublayout of any mod portable, because
          of the definition of t at line 1, characters 0-35.
 |}]
 
@@ -467,9 +469,10 @@ type t : any mod external_ = t_value
 Line 1, characters 0-36:
 1 | type t : any mod external_ = t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t_value is value, because
+Error: The layout of type t_value is value, because
          of the definition of t_value at line 1, characters 0-20.
-       But the kind of type t_value must be a subkind of any mod external_, because
+       But the layout of type t_value must be a sublayout of
+         any mod external_, because
          of the definition of t at line 1, characters 0-36.
 |}]
 
@@ -482,9 +485,9 @@ Line 2, characters 25-33:
                              ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod unique)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of value mod unique, because
+       But the layout of string must be a sublayout of value mod unique, because
          of the definition of t at line 1, characters 0-54.
 |}]
 
@@ -504,9 +507,9 @@ Line 2, characters 42-43:
                                               ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod global)
-       The kind of t is value mod many, because
+       The layout of t is value mod many, because
          of the definition of t at line 1, characters 0-23.
-       But the kind of t must be a subkind of value mod global, because
+       But the layout of t must be a sublayout of value mod global, because
          of the annotation on the type variable 'a.
 |}]
 
@@ -530,9 +533,9 @@ Line 3, characters 18-19:
                       ^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod unique)
-       The kind of t is value mod external64, because
+       The layout of t is value mod external64, because
          of the definition of t at line 1, characters 0-29.
-       But the kind of t must be a subkind of value mod unique, because
+       But the layout of t must be a sublayout of value mod unique, because
          of the definition of f at line 2, characters 6-44.
 |}]
 
@@ -562,9 +565,9 @@ module A : sig type t : value end
 Line 7, characters 0-24:
 7 | type t : immediate = A.t
     ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type A.t is value, because
+Error: The layout of type A.t is value, because
          of the definition of t at line 2, characters 2-16.
-       But the kind of type A.t must be a subkind of immediate, because
+       But the layout of type A.t must be a sublayout of immediate, because
          of the definition of t at line 7, characters 0-24.
 |}]
 
@@ -691,9 +694,9 @@ type t : any mod global = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod global = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod global, because
+       But the layout of type t must be a sublayout of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -702,9 +705,9 @@ type t : any mod unique = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod unique = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod unique, because
+       But the layout of type t must be a sublayout of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -713,9 +716,9 @@ type t : any mod external_ = { x : string }
 Line 1, characters 0-43:
 1 | type t : any mod external_ = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod external_, because
+       But the layout of type t must be a sublayout of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -726,9 +729,9 @@ type t : any mod uncontended = { x : string }
 Line 1, characters 0-38:
 1 | type t : any mod many = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod many, because
+       But the layout of type t must be a sublayout of any mod many, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
@@ -738,9 +741,9 @@ type t : any mod many = { x : t_value }
 Line 1, characters 0-39:
 1 | type t : any mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod many, because
+       But the layout of type t must be a sublayout of any mod many, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -749,9 +752,9 @@ type t : any mod uncontended = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : any mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod uncontended, because
+       But the layout of type t must be a sublayout of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -760,9 +763,9 @@ type t : any mod portable = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : any mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod portable, because
+       But the layout of type t must be a sublayout of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -771,9 +774,9 @@ type t : any mod many uncontended portable global = { x : t_value }
 Line 1, characters 0-67:
 1 | type t : any mod many uncontended portable global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of
+       But the layout of type t must be a sublayout of
          any mod global many uncontended portable, because
          of the annotation on the declaration of the type t.
 |}]
@@ -785,9 +788,9 @@ type u : immediate
 Line 2, characters 0-77:
 2 | type t : value mod portable many uncontended = { x : string; y : int; z : u }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of
+       But the layout of type t must be a sublayout of
          value mod many uncontended portable, because
          of the annotation on the declaration of the type t.
 |}]
@@ -802,9 +805,9 @@ Line 2, characters 43-59:
                                                ^^^^^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod external_)
-       The kind of t is value, because
+       The layout of t is value, because
          of the definition of t at line 1, characters 0-23.
-       But the kind of t must be a subkind of value mod external_, because
+       But the layout of t must be a sublayout of value mod external_, because
          of the annotation on the wildcard _ at line 2, characters 20-39.
 |}]
 
@@ -815,9 +818,9 @@ type t : any mod many = { x : int }
 Line 1, characters 0-42:
 1 | type t : any mod uncontended = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod uncontended, because
+       But the layout of type t must be a sublayout of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -827,9 +830,9 @@ type t : any mod global = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod global, because
+       But the layout of type t must be a sublayout of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -838,9 +841,9 @@ type t : any mod external_ = { x : int }
 Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod external_, because
+       But the layout of type t must be a sublayout of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -849,9 +852,9 @@ type t : any mod unique = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod unique = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of any mod unique, because
+       But the layout of type t must be a sublayout of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -899,9 +902,9 @@ type t : any mod global = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod global, because
+       But the layout of type t must be a sublayout of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -910,9 +913,9 @@ type t : any mod portable = { x : u } [@@unboxed]
 Line 1, characters 0-49:
 1 | type t : any mod portable = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod portable, because
+       But the layout of type t must be a sublayout of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -921,9 +924,9 @@ type t : any mod uncontended = { x : u } [@@unboxed]
 Line 1, characters 0-52:
 1 | type t : any mod uncontended = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod uncontended, because
+       But the layout of type t must be a sublayout of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -932,9 +935,9 @@ type t : any mod external_ = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod external_ = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod external_, because
+       But the layout of type t must be a sublayout of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -943,9 +946,9 @@ type t : any mod many = { x : u } [@@unboxed]
 Line 1, characters 0-45:
 1 | type t : any mod many = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod many, because
+       But the layout of type t must be a sublayout of any mod many, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -954,9 +957,9 @@ type t : any mod unique = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod unique = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          of the definition of u at line 1, characters 0-14.
-       But the kind of type t must be a subkind of any mod unique, because
+       But the layout of type t must be a sublayout of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -974,9 +977,10 @@ type ('a : immediate) t : value mod many portable = { mutable x : 'a }
 Line 1, characters 0-70:
 1 | type ('a : immediate) t : value mod many portable = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many portable, because
+       But the layout of type t must be a sublayout of
+         value mod many portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -986,9 +990,9 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global, because
+       But the layout of type t must be a sublayout of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -997,9 +1001,9 @@ type ('a : immediate) t : value mod unique = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod unique = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique, because
+       But the layout of type t must be a sublayout of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1008,9 +1012,9 @@ type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
 Line 1, characters 0-68:
 1 | type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod uncontended, because
+       But the layout of type t must be a sublayout of value mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1019,9 +1023,9 @@ type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external_, because
+       But the layout of type t must be a sublayout of value mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1030,9 +1034,9 @@ type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod external64, because
+       But the layout of type t must be a sublayout of value mod external64, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1062,9 +1066,9 @@ type t : any mod many = Foo of int | Bar
 Line 1, characters 0-47:
 1 | type t : any mod uncontended = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod uncontended, because
+       But the layout of type t must be a sublayout of any mod uncontended, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1074,9 +1078,9 @@ type t : any mod unique = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod unique = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod unique, because
+       But the layout of type t must be a sublayout of any mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1085,9 +1089,9 @@ type t : any mod global = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod global, because
+       But the layout of type t must be a sublayout of any mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1097,9 +1101,9 @@ type t : any mod external_ = Foo of int | Bar
 Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed variant type.
-       But the kind of type t must be a subkind of any mod external_, because
+       But the layout of type t must be a sublayout of any mod external_, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: Bad error message. The error message should be about a kind or mode
@@ -1133,9 +1137,9 @@ type t : any mod portable = Foo of string [@@unboxed]
 Line 1, characters 0-53:
 1 | type t : any mod portable = Foo of string [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it is the primitive value type string.
-       But the kind of type t must be a subkind of any mod portable, because
+       But the layout of type t must be a sublayout of any mod portable, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted portability *)
@@ -1149,10 +1153,10 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-67:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   { x : 'a @@ global portable uncontended many unique } [@@unboxed]
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it instantiates an unannotated type parameter of t,
-         defaulted to kind value.
-       But the kind of type t must be a subkind of
+         defaulted to layout value.
+       But the layout of type t must be a sublayout of
          value mod global unique many uncontended portable, because
          of the annotation on the declaration of the type t.
 |}]
@@ -1164,10 +1168,10 @@ type 'a t : value mod global portable uncontended many unique =
 Lines 1-2, characters 0-66:
 1 | type 'a t : value mod global portable uncontended many unique =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it instantiates an unannotated type parameter of t,
-         defaulted to kind value.
-       But the kind of type t must be a subkind of
+         defaulted to layout value.
+       But the layout of type t must be a sublayout of
          value mod global unique many uncontended portable, because
          of the annotation on the declaration of the type t.
 |}]
@@ -1194,9 +1198,9 @@ type ('a : value mod uncontended many) t : value mod uncontended many unique =
 Lines 1-2, characters 0-34:
 1 | type ('a : value mod uncontended many) t : value mod uncontended many unique =
 2 |   { x : 'a @@ unique } [@@unboxed]
-Error: The kind of type t is value mod many uncontended, because
+Error: The layout of type t is value mod many uncontended, because
          of the annotation on 'a in the declaration of the type t.
-       But the kind of type t must be a subkind of
+       But the layout of type t must be a sublayout of
          value mod unique many uncontended, because
          of the annotation on the declaration of the type t.
 |}]
@@ -1208,9 +1212,9 @@ type ('a : value mod external_) t : immediate =
 Lines 1-2, characters 0-66:
 1 | type ('a : value mod external_) t : immediate =
 2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
-Error: The kind of type t is value mod external_, because
+Error: The layout of type t is value mod external_, because
          of the annotation on 'a in the declaration of the type t.
-       But the kind of type t must be a subkind of immediate, because
+       But the layout of type t must be a sublayout of immediate, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1222,9 +1226,9 @@ type 'a t : value mod portable = { x : 'a @@ portable }
 Line 1, characters 0-47:
 1 | type 'a t : value mod many = { x : 'a @@ many }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many, because
+       But the layout of type t must be a sublayout of value mod many, because
          of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1234,9 +1238,9 @@ type 'a t : value mod unique = { x : 'a @@ unique }
 Line 1, characters 0-51:
 1 | type 'a t : value mod unique = { x : 'a @@ unique }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod unique, because
+       But the layout of type t must be a sublayout of value mod unique, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1245,9 +1249,9 @@ type 'a t : value mod global = { x : 'a @@ global }
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type t is value, because
+Error: The layout of type t is value, because
          it's a boxed record type.
-       But the kind of type t must be a subkind of value mod global, because
+       But the layout of type t must be a sublayout of value mod global, because
          of the annotation on the declaration of the type t.
 |}]
 
@@ -1383,9 +1387,9 @@ Line 17, characters 6-7:
            ^
 Error: This expression has type a but an expression was expected of type
          ('a : immediate)
-       The kind of a is value, because
+       The layout of a is value, because
          of the annotation on the abstract type declaration for a.
-       But the kind of a must be a subkind of immediate, because
+       But the layout of a must be a sublayout of immediate, because
          of the definition of f at line 16, characters 10-41.
 |}]
 
@@ -1402,9 +1406,9 @@ type t : value mod global = < >
 Line 1, characters 0-31:
 1 | type t : value mod global = < >
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type <  > is value, because
+Error: The layout of type <  > is value, because
          it's the type of an object.
-       But the kind of type <  > must be a subkind of value mod global, because
+       But the layout of type <  > must be a sublayout of value mod global, because
          of the definition of t at line 1, characters 0-31.
 |}]
 
@@ -1420,9 +1424,9 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod global)
-       The kind of <  > is value, because
+       The layout of <  > is value, because
          it's the type of an object.
-       But the kind of <  > must be a subkind of value mod global, because
+       But the layout of <  > must be a sublayout of value mod global, because
          of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
@@ -1433,9 +1437,9 @@ Line 1, characters 38-48:
                                           ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod many)
-       The kind of <  > is value, because
+       The layout of <  > is value, because
          it's the type of an object.
-       But the kind of <  > must be a subkind of value mod many, because
+       But the layout of <  > must be a sublayout of value mod many, because
          of the annotation on the wildcard _ at line 1, characters 19-33.
 |}]
 
@@ -1446,9 +1450,9 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod unique)
-       The kind of <  > is value, because
+       The layout of <  > is value, because
          it's the type of an object.
-       But the kind of <  > must be a subkind of value mod unique, because
+       But the layout of <  > must be a sublayout of value mod unique, because
          of the annotation on the wildcard _ at line 1, characters 19-35.
 |}]
 
@@ -1459,9 +1463,9 @@ Line 1, characters 42-52:
                                               ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod portable)
-       The kind of <  > is value, because
+       The layout of <  > is value, because
          it's the type of an object.
-       But the kind of <  > must be a subkind of value mod portable, because
+       But the layout of <  > must be a sublayout of value mod portable, because
          of the annotation on the wildcard _ at line 1, characters 19-37.
 |}]
 
@@ -1472,9 +1476,9 @@ Line 1, characters 45-55:
                                                  ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod uncontended)
-       The kind of <  > is value, because
+       The layout of <  > is value, because
          it's the type of an object.
-       But the kind of <  > must be a subkind of value mod uncontended, because
+       But the layout of <  > must be a sublayout of value mod uncontended, because
          of the annotation on the wildcard _ at line 1, characters 19-40.
 |}]
 
@@ -1485,9 +1489,9 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type <  > but an expression was expected of type
          ('a : value mod external_)
-       The kind of <  > is value, because
+       The layout of <  > is value, because
          it's the type of an object.
-       But the kind of <  > must be a subkind of value mod external_, because
+       But the layout of <  > must be a sublayout of value mod external_, because
          of the annotation on the wildcard _ at line 1, characters 19-38.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
@@ -35,10 +35,10 @@ Line 3, characters 14-36:
                   ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_1)
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the layout polymorphic type in an external declaration
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -54,10 +54,10 @@ Line 3, characters 14-38:
                   ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_any t
        but an expression was expected of type 'a t
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the layout polymorphic type in an external declaration
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -85,10 +85,10 @@ Line 4, characters 63-68:
                                                                    ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : float64)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of float64, because
-         of the definition of id' at line 2, characters 10-18.
+       The layout of string is value
+         because it is the primitive value type string.
+       But the layout of string must be a sublayout of float64
+         because of the definition of id' at line 2, characters 10-18.
 |}]
 
 (********************)
@@ -137,10 +137,10 @@ Error: Signature mismatch:
        is not included in
          external id : ('a : any). 'a s -> 'a s = "%identity"
        The type 'a s -> 'a s is not compatible with the type 'b s -> 'b s
-       The layout of 'a is any, because
-         of the definition of id at line 3, characters 2-54.
-       But the layout of 'a must be representable, because
-         it's the layout polymorphic type in an external declaration
+       The layout of 'a is any
+         because of the definition of id at line 3, characters 2-54.
+       But the layout of 'a must be representable
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -182,10 +182,10 @@ Error: Signature mismatch:
            = "%identity" [@@layout_poly]
        The type ('a, 'b) s -> ('a, 'b) s is not compatible with the type
          (t_any, 'c) s -> (t_any, 'c) s
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the layout polymorphic type in an external declaration
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -263,10 +263,10 @@ Line 2, characters 28-30:
 2 |   external id : ('a : any). 'a -> 'a = "%identity"
                                 ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 module S : sig
@@ -280,10 +280,10 @@ Line 4, characters 28-30:
 4 |   external id : ('a : any). 'a -> 'a = "%identity"
                                 ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 (* External in struct *)
@@ -309,10 +309,10 @@ Line 1, characters 36-41:
                                         ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : float64)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of float64, because
-         of the definition of id at line 2, characters 2-35.
+       The layout of string is value
+         because it is the primitive value type string.
+       But the layout of string must be a sublayout of float64
+         because of the definition of id at line 2, characters 2-35.
 |}]
 
 
@@ -339,10 +339,10 @@ Error: Signature mismatch:
        is not included in
          val id : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is any, because
-         of the definition of id at line 2, characters 2-31.
-       But the layout of 'a must be representable, because
-         it's the layout polymorphic type in an external declaration
+       The layout of 'a is any
+         because of the definition of id at line 2, characters 2-31.
+       But the layout of 'a must be representable
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -397,10 +397,10 @@ Line 9, characters 49-51:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of a1 is any, because
-         of the annotation on the abstract type declaration for a1.
-       But the layout of a1 must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of a1 is any
+         because of the annotation on the abstract type declaration for a1.
+       But the layout of a1 must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 let f (type a2 : any) () =
@@ -417,10 +417,10 @@ Line 4, characters 49-62:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of a2 t_with_any is any, because
-         of the annotation on the abstract type declaration for a2.
-       But the layout of a2 t_with_any must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of a2 t_with_any is any
+         because of the annotation on the abstract type declaration for a2.
+       But the layout of a2 t_with_any must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 let f (type a3 : any) () =
@@ -437,10 +437,10 @@ Line 4, characters 49-59:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of a3 M_any.t is any, because
-         of the annotation on the abstract type declaration for a3.
-       But the layout of a3 M_any.t must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of a3 M_any.t is any
+         because of the annotation on the abstract type declaration for a3.
+       But the layout of a3 M_any.t must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 module type S4 = sig
@@ -482,10 +482,10 @@ Line 4, characters 48-51:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of A.t is any, because
-         of the definition of t at line 2, characters 2-13.
-       But the layout of A.t must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of A.t is any
+         because of the definition of t at line 2, characters 2-13.
+       But the layout of A.t must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 module M (A : sig
@@ -545,10 +545,10 @@ Line 2, characters 28-32:
                                 ^^^^
 Error: This expression has type ('a : float64)
        but an expression was expected of type int64#
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of float64, because
-         it's the layout polymorphic type in an external declaration
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of float64
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites),
          defaulted to layout float64.
@@ -628,8 +628,8 @@ Line 1, characters 28-58:
 1 | external[@layout_poly] id : ('a : any). 'a list -> 'a list = "%identity"
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind any.
-       But it was inferred to have kind value, because
-         the type argument of list has kind value.
+       But it was inferred to have kind value
+         because the type argument of list has kind value.
 |}]
 
 (* Test this when sorts can be inside unboxed records *)

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
@@ -35,10 +35,10 @@ Line 3, characters 14-36:
                   ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_1)
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the layout polymorphic type in an external declaration
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -54,10 +54,10 @@ Line 3, characters 14-38:
                   ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_any t
        but an expression was expected of type 'a t
-       The layout of t_any is any, because
-         of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the layout polymorphic type in an external declaration
+       The layout of t_any is any
+         because of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -85,10 +85,10 @@ Line 4, characters 63-68:
                                                                    ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : float64)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of float64, because
-         of the definition of id' at line 2, characters 10-18.
+       The layout of string is value
+         because it is the primitive value type string.
+       But the layout of string must be a sublayout of float64
+         because of the definition of id' at line 2, characters 10-18.
 |}]
 
 (********************)
@@ -137,10 +137,10 @@ Error: Signature mismatch:
        is not included in
          external id : ('a : any). 'a s -> 'a s = "%identity"
        The type 'a s -> 'a s is not compatible with the type 'b s -> 'b s
-       The layout of 'a is any, because
-         of the definition of id at line 3, characters 2-54.
-       But the layout of 'a must be representable, because
-         it's the layout polymorphic type in an external declaration
+       The layout of 'a is any
+         because of the definition of id at line 3, characters 2-54.
+       But the layout of 'a must be representable
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -182,10 +182,10 @@ Error: Signature mismatch:
            = "%identity" [@@layout_poly]
        The type ('a, 'b) s -> ('a, 'b) s is not compatible with the type
          (t_any, 'c) s -> (t_any, 'c) s
-       The layout of t_any is any, because
-         of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable, because
-         it's the layout polymorphic type in an external declaration
+       The layout of t_any is any
+         because of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -263,10 +263,10 @@ Line 2, characters 28-30:
 2 |   external id : ('a : any). 'a -> 'a = "%identity"
                                 ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 module S : sig
@@ -280,10 +280,10 @@ Line 4, characters 28-30:
 4 |   external id : ('a : any). 'a -> 'a = "%identity"
                                 ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any, because
-         of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 (* External in struct *)
@@ -309,10 +309,10 @@ Line 1, characters 36-41:
                                         ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : float64)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of float64, because
-         of the definition of id at line 2, characters 2-35.
+       The layout of string is value
+         because it is the primitive value type string.
+       But the layout of string must be a sublayout of float64
+         because of the definition of id at line 2, characters 2-35.
 |}]
 
 
@@ -339,10 +339,10 @@ Error: Signature mismatch:
        is not included in
          val id : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is any, because
-         of the definition of id at line 2, characters 2-31.
-       But the layout of 'a must be representable, because
-         it's the layout polymorphic type in an external declaration
+       The layout of 'a is any
+         because of the definition of id at line 2, characters 2-31.
+       But the layout of 'a must be representable
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -397,10 +397,10 @@ Line 9, characters 49-51:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of a1 is any, because
-         of the annotation on the abstract type declaration for a1.
-       But the layout of a1 must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of a1 is any
+         because of the annotation on the abstract type declaration for a1.
+       But the layout of a1 must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 let f (type a2 : any) () =
@@ -417,10 +417,10 @@ Line 4, characters 49-62:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of a2 t_with_any is any, because
-         of the annotation on the abstract type declaration for a2.
-       But the layout of a2 t_with_any must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of a2 t_with_any is any
+         because of the annotation on the abstract type declaration for a2.
+       But the layout of a2 t_with_any must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 let f (type a3 : any) () =
@@ -437,10 +437,10 @@ Line 4, characters 49-59:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of a3 M_any.t is any, because
-         of the annotation on the abstract type declaration for a3.
-       But the layout of a3 M_any.t must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of a3 M_any.t is any
+         because of the annotation on the abstract type declaration for a3.
+       But the layout of a3 M_any.t must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 module type S4 = sig
@@ -482,10 +482,10 @@ Line 4, characters 48-51:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of A.t is any, because
-         of the definition of t at line 2, characters 2-13.
-       But the layout of A.t must be representable, because
-         it's the type of an argument in an external declaration.
+       The layout of A.t is any
+         because of the definition of t at line 2, characters 2-13.
+       But the layout of A.t must be representable
+         because it's the type of an argument in an external declaration.
 |}]
 
 module M (A : sig
@@ -545,12 +545,13 @@ Line 2, characters 28-32:
                                 ^^^^
 Error: This expression has type ('a : float64)
        but an expression was expected of type int64#
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of float64, because
-         it's the layout polymorphic type in an external declaration
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of float64
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
-         representable at call sites), defaulted to layout float64.
+         representable at call sites),
+         defaulted to layout float64.
 |}]
 (* CR layouts v2.9: the default part is not quite correct *)
 
@@ -627,8 +628,8 @@ Line 1, characters 28-58:
 1 | external[@layout_poly] id : ('a : any). 'a list -> 'a list = "%identity"
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind any.
-       But it was inferred to have kind value, because
-         the type argument of list has kind value.
+       But it was inferred to have kind value
+         because the type argument of list has kind value.
 |}]
 
 (* Test this when sorts can be inside unboxed records *)

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
@@ -35,10 +35,10 @@ Line 3, characters 14-36:
                   ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_any but an expression was expected of type
          ('a : '_representable_layout_1)
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the layout polymorphic type in an external declaration
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -54,10 +54,10 @@ Line 3, characters 14-38:
                   ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_any t
        but an expression was expected of type 'a t
-       The layout of t_any is any
-         because of the definition of t_any at line 3, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the layout polymorphic type in an external declaration
+       The layout of t_any is any, because
+         of the definition of t_any at line 3, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -85,10 +85,10 @@ Line 4, characters 63-68:
                                                                    ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : float64)
-       The layout of string is value
-         because it is the primitive value type string.
-       But the layout of string must be a sublayout of float64
-         because of the definition of id' at line 2, characters 10-18.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of float64, because
+         of the definition of id' at line 2, characters 10-18.
 |}]
 
 (********************)
@@ -137,10 +137,10 @@ Error: Signature mismatch:
        is not included in
          external id : ('a : any). 'a s -> 'a s = "%identity"
        The type 'a s -> 'a s is not compatible with the type 'b s -> 'b s
-       The layout of 'a is any
-         because of the definition of id at line 3, characters 2-54.
-       But the layout of 'a must be representable
-         because it's the layout polymorphic type in an external declaration
+       The layout of 'a is any, because
+         of the definition of id at line 3, characters 2-54.
+       But the layout of 'a must be representable, because
+         it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -182,10 +182,10 @@ Error: Signature mismatch:
            = "%identity" [@@layout_poly]
        The type ('a, 'b) s -> ('a, 'b) s is not compatible with the type
          (t_any, 'c) s -> (t_any, 'c) s
-       The layout of t_any is any
-         because of the definition of t_any at line 2, characters 0-16.
-       But the layout of t_any must be representable
-         because it's the layout polymorphic type in an external declaration
+       The layout of t_any is any, because
+         of the definition of t_any at line 2, characters 0-16.
+       But the layout of t_any must be representable, because
+         it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -263,10 +263,10 @@ Line 2, characters 28-30:
 2 |   external id : ('a : any). 'a -> 'a = "%identity"
                                 ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any
-         because of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable
-         because it's the type of an argument in an external declaration.
+       The layout of 'a is any, because
+         of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable, because
+         it's the type of an argument in an external declaration.
 |}]
 
 module S : sig
@@ -280,10 +280,10 @@ Line 4, characters 28-30:
 4 |   external id : ('a : any). 'a -> 'a = "%identity"
                                 ^^
 Error: Types in an external must have a representable layout.
-       The layout of 'a is any
-         because of the annotation on the universal variable 'a.
-       But the layout of 'a must be representable
-         because it's the type of an argument in an external declaration.
+       The layout of 'a is any, because
+         of the annotation on the universal variable 'a.
+       But the layout of 'a must be representable, because
+         it's the type of an argument in an external declaration.
 |}]
 
 (* External in struct *)
@@ -309,10 +309,10 @@ Line 1, characters 36-41:
                                         ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : float64)
-       The layout of string is value
-         because it is the primitive value type string.
-       But the layout of string must be a sublayout of float64
-         because of the definition of id at line 2, characters 2-35.
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of float64, because
+         of the definition of id at line 2, characters 2-35.
 |}]
 
 
@@ -339,10 +339,10 @@ Error: Signature mismatch:
        is not included in
          val id : ('a : any). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is any
-         because of the definition of id at line 2, characters 2-31.
-       But the layout of 'a must be representable
-         because it's the layout polymorphic type in an external declaration
+       The layout of 'a is any, because
+         of the definition of id at line 2, characters 2-31.
+       But the layout of 'a must be representable, because
+         it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
@@ -397,10 +397,10 @@ Line 9, characters 49-51:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of a1 is any
-         because of the annotation on the abstract type declaration for a1.
-       But the layout of a1 must be representable
-         because it's the type of an argument in an external declaration.
+       The layout of a1 is any, because
+         of the annotation on the abstract type declaration for a1.
+       But the layout of a1 must be representable, because
+         it's the type of an argument in an external declaration.
 |}]
 
 let f (type a2 : any) () =
@@ -417,10 +417,10 @@ Line 4, characters 49-62:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of a2 t_with_any is any
-         because of the annotation on the abstract type declaration for a2.
-       But the layout of a2 t_with_any must be representable
-         because it's the type of an argument in an external declaration.
+       The layout of a2 t_with_any is any, because
+         of the annotation on the abstract type declaration for a2.
+       But the layout of a2 t_with_any must be representable, because
+         it's the type of an argument in an external declaration.
 |}]
 
 let f (type a3 : any) () =
@@ -437,10 +437,10 @@ Line 4, characters 49-59:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of a3 M_any.t is any
-         because of the annotation on the abstract type declaration for a3.
-       But the layout of a3 M_any.t must be representable
-         because it's the type of an argument in an external declaration.
+       The layout of a3 M_any.t is any, because
+         of the annotation on the abstract type declaration for a3.
+       But the layout of a3 M_any.t must be representable, because
+         it's the type of an argument in an external declaration.
 |}]
 
 module type S4 = sig
@@ -482,10 +482,10 @@ Line 4, characters 48-51:
 Error: Types in an external must have a representable layout
        (locally-scoped type variables with layout 'any' are
        made representable by [@layout_poly]).
-       The layout of A.t is any
-         because of the definition of t at line 2, characters 2-13.
-       But the layout of A.t must be representable
-         because it's the type of an argument in an external declaration.
+       The layout of A.t is any, because
+         of the definition of t at line 2, characters 2-13.
+       But the layout of A.t must be representable, because
+         it's the type of an argument in an external declaration.
 |}]
 
 module M (A : sig
@@ -545,10 +545,10 @@ Line 2, characters 28-32:
                                 ^^^^
 Error: This expression has type ('a : float64)
        but an expression was expected of type int64#
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of float64
-         because it's the layout polymorphic type in an external declaration
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of float64, because
+         it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites),
          defaulted to layout float64.
@@ -628,8 +628,8 @@ Line 1, characters 28-58:
 1 | external[@layout_poly] id : ('a : any). 'a list -> 'a list = "%identity"
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind any.
-       But it was inferred to have kind value
-         because the type argument of list has kind value.
+       But it was inferred to have kind value, because
+         the type argument of list has kind value.
 |}]
 
 (* Test this when sorts can be inside unboxed records *)

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
@@ -626,9 +626,9 @@ external[@layout_poly] id : ('a : any). 'a list -> 'a list = "%identity"
 Line 1, characters 28-58:
 1 | external[@layout_poly] id : ('a : any). 'a list -> 'a list = "%identity"
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The universal type variable 'a was declared to have layout any.
-       But it was inferred to have layout value, because
-         the type argument of list has layout value.
+Error: The universal type variable 'a was declared to have kind any.
+       But it was inferred to have kind value, because
+         the type argument of list has kind value.
 |}]
 
 (* Test this when sorts can be inside unboxed records *)

--- a/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments.ml
@@ -465,10 +465,11 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64, because
-           of the definition of t_float64_id at line 1, characters 0-37.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t_cstr1, defaulted to layout value.
+         The layout of 'a is float64
+           because of the definition of t_float64_id at line 1, characters 0-37.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t_cstr1,
+           defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments.ml
@@ -465,10 +465,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64, because
-           of the definition of t_float64_id at line 1, characters 0-37.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t_cstr1,
+         The layout of 'a is float64
+           because of the definition of t_float64_id at line 1, characters 0-37.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t_cstr1,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.

--- a/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments.ml
@@ -465,10 +465,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64
-           because of the definition of t_float64_id at line 1, characters 0-37.
-         But the layout of 'a must overlap with value
-           because it instantiates an unannotated type parameter of t_cstr1,
+         The layout of 'a is float64, because
+           of the definition of t_float64_id at line 1, characters 0-37.
+         But the layout of 'a must overlap with value, because
+           it instantiates an unannotated type parameter of t_cstr1,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.

--- a/ocaml/testsuite/tests/typing-layouts/mixed_records.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_records.ml
@@ -206,10 +206,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64, because
-           of the definition of t_float64_id at line 1, characters 0-37.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t,
+         The layout of 'a is float64
+           because of the definition of t_float64_id at line 1, characters 0-37.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.

--- a/ocaml/testsuite/tests/typing-layouts/mixed_records.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_records.ml
@@ -206,10 +206,10 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64
-           because of the definition of t_float64_id at line 1, characters 0-37.
-         But the layout of 'a must overlap with value
-           because it instantiates an unannotated type parameter of t,
+         The layout of 'a is float64, because
+           of the definition of t_float64_id at line 1, characters 0-37.
+         But the layout of 'a must overlap with value, because
+           it instantiates an unannotated type parameter of t,
            defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.

--- a/ocaml/testsuite/tests/typing-layouts/mixed_records.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_records.ml
@@ -206,10 +206,11 @@ Error: Layout mismatch in final type declaration consistency check.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a is float64, because
-           of the definition of t_float64_id at line 1, characters 0-37.
-         But the layout of 'a must overlap with value, because
-           it instantiates an unannotated type parameter of t, defaulted to layout value.
+         The layout of 'a is float64
+           because of the definition of t_float64_id at line 1, characters 0-37.
+         But the layout of 'a must overlap with value
+           because it instantiates an unannotated type parameter of t,
+           defaulted to layout value.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -188,9 +188,9 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-25.
 |}]
 
@@ -265,9 +265,9 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type Bar3.t is value, because
+Error: The kind of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
-       But the layout of type Bar3.t must be a sublayout of immediate, because
+       But the kind of type Bar3.t must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-29.
 |}];;
 
@@ -450,9 +450,9 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of f at line 3, characters 2-20.
 |}]
 
@@ -466,9 +466,9 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The layout of type string is value, because
+Error: The kind of type string is value, because
          it is the primitive value type string.
-       But the layout of type string must be a sublayout of immediate, because
+       But the kind of type string must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}]
 
@@ -553,9 +553,9 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          it is the primitive value type string.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 
@@ -573,9 +573,9 @@ Error: In this `with' constraint, the new definition of t
          type t = s
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          of the definition of s at line 2, characters 2-8.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -70,10 +70,10 @@ Line 1, characters 34-36:
                                       ^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : float64)
-       The layout of 'a is float64, because
-         of the definition of t at line 2, characters 2-23.
-       But the layout of 'a must overlap with value, because
-         the type argument of list has layout value.
+       The layout of 'a is float64
+         because of the definition of t at line 2, characters 2-23.
+       But the layout of 'a must overlap with value
+         because the type argument of list has layout value.
 |}];;
 
 module type S1f'' = S1f with type s = t_float64;;
@@ -82,10 +82,10 @@ module type S1f'' = S1f with type s = t_float64;;
 Line 1, characters 29-47:
 1 | module type S1f'' = S1f with type s = t_float64;;
                                  ^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of type t_float64 must be a sublayout of value, because
-         of the definition of s at line 3, characters 2-8.
+Error: The layout of type t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value
+         because of the definition of s at line 3, characters 2-8.
 |}]
 
 module type S1_2 = sig
@@ -188,10 +188,10 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-25.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -265,10 +265,10 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type Bar3.t is value, because
-         of the annotation on the declaration of the type t.
-       But the kind of type Bar3.t must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-29.
+Error: The kind of type Bar3.t is value
+         because of the annotation on the declaration of the type t.
+       But the kind of type Bar3.t must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -303,10 +303,10 @@ Line 2, characters 27-29:
 2 |   type 'a t = 'a Bar3f.t * 'a list
                                ^^
 Error: This type ('a : float64) should be an instance of type ('b : value)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with value, because
-         the type argument of list has layout value.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value
+         because the type argument of list has layout value.
 |}];;
 
 type t3f : float64
@@ -331,10 +331,10 @@ Line 12, characters 11-18:
 12 |   type s = Foo3f.t t
                 ^^^^^^^
 Error: This type Foo3f.t should be an instance of type ('a : float64)
-       The layout of Foo3f.t is value, because
-         an abstract type has the value layout by default.
-       But the layout of Foo3f.t must be a sublayout of float64, because
-         of the definition of t at line 10, characters 2-23.
+       The layout of Foo3f.t is value
+         because an abstract type has the value layout by default.
+       But the layout of Foo3f.t must be a sublayout of float64
+         because of the definition of t at line 10, characters 2-23.
 |}];;
 
 (* Previous example works with annotation *)
@@ -386,10 +386,10 @@ Line 2, characters 12-16:
 2 | type t4f' = M4.s t4_float64;;
                 ^^^^
 Error: This type M4.s should be an instance of type ('a : float64)
-       The layout of M4.s is value, because
-         of the definition of s at line 2, characters 2-21.
-       But the layout of M4.s must be a sublayout of float64, because
-         of the definition of t4_float64 at line 1, characters 0-30.
+       The layout of M4.s is value
+         because of the definition of s at line 2, characters 2-21.
+       But the layout of M4.s must be a sublayout of float64
+         because of the definition of t4_float64 at line 1, characters 0-30.
 |}]
 
 module F4'(X : sig type t : immediate end) = struct
@@ -416,10 +416,10 @@ Line 1, characters 10-15:
 1 | type t4 = M4'.s t4_float64;;
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : float64)
-       The layout of M4'.s is value, because
-         of the definition of s at line 2, characters 2-45.
-       But the layout of M4'.s must be a sublayout of float64, because
-         of the definition of t4_float64 at line 1, characters 0-30.
+       The layout of M4'.s is value
+         because of the definition of s at line 2, characters 2-45.
+       But the layout of M4'.s must be a sublayout of float64
+         because of the definition of t4_float64 at line 1, characters 0-30.
 |}];;
 
 
@@ -450,10 +450,10 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of f at line 3, characters 2-20.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of f at line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig
@@ -466,10 +466,10 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The kind of type string is value, because
-         it is the primitive value type string.
-       But the kind of type string must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-20.
+Error: The kind of type string is value
+         because it is the primitive value type string.
+       But the kind of type string must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -505,10 +505,10 @@ Error: In this `with' constraint, the new definition of t
          type t = int
        is not included in
          type t : float64
-       The layout of the first is value, because
-         it is the primitive immediate type int.
-       But the layout of the first must be a sublayout of float64, because
-         of the definition of t at line 2, characters 2-18.
+       The layout of the first is value
+         because it is the primitive immediate type int.
+       But the layout of the first must be a sublayout of float64
+         because of the definition of t at line 2, characters 2-18.
 |}];;
 
 module type S6_3 = sig
@@ -529,10 +529,10 @@ Error: In this `with' constraint, the new definition of t
          type t = t_float64
        is not included in
          type t : value
-       The layout of the first is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of the first must be a sublayout of value, because
-         of the definition of t at line 2, characters 2-16.
+       The layout of the first is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of the first must be a sublayout of value
+         because of the definition of t at line 2, characters 2-16.
 |}];;
 
 module type S6_5 = sig
@@ -553,10 +553,10 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
-         it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-20.
+       The kind of the first is value
+         because it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -573,10 +573,10 @@ Error: In this `with' constraint, the new definition of t
          type t = s
        is not included in
          type t : immediate
-       The kind of the first is value, because
-         of the definition of s at line 2, characters 2-8.
-       But the kind of the first must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-20.
+       The kind of the first is value
+         because of the definition of s at line 2, characters 2-8.
+       But the kind of the first must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6'' = sig
@@ -611,10 +611,10 @@ Line 1, characters 28-33:
 1 | module type S = sig val x : t_any end
                                 ^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_any is any, because
-         of the definition of t_any at line 5, characters 0-18.
-       But the layout of type t_any must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_any is any
+         because of the definition of t_any at line 5, characters 0-18.
+       But the layout of type t_any must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}]
 
 (****************************************************************)
@@ -707,10 +707,10 @@ Line 4, characters 29-39:
 4 |   let print_one () = X.print (X.one ())
                                  ^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of X.t is any, because
-         of the definition of t at line 2, characters 2-14.
-       But the layout of X.t must be representable, because
-         we must know concretely how to pass a function argument.
+       The layout of X.t is any
+         because of the definition of t at line 2, characters 2-14.
+       But the layout of X.t must be representable
+         because we must know concretely how to pass a function argument.
 |}]
 
 (***********************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -188,9 +188,9 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-25.
 |}]
 
@@ -265,9 +265,9 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type Bar3.t is value, because
+Error: The kind of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
-       But the layout of type Bar3.t must be a sublayout of immediate, because
+       But the kind of type Bar3.t must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-29.
 |}];;
 
@@ -416,7 +416,7 @@ Line 1, characters 10-15:
 1 | type t4 = M4'.s t4_float64;;
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : float64)
-       The layout of M4'.s is immediate, because
+       The layout of M4'.s is value, because
          of the definition of s at line 2, characters 2-45.
        But the layout of M4'.s must be a sublayout of float64, because
          of the definition of t4_float64 at line 1, characters 0-30.
@@ -450,9 +450,9 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of f at line 3, characters 2-20.
 |}]
 
@@ -466,9 +466,9 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The layout of type string is value, because
+Error: The kind of type string is value, because
          it is the primitive value type string.
-       But the layout of type string must be a sublayout of immediate, because
+       But the kind of type string must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}]
 
@@ -505,7 +505,7 @@ Error: In this `with' constraint, the new definition of t
          type t = int
        is not included in
          type t : float64
-       The layout of the first is immediate, because
+       The layout of the first is value, because
          it is the primitive immediate type int.
        But the layout of the first must be a sublayout of float64, because
          of the definition of t at line 2, characters 2-18.
@@ -553,9 +553,9 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          it is the primitive value type string.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 
@@ -573,9 +573,9 @@ Error: In this `with' constraint, the new definition of t
          type t = s
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          of the definition of s at line 2, characters 2-8.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -188,9 +188,9 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-25.
 |}]
 
@@ -265,9 +265,9 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type Bar3.t is value, because
+Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
-       But the kind of type Bar3.t must be a subkind of immediate, because
+       But the layout of type Bar3.t must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-29.
 |}];;
 
@@ -450,9 +450,9 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of f at line 3, characters 2-20.
 |}]
 
@@ -466,9 +466,9 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The kind of type string is value, because
+Error: The layout of type string is value, because
          it is the primitive value type string.
-       But the kind of type string must be a subkind of immediate, because
+       But the layout of type string must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}]
 
@@ -553,9 +553,9 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
+       The layout of the first is value, because
          it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
+       But the layout of the first must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 
@@ -573,9 +573,9 @@ Error: In this `with' constraint, the new definition of t
          type t = s
        is not included in
          type t : immediate
-       The kind of the first is value, because
+       The layout of the first is value, because
          of the definition of s at line 2, characters 2-8.
-       But the kind of the first must be a subkind of immediate, because
+       But the layout of the first must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -70,10 +70,10 @@ Line 1, characters 34-36:
                                       ^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : float64)
-       The layout of 'a is float64
-         because of the definition of t at line 2, characters 2-23.
-       But the layout of 'a must overlap with value
-         because the type argument of list has layout value.
+       The layout of 'a is float64, because
+         of the definition of t at line 2, characters 2-23.
+       But the layout of 'a must overlap with value, because
+         the type argument of list has layout value.
 |}];;
 
 module type S1f'' = S1f with type s = t_float64;;
@@ -82,10 +82,10 @@ module type S1f'' = S1f with type s = t_float64;;
 Line 1, characters 29-47:
 1 | module type S1f'' = S1f with type s = t_float64;;
                                  ^^^^^^^^^^^^^^^^^^
-Error: The layout of type t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of type t_float64 must be a sublayout of value
-         because of the definition of s at line 3, characters 2-8.
+Error: The layout of type t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of type t_float64 must be a sublayout of value, because
+         of the definition of s at line 3, characters 2-8.
 |}]
 
 module type S1_2 = sig
@@ -188,10 +188,10 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-25.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -265,10 +265,10 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type Bar3.t is value
-         because of the annotation on the declaration of the type t.
-       But the kind of type Bar3.t must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-29.
+Error: The kind of type Bar3.t is value, because
+         of the annotation on the declaration of the type t.
+       But the kind of type Bar3.t must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -303,10 +303,10 @@ Line 2, characters 27-29:
 2 |   type 'a t = 'a Bar3f.t * 'a list
                                ^^
 Error: This type ('a : float64) should be an instance of type ('b : value)
-       The layout of 'a is float64
-         because of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with value
-         because the type argument of list has layout value.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value, because
+         the type argument of list has layout value.
 |}];;
 
 type t3f : float64
@@ -331,10 +331,10 @@ Line 12, characters 11-18:
 12 |   type s = Foo3f.t t
                 ^^^^^^^
 Error: This type Foo3f.t should be an instance of type ('a : float64)
-       The layout of Foo3f.t is value
-         because an abstract type has the value layout by default.
-       But the layout of Foo3f.t must be a sublayout of float64
-         because of the definition of t at line 10, characters 2-23.
+       The layout of Foo3f.t is value, because
+         an abstract type has the value layout by default.
+       But the layout of Foo3f.t must be a sublayout of float64, because
+         of the definition of t at line 10, characters 2-23.
 |}];;
 
 (* Previous example works with annotation *)
@@ -386,10 +386,10 @@ Line 2, characters 12-16:
 2 | type t4f' = M4.s t4_float64;;
                 ^^^^
 Error: This type M4.s should be an instance of type ('a : float64)
-       The layout of M4.s is value
-         because of the definition of s at line 2, characters 2-21.
-       But the layout of M4.s must be a sublayout of float64
-         because of the definition of t4_float64 at line 1, characters 0-30.
+       The layout of M4.s is value, because
+         of the definition of s at line 2, characters 2-21.
+       But the layout of M4.s must be a sublayout of float64, because
+         of the definition of t4_float64 at line 1, characters 0-30.
 |}]
 
 module F4'(X : sig type t : immediate end) = struct
@@ -416,10 +416,10 @@ Line 1, characters 10-15:
 1 | type t4 = M4'.s t4_float64;;
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : float64)
-       The layout of M4'.s is value
-         because of the definition of s at line 2, characters 2-45.
-       But the layout of M4'.s must be a sublayout of float64
-         because of the definition of t4_float64 at line 1, characters 0-30.
+       The layout of M4'.s is value, because
+         of the definition of s at line 2, characters 2-45.
+       But the layout of M4'.s must be a sublayout of float64, because
+         of the definition of t4_float64 at line 1, characters 0-30.
 |}];;
 
 
@@ -450,10 +450,10 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of f at line 3, characters 2-20.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of f at line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig
@@ -466,10 +466,10 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The kind of type string is value
-         because it is the primitive value type string.
-       But the kind of type string must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-20.
+Error: The kind of type string is value, because
+         it is the primitive value type string.
+       But the kind of type string must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -505,10 +505,10 @@ Error: In this `with' constraint, the new definition of t
          type t = int
        is not included in
          type t : float64
-       The layout of the first is value
-         because it is the primitive immediate type int.
-       But the layout of the first must be a sublayout of float64
-         because of the definition of t at line 2, characters 2-18.
+       The layout of the first is value, because
+         it is the primitive immediate type int.
+       But the layout of the first must be a sublayout of float64, because
+         of the definition of t at line 2, characters 2-18.
 |}];;
 
 module type S6_3 = sig
@@ -529,10 +529,10 @@ Error: In this `with' constraint, the new definition of t
          type t = t_float64
        is not included in
          type t : value
-       The layout of the first is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of the first must be a sublayout of value
-         because of the definition of t at line 2, characters 2-16.
+       The layout of the first is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of the first must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-16.
 |}];;
 
 module type S6_5 = sig
@@ -553,10 +553,10 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value
-         because it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-20.
+       The kind of the first is value, because
+         it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -573,10 +573,10 @@ Error: In this `with' constraint, the new definition of t
          type t = s
        is not included in
          type t : immediate
-       The kind of the first is value
-         because of the definition of s at line 2, characters 2-8.
-       But the kind of the first must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-20.
+       The kind of the first is value, because
+         of the definition of s at line 2, characters 2-8.
+       But the kind of the first must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6'' = sig
@@ -611,10 +611,10 @@ Line 1, characters 28-33:
 1 | module type S = sig val x : t_any end
                                 ^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_any is any
-         because of the definition of t_any at line 5, characters 0-18.
-       But the layout of type t_any must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_any is any, because
+         of the definition of t_any at line 5, characters 0-18.
+       But the layout of type t_any must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}]
 
 (****************************************************************)
@@ -707,10 +707,10 @@ Line 4, characters 29-39:
 4 |   let print_one () = X.print (X.one ())
                                  ^^^^^^^^^^
 Error: Function arguments and returns must be representable.
-       The layout of X.t is any
-         because of the definition of t at line 2, characters 2-14.
-       But the layout of X.t must be representable
-         because we must know concretely how to pass a function argument.
+       The layout of X.t is any, because
+         of the definition of t at line 2, characters 2-14.
+       But the layout of X.t must be representable, because
+         we must know concretely how to pass a function argument.
 |}]
 
 (***********************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -133,9 +133,9 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-25.
 |}]
 
@@ -191,9 +191,9 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type Bar3.t is value, because
+Error: The kind of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
-       But the layout of type Bar3.t must be a sublayout of immediate, because
+       But the kind of type Bar3.t must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-29.
 |}];;
 
@@ -343,7 +343,7 @@ Line 1, characters 10-15:
 1 | type t4 = M4'.s t4_void;;
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : void)
-       The layout of M4'.s is immediate, because
+       The layout of M4'.s is value, because
          of the definition of s at line 2, characters 2-45.
        But the layout of M4'.s must be a sublayout of void, because
          of the definition of t4_void at line 8, characters 0-24.
@@ -376,9 +376,9 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of f at line 3, characters 2-20.
 |}]
 
@@ -392,9 +392,9 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The layout of type string is value, because
+Error: The kind of type string is value, because
          it is the primitive value type string.
-       But the layout of type string must be a sublayout of immediate, because
+       But the kind of type string must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}]
 
@@ -418,7 +418,7 @@ Error: In this `with' constraint, the new definition of t
          type t = int
        is not included in
          type t : void
-       The layout of the first is immediate, because
+       The layout of the first is value, because
          it is the primitive immediate type int.
        But the layout of the first must be a sublayout of void, because
          of the definition of t at line 2, characters 2-15.
@@ -466,9 +466,9 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          it is the primitive value type string.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 
@@ -486,9 +486,9 @@ Error: In this `with' constraint, the new definition of t
          type t = s
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          of the definition of s at line 2, characters 2-8.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -37,10 +37,10 @@ Line 1, characters 32-34:
                                     ^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : void)
-       The layout of 'a is void, because
-         of the definition of t at line 10, characters 2-20.
-       But the layout of 'a must overlap with value, because
-         the type argument of list has layout value.
+       The layout of 'a is void
+         because of the definition of t at line 10, characters 2-20.
+       But the layout of 'a must overlap with value
+         because the type argument of list has layout value.
 |}];;
 
 module type S1'' = S1 with type s = t_void;;
@@ -49,10 +49,10 @@ module type S1'' = S1 with type s = t_void;;
 Line 1, characters 27-42:
 1 | module type S1'' = S1 with type s = t_void;;
                                ^^^^^^^^^^^^^^^
-Error: The layout of type t_void is void, because
-         of the definition of t_void at line 5, characters 0-19.
-       But the layout of type t_void must be a sublayout of value, because
-         of the definition of s at line 11, characters 2-8.
+Error: The layout of type t_void is void
+         because of the definition of t_void at line 5, characters 0-19.
+       But the layout of type t_void must be a sublayout of value
+         because of the definition of s at line 11, characters 2-8.
 |}]
 
 module type S1_2 = sig
@@ -133,10 +133,10 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-25.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -191,10 +191,10 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type Bar3.t is value, because
-         of the annotation on the declaration of the type t.
-       But the kind of type Bar3.t must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-29.
+Error: The kind of type Bar3.t is value
+         because of the annotation on the declaration of the type t.
+       But the kind of type Bar3.t must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -229,10 +229,10 @@ Line 2, characters 26-28:
 2 |   type 'a t = 'a Bar3.t * 'a list
                               ^^
 Error: This type ('a : void) should be an instance of type ('b : value)
-       The layout of 'a is void, because
-         of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with value, because
-         the type argument of list has layout value.
+       The layout of 'a is void
+         because of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value
+         because the type argument of list has layout value.
 |}];;
 
 (* One downside of the current approach - this could be allowed, but isn't.  You
@@ -260,10 +260,10 @@ Line 12, characters 11-17:
 12 |   type s = Foo3.t t
                 ^^^^^^
 Error: This type Foo3.t should be an instance of type ('a : void)
-       The layout of Foo3.t is value, because
-         an abstract type has the value layout by default.
-       But the layout of Foo3.t must be a sublayout of void, because
-         of the definition of t at line 10, characters 2-20.
+       The layout of Foo3.t is value
+         because an abstract type has the value layout by default.
+       But the layout of Foo3.t must be a sublayout of void
+         because of the definition of t at line 10, characters 2-20.
 |}];;
 
 (* Previous example works with annotation *)
@@ -313,10 +313,10 @@ Line 1, characters 11-15:
 1 | type t4' = M4.s t4_void;;
                ^^^^
 Error: This type M4.s should be an instance of type ('a : void)
-       The layout of M4.s is value, because
-         of the definition of s at line 2, characters 2-21.
-       But the layout of M4.s must be a sublayout of void, because
-         of the definition of t4_void at line 8, characters 0-24.
+       The layout of M4.s is value
+         because of the definition of s at line 2, characters 2-21.
+       But the layout of M4.s must be a sublayout of void
+         because of the definition of t4_void at line 8, characters 0-24.
 |}]
 
 module F4'(X : sig type t : immediate end) = struct
@@ -343,10 +343,10 @@ Line 1, characters 10-15:
 1 | type t4 = M4'.s t4_void;;
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : void)
-       The layout of M4'.s is value, because
-         of the definition of s at line 2, characters 2-45.
-       But the layout of M4'.s must be a sublayout of void, because
-         of the definition of t4_void at line 8, characters 0-24.
+       The layout of M4'.s is value
+         because of the definition of s at line 2, characters 2-45.
+       But the layout of M4'.s must be a sublayout of void
+         because of the definition of t4_void at line 8, characters 0-24.
 |}];;
 
 (************************************)
@@ -376,10 +376,10 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of f at line 3, characters 2-20.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of f at line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig
@@ -392,10 +392,10 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The kind of type string is value, because
-         it is the primitive value type string.
-       But the kind of type string must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-20.
+Error: The kind of type string is value
+         because it is the primitive value type string.
+       But the kind of type string must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -418,10 +418,10 @@ Error: In this `with' constraint, the new definition of t
          type t = int
        is not included in
          type t : void
-       The layout of the first is value, because
-         it is the primitive immediate type int.
-       But the layout of the first must be a sublayout of void, because
-         of the definition of t at line 2, characters 2-15.
+       The layout of the first is value
+         because it is the primitive immediate type int.
+       But the layout of the first must be a sublayout of void
+         because of the definition of t at line 2, characters 2-15.
 |}];;
 
 module type S6_3 = sig
@@ -442,10 +442,10 @@ Error: In this `with' constraint, the new definition of t
          type t = t_void
        is not included in
          type t : value
-       The layout of the first is void, because
-         of the definition of t_void at line 5, characters 0-19.
-       But the layout of the first must be a sublayout of value, because
-         of the definition of t at line 2, characters 2-16.
+       The layout of the first is void
+         because of the definition of t_void at line 5, characters 0-19.
+       But the layout of the first must be a sublayout of value
+         because of the definition of t at line 2, characters 2-16.
 |}];;
 
 module type S6_5 = sig
@@ -466,10 +466,10 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
-         it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-20.
+       The kind of the first is value
+         because it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -486,10 +486,10 @@ Error: In this `with' constraint, the new definition of t
          type t = s
        is not included in
          type t : immediate
-       The kind of the first is value, because
-         of the definition of s at line 2, characters 2-8.
-       But the kind of the first must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-20.
+       The kind of the first is value
+         because of the definition of s at line 2, characters 2-8.
+       But the kind of the first must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6'' = sig
@@ -524,10 +524,10 @@ Line 1, characters 28-33:
 1 | module type S = sig val x : t_any end
                                 ^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_any is any, because
-         of the definition of t_any at line 1, characters 0-18.
-       But the layout of type t_any must be a sublayout of value, because
-         it's the type of something stored in a module structure.
+       The layout of type t_any is any
+         because of the definition of t_any at line 1, characters 0-18.
+       But the layout of type t_any must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}]
 
 (****************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -133,9 +133,9 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-25.
 |}]
 
@@ -191,9 +191,9 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type Bar3.t is value, because
+Error: The layout of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
-       But the kind of type Bar3.t must be a subkind of immediate, because
+       But the layout of type Bar3.t must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-29.
 |}];;
 
@@ -376,9 +376,9 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of f at line 3, characters 2-20.
 |}]
 
@@ -392,9 +392,9 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The kind of type string is value, because
+Error: The layout of type string is value, because
          it is the primitive value type string.
-       But the kind of type string must be a subkind of immediate, because
+       But the layout of type string must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}]
 
@@ -466,9 +466,9 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
+       The layout of the first is value, because
          it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
+       But the layout of the first must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 
@@ -486,9 +486,9 @@ Error: In this `with' constraint, the new definition of t
          type t = s
        is not included in
          type t : immediate
-       The kind of the first is value, because
+       The layout of the first is value, because
          of the definition of s at line 2, characters 2-8.
-       But the kind of the first must be a subkind of immediate, because
+       But the layout of the first must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -133,9 +133,9 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-25.
 |}]
 
@@ -191,9 +191,9 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type Bar3.t is value, because
+Error: The kind of type Bar3.t is value, because
          of the annotation on the declaration of the type t.
-       But the layout of type Bar3.t must be a sublayout of immediate, because
+       But the kind of type Bar3.t must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-29.
 |}];;
 
@@ -376,9 +376,9 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of f at line 3, characters 2-20.
 |}]
 
@@ -392,9 +392,9 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The layout of type string is value, because
+Error: The kind of type string is value, because
          it is the primitive value type string.
-       But the layout of type string must be a sublayout of immediate, because
+       But the kind of type string must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}]
 
@@ -466,9 +466,9 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          it is the primitive value type string.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 
@@ -486,9 +486,9 @@ Error: In this `with' constraint, the new definition of t
          type t = s
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          of the definition of s at line 2, characters 2-8.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-20.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -37,10 +37,10 @@ Line 1, characters 32-34:
                                     ^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type ('b : void)
-       The layout of 'a is void
-         because of the definition of t at line 10, characters 2-20.
-       But the layout of 'a must overlap with value
-         because the type argument of list has layout value.
+       The layout of 'a is void, because
+         of the definition of t at line 10, characters 2-20.
+       But the layout of 'a must overlap with value, because
+         the type argument of list has layout value.
 |}];;
 
 module type S1'' = S1 with type s = t_void;;
@@ -49,10 +49,10 @@ module type S1'' = S1 with type s = t_void;;
 Line 1, characters 27-42:
 1 | module type S1'' = S1 with type s = t_void;;
                                ^^^^^^^^^^^^^^^
-Error: The layout of type t_void is void
-         because of the definition of t_void at line 5, characters 0-19.
-       But the layout of type t_void must be a sublayout of value
-         because of the definition of s at line 11, characters 2-8.
+Error: The layout of type t_void is void, because
+         of the definition of t_void at line 5, characters 0-19.
+       But the layout of type t_void must be a sublayout of value, because
+         of the definition of s at line 11, characters 2-8.
 |}]
 
 module type S1_2 = sig
@@ -133,10 +133,10 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-25.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-25.
 |}]
 
 (******************************************************************)
@@ -191,10 +191,10 @@ end;;
 Line 2, characters 2-29:
 2 |   type t : immediate = Bar3.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type Bar3.t is value
-         because of the annotation on the declaration of the type t.
-       But the kind of type Bar3.t must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-29.
+Error: The kind of type Bar3.t is value, because
+         of the annotation on the declaration of the type t.
+       But the kind of type Bar3.t must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-29.
 |}];;
 
 module rec Foo3 : sig
@@ -229,10 +229,10 @@ Line 2, characters 26-28:
 2 |   type 'a t = 'a Bar3.t * 'a list
                               ^^
 Error: This type ('a : void) should be an instance of type ('b : value)
-       The layout of 'a is void
-         because of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with value
-         because the type argument of list has layout value.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value, because
+         the type argument of list has layout value.
 |}];;
 
 (* One downside of the current approach - this could be allowed, but isn't.  You
@@ -260,10 +260,10 @@ Line 12, characters 11-17:
 12 |   type s = Foo3.t t
                 ^^^^^^
 Error: This type Foo3.t should be an instance of type ('a : void)
-       The layout of Foo3.t is value
-         because an abstract type has the value layout by default.
-       But the layout of Foo3.t must be a sublayout of void
-         because of the definition of t at line 10, characters 2-20.
+       The layout of Foo3.t is value, because
+         an abstract type has the value layout by default.
+       But the layout of Foo3.t must be a sublayout of void, because
+         of the definition of t at line 10, characters 2-20.
 |}];;
 
 (* Previous example works with annotation *)
@@ -313,10 +313,10 @@ Line 1, characters 11-15:
 1 | type t4' = M4.s t4_void;;
                ^^^^
 Error: This type M4.s should be an instance of type ('a : void)
-       The layout of M4.s is value
-         because of the definition of s at line 2, characters 2-21.
-       But the layout of M4.s must be a sublayout of void
-         because of the definition of t4_void at line 8, characters 0-24.
+       The layout of M4.s is value, because
+         of the definition of s at line 2, characters 2-21.
+       But the layout of M4.s must be a sublayout of void, because
+         of the definition of t4_void at line 8, characters 0-24.
 |}]
 
 module F4'(X : sig type t : immediate end) = struct
@@ -343,10 +343,10 @@ Line 1, characters 10-15:
 1 | type t4 = M4'.s t4_void;;
               ^^^^^
 Error: This type M4'.s should be an instance of type ('a : void)
-       The layout of M4'.s is value
-         because of the definition of s at line 2, characters 2-45.
-       But the layout of M4'.s must be a sublayout of void
-         because of the definition of t4_void at line 8, characters 0-24.
+       The layout of M4'.s is value, because
+         of the definition of s at line 2, characters 2-45.
+       But the layout of M4'.s must be a sublayout of void, because
+         of the definition of t4_void at line 8, characters 0-24.
 |}];;
 
 (************************************)
@@ -376,10 +376,10 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of f at line 3, characters 2-20.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of f at line 3, characters 2-20.
 |}]
 
 module type S3_2 = sig
@@ -392,10 +392,10 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The kind of type string is value
-         because it is the primitive value type string.
-       But the kind of type string must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-20.
+Error: The kind of type string is value, because
+         it is the primitive value type string.
+       But the kind of type string must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}]
 
 (*****************************************)
@@ -418,10 +418,10 @@ Error: In this `with' constraint, the new definition of t
          type t = int
        is not included in
          type t : void
-       The layout of the first is value
-         because it is the primitive immediate type int.
-       But the layout of the first must be a sublayout of void
-         because of the definition of t at line 2, characters 2-15.
+       The layout of the first is value, because
+         it is the primitive immediate type int.
+       But the layout of the first must be a sublayout of void, because
+         of the definition of t at line 2, characters 2-15.
 |}];;
 
 module type S6_3 = sig
@@ -442,10 +442,10 @@ Error: In this `with' constraint, the new definition of t
          type t = t_void
        is not included in
          type t : value
-       The layout of the first is void
-         because of the definition of t_void at line 5, characters 0-19.
-       But the layout of the first must be a sublayout of value
-         because of the definition of t at line 2, characters 2-16.
+       The layout of the first is void, because
+         of the definition of t_void at line 5, characters 0-19.
+       But the layout of the first must be a sublayout of value, because
+         of the definition of t at line 2, characters 2-16.
 |}];;
 
 module type S6_5 = sig
@@ -466,10 +466,10 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value
-         because it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-20.
+       The kind of the first is value, because
+         it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6' = sig
@@ -486,10 +486,10 @@ Error: In this `with' constraint, the new definition of t
          type t = s
        is not included in
          type t : immediate
-       The kind of the first is value
-         because of the definition of s at line 2, characters 2-8.
-       But the kind of the first must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-20.
+       The kind of the first is value, because
+         of the definition of s at line 2, characters 2-8.
+       But the kind of the first must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-20.
 |}];;
 
 module type S6_6'' = sig
@@ -524,10 +524,10 @@ Line 1, characters 28-33:
 1 | module type S = sig val x : t_any end
                                 ^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_any is any
-         because of the definition of t_any at line 1, characters 0-18.
-       But the layout of type t_any must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of type t_any must be a sublayout of value, because
+         it's the type of something stored in a module structure.
 |}]
 
 (****************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
@@ -4,10 +4,10 @@ Line 2, characters 22-24:
 2 | type ('a : void) t0 = 'a list;;
                           ^^
 Error: This type ('a : value) should be an instance of type ('a0 : void)
-       The layout of 'a is void
-         because of the annotation on 'a in the declaration of the type t0.
-       But the layout of 'a must overlap with value
-         because the type argument of list has layout value.
+       The layout of 'a is void, because
+         of the annotation on 'a in the declaration of the type t0.
+       But the layout of 'a must overlap with value, because
+         the type argument of list has layout value.
 Line 2, characters 11-15:
 2 | type ('a : valu) t0 = 'a list;;
                ^^^^

--- a/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
@@ -4,10 +4,10 @@ Line 2, characters 22-24:
 2 | type ('a : void) t0 = 'a list;;
                           ^^
 Error: This type ('a : value) should be an instance of type ('a0 : void)
-       The layout of 'a is void, because
-         of the annotation on 'a in the declaration of the type t0.
-       But the layout of 'a must overlap with value, because
-         the type argument of list has layout value.
+       The layout of 'a is void
+         because of the annotation on 'a in the declaration of the type t0.
+       But the layout of 'a must overlap with value
+         because the type argument of list has layout value.
 Line 2, characters 11-15:
 2 | type ('a : valu) t0 = 'a list;;
                ^^^^

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -73,10 +73,10 @@ Lines 14-21, characters 2-3:
 21 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of void_rec is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -135,10 +135,10 @@ Lines 4-11, characters 2-3:
 11 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of void_rec is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -224,10 +224,10 @@ Lines 17-35, characters 10-27:
 35 |        b2 = (cons_r 1; b2)}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -438,10 +438,10 @@ Line 5, characters 4-6:
         ^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -484,10 +484,10 @@ Lines 4-11, characters 2-24:
 11 |    b2 = (cons_r 2; {v})}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of void_rec is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -513,10 +513,10 @@ Lines 2-3, characters 2-32:
 3 |   (x, V b2.v, V b1.v, z, V a1.v)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -785,10 +785,10 @@ Lines 9-18, characters 2-29:
 18 |   cons_r uivrh.uivrh_x; uivrh
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of unboxed_inlined_void_rec is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of unboxed_inlined_void_rec must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of unboxed_inlined_void_rec is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of unboxed_inlined_void_rec must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -834,10 +834,10 @@ Lines 6-11, characters 2-7:
 11 |     end
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -902,10 +902,10 @@ Lines 4-11, characters 2-11:
 11 |   (y, V v')
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -946,10 +946,10 @@ Lines 4-12, characters 2-23:
 12 |   (x, V v1, V v2, V v3)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -73,10 +73,10 @@ Lines 14-21, characters 2-3:
 21 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -135,10 +135,10 @@ Lines 4-11, characters 2-3:
 11 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -224,10 +224,10 @@ Lines 17-35, characters 10-27:
 35 |        b2 = (cons_r 1; b2)}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -438,10 +438,10 @@ Line 5, characters 4-6:
         ^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -484,10 +484,10 @@ Lines 4-11, characters 2-24:
 11 |    b2 = (cons_r 2; {v})}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -513,10 +513,10 @@ Lines 2-3, characters 2-32:
 3 |   (x, V b2.v, V b1.v, z, V a1.v)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -785,10 +785,10 @@ Lines 9-18, characters 2-29:
 18 |   cons_r uivrh.uivrh_x; uivrh
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of unboxed_inlined_void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of unboxed_inlined_void_rec must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of unboxed_inlined_void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of unboxed_inlined_void_rec must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -834,10 +834,10 @@ Lines 6-11, characters 2-7:
 11 |     end
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -902,10 +902,10 @@ Lines 4-11, characters 2-11:
 11 |   (y, V v')
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -946,10 +946,10 @@ Lines 4-12, characters 2-23:
 12 |   (x, V v1, V v2, V v3)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after

--- a/ocaml/testsuite/tests/typing-missing-cmi-2/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-2/test.compilers.reference
@@ -3,9 +3,9 @@ File "baz.ml", line 1, characters 8-18:
             ^^^^^^^^^^
 Error: This expression has type 'a Foo.t
        but an expression was expected of type ('b : '_representable_layout_1)
-       The layout of 'a Foo.t is any
-         because the .cmi file for Foo.t is missing.
-       But the layout of 'a Foo.t must be representable
-         because it's the type of a variable bound by a `let`.
+       The layout of 'a Foo.t is any, because
+         the .cmi file for Foo.t is missing.
+       But the layout of 'a Foo.t must be representable, because
+         it's the type of a variable bound by a `let`.
        No .cmi file found containing Foo.t.
        Hint: Adding "foo" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi-2/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-2/test.compilers.reference
@@ -3,9 +3,9 @@ File "baz.ml", line 1, characters 8-18:
             ^^^^^^^^^^
 Error: This expression has type 'a Foo.t
        but an expression was expected of type ('b : '_representable_layout_1)
-       The layout of 'a Foo.t is any, because
-         the .cmi file for Foo.t is missing.
-       But the layout of 'a Foo.t must be representable, because
-         it's the type of a variable bound by a `let`.
+       The layout of 'a Foo.t is any
+         because the .cmi file for Foo.t is missing.
+       But the layout of 'a Foo.t must be representable
+         because it's the type of a variable bound by a `let`.
        No .cmi file found containing Foo.t.
        Hint: Adding "foo" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
@@ -2,9 +2,9 @@ File "client.ml", line 2, characters 0-19:
 2 | and alias = missing
     ^^^^^^^^^^^^^^^^^^^
 Error: 
-       The layout of alias is any, because
-         the .cmi file for Missing.t is missing.
-       But the layout of alias must be a sublayout of value, because
-         the type argument of list has layout value.
+       The layout of alias is any
+         because the .cmi file for Missing.t is missing.
+       But the layout of alias must be a sublayout of value
+         because the type argument of list has layout value.
        No .cmi file found containing Missing.t.
        Hint: Adding "missing" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi-indirections/test.compilers.reference
@@ -2,9 +2,9 @@ File "client.ml", line 2, characters 0-19:
 2 | and alias = missing
     ^^^^^^^^^^^^^^^^^^^
 Error: 
-       The layout of alias is any
-         because the .cmi file for Missing.t is missing.
-       But the layout of alias must be a sublayout of value
-         because the type argument of list has layout value.
+       The layout of alias is any, because
+         the .cmi file for Missing.t is missing.
+       But the layout of alias must be a sublayout of value, because
+         the type argument of list has layout value.
        No .cmi file found containing Missing.t.
        Hint: Adding "missing" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -3,9 +3,9 @@ File "main.ml", line 1, characters 8-11:
             ^^^
 Error: This expression has type M.a but an expression was expected of type
          ('a : value)
-       The layout of M.a is any
-         because the .cmi file for M.a is missing.
-       But the layout of M.a must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of M.a is any, because
+         the .cmi file for M.a is missing.
+       But the layout of M.a must be a sublayout of value, because
+         of layout requirements from an imported definition.
        No .cmi file found containing M.a.
        Hint: Adding "m" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -3,9 +3,9 @@ File "main.ml", line 1, characters 8-11:
             ^^^
 Error: This expression has type M.a but an expression was expected of type
          ('a : value)
-       The layout of M.a is any, because
-         the .cmi file for M.a is missing.
-       But the layout of M.a must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of M.a is any
+         because the .cmi file for M.a is missing.
+       But the layout of M.a must be a sublayout of value
+         because of layout requirements from an imported definition.
        No .cmi file found containing M.a.
        Hint: Adding "m" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-modules/package_constraint.ml
+++ b/ocaml/testsuite/tests/typing-modules/package_constraint.ml
@@ -56,9 +56,9 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
+       The layout of the first is value, because
          it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
+       But the layout of the first must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-22.
 |}];;
 
@@ -140,9 +140,9 @@ Line 6, characters 0-15:
 6 | and t2 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of t2 is value, because
+       The layout of t2 is value, because
          it is the primitive value type string.
-       But the kind of t2 must be a subkind of immediate, because
+       But the layout of t2 must be a sublayout of immediate, because
          of the definition of t at line 2, characters 2-22.
 |}];;
 
@@ -166,10 +166,10 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a t2 is value, because
+         The layout of 'a t2 is value, because
            it instantiates an unannotated type parameter of t2,
-           defaulted to kind value.
-         But the kind of 'a t2 must be a subkind of immediate, because
+           defaulted to layout value.
+         But the layout of 'a t2 must be a sublayout of immediate, because
            of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -192,10 +192,10 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a t2 is value, because
+         The layout of 'a t2 is value, because
            it instantiates an unannotated type parameter of t2,
-           defaulted to kind value.
-         But the kind of 'a t2 must be a subkind of immediate, because
+           defaulted to layout value.
+         But the layout of 'a t2 must be a sublayout of immediate, because
            of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -327,8 +327,8 @@ Line 8, characters 10-16:
 8 | type t2 = string t
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
+       The layout of string is value, because
          it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
+       But the layout of string must be a sublayout of immediate, because
          of the definition of t at line 5, characters 0-39.
 |}];;

--- a/ocaml/testsuite/tests/typing-modules/package_constraint.ml
+++ b/ocaml/testsuite/tests/typing-modules/package_constraint.ml
@@ -56,9 +56,9 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          it is the primitive value type string.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-22.
 |}];;
 
@@ -140,9 +140,9 @@ Line 6, characters 0-15:
 6 | and t2 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The layout of t2 is value, because
+       The kind of t2 is value, because
          it is the primitive value type string.
-       But the layout of t2 must be a sublayout of immediate, because
+       But the kind of t2 must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-22.
 |}];;
 
@@ -166,9 +166,9 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a t2 is value, because
-           it instantiates an unannotated type parameter of t2, defaulted to layout value.
-         But the layout of 'a t2 must be a sublayout of immediate, because
+         The kind of 'a t2 is value, because
+           it instantiates an unannotated type parameter of t2, defaulted to kind value.
+         But the kind of 'a t2 must be a subkind of immediate, because
            of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -191,9 +191,9 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a t2 is value, because
-           it instantiates an unannotated type parameter of t2, defaulted to layout value.
-         But the layout of 'a t2 must be a sublayout of immediate, because
+         The kind of 'a t2 is value, because
+           it instantiates an unannotated type parameter of t2, defaulted to kind value.
+         But the kind of 'a t2 must be a subkind of immediate, because
            of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -325,8 +325,8 @@ Line 8, characters 10-16:
 8 | type t2 = string t
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of t at line 5, characters 0-39.
 |}];;

--- a/ocaml/testsuite/tests/typing-modules/package_constraint.ml
+++ b/ocaml/testsuite/tests/typing-modules/package_constraint.ml
@@ -56,10 +56,10 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
-         it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-22.
+       The kind of the first is value
+         because it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-22.
 |}];;
 
 (* You may not constrain types with a manifest in a package *)
@@ -140,10 +140,10 @@ Line 6, characters 0-15:
 6 | and t2 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of t2 is value, because
-         it is the primitive value type string.
-       But the kind of t2 must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-22.
+       The kind of t2 is value
+         because it is the primitive value type string.
+       But the kind of t2 must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-22.
 |}];;
 
 (* Though this sometimes fails if the check would require particularly clever
@@ -166,11 +166,11 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a t2 is value, because
-           it instantiates an unannotated type parameter of t2,
+         The kind of 'a t2 is value
+           because it instantiates an unannotated type parameter of t2,
            defaulted to kind value.
-         But the kind of 'a t2 must be a subkind of immediate, because
-           of the definition of t at line 2, characters 2-22.
+         But the kind of 'a t2 must be a subkind of immediate
+           because of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;
@@ -192,11 +192,11 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a t2 is value, because
-           it instantiates an unannotated type parameter of t2,
+         The kind of 'a t2 is value
+           because it instantiates an unannotated type parameter of t2,
            defaulted to kind value.
-         But the kind of 'a t2 must be a subkind of immediate, because
-           of the definition of t at line 2, characters 2-22.
+         But the kind of 'a t2 must be a subkind of immediate
+           because of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;
@@ -327,8 +327,8 @@ Line 8, characters 10-16:
 8 | type t2 = string t
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of t at line 5, characters 0-39.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of t at line 5, characters 0-39.
 |}];;

--- a/ocaml/testsuite/tests/typing-modules/package_constraint.ml
+++ b/ocaml/testsuite/tests/typing-modules/package_constraint.ml
@@ -56,9 +56,9 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The layout of the first is value, because
+       The kind of the first is value, because
          it is the primitive value type string.
-       But the layout of the first must be a sublayout of immediate, because
+       But the kind of the first must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-22.
 |}];;
 
@@ -140,9 +140,9 @@ Line 6, characters 0-15:
 6 | and t2 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The layout of t2 is value, because
+       The kind of t2 is value, because
          it is the primitive value type string.
-       But the layout of t2 must be a sublayout of immediate, because
+       But the kind of t2 must be a subkind of immediate, because
          of the definition of t at line 2, characters 2-22.
 |}];;
 
@@ -166,10 +166,10 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a t2 is value, because
+         The kind of 'a t2 is value, because
            it instantiates an unannotated type parameter of t2,
-           defaulted to layout value.
-         But the layout of 'a t2 must be a sublayout of immediate, because
+           defaulted to kind value.
+         But the kind of 'a t2 must be a subkind of immediate, because
            of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -192,10 +192,10 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The layout of 'a t2 is value, because
+         The kind of 'a t2 is value, because
            it instantiates an unannotated type parameter of t2,
-           defaulted to layout value.
-         But the layout of 'a t2 must be a sublayout of immediate, because
+           defaulted to kind value.
+         But the kind of 'a t2 must be a subkind of immediate, because
            of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
@@ -327,8 +327,8 @@ Line 8, characters 10-16:
 8 | type t2 = string t
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The layout of string is value, because
+       The kind of string is value, because
          it is the primitive value type string.
-       But the layout of string must be a sublayout of immediate, because
+       But the kind of string must be a subkind of immediate, because
          of the definition of t at line 5, characters 0-39.
 |}];;

--- a/ocaml/testsuite/tests/typing-modules/package_constraint.ml
+++ b/ocaml/testsuite/tests/typing-modules/package_constraint.ml
@@ -56,10 +56,10 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value, because
-         it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-22.
+       The kind of the first is value
+         because it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-22.
 |}];;
 
 (* You may not constrain types with a manifest in a package *)
@@ -140,10 +140,10 @@ Line 6, characters 0-15:
 6 | and t2 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of t2 is value, because
-         it is the primitive value type string.
-       But the kind of t2 must be a subkind of immediate, because
-         of the definition of t at line 2, characters 2-22.
+       The kind of t2 is value
+         because it is the primitive value type string.
+       But the kind of t2 must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-22.
 |}];;
 
 (* Though this sometimes fails if the check would require particularly clever
@@ -166,10 +166,11 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a t2 is value, because
-           it instantiates an unannotated type parameter of t2, defaulted to kind value.
-         But the kind of 'a t2 must be a subkind of immediate, because
-           of the definition of t at line 2, characters 2-22.
+         The kind of 'a t2 is value
+           because it instantiates an unannotated type parameter of t2,
+           defaulted to kind value.
+         But the kind of 'a t2 must be a subkind of immediate
+           because of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;
@@ -191,10 +192,11 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a t2 is value, because
-           it instantiates an unannotated type parameter of t2, defaulted to kind value.
-         But the kind of 'a t2 must be a subkind of immediate, because
-           of the definition of t at line 2, characters 2-22.
+         The kind of 'a t2 is value
+           because it instantiates an unannotated type parameter of t2,
+           defaulted to kind value.
+         But the kind of 'a t2 must be a subkind of immediate
+           because of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;
@@ -325,8 +327,8 @@ Line 8, characters 10-16:
 8 | type t2 = string t
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value, because
-         it is the primitive value type string.
-       But the kind of string must be a subkind of immediate, because
-         of the definition of t at line 5, characters 0-39.
+       The kind of string is value
+         because it is the primitive value type string.
+       But the kind of string must be a subkind of immediate
+         because of the definition of t at line 5, characters 0-39.
 |}];;

--- a/ocaml/testsuite/tests/typing-modules/package_constraint.ml
+++ b/ocaml/testsuite/tests/typing-modules/package_constraint.ml
@@ -56,10 +56,10 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value
-         because it is the primitive value type string.
-       But the kind of the first must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-22.
+       The kind of the first is value, because
+         it is the primitive value type string.
+       But the kind of the first must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-22.
 |}];;
 
 (* You may not constrain types with a manifest in a package *)
@@ -140,10 +140,10 @@ Line 6, characters 0-15:
 6 | and t2 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of t2 is value
-         because it is the primitive value type string.
-       But the kind of t2 must be a subkind of immediate
-         because of the definition of t at line 2, characters 2-22.
+       The kind of t2 is value, because
+         it is the primitive value type string.
+       But the kind of t2 must be a subkind of immediate, because
+         of the definition of t at line 2, characters 2-22.
 |}];;
 
 (* Though this sometimes fails if the check would require particularly clever
@@ -166,11 +166,11 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a t2 is value
-           because it instantiates an unannotated type parameter of t2,
+         The kind of 'a t2 is value, because
+           it instantiates an unannotated type parameter of t2,
            defaulted to kind value.
-         But the kind of 'a t2 must be a subkind of immediate
-           because of the definition of t at line 2, characters 2-22.
+         But the kind of 'a t2 must be a subkind of immediate, because
+           of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;
@@ -192,11 +192,11 @@ Error: Layout mismatch in checking consistency of mutually recursive groups.
        clever enough to propagate layouts through variables in different
        declarations. It is also not clever enough to produce a good error
        message, so we'll say this instead:
-         The kind of 'a t2 is value
-           because it instantiates an unannotated type parameter of t2,
+         The kind of 'a t2 is value, because
+           it instantiates an unannotated type parameter of t2,
            defaulted to kind value.
-         But the kind of 'a t2 must be a subkind of immediate
-           because of the definition of t at line 2, characters 2-22.
+         But the kind of 'a t2 must be a subkind of immediate, because
+           of the definition of t at line 2, characters 2-22.
        A good next step is to add a layout annotation on a parameter to
        the declaration where this error is reported.
 |}];;
@@ -327,8 +327,8 @@ Line 8, characters 10-16:
 8 | type t2 = string t
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
-         because of the definition of t at line 5, characters 0-39.
+       The kind of string is value, because
+         it is the primitive value type string.
+       But the kind of string must be a subkind of immediate, because
+         of the definition of t at line 5, characters 0-39.
 |}];;

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1545,7 +1545,8 @@ module Format_history = struct
       format_immediate64_creation_reason ppf immediate64
     | Void_creation _ -> .
     | Value_or_null_creation _ -> .
-    | Value_creation value -> format_value_creation_reason ppf ~layout_or_kind value
+    | Value_creation value ->
+      format_value_creation_reason ppf ~layout_or_kind value
     | Float64_creation float -> format_float64_creation_reason ppf float
     | Float32_creation float -> format_float32_creation_reason ppf float
     | Word_creation word -> format_word_creation_reason ppf word
@@ -1586,12 +1587,11 @@ module Format_history = struct
     fprintf ppf "@[<v 2>%t" intro;
     (match t.history with
     | Creation reason -> (
-      fprintf ppf "@ because %a"
-        (format_creation_reason ~layout_or_kind)
-        reason;
+      fprintf ppf "@ because %a" (format_creation_reason ~layout_or_kind) reason;
       match reason, jkind_desc with
       | Concrete_default_creation _, Const _ ->
-        fprintf ppf ",@ defaulted to %s %a" layout_or_kind Desc.format jkind_desc
+        fprintf ppf ",@ defaulted to %s %a" layout_or_kind Desc.format
+          jkind_desc
       | _ -> ())
     | _ -> assert false);
     fprintf ppf ".";
@@ -1717,14 +1717,14 @@ module Violation = struct
       fprintf ppf "@[<v>%a@;%a@]"
         (Format_history.format_history
            ~intro:
-             (dprintf "@[<hov 2>The %s of %a is %a@]" layout_or_kind pp_former former
-                format_layout_or_kind k1)
+             (dprintf "@[<hov 2>The %s of %a is %a@]" layout_or_kind pp_former
+                former format_layout_or_kind k1)
            ~layout_or_kind)
         k1
         (Format_history.format_history
            ~intro:
-             (dprintf "@[<hov 2>But the %s of %a must %t@]" layout_or_kind pp_former former
-                connective)
+             (dprintf "@[<hov 2>But the %s of %a must %t@]" layout_or_kind
+                pp_former former connective)
            ~layout_or_kind)
         k2
     else

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1591,7 +1591,7 @@ module Format_history = struct
         reason;
       match reason, jkind_desc with
       | Concrete_default_creation _, Const _ ->
-        fprintf ppf ", defaulted to kind %a" Desc.format jkind_desc
+        fprintf ppf ", defaulted to %s %a" layout_or_kind Desc.format jkind_desc
       | _ -> ())
     | _ -> assert false);
     fprintf ppf ".";

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -633,21 +633,7 @@ module Const = struct
 
   let to_out_jkind_const = To_out_jkind_const.convert
 
-  let rec print_out_jkind_const ppf (ojkind : Outcometree.out_jkind_const) =
-    let open Format in
-    match ojkind with
-    | Ojkind_const_default -> fprintf ppf "_"
-    | Ojkind_const_abbreviation abbrev -> fprintf ppf "%s" abbrev
-    | Ojkind_const_mod (base, modes) ->
-      fprintf ppf "%a mod @[%a@]" print_out_jkind_const base
-        (pp_print_list
-           ~pp_sep:(fun ppf () -> fprintf ppf "@ ")
-           (fun ppf -> fprintf ppf "%s"))
-        modes
-    | Ojkind_const_with _ | Ojkind_const_kind_of _ ->
-      failwith "XXX unimplemented jkind syntax"
-
-  let format ppf jkind = to_out_jkind_const jkind |> print_out_jkind_const ppf
+  let format ppf jkind = to_out_jkind_const jkind |> !Oprint.out_jkind_const ppf
 
   let of_attribute : Builtin_attributes.jkind_attribute -> t = function
     | Immediate -> Primitive.immediate.jkind
@@ -1259,11 +1245,6 @@ let set_externality_upper_bound jk externality_upper_bound =
 
 (*********************************)
 (* pretty printing *)
-
-let print_out_jkind ppf (ojkind : Outcometree.out_jkind) =
-  match ojkind with
-  | Ojkind_var v -> Format.fprintf ppf "%s" v
-  | Ojkind_const jkind -> Const.print_out_jkind_const ppf jkind
 
 let format ppf jkind =
   match get jkind with

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1586,12 +1586,12 @@ module Format_history = struct
     fprintf ppf "@[<v 2>%t" intro;
     (match t.history with
     | Creation reason -> (
-      fprintf ppf ", because@ %a"
+      fprintf ppf "@ because %a"
         (format_creation_reason ~layout_or_kind)
         reason;
       match reason, jkind_desc with
       | Concrete_default_creation _, Const _ ->
-        fprintf ppf ", defaulted to %s %a" layout_or_kind Desc.format jkind_desc
+        fprintf ppf ",@ defaulted to %s %a" layout_or_kind Desc.format jkind_desc
       | _ -> ())
     | _ -> assert false);
     fprintf ppf ".";
@@ -1662,7 +1662,7 @@ module Violation = struct
     in
     let format_layout_or_kind =
       match mismatch_type with
-      | `Mode -> format
+      | `Mode -> fun ppf jkind -> Format.fprintf ppf "@,%a" format jkind
       | `Layout -> fun ppf jkind -> Layout.format ppf jkind.jkind.layout
     in
     let subjkind_format verb k2 =
@@ -1717,13 +1717,13 @@ module Violation = struct
       fprintf ppf "@[<v>%a@;%a@]"
         (Format_history.format_history
            ~intro:
-             (dprintf "The %s of %a is %a" layout_or_kind pp_former former
+             (dprintf "@[<hov 2>The %s of %a is %a@]" layout_or_kind pp_former former
                 format_layout_or_kind k1)
            ~layout_or_kind)
         k1
         (Format_history.format_history
            ~intro:
-             (dprintf "But the %s of %a must %t" layout_or_kind pp_former former
+             (dprintf "@[<hov 2>But the %s of %a must %t@]" layout_or_kind pp_former former
                 connective)
            ~layout_or_kind)
         k2

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1629,22 +1629,26 @@ module Violation = struct
 
   let is_missing_cmi viol = Option.is_some viol.missing_cmi
 
+  type locale =
+    | Mode
+    | Layout
+
   let report_general preamble pp_former former ppf t =
     let mismatch_type =
       match t.violation with
       | Not_a_subjkind (k1, k2) ->
         if Misc.Le_result.is_le (Layout.sub k1.jkind.layout k2.jkind.layout)
-        then `Mode
-        else `Layout
-      | No_intersection _ -> `Layout
+        then Mode
+        else Layout
+      | No_intersection _ -> Layout
     in
     let layout_or_kind =
-      match mismatch_type with `Mode -> "kind" | `Layout -> "layout"
+      match mismatch_type with Mode -> "kind" | Layout -> "layout"
     in
     let format_layout_or_kind =
       match mismatch_type with
-      | `Mode -> fun ppf jkind -> Format.fprintf ppf "@,%a" format jkind
-      | `Layout -> fun ppf jkind -> Layout.format ppf jkind.jkind.layout
+      | Mode -> fun ppf jkind -> Format.fprintf ppf "@,%a" format jkind
+      | Layout -> fun ppf jkind -> Layout.format ppf jkind.jkind.layout
     in
     let subjkind_format verb k2 =
       match get k2 with

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -170,9 +170,6 @@ module Const : sig
 
   val to_out_jkind_const : t -> Outcometree.out_jkind_const
 
-  val print_out_jkind_const :
-    Format.formatter -> Outcometree.out_jkind_const -> unit
-
   val format : Format.formatter -> t -> unit
 
   val equal : t -> t -> bool
@@ -424,8 +421,6 @@ val set_externality_upper_bound : t -> Externality.t -> t
 
 (*********************************)
 (* pretty printing *)
-
-val print_out_jkind : Format.formatter -> Outcometree.out_jkind -> unit
 
 val format : Format.formatter -> t -> unit
 

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -170,6 +170,9 @@ module Const : sig
 
   val to_out_jkind_const : t -> Outcometree.out_jkind_const
 
+  val print_out_jkind_const :
+    Format.formatter -> Outcometree.out_jkind_const -> unit
+
   val format : Format.formatter -> t -> unit
 
   val equal : t -> t -> bool
@@ -421,6 +424,8 @@ val set_externality_upper_bound : t -> Externality.t -> t
 
 (*********************************)
 (* pretty printing *)
+
+val print_out_jkind : Format.formatter -> Outcometree.out_jkind -> unit
 
 val format : Format.formatter -> t -> unit
 

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -323,37 +323,15 @@ let pr_var = Pprintast.tyvar
 let ty_var ~non_gen ppf s =
   pr_var ppf (if non_gen then "_" ^ s else s)
 
-let print_jkind_with_modes ppf print_jkind base modes =
-  fprintf ppf "%a mod @[%a@]" print_jkind base
-          (print_list (fun ppf -> fprintf ppf "%s") (fun ppf -> fprintf ppf "@ "))
-          modes
-
-let print_out_jkind ppf = function
-  | Ojkind_const { base; modal_bounds=[] } ->
-    fprintf ppf "%s" base
-  | Ojkind_const { base; modal_bounds=_::_ as modal_bounds } ->
-    print_jkind_with_modes ppf (fun ppf -> fprintf ppf "%s") base modal_bounds
-  | Ojkind_var v -> fprintf ppf "%s" v
-  | Ojkind_user jkind ->
-    let rec print_out_jkind_user ppf = function
-      | Ojkind_user_default -> fprintf ppf "_"
-      | Ojkind_user_abbreviation abbrev -> fprintf ppf "%s" abbrev
-      | Ojkind_user_mod (base, modes) ->
-        print_jkind_with_modes ppf print_out_jkind_user base modes
-      | Ojkind_user_with _ | Ojkind_user_kind_of _ ->
-        failwith "XXX unimplemented jkind syntax"
-    in
-    print_out_jkind_user ppf jkind
-
 let print_out_jkind_annot ppf = function
   | None -> ()
-  | Some lay -> fprintf ppf "@ : %a" print_out_jkind lay
+  | Some lay -> fprintf ppf "@ : %a" Jkind.print_out_jkind lay
 
 let pr_var_jkind ppf (v, l) = match l with
     | None -> pr_var ppf v
     | Some lay -> fprintf ppf "(%a : %a)"
                     pr_var v
-                    print_out_jkind lay
+                    Jkind.print_out_jkind lay
 
 let pr_var_jkinds =
   print_list pr_var_jkind (fun ppf -> fprintf ppf "@ ")
@@ -569,7 +547,7 @@ and print_out_type_3 ppf =
   | Otyp_jkind_annot (t, lay) ->
     fprintf ppf "@[<1>(%a@ :@ %a)@]"
       print_out_type_0 t
-      print_out_jkind lay
+      Jkind.print_out_jkind lay
 and print_out_type ppf typ =
   print_out_type_0 ppf typ
 and print_simple_out_type ppf typ =

--- a/ocaml/typing/oprint.mli
+++ b/ocaml/typing/oprint.mli
@@ -21,6 +21,8 @@ val out_value : (formatter -> out_value -> unit) ref
 val out_label : (formatter -> string * out_mutability * out_type
   * out_modality list -> unit) ref
 val out_modality : (formatter -> out_modality -> unit) ref
+val out_jkind_const : (formatter -> out_jkind_const -> unit) ref
+val out_jkind : (formatter -> out_jkind -> unit) ref
 val out_type : (formatter -> out_type -> unit) ref
 val out_type_args : (formatter -> out_type list -> unit) ref
 val out_constr : (formatter -> out_constructor -> unit) ref

--- a/ocaml/typing/outcometree.mli
+++ b/ocaml/typing/outcometree.mli
@@ -101,18 +101,15 @@ type out_ret_mode =
   (** The ret type is arrow, and need to print parens around the arrow, with
       modes annotating. *)
 
-(** Represents a user-written jkind annotation *)
-type out_jkind_user =
-  | Ojkind_user_default
-  | Ojkind_user_abbreviation of string
-  | Ojkind_user_mod of out_jkind_user * string list
-  | Ojkind_user_with of out_jkind_user * out_type
-  | Ojkind_user_kind_of of out_type
-
-and out_jkind_const = { base : string; modal_bounds : string list }
+(** Represents a constant jkind *)
+type out_jkind_const =
+  | Ojkind_const_default
+  | Ojkind_const_abbreviation of string
+  | Ojkind_const_mod of out_jkind_const * string list
+  | Ojkind_const_with of out_jkind_const * out_type
+  | Ojkind_const_kind_of of out_type
 
 and out_jkind =
-  | Ojkind_user of out_jkind_user
   | Ojkind_const of out_jkind_const
   | Ojkind_var of string
 

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1254,20 +1254,20 @@ let add_type_to_preparation = prepare_type
 let print_labels = ref true
 
 let out_jkind_of_user_jkind (jkind : Jane_syntax.Jkind.annotation) =
-  let rec out_jkind_user_of_user_jkind : Jane_syntax.Jkind.t -> out_jkind_user = function
-    | Default -> Ojkind_user_default
-    | Abbreviation abbrev -> Ojkind_user_abbreviation (abbrev :> string Location.loc).txt
+  let rec out_jkind_const_of_user_jkind : Jane_syntax.Jkind.t -> out_jkind_const = function
+    | Default -> Ojkind_const_default
+    | Abbreviation abbrev -> Ojkind_const_abbreviation (abbrev :> string Location.loc).txt
     | Mod (base, modes) ->
-      let base = out_jkind_user_of_user_jkind base in
+      let base = out_jkind_const_of_user_jkind base in
       let modes =
         List.map
           (fun mode -> (mode : Jane_syntax.Mode_expr.Const.t :> string Location.loc).txt)
           modes.txt
       in
-      Ojkind_user_mod (base, modes)
+      Ojkind_const_mod (base, modes)
     | With _ | Kind_of _ -> failwith "XXX unimplemented jkind syntax"
   in
-  Ojkind_user (out_jkind_user_of_user_jkind jkind.txt)
+  Ojkind_const (out_jkind_const_of_user_jkind jkind.txt)
 
 let out_jkind_of_const_jkind jkind =
   Ojkind_const (Jkind.Const.to_out_jkind_const jkind)

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -1456,15 +1456,15 @@ let report_error env ppf = function
       fprintf ppf ".@]";
   | Bad_univar_jkind { name; jkind_info; inferred_jkind } ->
       fprintf ppf
-        "@[<hov>The universal type variable %a was %s to have layout %a.@;%a@]"
+        "@[<hov>The universal type variable %a was %s to have kind %a.@;%a@]"
         Pprintast.tyvar name
         (if jkind_info.defaulted then "defaulted" else "declared")
         Jkind.format jkind_info.original_jkind
         (Jkind.format_history ~intro:(
           dprintf "But it was inferred to have %t"
             (fun ppf -> match Jkind.get inferred_jkind with
-            | Const c -> fprintf ppf "layout %a" Jkind.Const.format c
-            | Var _ -> fprintf ppf "a representable layout")))
+            | Const c -> fprintf ppf "kind %a" Jkind.Const.format c
+            | Var _ -> fprintf ppf "a representable kind")))
         inferred_jkind
   | Multiple_constraints_on_type s ->
       fprintf ppf "Multiple constraints for type %a" longident s


### PR DESCRIPTION
Improve errror messages for kind mismatches. The new behavior is:
1. If the layouts disagree, the error message will only be about layouts (regardless of whether modes agree), and modes are not included in the error message. Layouts are referred to by names like `float64`, even though this is a white lie, since that's actually the name of a kind.
2. If the layouts agree, then the message will be about kinds. The full jkind is printed out.

For the second case, I'd like to add some sort of hint at the end of the message about which modal axes disagree. But I don't have a great idea yet of what I think that should look like, so I chose to leave that for later work.

I think a reasonable alternative approach would be to completely get rid of case 1. Instead, always make the error message about kinds. When there is a layout disagreement, add a hint to the end of the message saying so. I'm not sure if this would be more or less confusing to users.

The diff is large, but most of it is tests. And most of those changes are the same change, repeated a bazillion times.