### PR TITLE
Use the right kinds when building shapes for unboxed variants

### DIFF
--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -153,9 +153,9 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
       Tag.Scannable.Map.map
         (fun (shape, block_fields) ->
           ( shape,
-            List.map
-              (fun (field : U.field_decision) ->
-                T.alias_type_of K.value (Simple.var field.epa.param))
+            List.mapi
+              (fun i (field : U.field_decision) ->
+                T.alias_type_of (K.Block_shape.element_kind shape i) (Simple.var field.epa.param))
               block_fields ))
         fields_by_tag
     in

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -155,7 +155,9 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
           ( shape,
             List.mapi
               (fun i (field : U.field_decision) ->
-                T.alias_type_of (K.Block_shape.element_kind shape i) (Simple.var field.epa.param))
+                T.alias_type_of
+                  (K.Block_shape.element_kind shape i)
+                  (Simple.var field.epa.param))
               block_fields ))
         fields_by_tag
     in

--- a/ocaml/testsuite/tests/mixed-blocks/variant_unboxing.ml
+++ b/ocaml/testsuite/tests/mixed-blocks/variant_unboxing.ml
@@ -1,0 +1,28 @@
+(* TEST
+   flags = "-extension layouts_beta";
+   native;
+*)
+
+(* Unboxing of variants with mixed constructors *)
+
+type t =
+  | Const_t
+  | Boxed of Float.t
+
+type u =
+  | Const_u
+  | Unboxed of float#
+
+external unbox : float -> float# = "%unbox_float"
+
+let t_to_u (t : t) : u =
+  match t with
+  | Const_t -> Const_u
+  | Boxed field -> Unboxed (unbox field)
+;;
+
+let f t =
+  (* The result of [t_to_u] is speculatively unboxed *)
+  let _ = t_to_u t in
+  ()
+;;


### PR DESCRIPTION
Fixes an oversight in #2533: variant unboxing generated a type manually for the unboxed variant with hardcoded `K.value` kinds for the constructor fields.