### PR TITLE
Implement `-no-approx` and `-no-code` in flambda-backend `ocamlobjinfo`

### DIFF
--- a/middle_end/flambda2/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.ml
@@ -210,27 +210,35 @@ let merge t1_opt t2_opt =
     in
     Some (t1 @ t2, nsections)
 
-let print0 ~sections ppf t =
+let print0 ~sections ~print_typing_env ~print_code ~print_offsets ppf t =
   Format.fprintf ppf "@[<hov>Original unit:@ %a@]@;" Compilation_unit.print
     t.original_compilation_unit;
   Compilation_unit.set_current (Some t.original_compilation_unit);
   let typing_env, code = import_typing_env_and_code0 ~sections t in
-  Format.fprintf ppf "@[<hov>Typing env:@ %a@]@;"
-    Flambda2_types.Typing_env.Serializable.print typing_env;
-  Format.fprintf ppf "@[<hov>Code:@ %a@]@;" Exported_code.print code;
-  Format.fprintf ppf "@[<hov>Offsets:@ %a@]@;" Exported_offsets.print
-    t.exported_offsets
+  if print_typing_env
+  then
+    Format.fprintf ppf "@[<hov>Typing env:@ %a@]@;"
+      Flambda2_types.Typing_env.Serializable.print typing_env;
+  if print_code
+  then Format.fprintf ppf "@[<hov>Code:@ %a@]@;" Exported_code.print code;
+  if print_offsets
+  then
+    Format.fprintf ppf "@[<hov>Offsets:@ %a@]@;" Exported_offsets.print
+      t.exported_offsets
 
-let print ppf (t, sections) =
+let print ~print_typing_env ~print_code ~print_offsets ppf (t, sections) =
   let rec print_rest ppf = function
     | [] -> ()
     | t0 :: t ->
-      Format.fprintf ppf "@ (%a)" (print0 ~sections) t0;
+      Format.fprintf ppf "@ (%a)"
+        (print0 ~sections ~print_typing_env ~print_code ~print_offsets)
+        t0;
       print_rest ppf t
   in
   match t with
   | [] -> assert false
-  | [t0] -> print0 ~sections ppf t0
+  | [t0] -> print0 ~sections ~print_typing_env ~print_code ~print_offsets ppf t0
   | t0 :: t ->
-    Format.fprintf ppf "Packed units:@ @[<v>(%a)%a@]" (print0 ~sections) t0
-      print_rest t
+    Format.fprintf ppf "Packed units:@ @[<v>(%a)%a@]"
+      (print0 ~sections ~print_typing_env ~print_code ~print_offsets)
+      t0 print_rest t

--- a/middle_end/flambda2/cmx/flambda_cmx_format.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.mli
@@ -42,4 +42,10 @@ val with_exported_offsets : t -> Exported_offsets.t -> t
 val merge : t option -> t option -> t option
 
 (** For ocamlobjinfo *)
-val print : Format.formatter -> t -> unit
+val print :
+  print_typing_env:bool ->
+  print_code:bool ->
+  print_offsets:bool ->
+  Format.formatter ->
+  t ->
+  unit

--- a/ocaml/testsuite/tests/tool-ocamlobjinfo/question.ml
+++ b/ocaml/testsuite/tests/tool-ocamlobjinfo/question.ml
@@ -8,11 +8,15 @@
  check-ocamlopt.byte-output;
  {
    ocamlobjinfo;
+
+   program = "-no-code question.cmx";
+   ocamlobjinfo;
+
    check-program-output;
  }{
    program = "question.cmx";
    ocamlobjinfo;
-   (* The cmx output varies too much to check. We're just happy it didn't
+   (* The full cmx output varies too much to check. We're just happy it didn't
       segfault on us. *)
  }
 *)

--- a/ocaml/testsuite/tests/tool-ocamlobjinfo/question.ml
+++ b/ocaml/testsuite/tests/tool-ocamlobjinfo/question.ml
@@ -12,6 +12,9 @@
    program = "-no-code -no-approx question.cmx";
    ocamlobjinfo;
 
+   program = "-no-code question.cmx";
+   ocamlobjinfo;
+
    check-program-output;
  }{
    program = "question.cmx";

--- a/ocaml/testsuite/tests/tool-ocamlobjinfo/question.ml
+++ b/ocaml/testsuite/tests/tool-ocamlobjinfo/question.ml
@@ -9,7 +9,7 @@
  {
    ocamlobjinfo;
 
-   program = "-no-code question.cmx";
+   program = "-no-code -no-approx question.cmx";
    ocamlobjinfo;
 
    check-program-output;

--- a/ocaml/testsuite/tests/tool-ocamlobjinfo/question.reference
+++ b/ocaml/testsuite/tests/tool-ocamlobjinfo/question.reference
@@ -8,3 +8,21 @@ Interfaces imported:
 	00000000000000000000000000000000	Question
 	00000000000000000000000000000000	CamlinternalFormatBasics
 Implementations imported:
+File question.cmx
+Name: Question
+CRC of implementation: 00000000000000000000000000000000
+Globals defined:
+	Question
+Interfaces imported:
+	00000000000000000000000000000000	Stdlib
+	00000000000000000000000000000000	Question
+	00000000000000000000000000000000	CamlinternalFormatBasics
+Implementations imported:
+Flambda 2 unit with export information
+Currying functions:
+Apply functions:
+Send functions:
+Force link: no
+Function summaries for static checks:
+		camlQuestion__answer_0_1_code = 0x29
+		camlQuestion__entry = 0x29

--- a/ocaml/testsuite/tests/tool-ocamlobjinfo/question.reference
+++ b/ocaml/testsuite/tests/tool-ocamlobjinfo/question.reference
@@ -23,3 +23,49 @@ Currying functions:
 Apply functions:
 Send functions:
 Force link: no
+File question.cmx
+Name: Question
+CRC of implementation: 00000000000000000000000000000000
+Globals defined:
+	Question
+Interfaces imported:
+	00000000000000000000000000000000	Stdlib
+	00000000000000000000000000000000	Question
+	00000000000000000000000000000000	CamlinternalFormatBasics
+Implementations imported:
+Flambda 2 export information:
+Original unit: Question
+Typing env:
+((defined_symbols_without_equations ())
+ (code_age_relation
+  {([0m[38;5;169;1mcamlQuestion__answer_0_1_code[0m [0m[38;5;169;1mcamlQuestion__answer_0_0_code[0m)})
+ (type_equations
+  {([0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion[0m[38;5;111;1m[0m
+    (Val
+     (Variant
+      (blocks
+       ((alloc_mode Heap) (known
+         {(tag_0 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m))))})
+        (other Bottom))) (tagged_imms (Naked_immediate [0m[38;5;37;1m⊥[0m)))))
+   ([0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m
+    (Val
+     ((alloc_mode Heap) (known
+       {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m
+         => (Known ((closures { [0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m }) (value_slots { }))),
+         ((function_types
+           {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m
+             (Ok (function_type (code_id [0m[38;5;169;1mcamlQuestion__answer_0_1_code[0m)
+                  (rec_info (Rec_info [0m[38;5;249;1m0[0m)))))})
+          (closure_types
+           ((function_slot_components_by_index
+             {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m)))})))
+          (value_slot_types ((value_slot_components_by_index {})))))})
+      (other Bottom))))})
+ (aliases
+  ((canonical_elements {}) (aliases_of_canonical_names {})
+   (aliases_of_consts {}))))
+
+Currying functions:
+Apply functions:
+Send functions:
+Force link: no

--- a/ocaml/testsuite/tests/tool-ocamlobjinfo/question.reference
+++ b/ocaml/testsuite/tests/tool-ocamlobjinfo/question.reference
@@ -23,6 +23,3 @@ Currying functions:
 Apply functions:
 Send functions:
 Force link: no
-Function summaries for static checks:
-		camlQuestion__answer_0_1_code = 0x29
-		camlQuestion__entry = 0x29

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -268,13 +268,16 @@ let print_cmx_infos (uir, sections, crc) =
     match uir.uir_export_info with
     | None ->
       printf "Flambda 2 unit (with no export information)\n"
-    | Some _ when !no_code || !no_approx ->
+    | Some _ when !no_code && !no_approx ->
       printf "Flambda 2 unit with export information\n"
     | Some cmx ->
       printf "Flambda 2 export information:\n";
       flush stdout;
+      let print_typing_env = not !no_approx in
+      let print_code = not !no_code in
+      let print_offsets = print_code && print_typing_env in
       let cmx = Flambda2_cmx.Flambda_cmx_format.from_raw cmx ~sections in
-      Format.printf "%a\n%!" Flambda2_cmx.Flambda_cmx_format.print cmx
+      Format.printf "%a\n%!" (Flambda2_cmx.Flambda_cmx_format.print ~print_typing_env ~print_code ~print_offsets) cmx
   end;
   print_generic_fns uir.uir_generic_fns;
   printf "Force link: %s\n" (if uir.uir_force_link then "YES" else "no");

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -268,6 +268,8 @@ let print_cmx_infos (uir, sections, crc) =
     match uir.uir_export_info with
     | None ->
       printf "Flambda 2 unit (with no export information)\n"
+    | Some _ when !no_code || !no_approx ->
+      printf "Flambda 2 unit with export information\n"
     | Some cmx ->
       printf "Flambda 2 export information:\n";
       flush stdout;

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -278,7 +278,9 @@ let print_cmx_infos (uir, sections, crc) =
   end;
   print_generic_fns uir.uir_generic_fns;
   printf "Force link: %s\n" (if uir.uir_force_link then "YES" else "no");
-  Zero_alloc_info.Raw.print uir.uir_zero_alloc_info
+  if not (!no_code || !no_approx) then begin
+    Zero_alloc_info.Raw.print uir.uir_zero_alloc_info
+  end
 
 let print_cmxa_infos (lib : Cmx_format.library_infos) =
   printf "Extra C object files:";


### PR DESCRIPTION
(Edit: Thanks to @lthls with lukemaurer#2, this now has finer-grained behavior for `-no-approx` and `-no-code`.)

The old `-no-approx` and `-no-code` options are currently parsed but ignored. This is inconvenient, since the output for an flambda2 .cmx can be screenfuls long even for relatively small modules.

This PR implements `-no-approx` by just suppressing .cmx export information altogether (roughly equivalent to what the old one did).

Also implements `-no-code` by doing exactly the same thing as `-no-approx`. (Which does indeed mean there's no code.)
