### PR TITLE
Move the curry attribute name into the `Jane_syntax` module

### DIFF
--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -641,7 +641,8 @@ let has_layout_poly attrs =
   has_attribute ["ocaml.layout_poly"; "layout_poly"] attrs
 
 let has_curry attrs =
-  has_attribute ["extension.curry"; "ocaml.curry"; "curry"] attrs
+  has_attribute
+    [Jane_syntax.Arrow_curry.curry_attr_name; "ocaml.curry"; "curry"] attrs
 
 let tailcall attr =
   let has_nontail = has_attribute ["ocaml.nontail"; "nontail"] attr in

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -338,6 +338,15 @@ module Make_payload_protocol_of_stringable (Stringable : Stringable) :
   Make_payload_protocol_of_structure_item_encodable
     (Make_structure_item_encodable_of_stringable (Stringable))
 
+module Arrow_curry = struct
+  let curry_attr_name = "extension.curry"
+
+  let curry_attr loc =
+    Ast_helper.Attr.mk ~loc:Location.none
+      (Location.mkloc curry_attr_name loc)
+      (PStr [])
+end
+
 module Mode_expr = struct
   module Const : sig
     type raw = string

--- a/ocaml/parsing/jane_syntax.mli
+++ b/ocaml/parsing/jane_syntax.mli
@@ -100,6 +100,17 @@ module Immutable_arrays : sig
   val pat_of : loc:Location.t -> pattern -> Parsetree.pattern
 end
 
+(** The attribute placed on the inner [Ptyp_arrow] node in [x -> (y -> z)]
+    (meaning the [y -> z] node) to indicate parenthesization. This is relevant
+    for locals, as [local_ x -> (y -> z)] is different than
+    [local_ x -> y -> z].
+*)
+module Arrow_curry : sig
+  val curry_attr_name : string
+
+  val curry_attr : Location.t -> Parsetree.attribute
+end
+
 module Mode_expr : sig
   (** [Mode_expr] appears in several places:
   - let local_ x = ...

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -206,14 +206,12 @@ let exclave_extension loc =
 let mkexp_exclave ~loc ~kwd_loc exp =
   ghexp ~loc (Pexp_apply(exclave_extension (make_loc kwd_loc), [Nolabel, exp]))
 
-let curry_attr loc =
-  mk_attr ~loc:Location.none (mkloc "extension.curry" loc) (PStr [])
-
 let is_curry_attr attr =
-  attr.attr_name.txt = "extension.curry"
+  attr.attr_name.txt = Jane_syntax.Arrow_curry.curry_attr_name
 
 let mktyp_curry typ loc =
-  {typ with ptyp_attributes = curry_attr loc :: typ.ptyp_attributes}
+  {typ with ptyp_attributes =
+     Jane_syntax.Arrow_curry.curry_attr loc :: typ.ptyp_attributes}
 
 let maybe_curry_typ typ loc =
   match typ.ptyp_desc with

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -112,9 +112,7 @@ let protect_longident ppf print_longident longprefix txt =
   fprintf ppf format print_longident longprefix txt
 
 let is_curry_attr attr =
-  match attr.attr_name.txt with
-  | "extension.curry" -> true
-  | _ -> false
+  attr.attr_name.txt = Jane_syntax.Arrow_curry.curry_attr_name
 
 let filter_curry_attrs attrs =
   List.filter (fun attr -> not (is_curry_attr attr)) attrs


### PR DESCRIPTION
Move `extension.curry` into `Jane_syntax` so we can import it into `Ppxlib_jane` and use it for ppx generation of parenthesized functions. See the code comment in` Jane_syntax.mli` for an example. By request of @carl-eastlund.