### PR TITLE
eliminate Ekdohibs review obligation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,4 @@ flambda_backend.opam    @mshinwell @lthls
 
 build_ocaml_compiler.sexp       @poechsel
 
-chamelon/                       @Ekdohibs
-
 external/memtrace/              @stedolan


### PR DESCRIPTION
Enough of us have some understanding of chamelon now that I think it no longer makes sense to gate every small change to it behind @Ekdohibs review.  Of course, it will still make sense to get expert review for big changes, but we can do that manually as we do for other parts of the repo.

@Ekdohibs and @mshinwell should confirm this seems reasonable before merging.