### PR TITLE
Demote calls to non-simplified code only

### DIFF
--- a/middle_end/flambda2/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/downwards_acc.ml
@@ -29,6 +29,7 @@ type t =
     demoted_exn_handlers : Continuation.Set.t;
     code_ids_to_remember : Code_id.Set.t;
     code_ids_to_never_delete : Code_id.Set.t;
+    code_ids_never_simplified : Code_id.Set.t;
     slot_offsets : Slot_offsets.t Code_id.Map.t;
     debuginfo_rewrites : Debuginfo.t Simple.Map.t
   }
@@ -36,7 +37,7 @@ type t =
 let [@ocamlformat "disable"] print ppf
       { denv; continuation_uses_env; shareable_constants; used_value_slots;
         lifted_constants; flow_acc; demoted_exn_handlers; code_ids_to_remember;
-        code_ids_to_never_delete; slot_offsets; debuginfo_rewrites } =
+        code_ids_to_never_delete; code_ids_never_simplified; slot_offsets; debuginfo_rewrites } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(denv@ %a)@]@ \
       @[<hov 1>(continuation_uses_env@ %a)@]@ \
@@ -47,6 +48,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>(demoted_exn_handlers@ %a)@]@ \
       @[<hov 1>(code_ids_to_remember@ %a)@]@ \
       @[<hov 1>(code_ids_to_never_delete@ %a)@]@ \
+      @[<hov 1>(code_ids_never_simplified@ %a)@]@ \
       @[<hov 1>(slot_offsets@ %a)@ \
       @[<hov 1>(debuginfo_rewrites@ %a)@]\
       )@]"
@@ -59,6 +61,7 @@ let [@ocamlformat "disable"] print ppf
     Continuation.Set.print demoted_exn_handlers
     Code_id.Set.print code_ids_to_remember
     Code_id.Set.print code_ids_to_never_delete
+    Code_id.Set.print code_ids_never_simplified
     (Code_id.Map.print Slot_offsets.print) slot_offsets
     (Simple.Map.print Debuginfo.print_compact) debuginfo_rewrites
 
@@ -73,6 +76,7 @@ let create denv slot_offsets continuation_uses_env =
     demoted_exn_handlers = Continuation.Set.empty;
     code_ids_to_remember = Code_id.Set.empty;
     code_ids_to_never_delete = Code_id.Set.empty;
+    code_ids_never_simplified = Code_id.Set.empty;
     debuginfo_rewrites = Simple.Map.empty
   }
 
@@ -199,6 +203,17 @@ let code_ids_to_never_delete t = t.code_ids_to_never_delete
 
 let with_code_ids_to_never_delete t ~code_ids_to_never_delete =
   { t with code_ids_to_never_delete }
+
+let add_code_ids_never_simplified t ~old_code_ids =
+  { t with
+    code_ids_never_simplified =
+      Code_id.Set.union old_code_ids t.code_ids_never_simplified
+  }
+
+let code_ids_never_simplified t = t.code_ids_never_simplified
+
+let with_code_ids_never_simplified t ~code_ids_never_simplified =
+  { t with code_ids_never_simplified }
 
 let are_rebuilding_terms t = DE.are_rebuilding_terms t.denv
 

--- a/middle_end/flambda2/simplify/env/downwards_acc.mli
+++ b/middle_end/flambda2/simplify/env/downwards_acc.mli
@@ -102,6 +102,13 @@ val code_ids_to_never_delete : t -> Code_id.Set.t
 val with_code_ids_to_never_delete :
   t -> code_ids_to_never_delete:Code_id.Set.t -> t
 
+val add_code_ids_never_simplified : t -> old_code_ids:Code_id.Set.t -> t
+
+val code_ids_never_simplified : t -> Code_id.Set.t
+
+val with_code_ids_never_simplified :
+  t -> code_ids_never_simplified:Code_id.Set.t -> t
+
 val are_rebuilding_terms : t -> Are_rebuilding_terms.t
 
 val slot_offsets : t -> Slot_offsets.t Code_id.Map.t

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -906,11 +906,13 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
       Call_kind.indirect_function_call_unknown_arity apply_alloc_mode
     | Indirect_known_arity ->
       Call_kind.indirect_function_call_known_arity apply_alloc_mode
-    | Direct _code_id ->
-      (* Some types have regressed in precision. Since this used to be a direct
-         call, however, we know the function's arity even though we don't know
-         which function it is. *)
-      Call_kind.indirect_function_call_known_arity apply_alloc_mode
+    | Direct code_id ->
+      (* Keep the code ID if it corresponds to a simplified function,
+         otherwise demote it to avoid keeping non-simplified code alive.
+         Keep the function's arity as it is never allowed to change. *)
+      if Code_id.Set.mem code_id (DA.code_ids_never_simplified dacc)
+      then Call_kind.indirect_function_call_known_arity apply_alloc_mode
+      else Call_kind.direct_function_call code_id apply_alloc_mode
   in
   let apply = Apply_expr.with_call_kind apply call_kind in
   let dacc =

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -82,6 +82,7 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
   let dacc = DA.with_denv dacc denv in
   let code_ids_to_remember = DA.code_ids_to_remember outer_dacc in
   let code_ids_to_never_delete = DA.code_ids_to_never_delete outer_dacc in
+  let code_ids_never_simplified = DA.code_ids_never_simplified outer_dacc in
   let used_value_slots = DA.used_value_slots outer_dacc in
   let shareable_constants = DA.shareable_constants outer_dacc in
   let slot_offsets = DA.slot_offsets outer_dacc in
@@ -91,6 +92,7 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
   dacc
   |> DA.with_code_ids_to_remember ~code_ids_to_remember
   |> DA.with_code_ids_to_never_delete ~code_ids_to_never_delete
+  |> DA.with_code_ids_never_simplified ~code_ids_never_simplified
   |> DA.with_used_value_slots ~used_value_slots
   |> DA.with_shareable_constants ~shareable_constants
   |> DA.with_slot_offsets ~slot_offsets
@@ -110,6 +112,7 @@ let extract_accumulators_from_function outer_dacc ~dacc_after_body
   in
   let code_ids_to_remember = DA.code_ids_to_remember dacc_after_body in
   let code_ids_to_never_delete = DA.code_ids_to_never_delete dacc_after_body in
+  let code_ids_never_simplified = DA.code_ids_never_simplified dacc_after_body in
   let used_value_slots = UA.used_value_slots uacc_after_upwards_traversal in
   let shareable_constants =
     UA.shareable_constants uacc_after_upwards_traversal
@@ -123,6 +126,7 @@ let extract_accumulators_from_function outer_dacc ~dacc_after_body
       lifted_consts_this_function
     |> DA.with_code_ids_to_remember ~code_ids_to_remember
     |> DA.with_code_ids_to_never_delete ~code_ids_to_never_delete
+    |> DA.with_code_ids_never_simplified ~code_ids_never_simplified
     |> DA.with_used_value_slots ~used_value_slots
     |> DA.with_shareable_constants ~shareable_constants
     |> DA.with_slot_offsets ~slot_offsets

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -288,11 +288,34 @@ let simplify_static_consts dacc (bound_static : Bound_static.t) static_consts
      and for some reason the type of the closure is either not available or does
      not have a more precise code ID.
 
-     I suspect we will eventually need to deal with this in a more principled
-     way (maybe by making offset constraints part of the required fields to
-     create code, similar to the free names), but for now we're relying on the
-     fact that Closure_conversion never produces such examples, and Simplify
-     only has a single round. *)
+     We don't want to keep old code alive for two reasons. First, as it is not
+     simplified it will often be noticeably slower than its newer versions.
+     Second, it can contain value slot projections that we never registered in
+     the accumulators, so we might remove the associated value slots. The last
+     issue is critical: if the value slots are removed, their projections will
+     be compiled to Invalid, which will trigger at runtime.
+
+     To solve this, for now we track these old code IDs in the accumulator and
+     demote any direct calls to them. That ensures that we don't keep any use
+     of non-simplified code. We could also change the slot offsets data to
+     include projections in addition to sets of closures; this piece of data
+     is always computed (during closure conversion for old code IDs) so by
+     using the additional info we could make more accurate decisions on which
+     value slots can be removed. *)
+  let dacc =
+    let old_code_ids =
+      Code_id.Map.fold (fun code_id code old_code_ids ->
+          if Code.stub code then old_code_ids
+          else
+            match Code.newer_version_of code with
+            | None ->
+              if Code_id.is_imported code_id then old_code_ids
+              else Code_id.Set.add code_id old_code_ids
+            | Some _ -> old_code_ids)
+        all_code Code_id.Set.empty
+    in
+    DA.add_code_ids_never_simplified dacc ~old_code_ids
+  in
   let bound_static', static_consts', dacc =
     Static_const_group.match_against_bound_static static_consts bound_static
       ~init:([], [], dacc)


### PR DESCRIPTION
This is an alternative to #2651 and #2663.
The idea stays similar: we want to stop demoting direct calls in cases where we already know the right function to call but have lost the approximation on the closure for some reason (typically a missing cmx).
But we still need to be careful with code that has never been simplified: this code could be slow, so we don't want to call it if there is an alternative (i.e. going through an indirect call), and keeping it alive would require us to compute things like free names and slot offset constraints that we normally only compute when simplifying. The bugs that caused us to revert #2663 shows that we currently don't compute enough information in Closure_conversion: we do have the constraints on slot offsets generated by the sets of closures in non-simplified code, but we don't see the slot projections so we might incorrectly treat some value slots as unused.
While fixing this issue is possible (by storing more information in the slot_offsets structure), this PR goes in the other direction, making sure that we don't call non-simplified code.