### PR TITLE
Support type directed disambiguation better for `exclave_`

### DIFF
--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -2979,10 +2979,7 @@ val _ret : unit -> local_ (M.t -> unit) = <fun>
 
 let _ret () : M.t -> unit = exclave_ (fun M_constructor -> ())
 [%%expect{|
-Line 1, characters 42-55:
-1 | let _ret () : M.t -> unit = exclave_ (fun M_constructor -> ())
-                                              ^^^^^^^^^^^^^
-Error: Unbound constructor M_constructor
+val _ret : unit -> local_ (M.t -> unit) = <fun>
 |}]
 
 type r = {global_ x : string; y : string}

--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -2967,6 +2967,24 @@ let () = foo_f (local_ (fun M_constructor -> ()))
 [%%expect{|
 |}]
 
+let _ret () : M.t -> unit = (fun M_constructor -> ())
+[%%expect{|
+val _ret : unit -> M.t -> unit = <fun>
+|}]
+
+let _ret () : M.t -> unit = local_ (fun M_constructor -> ())
+[%%expect{|
+val _ret : unit -> local_ (M.t -> unit) = <fun>
+|}]
+
+let _ret () : M.t -> unit = exclave_ (fun M_constructor -> ())
+[%%expect{|
+Line 1, characters 42-55:
+1 | let _ret () : M.t -> unit = exclave_ (fun M_constructor -> ())
+                                              ^^^^^^^^^^^^^
+Error: Unbound constructor M_constructor
+|}]
+
 type r = {global_ x : string; y : string}
 
 let foo () =


### PR DESCRIPTION
Like #2303, but for `exclave_`. (We just didn't think about this in the first PR, but `exclave_` and `local_` affect type inference in similar ways so should interact with type-directed disambiguation in the same way.)