### PR TITLE
Allow `Maybe_null` jkinds in more places

### DIFF
--- a/ocaml/jane/doc/extensions/unboxed-types/index.md
+++ b/ocaml/jane/doc/extensions/unboxed-types/index.md
@@ -36,6 +36,14 @@ by a *type*. There is a small fixed set of layouts:
 * `any` is a layout that is the superlayout of all other layouts.  It doesn't correspond
   to a specific runtime representation. More information [below](#the-any-layout).
 
+* `value_or_null` is a superlayout of `value` including normal OCaml values
+  and null pointers. Unless `-extension-universe alpha` is set, it is displayed
+  as `value` and can't be used in jkind annotations.
+* `any_non_null` is a sublayout of `any` forbidding null pointers. Unless
+  `-extension-universe alpha` is set, it is displayed as `any`.
+  Additionally, `any` jkind annotations are interpreted as `any_non_null` for
+  backwards compatibility for definitions using arrays.
+
 Over time, we'll be adding more layouts here.
 
 # Layout annotation
@@ -353,7 +361,7 @@ orders:
 
   * Records
   * Constructors
-  
+
 Unboxed numbers can't be put in these structures:
 
   * Constructors with inline record fields
@@ -361,11 +369,11 @@ Unboxed numbers can't be put in these structures:
   * Extensible variant constructors
   * Top-level fields of modules
   * Tuples
-  
+
 There aren't fundamental issues with the structures that lack support. They will
 just take some work to implement.
 
-Here's an example of a record with an unboxed field. We call such a record 
+Here's an example of a record with an unboxed field. We call such a record
 a "mixed record".
 
 ```ocaml
@@ -429,7 +437,7 @@ These operations aren't supported:
   * polymorphic comparison and equality
   * polymorphic hash
   * marshaling
-  
+
 These operations raise an exception at runtime, similar to how polymorphic
 comparison raises when called on a function.
 
@@ -453,7 +461,7 @@ scanned by the garbage collector.
 [^can-or-must]: "Can-or-must" is a bit of a mouthful, but it captures the right nuance. Pointer values *must* be scanned, unboxed number fields *must* be skipped, and immediate values *can* be scanned or skipped.
 
 The ordering constraint on structure fields is a reflection of the same
-ordering restriction in the runtime representation. 
+ordering restriction in the runtime representation.
 
 ## C bindings for mixed blocks
 

--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
@@ -85,10 +85,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type float# array
        but an expression was expected of type 'a array
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f (x : float# array) = Array.length x
@@ -98,10 +98,10 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type float# array
        but an expression was expected of type 'a array
-       The layout of float# is float64, because
-         it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of float# is float64
+         because it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 (*****************************************************************)
@@ -139,10 +139,10 @@ Line 2, characters 23-30:
 2 | let d (x : 'a array) = get x 0
                            ^^^^^^^
 Error: A representable layout is required here.
-       The layout of 'a is any_non_null, because
-         of the definition of d at line 2, characters 6-30.
-       But the layout of 'a must be representable, because
-         it's the type of an array element.
+       The layout of 'a is any
+         because of the definition of d at line 2, characters 6-30.
+       But the layout of 'a must be representable
+         because it's the type of an array element.
 |}];;
 
 external get : int32# array -> int -> float = "%floatarray_safe_get"
@@ -252,10 +252,10 @@ Line 11, characters 79-82:
                                                                                     ^^^
 Error: This expression has type int64# but an expression was expected of type
          ('a : bits32)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of bits32, because
-         of the definition of get_third at lines 4-7, characters 16-23.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of bits32
+         because of the definition of get_third at lines 4-7, characters 16-23.
 |}]
 
 module M6_2 = struct
@@ -277,10 +277,10 @@ Line 9, characters 24-35:
                             ^^^^^^^^^^^
 Error: This expression has type ('a : float64)
        but an expression was expected of type int32#
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of float64, because
-         of the definition of arr at line 6, characters 12-16.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of float64
+         because of the definition of arr at line 6, characters 12-16.
 |}]
 
 (*********************)

--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
@@ -2,10 +2,7 @@
  include stdlib_upstream_compatible;
  flambda2;
  {
-   flags = "-extension layouts_beta -extension small_numbers";
-   expect;
- }{
-   flags = "-extension small_numbers";
+   flags = "-extension layouts_alpha -extension small_numbers";
    expect;
  }
 *)
@@ -15,35 +12,35 @@
 (*******************************************)
 (* Test 1: Support unboxed types in arrays *)
 
-type t_any : any
+type t_any_non_null : any_non_null
 
 type t1 = float# array
 type t2 = int32# array
 type t3 = int64# array
 type t4 = nativeint# array
-type t5 = t_any array
+type t5 = t_any_non_null array
 type t6 = float32# array
 
 type ('a : float64) t1' = 'a array
 type ('a : bits32) t2' = 'a array
 type ('a : bits64) t3' = 'a array
 type ('a : word) t4' = 'a array
-type ('a : any) t5' = 'a array
+type ('a : any_non_null) t5' = 'a array
 type ('a : float32) t6' = 'a array
 
 [%%expect{|
-type t_any : any
+type t_any_non_null : any_non_null
 type t1 = float# array
 type t2 = int32# array
 type t3 = int64# array
 type t4 = nativeint# array
-type t5 = t_any array
+type t5 = t_any_non_null array
 type t6 = float32# array
 type ('a : float64) t1' = 'a array
 type ('a : bits32) t2' = 'a array
 type ('a : bits64) t3' = 'a array
 type ('a : word) t4' = 'a array
-type ('a : any) t5' = 'a array
+type ('a : any_non_null) t5' = 'a array
 type ('a : float32) t6' = 'a array
 |}];;
 
@@ -88,10 +85,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type float# array
        but an expression was expected of type 'a array
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f (x : float# array) = Array.length x
@@ -101,10 +98,10 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type float# array
        but an expression was expected of type 'a array
-       The layout of float# is float64
-         because it is the primitive float64 type float#.
-       But the layout of float# must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of float# is float64, because
+         it is the primitive float64 type float#.
+       But the layout of float# must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 (*****************************************************************)
@@ -132,19 +129,20 @@ external get : floatarray -> int -> float = "%floatarray_safe_get"
 val d : float# array -> float = <fun>
 |}];;
 
-external get : ('a : any). 'a array -> int -> float = "%floatarray_safe_get"
+external get : ('a : any_non_null). 'a array -> int -> float = "%floatarray_safe_get"
 let d (x : 'a array) = get x 0
 
 [%%expect{|
-external get : ('a : any). 'a array -> int -> float = "%floatarray_safe_get"
+external get : ('a : any_non_null). 'a array -> int -> float
+  = "%floatarray_safe_get"
 Line 2, characters 23-30:
 2 | let d (x : 'a array) = get x 0
                            ^^^^^^^
 Error: A representable layout is required here.
-       The layout of 'a is any
-         because of the definition of d at line 2, characters 6-30.
-       But the layout of 'a must be representable
-         because it's the type of an array element.
+       The layout of 'a is any_non_null, because
+         of the definition of d at line 2, characters 6-30.
+       But the layout of 'a must be representable, because
+         it's the type of an array element.
 |}];;
 
 external get : int32# array -> int -> float = "%floatarray_safe_get"
@@ -198,7 +196,7 @@ Error: Floatarray primitives can't be used on arrays containing
 (**************************)
 (* Test 5: [@layout_poly] *)
 
-external[@layout_poly] get : ('a : any). 'a array -> int -> 'a = "%array_safe_get"
+external[@layout_poly] get : ('a : any_non_null). 'a array -> int -> 'a = "%array_safe_get"
 let f1 (x : float# array) = get x 0
 let f2 (x : int32# array) = get x 0
 let f3 (x : int64# array) = get x 0
@@ -206,7 +204,7 @@ let f4 (x : nativeint# array) = get x 0
 let f5 (x : float32# array) = get x 0
 
 [%%expect{|
-external get : ('a : any). 'a array -> int -> 'a = "%array_safe_get"
+external get : ('a : any_non_null). 'a array -> int -> 'a = "%array_safe_get"
   [@@layout_poly]
 val f1 : float# array -> float# = <fun>
 val f2 : int32# array -> int32# = <fun>
@@ -215,7 +213,7 @@ val f4 : nativeint# array -> nativeint# = <fun>
 val f5 : float32# array -> float32# = <fun>
 |}];;
 
-external[@layout_poly] set : ('a : any). 'a array -> int -> 'a -> unit = "%array_safe_set"
+external[@layout_poly] set : ('a : any_non_null). 'a array -> int -> 'a -> unit = "%array_safe_set"
 let f1 (x : float# array) v = set x 0 v
 let f2 (x : int32# array) v = set x 0 v
 let f3 (x : int64# array) v = set x 0 v
@@ -223,8 +221,8 @@ let f4 (x : nativeint# array) v = set x 0 v
 let f5 (x : float32# array) v = set x 0 v
 
 [%%expect{|
-external set : ('a : any). 'a array -> int -> 'a -> unit = "%array_safe_set"
-  [@@layout_poly]
+external set : ('a : any_non_null). 'a array -> int -> 'a -> unit
+  = "%array_safe_set" [@@layout_poly]
 val f1 : float# array -> float# -> unit = <fun>
 val f2 : int32# array -> int32# -> unit = <fun>
 val f3 : int64# array -> int64# -> unit = <fun>
@@ -254,16 +252,16 @@ Line 11, characters 79-82:
                                                                                     ^^^
 Error: This expression has type int64# but an expression was expected of type
          ('a : bits32)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of bits32
-         because of the definition of get_third at lines 4-7, characters 16-23.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of bits32, because
+         of the definition of get_third at lines 4-7, characters 16-23.
 |}]
 
 module M6_2 = struct
   (* sort var in exp *)
 
-  external[@layout_poly] get : ('a : any). 'a array -> int -> 'a = "%array_safe_get"
+  external[@layout_poly] get : ('a : any_non_null). 'a array -> int -> 'a = "%array_safe_get"
 
   let arr = [||]
 
@@ -279,10 +277,10 @@ Line 9, characters 24-35:
                             ^^^^^^^^^^^
 Error: This expression has type ('a : float64)
        but an expression was expected of type int32#
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of float64
-         because of the definition of arr at line 6, characters 12-16.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of float64, because
+         of the definition of arr at line 6, characters 12-16.
 |}]
 
 (*********************)

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -193,10 +193,10 @@ Line 1, characters 31-33:
 1 | type ('a : bits32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits32)
-       The layout of 'a is bits32
-         because of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
 |}]
 
 (*********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -190,10 +190,11 @@ Line 1, characters 31-33:
 1 | type ('a : bits32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it instantiates an unannotated type parameter of t4_7,
+         defaulted to layout value.
 |}]
 
 (*********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
@@ -113,10 +113,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value_or_null)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_bits32_id) = x, false;;
@@ -126,10 +126,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value_or_null)
-       The layout of 'a t_bits32_id is bits32, because
-         of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value_or_null, because
-         it's the type of a tuple element.
+       The layout of 'a t_bits32_id is bits32
+         because of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : int32#) = x, false;;
@@ -139,10 +139,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value_or_null)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_bits32 * string;;
@@ -151,10 +151,10 @@ Line 1, characters 12-20:
 1 | type t4_4 = t_bits32 * string;;
                 ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * int32#;;
@@ -163,10 +163,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * int32#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type ('a : bits32) t4_6 = 'a * 'a
@@ -176,10 +176,10 @@ Line 1, characters 26-28:
                               ^^
 Error: This type ('a : value_or_null) should be an instance of type
          ('a0 : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value_or_null, because
-         it's the type of a tuple element.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -189,10 +189,11 @@ Line 1, characters 31-33:
 1 | type ('a : bits32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it instantiates an unannotated type parameter of t4_7,
+         defaulted to layout value.
 |}]
 
 (*********************************************************)
@@ -271,10 +272,10 @@ Line 1, characters 31-39:
 1 | module type S6_1 = sig val x : t_bits32 end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of type t_bits32 must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of type t_bits32 must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_bits32_id end
@@ -283,10 +284,10 @@ Line 1, characters 31-45:
 1 | module type S6_2 = sig val x : 'a t_bits32_id end
                                    ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_bits32_id is bits32, because
-         of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of type 'a t_bits32_id must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type 'a t_bits32_id is bits32
+         because of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of type 'a t_bits32_id must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : int32# end
@@ -295,10 +296,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : int32# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of type int32# must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of type int32# must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 
@@ -311,10 +312,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value_or_null)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_bits32_id) = `A x;;
@@ -324,10 +325,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value_or_null)
-       The layout of 'a t_bits32_id is bits32, because
-         of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a t_bits32_id is bits32
+         because of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : int32#) = `A x;;
@@ -337,10 +338,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value_or_null)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_bits32 ];;
@@ -349,10 +350,10 @@ Line 1, characters 20-28:
 1 | type f7_4 = [ `A of t_bits32 ];;
                         ^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : bits32) f7_5 = [ `A of 'a ];;
@@ -362,10 +363,10 @@ Line 1, characters 34-36:
                                       ^^
 Error: This type ('a : value_or_null) should be an instance of type
          ('a0 : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -390,10 +391,10 @@ Line 1, characters 20-38:
                         ^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value_or_null)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value_or_null, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_bits32_id ());;
@@ -403,10 +404,10 @@ Line 1, characters 20-41:
                         ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
        but an expression was expected of type ('b : value_or_null)
-       The layout of 'a t_bits32_id is bits32, because
-         of the definition of make_t_bits32_id at line 2, characters 21-55.
-       But the layout of 'a t_bits32_id must overlap with value_or_null, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_bits32_id is bits32
+         because of the definition of make_t_bits32_id at line 2, characters 21-55.
+       But the layout of 'a t_bits32_id must overlap with value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_int32u ());;
@@ -416,10 +417,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type int32# but an expression was expected of type
          ('a : value_or_null)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value_or_null, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -558,10 +559,10 @@ Line 1, characters 15-27:
 1 | type t12_1 = < x : t_bits32 >;;
                    ^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 type ('a : bits32) t12_2 = < x : 'a >;;
@@ -570,10 +571,10 @@ Line 1, characters 33-35:
 1 | type ('a : bits32) t12_2 = < x : 'a >;;
                                      ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32, because
-         of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a is bits32
+         because of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value
+         because it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_bits32 = assert false end;;
@@ -583,10 +584,10 @@ Line 1, characters 21-55:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_bits32 but is expected to have type
          ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -597,10 +598,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_bits32_id -> 'a t_bits32_id = assert false
                  ^^
 Error: This type ('a : bits32) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits32, because
-         of the definition of t_bits32_id at line 2, characters 0-35.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits32
+         because of the definition of t_bits32_id at line 2, characters 0-35.
 |}];;
 
 class c12_5 = object val x : t_bits32 = assert false end;;
@@ -609,10 +610,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_bits32 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of x must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of x is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of x must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : int32# end;;
@@ -621,10 +622,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : int32# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type int32# but is expected to have type ('a : value)
-       The layout of int32# is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of int32# is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : int32# end
@@ -633,10 +634,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : int32# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits32, because
-         it is the primitive bits32 type int32#.
-       But the layout of x must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of x is bits32
+         because it is the primitive bits32 type int32#.
+       But the layout of x must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -647,10 +648,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_bits32_id -> 'a t_bits32_id
               ^^
 Error: This type ('a : bits32) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits32, because
-         of the definition of t_bits32_id at line 2, characters 0-35.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits32
+         because of the definition of t_bits32_id at line 2, characters 0-35.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -686,10 +687,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_bits32
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_bits32) (m2 : t_bits32) = object
@@ -703,10 +704,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -722,10 +723,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_bits32) = compare x x;;
@@ -735,10 +736,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_bits32) = Marshal.to_bytes x;;
@@ -748,10 +749,10 @@ Line 1, characters 44-45:
                                                 ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_bits32) = Hashtbl.hash x;;
@@ -761,8 +762,8 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32, because
-         of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32
+         because of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
@@ -1,8 +1,6 @@
 (* TEST
  {
-   expect;
- }{
-   flags = "-extension layouts_beta";
+   flags = "-extension layouts_alpha";
    expect;
  }
 *)
@@ -114,11 +112,11 @@ Line 1, characters 26-27:
 1 | let f4_1 (x : t_bits32) = x, false;;
                               ^
 Error: This expression has type t_bits32
-       but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of a tuple element.
+       but an expression was expected of type ('a : value_or_null)
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_bits32_id) = x, false;;
@@ -127,11 +125,11 @@ Line 1, characters 32-33:
 1 | let f4_2 (x : 'a t_bits32_id) = x, false;;
                                     ^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
-       but an expression was expected of type ('b : value)
-       The layout of 'a t_bits32_id is bits32
-         because of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value
-         because it's the type of a tuple element.
+       but an expression was expected of type ('b : value_or_null)
+       The layout of 'a t_bits32_id is bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must overlap with value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : int32#) = x, false;;
@@ -140,11 +138,11 @@ Line 1, characters 24-25:
 1 | let f4_3 (x : int32#) = x, false;;
                             ^
 Error: This expression has type int32# but an expression was expected of type
-         ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's the type of a tuple element.
+         ('a : value_or_null)
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_bits32 * string;;
@@ -153,10 +151,10 @@ Line 1, characters 12-20:
 1 | type t4_4 = t_bits32 * string;;
                 ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * int32#;;
@@ -165,10 +163,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * int32#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : bits32) t4_6 = 'a * 'a
@@ -176,11 +174,12 @@ type ('a : bits32) t4_6 = 'a * 'a
 Line 1, characters 26-28:
 1 | type ('a : bits32) t4_6 = 'a * 'a
                               ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32
-         because of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+Error: This type ('a : value_or_null) should be an instance of type
+         ('a0 : bits32)
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -262,15 +261,6 @@ Error: Type t_bits32 has layout bits32.
        Unboxed variants may not yet contain types of this layout.
 |}];;
 
-type t5_6_1 = A of { x : t_bits32 } [@@unboxed];;
-[%%expect{|
-Line 1, characters 21-33:
-1 | type t5_6_1 = A of { x : t_bits32 } [@@unboxed];;
-                         ^^^^^^^^^^^^
-Error: Type t_bits32 has layout bits32.
-       Unboxed inlined records may not yet contain types of this layout.
-|}];;
-
 (****************************************************)
 (* Test 6: Can't be put at top level of signatures. *)
 module type S6_1 = sig val x : t_bits32 end
@@ -281,10 +271,10 @@ Line 1, characters 31-39:
 1 | module type S6_1 = sig val x : t_bits32 end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of type t_bits32 must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of type t_bits32 must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_bits32_id end
@@ -293,10 +283,10 @@ Line 1, characters 31-45:
 1 | module type S6_2 = sig val x : 'a t_bits32_id end
                                    ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_bits32_id is bits32
-         because of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of type 'a t_bits32_id must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type 'a t_bits32_id is bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of type 'a t_bits32_id must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : int32# end
@@ -305,10 +295,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : int32# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of type int32# must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of type int32# must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -320,11 +310,11 @@ Line 1, characters 29-30:
 1 | let f7_1 (x : t_bits32) = `A x;;
                                  ^
 Error: This expression has type t_bits32
-       but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       but an expression was expected of type ('a : value_or_null)
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_bits32_id) = `A x;;
@@ -333,11 +323,11 @@ Line 1, characters 35-36:
 1 | let f7_2 (x : 'a t_bits32_id) = `A x;;
                                        ^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
-       but an expression was expected of type ('b : value)
-       The layout of 'a t_bits32_id is bits32
-         because of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       but an expression was expected of type ('b : value_or_null)
+       The layout of 'a t_bits32_id is bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must overlap with value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : int32#) = `A x;;
@@ -346,11 +336,11 @@ Line 1, characters 27-28:
 1 | let f7_3 (x : int32#) = `A x;;
                                ^
 Error: This expression has type int32# but an expression was expected of type
-         ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+         ('a : value_or_null)
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_bits32 ];;
@@ -359,10 +349,10 @@ Line 1, characters 20-28:
 1 | type f7_4 = [ `A of t_bits32 ];;
                         ^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : bits32) f7_5 = [ `A of 'a ];;
@@ -370,11 +360,12 @@ type ('a : bits32) f7_5 = [ `A of 'a ];;
 Line 1, characters 34-36:
 1 | type ('a : bits32) f7_5 = [ `A of 'a ];;
                                       ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32
-         because of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value
-         because it's the type of the field of a polymorphic variant.
+Error: This type ('a : value_or_null) should be an instance of type
+         ('a0 : bits32)
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -389,7 +380,7 @@ let id_value x = x;;
 val make_t_bits32 : unit -> t_bits32 = <fun>
 val make_t_bits32_id : ('a : bits32). unit -> 'a t_bits32_id = <fun>
 val make_int32u : unit -> int32# = <fun>
-val id_value : 'a -> 'a = <fun>
+val id_value : ('a : value_or_null). 'a -> 'a = <fun>
 |}];;
 
 let x8_1 = id_value (make_t_bits32 ());;
@@ -398,11 +389,11 @@ Line 1, characters 20-38:
 1 | let x8_1 = id_value (make_t_bits32 ());;
                         ^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_bits32
-       but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       but an expression was expected of type ('a : value_or_null)
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value_or_null, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_bits32_id ());;
@@ -411,11 +402,11 @@ Line 1, characters 20-41:
 1 | let x8_2 = id_value (make_t_bits32_id ());;
                         ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_bits32_id = ('a : bits32)
-       but an expression was expected of type ('b : value)
-       The layout of 'a t_bits32_id is bits32
-         because of the definition of make_t_bits32_id at line 2, characters 21-55.
-       But the layout of 'a t_bits32_id must overlap with value
-         because of the definition of id_value at line 5, characters 13-18.
+       but an expression was expected of type ('b : value_or_null)
+       The layout of 'a t_bits32_id is bits32, because
+         of the definition of make_t_bits32_id at line 2, characters 21-55.
+       But the layout of 'a t_bits32_id must overlap with value_or_null, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_int32u ());;
@@ -424,11 +415,11 @@ Line 1, characters 20-36:
 1 | let x8_3 = id_value (make_int32u ());;
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type int32# but an expression was expected of type
-         ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+         ('a : value_or_null)
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value_or_null, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -567,10 +558,10 @@ Line 1, characters 15-27:
 1 | type t12_1 = < x : t_bits32 >;;
                    ^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : bits32) t12_2 = < x : 'a >;;
@@ -579,10 +570,10 @@ Line 1, characters 33-35:
 1 | type ('a : bits32) t12_2 = < x : 'a >;;
                                      ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32
-         because of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value
-         because it's the type of an object field.
+       The layout of 'a is bits32, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_bits32 = assert false end;;
@@ -592,10 +583,10 @@ Line 1, characters 21-55:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_bits32 but is expected to have type
          ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -606,10 +597,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_bits32_id -> 'a t_bits32_id = assert false
                  ^^
 Error: This type ('a : bits32) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits32
-         because of the definition of t_bits32_id at line 2, characters 0-35.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
 |}];;
 
 class c12_5 = object val x : t_bits32 = assert false end;;
@@ -618,10 +609,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_bits32 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of x must be a sublayout of value
-         because it's the type of a class field.
+       The layout of x is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : int32# end;;
@@ -630,10 +621,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : int32# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type int32# but is expected to have type ('a : value)
-       The layout of int32# is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of int32# must be a sublayout of value
-         because it's the type of an object field.
+       The layout of int32# is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of int32# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : int32# end
@@ -642,10 +633,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : int32# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits32
-         because it is the primitive bits32 type int32#.
-       But the layout of x must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of x is bits32, because
+         it is the primitive bits32 type int32#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -656,10 +647,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_bits32_id -> 'a t_bits32_id
               ^^
 Error: This type ('a : bits32) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits32
-         because of the definition of t_bits32_id at line 2, characters 0-35.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits32, because
+         of the definition of t_bits32_id at line 2, characters 0-35.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -695,10 +686,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_bits32
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_bits32) (m2 : t_bits32) = object
@@ -712,10 +703,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -731,10 +722,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_bits32) = compare x x;;
@@ -744,10 +735,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_bits32) = Marshal.to_bytes x;;
@@ -757,10 +748,10 @@ Line 1, characters 44-45:
                                                 ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_bits32) = Hashtbl.hash x;;
@@ -770,8 +761,8 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type t_bits32
        but an expression was expected of type ('a : value)
-       The layout of t_bits32 is bits32
-         because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits32 is bits32, because
+         of the definition of t_bits32 at line 1, characters 0-22.
+       But the layout of t_bits32 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -190,10 +190,11 @@ Line 1, characters 31-33:
 1 | type ('a : bits64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits64)
-       The layout of 'a is bits64, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
+       The layout of 'a is bits64
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it instantiates an unannotated type parameter of t4_7,
+         defaulted to layout value.
 |}]
 
 (****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -193,10 +193,10 @@ Line 1, characters 31-33:
 1 | type ('a : bits64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits64)
-       The layout of 'a is bits64
-         because of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
 |}]
 
 (****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
@@ -113,10 +113,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value_or_null)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_bits64_id) = x, false;;
@@ -126,10 +126,10 @@ Line 1, characters 32-33:
                                     ^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value_or_null)
-       The layout of 'a t_bits64_id is bits64, because
-         of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value_or_null, because
-         it's the type of a tuple element.
+       The layout of 'a t_bits64_id is bits64
+         because of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : int64#) = x, false;;
@@ -139,10 +139,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value_or_null)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_bits64 * string;;
@@ -151,10 +151,10 @@ Line 1, characters 12-20:
 1 | type t4_4 = t_bits64 * string;;
                 ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * int64#;;
@@ -163,10 +163,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * int64#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type ('a : bits64) t4_6 = 'a * 'a
@@ -176,10 +176,10 @@ Line 1, characters 26-28:
                               ^^
 Error: This type ('a : value_or_null) should be an instance of type
          ('a0 : bits64)
-       The layout of 'a is bits64, because
-         of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value_or_null, because
-         it's the type of a tuple element.
+       The layout of 'a is bits64
+         because of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -189,10 +189,11 @@ Line 1, characters 31-33:
 1 | type ('a : bits64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                    ^^
 Error: This type ('b : value) should be an instance of type ('a : bits64)
-       The layout of 'a is bits64, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
+       The layout of 'a is bits64
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it instantiates an unannotated type parameter of t4_7,
+         defaulted to layout value.
 |}]
 
 (****************************************************)
@@ -271,10 +272,10 @@ Line 1, characters 31-39:
 1 | module type S6_1 = sig val x : t_bits64 end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of type t_bits64 must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of type t_bits64 must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_bits64_id end
@@ -283,10 +284,10 @@ Line 1, characters 31-45:
 1 | module type S6_2 = sig val x : 'a t_bits64_id end
                                    ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_bits64_id is bits64, because
-         of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of type 'a t_bits64_id must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type 'a t_bits64_id is bits64
+         because of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of type 'a t_bits64_id must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : int64# end
@@ -295,10 +296,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : int64# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of type int64# must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of type int64# must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 
@@ -311,10 +312,10 @@ Line 1, characters 29-30:
                                  ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value_or_null)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_bits64_id) = `A x;;
@@ -324,10 +325,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value_or_null)
-       The layout of 'a t_bits64_id is bits64, because
-         of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a t_bits64_id is bits64
+         because of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : int64#) = `A x;;
@@ -337,10 +338,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value_or_null)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_bits64 ];;
@@ -349,10 +350,10 @@ Line 1, characters 20-28:
 1 | type f7_4 = [ `A of t_bits64 ];;
                         ^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : bits64) f7_5 = [ `A of 'a ];;
@@ -362,10 +363,10 @@ Line 1, characters 34-36:
                                       ^^
 Error: This type ('a : value_or_null) should be an instance of type
          ('a0 : bits64)
-       The layout of 'a is bits64, because
-         of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a is bits64
+         because of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -390,10 +391,10 @@ Line 1, characters 20-38:
                         ^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value_or_null)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value_or_null, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_bits64_id ());;
@@ -403,10 +404,10 @@ Line 1, characters 20-41:
                         ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
        but an expression was expected of type ('b : value_or_null)
-       The layout of 'a t_bits64_id is bits64, because
-         of the definition of make_t_bits64_id at line 2, characters 21-55.
-       But the layout of 'a t_bits64_id must overlap with value_or_null, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_bits64_id is bits64
+         because of the definition of make_t_bits64_id at line 2, characters 21-55.
+       But the layout of 'a t_bits64_id must overlap with value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_int64u ());;
@@ -416,10 +417,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type int64# but an expression was expected of type
          ('a : value_or_null)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value_or_null, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -560,10 +561,10 @@ Line 1, characters 15-27:
 1 | type t12_1 = < x : t_bits64 >;;
                    ^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 type ('a : bits64) t12_2 = < x : 'a >;;
@@ -572,10 +573,10 @@ Line 1, characters 33-35:
 1 | type ('a : bits64) t12_2 = < x : 'a >;;
                                      ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       The layout of 'a is bits64, because
-         of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a is bits64
+         because of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value
+         because it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_bits64 = assert false end;;
@@ -585,10 +586,10 @@ Line 1, characters 21-55:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_bits64 but is expected to have type
          ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -599,10 +600,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_bits64_id -> 'a t_bits64_id = assert false
                  ^^
 Error: This type ('a : bits64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits64, because
-         of the definition of t_bits64_id at line 2, characters 0-35.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits64
+         because of the definition of t_bits64_id at line 2, characters 0-35.
 |}];;
 
 class c12_5 = object val x : t_bits64 = assert false end;;
@@ -611,10 +612,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_bits64 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of x must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of x is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of x must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : int64# end;;
@@ -623,10 +624,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : int64# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type int64# but is expected to have type ('a : value)
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : int64# end
@@ -635,10 +636,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : int64# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of x must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of x is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of x must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -649,10 +650,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_bits64_id -> 'a t_bits64_id
               ^^
 Error: This type ('a : bits64) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits64, because
-         of the definition of t_bits64_id at line 2, characters 0-35.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits64
+         because of the definition of t_bits64_id at line 2, characters 0-35.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -688,10 +689,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_bits64
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_bits64) (m2 : t_bits64) = object
@@ -705,10 +706,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -724,10 +725,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_bits64) = compare x x;;
@@ -737,10 +738,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_bits64) = Marshal.to_bytes x;;
@@ -750,10 +751,10 @@ Line 1, characters 44-45:
                                                 ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_bits64) = Hashtbl.hash x;;
@@ -763,8 +764,8 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64, because
-         of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64
+         because of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
@@ -1,8 +1,6 @@
 (* TEST
  {
-   expect;
- }{
-   flags = "-extension layouts_beta";
+   flags = "-extension layouts_alpha";
    expect;
  }
 *)
@@ -114,11 +112,11 @@ Line 1, characters 26-27:
 1 | let f4_1 (x : t_bits64) = x, false;;
                               ^
 Error: This expression has type t_bits64
-       but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of a tuple element.
+       but an expression was expected of type ('a : value_or_null)
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_bits64_id) = x, false;;
@@ -127,11 +125,11 @@ Line 1, characters 32-33:
 1 | let f4_2 (x : 'a t_bits64_id) = x, false;;
                                     ^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
-       but an expression was expected of type ('b : value)
-       The layout of 'a t_bits64_id is bits64
-         because of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value
-         because it's the type of a tuple element.
+       but an expression was expected of type ('b : value_or_null)
+       The layout of 'a t_bits64_id is bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must overlap with value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : int64#) = x, false;;
@@ -140,11 +138,11 @@ Line 1, characters 24-25:
 1 | let f4_3 (x : int64#) = x, false;;
                             ^
 Error: This expression has type int64# but an expression was expected of type
-         ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's the type of a tuple element.
+         ('a : value_or_null)
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_bits64 * string;;
@@ -153,10 +151,10 @@ Line 1, characters 12-20:
 1 | type t4_4 = t_bits64 * string;;
                 ^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * int64#;;
@@ -165,10 +163,10 @@ Line 1, characters 18-24:
 1 | type t4_5 = int * int64#;;
                       ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : bits64) t4_6 = 'a * 'a
@@ -176,11 +174,12 @@ type ('a : bits64) t4_6 = 'a * 'a
 Line 1, characters 26-28:
 1 | type ('a : bits64) t4_6 = 'a * 'a
                               ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       The layout of 'a is bits64
-         because of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+Error: This type ('a : value_or_null) should be an instance of type
+         ('a0 : bits64)
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -262,15 +261,6 @@ Error: Type t_bits64 has layout bits64.
        Unboxed variants may not yet contain types of this layout.
 |}];;
 
-type t5_6_1 = A of { x : t_bits64 } [@@unboxed];;
-[%%expect{|
-Line 1, characters 21-33:
-1 | type t5_6_1 = A of { x : t_bits64 } [@@unboxed];;
-                         ^^^^^^^^^^^^
-Error: Type t_bits64 has layout bits64.
-       Unboxed inlined records may not yet contain types of this layout.
-|}];;
-
 (****************************************************)
 (* Test 6: Can't be put at top level of signatures. *)
 module type S6_1 = sig val x : t_bits64 end
@@ -281,10 +271,10 @@ Line 1, characters 31-39:
 1 | module type S6_1 = sig val x : t_bits64 end
                                    ^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of type t_bits64 must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of type t_bits64 must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_bits64_id end
@@ -293,10 +283,10 @@ Line 1, characters 31-45:
 1 | module type S6_2 = sig val x : 'a t_bits64_id end
                                    ^^^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_bits64_id is bits64
-         because of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of type 'a t_bits64_id must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type 'a t_bits64_id is bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of type 'a t_bits64_id must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : int64# end
@@ -305,10 +295,10 @@ Line 1, characters 31-37:
 1 | module type S6_3 = sig val x : int64# end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of type int64# must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of type int64# must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -320,11 +310,11 @@ Line 1, characters 29-30:
 1 | let f7_1 (x : t_bits64) = `A x;;
                                  ^
 Error: This expression has type t_bits64
-       but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       but an expression was expected of type ('a : value_or_null)
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_bits64_id) = `A x;;
@@ -333,11 +323,11 @@ Line 1, characters 35-36:
 1 | let f7_2 (x : 'a t_bits64_id) = `A x;;
                                        ^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
-       but an expression was expected of type ('b : value)
-       The layout of 'a t_bits64_id is bits64
-         because of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       but an expression was expected of type ('b : value_or_null)
+       The layout of 'a t_bits64_id is bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must overlap with value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : int64#) = `A x;;
@@ -346,11 +336,11 @@ Line 1, characters 27-28:
 1 | let f7_3 (x : int64#) = `A x;;
                                ^
 Error: This expression has type int64# but an expression was expected of type
-         ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+         ('a : value_or_null)
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_bits64 ];;
@@ -359,10 +349,10 @@ Line 1, characters 20-28:
 1 | type f7_4 = [ `A of t_bits64 ];;
                         ^^^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : bits64) f7_5 = [ `A of 'a ];;
@@ -370,11 +360,12 @@ type ('a : bits64) f7_5 = [ `A of 'a ];;
 Line 1, characters 34-36:
 1 | type ('a : bits64) f7_5 = [ `A of 'a ];;
                                       ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       The layout of 'a is bits64
-         because of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value
-         because it's the type of the field of a polymorphic variant.
+Error: This type ('a : value_or_null) should be an instance of type
+         ('a0 : bits64)
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -389,7 +380,7 @@ let id_value x = x;;
 val make_t_bits64 : unit -> t_bits64 = <fun>
 val make_t_bits64_id : ('a : bits64). unit -> 'a t_bits64_id = <fun>
 val make_int64u : unit -> int64# = <fun>
-val id_value : 'a -> 'a = <fun>
+val id_value : ('a : value_or_null). 'a -> 'a = <fun>
 |}];;
 
 let x8_1 = id_value (make_t_bits64 ());;
@@ -398,11 +389,11 @@ Line 1, characters 20-38:
 1 | let x8_1 = id_value (make_t_bits64 ());;
                         ^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_bits64
-       but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       but an expression was expected of type ('a : value_or_null)
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value_or_null, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_bits64_id ());;
@@ -411,11 +402,11 @@ Line 1, characters 20-41:
 1 | let x8_2 = id_value (make_t_bits64_id ());;
                         ^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_bits64_id = ('a : bits64)
-       but an expression was expected of type ('b : value)
-       The layout of 'a t_bits64_id is bits64
-         because of the definition of make_t_bits64_id at line 2, characters 21-55.
-       But the layout of 'a t_bits64_id must overlap with value
-         because of the definition of id_value at line 5, characters 13-18.
+       but an expression was expected of type ('b : value_or_null)
+       The layout of 'a t_bits64_id is bits64, because
+         of the definition of make_t_bits64_id at line 2, characters 21-55.
+       But the layout of 'a t_bits64_id must overlap with value_or_null, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_int64u ());;
@@ -424,11 +415,11 @@ Line 1, characters 20-36:
 1 | let x8_3 = id_value (make_int64u ());;
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type int64# but an expression was expected of type
-         ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+         ('a : value_or_null)
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value_or_null, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -569,10 +560,10 @@ Line 1, characters 15-27:
 1 | type t12_1 = < x : t_bits64 >;;
                    ^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : bits64) t12_2 = < x : 'a >;;
@@ -581,10 +572,10 @@ Line 1, characters 33-35:
 1 | type ('a : bits64) t12_2 = < x : 'a >;;
                                      ^^
 Error: This type ('a : value) should be an instance of type ('a0 : bits64)
-       The layout of 'a is bits64
-         because of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value
-         because it's the type of an object field.
+       The layout of 'a is bits64, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_bits64 = assert false end;;
@@ -594,10 +585,10 @@ Line 1, characters 21-55:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_bits64 but is expected to have type
          ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -608,10 +599,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_bits64_id -> 'a t_bits64_id = assert false
                  ^^
 Error: This type ('a : bits64) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits64
-         because of the definition of t_bits64_id at line 2, characters 0-35.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
 |}];;
 
 class c12_5 = object val x : t_bits64 = assert false end;;
@@ -620,10 +611,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_bits64 = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of x must be a sublayout of value
-         because it's the type of a class field.
+       The layout of x is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : int64# end;;
@@ -632,10 +623,10 @@ Line 1, characters 26-43:
 1 | class type c12_6 = object method x : int64# end;;
                               ^^^^^^^^^^^^^^^^^
 Error: The method x has type int64# but is expected to have type ('a : value)
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of value
-         because it's the type of an object field.
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : int64# end
@@ -644,10 +635,10 @@ Line 1, characters 26-40:
 1 | class type c12_7 = object val x : int64# end
                               ^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of x must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of x is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -658,10 +649,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_bits64_id -> 'a t_bits64_id
               ^^
 Error: This type ('a : bits64) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with bits64
-         because of the definition of t_bits64_id at line 2, characters 0-35.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with bits64, because
+         of the definition of t_bits64_id at line 2, characters 0-35.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -697,10 +688,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_bits64
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_bits64) (m2 : t_bits64) = object
@@ -714,10 +705,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -733,10 +724,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_bits64) = compare x x;;
@@ -746,10 +737,10 @@ Line 1, characters 35-36:
                                        ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_bits64) = Marshal.to_bytes x;;
@@ -759,10 +750,10 @@ Line 1, characters 44-45:
                                                 ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_bits64) = Hashtbl.hash x;;
@@ -772,8 +763,8 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression has type t_bits64
        but an expression was expected of type ('a : value)
-       The layout of t_bits64 is bits64
-         because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_bits64 is bits64, because
+         of the definition of t_bits64 at line 1, characters 0-22.
+       But the layout of t_bits64 must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/debug_printer.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/debug_printer.compilers.reference
@@ -1,4 +1,4 @@
 type ('a : float64) t = 'a
-val f : 'b ('a : float64). 'b -> 'a t -> unit = <fun>
+val f : ('b : value_or_null) ('a : float64). 'b -> 'a t -> unit = <fun>
 f has the wrong type for a printing function.
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -171,11 +171,11 @@ Line 1, characters 26-27:
 1 | let f2 (x: t_void) = A.f2 x
                               ^
 Error: This expression has type t_void but an expression was expected of type
-         ('a : value)
-       The layout of t_void is void
-         because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because of layout requirements from an imported definition.
+         ('a : value_or_null)
+       The layout of t_void is void, because
+         of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value_or_null, because
+         of layout requirements from an imported definition.
 |}]
 
 type ('a : value) t_v = 'a

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -172,10 +172,10 @@ Line 1, characters 26-27:
                               ^
 Error: This expression has type t_void but an expression was expected of type
          ('a : value_or_null)
-       The layout of t_void is void, because
-         of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value_or_null, because
-         of layout requirements from an imported definition.
+       The layout of t_void is void
+         because of the definition of t_void at line 2, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}]
 
 type ('a : value) t_v = 'a

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -45,10 +45,10 @@ Line 1, characters 9-14:
 1 | type t = t_any * t_any
              ^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of t_any is any
+         because of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 (* Probe *)
@@ -279,10 +279,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_float64
        but an expression was expected of type ('a : value_or_null)
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (* Default_type_jkind *)
@@ -375,10 +375,10 @@ Line 1, characters 28-34:
 1 | module type S = sig val x : t_void end
                                 ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_void is void, because
-         of the definition of t_void at line 6, characters 0-19.
-       But the layout of type t_void must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type t_void is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of type t_void must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 (* Debug_printer_argument *)

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -45,10 +45,10 @@ Line 1, characters 9-14:
 1 | type t = t_any * t_any
              ^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_any is any
-         because of the definition of t_any at line 1, characters 0-18.
-       But the layout of t_any must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of t_any must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 (* Probe *)
@@ -278,11 +278,11 @@ Line 1, characters 27-28:
 1 | let f (x : t_float64) = `A x;;
                                ^
 Error: This expression has type t_float64
-       but an expression was expected of type ('a : value)
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       but an expression was expected of type ('a : value_or_null)
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 5, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 (* Default_type_jkind *)
@@ -375,10 +375,10 @@ Line 1, characters 28-34:
 1 | module type S = sig val x : t_void end
                                 ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_void is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of type t_void must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_void is void, because
+         of the definition of t_void at line 6, characters 0-19.
+       But the layout of type t_void must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}];;
 
 (* Debug_printer_argument *)

--- a/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
@@ -188,10 +188,10 @@ Line 1, characters 32-34:
 1 | type ('a : float32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float32)
-       The layout of 'a is float32
-         because of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is float32, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
 |}]
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
@@ -188,10 +188,11 @@ Line 1, characters 32-34:
 1 | type ('a : float32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float32)
-       The layout of 'a is float32, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
+       The layout of 'a is float32
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it instantiates an unannotated type parameter of t4_7,
+         defaulted to layout value.
 |}]
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -188,10 +188,10 @@ Line 1, characters 32-34:
 1 | type ('a : float64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float64)
-       The layout of 'a is float64
-         because of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is float64, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
 |}]
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -188,10 +188,11 @@ Line 1, characters 32-34:
 1 | type ('a : float64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                     ^^
 Error: This type ('b : value) should be an instance of type ('a : float64)
-       The layout of 'a is float64, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it instantiates an unannotated type parameter of t4_7,
+         defaulted to layout value.
 |}]
 
 (*****************************************)

--- a/ocaml/testsuite/tests/typing-layouts-or-null/array.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/array.ml
@@ -3,7 +3,7 @@
  expect;
 *)
 
-(* CR layouts v3.0: array type arguments should be [any_non_null]: *)
+(* Array type arguments are [any_non_null]: *)
 
 type t_any : any
 
@@ -11,7 +11,14 @@ type should_fail = t_any array
 
 [%%expect{|
 type t_any : any
-type should_fail = t_any array
+Line 3, characters 19-24:
+3 | type should_fail = t_any array
+                       ^^^^^
+Error: This type t_any should be an instance of type ('a : any_non_null)
+       The layout of t_any is any, because
+         of the definition of t_any at line 1, characters 0-16.
+       But the layout of t_any must be a sublayout of any_non_null, because
+         it's the type argument to the array type.
 |}]
 
 type t_value_or_null : value_or_null
@@ -20,5 +27,13 @@ type should_fail = t_value_or_null array
 
 [%%expect{|
 type t_value_or_null : value_or_null
-type should_fail = t_value_or_null array
+Line 3, characters 19-34:
+3 | type should_fail = t_value_or_null array
+                       ^^^^^^^^^^^^^^^
+Error: This type t_value_or_null should be an instance of type
+         ('a : any_non_null)
+       The layout of t_value_or_null is value_or_null, because
+         of the definition of t_value_or_null at line 1, characters 0-36.
+       But the layout of t_value_or_null must be a sublayout of any_non_null, because
+         it's the type argument to the array type.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/array.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/array.ml
@@ -15,10 +15,10 @@ Line 3, characters 19-24:
 3 | type should_fail = t_any array
                        ^^^^^
 Error: This type t_any should be an instance of type ('a : any_non_null)
-       The layout of t_any is any, because
-         of the definition of t_any at line 1, characters 0-16.
-       But the layout of t_any must be a sublayout of any_non_null, because
-         it's the type argument to the array type.
+       The kind of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the kind of t_any must be a subkind of any_non_null
+         because it's the type argument to the array type.
 |}]
 
 type t_value_or_null : value_or_null
@@ -32,8 +32,8 @@ Line 3, characters 19-34:
                        ^^^^^^^^^^^^^^^
 Error: This type t_value_or_null should be an instance of type
          ('a : any_non_null)
-       The layout of t_value_or_null is value_or_null, because
-         of the definition of t_value_or_null at line 1, characters 0-36.
-       But the layout of t_value_or_null must be a sublayout of any_non_null, because
-         it's the type argument to the array type.
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -57,7 +57,7 @@ Line 2, characters 10-24:
 Error: This type signature for x is not a value type.
        The layout of type t_any_non_null is any
          because of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of type t_any_non_null must be a sublayout of value
+       But the layout of type t_any_non_null must be a sublayout of value_or_null
          because it's the type of something stored in a module structure.
 |}]
 
@@ -86,35 +86,18 @@ Error: This expression has type t_any_non_null
          because we must know concretely how to return a function result.
 |}]
 
-(* CR layouts v3.0: [value_or_null] should be representable *)
+(* [value_or_null] is representable *)
 
 let f (x : t_value_or_null) = x
 
 [%%expect{|
-Line 1, characters 6-27:
-1 | let f (x : t_value_or_null) = x
-          ^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type t_value_or_null
-       but a pattern was expected which matches values of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because we must know concretely how to pass a function argument,
-         defaulted to kind value.
+val f : t_value_or_null -> t_value_or_null = <fun>
 |}]
 
 type t = { x : t_value_or_null }
 
 [%%expect {|
-Line 1, characters 11-30:
-1 | type t = { x : t_value_or_null }
-               ^^^^^^^^^^^^^^^^^^^
-Error: Record element types must have a representable layout.
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because it is the type of record field x,
-         defaulted to kind value.
+type t = { x : t_value_or_null; }
 |}]
 
 module type S1 = sig
@@ -122,14 +105,7 @@ module type S1 = sig
 end
 
 [%%expect {|
-Line 2, characters 10-25:
-2 |   val x : t_value_or_null
-              ^^^^^^^^^^^^^^^
-Error: This type signature for x is not a value type.
-       The kind of type t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of type t_value_or_null must be a subkind of value
-         because it's the type of something stored in a module structure.
+module type S1 = sig val x : t_value_or_null end
 |}]
 
 module type S2 = sig
@@ -145,16 +121,7 @@ module M2 (X : S2) = struct
 end
 
 [%%expect{|
-Line 2, characters 13-19:
-2 |   let f () = X.f ()
-                 ^^^^^^
-Error: This expression has type t_value_or_null
-       but an expression was expected of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 3, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because we must know concretely how to return a function result,
-         defaulted to kind value.
+module M2 : functor (X : S2) -> sig val f : unit -> t_value_or_null end
 |}]
 
 type ('a : any) id_any = 'a

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -57,7 +57,7 @@ Line 2, characters 10-24:
 Error: This type signature for x is not a value type.
        The layout of type t_any_non_null is any
          because of the definition of t_any_non_null at line 2, characters 0-34.
-       But the layout of type t_any_non_null must be a sublayout of value_or_null
+       But the layout of type t_any_non_null must be a sublayout of value
          because it's the type of something stored in a module structure.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -31,8 +31,7 @@ Error: This type t_value_or_null should be an instance of type ('a : value)
          because of the definition of should_not_accept_or_null at line 1, characters 0-55.
 |}]
 
-(* CR layouts v3.0: [value_or_null] types should be accepted for
-   function arguments and results. *)
+(* [value_or_null] is accepted for function arguments and results. *)
 
 let should_work (x : t_value_or_null) = x
 
@@ -283,9 +282,9 @@ Error: Signature mismatch:
 (* CR layouts v3.0: this should work. *)
 
 module M : sig
-  val f : ('a : value_or_null). 'a -> 'a
+  val f : ('a : value_or_null) . 'a -> 'a
 end = struct
-  let f x = x
+  let f : type a. a -> a = fun x -> x
 end
 
 [%%expect{|

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -264,10 +264,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is value_or_null, because
-         of the definition of f at line 2, characters 2-41.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of f at line 4, characters 6-7.
+       The kind of 'a is value_or_null
+         because of the definition of f at line 2, characters 2-41.
+       But the kind of 'a must be a subkind of value
+         because of the definition of f at line 4, characters 6-7.
 |}]
 
 (* CR layouts v3.0: this should work. *)
@@ -293,10 +293,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The layout of 'a is value_or_null, because
-         of the definition of f at line 2, characters 2-41.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of f at line 4, characters 6-7.
+       The kind of 'a is value_or_null
+         because of the definition of f at line 2, characters 2-41.
+       But the kind of 'a must be a subkind of value
+         because of the definition of f at line 4, characters 6-7.
 |}]
 
 (* CR layouts v3.0: annotations on non-rigid type variables are upper bounds.

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -17,6 +17,7 @@ type ('a : value_or_null) id_value_or_null = 'a
 type 'a should_not_accept_or_null = 'a id_value_or_null
 
 type should_not_work = t_value_or_null should_not_accept_or_null
+type should_not_work = t_value_or_null should_not_accept_or_null
 
 [%%expect{|
 type 'a should_not_accept_or_null = 'a id_value_or_null
@@ -249,6 +250,34 @@ Error: Signature mismatch:
          because of the definition of f at line 2, characters 2-41.
        But the kind of 'a must be a subkind of value
          because of the definition of f at line 4, characters 6-7.
+|}]
+
+
+module M : sig
+  val f : ('a : value_or_null) . 'a -> 'a
+end = struct
+  let f : type a. a -> a = fun x -> x
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f : type a. a -> a = fun x -> x
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a end
+       is not included in
+         sig val f : ('a : value_or_null). 'a -> 'a end
+       Values do not match:
+         val f : 'a -> 'a
+       is not included in
+         val f : ('a : value_or_null). 'a -> 'a
+       The type 'a -> 'a is not compatible with the type 'b -> 'b
+       The layout of 'a is value_or_null, because
+         of the definition of f at line 2, characters 2-41.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of f at line 4, characters 6-7.
 |}]
 
 (* CR layouts v3.0: this should work. *)

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -36,16 +36,7 @@ Error: This type t_value_or_null should be an instance of type ('a : value)
 let should_work (x : t_value_or_null) = x
 
 [%%expect{|
-Line 1, characters 16-37:
-1 | let should_work (x : t_value_or_null) = x
-                    ^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type t_value_or_null
-       but a pattern was expected which matches values of type ('a : value)
-       The kind of t_value_or_null is value_or_null
-         because of the definition of t_value_or_null at line 1, characters 0-36.
-       But the kind of t_value_or_null must be a subkind of value
-         because we must know concretely how to pass a function argument,
-         defaulted to kind value.
+val should_work : t_value_or_null -> t_value_or_null = <fun>
 |}]
 
 (* Type variables in function definitions default to [value]. *)
@@ -290,7 +281,7 @@ end
 [%%expect{|
 Lines 3-5, characters 6-3:
 3 | ......struct
-4 |   let f x = x
+4 |   let f : type a. a -> a = fun x -> x
 5 | end
 Error: Signature mismatch:
        Modules do not match:
@@ -302,10 +293,10 @@ Error: Signature mismatch:
        is not included in
          val f : ('a : value_or_null). 'a -> 'a
        The type 'a -> 'a is not compatible with the type 'b -> 'b
-       The kind of 'a is value_or_null
-         because of the definition of f at line 2, characters 2-40.
-       But the kind of 'a must be a subkind of value
-         because of the definition of f at line 4, characters 8-13.
+       The layout of 'a is value_or_null, because
+         of the definition of f at line 2, characters 2-41.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of f at line 4, characters 6-7.
 |}]
 
 (* CR layouts v3.0: annotations on non-rigid type variables are upper bounds.

--- a/ocaml/testsuite/tests/typing-layouts-word/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics.ml
@@ -190,10 +190,11 @@ Line 1, characters 29-31:
 1 | type ('a : word, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                  ^^
 Error: This type ('b : value) should be an instance of type ('a : word)
-       The layout of 'a is word, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
+       The layout of 'a is word
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it instantiates an unannotated type parameter of t4_7,
+         defaulted to layout value.
 |}]
 
 (****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-word/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics.ml
@@ -193,10 +193,10 @@ Line 1, characters 29-31:
 1 | type ('a : word, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                  ^^
 Error: This type ('b : value) should be an instance of type ('a : word)
-       The layout of 'a is word
-         because of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value, because
+         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
 |}]
 
 (****************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
@@ -1,8 +1,6 @@
 (* TEST
  {
-   expect;
- }{
-   flags = "-extension layouts_beta";
+   flags = "-extension layouts_alpha";
    expect;
  }
 *)
@@ -114,11 +112,11 @@ Line 1, characters 24-25:
 1 | let f4_1 (x : t_word) = x, false;;
                             ^
 Error: This expression has type t_word but an expression was expected of type
-         ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of a tuple element.
+         ('a : value_or_null)
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_word_id) = x, false;;
@@ -127,11 +125,11 @@ Line 1, characters 30-31:
 1 | let f4_2 (x : 'a t_word_id) = x, false;;
                                   ^
 Error: This expression has type 'a t_word_id = ('a : word)
-       but an expression was expected of type ('b : value)
-       The layout of 'a t_word_id is word
-         because of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value
-         because it's the type of a tuple element.
+       but an expression was expected of type ('b : value_or_null)
+       The layout of 'a t_word_id is word, because
+         of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must overlap with value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : nativeint#) = x, false;;
@@ -140,11 +138,11 @@ Line 1, characters 28-29:
 1 | let f4_3 (x : nativeint#) = x, false;;
                                 ^
 Error: This expression has type nativeint#
-       but an expression was expected of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's the type of a tuple element.
+       but an expression was expected of type ('a : value_or_null)
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_word * string;;
@@ -153,10 +151,10 @@ Line 1, characters 12-18:
 1 | type t4_4 = t_word * string;;
                 ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * nativeint#;;
@@ -165,10 +163,10 @@ Line 1, characters 18-28:
 1 | type t4_5 = int * nativeint#;;
                       ^^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 type ('a : word) t4_6 = 'a * 'a
@@ -176,11 +174,12 @@ type ('a : word) t4_6 = 'a * 'a
 Line 1, characters 24-26:
 1 | type ('a : word) t4_6 = 'a * 'a
                             ^^
-Error: This type ('a : value) should be an instance of type ('a0 : word)
-       The layout of 'a is word
-         because of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value
-         because it's the type of a tuple element.
+Error: This type ('a : value_or_null) should be an instance of type
+         ('a0 : word)
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value_or_null, because
+         it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -261,15 +260,6 @@ Error: Type t_word has layout word.
        Unboxed variants may not yet contain types of this layout.
 |}];;
 
-type t5_6_1 = A of { x : t_word } [@@unboxed];;
-[%%expect{|
-Line 1, characters 21-31:
-1 | type t5_6_1 = A of { x : t_word } [@@unboxed];;
-                         ^^^^^^^^^^
-Error: Type t_word has layout word.
-       Unboxed inlined records may not yet contain types of this layout.
-|}];;
-
 (****************************************************)
 (* Test 6: Can't be put at top level of signatures. *)
 module type S6_1 = sig val x : t_word end
@@ -280,10 +270,10 @@ Line 1, characters 31-37:
 1 | module type S6_1 = sig val x : t_word end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of type t_word must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of type t_word must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_word_id end
@@ -292,10 +282,10 @@ Line 1, characters 31-43:
 1 | module type S6_2 = sig val x : 'a t_word_id end
                                    ^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_word_id is word
-         because of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of type 'a t_word_id must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type 'a t_word_id is word, because
+         of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of type 'a t_word_id must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : nativeint# end
@@ -304,10 +294,10 @@ Line 1, characters 31-41:
 1 | module type S6_3 = sig val x : nativeint# end
                                    ^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of type nativeint# must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of type nativeint# must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}];;
 
 
@@ -319,11 +309,11 @@ Line 1, characters 27-28:
 1 | let f7_1 (x : t_word) = `A x;;
                                ^
 Error: This expression has type t_word but an expression was expected of type
-         ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+         ('a : value_or_null)
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_word_id) = `A x;;
@@ -332,11 +322,11 @@ Line 1, characters 33-34:
 1 | let f7_2 (x : 'a t_word_id) = `A x;;
                                      ^
 Error: This expression has type 'a t_word_id = ('a : word)
-       but an expression was expected of type ('b : value)
-       The layout of 'a t_word_id is word
-         because of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value
-         because it's the type of the field of a polymorphic variant.
+       but an expression was expected of type ('b : value_or_null)
+       The layout of 'a t_word_id is word, because
+         of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must overlap with value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : nativeint#) = `A x;;
@@ -345,11 +335,11 @@ Line 1, characters 31-32:
 1 | let f7_3 (x : nativeint#) = `A x;;
                                    ^
 Error: This expression has type nativeint#
-       but an expression was expected of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       but an expression was expected of type ('a : value_or_null)
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_word ];;
@@ -358,10 +348,10 @@ Line 1, characters 20-26:
 1 | type f7_4 = [ `A of t_word ];;
                         ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : word) f7_5 = [ `A of 'a ];;
@@ -369,11 +359,12 @@ type ('a : word) f7_5 = [ `A of 'a ];;
 Line 1, characters 32-34:
 1 | type ('a : word) f7_5 = [ `A of 'a ];;
                                     ^^
-Error: This type ('a : value) should be an instance of type ('a0 : word)
-       The layout of 'a is word
-         because of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value
-         because it's the type of the field of a polymorphic variant.
+Error: This type ('a : value_or_null) should be an instance of type
+         ('a0 : word)
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value_or_null, because
+         it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -388,7 +379,7 @@ let id_value x = x;;
 val make_t_word : unit -> t_word = <fun>
 val make_t_word_id : ('a : word). unit -> 'a t_word_id = <fun>
 val make_nativeintu : unit -> nativeint# = <fun>
-val id_value : 'a -> 'a = <fun>
+val id_value : ('a : value_or_null). 'a -> 'a = <fun>
 |}];;
 
 let x8_1 = id_value (make_t_word ());;
@@ -397,11 +388,11 @@ Line 1, characters 20-36:
 1 | let x8_1 = id_value (make_t_word ());;
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type t_word but an expression was expected of type
-         ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+         ('a : value_or_null)
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value_or_null, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_word_id ());;
@@ -410,11 +401,11 @@ Line 1, characters 20-39:
 1 | let x8_2 = id_value (make_t_word_id ());;
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_word_id = ('a : word)
-       but an expression was expected of type ('b : value)
-       The layout of 'a t_word_id is word
-         because of the definition of make_t_word_id at line 2, characters 19-51.
-       But the layout of 'a t_word_id must overlap with value
-         because of the definition of id_value at line 5, characters 13-18.
+       but an expression was expected of type ('b : value_or_null)
+       The layout of 'a t_word_id is word, because
+         of the definition of make_t_word_id at line 2, characters 19-51.
+       But the layout of 'a t_word_id must overlap with value_or_null, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_nativeintu ());;
@@ -423,11 +414,11 @@ Line 1, characters 20-40:
 1 | let x8_3 = id_value (make_nativeintu ());;
                         ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type nativeint#
-       but an expression was expected of type ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because of the definition of id_value at line 5, characters 13-18.
+       but an expression was expected of type ('a : value_or_null)
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value_or_null, because
+         of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -567,10 +558,10 @@ Line 1, characters 15-25:
 1 | type t12_1 = < x : t_word >;;
                    ^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 type ('a : word) t12_2 = < x : 'a >;;
@@ -579,10 +570,10 @@ Line 1, characters 31-33:
 1 | type ('a : word) t12_2 = < x : 'a >;;
                                    ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       The layout of 'a is word
-         because of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value
-         because it's the type of an object field.
+       The layout of 'a is word, because
+         of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value, because
+         it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_word = assert false end;;
@@ -591,10 +582,10 @@ Line 1, characters 21-53:
 1 | class c12_3 = object method x : t_word = assert false end;;
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_word but is expected to have type ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of an object field.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -605,10 +596,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_word_id -> 'a t_word_id = assert false
                  ^^
 Error: This type ('a : word) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with word
-         because of the definition of t_word_id at line 2, characters 0-31.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with word, because
+         of the definition of t_word_id at line 2, characters 0-31.
 |}];;
 
 class c12_5 = object val x : t_word = assert false end;;
@@ -617,10 +608,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_word = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of x must be a sublayout of value
-         because it's the type of a class field.
+       The layout of x is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of x must be a sublayout of value, because
+         it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : nativeint# end;;
@@ -630,10 +621,10 @@ Line 1, characters 26-47:
                               ^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type nativeint# but is expected to have type
          ('a : value)
-       The layout of nativeint# is word
-         because it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value
-         because it's the type of an object field.
+       The layout of nativeint# is word, because
+         it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value, because
+         it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : nativeint# end
@@ -642,10 +633,10 @@ Line 1, characters 26-44:
 1 | class type c12_7 = object val x : nativeint# end
                               ^^^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is word
-         because it is the primitive word type nativeint#.
-       But the layout of x must be a sublayout of value
-         because it's the type of an instance variable.
+       The layout of x is word, because
+         it is the primitive word type nativeint#.
+       But the layout of x must be a sublayout of value, because
+         it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -656,10 +647,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_word_id -> 'a t_word_id
               ^^
 Error: This type ('a : word) should be an instance of type ('a0 : value)
-       The layout of 'a is value
-         because it's a type argument to a class constructor.
-       But the layout of 'a must overlap with word
-         because of the definition of t_word_id at line 2, characters 0-31.
+       The layout of 'a is value, because
+         it's a type argument to a class constructor.
+       But the layout of 'a must overlap with word, because
+         of the definition of t_word_id at line 2, characters 0-31.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -695,10 +686,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_word
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_word) (m2 : t_word) = object
@@ -712,10 +703,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because it's the type of a variable captured in an object.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -731,10 +722,10 @@ Line 1, characters 25-26:
                              ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_word) = compare x x;;
@@ -744,10 +735,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_word) = Marshal.to_bytes x;;
@@ -757,10 +748,10 @@ Line 1, characters 42-43:
                                               ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_word) = Hashtbl.hash x;;
@@ -770,8 +761,8 @@ Line 1, characters 38-39:
                                           ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word
-         because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       The layout of t_word is word, because
+         of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value, because
+         of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
@@ -113,10 +113,10 @@ Line 1, characters 24-25:
                             ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value_or_null)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_2 (x : 'a t_word_id) = x, false;;
@@ -126,10 +126,10 @@ Line 1, characters 30-31:
                                   ^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value_or_null)
-       The layout of 'a t_word_id is word, because
-         of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value_or_null, because
-         it's the type of a tuple element.
+       The layout of 'a t_word_id is word
+         because of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 let f4_3 (x : nativeint#) = x, false;;
@@ -139,10 +139,10 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value_or_null)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_4 = t_word * string;;
@@ -151,10 +151,10 @@ Line 1, characters 12-18:
 1 | type t4_4 = t_word * string;;
                 ^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type t4_5 = int * nativeint#;;
@@ -163,10 +163,10 @@ Line 1, characters 18-28:
 1 | type t4_5 = int * nativeint#;;
                       ^^^^^^^^^^
 Error: Tuple element types must have layout value.
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value_or_null, because
-         it's the type of a tuple element.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's the type of a tuple element.
 |}];;
 
 type ('a : word) t4_6 = 'a * 'a
@@ -176,10 +176,10 @@ Line 1, characters 24-26:
                             ^^
 Error: This type ('a : value_or_null) should be an instance of type
          ('a0 : word)
-       The layout of 'a is word, because
-         of the annotation on 'a in the declaration of the type t4_6.
-       But the layout of 'a must overlap with value_or_null, because
-         it's the type of a tuple element.
+       The layout of 'a is word
+         because of the annotation on 'a in the declaration of the type t4_6.
+       But the layout of 'a must overlap with value
+         because it's the type of a tuple element.
 |}];;
 
 (* check for layout propagation *)
@@ -189,10 +189,11 @@ Line 1, characters 29-31:
 1 | type ('a : word, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
                                  ^^
 Error: This type ('b : value) should be an instance of type ('a : word)
-       The layout of 'a is word, because
-         of the annotation on 'a in the declaration of the type t4_7.
-       But the layout of 'a must overlap with value, because
-         it instantiates an unannotated type parameter of t4_7, defaulted to layout value.
+       The layout of 'a is word
+         because of the annotation on 'a in the declaration of the type t4_7.
+       But the layout of 'a must overlap with value
+         because it instantiates an unannotated type parameter of t4_7,
+         defaulted to layout value.
 |}]
 
 (****************************************************)
@@ -270,10 +271,10 @@ Line 1, characters 31-37:
 1 | module type S6_1 = sig val x : t_word end
                                    ^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of type t_word must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of type t_word must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_2 = sig val x : 'a t_word_id end
@@ -282,10 +283,10 @@ Line 1, characters 31-43:
 1 | module type S6_2 = sig val x : 'a t_word_id end
                                    ^^^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type 'a t_word_id is word, because
-         of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of type 'a t_word_id must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type 'a t_word_id is word
+         because of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of type 'a t_word_id must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 module type S6_3 = sig val x : nativeint# end
@@ -294,10 +295,10 @@ Line 1, characters 31-41:
 1 | module type S6_3 = sig val x : nativeint# end
                                    ^^^^^^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of type nativeint# must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of type nativeint# must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}];;
 
 
@@ -310,10 +311,10 @@ Line 1, characters 27-28:
                                ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value_or_null)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_2 (x : 'a t_word_id) = `A x;;
@@ -323,10 +324,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value_or_null)
-       The layout of 'a t_word_id is word, because
-         of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a t_word_id is word
+         because of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 let f7_3 (x : nativeint#) = `A x;;
@@ -336,10 +337,10 @@ Line 1, characters 31-32:
                                    ^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value_or_null)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type f7_4 = [ `A of t_word ];;
@@ -348,10 +349,10 @@ Line 1, characters 20-26:
 1 | type f7_4 = [ `A of t_word ];;
                         ^^^^^^
 Error: Polymorphic variant constructor argument types must have layout value.
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 type ('a : word) f7_5 = [ `A of 'a ];;
@@ -361,10 +362,10 @@ Line 1, characters 32-34:
                                     ^^
 Error: This type ('a : value_or_null) should be an instance of type
          ('a0 : word)
-       The layout of 'a is word, because
-         of the annotation on 'a in the declaration of the type f7_5.
-       But the layout of 'a must overlap with value_or_null, because
-         it's the type of the field of a polymorphic variant.
+       The layout of 'a is word
+         because of the annotation on 'a in the declaration of the type f7_5.
+       But the layout of 'a must overlap with value
+         because it's the type of the field of a polymorphic variant.
 |}];;
 
 (************************************************************)
@@ -389,10 +390,10 @@ Line 1, characters 20-36:
                         ^^^^^^^^^^^^^^^^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value_or_null)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value_or_null, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_2 = id_value (make_t_word_id ());;
@@ -402,10 +403,10 @@ Line 1, characters 20-39:
                         ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a t_word_id = ('a : word)
        but an expression was expected of type ('b : value_or_null)
-       The layout of 'a t_word_id is word, because
-         of the definition of make_t_word_id at line 2, characters 19-51.
-       But the layout of 'a t_word_id must overlap with value_or_null, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of 'a t_word_id is word
+         because of the definition of make_t_word_id at line 2, characters 19-51.
+       But the layout of 'a t_word_id must overlap with value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 let x8_3 = id_value (make_nativeintu ());;
@@ -415,10 +416,10 @@ Line 1, characters 20-40:
                         ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type nativeint#
        but an expression was expected of type ('a : value_or_null)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value_or_null, because
-         of the definition of id_value at line 5, characters 13-18.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because of the definition of id_value at line 5, characters 13-18.
 |}];;
 
 (*************************************)
@@ -558,10 +559,10 @@ Line 1, characters 15-25:
 1 | type t12_1 = < x : t_word >;;
                    ^^^^^^^^^^
 Error: Object field types must have layout value.
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 type ('a : word) t12_2 = < x : 'a >;;
@@ -570,10 +571,10 @@ Line 1, characters 31-33:
 1 | type ('a : word) t12_2 = < x : 'a >;;
                                    ^^
 Error: This type ('a : value) should be an instance of type ('a0 : word)
-       The layout of 'a is word, because
-         of the annotation on 'a in the declaration of the type t12_2.
-       But the layout of 'a must overlap with value, because
-         it's the type of an object field.
+       The layout of 'a is word
+         because of the annotation on 'a in the declaration of the type t12_2.
+       But the layout of 'a must overlap with value
+         because it's the type of an object field.
 |}]
 
 class c12_3 = object method x : t_word = assert false end;;
@@ -582,10 +583,10 @@ Line 1, characters 21-53:
 1 | class c12_3 = object method x : t_word = assert false end;;
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type t_word but is expected to have type ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class ['a] c12_4 = object
@@ -596,10 +597,10 @@ Line 2, characters 13-15:
 2 |   method x : 'a t_word_id -> 'a t_word_id = assert false
                  ^^
 Error: This type ('a : word) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with word, because
-         of the definition of t_word_id at line 2, characters 0-31.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with word
+         because of the definition of t_word_id at line 2, characters 0-31.
 |}];;
 
 class c12_5 = object val x : t_word = assert false end;;
@@ -608,10 +609,10 @@ Line 1, characters 25-26:
 1 | class c12_5 = object val x : t_word = assert false end;;
                              ^
 Error: Variables bound in a class must have layout value.
-       The layout of x is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of x must be a sublayout of value, because
-         it's the type of a class field.
+       The layout of x is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of x must be a sublayout of value
+         because it's the type of a class field.
 |}];;
 
 class type c12_6 = object method x : nativeint# end;;
@@ -621,10 +622,10 @@ Line 1, characters 26-47:
                               ^^^^^^^^^^^^^^^^^^^^^
 Error: The method x has type nativeint# but is expected to have type
          ('a : value)
-       The layout of nativeint# is word, because
-         it is the primitive word type nativeint#.
-       But the layout of nativeint# must be a sublayout of value, because
-         it's the type of an object field.
+       The layout of nativeint# is word
+         because it is the primitive word type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's the type of an object field.
 |}];;
 
 class type c12_7 = object val x : nativeint# end
@@ -633,10 +634,10 @@ Line 1, characters 26-44:
 1 | class type c12_7 = object val x : nativeint# end
                               ^^^^^^^^^^^^^^^^^^
 Error: Variables bound in a class must have layout value.
-       The layout of x is word, because
-         it is the primitive word type nativeint#.
-       But the layout of x must be a sublayout of value, because
-         it's the type of an instance variable.
+       The layout of x is word
+         because it is the primitive word type nativeint#.
+       But the layout of x must be a sublayout of value
+         because it's the type of an instance variable.
 |}];;
 
 class type ['a] c12_8 = object
@@ -647,10 +648,10 @@ Line 2, characters 10-12:
 2 |   val x : 'a t_word_id -> 'a t_word_id
               ^^
 Error: This type ('a : word) should be an instance of type ('a0 : value)
-       The layout of 'a is value, because
-         it's a type argument to a class constructor.
-       But the layout of 'a must overlap with word, because
-         of the definition of t_word_id at line 2, characters 0-31.
+       The layout of 'a is value
+         because it's a type argument to a class constructor.
+       But the layout of 'a must overlap with word
+         because of the definition of t_word_id at line 2, characters 0-31.
 |}];;
 
 (* Second, allowed uses: as method parameters / returns *)
@@ -686,10 +687,10 @@ Line 3, characters 17-19:
                      ^^
 Error: This expression has type ('a : value)
        but an expression was expected of type t_word
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 let f12_14 (m1 : t_word) (m2 : t_word) = object
@@ -703,10 +704,10 @@ Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
 Error: m1 must have a type of layout value because it is captured by an object.
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         it's the type of a variable captured in an object.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because it's the type of a variable captured in an object.
 |}];;
 
 (*********************************************************************)
@@ -722,10 +723,10 @@ Line 1, characters 25-26:
                              ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_2 (x : t_word) = compare x x;;
@@ -735,10 +736,10 @@ Line 1, characters 33-34:
                                      ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_3 (x : t_word) = Marshal.to_bytes x;;
@@ -748,10 +749,10 @@ Line 1, characters 42-43:
                                               ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;
 
 let f13_4 (x : t_word) = Hashtbl.hash x;;
@@ -761,8 +762,8 @@ Line 1, characters 38-39:
                                           ^
 Error: This expression has type t_word but an expression was expected of type
          ('a : value)
-       The layout of t_word is word, because
-         of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value, because
-         of layout requirements from an imported definition.
+       The layout of t_word is word
+         because of the definition of t_word at line 1, characters 0-18.
+       But the layout of t_word must be a sublayout of value
+         because of layout requirements from an imported definition.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -44,7 +44,7 @@ type t_value_or_null : value_or_null;;
 Line 1, characters 23-36:
 1 | type t_value_or_null : value_or_null;;
                            ^^^^^^^^^^^^^
-Error: Layout value is more experimental than allowed by the enabled layouts extension.
+Error: Layout value_or_null is more experimental than allowed by the enabled layouts extension.
        You must enable -extension layouts_alpha to use this feature.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -35,11 +35,7 @@ Error: Layout void is more experimental than allowed by the enabled layouts exte
 type t_any_non_null : any_non_null;;
 
 [%%expect{|
-Line 1, characters 22-34:
-1 | type t_any_non_null : any_non_null;;
-                          ^^^^^^^^^^^^
-Error: Layout any_non_null is more experimental than allowed by the enabled layouts extension.
-       You must enable -extension layouts_alpha to use this feature.
+type t_any_non_null : any_non_null
 |}]
 
 type t_value_or_null : value_or_null;;
@@ -48,7 +44,7 @@ type t_value_or_null : value_or_null;;
 Line 1, characters 23-36:
 1 | type t_value_or_null : value_or_null;;
                            ^^^^^^^^^^^^^
-Error: Layout value_or_null is more experimental than allowed by the enabled layouts extension.
+Error: Layout value is more experimental than allowed by the enabled layouts extension.
        You must enable -extension layouts_alpha to use this feature.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -34,11 +34,7 @@ Error: Layout void is more experimental than allowed by the enabled layouts exte
 type t_any_non_null : any_non_null;;
 
 [%%expect{|
-Line 1, characters 22-34:
-1 | type t_any_non_null : any_non_null;;
-                          ^^^^^^^^^^^^
-Error: Layout any_non_null is more experimental than allowed by the enabled layouts extension.
-       You must enable -extension layouts_alpha to use this feature.
+type t_any_non_null : any_non_null
 |}]
 
 type t_value_or_null : value_or_null;;
@@ -47,7 +43,7 @@ type t_value_or_null : value_or_null;;
 Line 1, characters 23-36:
 1 | type t_value_or_null : value_or_null;;
                            ^^^^^^^^^^^^^
-Error: Layout value_or_null is more experimental than allowed by the enabled layouts extension.
+Error: Layout value is more experimental than allowed by the enabled layouts extension.
        You must enable -extension layouts_alpha to use this feature.
 |}]
 
@@ -764,10 +760,10 @@ Line 2, characters 54-68:
                                                           ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it instantiates an unannotated type parameter of t, defaulted to layout value.
 |}];;
 
 module type S8_5f = sig
@@ -860,10 +856,10 @@ Line 2, characters 34-48:
                                       ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64
-         because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because it's the type of a tuple element.
+       The layout of t_float64 is float64, because
+         of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value, because
+         it instantiates an unannotated type parameter of t, defaulted to layout value.
 |}];;
 
 module type S9_7f = sig

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -43,7 +43,7 @@ type t_value_or_null : value_or_null;;
 Line 1, characters 23-36:
 1 | type t_value_or_null : value_or_null;;
                            ^^^^^^^^^^^^^
-Error: Layout value is more experimental than allowed by the enabled layouts extension.
+Error: Layout value_or_null is more experimental than allowed by the enabled layouts extension.
        You must enable -extension layouts_alpha to use this feature.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -760,10 +760,11 @@ Line 2, characters 54-68:
                                                           ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it instantiates an unannotated type parameter of t, defaulted to layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it instantiates an unannotated type parameter of t,
+         defaulted to layout value.
 |}];;
 
 module type S8_5f = sig
@@ -856,10 +857,11 @@ Line 2, characters 34-48:
                                       ^^^^^^^^^^^^^^
 Error: The type constraints are not consistent.
        Type ('a : value) is not compatible with type t_float64
-       The layout of t_float64 is float64, because
-         of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value, because
-         it instantiates an unannotated type parameter of t, defaulted to layout value.
+       The layout of t_float64 is float64
+         because of the definition of t_float64 at line 4, characters 0-24.
+       But the layout of t_float64 must be a sublayout of value
+         because it instantiates an unannotated type parameter of t,
+         defaulted to layout value.
 |}];;
 
 module type S9_7f = sig

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -202,7 +202,7 @@ Line 1, characters 27-33:
 Error: This type signature for x is not a value type.
        The layout of type t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of type t_void must be a sublayout of value
+       But the layout of type t_void must be a sublayout of value_or_null
          because it's the type of something stored in a module structure.
 |}];;
 (* CR layouts v5: the test above should be made to work *)
@@ -218,7 +218,7 @@ Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
+       But the layout of t_void must be a sublayout of value_or_null
          because it has to be value for the V1 safety check.
 |}];;
 
@@ -387,7 +387,7 @@ Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void
          because of the definition of void5 at line 1, characters 0-37.
-       But the layout of 'a must be a sublayout of value
+       But the layout of 'a must be a sublayout of value_or_null
          because it has to be value for the V1 safety check.
 |}];;
 
@@ -511,7 +511,7 @@ Line 2, characters 40-46:
 Error: Polymorphic variant constructor argument types must have layout value.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
+       But the layout of t_void must be a sublayout of value_or_null
          because it's the type of the field of a polymorphic variant.
 |}];;
 
@@ -560,7 +560,7 @@ Error: The type constraints are not consistent.
        The layout of void_unboxed_record is void
          because of the definition of t_void at line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value
-         because it's the type of the field of a polymorphic variant.
+         because it instantiates an unannotated type parameter of t, defaulted to layout value.
 |}];;
 
 module type S8_5 = sig
@@ -573,7 +573,7 @@ Line 2, characters 17-23:
 Error: Polymorphic variant constructor argument types must have layout value.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
+       But the layout of t_void must be a sublayout of value_or_null
          because it's the type of the field of a polymorphic variant.
 |}]
 
@@ -591,7 +591,7 @@ Line 2, characters 20-26:
 Error: Tuple element types must have layout value.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
+       But the layout of t_void must be a sublayout of value_or_null
          because it's the type of a tuple element.
 |}];;
 
@@ -605,7 +605,7 @@ Line 2, characters 31-50:
 Error: Tuple element types must have layout value.
        The layout of void_unboxed_record is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value
+       But the layout of void_unboxed_record must be a sublayout of value_or_null
          because it's the type of a tuple element.
 |}];;
 
@@ -622,10 +622,10 @@ Line 7, characters 13-14:
 7 |     | V t -> t, 27
                  ^
 Error: This expression has type void_unboxed_record
-       but an expression was expected of type ('a : value)
+       but an expression was expected of type ('a : value_or_null)
        The layout of void_unboxed_record is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value
+       But the layout of void_unboxed_record must be a sublayout of value_or_null
          because it's the type of a tuple element.
 |}];;
 
@@ -674,7 +674,7 @@ Error: The type constraints are not consistent.
        The layout of void_unboxed_record is void
          because of the definition of t_void at line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value
-         because it's the type of a tuple element.
+         because it instantiates an unannotated type parameter of t, defaulted to layout value.
 |}];;
 
 module type S9_7 = sig
@@ -687,7 +687,7 @@ Line 2, characters 16-22:
 Error: Tuple element types must have layout value.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
+       But the layout of t_void must be a sublayout of value_or_null
          because it's the type of a tuple element.
 |}];;
 
@@ -703,10 +703,10 @@ Line 5, characters 11-23:
 5 |   match 3, X.vr.vr_void with
                ^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
-         ('a : value)
+         ('a : value_or_null)
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
+       But the layout of t_void must be a sublayout of value_or_null
          because it's the type of a tuple element.
 |}];;
 
@@ -1173,7 +1173,7 @@ Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value
+       But the layout of t_void must be a sublayout of value_or_null
          because it has to be value for the V1 safety check.
 |}];;
 
@@ -1319,7 +1319,7 @@ Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void
          because of the definition of r at line 3, characters 0-40.
-       But the layout of 'a must be a sublayout of value
+       But the layout of 'a must be a sublayout of value_or_null
          because it has to be value for the V1 safety check.
 |}];;
 
@@ -1448,7 +1448,7 @@ let q () =
   ()
 
 [%%expect{|
-val ( let* ) : t_float64 -> 'a -> unit = <fun>
+val ( let* ) : ('a : value_or_null). t_float64 -> 'a -> unit = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1474,7 +1474,8 @@ let q () =
   ()
 
 [%%expect{|
-val ( let* ) : 'a ('b : any). 'a -> (t_float64 -> 'b) -> unit = <fun>
+val ( let* ) :
+  ('a : value_or_null) ('b : any). 'a -> (t_float64 -> 'b) -> unit = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1500,7 +1501,8 @@ let q () =
   assert false
 
 [%%expect{|
-val ( let* ) : 'a ('b : any). 'a -> ('b -> t_float64) -> unit = <fun>
+val ( let* ) :
+  ('a : value_or_null) ('b : any). 'a -> ('b -> t_float64) -> unit = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1526,7 +1528,8 @@ let q () =
   ()
 
 [%%expect{|
-val ( let* ) : 'a -> 'b -> t_float64 = <fun>
+val ( let* ) :
+  ('a : value_or_null) ('b : value_or_null). 'a -> 'b -> t_float64 = <fun>
 val q : unit -> t_float64 = <fun>
 |}]
 
@@ -1556,8 +1559,9 @@ let q () =
     ()
 
 [%%expect{|
-val ( let* ) : 'a -> 'b -> unit = <fun>
-val ( and* ) : 'a -> t_float64 -> unit = <fun>
+val ( let* ) : ('a : value_or_null) ('b : value_or_null). 'a -> 'b -> unit =
+  <fun>
+val ( and* ) : ('a : value_or_null). 'a -> t_float64 -> unit = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1587,8 +1591,9 @@ let q () =
     ()
 
 [%%expect{|
-val ( let* ) : 'a -> 'b -> unit = <fun>
-val ( and* ) : t_float64 -> 'a -> unit = <fun>
+val ( let* ) : ('a : value_or_null) ('b : value_or_null). 'a -> 'b -> unit =
+  <fun>
+val ( and* ) : ('a : value_or_null). t_float64 -> 'a -> unit = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1618,8 +1623,9 @@ let q () =
     ()
 
 [%%expect{|
-val ( let* ) : ('a : float64) 'b. 'a -> 'b -> unit = <fun>
-val ( and* ) : 'a -> 'b -> t_float64 = <fun>
+val ( let* ) : ('a : float64) ('b : value_or_null). 'a -> 'b -> unit = <fun>
+val ( and* ) :
+  ('a : value_or_null) ('b : value_or_null). 'a -> 'b -> t_float64 = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1639,10 +1645,11 @@ Line 4, characters 9-19:
 4 |     let* x : t_void = assert false
              ^^^^^^^^^^
 Error: This pattern matches values of type t_void
-       but a pattern was expected which matches values of type ('a : value)
+       but a pattern was expected which matches values of type
+         ('a : value_or_null)
        The layout of t_void is void
          because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
+       But the layout of t_void must be a sublayout of value_or_null
          because it's the type of a tuple element.
 |}]
 
@@ -1655,16 +1662,21 @@ let q () =
     ()
 
 [%%expect{|
-val ( let* ) : 'a -> 'b -> unit = <fun>
-val ( and* ) : 'a -> 'b -> 'c = <fun>
+val ( let* ) : ('a : value_or_null) ('b : value_or_null). 'a -> 'b -> unit =
+  <fun>
+val ( and* ) :
+  ('a : value_or_null) ('b : value_or_null) ('c : value_or_null).
+    'a -> 'b -> 'c =
+  <fun>
 Line 4, characters 9-22:
 4 |     let* x : t_float64 = assert false
              ^^^^^^^^^^^^^
 Error: This pattern matches values of type t_float64
-       but a pattern was expected which matches values of type ('a : value)
+       but a pattern was expected which matches values of type
+         ('a : value_or_null)
        The layout of t_float64 is float64
          because of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
+       But the layout of t_float64 must be a sublayout of value_or_null
          because it's the type of a tuple element.
 |}]
 
@@ -1734,11 +1746,12 @@ let f #poly_var = "hello"
 Line 1, characters 41-43:
 1 | type ('a : void) poly_var = [`A of int * 'a | `B]
                                              ^^
-Error: This type ('a : value) should be an instance of type ('a0 : void)
+Error: This type ('a : value_or_null) should be an instance of type
+         ('a0 : void)
        The layout of 'a is void
          because of the annotation on 'a in the declaration of the type
                                       poly_var.
-       But the layout of 'a must overlap with value
+       But the layout of 'a must overlap with value_or_null
          because it's the type of a tuple element.
 |}]
 
@@ -1757,10 +1770,10 @@ Line 1, characters 14-37:
 1 | let f _ = `Mk (assert false : t_void)
                   ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type t_void but an expression was expected of type
-         ('a : value)
+         ('a : value_or_null)
        The layout of t_void is void
          because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
+       But the layout of t_void must be a sublayout of value_or_null
          because it's the type of the field of a polymorphic variant.
 |}]
 
@@ -1775,7 +1788,7 @@ Line 1, characters 17-22:
 Error: This type signature for foo33 is not a value type.
        The layout of type t_any is any
          because of the definition of t_any at line 1, characters 0-18.
-       But the layout of type t_any must be a sublayout of value
+       But the layout of type t_any must be a sublayout of value_or_null
          because it's the type of something stored in a module structure.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -202,7 +202,7 @@ Line 1, characters 27-33:
 Error: This type signature for x is not a value type.
        The layout of type t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of type t_void must be a sublayout of value_or_null
+       But the layout of type t_void must be a sublayout of value
          because it's the type of something stored in a module structure.
 |}];;
 (* CR layouts v5: the test above should be made to work *)
@@ -218,7 +218,7 @@ Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value_or_null
+       But the layout of t_void must be a sublayout of value
          because it has to be value for the V1 safety check.
 |}];;
 
@@ -387,7 +387,7 @@ Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void
          because of the definition of void5 at line 1, characters 0-37.
-       But the layout of 'a must be a sublayout of value_or_null
+       But the layout of 'a must be a sublayout of value
          because it has to be value for the V1 safety check.
 |}];;
 
@@ -511,7 +511,7 @@ Line 2, characters 40-46:
 Error: Polymorphic variant constructor argument types must have layout value.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value_or_null
+       But the layout of t_void must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
 
@@ -560,7 +560,8 @@ Error: The type constraints are not consistent.
        The layout of void_unboxed_record is void
          because of the definition of t_void at line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value
-         because it instantiates an unannotated type parameter of t, defaulted to layout value.
+         because it instantiates an unannotated type parameter of t,
+         defaulted to layout value.
 |}];;
 
 module type S8_5 = sig
@@ -573,7 +574,7 @@ Line 2, characters 17-23:
 Error: Polymorphic variant constructor argument types must have layout value.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value_or_null
+       But the layout of t_void must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}]
 
@@ -591,7 +592,7 @@ Line 2, characters 20-26:
 Error: Tuple element types must have layout value.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value_or_null
+       But the layout of t_void must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -605,7 +606,7 @@ Line 2, characters 31-50:
 Error: Tuple element types must have layout value.
        The layout of void_unboxed_record is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value_or_null
+       But the layout of void_unboxed_record must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -625,7 +626,7 @@ Error: This expression has type void_unboxed_record
        but an expression was expected of type ('a : value_or_null)
        The layout of void_unboxed_record is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value_or_null
+       But the layout of void_unboxed_record must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -674,7 +675,8 @@ Error: The type constraints are not consistent.
        The layout of void_unboxed_record is void
          because of the definition of t_void at line 6, characters 0-19.
        But the layout of void_unboxed_record must be a sublayout of value
-         because it instantiates an unannotated type parameter of t, defaulted to layout value.
+         because it instantiates an unannotated type parameter of t,
+         defaulted to layout value.
 |}];;
 
 module type S9_7 = sig
@@ -687,7 +689,7 @@ Line 2, characters 16-22:
 Error: Tuple element types must have layout value.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value_or_null
+       But the layout of t_void must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -706,7 +708,7 @@ Error: This expression has type t_void but an expression was expected of type
          ('a : value_or_null)
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value_or_null
+       But the layout of t_void must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -1173,7 +1175,7 @@ Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of t_void is void
          because of the definition of t_void at line 6, characters 0-19.
-       But the layout of t_void must be a sublayout of value_or_null
+       But the layout of t_void must be a sublayout of value
          because it has to be value for the V1 safety check.
 |}];;
 
@@ -1319,7 +1321,7 @@ Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of 'a is void
          because of the definition of r at line 3, characters 0-40.
-       But the layout of 'a must be a sublayout of value_or_null
+       But the layout of 'a must be a sublayout of value
          because it has to be value for the V1 safety check.
 |}];;
 
@@ -1649,7 +1651,7 @@ Error: This pattern matches values of type t_void
          ('a : value_or_null)
        The layout of t_void is void
          because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value_or_null
+       But the layout of t_void must be a sublayout of value
          because it's the type of a tuple element.
 |}]
 
@@ -1676,7 +1678,7 @@ Error: This pattern matches values of type t_float64
          ('a : value_or_null)
        The layout of t_float64 is float64
          because of the definition of t_float64 at line 5, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value_or_null
+       But the layout of t_float64 must be a sublayout of value
          because it's the type of a tuple element.
 |}]
 
@@ -1751,7 +1753,7 @@ Error: This type ('a : value_or_null) should be an instance of type
        The layout of 'a is void
          because of the annotation on 'a in the declaration of the type
                                       poly_var.
-       But the layout of 'a must overlap with value_or_null
+       But the layout of 'a must overlap with value
          because it's the type of a tuple element.
 |}]
 
@@ -1773,7 +1775,7 @@ Error: This expression has type t_void but an expression was expected of type
          ('a : value_or_null)
        The layout of t_void is void
          because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value_or_null
+       But the layout of t_void must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}]
 
@@ -1788,7 +1790,7 @@ Line 1, characters 17-22:
 Error: This type signature for foo33 is not a value type.
        The layout of type t_any is any
          because of the definition of t_any at line 1, characters 0-18.
-       But the layout of type t_any must be a sublayout of value_or_null
+       But the layout of type t_any must be a sublayout of value
          because it's the type of something stored in a module structure.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
@@ -83,8 +83,12 @@ end
 Line 4, characters 63-68:
 4 |   let () = Format.printf "%f %s\n" (F.to_float (id' #1.)) (id' "abc")
                                                                    ^^^^^
-Error: Uncaught exception: Typecore.Error(_, _, _)
-
+Error: This expression has type string but an expression was expected of type
+         ('a : float64)
+       The layout of string is value, because
+         it is the primitive value type string.
+       But the layout of string must be a sublayout of float64, because
+         of the definition of id' at line 2, characters 10-18.
 |}]
 
 (********************)
@@ -539,8 +543,14 @@ external id : ('a : any) ('b : any). 'a -> 'b = "%identity" [@@layout_poly]
 Line 2, characters 28-32:
 2 | let f (x: float#): int64# = id x
                                 ^^^^
-Error: Uncaught exception: Typecore.Error(_, _, _)
-
+Error: This expression has type ('a : float64)
+       but an expression was expected of type int64#
+       The layout of int64# is bits64, because
+         it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of float64, because
+         it's the layout polymorphic type in an external declaration
+         ([@layout_poly] forces all variables of layout 'any' to be
+         representable at call sites).
 |}]
 (* CR layouts v2.9: the default part is not quite correct *)
 

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
@@ -85,10 +85,10 @@ Line 4, characters 63-68:
                                                                    ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : float64)
-       The layout of string is value, because
-         it is the primitive value type string.
-       But the layout of string must be a sublayout of float64, because
-         of the definition of id' at line 2, characters 10-18.
+       The layout of string is value
+         because it is the primitive value type string.
+       But the layout of string must be a sublayout of float64
+         because of the definition of id' at line 2, characters 10-18.
 |}]
 
 (********************)
@@ -545,10 +545,10 @@ Line 2, characters 28-32:
                                 ^^^^
 Error: This expression has type ('a : float64)
        but an expression was expected of type int64#
-       The layout of int64# is bits64, because
-         it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of float64, because
-         it's the layout polymorphic type in an external declaration
+       The layout of int64# is bits64
+         because it is the primitive bits64 type int64#.
+       But the layout of int64# must be a sublayout of float64
+         because it's the layout polymorphic type in an external declaration
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
@@ -83,12 +83,8 @@ end
 Line 4, characters 63-68:
 4 |   let () = Format.printf "%f %s\n" (F.to_float (id' #1.)) (id' "abc")
                                                                    ^^^^^
-Error: This expression has type string but an expression was expected of type
-         ('a : float64)
-       The layout of string is value
-         because it is the primitive value type string.
-       But the layout of string must be a sublayout of float64
-         because of the definition of id' at line 2, characters 10-18.
+Error: Uncaught exception: Typecore.Error(_, _, _)
+
 |}]
 
 (********************)
@@ -543,15 +539,8 @@ external id : ('a : any) ('b : any). 'a -> 'b = "%identity" [@@layout_poly]
 Line 2, characters 28-32:
 2 | let f (x: float#): int64# = id x
                                 ^^^^
-Error: This expression has type ('a : float64)
-       but an expression was expected of type int64#
-       The layout of int64# is bits64
-         because it is the primitive bits64 type int64#.
-       But the layout of int64# must be a sublayout of float64
-         because it's the layout polymorphic type in an external declaration
-         ([@layout_poly] forces all variables of layout 'any' to be
-         representable at call sites),
-         defaulted to layout float64.
+Error: Uncaught exception: Typecore.Error(_, _, _)
+
 |}]
 (* CR layouts v2.9: the default part is not quite correct *)
 

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -524,10 +524,10 @@ Line 1, characters 28-33:
 1 | module type S = sig val x : t_any end
                                 ^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_any is any, because
-         of the definition of t_any at line 1, characters 0-18.
-       But the layout of type t_any must be a sublayout of value_or_null, because
-         it's the type of something stored in a module structure.
+       The layout of type t_any is any
+         because of the definition of t_any at line 1, characters 0-18.
+       But the layout of type t_any must be a sublayout of value
+         because it's the type of something stored in a module structure.
 |}]
 
 (****************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -524,10 +524,10 @@ Line 1, characters 28-33:
 1 | module type S = sig val x : t_any end
                                 ^^^^^
 Error: This type signature for x is not a value type.
-       The layout of type t_any is any
-         because of the definition of t_any at line 1, characters 0-18.
-       But the layout of type t_any must be a sublayout of value
-         because it's the type of something stored in a module structure.
+       The layout of type t_any is any, because
+         of the definition of t_any at line 1, characters 0-18.
+       But the layout of type t_any must be a sublayout of value_or_null, because
+         it's the type of something stored in a module structure.
 |}]
 
 (****************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -73,10 +73,10 @@ Lines 14-21, characters 2-3:
 21 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value_or_null, because
-         it has to be value for the V1 safety check.
+       The layout of void_rec is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -135,10 +135,10 @@ Lines 4-11, characters 2-3:
 11 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value_or_null, because
-         it has to be value for the V1 safety check.
+       The layout of void_rec is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -224,10 +224,10 @@ Lines 17-35, characters 10-27:
 35 |        b2 = (cons_r 1; b2)}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value_or_null, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -438,10 +438,10 @@ Line 5, characters 4-6:
         ^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value_or_null, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -484,10 +484,10 @@ Lines 4-11, characters 2-24:
 11 |    b2 = (cons_r 2; {v})}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value_or_null, because
-         it has to be value for the V1 safety check.
+       The layout of void_rec is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -513,10 +513,10 @@ Lines 2-3, characters 2-32:
 3 |   (x, V b2.v, V b1.v, z, V a1.v)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value_or_null, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -785,10 +785,10 @@ Lines 9-18, characters 2-29:
 18 |   cons_r uivrh.uivrh_x; uivrh
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of unboxed_inlined_void_rec is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of unboxed_inlined_void_rec must be a sublayout of value_or_null, because
-         it has to be value for the V1 safety check.
+       The layout of unboxed_inlined_void_rec is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of unboxed_inlined_void_rec must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -834,10 +834,10 @@ Lines 6-11, characters 2-7:
 11 |     end
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value_or_null, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -902,10 +902,10 @@ Lines 4-11, characters 2-11:
 11 |   (y, V v')
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value_or_null, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -946,10 +946,10 @@ Lines 4-12, characters 2-23:
 12 |   (x, V v1, V v2, V v3)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void, because
-         of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value_or_null, because
-         it has to be value for the V1 safety check.
+       The layout of t_void is void
+         because of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value
+         because it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -73,10 +73,10 @@ Lines 14-21, characters 2-3:
 21 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value_or_null, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -135,10 +135,10 @@ Lines 4-11, characters 2-3:
 11 |   }
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value_or_null, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -224,10 +224,10 @@ Lines 17-35, characters 10-27:
 35 |        b2 = (cons_r 1; b2)}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value_or_null, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -438,10 +438,10 @@ Line 5, characters 4-6:
         ^^
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value_or_null, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -484,10 +484,10 @@ Lines 4-11, characters 2-24:
 11 |    b2 = (cons_r 2; {v})}
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of void_rec must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of void_rec must be a sublayout of value_or_null, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -513,10 +513,10 @@ Lines 2-3, characters 2-32:
 3 |   (x, V b2.v, V b1.v, z, V a1.v)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value_or_null, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -785,10 +785,10 @@ Lines 9-18, characters 2-29:
 18 |   cons_r uivrh.uivrh_x; uivrh
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of unboxed_inlined_void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of unboxed_inlined_void_rec must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of unboxed_inlined_void_rec is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of unboxed_inlined_void_rec must be a sublayout of value_or_null, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -834,10 +834,10 @@ Lines 6-11, characters 2-7:
 11 |     end
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value_or_null, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -902,10 +902,10 @@ Lines 4-11, characters 2-11:
 11 |   (y, V v')
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value_or_null, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -946,10 +946,10 @@ Lines 4-12, characters 2-23:
 12 |   (x, V v1, V v2, V v3)
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
-       The layout of t_void is void
-         because of the definition of t_void at line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+       The layout of t_void is void, because
+         of the definition of t_void at line 1, characters 0-18.
+       But the layout of t_void must be a sublayout of value_or_null, because
+         it has to be value for the V1 safety check.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2278,6 +2278,12 @@ let type_sort ~why env ty =
   | Ok _ -> Ok sort
   | Error _ as e -> e
 
+let type_non_null_sort ~why env ty =
+  let jkind, sort = Jkind.of_new_non_null_sort_var ~why in
+  match constrain_type_jkind env ty jkind with
+  | Ok _ -> Ok sort
+  | Error _ as e -> e
+
 (* Note: Because [estimate_type_jkind] actually returns an upper bound, this
    function computes an inaccurate intersection in some cases.
 

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2279,7 +2279,7 @@ let type_sort ~why env ty =
   | Error _ as e -> e
 
 let type_non_null_sort ~why env ty =
-  let jkind, sort = Jkind.of_new_non_null_sort_var ~why in
+  let jkind, sort = Jkind.of_new_default_sort_var ~why in
   match constrain_type_jkind env ty jkind with
   | Ok _ -> Ok sort
   | Error _ as e -> e

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2278,8 +2278,8 @@ let type_sort ~why env ty =
   | Ok _ -> Ok sort
   | Error _ as e -> e
 
-let type_non_null_sort ~why env ty =
-  let jkind, sort = Jkind.of_new_default_sort_var ~why in
+let type_legacy_sort ~why env ty =
+  let jkind, sort = Jkind.of_new_legacy_sort_var ~why in
   match constrain_type_jkind env ty jkind with
   | Ok _ -> Ok sort
   | Error _ as e -> e

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -78,10 +78,9 @@ val newty: type_desc -> type_expr
 val new_scoped_ty: int -> type_desc -> type_expr
 val newvar: ?name:string -> Jkind.t -> type_expr
 
-(* CR layouts v3.0: this should allow [or_null]. *)
 val new_rep_var
   : ?name:string
-  -> why:Jkind.History.concrete_default_creation_reason
+  -> why:Jkind.History.concrete_creation_reason
   -> unit
   -> type_expr * Jkind.sort
         (* Return a fresh representable variable, along with its sort *)
@@ -551,10 +550,15 @@ val type_jkind : Env.t -> type_expr -> jkind
    expansion. *)
 val type_jkind_purely : Env.t -> type_expr -> jkind
 
-(* CR layouts v3.0: this should allow [or_null]. *)
 (* Find a type's sort (constraining it to be an arbitrary sort variable, if
    needed) *)
 val type_sort :
+  why:Jkind.History.concrete_creation_reason ->
+  Env.t -> type_expr -> (Jkind.sort, Jkind.Violation.t) result
+
+(* As [type_sort], but constrain the jkind to be non-null.
+   Used for checking array elements. *)
+val type_non_null_sort :
   why:Jkind.History.concrete_default_creation_reason ->
   Env.t -> type_expr -> (Jkind.sort, Jkind.Violation.t) result
 

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -558,8 +558,8 @@ val type_sort :
 
 (* As [type_sort], but constrain the jkind to be non-null.
    Used for checking array elements. *)
-val type_non_null_sort :
-  why:Jkind.History.concrete_default_creation_reason ->
+val type_legacy_sort :
+  why:Jkind.History.concrete_legacy_creation_reason ->
   Env.t -> type_expr -> (Jkind.sort, Jkind.Violation.t) result
 
 (* Jkind checking. [constrain_type_jkind] will update the jkind of type

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1442,13 +1442,13 @@ module Format_history = struct
     | Initial_typedecl_env ->
       format_with_notify_js ppf
         "a dummy kind of any is used to check mutually recursive datatypes"
+    | Wildcard -> format_with_notify_js ppf "there's a _ in the type"
+    | Unification_var ->
+      format_with_notify_js ppf "it's a fresh unification variable"
     | Dummy_jkind ->
       format_with_notify_js ppf
         "it's assigned a dummy kind that should have been overwritten"
     (* CR layouts: Improve output or remove this constructor ^^ *)
-    | Wildcard -> format_with_notify_js ppf "there's a _ in the type"
-    | Unification_var ->
-      format_with_notify_js ppf "it's a fresh unification variable"
     | Type_expression_call ->
       format_with_notify_js ppf
         "there's a call to [type_expression] via the ocaml API"

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1396,9 +1396,6 @@ module Format_history = struct
     function
     | Missing_cmi p ->
       fprintf ppf "the .cmi file for %a is missing" !printtyp_path p
-    | Wildcard -> format_with_notify_js ppf "there's a _ in the type"
-    | Unification_var ->
-      format_with_notify_js ppf "it's a fresh unification variable"
     | Initial_typedecl_env ->
       format_with_notify_js ppf
         "a dummy kind of any is used to check mutually recursive datatypes"
@@ -1406,10 +1403,16 @@ module Format_history = struct
       format_with_notify_js ppf
         "it's assigned a dummy kind that should have been overwritten"
     (* CR layouts: Improve output or remove this constructor ^^ *)
+    | Wildcard -> format_with_notify_js ppf "there's a _ in the type"
+    | Unification_var ->
+      format_with_notify_js ppf "it's a fresh unification variable"
     | Type_expression_call ->
       format_with_notify_js ppf
         "there's a call to [type_expression] via the ocaml API"
     | Inside_of_Tarrow -> fprintf ppf "argument or result of a function type"
+
+  let format_any_non_null_creation_reason ppf :
+      History.any_non_null_creation_reason -> unit = function
     | Array_type_argument ->
       fprintf ppf "it's the type argument to the array type"
 
@@ -1532,7 +1535,7 @@ module Format_history = struct
     | Missing_cmi p ->
       fprintf ppf "the .cmi file for %a is missing" !printtyp_path p
     | Any_creation any -> format_any_creation_reason ppf any
-    | Any_non_null_creation _ -> .
+    | Any_non_null_creation any -> format_any_non_null_creation_reason ppf any
     | Immediate_creation immediate ->
       format_immediate_creation_reason ppf immediate
     | Immediate64_creation immediate64 ->
@@ -1881,10 +1884,13 @@ module Debug_printers = struct
     | Missing_cmi p -> fprintf ppf "Missing_cmi %a" Path.print p
     | Initial_typedecl_env -> fprintf ppf "Initial_typedecl_env"
     | Dummy_jkind -> fprintf ppf "Dummy_jkind"
-    | Type_expression_call -> fprintf ppf "Type_expression_call"
-    | Inside_of_Tarrow -> fprintf ppf "Inside_of_Tarrow"
     | Wildcard -> fprintf ppf "Wildcard"
     | Unification_var -> fprintf ppf "Unification_var"
+    | Type_expression_call -> fprintf ppf "Type_expression_call"
+    | Inside_of_Tarrow -> fprintf ppf "Inside_of_Tarrow"
+
+  let any_non_null_creation_reason ppf :
+      History.any_non_null_creation_reason -> unit = function
     | Array_type_argument -> fprintf ppf "Array_type_argument"
 
   let immediate_creation_reason ppf : History.immediate_creation_reason -> _ =
@@ -1965,7 +1971,8 @@ module Debug_printers = struct
         loc
     | Missing_cmi p -> fprintf ppf "Missing_cmi %a" !printtyp_path p
     | Any_creation any -> fprintf ppf "Any_creation %a" any_creation_reason any
-    | Any_non_null_creation _ -> .
+    | Any_non_null_creation any ->
+      fprintf ppf "Any_non_null_creation %a" any_non_null_creation_reason any
     | Immediate_creation immediate ->
       fprintf ppf "Immediate_creation %a" immediate_creation_reason immediate
     | Immediate64_creation immediate64 ->

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1879,8 +1879,8 @@ let has_layout_any jkind =
 module Debug_printers = struct
   open Format
 
-  let concrete_creation_reason ppf :
-      History.concrete_creation_reason -> unit = function
+  let concrete_creation_reason ppf : History.concrete_creation_reason -> unit =
+    function
     | Match -> fprintf ppf "Match"
     | Constructor_declaration idx ->
       fprintf ppf "Constructor_declaration %d" idx

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1131,11 +1131,11 @@ let of_new_sort_var ~why =
 
 let of_new_sort ~why = fst (of_new_sort_var ~why)
 
-let of_new_default_sort_var ~why =
+let of_new_legacy_sort_var ~why =
   let jkind, sort = Jkind_desc.of_new_sort_var Non_null in
-  fresh_jkind jkind ~why:(Concrete_default_creation why), sort
+  fresh_jkind jkind ~why:(Concrete_legacy_creation why), sort
 
-let of_new_default_sort ~why = fst (of_new_default_sort_var ~why)
+let of_new_legacy_sort ~why = fst (of_new_legacy_sort_var ~why)
 
 (* CR layouts v2.8: remove this function *)
 let of_const ~why
@@ -1392,8 +1392,8 @@ module Format_history = struct
          ([@@layout_poly] forces all variables of layout 'any' to be@ \
          representable at call sites)"
 
-  let format_concrete_default_creation_reason ppf :
-      History.concrete_default_creation_reason -> unit = function
+  let format_concrete_legacy_creation_reason ppf :
+      History.concrete_legacy_creation_reason -> unit = function
     | Unannotated_type_parameter path ->
       fprintf ppf "it instantiates an unannotated type parameter of %a"
         !printtyp_path path
@@ -1581,8 +1581,8 @@ module Format_history = struct
     | Bits32_creation bits32 -> format_bits32_creation_reason ppf bits32
     | Bits64_creation bits64 -> format_bits64_creation_reason ppf bits64
     | Concrete_creation concrete -> format_concrete_creation_reason ppf concrete
-    | Concrete_default_creation concrete ->
-      format_concrete_default_creation_reason ppf concrete
+    | Concrete_legacy_creation concrete ->
+      format_concrete_legacy_creation_reason ppf concrete
     | Imported ->
       fprintf ppf "of %s requirements from an imported definition"
         layout_or_kind
@@ -1617,7 +1617,7 @@ module Format_history = struct
     | Creation reason -> (
       fprintf ppf "@ because %a" (format_creation_reason ~layout_or_kind) reason;
       match reason, jkind_desc with
-      | Concrete_default_creation _, Const _ ->
+      | Concrete_legacy_creation _, Const _ ->
         fprintf ppf ",@ defaulted to %s %a" layout_or_kind Desc.format
           jkind_desc
       | _ -> ())
@@ -1798,7 +1798,7 @@ let score_reason = function
   (* error_message annotated by the user should always take priority *)
   | Creation (Annotated (With_error_message _, _)) -> 1
   (* Concrete creation is quite vague, prefer more specific reasons *)
-  | Creation (Concrete_creation _ | Concrete_default_creation _) -> -1
+  | Creation (Concrete_creation _ | Concrete_legacy_creation _) -> -1
   | _ -> 0
 
 let combine_histories reason lhs rhs =
@@ -1885,8 +1885,8 @@ module Debug_printers = struct
     | Optional_arg_default -> fprintf ppf "Optional_arg_default"
     | Layout_poly_in_external -> fprintf ppf "Layout_poly_in_external"
 
-  let concrete_default_creation_reason ppf :
-      History.concrete_default_creation_reason -> unit = function
+  let concrete_legacy_creation_reason ppf :
+      History.concrete_legacy_creation_reason -> unit = function
     | Unannotated_type_parameter path ->
       fprintf ppf "Unannotated_type_parameter %a" !printtyp_path path
     | Wildcard -> fprintf ppf "Wildcard"
@@ -2026,9 +2026,9 @@ module Debug_printers = struct
       fprintf ppf "Bits64_creation %a" bits64_creation_reason bits64
     | Concrete_creation concrete ->
       fprintf ppf "Concrete_creation %a" concrete_creation_reason concrete
-    | Concrete_default_creation concrete ->
-      fprintf ppf "Concrete_default_creation %a"
-        concrete_default_creation_reason concrete
+    | Concrete_legacy_creation concrete ->
+      fprintf ppf "Concrete_legacy_creation %a" concrete_legacy_creation_reason
+        concrete
     | Imported -> fprintf ppf "Imported"
     | Imported_type_argument { parent_path; position; arity } ->
       fprintf ppf "Imported_type_argument (pos %d, arity %d) of %a" position

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -638,9 +638,26 @@ module Const = struct
                 }
               jkind
           in
+          match out_jkind_verbose with
+        | Some out_jkind -> out_jkind
+        | None ->
+          (* If we fail, try again with nullable jkinds. *)
+          let out_jkind_verbose =
+            convert_with_base
+              ~base:
+                { jkind =
+                    { layout = jkind.layout;
+                      modes_upper_bounds = Modes.max;
+                      externality_upper_bound = Externality.max;
+                      nullability_upper_bound = Nullability.max
+                    };
+                  name = Layout.Const.to_string jkind.layout
+                }
+              jkind
+          in
           (* convert_with_base is guaranteed to succeed since the layout matches and the
-             modal bounds are all max *)
-          Option.get out_jkind_verbose
+              modal bounds are all max *)
+            Option.get out_jkind_verbose
       in
       match printable_jkind with
       | { base; modal_bounds = _ :: _ as modal_bounds } ->

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1148,7 +1148,7 @@ let of_new_default_sort_var ~why =
   let jkind, sort = Jkind_desc.of_new_sort_var Non_null in
   fresh_jkind jkind ~why:(Concrete_default_creation why), sort
 
-let of_new_non_null_sort ~why = fst (of_new_default_sort_var ~why)
+let of_new_default_sort ~why = fst (of_new_default_sort_var ~why)
 
 (* CR layouts v2.8: remove this function *)
 let of_const ~why

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -91,7 +91,6 @@ module Layout : sig
         | Word
         | Bits32
         | Bits64
-
     end
   end
 end

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -92,7 +92,7 @@ module Layout : sig
         | Bits32
         | Bits64
 
-      val to_string : t -> string
+      (* val to_string : t -> string *)
     end
   end
 end

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -311,14 +311,16 @@ val of_new_sort_var : why:History.concrete_creation_reason -> t * sort
 (** Create a fresh sort variable, packed into a jkind. *)
 val of_new_sort : why:History.concrete_creation_reason -> t
 
-(** Same as [of_new_sort_var], but the jkind is lowered to [Non_null].
+(** Same as [of_new_sort_var], but the jkind is lowered to [Non_null]
+    to mirror "legacy" OCaml values.
     Defaulting the sort variable produces exactly [value].  *)
-val of_new_default_sort_var :
-  why:History.concrete_default_creation_reason -> t * sort
+val of_new_legacy_sort_var :
+  why:History.concrete_legacy_creation_reason -> t * sort
 
-(** Same as [of_new_sort], but the jkind is lowered to [Non_null].
+(** Same as [of_new_sort], but the jkind is lowered to [Non_null]
+    to mirror "legacy" OCaml values.
     Defaulting the sort variable produces exactly [value].  *)
-val of_new_default_sort : why:History.concrete_default_creation_reason -> t
+val of_new_legacy_sort : why:History.concrete_legacy_creation_reason -> t
 
 val of_const : why:History.creation_reason -> Const.t -> t
 

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -92,7 +92,6 @@ module Layout : sig
         | Bits32
         | Bits64
 
-      (* val to_string : t -> string *)
     end
   end
 end

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -306,15 +306,21 @@ val add_portability_and_contention_crossing : from:t -> t -> t * bool
 (******************************)
 (* construction *)
 
-(* CR layouts v3.0: split those functions in two versions,
-   one [or_null] and one [non_null]. *)
-
 (** Create a fresh sort variable, packed into a jkind, returning both
     the resulting kind and the sort. *)
-val of_new_sort_var : why:History.concrete_default_creation_reason -> t * sort
+val of_new_sort_var : why:History.concrete_creation_reason -> t * sort
 
 (** Create a fresh sort variable, packed into a jkind. *)
-val of_new_sort : why:History.concrete_default_creation_reason -> t
+val of_new_sort : why:History.concrete_creation_reason -> t
+
+(** Same as [of_new_sort_var], but the jkind is lowered to [Non_null].
+    Defaulting the sort variable produces exactly [value].  *)
+val of_new_default_sort_var :
+  why:History.concrete_default_creation_reason -> t * sort
+
+(** Same as [of_new_sort], but the jkind is lowered to [Non_null].
+    Defaulting the sort variable produces exactly [value].  *)
+val of_new_default_sort : why:History.concrete_default_creation_reason -> t
 
 val of_const : why:History.creation_reason -> Const.t -> t
 

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -148,17 +148,11 @@ module type Sort = sig
 end
 
 module History = struct
-  (* CR layouts v3: move most [concrete_default_creation_reason]s here. *)
   (* For sort variables that are topmost on the jkind lattice. *)
-  type concrete_creation_reason = |
-
-  (* For sort variables that are in the "default" position
-     on the jkind lattice, defaulting exactly to [value]. *)
-  type concrete_default_creation_reason =
+  type concrete_creation_reason =
     | Match
     | Constructor_declaration of int
     | Label_declaration of Ident.t
-    | Unannotated_type_parameter of Path.t
     | Record_projection
     | Record_assignment
     | Let_binding
@@ -168,10 +162,17 @@ module History = struct
     | External_argument
     | External_result
     | Statement
-    | Wildcard
-    | Unification_var
     | Optional_arg_default
     | Layout_poly_in_external
+
+  (* For sort variables that are in the "default" position
+     on the jkind lattice, defaulting exactly to [value]. *)
+  (* CR layouts v3: after implementing separability, [Array_element]
+     should instead accept representable separable jkinds. *)
+  type concrete_default_creation_reason =
+    | Unannotated_type_parameter of Path.t
+    | Wildcard
+    | Unification_var
     | Array_element
 
   type annotation_context =

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -165,11 +165,11 @@ module History = struct
     | Optional_arg_default
     | Layout_poly_in_external
 
-  (* For sort variables that are in the "default" position
+  (* For sort variables that are in the "legacy" position
      on the jkind lattice, defaulting exactly to [value]. *)
   (* CR layouts v3: after implementing separability, [Array_element]
      should instead accept representable separable jkinds. *)
-  type concrete_default_creation_reason =
+  type concrete_legacy_creation_reason =
     | Unannotated_type_parameter of Path.t
     | Wildcard
     | Unification_var
@@ -284,7 +284,7 @@ module History = struct
     | Bits32_creation of bits32_creation_reason
     | Bits64_creation of bits64_creation_reason
     | Concrete_creation of concrete_creation_reason
-    | Concrete_default_creation of concrete_default_creation_reason
+    | Concrete_legacy_creation of concrete_legacy_creation_reason
     | Imported
     | Imported_type_argument of
         { parent_path : Path.t;

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -185,12 +185,20 @@ module History = struct
     | Type_wildcard of Location.t
     | With_error_message of string * annotation_context
 
-  (* CR layouts v3: move some [value_creation_reason]s here. *)
-  type value_or_null_creation_reason = |
+  (* CR layouts v3: move some [value_creation_reason]s
+     related to objects here. *)
+  (* CR layouts v3: add a copy of [Type_argument] once we support
+     enough subjkinding for interfaces to accept [value_or_null]
+     in [list] or [option]. *)
+  type value_or_null_creation_reason =
+    | Tuple_element
+    | Separability_check
+    | Polymorphic_variant_field
+    | Structure_element
+    | V1_safety_check
 
   type value_creation_reason =
     | Class_let_binding
-    | Tuple_element
     | Probe
     | Object
     | Instance_variable
@@ -213,18 +221,14 @@ module History = struct
     | Tfield
     | Tnil
     | First_class_module
-    | Separability_check
     | Univar
-    | Polymorphic_variant_field
     | Default_type_jkind
     | Existential_type_variable
     | Array_comprehension_element
     | Lazy_expression
     | Class_type_argument
     | Class_term_argument
-    | Structure_element
     | Debug_printer_argument
-    | V1_safety_check
     | Captured_in_object
     | Recmod_fun_arg
     | Unknown of string (* CR layouts: get rid of these *)

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -251,10 +251,10 @@ module History = struct
       (* This is used when the jkind is about to get overwritten;
          key example: when creating a fresh tyvar that is immediately
          unified to correct levels *)
-    | Wildcard
-    | Unification_var
     | Type_expression_call
     | Inside_of_Tarrow
+    | Wildcard
+    | Unification_var
 
   type any_non_null_creation_reason = Array_type_argument
 

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -251,14 +251,12 @@ module History = struct
       (* This is used when the jkind is about to get overwritten;
          key example: when creating a fresh tyvar that is immediately
          unified to correct levels *)
-    | Type_expression_call
-    | Inside_of_Tarrow
     | Wildcard
     | Unification_var
-    | Array_type_argument
+    | Type_expression_call
+    | Inside_of_Tarrow
 
-  (* CR layouts v3: move some [any_creation_reason]s here. *)
-  type any_non_null_creation_reason = |
+  type any_non_null_creation_reason = Array_type_argument
 
   type float64_creation_reason = Primitive of Ident.t
 

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -326,7 +326,7 @@ let build_initial_env add_type add_extension empty_env =
   |> add_type1 ident_array
        ~variance:Variance.full
        ~separability:Separability.Ind
-       ~param_jkind:(Jkind.Primitive.any ~why:Array_type_argument)
+       ~param_jkind:(Jkind.Primitive.any_non_null ~why:Array_type_argument)
   |> add_type1 ident_iarray
        ~variance:Variance.covariant
        ~separability:Separability.Ind

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1278,6 +1278,7 @@ let out_jkind_option_of_jkind jkind =
   match Jkind.get jkind with
   | Const jkind ->
     let is_value = Jkind.Const.equal jkind Jkind.Const.Primitive.value.jkind
+      (* CR layouts v3.0: remove this hack once [or_null] is out of [Alpha]. *)
       || (not Language_extension.(is_at_least Layouts Alpha)
           && Jkind.Const.equal jkind Jkind.Const.Primitive.value_or_null.jkind)
     in

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1277,7 +1277,11 @@ let out_jkind_of_const_jkind jkind =
 let out_jkind_option_of_jkind jkind =
   match Jkind.get jkind with
   | Const jkind ->
-    begin match Jkind.Const.equal jkind Jkind.Const.Primitive.value.jkind with
+    let is_value = Jkind.Const.equal jkind Jkind.Const.Primitive.value.jkind
+      || (not Language_extension.(is_at_least Layouts Alpha)
+          && Jkind.Const.equal jkind Jkind.Const.Primitive.value_or_null.jkind)
+    in
+    begin match is_value with
     | true -> None
     | false -> Some (out_jkind_of_const_jkind jkind)
     end

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -1622,7 +1622,7 @@ let solve_Ppat_array ~refine loc env mutability expected_ty =
     if Types.is_mutable mutability then Predef.type_array
     else Predef.type_iarray
   in
-  let jkind, arg_sort = Jkind.of_new_non_null_sort_var ~why:Array_element in
+  let jkind, arg_sort = Jkind.of_new_default_sort_var ~why:Array_element in
   let ty_elt = newgenvar jkind in
   let expected_ty = generic_instance expected_ty in
   unify_pat_types ~refine
@@ -8753,7 +8753,7 @@ and type_generic_array
   in
   check_construct_mutability ~loc ~env mutability argument_mode;
   let argument_mode = mode_modality modalities argument_mode in
-  let jkind, elt_sort = Jkind.of_new_non_null_sort_var ~why:Array_element in
+  let jkind, elt_sort = Jkind.of_new_default_sort_var ~why:Array_element in
   let ty = newgenvar jkind in
   let to_unify = type_ ty in
   with_explanation explanation (fun () ->

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -1622,7 +1622,7 @@ let solve_Ppat_array ~refine loc env mutability expected_ty =
     if Types.is_mutable mutability then Predef.type_array
     else Predef.type_iarray
   in
-  let jkind, arg_sort = Jkind.of_new_default_sort_var ~why:Array_element in
+  let jkind, arg_sort = Jkind.of_new_legacy_sort_var ~why:Array_element in
   let ty_elt = newgenvar jkind in
   let expected_ty = generic_instance expected_ty in
   unify_pat_types ~refine
@@ -8753,7 +8753,7 @@ and type_generic_array
   in
   check_construct_mutability ~loc ~env mutability argument_mode;
   let argument_mode = mode_modality modalities argument_mode in
-  let jkind, elt_sort = Jkind.of_new_default_sort_var ~why:Array_element in
+  let jkind, elt_sort = Jkind.of_new_legacy_sort_var ~why:Array_element in
   let ty = newgenvar jkind in
   let to_unify = type_ ty in
   with_explanation explanation (fun () ->

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -1453,7 +1453,7 @@ let solve_Ppat_tuple ~refine ~alloc_mode loc env args expected_ty =
       (fun (label, p) mode ->
         ( label,
           p,
-          newgenvar (Jkind.Primitive.value ~why:Tuple_element),
+          newgenvar (Jkind.Primitive.value_or_null ~why:Tuple_element),
           simple_pat_mode mode ))
       args arg_modes
   in
@@ -1656,7 +1656,7 @@ let solve_Ppat_variant ~refine loc env tag no_arg expected_ty =
   let arg_type =
     if no_arg
     then []
-    else [newgenvar (Jkind.Primitive.value ~why:Polymorphic_variant_field)]
+    else [newgenvar (Jkind.Primitive.value_or_null ~why:Polymorphic_variant_field)]
   in
   let fields = [tag, rf_either ~no_arg arg_type ~matched:true] in
   let make_row more =
@@ -4248,7 +4248,7 @@ and type_approx_aux_jane_syntax
 
 and type_tuple_approx (env: Env.t) loc ty_expected l =
   let labeled_tys = List.map
-    (fun (label, _) -> label, newvar (Jkind.Primitive.value ~why:Tuple_element)) l
+    (fun (label, _) -> label, newvar (Jkind.Primitive.value_or_null ~why:Tuple_element)) l
   in
   let ty = newty (Ttuple labeled_tys) in
   begin try unify env ty ty_expected with Unify err ->
@@ -5552,7 +5552,7 @@ and type_expect_
         | None -> None
         | Some sarg ->
             let ty_expected =
-              newvar (Jkind.Primitive.value ~why:Polymorphic_variant_field)
+              newvar (Jkind.Primitive.value_or_null ~why:Polymorphic_variant_field)
             in
             let alloc_mode, argument_mode = register_allocation expected_mode in
             let arg =
@@ -6289,7 +6289,7 @@ and type_expect_
         | [] -> spat_acc, ty_acc, ty_acc_sort
         | { pbop_pat = spat; _} :: rest ->
             (* CR layouts v5: eliminate value requirement *)
-            let ty = newvar (Jkind.Primitive.value ~why:Tuple_element) in
+            let ty = newvar (Jkind.Primitive.value_or_null ~why:Tuple_element) in
             let loc = Location.ghostify slet.pbop_op.loc in
             let spat_acc = Ast_helper.Pat.tuple ~loc [spat_acc; spat] in
             let ty_acc = newty (Ttuple [None, ty_acc; None, ty]) in
@@ -6308,7 +6308,7 @@ and type_expect_
               | [] ->
                 Jkind.of_new_sort_var ~why:Function_argument
               (* CR layouts v5: eliminate value requirement for tuple elements *)
-              | _ -> Jkind.Primitive.value ~why:Tuple_element, Jkind.Sort.value
+              | _ -> Jkind.Primitive.value_or_null ~why:Tuple_element, Jkind.Sort.value
             in
             loop slet.pbop_pat (newvar initial_jkind) initial_sort sands
           in
@@ -7727,7 +7727,7 @@ and type_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
   (* CR layouts v5: non-values in tuples *)
   let labeled_subtypes =
     List.map (fun (label, _) -> label,
-                                newgenvar (Jkind.Primitive.value ~why:Tuple_element))
+                                newgenvar (Jkind.Primitive.value_or_null ~why:Tuple_element))
     sexpl
   in
   let to_unify = newgenty (Ttuple labeled_subtypes) in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -1622,7 +1622,7 @@ let solve_Ppat_array ~refine loc env mutability expected_ty =
     if Types.is_mutable mutability then Predef.type_array
     else Predef.type_iarray
   in
-  let jkind, arg_sort = Jkind.of_new_sort_var ~why:Array_element in
+  let jkind, arg_sort = Jkind.of_new_non_null_sort_var ~why:Array_element in
   let ty_elt = newgenvar jkind in
   let expected_ty = generic_instance expected_ty in
   unify_pat_types ~refine
@@ -8753,7 +8753,7 @@ and type_generic_array
   in
   check_construct_mutability ~loc ~env mutability argument_mode;
   let argument_mode = mode_modality modalities argument_mode in
-  let jkind, elt_sort = Jkind.of_new_sort_var ~why:Array_element in
+  let jkind, elt_sort = Jkind.of_new_non_null_sort_var ~why:Array_element in
   let ty = newgenvar jkind in
   let to_unify = type_ ty in
   with_explanation explanation (fun () ->

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -128,7 +128,7 @@ val type_let:
 val type_expression:
         Env.t -> Parsetree.expression -> Typedtree.expression
 val type_representable_expression:
-        why:Jkind.History.concrete_default_creation_reason ->
+        why:Jkind.History.concrete_creation_reason ->
         Env.t -> Parsetree.expression -> Typedtree.expression * Jkind.sort
 val type_class_arg_pattern:
         string -> Env.t -> Env.t -> arg_label -> Parsetree.pattern ->

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -2907,7 +2907,7 @@ let transl_value_decl env loc valdecl =
   in
   (* CR layouts v5: relax this to check for representability. *)
   begin match Ctype.constrain_type_jkind env cty.ctyp_type
-                (Jkind.Primitive.value ~why:Structure_element) with
+                (Jkind.Primitive.value_or_null ~why:Structure_element) with
   | Ok () -> ()
   | Error err ->
     raise(Error(cty.ctyp_loc, Non_value_in_sig(err,valdecl.pval_name.txt,cty.ctyp_type)))

--- a/ocaml/typing/typedecl_separability.ml
+++ b/ocaml/typing/typedecl_separability.ml
@@ -480,7 +480,7 @@ let msig_of_external_type env decl =
   let check_jkind =
     Ctype.check_decl_jkind env decl
   in
-  if Result.is_error (check_jkind (Jkind.Primitive.value ~why:Separability_check))
+  if Result.is_error (check_jkind (Jkind.Primitive.value_or_null ~why:Separability_check))
      || Result.is_ok
           (check_jkind (Jkind.Primitive.immediate64 ~why:Separability_check))
   then best_msig decl

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -347,13 +347,13 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
 
        This should be understood, but for now the simple fall back thing is
        sufficient.  *)
-    match Ctype.check_type_jkind env scty (Jkind.Primitive.value ~why:V1_safety_check)
+    match Ctype.check_type_jkind env scty (Jkind.Primitive.value_or_null ~why:V1_safety_check)
     with
     | Ok _ -> ()
     | Error _ ->
       match
         Ctype.(check_type_jkind env
-                 (correct_levels ty) (Jkind.Primitive.value ~why:V1_safety_check))
+                 (correct_levels ty) (Jkind.Primitive.value_or_null ~why:V1_safety_check))
       with
       | Ok _ -> ()
       | Error violation ->

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -99,13 +99,15 @@ let maybe_pointer_type env ty =
 
 let maybe_pointer exp = maybe_pointer_type exp.exp_env exp.exp_type
 
-(* CR layouts v2.8: Calling [type_sort] in [typeopt] is not ideal and
-   this function should be removed at some point. To do that, there
+(* CR layouts v2.8: Calling [type_non_null_sort] in [typeopt] is not ideal
+   and this function should be removed at some point. To do that, there
    needs to be a way to store sort vars on [Tconstr]s. That means
    either introducing a [Tpoly_constr], allow type parameters with
    sort info, or do something else. *)
-let type_sort ~why env loc ty =
-  match Ctype.type_sort ~why env ty with
+(* CR layouts v3.0: have a better error message
+   for nullable jkinds.*)
+let type_non_null_sort ~why env loc ty =
+  match Ctype.type_non_null_sort ~why env ty with
   | Ok sort -> sort
   | Error err -> raise (Error (loc, Not_a_sort (ty, err)))
 
@@ -172,7 +174,7 @@ let array_type_kind ~elt_sort env loc ty =
         match elt_sort with
         | Some s -> s
         | None ->
-          type_sort ~why:Array_element env loc elt_ty
+          type_non_null_sort ~why:Array_element env loc elt_ty
       in
       begin match classify env loc elt_ty elt_sort with
       | Any -> if Config.flat_float_array then Pgenarray else Paddrarray

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -99,15 +99,15 @@ let maybe_pointer_type env ty =
 
 let maybe_pointer exp = maybe_pointer_type exp.exp_env exp.exp_type
 
-(* CR layouts v2.8: Calling [type_non_null_sort] in [typeopt] is not ideal
+(* CR layouts v2.8: Calling [type_legacy_sort] in [typeopt] is not ideal
    and this function should be removed at some point. To do that, there
    needs to be a way to store sort vars on [Tconstr]s. That means
    either introducing a [Tpoly_constr], allow type parameters with
    sort info, or do something else. *)
 (* CR layouts v3.0: have a better error message
    for nullable jkinds.*)
-let type_non_null_sort ~why env loc ty =
-  match Ctype.type_non_null_sort ~why env ty with
+let type_legacy_sort ~why env loc ty =
+  match Ctype.type_legacy_sort ~why env ty with
   | Ok sort -> sort
   | Error err -> raise (Error (loc, Not_a_sort (ty, err)))
 
@@ -174,7 +174,7 @@ let array_type_kind ~elt_sort env loc ty =
         match elt_sort with
         | Some s -> s
         | None ->
-          type_non_null_sort ~why:Array_element env loc elt_ty
+          type_legacy_sort ~why:Array_element env loc elt_ty
       in
       begin match classify env loc elt_ty elt_sort with
       | Any -> if Config.flat_float_array then Pgenarray else Paddrarray

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -435,7 +435,7 @@ end = struct
        preserve backwards compatibility. But we also need [Any] callsites
        to accept nullable jkinds to allow cases like [type ('a : value_or_null) t = 'a]. *)
     | Any -> Jkind.Primitive.any ~why:(if is_named then Unification_var else Wildcard)
-    | Sort -> Jkind.of_new_non_null_sort ~why:(if is_named then Unification_var else Wildcard)
+    | Sort -> Jkind.of_new_default_sort ~why:(if is_named then Unification_var else Wildcard)
 
   let new_any_var loc env jkind = function
     | { extensibility = Fixed } -> raise(Error(loc, env, No_type_wildcards))
@@ -541,7 +541,7 @@ let transl_type_param env path styp =
    to ask for it with an annotation.  Some restriction here seems necessary
    for backwards compatibility (e.g., we wouldn't want [type 'a id = 'a] to
    have jkind any).  But it might be possible to infer [any] in some cases. *)
-  let jkind = Jkind.of_new_non_null_sort ~why:(Unannotated_type_parameter path) in
+  let jkind = Jkind.of_new_default_sort ~why:(Unannotated_type_parameter path) in
   let attrs = styp.ptyp_attributes in
   match styp.ptyp_desc with
     Ptyp_any -> transl_type_param_var env loc attrs None jkind None
@@ -557,7 +557,7 @@ let transl_type_param env path styp =
 
 let get_type_param_jkind path styp =
   match Jane_syntax.Core_type.of_ast styp with
-  | None -> Jkind.of_new_non_null_sort ~why:(Unannotated_type_parameter path)
+  | None -> Jkind.of_new_default_sort ~why:(Unannotated_type_parameter path)
   | Some (Jtyp_layout (Ltyp_var { name; jkind }), _attrs) ->
     let jkind, _ =
       Jkind.of_annotation

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -431,8 +431,9 @@ end = struct
   let new_jkind ~is_named { jkind_initialization } =
     match jkind_initialization with
     (* CR layouts v3.0: while [Any] case allows nullable jkinds, [Sort] does not.
-       But there might be cases in which even [Sort] initialization can allow
-       nullable jkinds. Split [Non_null_sort] away from [Sort]. *)
+       From testing, we need all callsites that use [Sort] to be non-null to
+       preserve backwards compatibility. But we also need [Any] callsites
+       to accept nullable jkinds to allow cases like [type ('a : value_or_null) t = 'a]. *)
     | Any -> Jkind.Primitive.any ~why:(if is_named then Unification_var else Wildcard)
     | Sort -> Jkind.of_new_non_null_sort ~why:(if is_named then Unification_var else Wildcard)
 

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -435,7 +435,7 @@ end = struct
        preserve backwards compatibility. But we also need [Any] callsites
        to accept nullable jkinds to allow cases like [type ('a : value_or_null) t = 'a]. *)
     | Any -> Jkind.Primitive.any ~why:(if is_named then Unification_var else Wildcard)
-    | Sort -> Jkind.of_new_default_sort ~why:(if is_named then Unification_var else Wildcard)
+    | Sort -> Jkind.of_new_legacy_sort ~why:(if is_named then Unification_var else Wildcard)
 
   let new_any_var loc env jkind = function
     | { extensibility = Fixed } -> raise(Error(loc, env, No_type_wildcards))
@@ -541,7 +541,7 @@ let transl_type_param env path styp =
    to ask for it with an annotation.  Some restriction here seems necessary
    for backwards compatibility (e.g., we wouldn't want [type 'a id = 'a] to
    have jkind any).  But it might be possible to infer [any] in some cases. *)
-  let jkind = Jkind.of_new_default_sort ~why:(Unannotated_type_parameter path) in
+  let jkind = Jkind.of_new_legacy_sort ~why:(Unannotated_type_parameter path) in
   let attrs = styp.ptyp_attributes in
   match styp.ptyp_desc with
     Ptyp_any -> transl_type_param_var env loc attrs None jkind None
@@ -557,7 +557,7 @@ let transl_type_param env path styp =
 
 let get_type_param_jkind path styp =
   match Jane_syntax.Core_type.of_ast styp with
-  | None -> Jkind.of_new_default_sort ~why:(Unannotated_type_parameter path)
+  | None -> Jkind.of_new_legacy_sort ~why:(Unannotated_type_parameter path)
   | Some (Jtyp_layout (Ltyp_var { name; jkind }), _attrs) ->
     let jkind, _ =
       Jkind.of_annotation

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -853,7 +853,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
                  polymorphic variants. *)
               match
                 constrain_type_jkind env ctyp_type
-                  (Jkind.Primitive.value ~why:Polymorphic_variant_field)
+                  (Jkind.Primitive.value_or_null ~why:Polymorphic_variant_field)
               with
               | Ok _ -> ()
               | Error e ->
@@ -1146,7 +1146,7 @@ and transl_type_aux_tuple env ~policy ~row_context stl =
   List.iter (fun (_, {ctyp_type; ctyp_loc}) ->
     (* CR layouts v5: remove value requirement *)
     match
-      constrain_type_jkind env ctyp_type (Jkind.Primitive.value ~why:Tuple_element)
+      constrain_type_jkind env ctyp_type (Jkind.Primitive.value_or_null ~why:Tuple_element)
     with
     | Ok _ -> ()
     | Error e ->

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -431,7 +431,7 @@ end = struct
   let new_jkind ~is_named { jkind_initialization } =
     match jkind_initialization with
     | Any -> Jkind.Primitive.any ~why:(if is_named then Unification_var else Wildcard)
-    | Sort -> Jkind.of_new_sort ~why:(if is_named then Unification_var else Wildcard)
+    | Sort -> Jkind.of_new_non_null_sort ~why:(if is_named then Unification_var else Wildcard)
 
 
   let new_any_var loc env jkind = function
@@ -538,7 +538,7 @@ let transl_type_param env path styp =
    to ask for it with an annotation.  Some restriction here seems necessary
    for backwards compatibility (e.g., we wouldn't want [type 'a id = 'a] to
    have jkind any).  But it might be possible to infer [any] in some cases. *)
-  let jkind = Jkind.of_new_sort ~why:(Unannotated_type_parameter path) in
+  let jkind = Jkind.of_new_non_null_sort ~why:(Unannotated_type_parameter path) in
   let attrs = styp.ptyp_attributes in
   match styp.ptyp_desc with
     Ptyp_any -> transl_type_param_var env loc attrs None jkind None
@@ -554,7 +554,7 @@ let transl_type_param env path styp =
 
 let get_type_param_jkind path styp =
   match Jane_syntax.Core_type.of_ast styp with
-  | None -> Jkind.of_new_sort ~why:(Unannotated_type_parameter path)
+  | None -> Jkind.of_new_non_null_sort ~why:(Unannotated_type_parameter path)
   | Some (Jtyp_layout (Ltyp_var { name; jkind }), _attrs) ->
     let jkind, _ =
       Jkind.of_annotation

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -430,9 +430,11 @@ end = struct
 
   let new_jkind ~is_named { jkind_initialization } =
     match jkind_initialization with
+    (* CR layouts v3.0: while [Any] case allows nullable jkinds, [Sort] does not.
+       But there might be cases in which even [Sort] initialization can allow
+       nullable jkinds. Split [Non_null_sort] away from [Sort]. *)
     | Any -> Jkind.Primitive.any ~why:(if is_named then Unification_var else Wildcard)
     | Sort -> Jkind.of_new_non_null_sort ~why:(if is_named then Unification_var else Wildcard)
-
 
   let new_any_var loc env jkind = function
     | { extensibility = Fixed } -> raise(Error(loc, env, No_type_wildcards))


### PR DESCRIPTION
Make most jkinds created from sort variables `Maybe_null`. This allows types like `or_null` in function arguments, function results, record fields and so on. This excludes:
* Unannotated type parameters for compatibility reasons
* Jkinds created by `transl_simple_type ~new_var_jkind:Sort`
  - Changing any of those to accept `or_null` breaks compatibility with existing code due to more permissive type inference in signatures
* Array elements, to prohibit `float or_null array`

Accept `value_or_null` for the V1 safety check, for the separability check, for tuple elements, for structure elements, and for polymorphic variant fields.

Require array type parameters to be non-null.

Hide `value_or_null` and `any_non_null` from users if the layouts extension is below `Alpha`, replacing them with `value` or `any` in the compiler output.

Convert `any` annotations to `any_non_null` if the layouts extension is below `Alpha` for compatibility with existing code using arrays.

Split some tests into alpha and non-alpha versions due to different printing behavior.

Tests in `typing-layouts-or-null` cover some changes in this PR, but not all. More tests will be added in the PR implementing the `or_null` type.