### PR TITLE
Implement `'a or_null`

### DIFF
--- a/ocaml/otherlibs/stdlib_alpha/or_null.ml
+++ b/ocaml/otherlibs/stdlib_alpha/or_null.ml
@@ -1,0 +1,45 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*               Diana Kalinichenko, Jane Street, New York                *)
+(*                                                                        *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type 'a t : value_or_null = 'a or_null = Null | This of 'a
+
+let null = Null
+let this v = This v
+let value t ~default = match t with Null -> default | This v -> v
+let get = function Null -> invalid_arg "or_null is Null" | This v -> v
+let bind t f = match t with Null -> Null | This v -> f v
+let map f t = match t with Null -> Null | This v -> This (f v)
+let fold ~null ~this t = match t with Null -> null | This v -> this v
+let iter f t = match t with Null -> () | This v -> f v
+let is_null = function Null -> true | This _ -> false
+let is_this = function Null -> false | This _ -> true
+
+let equal eq t0 t1 =
+  match (t0, t1) with
+  | Null, Null -> true
+  | This v0, This v1 -> eq v0 v1
+  | _ -> false
+
+let compare cmp t0 t1 =
+  match (t0, t1) with
+  | Null, Null -> 0
+  | Null, This _ -> -1
+  | This _, Null -> 1
+  | This v0, This v1 -> cmp v0 v1
+
+let to_result ~null = function Null -> Error null | This v -> Ok v
+let to_list = function Null -> [] | This v -> [ v ]
+let to_seq = function Null -> Seq.empty | This v -> Seq.return v
+let to_option = function Null -> None | This v -> Some v
+let of_option = function None -> Null | Some v -> This v

--- a/ocaml/otherlibs/stdlib_alpha/or_null.mli
+++ b/ocaml/otherlibs/stdlib_alpha/or_null.mli
@@ -1,0 +1,88 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*               Diana Kalinichenko, Jane Street, New York                *)
+(*                                                                        *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Nullable values.
+
+    Nullable values explicitly indicate the presence or absence of a value,
+    representing present values as themselves and absent ones as null pointers.
+    Unlike the regular [option], the [or_null] type can't be nested.
+
+    This module mirrors [Option], except for [join] which can't be defined.
+*)
+
+(* CR layouts: enable ocamlformat for this module when it starts supporting
+   jkind annotations. *)
+
+type 'a t : value_or_null = 'a or_null =
+  | Null
+  | This of 'a
+      (** The type of nullable values. Either [Null] or a value [This v].
+          ['a or_null] has a non-standard layout [value_or_null],
+          preventing the type constructor from being nested. *)
+
+val null : 'a or_null
+(** [null] is [Null]. *)
+
+val this : 'a -> 'a or_null
+(** [this v] is [This v]. *)
+
+val value : 'a or_null -> default:'a -> 'a
+(** [value o ~default] is [v] if [o] is [This v] and [default] otherwise. *)
+
+val get : 'a or_null -> 'a
+(** [get o] is [v] if [o] is [This v] and raise otherwise. *)
+
+val bind : 'a or_null -> ('a -> 'b or_null) -> 'b or_null
+(** [bind o f] is [f v] if [o] is [This v] and [Null] if [o] is [Null]. *)
+
+val map : ('a -> 'b) -> 'a or_null -> 'b or_null
+(** [map f o] is [Null] if [o] is [Null] and [This v] if [o] is [This v]. *)
+
+val fold : null:'a -> this:('b -> 'a) -> 'b or_null -> 'a
+(** [fold ~null ~this o] is [null] if [o] is [Null] and [this v]
+    if [o] is [This v]. *)
+
+val iter : ('a -> unit) -> 'a or_null -> unit
+(** [iter f o] is [f v] if [o] is [This v] and [()] otherwise. *)
+
+val is_null : 'a or_null -> bool
+(** [is_null o] is [true] if [o] is [Null] and [false] otherwise. *)
+
+val is_this : 'a or_null -> bool
+(** [is_this o] is [true] if [o] is [This v] and [false] otherwise. *)
+
+val equal : ('a -> 'a -> bool) -> 'a or_null -> 'a or_null -> bool
+(** [equal eq o0 o1] is [true] if and only if [o0] and [o1] are both [Null]
+    or if they are [This v0] and [This v1] and [eq v0 v1] is [true]. *)
+
+val compare : ('a -> 'a -> int) -> 'a or_null -> 'a or_null -> int
+(** [compare f o o'] is a total order on [or_null] using [cmp] to compare
+    values wrapped by [This _]. [Null] is smaller than [This _] values. *)
+
+val to_result : null:'e -> 'a or_null -> ('a, 'e) result
+(** [to_result ~null o] is [Ok v] if [o] is [This v] and
+    [Error null] otherwise. *)
+
+val to_list : 'a or_null -> 'a list
+(** [to_list] is [[]] if [o] is [Null] and [[v]] if [o] is [This v]. *)
+
+val to_seq : 'a or_null -> 'a Seq.t
+(** [to_seq o] is [o] as a sequence. [Null] is the empty sequence and
+    [This v] is the singleton sequence containing [v]. *)
+
+val to_option : 'a or_null -> 'a option
+(** [to_option o] is [Some v] if [o] is [This v] and [None] otherwise. *)
+
+val of_option : 'a option -> 'a or_null
+(** [of_option o] is [This v] if [o] is [Some v] and [Null] otherwise. *)

--- a/ocaml/otherlibs/stdlib_alpha/stdlib_alpha.ml
+++ b/ocaml/otherlibs/stdlib_alpha/stdlib_alpha.ml
@@ -1,0 +1,1 @@
+module Or_null = Or_null

--- a/ocaml/otherlibs/stdlib_alpha/stdlib_alpha.mli
+++ b/ocaml/otherlibs/stdlib_alpha/stdlib_alpha.mli
@@ -1,0 +1,1 @@
+module Or_null = Or_null

--- a/ocaml/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/ocaml/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -7,31 +7,31 @@
      empty_cases_returning_float64/273 =
        (function {nlocal = 0} param/275 : unboxed_float
          (raise
-           (makeblock 0 (getpredef Match_failure/32!!) [0: "test.ml" 29 50])))
+           (makeblock 0 (getpredef Match_failure/33!!) [0: "test.ml" 29 50])))
      empty_cases_accepting_string/276 =
        (function {nlocal = 0} param/278
          (raise
-           (makeblock 0 (getpredef Match_failure/32!!) [0: "test.ml" 30 50])))
+           (makeblock 0 (getpredef Match_failure/33!!) [0: "test.ml" 30 50])))
      empty_cases_accepting_float64/279 =
        (function {nlocal = 0} param/281[unboxed_float]
          (raise
-           (makeblock 0 (getpredef Match_failure/32!!) [0: "test.ml" 31 50])))
+           (makeblock 0 (getpredef Match_failure/33!!) [0: "test.ml" 31 50])))
      non_empty_cases_returning_string/282 =
        (function {nlocal = 0} param/284
          (raise
-           (makeblock 0 (getpredef Assert_failure/42!!) [0: "test.ml" 32 68])))
+           (makeblock 0 (getpredef Assert_failure/43!!) [0: "test.ml" 32 68])))
      non_empty_cases_returning_float64/285 =
        (function {nlocal = 0} param/287 : unboxed_float
          (raise
-           (makeblock 0 (getpredef Assert_failure/42!!) [0: "test.ml" 33 68])))
+           (makeblock 0 (getpredef Assert_failure/43!!) [0: "test.ml" 33 68])))
      non_empty_cases_accepting_string/288 =
        (function {nlocal = 0} param/290
          (raise
-           (makeblock 0 (getpredef Assert_failure/42!!) [0: "test.ml" 34 68])))
+           (makeblock 0 (getpredef Assert_failure/43!!) [0: "test.ml" 34 68])))
      non_empty_cases_accepting_float64/291 =
        (function {nlocal = 0} param/293[unboxed_float]
          (raise
-           (makeblock 0 (getpredef Assert_failure/42!!) [0: "test.ml" 35 68]))))
+           (makeblock 0 (getpredef Assert_failure/43!!) [0: "test.ml" 35 68]))))
     (makeblock 0 empty_cases_returning_string/270
       empty_cases_returning_float64/273 empty_cases_accepting_string/276
       empty_cases_accepting_float64/279 non_empty_cases_returning_string/282

--- a/ocaml/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/ocaml/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -3,7 +3,7 @@
     (empty_cases_returning_string/270 =
        (function {nlocal = 0} param/272
          (raise
-           (makeblock 0 (getpredef Match_failure/32!!) [0: "test.ml" 28 50])))
+           (makeblock 0 (getpredef Match_failure/33!!) [0: "test.ml" 28 50])))
      empty_cases_returning_float64/273 =
        (function {nlocal = 0} param/275 : unboxed_float
          (raise

--- a/ocaml/testsuite/tests/typing-layouts-or-null/stdlib_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/stdlib_or_null.ml
@@ -1,0 +1,155 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ include stdlib_alpha;
+ expect;
+*)
+
+module Or_null = Stdlib_alpha.Or_null
+
+[%%expect{|
+module Or_null = Stdlib_alpha.Or_null
+|}]
+
+let _ = Or_null.null
+let _ = Or_null.this 3.14
+
+[%%expect{|
+- : 'a or_null = Null
+- : float or_null = This 3.14
+|}]
+
+let _ = Or_null.value Null ~default:3
+let _ = Or_null.value (This 5) ~default:3
+
+[%%expect{|
+- : int = 3
+- : int = 5
+|}]
+
+let _ = Or_null.get (This "foo")
+let _ = Or_null.get (Null)
+
+[%%expect{|
+- : string = "foo"
+Exception: Invalid_argument "or_null is Null".
+|}]
+
+let _ = Or_null.bind Null (fun x -> This (x + 5))
+let _ = Or_null.bind (This 7) (fun x -> Null)
+let _ = Or_null.bind (This 3) (fun x -> This (x + 5))
+
+[%%expect{|
+- : int or_null = Null
+- : 'a or_null = Null
+- : int or_null = This 8
+|}]
+
+let _ = Or_null.map ((+) 5) Null
+let _ = Or_null.map ((+) 5) (This 3)
+
+[%%expect{|
+- : int or_null = Null
+- : int or_null = This 8
+|}]
+
+let _ = Or_null.fold ~null:3 ~this:((+) 5) Null
+let _ = Or_null.fold ~null:3 ~this:((+) 5) (This 9)
+
+[%%expect{|
+- : int = 3
+- : int = 14
+|}]
+
+let cell = ref 0
+let _ = Or_null.iter ((:=) cell) Null
+let _ = !cell
+let _ = Or_null.iter ((:=) cell)  (This 2)
+let _ = !cell
+
+[%%expect{|
+val cell : int ref = {contents = 0}
+- : unit = ()
+- : int = 0
+- : unit = ()
+- : int = 2
+|}]
+
+let _ = Or_null.is_null Null
+let _ = Or_null.is_null (This 3)
+let _ = Or_null.is_this Null
+let _ = Or_null.is_this (This "42")
+
+[%%expect{|
+- : bool = true
+- : bool = false
+- : bool = false
+- : bool = true
+|}]
+
+let _ = Or_null.equal (=) Null Null
+let _ = Or_null.equal (=) (This 5) Null
+let _ = Or_null.equal (=) Null (This 8)
+let _ = Or_null.equal (=) (This 3) (This 3)
+let _ = Or_null.equal (=) (This 3) (This 5)
+
+[%%expect{|
+- : bool = true
+- : bool = false
+- : bool = false
+- : bool = true
+- : bool = false
+|}]
+
+let _ = Or_null.compare Int.compare Null Null
+let _ = Or_null.compare Int.compare (This 5) Null
+let _ = Or_null.compare Int.compare Null (This 8)
+let _ = Or_null.compare Int.compare (This 3) (This 3)
+let _ = Or_null.compare Int.compare (This 3) (This 5)
+let _ = Or_null.compare Int.compare (This 5) (This 0)
+
+[%%expect{|
+- : int = 0
+- : int = 1
+- : int = -1
+- : int = 0
+- : int = -1
+- : int = 1
+|}]
+
+let _ = Or_null.to_result ~null:"null" Null
+let _ = Or_null.to_result ~null:"null" (This "this")
+
+[%%expect{|
+- : ('a, string) result = Error "null"
+- : (string, string) result = Ok "this"
+|}]
+
+let _ = Or_null.to_list Null
+let _ = Or_null.to_list (This 1.)
+
+[%%expect{|
+- : 'a list = []
+- : float list = [1.]
+|}]
+
+let _ = Or_null.to_seq Null ()
+let _ = Or_null.to_seq (This 5.) ()
+let _ = Seq.drop 1 (Or_null.to_seq (This 5.)) ()
+
+[%%expect{|
+- : 'a Seq.node = Seq.Nil
+- : float Seq.node = Seq.Cons (5., <fun>)
+- : float Seq.node = Seq.Nil
+|}]
+
+let _ = Or_null.to_option Null
+let _ = Or_null.to_option (This 5)
+let _ = Or_null.of_option None
+let _ = Or_null.of_option (Some "test")
+
+[%%expect{|
+- : 'a option = None
+- : int option = Some 5
+- : 'a or_null = Null
+- : string or_null = This "test"
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/test_beta.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/test_beta.ml
@@ -1,0 +1,47 @@
+(* TEST
+ flags = "-extension layouts_beta";
+ expect;
+*)
+
+type t_any_non_null : any_non_null
+
+[%%expect{|
+type t_any_non_null : any_non_null
+|}]
+
+type t_value_or_null : value_or_null
+
+[%%expect{|
+Line 1, characters 23-36:
+1 | type t_value_or_null : value_or_null
+                           ^^^^^^^^^^^^^
+Error: Layout value_or_null is more experimental than allowed by the enabled layouts extension.
+       You must enable -extension layouts_alpha to use this feature.
+|}]
+
+type 'a t = 'a or_null
+
+[%%expect{|
+Line 1, characters 15-22:
+1 | type 'a t = 'a or_null
+                   ^^^^^^^
+Error: Unbound type constructor or_null
+|}]
+
+let x = This 3.14
+
+[%%expect{|
+Line 1, characters 8-12:
+1 | let x = This 3.14
+            ^^^^
+Error: Unbound constructor This
+|}]
+
+let y = Null
+
+[%%expect{|
+Line 1, characters 8-12:
+1 | let y = Null
+            ^^^^
+Error: Unbound constructor Null
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -1,0 +1,130 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+type ('a : value) t : value_or_null = 'a or_null =
+  | Null
+  | This of 'a
+
+[%%expect{|
+type 'a t = 'a or_null = Null | This of 'a
+|}]
+
+let to_option (x : 'a or_null) =
+  match x with
+  | Null -> None
+  | This x -> Some x
+
+[%%expect{|
+val to_option : 'a or_null -> 'a option = <fun>
+|}]
+
+let of_option (x : 'a option) =
+  match x with
+  | None -> Null
+  | Some x -> This x
+
+[%%expect{|
+val of_option : 'a option -> 'a t = <fun>
+|}]
+
+let pi = This 3.14
+
+[%%expect{|
+val pi : float t = This 3.14
+|}]
+
+let pi' =
+  let value = This 3.14 in
+  value
+
+[%%expect{|
+val pi' : float t = This 3.14
+|}]
+
+type myrec = { x : int
+         ; y : int or_null
+         }
+
+[%%expect{|
+type myrec = { x : int; y : int or_null; }
+|}]
+
+let fst { x; y } = x
+
+[%%expect{|
+val fst : myrec -> int = <fun>
+|}]
+
+let snd { x; y } = y
+
+[%%expect{|
+val snd : myrec -> int or_null = <fun>
+|}]
+
+let snd' (a : myrec) = a.y
+
+[%%expect{|
+val snd' : myrec -> int or_null = <fun>
+|}]
+
+let mk n = { x = n; y = This n }
+
+[%%expect{|
+val mk : int -> myrec = <fun>
+|}]
+
+let test =
+  let a = mk 4 in
+  let a' = { a with y = Null } in
+  a'.y
+
+[%%expect{|
+val test : int or_null = Null
+|}]
+
+let mytup = (4, This 5)
+
+[%%expect{|
+val mytup : int * int t = (4, This 5)
+|}]
+
+type mytup' = int * int t
+
+[%%expect{|
+type mytup' = int * int t
+|}]
+
+type nested = int or_null or_null
+
+[%%expect{|
+Line 1, characters 14-25:
+1 | type nested = int or_null or_null
+                  ^^^^^^^^^^^
+Error: This type int or_null should be an instance of type ('a : value)
+       The layout of int or_null is value_or_null, because
+         it is the primitive value_or_null type or_null.
+       But the layout of int or_null must be a sublayout of value, because
+         the type argument of or_null has layout value.
+|}]
+
+let should_fail = This (This 5)
+
+[%%expect{|
+Line 1, characters 23-31:
+1 | let should_fail = This (This 5)
+                           ^^^^^^^^
+Error: This expression has type 'a t = 'a or_null
+       but an expression was expected of type ('b : value)
+       The layout of 'a t is value_or_null, because
+         it is the primitive value_or_null type or_null.
+       But the layout of 'a t must be a sublayout of value, because
+         of the definition of t at lines 1-3, characters 0-14.
+|}]
+
+let mk' n = `Foo (This n)
+
+[%%expect{|
+val mk' : 'a -> [> `Foo of 'a t ] = <fun>
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -101,10 +101,10 @@ Line 1, characters 14-25:
 1 | type nested = int or_null or_null
                   ^^^^^^^^^^^
 Error: This type int or_null should be an instance of type ('a : value)
-       The layout of int or_null is value_or_null, because
-         it is the primitive value_or_null type or_null.
-       But the layout of int or_null must be a sublayout of value, because
-         the type argument of or_null has layout value.
+       The kind of int or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of int or_null must be a subkind of value
+         because the type argument of or_null has kind value.
 |}]
 
 let should_fail = This (This 5)
@@ -115,10 +115,10 @@ Line 1, characters 23-31:
                            ^^^^^^^^
 Error: This expression has type 'a t = 'a or_null
        but an expression was expected of type ('b : value)
-       The layout of 'a t is value_or_null, because
-         it is the primitive value_or_null type or_null.
-       But the layout of 'a t must be a sublayout of value, because
-         of the definition of t at lines 1-3, characters 0-14.
+       The kind of 'a t is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of 'a t must be a subkind of value
+         because of the definition of t at lines 1-3, characters 0-14.
 |}]
 
 let mk' n = `Foo (This n)
@@ -180,10 +180,11 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This expression has type 'a t = 'a or_null
        but an expression was expected of type ('b : value)
-       The layout of 'a t is value_or_null, because
-         it is the primitive value_or_null type or_null.
-       But the layout of 'a t must be a sublayout of value, because
-         it's the type of an array element, defaulted to layout value.
+       The kind of 'a t is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of 'a t must be a subkind of value
+         because it's the type of an array element,
+         defaulted to kind value.
 |}]
 
 type should_fail = float or_null array
@@ -194,8 +195,8 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type float or_null should be an instance of type
          ('a : any_non_null)
-       The layout of float or_null is value_or_null, because
-         it is the primitive value_or_null type or_null.
-       But the layout of float or_null must be a sublayout of any_non_null, because
-         it's the type argument to the array type.
+       The kind of float or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of float or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -121,6 +121,20 @@ Error: This expression has type 'a t = 'a or_null
          because of the definition of t at lines 1-3, characters 0-14.
 |}]
 
+let should_also_fail = This Null
+
+[%%expect{|
+Line 1, characters 28-32:
+1 | let should_also_fail = This Null
+                                ^^^^
+Error: This expression has type 'a t = 'a or_null
+       but an expression was expected of type ('b : value)
+       The kind of 'a t is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of 'a t must be a subkind of value
+         because of the definition of t at lines 1-3, characters 0-14.
+|}]
+
 let mk' n = `Foo (This n)
 
 [%%expect{|
@@ -177,6 +191,66 @@ let should_fail = [| Null; This 5 |]
 [%%expect{|
 Line 1, characters 21-25:
 1 | let should_fail = [| Null; This 5 |]
+                         ^^^^
+Error: This expression has type 'a t = 'a or_null
+       but an expression was expected of type ('b : value)
+       The kind of 'a t is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of 'a t must be a subkind of value
+         because it's the type of an array element,
+         defaulted to kind value.
+|}]
+
+type should_fail = float or_null array
+
+[%%expect{|
+Line 1, characters 19-32:
+1 | type should_fail = float or_null array
+                       ^^^^^^^^^^^^^
+Error: This type float or_null should be an instance of type
+         ('a : any_non_null)
+       The kind of float or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of float or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}]
+
+(* CR layouts v3.0: this should eventually work but
+   [list] only accepts values now. *)
+let null_list = [ Null; This 5 ]
+
+[%%expect{|
+Line 1, characters 18-22:
+1 | let null_list = [ Null; This 5 ]
+                      ^^^^
+Error: This expression has type 'a t = 'a or_null
+       but an expression was expected of type ('b : value)
+       The kind of 'a t is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of 'a t must be a subkind of value
+         because the type argument of list has kind value.
+|}]
+
+type null_list = float or_null list
+
+[%%expect{|
+Line 1, characters 17-30:
+1 | type null_list = float or_null list
+                     ^^^^^^^^^^^^^
+Error: This type float or_null should be an instance of type ('a : value)
+       The kind of float or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of float or_null must be a subkind of value
+         because the type argument of list has kind value.
+|}]
+
+(* Immutable arrays should work the same as mutable: *)
+
+let should_fail = [: Null; This 5 :]
+
+[%%expect{|
+Line 1, characters 21-25:
+1 | let should_fail = [: Null; This 5 :]
                          ^^^^
 Error: This expression has type 'a t = 'a or_null
        but an expression was expected of type ('b : value)

--- a/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -274,3 +274,34 @@ Error: This type float or_null should be an instance of type
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
+
+(* CR layouts v3: object fields should accept null, but it's low priority. *)
+type object_with_null = < x : int or_null; .. >
+
+[%%expect{|
+Line 1, characters 26-42:
+1 | type object_with_null = < x : int or_null; .. >
+                              ^^^^^^^^^^^^^^^^
+Error: Object field types must have layout value.
+       The kind of int or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of int or_null must be a subkind of value
+         because it's the type of an object field.
+|}]
+
+(* CR layouts v3: instance variables should accept null, but it's low priority. *)
+class a_with_null =
+  object
+    val x = Null
+  end
+
+[%%expect{|
+Line 3, characters 8-9:
+3 |     val x = Null
+            ^
+Error: Variables bound in a class must have layout value.
+       The kind of x is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of x must be a subkind of value
+         because it's the type of a class field.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/test_stable.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/test_stable.ml
@@ -1,0 +1,47 @@
+(* TEST
+ flags = "-extension layouts";
+ expect;
+*)
+
+type t_any_non_null : any_non_null
+
+[%%expect{|
+type t_any_non_null : any_non_null
+|}]
+
+type t_value_or_null : value_or_null
+
+[%%expect{|
+Line 1, characters 23-36:
+1 | type t_value_or_null : value_or_null
+                           ^^^^^^^^^^^^^
+Error: Layout value_or_null is more experimental than allowed by the enabled layouts extension.
+       You must enable -extension layouts_alpha to use this feature.
+|}]
+
+type 'a t = 'a or_null
+
+[%%expect{|
+Line 1, characters 15-22:
+1 | type 'a t = 'a or_null
+                   ^^^^^^^
+Error: Unbound type constructor or_null
+|}]
+
+let x = This 3.14
+
+[%%expect{|
+Line 1, characters 8-12:
+1 | let x = This 3.14
+            ^^^^
+Error: Unbound constructor This
+|}]
+
+let y = Null
+
+[%%expect{|
+Line 1, characters 8-12:
+1 | let y = Null
+            ^^^^
+Error: Unbound constructor Null
+|}]

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -2785,8 +2785,8 @@ let initial =
     empty
 
 let add_language_extension_types env =
-  let add ext f env  =
-    match Language_extension.is_enabled ext with
+  let add ext lvl f env  =
+    match Language_extension.is_at_least ext lvl with
     | true ->
       (* CR-someday poechsel: Pass a correct shape here *)
       f (add_type ?shape:None ~check:false) env
@@ -2794,8 +2794,9 @@ let add_language_extension_types env =
   in
   lazy
     (env
-    |> add SIMD Predef.add_simd_extension_types
-    |> add Small_numbers Predef.add_small_number_extension_types)
+    |> add SIMD () Predef.add_simd_extension_types
+    |> add Small_numbers () Predef.add_small_number_extension_types
+    |> add Layouts Language_extension.Alpha Predef.add_or_null)
 
 (* Some predefined types are part of language extensions, and we don't want to
    make them available in the initial environment if those extensions are not

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -2793,10 +2793,10 @@ let add_language_extension_types env =
     | false -> env
   in
   lazy
-    (env
+    Language_extension.(env
     |> add SIMD () Predef.add_simd_extension_types
-    |> add Small_numbers () Predef.add_small_number_extension_types
-    |> add Layouts Language_extension.Alpha Predef.add_or_null)
+    |> add Small_numbers Stable Predef.add_small_number_extension_types
+    |> add Layouts Alpha Predef.add_or_null)
 
 (* Some predefined types are part of language extensions, and we don't want to
    make them available in the initial environment if those extensions are not

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1466,6 +1466,8 @@ module Format_history = struct
 
   let format_value_or_null_creation_reason ppf :
       History.value_or_null_creation_reason -> _ = function
+    | Primitive id ->
+      fprintf ppf "it is the primitive value_or_null type %s" (Ident.name id)
     | Tuple_element -> fprintf ppf "it's the type of a tuple element"
     | Separability_check ->
       fprintf ppf "the check that a type is definitely not `float`"
@@ -1937,6 +1939,7 @@ module Debug_printers = struct
 
   let value_or_null_creation_reason ppf :
       History.value_or_null_creation_reason -> _ = function
+    | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
     | Tuple_element -> fprintf ppf "Tuple_element"
     | Separability_check -> fprintf ppf "Separability_check"
     | Polymorphic_variant_field -> fprintf ppf "Polymorphic_variant_field"

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -191,6 +191,7 @@ module History = struct
      enough subjkinding for interfaces to accept [value_or_null]
      in [list] or [option]. *)
   type value_or_null_creation_reason =
+    | Primitive of Ident.t
     | Tuple_element
     | Separability_check
     | Polymorphic_variant_field

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -479,7 +479,14 @@ let add_or_null add_type env =
   env
   |> add_type1 ident_or_null
   ~variance:Variance.covariant
-  ~separability:Separability.Sep
+  ~separability:Separability.Ind
+  (* CR layouts v3: [or_null] is separable only if the argument type
+     is non-float. The current separability system can't track that.
+     We also want to allow [float or_null] despite it being non-separable.
+
+     For now, we mark the type argument as [Separability.Ind] to permit
+     the most argument types, and forbid arrays from accepting [or_null]s.
+     In the future, we will track separability in the jkind system. *)
   ~kind:(fun tvar ->
     variant [cstr ident_null []; cstr ident_this [unrestricted tvar]]
       [| Constructor_uniform_value, [| |];

--- a/ocaml/typing/predef.mli
+++ b/ocaml/typing/predef.mli
@@ -123,6 +123,11 @@ val add_simd_extension_types :
 val add_small_number_extension_types :
    (Ident.t -> type_declaration -> 'a -> 'a) -> 'a -> 'a
 
+(* Add [or_null] to an environment.  This is separate from [build_initial_env]
+   because we'd like to only do it if layouts are set to [Alpha]. *)
+val add_or_null :
+   (Ident.t -> type_declaration -> 'a -> 'a) -> 'a -> 'a
+
 (* To initialize linker tables *)
 
 val builtin_values: (string * Ident.t) list

--- a/ocaml/typing/predef.mli
+++ b/ocaml/typing/predef.mli
@@ -42,6 +42,7 @@ val type_unboxed_float32:type_expr
 val type_unboxed_nativeint:type_expr
 val type_unboxed_int32:type_expr
 val type_unboxed_int64:type_expr
+val type_or_null: type_expr -> type_expr
 
 val type_int8x16: type_expr
 val type_int16x8: type_expr
@@ -76,6 +77,7 @@ val path_unboxed_float32: Path.t
 val path_unboxed_nativeint: Path.t
 val path_unboxed_int32: Path.t
 val path_unboxed_int64: Path.t
+val path_or_null: Path.t
 
 val path_int8x16: Path.t
 val path_int16x8: Path.t

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1623,7 +1623,7 @@ let update_decl_jkind env dpath decl =
       type_jkind
   in
 
-  (* Do not override the jkind if the manifest jkind if available. This is
+  (* Do not override the jkind if the manifest jkind is available. This is
      necessary to support types like ['a or_null], which have a non-standard
      jkind. [check_coherence] will update the jkind to match the manifest. *)
   let new_decl, new_jkind =

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1094,26 +1094,28 @@ let check_constraints env sdecl (_, decl) =
       check_constraints_rec env sty.ptyp_loc visited ty
   end
 
-(*
-   Check that the type expression (if present) is compatible with the kind.
+(* Check that [type_jkind] (where we've stored the jkind annotation, if any)
+   corresponds to the manifest (e.g., in the case where [type_jkind] is
+   immediate, we should check the manifest is immediate). Also, update the
+   resulting jkind to match the manifest. *)
+let narrow_to_manifest_jkind env loc decl =
+  match decl.type_manifest with
+  | None -> decl
+  | Some ty ->
+    let jkind' = Ctype.type_jkind_purely env ty in
+    match Jkind.sub_with_history jkind' decl.type_jkind with
+    | Ok jkind' -> { decl with type_jkind = jkind' }
+    | Error v ->
+      raise (Error (loc, Jkind_mismatch_of_type (ty,v)))
+
+(* Check that the type expression (if present) is compatible with the kind.
    If both a variant/record definition and a type equation are given,
    need to check that the equation refers to a type of the same kind
-   with the same constructors and labels.
-
-   If the kind is [Type_abstract], we need to check that [type_jkind] (where
-   we've stored the jkind annotation, if any) corresponds to the manifest
-   (e.g., in the case where [type_jkind] is immediate, we should check the
-   manifest is immediate).  It would also be nice to store the best possible
-   jkind for this type in the kind, to avoid expansions later.  So, we do the
-   relatively expensive thing of computing the best possible jkind for the
-   manifest, checking that it's a subjkind of [type_jkind], and then replacing
-   [type_jkind] with what we computed.
-*)
-let check_coherence env loc dpath decl =
-  match decl with
-    { type_kind = (Type_variant _ | Type_record _| Type_open);
-      type_manifest = Some ty } ->
-      if !Clflags.allow_illegal_crossing then begin 
+   with the same constructors and labels. *)
+let check_kind_coherence env loc dpath decl =
+  match decl.type_kind, decl.type_manifest with
+  | (Type_variant _ | Type_record _ | Type_open), Some ty ->
+      if !Clflags.allow_illegal_crossing then begin
         let jkind' = Ctype.type_jkind_purely env ty in
         begin match Jkind.sub_with_history jkind' decl.type_jkind with
         | Ok _ -> ()
@@ -1121,45 +1123,40 @@ let check_coherence env loc dpath decl =
           raise (Error (loc, Jkind_mismatch_of_type (ty,v)))
         end
       end;
-      begin match get_desc ty with
-        Tconstr(path, args, _) ->
-          begin try
-            let decl' = Env.find_type path env in
-            let err =
-              if List.length args <> List.length decl.type_params
-              then Some Includecore.Arity
-              else begin
-                match Ctype.equal env false args decl.type_params with
-                | exception Ctype.Equality err ->
-                    Some (Includecore.Constraint err)
-                | () ->
-                    Includecore.type_declarations ~loc ~equality:true env
-                      ~mark:true
-                      (Path.last path)
-                      decl'
-                      dpath
-                      (Subst.type_declaration
-                         (Subst.add_type_path dpath path Subst.identity) decl)
-              end
-            in
-            if err <> None then
-              raise(Error(loc, Definition_mismatch (ty, env, err)))
-            else
-              decl
-          with Not_found ->
-            raise(Error(loc, Unavailable_type_constructor path))
+    begin match get_desc ty with
+    | Tconstr(path, args, _) ->
+      begin
+      try
+        let decl' = Env.find_type path env in
+        let err =
+          if List.length args <> List.length decl.type_params
+          then Some Includecore.Arity
+          else begin
+            match Ctype.equal env false args decl.type_params with
+            | exception Ctype.Equality err ->
+                Some (Includecore.Constraint err)
+            | () ->
+                Includecore.type_declarations ~loc ~equality:true env
+                  ~mark:true
+                  (Path.last path)
+                  decl'
+                  dpath
+                  (Subst.type_declaration
+                     (Subst.add_type_path dpath path Subst.identity) decl)
           end
-      | _ -> raise(Error(loc, Definition_mismatch (ty, env, None)))
+        in
+        if err <> None then
+          raise (Error(loc, Definition_mismatch (ty, env, err)))
+      with Not_found ->
+        raise(Error(loc, Unavailable_type_constructor path))
       end
-  | { type_kind = Type_abstract _;
-      type_manifest = Some ty } ->
-    let jkind' = Ctype.type_jkind_purely env ty in
-    begin match Jkind.sub_with_history jkind' decl.type_jkind with
-    | Ok jkind' -> { decl with type_jkind = jkind' }
-    | Error v ->
-      raise (Error (loc, Jkind_mismatch_of_type (ty,v)))
+    | _ -> ()
     end
-  | { type_manifest = None } -> decl
+  | _ -> ()
+
+let check_coherence env loc dpath decl =
+  check_kind_coherence env loc dpath decl;
+  narrow_to_manifest_jkind env loc decl
 
 let check_abbrev env sdecl (id, decl) =
   (id, check_coherence env sdecl.ptype_loc (Path.Pident id) decl)
@@ -1605,7 +1602,7 @@ let update_decl_jkind env dpath decl =
     | false -> jkind, false
   in
 
-  let new_decl, new_jkind = match decl.type_kind with
+  let inferred_decl, inferred_jkind = match decl.type_kind with
     | Type_abstract _ -> decl, decl.type_jkind
     | Type_open ->
       let type_jkind = Jkind.Primitive.value ~why:Extensible_variant in
@@ -1624,6 +1621,17 @@ let update_decl_jkind env dpath decl =
                   type_jkind;
                   type_has_illegal_crossings },
       type_jkind
+  in
+
+  (* Do not override the jkind if the manifest jkind if available. This is
+     necessary to support types like ['a or_null], which have a non-standard
+     jkind. [check_coherence] will update the jkind to match the manifest. *)
+  let new_decl, new_jkind =
+    match decl.type_manifest with
+    | None -> inferred_decl, inferred_jkind
+    | Some _ ->
+      let type_jkind = decl.type_jkind in
+      { inferred_decl with type_jkind }, type_jkind
   in
 
   (* check that the jkind computed from the kind matches the jkind

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1623,9 +1623,13 @@ let update_decl_jkind env dpath decl =
       type_jkind
   in
 
-  (* Do not override the jkind if the manifest jkind is available. This is
-     necessary to support types like ['a or_null], which have a non-standard
-     jkind. [check_coherence] will update the jkind to match the manifest. *)
+  (* If the type manifest jkind is available, we roll back to
+     the previous [decl.type_jkind] from the annotation, delaying
+     computing the final jkind until [check_coherence].
+
+     This is necessary to support types like ['a or_null], which have a
+     non-standard jkind for their [type_kind]. When jkind-from-kind
+     and jkind-from-manifest conflict, we want to pick the one from manifest. *)
   let new_decl, new_jkind =
     match decl.type_manifest with
     | None -> inferred_decl, inferred_jkind

--- a/testsuite/tests/lib-extensions/alpha_exports.ml
+++ b/testsuite/tests/lib-extensions/alpha_exports.ml
@@ -9,3 +9,11 @@
 *)
 
 open Stdlib_alpha
+
+(* Test that [Or_null] is exported. *)
+
+let () =
+  match Or_null.null with
+  | Null -> ()
+  | This _ -> assert false
+;;


### PR DESCRIPTION
Do not update the jkind in `update_decl_jkind` if the manifest is available; always copy the manifest's jkind in `check_coherence`. This allows us to give types like `'a or_null` non-standard jkinds for their kinds (i.e. `value_or_null` for `Type_variant`).

Pre-define `or_null` when `Layouts` has level `Alpha`. Add tests for `or_null`.

`or_null` will be added to `stdlib_alpha` in the next PR.