### PR TITLE
Honor `[@error_message]` attribute even when its location is ghost

### DIFF
--- a/ocaml/testsuite/tests/ppx-error-message/ppx_error_message.ml
+++ b/ocaml/testsuite/tests/ppx-error-message/ppx_error_message.ml
@@ -1,0 +1,53 @@
+open Ast_mapper
+
+(* Assert statically that a string that appears in the source text
+   is alphabetically ordered. This is a bit contrived so that we
+   can exercise [@ocaml.error_message].
+*)
+
+let () =
+  register "sorted" (fun _ ->
+    { default_mapper with expr = fun self expr ->
+      match expr.pexp_desc with
+      | Pexp_extension
+         ( { txt = "sorted" },
+           PStr
+             [ { pstr_desc =
+                   Pstr_eval
+                     ( { pexp_desc = Pexp_constant (Pconst_string (str, loc, _)) }
+                     , _ ) } ] )
+         ->
+        (* Use a ghost location, as is typical for ppxes *)
+        let loc = { loc with loc_ghost = true } in
+        let sorted =
+          String.to_seq str
+          |> List.of_seq
+          |> List.sort Char.compare
+          |> List.to_seq
+          |> String.of_seq
+        in
+        Ast_helper.with_default_loc loc (fun () ->
+          Ast_helper.Exp.apply
+            (Ast_helper.Exp.ident { txt = Lident "ignore"; loc})
+            [ Nolabel,
+                Ast_helper.Exp.attr
+                  (Ast_helper.Exp.constraint_
+                    (Ast_helper.Exp.variant sorted None)
+                    (Ast_helper.Typ.variant
+                      [ Ast_helper.Rf.tag { txt = str; loc } true [] ]
+                      Closed
+                      None ))
+                  (Ast_helper.Attr.mk
+                     { txt = "ocaml.error_message"; loc }
+                     (PStr
+                       [ Ast_helper.Exp.constant
+                           (Ast_helper.Const.string
+                             (Printf.sprintf
+                               "The %s string is not in alphabetical order."
+                               str))
+                         |> Ast_helper.Str.eval
+                        ]))
+            ])
+      | _ -> default_mapper.expr self expr
+    }
+  )

--- a/ocaml/testsuite/tests/ppx-error-message/test.compilers.reference
+++ b/ocaml/testsuite/tests/ppx-error-message/test.compilers.reference
@@ -1,0 +1,7 @@
+File "test.ml", line 20, characters 21-46:
+20 |   let () = [%sorted "not_in_alphabetical_order"]
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type [> `___aaabcdeehiillnnooprrtt ]
+       but an expression was expected of type [ `not_in_alphabetical_order ]
+       The second variant type does not allow tag(s)
+       `___aaabcdeehiillnnooprrtt

--- a/ocaml/testsuite/tests/ppx-error-message/test.compilers.reference
+++ b/ocaml/testsuite/tests/ppx-error-message/test.compilers.reference
@@ -2,6 +2,8 @@ File "test.ml", line 20, characters 21-46:
 20 |   let () = [%sorted "not_in_alphabetical_order"]
                           ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type [> `___aaabcdeehiillnnooprrtt ]
-       but an expression was expected of type [ `not_in_alphabetical_order ]
+       but an expression was expected of type
+         [ `not_in_alphabetical_order ]
+       The not_in_alphabetical_order string is not in alphabetical order.
        The second variant type does not allow tag(s)
        `___aaabcdeehiillnnooprrtt

--- a/ocaml/testsuite/tests/ppx-error-message/test.ml
+++ b/ocaml/testsuite/tests/ppx-error-message/test.ml
@@ -1,0 +1,23 @@
+(* TEST
+ readonly_files = "ppx_error_message.ml";
+ include ocamlcommon;
+ setup-ocamlc.byte-build-env;
+ program = "${test_build_directory}/ppx_error_message.exe";
+ all_modules = "ppx_error_message.ml";
+ ocamlc.byte;
+ module = "test.ml";
+ flags = "-I ${test_build_directory} -ppx ${program}";
+ ocamlc_byte_exit_status = "2";
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+*)
+
+module Good = struct
+  let () = [%sorted "abcd"]
+end
+
+module Bad = struct
+  let () = [%sorted "not_in_alphabetical_order"]
+end
+
+


### PR DESCRIPTION
Make the compiler report the error payload of `[@error_message ...]` even in the event that the constrained location is a ghost. This better enables ppxes to insert `[@error_message ...]` themselves, as ppxes often create ghost locations.

Cross-linking with #1943 and #1954. 

Most of this feature is a regression test. It's kind of finicky to get `[@error_message ...]` to work &mdash; it only works when certain syntactic constructs appears as the payload of the constraint. (E.g., it works for variants and not for identifiers &mdash; the explanation mechanism has an interaction with whether the construct is "inferred", and `[@error_message ...]` inherits that interaction.) So the test is fairly contrived.