### PR TITLE
Select `lea` in more cases

### DIFF
--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -52,6 +52,9 @@ let rec select_addr exp =
       | ((Asymbol _ | Aadd (_, _) | Ascale (_,_) | Ascaledadd (_, _, _)), _)
         -> default
       end
+  | Cop(Cmuli, [(Cvar _ as arg); Cconst_int(3|5|9 as mult, _)], _)
+  | Cop(Cmuli, [Cconst_int(3|5|9 as mult, _); (Cvar _ as arg)], _) ->
+      Ascaledadd (arg, arg, mult - 1), 0
   | Cop(Cmuli, [arg; Cconst_int((2|4|8 as mult), _)], _)
   | Cop(Cmuli, [Cconst_int((2|4|8 as mult), _); arg], _) ->
       let default = (Ascale (arg, mult), 0) in


### PR DESCRIPTION
This pull request tweaks address selection on
`amd64` to select `lea` in more cases.
It was prompted by a report that `(x lsl 2) + x`
would result in a `lea` while `x * 5` would not.
That was because by using two instructions,
adress selection would build an `Ascaledadd`.
This pull request adds cases to build
`Ascaledadd` from mere multiplications by
3, 5, and 9.