### PR TITLE
Fix int64->float32 cast codegen

### DIFF
--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -138,7 +138,7 @@ let print_instr b = function
   | CQO ->  i0 b "cqto"
   | CVTSS2SI (arg1, arg2) -> i2 b "cvtss2si" arg1 arg2
   | CVTSD2SI (arg1, arg2) -> i2 b "cvtsd2si" arg1 arg2
-  | CVTSI2SS (arg1, arg2) -> i2 b "cvtsi2ss" arg1 arg2
+  | CVTSI2SS (arg1, arg2) -> i2 b ("cvtsi2ss" ^ suf arg1) arg1 arg2
   | CVTSD2SS (arg1, arg2) -> i2 b "cvtsd2ss" arg1 arg2
   | CVTSI2SD (arg1, arg2) -> i2 b ("cvtsi2sd" ^ suf arg1) arg1 arg2
   | CVTSS2SD (arg1, arg2) -> i2 b "cvtss2sd" arg1 arg2


### PR DESCRIPTION
If `gas` encounters `cvtsi2ss` where the first (integer) operand is a memory location, it will assume that the int is 32 bits wide.
Hence, we need to suffix the instruction name with the width of the integer operand.
This matches the usage of `cvtsi2sd`.

This bug does not apply to the internal assembler, which already cases on the operand width.
We believe it does not apply to the nasm assembler (no suffix was required for `cvtsi2sd`), but nasm isn't tested, and isn't supported in flambda-backend anyway.

(Bug found / fix tested in #2697)