### PR TITLE
Fix build (`Poll_and_jump` removed)

### DIFF
--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -117,7 +117,7 @@ let evaluate_terminator ~(reg : Reg.t) ~(const : nativeint)
   | Never -> assert false
   | Always _ | Float_test _ | Return | Raise _ | Tailcall_self _
   | Tailcall_func _ | Call_no_return _ | Call _ | Prim _ | Specific_can_raise _
-  | Poll_and_jump _ ->
+    ->
     None
 
 (* CR-someday gyorsh: merge (Lbranch | Lcondbranch | Lcondbranch3)+ into a


### PR DESCRIPTION
`Poll_and_jump` was removed in #1927 but the merge of #1809 re-introduced a use.