### PR TITLE
Fix padding bug for float32 static values

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3882,6 +3882,8 @@ let infix_field_address ~dbg ptr n =
 
 let cint i = Cmm.Cint i
 
+let cint32 i = Cmm.Cint32 (Nativeint.of_int32 i)
+
 let cfloat32 f = Cmm.Csingle f
 
 let cfloat f = Cmm.Cdouble f

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -876,6 +876,9 @@ val infix_field_address : dbg:Debuginfo.t -> expression -> int -> expression
 (** Static integer. *)
 val cint : nativeint -> data_item
 
+(** Static 32-bit integer. *)
+val cint32 : int32 -> data_item
+
 (** Static float32. *)
 val cfloat32 : float -> data_item
 

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -214,7 +214,9 @@ let const_static cst =
   | Naked_float f -> [cfloat (Numeric_types.Float_by_bit_pattern.to_float f)]
   | Naked_float32 f ->
     (* Statically-allocated float32 values are zero padded. We must explicitly
-       add the padding otherwise subsequent values will be misaligned. *)
+       add the padding otherwise subsequent values will be misaligned. If this
+       code is ever used on big-endian systems (which seems unlikely), this
+       needs checking. *)
     [cfloat32 (Numeric_types.Float32_by_bit_pattern.to_float f); cint32 0l]
   | Naked_int32 i -> [cint (Nativeint.of_int32 i)]
   (* We don't compile flambda-backend in 32-bit mode, so nativeint is 64

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -213,10 +213,9 @@ let const_static cst =
            (tag_targetint (Targetint_31_63.to_targetint i))) ]
   | Naked_float f -> [cfloat (Numeric_types.Float_by_bit_pattern.to_float f)]
   | Naked_float32 f ->
-    (* Here we are relying on the data section being zero initialized to
-       maintain the invariant that statically-allocated float32 values are zero
-       padded. *)
-    [cfloat32 (Numeric_types.Float32_by_bit_pattern.to_float f)]
+    (* Statically-allocated float32 values are zero padded. We must explicitly
+       add the padding otherwise subsequent values will be misaligned. *)
+    [cfloat32 (Numeric_types.Float32_by_bit_pattern.to_float f); cint32 0l]
   | Naked_int32 i -> [cint (Nativeint.of_int32 i)]
   (* We don't compile flambda-backend in 32-bit mode, so nativeint is 64
      bits. *)

--- a/ocaml/testsuite/tests/mixed-blocks/closure_padding_float32.ml
+++ b/ocaml/testsuite/tests/mixed-blocks/closure_padding_float32.ml
@@ -1,7 +1,7 @@
 (* TEST
    runtime5;
    include stdlib_beta;
-   ocamlopt_flags="-extension layouts_alpha -extension small_numbers"
+   ocamlopt_flags="-extension layouts_alpha -extension small_numbers";
    native;
 *)
 

--- a/ocaml/testsuite/tests/mixed-blocks/closure_padding_float32.ml
+++ b/ocaml/testsuite/tests/mixed-blocks/closure_padding_float32.ml
@@ -1,0 +1,35 @@
+(* TEST
+   runtime5;
+   include stdlib_beta;
+   ocamlopt_flags="-extension layouts_alpha -extension small_numbers"
+   native;
+*)
+
+(* From https://github.com/ocaml-flambda/flambda-backend/pull/2698
+   although submitted as part of
+   https://github.com/ocaml-flambda/flambda-backend/pull/2763
+*)
+
+module Float32_u = Stdlib_beta.Float32_u
+
+type t =
+  | Mutable_str of { mutable x : string }
+  | Float32 of float32#
+
+let[@inline always] go x y =
+  let f =
+    match x with
+    | Float32 f32 ->
+      (fun[@inline never] () ->
+         match y with
+         | Mutable_str _ -> f32
+         | Float32 _ -> assert false)
+    | Mutable_str _ -> assert false
+  in
+  f ()
+
+let () =
+  let x = Float32 #4.s in
+  let y = Mutable_str { x = "s" } in
+  let _ = go x y in
+  ()


### PR DESCRIPTION
The code in flambda2 to dynamically initialize static values containing `float32`s was correctly taking into account that they must be put into word-width slots.  However the code for constant static fields was not, meaning that fields after a `float32` would be at addresses 4 bytes too low.

The test case is in https://github.com/ocaml-flambda/flambda-backend/pull/2698.  @ncik-roberts please add that as a test case in PR2698, since it needs inline mixed blocks.