### PR TITLE
Use correct `zap` function for modalities in `with module` constraints

### DIFF
--- a/ocaml/testsuite/tests/typing-modes/val_modalities.ml
+++ b/ocaml/testsuite/tests/typing-modes/val_modalities.ml
@@ -398,47 +398,9 @@ end = struct
 end
 [%%expect{|
 module type S = sig module M : sig val f : int -> int end end
-Lines 13-19, characters 6-3:
-13 | ......struct
-14 |   module Plain = struct
-15 |     let f x = x+1
-16 |   end
-17 |
-18 |   module type S_plain = S with module M = Plain
-19 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module Plain : sig val f : int -> int @@ global many end
-           module type S_plain =
-             sig module M : sig val f : int -> int @@ global many end end
-         end
-       is not included in
-         sig
-           module Plain : sig val f : int -> int end
-           module type S_plain =
-             sig module M : sig val f : int -> int end end
-         end
-       Module type declarations do not match:
-         module type S_plain =
-           sig module M : sig val f : int -> int @@ global many end end
-       does not match
-         module type S_plain = sig module M : sig val f : int -> int end end
-       The second module type is not included in the first
-       At position module type S_plain = <here>
-       Module types do not match:
-         sig module M : sig val f : int -> int end end
-       is not equal to
-         sig module M : sig val f : int -> int @@ global many end end
-       At position module type S_plain = sig module M : <here> end
-       Modules do not match:
-         sig val f : int -> int end
-       is not included in
-         sig val f : int -> int @@ global many end
-       At position module type S_plain = sig module M : <here> end
-       Values do not match:
-         val f : int -> int
-       is not included in
-         val f : int -> int @@ global many
-       The second is global_ and the first is not.
+module N :
+  sig
+    module Plain : sig val f : int -> int end
+    module type S_plain = sig module M : sig val f : int -> int end end
+  end
 |}]

--- a/ocaml/testsuite/tests/typing-modes/val_modalities.ml
+++ b/ocaml/testsuite/tests/typing-modes/val_modalities.ml
@@ -373,3 +373,72 @@ Line 7, characters 21-29:
                          ^^^^^^^^
 Error: This value is nonportable but expected to be portable.
 |}]
+
+(* The example below demonstrates the need to zap modalities from [with module]
+   constraints.  A similar example appears in the zero_alloc tests, because
+   [zero_alloc] variables must be treated similarly. *)
+module type S = sig
+  module M : sig
+    val f : int -> int
+  end
+end
+
+module N : sig
+  module Plain : sig
+    val f : int -> int
+  end
+
+  module type S_plain = S with module M = Plain
+end = struct
+  module Plain = struct
+    let f x = x+1
+  end
+
+  module type S_plain = S with module M = Plain
+end
+[%%expect{|
+module type S = sig module M : sig val f : int -> int end end
+Lines 13-19, characters 6-3:
+13 | ......struct
+14 |   module Plain = struct
+15 |     let f x = x+1
+16 |   end
+17 |
+18 |   module type S_plain = S with module M = Plain
+19 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           module Plain : sig val f : int -> int @@ global many end
+           module type S_plain =
+             sig module M : sig val f : int -> int @@ global many end end
+         end
+       is not included in
+         sig
+           module Plain : sig val f : int -> int end
+           module type S_plain =
+             sig module M : sig val f : int -> int end end
+         end
+       Module type declarations do not match:
+         module type S_plain =
+           sig module M : sig val f : int -> int @@ global many end end
+       does not match
+         module type S_plain = sig module M : sig val f : int -> int end end
+       The second module type is not included in the first
+       At position module type S_plain = <here>
+       Module types do not match:
+         sig module M : sig val f : int -> int end end
+       is not equal to
+         sig module M : sig val f : int -> int @@ global many end end
+       At position module type S_plain = sig module M : <here> end
+       Modules do not match:
+         sig val f : int -> int end
+       is not included in
+         sig val f : int -> int @@ global many end
+       At position module type S_plain = sig module M : <here> end
+       Values do not match:
+         val f : int -> int
+       is not included in
+         val f : int -> int @@ global many
+       The second is global_ and the first is not.
+|}]

--- a/ocaml/testsuite/tests/typing-modes/val_modalities.ml
+++ b/ocaml/testsuite/tests/typing-modes/val_modalities.ml
@@ -404,3 +404,62 @@ module N :
     module type S_plain = sig module M : sig val f : int -> int end end
   end
 |}]
+
+(* This revised version of that example does not typecheck. It would be nice if
+   it did, but to make it do so seems hard. In the case of zero_alloc we can fix
+   this with a zero_alloc annotation in the structure, but there is currently no
+   equivalent for that with modalities. *)
+module type S = sig
+  module M : sig
+    val f : int -> int
+  end
+end
+
+module N : sig
+  module Plain : sig
+    val f : int -> int @@ portable
+  end
+
+  module type S_plain = S with module M = Plain
+end = struct
+  module Plain = struct
+    let f x = x+1
+  end
+
+  module type S_plain = S with module M = Plain
+end
+[%%expect{|
+module type S = sig module M : sig val f : int -> int end end
+Lines 13-19, characters 6-3:
+13 | ......struct
+14 |   module Plain = struct
+15 |     let f x = x+1
+16 |   end
+17 |
+18 |   module type S_plain = S with module M = Plain
+19 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           module Plain : sig val f : int -> int @@ global many end
+           module type S_plain =
+             sig module M : sig val f : int -> int end end
+         end
+       is not included in
+         sig
+           module Plain : sig val f : int -> int @@ portable end
+           module type S_plain =
+             sig module M : sig val f : int -> int @@ portable end end
+         end
+       In module Plain:
+       Modules do not match:
+         sig val f : int -> int @@ global many end
+       is not included in
+         sig val f : int -> int @@ portable end
+       In module Plain:
+       Values do not match:
+         val f : int -> int @@ global many
+       is not included in
+         val f : int -> int @@ portable
+       The second is portable and the first is not.
+|}]

--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -1205,7 +1205,7 @@ module type S1 = sig
 end
 
 module N1 : sig
-  module Plain : sig
+  module Plain1 : sig
     val f : int -> int
   end
 
@@ -1219,11 +1219,11 @@ end = struct
 end
 [%%expect{|
 module type S1 = sig module M1 : sig val f : int -> int end end
-Line 12, characters 25-51:
-12 |   module type S_plain1 = S1 with module M1 = Plain1
-                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Unbound module Plain1
-Hint: Did you mean Plain?
+module N1 :
+  sig
+    module Plain1 : sig val f : int -> int end
+    module type S_plain1 = sig module M1 : sig val f : int -> int end end
+  end
 |}]
 
 (* This revised version does not typecheck, because the signature on [S_plain2]

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -803,7 +803,7 @@ let merge_constraint initial_env loc sg lid constr =
         let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
         let mty =
           remove_modality_and_zero_alloc_variables_mty sig_env
-            ~zap_modality:Mode.Modality.Value.zap_to_floor mty
+            ~zap_modality:Mode.Modality.Value.zap_to_id mty
         in
         let md'' = { md' with md_type = mty } in
         let newmd = Mtype.strengthen_decl ~aliasable:false md'' path in


### PR DESCRIPTION
This fixes a bug in #2764, which "fixed" a bug in #2742.

The original bug was that `zero_alloc` and modality variables could creep into signatures in a disallowed way when using a `with module` constraint.  The fix was to make these variables into constants in the computed signature for the constraint.  But in the case of modality variables, I picked a constant that could lead to spurious typing errors, and failed to notice it because we only create these variables if `-extension mode_alpha` is used.

There are three commits:
* The first adds a test demonstrating the issue
* The second fixes it
* The third adds more test documenting the behavior.

(There remain some questions about whether the revised behavior is ideal, and the tests in the third commit document the behavior.)