### PR TITLE
Ensure no alias equation remains in exported Flambda2 environments

### DIFF
--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -93,13 +93,18 @@ let clean_for_export t ~reachable_names =
            && Compilation_unit.equal
                 (Name.compilation_unit name)
                 current_compilation_unit
-        then
+        then (
           let binding_time_and_mode =
             if Name.is_var name
             then Binding_time.With_name_mode.imported_variables
             else binding_time_and_mode
           in
-          Some (ty, binding_time_and_mode)
+          (match Type_grammar.get_alias_opt ty with
+          | None -> ()
+          | Some alias ->
+            Misc.fatal_errorf "Remaining alias after cleanup: %a -> %a@."
+              Name.print name Simple.print alias);
+          Some (ty, binding_time_and_mode))
         else None)
       t.names_to_types
   in

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -1959,7 +1959,6 @@ and remove_unused_value_slots_and_shortcut_aliases_function_type
 
 and remove_unused_value_slots_and_shortcut_aliases_env_extension
     ({ equations } as env_extension) ~used_value_slots ~canonicalise =
-  let changed = ref false in
   let equations' =
     Name.Map.map_sharing
       (fun ty ->
@@ -1967,7 +1966,7 @@ and remove_unused_value_slots_and_shortcut_aliases_env_extension
           ~canonicalise)
       equations
   in
-  if !changed then { equations = equations' } else env_extension
+  if equations == equations' then env_extension else { equations = equations' }
 
 let rec project_variables_out ~to_project ~expand t =
   match t with


### PR DESCRIPTION
On export, all occurrences of variables in the typing env are canonicalised, and all non-canonical variables should then disappear. This PR adds a check that no alias equation remains in the final typing environment (because that would mean that the non-canonical variable still occurs somewhere) and fixes one bug which could cause non-canonical variables to remain.