### PR TITLE
Parse syntax for declaring module type with an underscore

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,13 @@
 {
         "ocaml.sandbox": {
                 "kind": "opam",
-                "switch": "4.14.1"
+                "switch": "4.14.2"
         },
         "files.associations": {
                 "*.mlp": "ocaml",
                 "smmintrin.h": "c",
                 "tmmintrin.h": "c",
                 "pmmintrin.h": "c"
-        }
+        },
+        "git.enabled": true
 }

--- a/ocaml/ocamldoc/odoc_analyse.ml
+++ b/ocaml/ocamldoc/odoc_analyse.ml
@@ -393,6 +393,7 @@ and remove_module_elements_between_stop_in_module_type_kind tk =
   | Odoc_module.Module_type_with (tk2, s) ->
       Odoc_module.Module_type_with (remove_module_elements_between_stop_in_module_type_kind tk2, s)
   | Odoc_module.Module_type_typeof _ -> tk
+  | Odoc_module.Module_type_underscore -> tk
 
 (** Remove elements between the stop special comment. *)
 let remove_elements_between_stop module_list =

--- a/ocaml/ocamldoc/odoc_ast.ml
+++ b/ocaml/ocamldoc/odoc_ast.ml
@@ -1499,10 +1499,12 @@ module Analyser =
           in
           let kind, sig_mtype =
             match modtype, tt_module_type.mtd_type with
-            | Some modtype, Some mty_type ->
+            | Pmtd_define modtype, Some mty_type ->
                 Some (Sig.analyse_module_type_kind env complete_name
                         modtype mty_type.mty_type),
                 Some mty_type.mty_type
+            | Pmtd_underscore, Some mty_type ->
+                Some Module_type_underscore, Some mty_type.mty_type
             | _ -> None, None
           in
           let comment_opt =

--- a/ocaml/ocamldoc/odoc_cross.ml
+++ b/ocaml/ocamldoc/odoc_cross.ml
@@ -425,7 +425,11 @@ and associate_in_module_type module_list (acc_b_modif, acc_incomplete_top_module
                   mta.mta_module <- Some mt ;
                   (true, acc_inc, acc_names)
         end
+
     | Module_type_typeof _ ->
+        (acc_b, acc_inc, acc_names)
+
+    | Module_type_underscore ->
         (acc_b, acc_inc, acc_names)
   in
   match mt.mt_kind with
@@ -968,6 +972,7 @@ and assoc_comments_module_type_kind parent_name module_list mtk =
       Module_type_with
         (assoc_comments_module_type_kind parent_name module_list mtk1, s)
   | Module_type_typeof _ -> mtk
+  | Module_type_underscore -> mtk
 
 and assoc_comments_class_kind parent_name module_list ck =
   match ck with

--- a/ocaml/ocamldoc/odoc_html.ml
+++ b/ocaml/ocamldoc/odoc_html.ml
@@ -1530,6 +1530,8 @@ class html =
           bs b "<code class=\"type\">module type of ";
           bs b (self#create_fully_qualified_module_idents_links father s);
           bs b "</code>"
+      | Module_type_underscore ->
+          bs b "<code class=\"type\">_</code>"
 
     (** Print html code to display the type of a module parameter.. *)
     method html_of_module_parameter_type b m_name p =

--- a/ocaml/ocamldoc/odoc_info.mli
+++ b/ocaml/ocamldoc/odoc_info.mli
@@ -566,6 +566,7 @@ module Module :
             (** The module type kind and the code of the with constraint. *)
       | Module_type_typeof of string
             (** by now only the code of the module expression *)
+      | Module_type_underscore
 
     (** Representation of a module type. *)
     and t_module_type = Odoc_module.t_module_type =

--- a/ocaml/ocamldoc/odoc_latex.ml
+++ b/ocaml/ocamldoc/odoc_latex.ml
@@ -786,6 +786,9 @@ class latex =
             [ Code "module type of ";
               Code (self#relative_idents father s);
             ]
+      | Module_type_underscore ->
+          self#latex_of_text fmt
+            [ Code "_" ];
 
     method latex_of_module_kind fmt father kind =
       match kind with

--- a/ocaml/ocamldoc/odoc_module.ml
+++ b/ocaml/ocamldoc/odoc_module.ml
@@ -88,6 +88,7 @@ and module_type_kind =
   | Module_type_alias of module_type_alias (** complete name and corresponding module type if we found it *)
   | Module_type_with of module_type_kind * string (** the module type kind and the code of the with constraint *)
   | Module_type_typeof of string (** by now only the code of the module expression *)
+  | Module_type_underscore
 
 and t_module_type = {
     mt_name : Name.t ;
@@ -218,6 +219,7 @@ let rec module_type_elements ?(trans=true) mt =
         else
           []
   | Some (Module_type_typeof _) -> []
+  | Some (Module_type_underscore) -> []
   in
   iter_kind mt.mt_kind
 
@@ -341,6 +343,7 @@ let rec module_type_parameters ?(trans=true) mt =
     | Some (Module_type_typeof _) -> []
       | None ->
         []
+    | Some (Module_type_underscore) -> []
   in
   iter mt.mt_kind
 
@@ -405,6 +408,7 @@ let rec module_type_is_functor mt =
         iter (Some k)
     | Some (Module_type_struct _)
     | Some (Module_type_typeof _)
+    | Some (Module_type_underscore)
     | None -> false
   in
   iter mt.mt_kind

--- a/ocaml/ocamldoc/odoc_module.mli
+++ b/ocaml/ocamldoc/odoc_module.mli
@@ -79,6 +79,7 @@ and module_type_kind =
   | Module_type_alias of module_type_alias
   | Module_type_with of module_type_kind * string
   | Module_type_typeof of string
+  | Module_type_underscore
 and t_module_type = {
   mt_name : Name.t;
   mutable mt_info : Odoc_types.info option;

--- a/ocaml/ocamldoc/odoc_sig.ml
+++ b/ocaml/ocamldoc/odoc_sig.ml
@@ -1431,8 +1431,9 @@ module Analyser =
             in
             let module_type_kind =
               match pmodtype_decl with
-                None -> None
-              | Some module_type ->
+                Pmtd_abstract -> None
+              | Pmtd_underscore -> raise (Failure (Odoc_messages.module_type_not_found current_module_name name.txt))
+              | Pmtd_define module_type ->
                 match sig_mtype with
                 | Some sig_mtype -> Some (analyse_module_type_kind env complete_name module_type sig_mtype)
                 | None -> None

--- a/ocaml/ocamldoc/odoc_to_text.ml
+++ b/ocaml/ocamldoc/odoc_to_text.ml
@@ -623,4 +623,10 @@ class virtual to_text =
             (if with_def_syntax then " = " else "") s
           in
           [ Code code ]
+
+      | Module_type_underscore ->
+          let code = Printf.sprintf "%s_"
+            (if with_def_syntax then " = " else "")
+          in
+          [ Code code ]
   end

--- a/ocaml/parsing/ast_helper.ml
+++ b/ocaml/parsing/ast_helper.ml
@@ -449,7 +449,7 @@ end
 
 module Mtd = struct
   let mk ?(loc = !default_loc) ?(attrs = [])
-        ?(docs = empty_docs) ?(text = []) ?typ name =
+        ?(docs = empty_docs) ?(text = []) name typ =
     {
      pmtd_name = name;
      pmtd_type = typ;

--- a/ocaml/parsing/ast_helper.mli
+++ b/ocaml/parsing/ast_helper.mli
@@ -359,7 +359,7 @@ module Ms:
 module Mtd:
   sig
     val mk: ?loc:loc -> ?attrs:attrs -> ?docs:docs -> ?text:text ->
-      ?typ:module_type -> str -> module_type_declaration
+      str -> module_type_declaration_type -> module_type_declaration
   end
 
 (** Module bindings *)

--- a/ocaml/parsing/ast_invariants.ml
+++ b/ocaml/parsing/ast_invariants.ml
@@ -37,6 +37,10 @@ let empty_type loc = err loc "Type declarations cannot be empty."
 let complex_id loc = err loc "Functor application not allowed here."
 let module_type_substitution_missing_rhs loc =
   err loc "Module type substitution with no right hand side"
+
+let module_type_substitution_underscore_rhs loc =
+  err loc "Module type substitution with underscore as the right hand side"
+
 let empty_comprehension loc = err loc "Comprehension with no clauses"
 let no_val_params loc = err loc "Functions must have a value parameter."
 
@@ -226,8 +230,12 @@ let iterator =
     let loc = sg.psig_loc in
     match sg.psig_desc with
     | Psig_type (_, []) -> empty_type loc
-    | Psig_modtypesubst {pmtd_type=None; _ } ->
-        module_type_substitution_missing_rhs loc
+    | Psig_modtypesubst {pmtd_type; _ } ->
+      begin match pmtd_type with
+      | Pmtd_abstract -> module_type_substitution_missing_rhs loc
+      | Pmtd_underscore -> module_type_substitution_underscore_rhs loc
+      | Pmtd_define _ -> ()
+      end
     | _ -> ()
   in
   let row_field self field =

--- a/ocaml/parsing/ast_iterator.ml
+++ b/ocaml/parsing/ast_iterator.ml
@@ -410,6 +410,10 @@ module MT = struct
     | Jmty_strengthen { mty; mod_id } ->
        iter sub mty;
        iter_loc sub mod_id
+
+  let iter_module_type_declaration_type sub = function
+    | Pmtd_abstract | Pmtd_underscore -> ()
+    | Pmtd_define ty -> sub.module_type sub ty
 end
 
 
@@ -870,7 +874,7 @@ let default_iterator =
     module_type_declaration =
       (fun this {pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc} ->
          iter_loc this pmtd_name;
-         iter_opt (this.module_type this) pmtd_type;
+         MT.iter_module_type_declaration_type this pmtd_type;
          this.location this pmtd_loc;
          this.attributes this pmtd_attributes;
       );

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -490,6 +490,10 @@ module MT = struct
        let mty = sub.module_type sub mty in
        let mod_id = map_loc sub mod_id in
        Jmty_strengthen { mty; mod_id }
+
+  let map_module_type_declaration_type sub = function
+    | Pmtd_abstract | Pmtd_underscore as decl_type -> decl_type
+    | Pmtd_define ty -> Pmtd_define (sub.module_type sub ty)
 end
 
 
@@ -996,7 +1000,7 @@ let default_mapper =
       (fun this {pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc} ->
          Mtd.mk
            (map_loc this pmtd_name)
-           ?typ:(map_opt (this.module_type this) pmtd_type)
+           (MT.map_module_type_declaration_type this pmtd_type)
            ~attrs:(this.attributes this pmtd_attributes)
            ~loc:(this.location this pmtd_loc)
       );

--- a/ocaml/parsing/depend.ml
+++ b/ocaml/parsing/depend.ml
@@ -582,8 +582,8 @@ and add_sig_item (bv, m) item =
       (bv', m')
   | Psig_modtype x | Psig_modtypesubst x->
       begin match x.pmtd_type with
-        None -> ()
-      | Some mty -> add_modtype bv mty
+      | Pmtd_abstract | Pmtd_underscore -> ()
+      | Pmtd_define mty -> add_modtype bv mty
       end;
       (bv, m)
   | Psig_open od ->
@@ -741,8 +741,8 @@ and add_struct_item (bv, m) item : _ String.Map.t * _ String.Map.t =
       (bv', m)
   | Pstr_modtype x ->
       begin match x.pmtd_type with
-        None -> ()
-      | Some mty -> add_modtype bv mty
+      | Pmtd_abstract | Pmtd_underscore -> ()
+      | Pmtd_define mty -> add_modtype bv mty
       end;
       (bv, m)
   | Pstr_open od ->

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -1891,30 +1891,20 @@ module_type_declaration:
     ext = ext
     attrs1 = attributes
     id = mkrhs(ident)
-    typ = preceded(EQUAL, module_type)?
+    typ = module_type_declaration_type
     attrs2 = post_item_attributes
     {
       let attrs = attrs1 @ attrs2 in
       let loc = make_loc $sloc in
       let docs = symbol_docs $sloc in
-      let pmtd_typ = match typ with
-        | None -> Pmtd_abstract
-        | Some t -> Pmtd_define t
-      in
-      Mtd.mk id pmtd_typ ~attrs ~loc ~docs, ext
+      Mtd.mk id typ ~attrs ~loc ~docs, ext
     }
-  | MODULE TYPE
-    ext = ext
-    attrs1 = attributes
-    id = mkrhs(ident)
-    EQUAL UNDERSCORE
-    attrs2 = post_item_attributes
-    {
-      let attrs = attrs1 @ attrs2 in
-      let loc = make_loc $sloc in
-      let docs = symbol_docs $sloc in
-      Mtd.mk id Pmtd_underscore ~attrs ~loc ~docs, ext
-    }
+;
+
+module_type_declaration_type:
+  | (* empty *)         { Pmtd_abstract }
+  | EQUAL module_type   { Pmtd_define $2 }
+  | EQUAL UNDERSCORE    { Pmtd_underscore }
 ;
 
 (* -------------------------------------------------------------------------- *)

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -1887,18 +1887,34 @@ include_maybe_functor:
 
 (* A module type declaration. *)
 module_type_declaration:
-  MODULE TYPE
-  ext = ext
-  attrs1 = attributes
-  id = mkrhs(ident)
-  typ = preceded(EQUAL, module_type)?
-  attrs2 = post_item_attributes
-  {
-    let attrs = attrs1 @ attrs2 in
-    let loc = make_loc $sloc in
-    let docs = symbol_docs $sloc in
-    Mtd.mk id ?typ ~attrs ~loc ~docs, ext
-  }
+  | MODULE TYPE
+    ext = ext
+    attrs1 = attributes
+    id = mkrhs(ident)
+    typ = preceded(EQUAL, module_type)?
+    attrs2 = post_item_attributes
+    {
+      let attrs = attrs1 @ attrs2 in
+      let loc = make_loc $sloc in
+      let docs = symbol_docs $sloc in
+      let pmtd_typ = match typ with
+        | None -> Pmtd_abstract
+        | Some t -> Pmtd_define t
+      in
+      Mtd.mk id pmtd_typ ~attrs ~loc ~docs, ext
+    }
+  | MODULE TYPE
+    ext = ext
+    attrs1 = attributes
+    id = mkrhs(ident)
+    EQUAL UNDERSCORE
+    attrs2 = post_item_attributes
+    {
+      let attrs = attrs1 @ attrs2 in
+      let loc = make_loc $sloc in
+      let docs = symbol_docs $sloc in
+      Mtd.mk id Pmtd_underscore ~attrs ~loc ~docs, ext
+    }
 ;
 
 (* -------------------------------------------------------------------------- *)
@@ -2181,7 +2197,7 @@ module_type_subst:
     let attrs = attrs1 @ attrs2 in
     let loc = make_loc $sloc in
     let docs = symbol_docs $sloc in
-    Mtd.mk id ~typ ~attrs ~loc ~docs, ext
+    Mtd.mk id (Pmtd_define typ) ~attrs ~loc ~docs, ext
   }
 
 

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -1887,18 +1887,18 @@ include_maybe_functor:
 
 (* A module type declaration. *)
 module_type_declaration:
-  | MODULE TYPE
-    ext = ext
-    attrs1 = attributes
-    id = mkrhs(ident)
-    typ = module_type_declaration_type
-    attrs2 = post_item_attributes
-    {
-      let attrs = attrs1 @ attrs2 in
-      let loc = make_loc $sloc in
-      let docs = symbol_docs $sloc in
-      Mtd.mk id typ ~attrs ~loc ~docs, ext
-    }
+  MODULE TYPE
+  ext = ext
+  attrs1 = attributes
+  id = mkrhs(ident)
+  typ = module_type_declaration_type
+  attrs2 = post_item_attributes
+  {
+    let attrs = attrs1 @ attrs2 in
+    let loc = make_loc $sloc in
+    let docs = symbol_docs $sloc in
+    Mtd.mk id typ ~attrs ~loc ~docs, ext
+  }
 ;
 
 module_type_declaration_type:

--- a/ocaml/parsing/parsetree.mli
+++ b/ocaml/parsing/parsetree.mli
@@ -930,7 +930,7 @@ and module_type_declaration =
      when {{!module_type_declaration.pmtd_type}[pmtd_type]} is [Pmtd_define MT].
    - [S] for abstract module type declaration,
      when {{!module_type_declaration.pmtd_type}[pmtd_type]} is [Pmtd_abstract].
-   - [S = _] for inferring module type from definition in the signature,
+   - [S = _] for inferring module type,
      when {{!module_type_declaration.pmtd_type}[pmtd_type]} is [Pmtd_underscore].
 *)
 

--- a/ocaml/parsing/parsetree.mli
+++ b/ocaml/parsing/parsetree.mli
@@ -921,15 +921,23 @@ and module_substitution =
 and module_type_declaration =
     {
      pmtd_name: string loc;
-     pmtd_type: module_type option;
+     pmtd_type: module_type_declaration_type;
      pmtd_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
      pmtd_loc: Location.t;
     }
 (** Values of type [module_type_declaration] represents:
    - [S = MT],
+     when {{!module_type_declaration.pmtd_type}[pmtd_type]} is [Pmtd_define MT].
    - [S] for abstract module type declaration,
-     when {{!module_type_declaration.pmtd_type}[pmtd_type]} is [None].
+     when {{!module_type_declaration.pmtd_type}[pmtd_type]} is [Pmtd_abstract].
+   - [S = _] for inferring module type from definition in the signature,
+     when {{!module_type_declaration.pmtd_type}[pmtd_type]} is [Pmtd_underscore].
 *)
+
+and module_type_declaration_type =
+  | Pmtd_abstract
+  | Pmtd_underscore
+  | Pmtd_define of module_type
 
 and 'a open_infos =
     {

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -1468,16 +1468,16 @@ and signature_item ctxt f x : unit =
       pp f "@[<hov2>module@ type@ %s%a@]%a"
         s.txt
         (fun f md -> match md with
-           | None -> ()
-           | Some mt ->
+           | Pmtd_abstract | Pmtd_underscore -> ()
+           | Pmtd_define mt ->
                pp_print_space f () ;
                pp f "@ =@ %a" (module_type ctxt) mt
         ) md
         (item_attributes ctxt) attrs
   | Psig_modtypesubst {pmtd_name=s; pmtd_type=md; pmtd_attributes=attrs} ->
       let md = match md with
-        | None -> assert false (* ast invariant *)
-        | Some mt -> mt in
+        | Pmtd_abstract | Pmtd_underscore -> assert false (* ast invariant *)
+        | Pmtd_define mt -> mt in
       pp f "@[<hov2>module@ type@ %s@ :=@ %a@]%a"
         s.txt (module_type ctxt) md
         (item_attributes ctxt) attrs
@@ -1766,8 +1766,8 @@ and structure_item ctxt f x =
       pp f "@[<hov2>module@ type@ %s%a@]%a"
         s.txt
         (fun f md -> match md with
-           | None -> ()
-           | Some mt ->
+           | Pmtd_abstract | Pmtd_underscore -> ()
+           | Pmtd_define mt ->
                pp_print_space f () ;
                pp f "@ =@ %a" (module_type ctxt) mt
         ) md

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -1468,7 +1468,8 @@ and signature_item ctxt f x : unit =
       pp f "@[<hov2>module@ type@ %s%a@]%a"
         s.txt
         (fun f md -> match md with
-           | Pmtd_abstract | Pmtd_underscore -> ()
+           | Pmtd_abstract -> ()
+           | Pmtd_underscore -> pp f "@ =@ _"
            | Pmtd_define mt ->
                pp_print_space f () ;
                pp f "@ =@ %a" (module_type ctxt) mt
@@ -1766,7 +1767,8 @@ and structure_item ctxt f x =
       pp f "@[<hov2>module@ type@ %s%a@]%a"
         s.txt
         (fun f md -> match md with
-           | Pmtd_abstract | Pmtd_underscore -> ()
+           | Pmtd_abstract -> ()
+           | Pmtd_underscore -> pp f "@ =@ _"
            | Pmtd_define mt ->
                pp_print_space f () ;
                pp f "@ =@ %a" (module_type ctxt) mt

--- a/ocaml/parsing/printast.ml
+++ b/ocaml/parsing/printast.ml
@@ -743,8 +743,9 @@ and signature_item i ppf x =
       attribute i ppf "Psig_attribute" a
 
 and modtype_declaration i ppf = function
-  | None -> line i ppf "#abstract"
-  | Some mt -> module_type (i+1) ppf mt
+  | Pmtd_abstract -> line i ppf "#abstract"
+  | Pmtd_underscore -> line i ppf "#underscore"
+  | Pmtd_define mt -> module_type (i+1) ppf mt
 
 and with_constraint i ppf x =
   match x with

--- a/ocaml/testsuite/tests/module-type-underscore/syntax_error.compilers.reference
+++ b/ocaml/testsuite/tests/module-type-underscore/syntax_error.compilers.reference
@@ -1,0 +1,5 @@
+Line 12, characters 19-20:
+12 |   module type T := _
+                        ^
+Error: Syntax error
+

--- a/ocaml/testsuite/tests/module-type-underscore/syntax_error.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/syntax_error.ml
@@ -1,0 +1,15 @@
+(* TEST
+ toplevel;
+*)
+
+module M : sig
+  module type S = sig
+    type t
+    val foo : t -> t
+    val bar : t list -> t
+  end
+
+  module type T := _
+end = struct
+  module type S = _
+end ;;

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -84,8 +84,6 @@ and ASet
   = Set.Make(A)
 
 [%%expect{|
-Line 4, characters 2-19:
-4 |   module type S = _
-      ^^^^^^^^^^^^^^^^^
-Error: Inferrence of module types is not allowed within a signature.
+Uncaught exception: Failure("underscore not implemented")
+
 |}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1,0 +1,91 @@
+(* TEST
+ expect;
+*)
+
+module M : sig
+  module type S = sig
+    type t
+    val foo : t -> t
+    val bar : t list -> t
+  end
+end = struct
+  module type S = _
+end ;;
+[%%expect {|
+Uncaught exception: Failure("underscore not implemented")
+
+|}]
+
+module M : sig
+  module type S = _
+end = struct
+  module type S = sig
+    type t
+    val foo : t -> t
+    val bar : t list -> t
+  end
+end ;;
+[%%expect {|
+Uncaught exception: Failure("underscore not implemented")
+
+|}]
+
+module M = struct
+  module type S = _
+end ;;
+[%%expect {|
+Uncaught exception: Failure("underscore not implemented")
+
+|}]
+
+module M : sig end = struct
+  module type S = _
+end ;;
+[%%expect {|
+Uncaught exception: Failure("underscore not implemented")
+
+|}]
+
+module M : sig
+  module type S = sig
+    type t
+    val foo : t -> t
+    val bar : t list -> t
+  end
+end = struct
+  module type S1 = _
+end ;;
+[%%expect {|
+Uncaught exception: Failure("underscore not implemented")
+
+|}]
+
+(* Test approx_modtype_info with mutually recursive types
+   Example from manual section 12.2
+   https://ocaml.org/manual/5.2/recursivemodules.html#s%3Arecursive-modules *)
+
+module rec A : sig
+  type t = Leaf of string | Node of ASet.t
+  val compare: t -> t -> int
+  module type S = _
+end = struct
+  type t = Leaf of string | Node of ASet.t
+  let compare t1 t2 =
+    match (t1, t2) with
+    | (Leaf s1, Leaf s2) -> Stdlib.compare s1 s2
+    | (Leaf _, Node _) -> 1
+    | (Node _, Leaf _) -> -1
+    | (Node n1, Node n2) -> ASet.compare n1 n2
+
+  module type S = _
+end
+and ASet
+  : Set.S with type elt = A.t
+  = Set.Make(A)
+
+[%%expect{|
+Line 4, characters 2-19:
+4 |   module type S = _
+      ^^^^^^^^^^^^^^^^^
+Error: Inferrence of module types is not allowed within a signature.
+|}]

--- a/ocaml/testsuite/tests/parsing/broken_invariants.compilers.reference
+++ b/ocaml/testsuite/tests/parsing/broken_invariants.compilers.reference
@@ -26,6 +26,10 @@ Line 2, characters 4-15:
 2 |  [%%missing_rhs]
         ^^^^^^^^^^^
 Error: broken invariant in parsetree: Module type substitution with no right hand side
+Line 3, characters 5-22:
+3 |   [%%underscore_as_rhs]
+         ^^^^^^^^^^^^^^^^^
+Error: broken invariant in parsetree: Module type substitution with underscore as the right hand side
 Line 2, characters 9-26:
 2 | let f ([%lt_empty_open_pat]) = ();;
              ^^^^^^^^^^^^^^^^^

--- a/ocaml/testsuite/tests/parsing/broken_invariants.ml
+++ b/ocaml/testsuite/tests/parsing/broken_invariants.ml
@@ -19,6 +19,10 @@ module type s = sig
  [%%missing_rhs]
 end;;
 
+module type s = sig
+  [%%underscore_as_rhs]
+end;;
+
 let f ([%lt_empty_open_pat]) = ();;
 let f ([%lt_short_closed_pat]) = ();;
 

--- a/ocaml/testsuite/tests/parsing/illegal_ppx.ml
+++ b/ocaml/testsuite/tests/parsing/illegal_ppx.ml
@@ -8,7 +8,12 @@ let empty_apply loc f =
 
 let missing_rhs loc =
   let name = Location.mkloc "T" loc in
-  let mtd = H.Mtd.mk ~loc name in
+  let mtd = H.Mtd.mk ~loc name Pmtd_abstract in
+  H.Sig.modtype_subst ~loc mtd
+
+let underscore_as_rhs loc =
+  let name = Location.mkloc "T" loc in
+  let mtd = H.Mtd.mk ~loc name Pmtd_underscore in
   H.Sig.modtype_subst ~loc mtd
 
 let empty_let loc = H.Str.value ~loc Asttypes.Nonrecursive []
@@ -60,6 +65,7 @@ let structure_item mapper stri = match stri.pstr_desc with
 
 let signature_item mapper stri = match stri.psig_desc with
   | Psig_extension (({Location.txt="missing_rhs";loc},_),_) -> missing_rhs loc
+  | Psig_extension (({Location.txt="underscore_as_rhs";loc},_),_) -> underscore_as_rhs loc
   | _ -> super.signature_item mapper stri
 
 

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -551,12 +551,12 @@ and module_substitution =
 
 and module_type_declaration =
     {
-     mtd_id: Ident.t;
-     mtd_name: string loc;
-     mtd_uid: Uid.t;
-     mtd_type: module_type option;
-     mtd_attributes: attribute list;
-     mtd_loc: Location.t;
+      mtd_id: Ident.t;
+      mtd_name: string loc;
+      mtd_uid: Uid.t;
+      mtd_type: module_type option;
+      mtd_attributes: attribute list;
+      mtd_loc: Location.t;
     }
 
 and 'a open_infos =

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -551,12 +551,12 @@ and module_substitution =
 
 and module_type_declaration =
     {
-      mtd_id: Ident.t;
-      mtd_name: string loc;
-      mtd_uid: Uid.t;
-      mtd_type: module_type option;
-      mtd_attributes: attribute list;
-      mtd_loc: Location.t;
+     mtd_id: Ident.t;
+     mtd_name: string loc;
+     mtd_uid: Uid.t;
+     mtd_type: module_type option;
+     mtd_attributes: attribute list;
+     mtd_loc: Location.t;
     }
 
 and 'a open_infos =

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -1117,7 +1117,7 @@ and approx_sig env ssg =
 
 and approx_modtype_info env sinfo =
   let mtd_type = match sinfo.pmtd_type with
-    | Pmtd_underscore -> raise (Error (sinfo.pmtd_loc, env, Underscore_not_allowed_in_signature))
+    | Pmtd_underscore -> failwith "underscore not implemented"
     | Pmtd_abstract -> None
     | Pmtd_define ty -> Some (approx_modtype env ty)
   in
@@ -4119,8 +4119,8 @@ let report_error ~loc _env = function
         (Mode.Value.Const.print_axis ax) left
         (Mode.Value.Const.print_axis ax) right
   | Underscore_not_allowed_in_signature ->
-    Location.errorf ~loc
-      "Inferrence of module types is not allowed within a signature."
+      Location.errorf ~loc
+        "Inferrence of module types is not allowed within a signature."
 
 let report_error env ~loc err =
   Printtyp.wrap_printing_env_error env

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -100,7 +100,6 @@ type error =
       old_source_file : Misc.filepath;
     }
   | Submode_failed of Mode.Value.error
-  | Underscore_not_allowed_in_signature
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -4118,9 +4117,6 @@ let report_error ~loc _env = function
         "This value is %a, but expected to be %a because it is inside a module."
         (Mode.Value.Const.print_axis ax) left
         (Mode.Value.Const.print_axis ax) right
-  | Underscore_not_allowed_in_signature ->
-      Location.errorf ~loc
-        "Inferrence of module types is not allowed within a signature."
 
 let report_error env ~loc err =
   Printtyp.wrap_printing_env_error env

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -162,6 +162,7 @@ type error =
       old_source_file: Misc.filepath;
     }
   | Submode_failed of Mode.Value.error
+  | Underscore_not_allowed_in_signature
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -162,7 +162,6 @@ type error =
       old_source_file: Misc.filepath;
     }
   | Submode_failed of Mode.Value.error
-  | Underscore_not_allowed_in_signature
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -776,9 +776,13 @@ let package_type sub pack =
 let module_type_declaration sub mtd =
   let loc = sub.location sub mtd.mtd_loc in
   let attrs = sub.attributes sub mtd.mtd_attributes in
+  let typ = match mtd.mtd_type with
+    | None -> Pmtd_abstract
+    | Some ty -> Pmtd_define (sub.module_type sub ty)
+  in
   Mtd.mk ~loc ~attrs
-    ?typ:(Option.map (sub.module_type sub) mtd.mtd_type)
     (map_loc sub mtd.mtd_name)
+    typ
 
 let signature sub sg =
   List.map (sub.signature_item sub) sg.sig_items

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -791,8 +791,9 @@ and signature_item i ppf x =
   )
 
 and modtype_declaration i ppf = function
-  | None -> line i ppf "#abstract"
-  | Some mt -> module_type (i+1) ppf mt
+  | Pmtd_abstract -> line i ppf "#abstract"
+  | Pmtd_underscore -> line i ppf "#underscore"
+  | Pmtd_define mt -> module_type (i+1) ppf mt
 
 and with_constraint i ppf x =
   match x with


### PR DESCRIPTION
The goal is to allow syntax that looks like
```ocaml
module M : sig
  module type S = sig ... end
end = struct
  module type S = _
end
```
where the usage of the underscore allows the typechecker to infer the type of `S` from the earlier definition.
This PR makes necessary changes to the parser and parsetree (as well as miscellaneous changes to accommodate the new parsetree) to recognise this syntax.