### PR TITLE
Port pull requests about atomic loads

### DIFF
--- a/backend/CSEgen.ml
+++ b/backend/CSEgen.ml
@@ -63,11 +63,12 @@ method class_of_operation op =
   | Istackoffset _ -> Op_other
   | Iload { mutability; is_atomic } ->
     (* #12173: disable CSE for atomic loads.
-          #12825: atomic loads cannot be treated as Op_other
-            because they update our view / the frontier of the
-            non-atomic locations, so past non-atomic (mutable) loads
-            may be not be valid anymore.
-          We conservatively tread them as non-initializing stores.
+       #12825: atomic loads cannot be treated as Op_other
+               because they update our view / the frontier of the
+               non-atomic locations, so past non-atomic (mutable) loads
+               may be not be valid anymore.
+               We conservatively treat them as non-initializing stores.
+       (the above are upstream PR numbers)
     *)
     if is_atomic then Op_store true
     else Op_load (match mutability with

--- a/backend/CSEgen.ml
+++ b/backend/CSEgen.ml
@@ -62,8 +62,14 @@ method class_of_operation op =
   | Iextcall _ | Iprobe _ | Iopaque -> assert false  (* treated specially *)
   | Istackoffset _ -> Op_other
   | Iload { mutability; is_atomic } ->
-    (* #12173: disable CSE for atomic loads. *)
-    if is_atomic then Op_other
+    (* #12173: disable CSE for atomic loads.
+          #12825: atomic loads cannot be treated as Op_other
+            because they update our view / the frontier of the
+            non-atomic locations, so past non-atomic (mutable) loads
+            may be not be valid anymore.
+          We conservatively tread them as non-initializing stores.
+    *)
+    if is_atomic then Op_store true
     else Op_load (match mutability with
       | Mutable -> Mutable
       | Immutable -> Immutable)

--- a/backend/schedgen.ml
+++ b/backend/schedgen.ml
@@ -181,12 +181,17 @@ method private instr_in_basic_block instr =
    Can be overridden for some processors to signal specific
    load or store instructions (e.g. on the I386). *)
 
+(* Stores are not reordered with other stores nor with loads.
+   Loads can be reordered with other loads, but not with stores.
+   Atomic loads must not be reordered, so we treat them like stores. *)
+
 method is_store = function
     Istore(_, _, _) -> true
+  | Iload {is_atomic = true} -> true
   | _ -> false
 
 method is_load = function
-    Iload _ -> true
+    Iload {is_atomic = false} -> true
   | _ -> false
 
 method private instr_is_store instr =

--- a/backend/schedgen.mli
+++ b/backend/schedgen.mli
@@ -37,9 +37,10 @@ class virtual scheduler_generic : object
   method oper_in_basic_block : Mach.operation -> bool
       (* Says whether the given operation terminates a basic block *)
   method is_store : Mach.operation -> bool
-      (* Says whether the given operation is a memory store *)
+      (* Says whether the given operation is a memory store
+         or an atomic load. *)
   method is_load : Mach.operation -> bool
-      (* Says whether the given operation is a memory load *)
+      (* Says whether the given operation is a non-atomic memory load *)
   (* Entry point *)
   method schedule_fundecl : Linear.fundecl -> Linear.fundecl
 end


### PR DESCRIPTION
Port upstream's pull requests about atomic loads:

- https://github.com/ocaml/ocaml//commit/8d1af245ef46e40652be4509f03ab600405aef63;
- https://github.com/ocaml/ocaml/pull/12715 (already present)
- https://github.com/ocaml/ocaml//pull/12856