### PR TITLE
Remove all occurrences of non-canonical aliases in extensions

### DIFF
--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -198,6 +198,22 @@ and env_extension = { equations : t Name.Map.t } [@@unboxed]
 
 type flambda_type = t
 
+let get_alias_exn t =
+  match t with
+  | Value ty -> TD.get_alias_exn ty
+  | Naked_immediate ty -> TD.get_alias_exn ty
+  | Naked_float32 ty -> TD.get_alias_exn ty
+  | Naked_float ty -> TD.get_alias_exn ty
+  | Naked_int32 ty -> TD.get_alias_exn ty
+  | Naked_int64 ty -> TD.get_alias_exn ty
+  | Naked_nativeint ty -> TD.get_alias_exn ty
+  | Naked_vec128 ty -> TD.get_alias_exn ty
+  | Rec_info ty -> TD.get_alias_exn ty
+  | Region ty -> TD.get_alias_exn ty
+
+let get_alias_opt t =
+  match get_alias_exn t with s -> Some s | exception Not_found -> None
+
 let row_like_is_bottom ~known ~(other : _ Or_bottom.t) ~is_empty_map_known =
   is_empty_map_known known && match other with Bottom -> true | Ok _ -> false
 
@@ -1957,16 +1973,36 @@ and remove_unused_value_slots_and_shortcut_aliases_function_type
   then function_type
   else { code_id; rec_info = rec_info' }
 
-and remove_unused_value_slots_and_shortcut_aliases_env_extension
-    ({ equations } as env_extension) ~used_value_slots ~canonicalise =
-  let equations' =
-    Name.Map.map_sharing
-      (fun ty ->
-        remove_unused_value_slots_and_shortcut_aliases ty ~used_value_slots
-          ~canonicalise)
-      equations
+and remove_unused_value_slots_and_shortcut_aliases_env_extension { equations }
+    ~used_value_slots ~canonicalise =
+  (* CR vlaviron: Two things can be improved here. First, we could try to
+     preserve sharing. Currently we lose sharing as soon as the extension isn't
+     empty (the [env_extension] type is unboxed so the final record expression
+     doesn't lose sharing). With a bit of work we could recover sharing in the
+     general case, but it's unclear whether it's worth the trouble because this
+     function is only called just before emitting the cmx. The second
+     improvement would be to make this function return [Bottom] when an
+     inconsistency is discovered, and use this to remove incompatible cases in
+     the type that contains the extension. *)
+  let equations =
+    Name.Map.fold
+      (fun name ty acc ->
+        let ty' =
+          remove_unused_value_slots_and_shortcut_aliases ty ~used_value_slots
+            ~canonicalise
+        in
+        let lhs = canonicalise (Simple.name name) in
+        Simple.pattern_match lhs
+          ~name:(fun name' ~coercion ->
+            match get_alias_opt ty' with
+            | Some rhs when Simple.equal lhs rhs -> acc
+            | Some _ | None ->
+              let ty' = apply_coercion ty' (Coercion.inverse coercion) in
+              Name.Map.add name' ty' acc)
+          ~const:(fun _c -> acc (* CR vlaviron: check bottom and propagate *)))
+      equations Name.Map.empty
   in
-  if equations == equations' then env_extension else { equations = equations' }
+  { equations }
 
 let rec project_variables_out ~to_project ~expand t =
   match t with
@@ -2874,22 +2910,6 @@ module Env_extension = struct
 
   let to_map t = t.equations
 end
-
-let get_alias_exn t =
-  match t with
-  | Value ty -> TD.get_alias_exn ty
-  | Naked_immediate ty -> TD.get_alias_exn ty
-  | Naked_float32 ty -> TD.get_alias_exn ty
-  | Naked_float ty -> TD.get_alias_exn ty
-  | Naked_int32 ty -> TD.get_alias_exn ty
-  | Naked_int64 ty -> TD.get_alias_exn ty
-  | Naked_nativeint ty -> TD.get_alias_exn ty
-  | Naked_vec128 ty -> TD.get_alias_exn ty
-  | Rec_info ty -> TD.get_alias_exn ty
-  | Region ty -> TD.get_alias_exn ty
-
-let get_alias_opt t =
-  match get_alias_exn t with s -> Some s | exception Not_found -> None
 
 let is_obviously_bottom t =
   match t with


### PR DESCRIPTION
Environment extensions contain constraints in the form of equations. Unlike the equations found in the typing env itself, these equations are not directed: `x : =y` is the same extension as `y : =x`.
When cleaning up the typing env before generating the cmx, in the typing env itself only the right-hand side of equations needs to be canonicalised; equations where the left-hand side is not canonical will simply be dropped as non-canonical variables will never be reachable from canonicalised types.
However, for extensions this means we have to canonicalise the left-hand sides too, otherwise we could leave a non-canonical alias as the left-hand side of an equation in an extension reachable from the root, and that would break the property above (that non-canonical aliases are unreachable from the root).
This is what this PR does. I have left some comments explaining a few things that we could do better, but I don't think they are high priority.