### PR TITLE
Allow modalities on primitives

### DIFF
--- a/ocaml/testsuite/tests/typing-modes/modes.ml
+++ b/ocaml/testsuite/tests/typing-modes/modes.ml
@@ -385,18 +385,6 @@ let foo () =
 val foo : unit -> unit = <fun>
 |}]
 
-(* modalities on primitives are parsed but not supported yet. *)
-
-module type S = sig
-  external x : string -> string @ local @@ foo bar = "%hello"
-end
-[%%expect{|
-Line 2, characters 43-46:
-2 |   external x : string -> string @ local @@ foo bar = "%hello"
-                                               ^^^
-Error: Modality on primitive is not supported yet.
-|}]
-
 (* modalities on normal values requires [-extension mode_alpha] *)
 module type S = sig
   val x : string -> string @ local @@ foo bar

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -174,7 +174,6 @@ type error =
   | Local_not_enabled
   | Unexpected_layout_any_in_primitive of string
   | Useless_layout_poly
-  | Modality_on_primitive
   | Zero_alloc_attr_unsupported of Builtin_attributes.zero_alloc_attribute
   | Zero_alloc_attr_non_function
   | Zero_alloc_attr_bad_user_arity


### PR DESCRIPTION
This PR allows modalities on primitives.

A proper design would be:
```
module M : sig
    external length : string -> int @@ portable = "%string_length"
end = struct
    external (length @ portable) : string -> int = "%string_length"
end
```
where the first `portable` is modality, while the second is mode. However, this would involve changing the parsetree (and hence our internal code base), which slows down other projects.

Instead, this PR allows:
```
module M : sig
    external length : string -> int @@ portable = "%string_length"
end = struct
    external length : string -> int @@ portable = "%string_length"
end
```
where both `portable` are modalities. As modules are now fixed to be legacy, the outcome of applying the modalites on the module's mode is predictable to the user. 

We must adopt the proper design above before we allow modules to be non-legacy.