### PR TITLE
Port 12375 (extend `[@Untagged]` external attribute to all immediate types)

### DIFF
--- a/ocaml/asmcomp/cmmgen.ml
+++ b/ocaml/asmcomp/cmmgen.ml
@@ -837,7 +837,7 @@ and transl_ccall env prim args dbg =
     | Unboxed_vector _ ->
       Misc.fatal_error
         "SIMD vectors are not supported in the upstream compiler build."
-    | Untagged_int ->
+    | Untagged_immediate ->
         (XInt, untag_int (transl env arg) dbg)
   in
   let rec transl_args native_repr_args args =
@@ -862,7 +862,7 @@ and transl_ccall env prim args dbg =
       Misc.fatal_error
         "float32 is not supported in the upstream compiler build."
     | _, Unboxed_integer bi -> (typ_int, box_int dbg bi alloc_heap)
-    | _, Untagged_int -> (typ_int, (fun i -> tag_int i dbg))
+    | _, Untagged_immediate -> (typ_int, (fun i -> tag_int i dbg))
     | _, Unboxed_vector _ ->
       Misc.fatal_error
         "SIMD vectors are not supported in the upstream compiler build."

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -94,7 +94,7 @@
    typedtree printtyped ctype printtyp includeclass mtype envaux includecore
    tast_iterator tast_mapper signature_group cmt_format cms_format untypeast
    includemod includemod_errorprinter
-   typemode typetexp patterns printpat parmatch stypes typedecl typeopt
+   typemode typetexp patterns printpat parmatch stypes typeopt typedecl
    value_rec_check typecore solver_intf solver mode_intf mode uniqueness_analysis
    typeclass typemod typedecl_variance typedecl_properties
    typedecl_separability cmt2annot

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -150,7 +150,7 @@ let extern_repr_of_native_repr:
   | Unboxed_float f, _ -> Unboxed_float f
   | Unboxed_integer i, _ -> Unboxed_integer i
   | Unboxed_vector i, _ -> Unboxed_vector i
-  | Untagged_int, _ -> Untagged_int
+  | Untagged_immediate, _ -> Untagged_int
 
 let sort_of_native_repr ~poly_sort repr =
   match extern_repr_of_native_repr ~poly_sort repr with

--- a/ocaml/manual/src/cmds/intf-c.etex
+++ b/ocaml/manual/src/cmds/intf-c.etex
@@ -2407,6 +2407,11 @@ The corresponding C type must be "intnat".
 {\bf Note:} Do not use the C "int" type in correspondence with "(int
 [\@untagged])". This is because they often differ in size.
 
+It is possible to annotate with "[\@untagged]" any immediate type, i.e. types
+that are represented like "int". This includes "bool", "char", any variant
+type with only constant constructors. Note: this does not include
+"Unix.file_descr" which is not represented as an interger on all platforms.
+
 \subsection{ss:c-direct-call}{Direct C call}
 
 In order to be able to run the garbage collector in the middle of

--- a/ocaml/testsuite/tests/c-api/external.ml
+++ b/ocaml/testsuite/tests/c-api/external.ml
@@ -1,0 +1,24 @@
+(* TEST
+ modules = "external_stubs.c";
+{
+   native;
+ }
+ *)
+
+type data = A | B | C | D | E | F
+
+external test_int : (int [@untagged])
+                    -> (char [@untagged]) -> (data [@untagged])
+                    -> (int [@untagged]) = "unavailable" "test" [@@noalloc]
+
+external test_char : (int [@untagged])
+                    -> (char [@untagged]) -> (data [@untagged])
+                    -> (char [@untagged]) = "unavailable" "test" [@@noalloc]
+
+external test_data : (int [@untagged])
+                    -> (char [@untagged]) -> (data [@untagged])
+                    -> (data [@untagged]) = "unavailable" "test" [@@noalloc]
+
+let _ = assert(test_int 1 '\001' B = 3)
+let _ = assert(test_char 1 '\001' B = '\003')
+let _ = assert(test_data 1 '\001' B = D)

--- a/ocaml/testsuite/tests/c-api/external_stubs.c
+++ b/ocaml/testsuite/tests/c-api/external_stubs.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <caml/mlvalues.h>
+
+intnat test(intnat b,intnat c,intnat d) {
+  return(b+c+d);
+}

--- a/ocaml/testsuite/tests/typing-unboxed/test.ml
+++ b/ocaml/testsuite/tests/typing-unboxed/test.ml
@@ -636,7 +636,8 @@ external g : (float [@untagged]) -> float = "g" "g_nat";;
 Line 1, characters 14-19:
 1 | external g : (float [@untagged]) -> float = "g" "g_nat";;
                   ^^^^^
-Error: Don't know how to untag this type. Only int can be untagged.
+Error: Don't know how to untag this type. Only int
+       and other immediate types can be untagged.
 |}]
 external h : (int [@unboxed]) -> float = "h" "h_nat";;
 [%%expect{|

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -32,7 +32,7 @@ type native_repr =
   | Unboxed_float of boxed_float
   | Unboxed_vector of boxed_vector
   | Unboxed_integer of boxed_integer
-  | Untagged_int
+  | Untagged_immediate
 
 type effects = No_effects | Only_generative_effects | Arbitrary_effects
 type coeffects = No_coeffects | Has_coeffects
@@ -78,7 +78,7 @@ let check_ocaml_value = function
   | _, Unboxed_float _
   | _, Unboxed_vector _
   | _, Unboxed_integer _
-  | _, Untagged_int -> Bad_attribute
+  | _, Untagged_immediate -> Bad_attribute
 
 let is_builtin_prim_name name = String.length name > 0 && name.[0] = '%'
 
@@ -255,7 +255,7 @@ let print p osig_val_decl =
   let is_unboxed = function
     | _, Same_as_ocaml_repr Value
     | _, Repr_poly
-    | _, Untagged_int -> false
+    | _, Untagged_immediate -> false
     | _, Unboxed_float _
     | _, Unboxed_vector _
     | _, Unboxed_integer _ -> true
@@ -267,7 +267,7 @@ let print p osig_val_decl =
       Language_extension.erasable_extensions_only ()
   in
   let is_untagged = function
-    | _, Untagged_int -> true
+    | _, Untagged_immediate -> true
     | _, Same_as_ocaml_repr _
     | _, Unboxed_float _
     | _, Unboxed_vector _
@@ -312,7 +312,7 @@ let print p osig_val_decl =
      | Unboxed_float _
      | Unboxed_vector _
      | Unboxed_integer _ -> if all_unboxed then [] else [oattr_unboxed]
-     | Untagged_int -> if all_untagged then [] else [oattr_untagged]
+     | Untagged_immediate -> if all_untagged then [] else [oattr_untagged]
      | Same_as_ocaml_repr _->
       if all_unboxed || not (is_unboxed (m, repr))
       then []
@@ -378,27 +378,27 @@ let equal_native_repr nr1 nr2 =
   match nr1, nr2 with
   | Repr_poly, Repr_poly -> true
   | Repr_poly, (Unboxed_float _ | Unboxed_integer _
-               | Untagged_int | Unboxed_vector _ | Same_as_ocaml_repr _)
+               | Untagged_immediate | Unboxed_vector _ | Same_as_ocaml_repr _)
   | (Unboxed_float _ | Unboxed_integer _
-    | Untagged_int | Unboxed_vector _ | Same_as_ocaml_repr _), Repr_poly -> false
+    | Untagged_immediate | Unboxed_vector _ | Same_as_ocaml_repr _), Repr_poly -> false
   | Same_as_ocaml_repr s1, Same_as_ocaml_repr s2 -> Jkind_types.Sort.Const.equal s1 s2
   | Same_as_ocaml_repr _,
-    (Unboxed_float _ | Unboxed_integer _ | Untagged_int |
+    (Unboxed_float _ | Unboxed_integer _ | Untagged_immediate |
      Unboxed_vector _) -> false
   | Unboxed_float f1, Unboxed_float f2 -> equal_boxed_float f1 f2
   | Unboxed_float _,
-    (Same_as_ocaml_repr _ | Unboxed_integer _ | Untagged_int |
+    (Same_as_ocaml_repr _ | Unboxed_integer _ | Untagged_immediate |
      Unboxed_vector _) -> false
   | Unboxed_vector vi1, Unboxed_vector vi2 -> equal_boxed_vector_size vi1 vi2
   | Unboxed_vector _,
-    (Same_as_ocaml_repr _ | Unboxed_float _ | Untagged_int |
+    (Same_as_ocaml_repr _ | Unboxed_float _ | Untagged_immediate |
      Unboxed_integer _) -> false
   | Unboxed_integer bi1, Unboxed_integer bi2 -> equal_boxed_integer bi1 bi2
   | Unboxed_integer _,
-    (Same_as_ocaml_repr _ | Unboxed_float _ | Untagged_int |
+    (Same_as_ocaml_repr _ | Unboxed_float _ | Untagged_immediate |
      Unboxed_vector _) -> false
-  | Untagged_int, Untagged_int -> true
-  | Untagged_int,
+  | Untagged_immediate, Untagged_immediate -> true
+  | Untagged_immediate,
     (Same_as_ocaml_repr _ | Unboxed_float _ | Unboxed_integer _ |
      Unboxed_vector _) -> false
 
@@ -440,7 +440,7 @@ module Repr_check = struct
   let value_or_unboxed_or_untagged = function
     | Same_as_ocaml_repr Value
     | Unboxed_float _ | Unboxed_integer _ | Unboxed_vector _
-    | Untagged_int -> true
+    | Untagged_immediate -> true
     | Same_as_ocaml_repr _ | Repr_poly -> false
 
   let check checks prim =

--- a/ocaml/typing/primitive.mli
+++ b/ocaml/typing/primitive.mli
@@ -31,7 +31,7 @@ type native_repr =
   | Unboxed_float of boxed_float
   | Unboxed_vector of boxed_vector
   | Unboxed_integer of boxed_integer
-  | Untagged_int
+  | Untagged_immediate
 
 (* See [middle_end/semantics_of_primitives.mli] *)
 type effects = No_effects | Only_generative_effects | Arbitrary_effects

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1113,7 +1113,7 @@ let check_coherence env loc dpath decl =
   match decl with
     { type_kind = (Type_variant _ | Type_record _| Type_open);
       type_manifest = Some ty } ->
-      if !Clflags.allow_illegal_crossing then begin 
+      if !Clflags.allow_illegal_crossing then begin
         let jkind' = Ctype.type_jkind_purely env ty in
         begin match Jkind.sub_with_history jkind' decl.type_jkind with
         | Ok _ -> ()
@@ -2621,8 +2621,9 @@ let is_upstream_compatible_non_value_unbox env ty =
 
 let native_repr_of_type env kind ty =
   match kind, get_desc (Ctype.expand_head_opt env ty) with
-  | Untagged, Tconstr (path, _, _) when Path.same path Predef.path_int ->
-    Some Untagged_int
+  | Untagged, Tconstr (_, _, _) when
+         Typeopt.maybe_pointer_type env ty = Lambda.Immediate ->
+    Some Untagged_immediate
   | Unboxed, Tconstr (path, _, _) when Path.same path Predef.path_float ->
     Some (Unboxed_float Pfloat64)
   | Unboxed, Tconstr (path, _, _) when Path.same path Predef.path_float32 ->
@@ -3595,8 +3596,8 @@ let report_error ppf = function
                    Only float, int32, int64, nativeint, vector primitives, and@ \
                    concrete unboxed types can be marked unboxed.@]"
   | Cannot_unbox_or_untag_type Untagged ->
-      fprintf ppf "@[Don't know how to untag this type.@ \
-                   Only int can be untagged.@]"
+      fprintf ppf "@[Don't know how to untag this type. Only int@ \
+                   and other immediate types can be untagged.@]"
   | Deep_unbox_or_untag_attribute kind ->
       fprintf ppf
         "@[The attribute '%s' should be attached to@ \


### PR DESCRIPTION
Imports https://github.com/ocaml/ocaml//commit/42035d062c712a3530766cc63efb277514d46af3 (https://github.com/ocaml/ocaml/pull/12375) from upstream.