### PR TITLE
Add counters to profiler (for CFG spill and reload instructions)

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -464,12 +464,11 @@ let compile_phrases ~ppf_dump ps =
           if !dump_cmm then fprintf ppf_dump "%a@." Printcmm.phrase p;
           match p with
           | Cfunction fd ->
-            let compile_fundec = compile_fundecl ~ppf_dump ~funcnames in
             (* Only profile if function level granularity selected*)
-            let profiled_compile_fundec = match !profile_granularity with
-            | Function_level -> Profile.record ~accumulate:true fd.fun_name.sym_name compile_fundec
-            | File_level -> compile_fundec
-            in profiled_compile_fundec fd;
+            let profile_wrapper = match !profile_granularity with
+            | Function_level -> Profile.record ~accumulate:true fd.fun_name.sym_name
+            | File_level -> fun x -> x
+            in profile_wrapper (compile_fundecl ~ppf_dump ~funcnames) fd;
             compile ~funcnames:(String.Set.remove fd.fun_name.sym_name funcnames) ps
           | Cdata dl ->
             compile_data dl;

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -466,7 +466,7 @@ let compile_phrases ~ppf_dump ps =
             (* Output function-level profiling if specified by user *)
             if !Clflags.profile_granularity = Profile.Function_level then
               (
-                Printf.printf "%s:\n" fd.fun_name.sym_name;
+                Printf.printf "%s\n" fd.fun_name.sym_name;
                 Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
                 Printf.printf "\n";
               );

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -464,7 +464,7 @@ let compile_phrases ~ppf_dump ps =
             compile_fundecl ~ppf_dump ~funcnames fd;
 
             (* Output function-level profiling if specified by user *)
-            if !Clflags.profile_granularity = Profile.Function_level then
+            if !profile_granularity = Function_level then
               (
                 Printf.printf "%s\n" fd.fun_name.sym_name;
                 Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -449,7 +449,15 @@ let compile_phrases ~ppf_dump ps =
           match p with
           | Cfunction fd ->
             compile_fundecl ~ppf_dump ~funcnames fd;
-            compile ~funcnames:(String.Set.remove fd.fun_name.sym_name funcnames) ps
+            compile ~funcnames:(String.Set.remove fd.fun_name.sym_name funcnames) ps;
+
+            (* Output function-level profiling if specified by user *)
+            if !Clflags.profile_granularity = Profile.Function_level then
+              (
+                Printf.printf "%s:\n" fd.fun_name.sym_name;
+                Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
+                Printf.printf "\n";
+              )
           | Cdata dl ->
             compile_data dl;
             compile ~funcnames ps

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -462,9 +462,10 @@ let compile_phrases ~ppf_dump ps =
           match p with
           | Cfunction fd ->
             let compile_fundec = compile_fundecl ~ppf_dump ~funcnames in
+            (* Only profile if function level granularity selected*)
             let profiled_compile_fundec = match !profile_granularity with
             | Function_level -> Profile.record ~accumulate:true fd.fun_name.sym_name compile_fundec
-            | _ -> compile_fundec (* Don't profile if function level granularity not selected*)
+            | File_level -> compile_fundec
             in profiled_compile_fundec fd;
             compile ~funcnames:(String.Set.remove fd.fun_name.sym_name funcnames) ps
           | Cdata dl ->

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -464,7 +464,7 @@ let compile_phrases ~ppf_dump ps =
             let compile_fundec = compile_fundecl ~ppf_dump ~funcnames in
             let profiled_compile_fundec = match !profile_granularity with
             | Function_level -> Profile.record ~accumulate:true fd.fun_name.sym_name compile_fundec
-            | _ -> compile_fundec (* Don't profile if -dfunc-level not selected*)
+            | _ -> compile_fundec (* Don't profile if function level granularity not selected*)
             in profiled_compile_fundec fd;
             compile ~funcnames:(String.Set.remove fd.fun_name.sym_name funcnames) ps
           | Cdata dl ->

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -230,8 +230,8 @@ let iter_blocks t ~f = Label.Tbl.iter f t.blocks
 let fold_blocks t ~f ~init = Label.Tbl.fold f t.blocks init
 
 let fold_body_instructions t ~f ~init =
-  let helper _ block acc = DLL.fold_left block.body ~f ~init:acc
-  in fold_blocks t ~f:helper ~init
+  let helper _ block acc = DLL.fold_left block.body ~f ~init:acc in
+  fold_blocks t ~f:helper ~init
 
 let register_predecessors_for_all_blocks (t : t) =
   Label.Tbl.iter

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -229,6 +229,10 @@ let iter_blocks t ~f = Label.Tbl.iter f t.blocks
 
 let fold_blocks t ~f ~init = Label.Tbl.fold f t.blocks init
 
+let fold_body_instructions t ~f ~init =
+  let helper _ block acc = DLL.fold_left block.body ~f ~init:acc
+  in fold_blocks t ~f:helper ~init
+
 let register_predecessors_for_all_blocks (t : t) =
   Label.Tbl.iter
     (fun label block ->

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -154,6 +154,8 @@ val iter_blocks : t -> f:(Label.t -> basic_block -> unit) -> unit
 
 val fold_blocks : t -> f:(Label.t -> basic_block -> 'a -> 'a) -> init:'a -> 'a
 
+val fold_body_instructions : t -> f:('a -> basic instruction -> 'a) -> init:'a -> 'a
+
 val register_predecessors_for_all_blocks : t -> unit
 
 (** Printing *)

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -154,7 +154,8 @@ val iter_blocks : t -> f:(Label.t -> basic_block -> unit) -> unit
 
 val fold_blocks : t -> f:(Label.t -> basic_block -> 'a -> 'a) -> init:'a -> 'a
 
-val fold_body_instructions : t -> f:('a -> basic instruction -> 'a) -> init:'a -> 'a
+val fold_body_instructions :
+  t -> f:('a -> basic instruction -> 'a) -> init:'a -> 'a
 
 val register_predecessors_for_all_blocks : t -> unit
 

--- a/backend/cfg/cfg_with_infos.ml
+++ b/backend/cfg/cfg_with_infos.ml
@@ -35,6 +35,8 @@ let cfg t = Cfg_with_layout.cfg t.cfg_with_layout
 
 let fold_blocks t ~f ~init = Cfg.fold_blocks (cfg t) ~f ~init
 
+let fold_body_instructions t = Cfg.fold_body_instructions (cfg t)
+
 let get_block_exn t label = Cfg.get_block_exn (cfg t) label
 
 let[@inline] compute_if_necessary r ~f =

--- a/backend/cfg/cfg_with_infos.mli
+++ b/backend/cfg/cfg_with_infos.mli
@@ -25,6 +25,9 @@ val cfg : t -> Cfg.t
 val fold_blocks :
   t -> f:(Label.t -> Cfg.basic_block -> 'a -> 'a) -> init:'a -> 'a
 
+val fold_body_instructions :
+  t -> f:('a -> Cfg.basic Cfg.instruction -> 'a) -> init:'a -> 'a
+
 val get_block_exn : t -> Label.t -> Cfg.basic_block
 
 val liveness : t -> liveness

--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -482,12 +482,19 @@ let read_one_param ppf position name v =
   | "can-discard" ->
     can_discard := v ::!can_discard
 
-  | "timings" | "profile" ->
-     let if_on = if name = "timings" then [ `Time ] else Profile.all_columns in
+  | "timings" | "counters" | "profile" ->
+    let if_on = match name with
+      | "timings" -> [ `Time ]
+      | "counters" -> [ `Counters ]
+      | "profile" -> Profile.all_columns
+      | _ -> assert false
+    in
      profile_columns := if check_bool ppf name v then if_on else []
 
   | "timings-precision" ->
      int_setter ppf "timings-precision" timings_precision v
+
+  | "granularity" -> Clflags.set_profile_granularity v
 
   | "stop-after" ->
     set_compiler_pass ppf v ~name Clflags.stop_after ~filter:(fun _ -> true)

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -534,8 +534,10 @@ let mk_dcounters f =
 let mk_dprofile f =
   "-dprofile", Arg.Unit f, Profile.options_doc
 
-let mk_dfunc_level f =
-  "-dfunc-level", Arg.Unit f, " Print function level profile information (default file)";
+let mk_dgranularity f =
+  "-dgranularity",
+  Arg.Symbol (["file"; "func"], f),
+  " Specify granularity level for profile information (-dtimings, -dcounters, -dprofile)";
 ;;
 
 let mk_unbox_closures f =
@@ -1040,7 +1042,7 @@ module type Compiler_options = sig
   val _dtimings_precision : int -> unit
   val _dcounters : unit -> unit
   val _dprofile : unit -> unit
-  val _dfunc_level : unit -> unit
+  val _dgranularity : string -> unit
   val _dump_into_file : unit -> unit
   val _dump_dir : string -> unit
 
@@ -1315,7 +1317,7 @@ struct
     mk_dtimings_precision F._dtimings_precision;
     mk_dcounters F._dcounters;
     mk_dprofile F._dprofile;
-    mk_dfunc_level F._dfunc_level;
+    mk_dgranularity F._dgranularity;
     mk_dump_into_file F._dump_into_file;
     mk_dump_dir F._dump_dir;
     mk_debug_ocaml F._debug_ocaml;
@@ -1583,7 +1585,7 @@ struct
     mk_dtimings_precision F._dtimings_precision;
     mk_dcounters F._dcounters;
     mk_dprofile F._dprofile;
-    mk_dfunc_level F._dfunc_level;
+    mk_dgranularity F._dgranularity;
     mk_dump_into_file F._dump_into_file;
     mk_dump_dir F._dump_dir;
     mk_dump_pass F._dump_pass;
@@ -2027,7 +2029,7 @@ module Default = struct
     let _dtimings () = profile_columns := [`Time]
     let _dtimings_precision n = timings_precision := n
     let _dcounters () = profile_columns := [`Counters]
-    let _dfunc_level () = profile_granularity := Function_level
+    let _dgranularity = Clflags.set_profile_granularity
     let _dump_into_file = set dump_into_file
     let _dump_dir s = dump_dir := Some s
     let _for_pack s = for_package := (Some (String.capitalize_ascii s))

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -2027,7 +2027,7 @@ module Default = struct
     let _dtimings () = profile_columns := [`Time]
     let _dtimings_precision n = timings_precision := n
     let _dcounters () = profile_columns := [`Counters]
-    let _dfunc_level () = profile_granularity := Profile.Function_level
+    let _dfunc_level () = profile_granularity := Function_level
     let _dump_into_file = set dump_into_file
     let _dump_dir s = dump_dir := Some s
     let _for_pack s = for_package := (Some (String.capitalize_ascii s))

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -534,6 +534,10 @@ let mk_dcounters f =
 let mk_dprofile f =
   "-dprofile", Arg.Unit f, Profile.options_doc
 
+let mk_dfunc_level f =
+  "-dfunc-level", Arg.Unit f, " Print function level profile information (default file)";
+;;
+
 let mk_unbox_closures f =
   "-unbox-closures", Arg.Unit f,
   " Pass free variables via specialised arguments rather than closures"
@@ -1036,6 +1040,7 @@ module type Compiler_options = sig
   val _dtimings_precision : int -> unit
   val _dcounters : unit -> unit
   val _dprofile : unit -> unit
+  val _dfunc_level : unit -> unit
   val _dump_into_file : unit -> unit
   val _dump_dir : string -> unit
 
@@ -1310,6 +1315,7 @@ struct
     mk_dtimings_precision F._dtimings_precision;
     mk_dcounters F._dcounters;
     mk_dprofile F._dprofile;
+    mk_dfunc_level F._dfunc_level;
     mk_dump_into_file F._dump_into_file;
     mk_dump_dir F._dump_dir;
     mk_debug_ocaml F._debug_ocaml;
@@ -1577,6 +1583,7 @@ struct
     mk_dtimings_precision F._dtimings_precision;
     mk_dcounters F._dcounters;
     mk_dprofile F._dprofile;
+    mk_dfunc_level F._dfunc_level;
     mk_dump_into_file F._dump_into_file;
     mk_dump_dir F._dump_dir;
     mk_dump_pass F._dump_pass;
@@ -2020,6 +2027,7 @@ module Default = struct
     let _dtimings () = profile_columns := [`Time]
     let _dtimings_precision n = timings_precision := n
     let _dcounters () = profile_columns := [`Counters]
+    let _dfunc_level () = profile_granularity := Profile.Function_level
     let _dump_into_file = set dump_into_file
     let _dump_dir s = dump_dir := Some s
     let _for_pack s = for_package := (Some (String.capitalize_ascii s))

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -527,6 +527,10 @@ let mk_dtimings_precision f =
       Clflags.default_timings_precision
 ;;
 
+let mk_dcounters f =
+  "-dcounters", Arg.Unit f, " Print counter information for each pass";
+;;
+
 let mk_dprofile f =
   "-dprofile", Arg.Unit f, Profile.options_doc
 
@@ -1030,6 +1034,7 @@ module type Compiler_options = sig
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
   val _dtimings_precision : int -> unit
+  val _dcounters : unit -> unit
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
   val _dump_dir : string -> unit
@@ -1303,6 +1308,7 @@ struct
     mk_dcamlprimc F._dcamlprimc;
     mk_dtimings F._dtimings;
     mk_dtimings_precision F._dtimings_precision;
+    mk_dcounters F._dcounters;
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
     mk_dump_dir F._dump_dir;
@@ -1569,6 +1575,7 @@ struct
     mk_dstartup F._dstartup;
     mk_dtimings F._dtimings;
     mk_dtimings_precision F._dtimings_precision;
+    mk_dcounters F._dcounters;
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
     mk_dump_dir F._dump_dir;
@@ -2012,6 +2019,7 @@ module Default = struct
     let _dprofile () = profile_columns := Profile.all_columns
     let _dtimings () = profile_columns := [`Time]
     let _dtimings_precision n = timings_precision := n
+    let _dcounters () = profile_columns := [`Counters]
     let _dump_into_file = set dump_into_file
     let _dump_dir s = dump_dir := Some s
     let _for_pack s = for_package := (Some (String.capitalize_ascii s))

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -140,6 +140,7 @@ module type Compiler_options = sig
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
   val _dtimings_precision : int -> unit
+  val _dcounters : unit -> unit
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
   val _dump_dir : string -> unit

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -142,6 +142,7 @@ module type Compiler_options = sig
   val _dtimings_precision : int -> unit
   val _dcounters : unit -> unit
   val _dprofile : unit -> unit
+  val _dfunc_level : unit -> unit
   val _dump_into_file : unit -> unit
   val _dump_dir : string -> unit
 

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -142,7 +142,7 @@ module type Compiler_options = sig
   val _dtimings_precision : int -> unit
   val _dcounters : unit -> unit
   val _dprofile : unit -> unit
-  val _dfunc_level : unit -> unit
+  val _dgranularity : string -> unit
   val _dump_into_file : unit -> unit
   val _dump_dir : string -> unit
 

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -354,8 +354,8 @@
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Arg_helper.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Identifiable.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Numbers.cmo
-      .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Profile.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Clflags.cmo
+      .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Profile.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Debug.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Language_extension_kernel.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Language_extension.cmo
@@ -439,8 +439,8 @@
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Arg_helper.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Identifiable.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Numbers.cmx
-      .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Profile.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Clflags.cmx
+      .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Profile.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Debug.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Language_extension_kernel.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Language_extension.cmx

--- a/ocaml/testsuite/tools/codegen_main.ml
+++ b/ocaml/testsuite/tools/codegen_main.ml
@@ -78,6 +78,7 @@ let main() =
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
      "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";
+     "-dfunc_level", Arg.Unit (fun () -> profile_granularity := Function_level), "";
     ] compile_file usage
 
 let () =

--- a/ocaml/testsuite/tools/codegen_main.ml
+++ b/ocaml/testsuite/tools/codegen_main.ml
@@ -78,7 +78,7 @@ let main() =
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
      "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";
-     "-dfunc_level", Arg.Unit (fun () -> profile_granularity := Function_level), "";
+     "-dgranularity", Arg.Symbol (["file"; "func"], Clflags.set_profile_granularity), "";
     ] compile_file usage
 
 let () =

--- a/ocaml/testsuite/tools/codegen_main.ml
+++ b/ocaml/testsuite/tools/codegen_main.ml
@@ -77,6 +77,7 @@ let main() =
      "-dscheduling", Arg.Set dump_scheduling, "";
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
+     "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";
     ] compile_file usage
 
 let () =

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -157,6 +157,7 @@ let debug_ocaml = ref false             (* -debug-ocaml *)
 let default_timings_precision  = 3
 let timings_precision = ref default_timings_precision (* -dtimings-precision *)
 let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings/-dcounters *)
+let profile_granularity : Profile.granularity ref = ref Profile.File_level (* -dfunc_level *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
 

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -160,7 +160,13 @@ let debug_ocaml = ref false             (* -debug-ocaml *)
 let default_timings_precision  = 3
 let timings_precision = ref default_timings_precision (* -dtimings-precision *)
 let profile_columns : profile_column list ref = ref [] (* -dprofile/-dtimings/-dcounters *)
-let profile_granularity : profile_granularity_level ref = ref File_level (* -dfunc-level *)
+let profile_granularity : profile_granularity_level ref = ref File_level (* -dgranularity *)
+
+let set_profile_granularity v =
+  profile_granularity := match v with
+  | "file" -> File_level
+  | "func" -> Function_level
+  | _ -> raise (Invalid_argument (Format.sprintf "profile granularity: %s" v))
 
 let native_code = ref false             (* set to true under ocamlopt *)
 

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -156,7 +156,7 @@ let dump_combine = ref false            (* -dcombine *)
 let debug_ocaml = ref false             (* -debug-ocaml *)
 let default_timings_precision  = 3
 let timings_precision = ref default_timings_precision (* -dtimings-precision *)
-let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings *)
+let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings/-dcounters *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
 

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -52,6 +52,9 @@ module Libloc = struct
   }
 end
 
+type profile_column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap | `Counters ]
+type profile_granularity_level = File_level | Function_level
+
 let compile_only = ref false            (* -c *)
 and output_name = ref (None : string option) (* -o *)
 and include_dirs = ref ([] : string list) (* -I *)
@@ -156,8 +159,8 @@ let dump_combine = ref false            (* -dcombine *)
 let debug_ocaml = ref false             (* -debug-ocaml *)
 let default_timings_precision  = 3
 let timings_precision = ref default_timings_precision (* -dtimings-precision *)
-let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings/-dcounters *)
-let profile_granularity : Profile.granularity ref = ref Profile.File_level (* -dfunc_level *)
+let profile_columns : profile_column list ref = ref [] (* -dprofile/-dtimings/-dcounters *)
+let profile_granularity : profile_granularity_level ref = ref File_level (* -dfunc-level *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
 

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -59,6 +59,9 @@ module Libloc : sig
   }
 end
 
+type profile_column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap | `Counters ]
+type profile_granularity_level = File_level | Function_level
+
 val objfiles : string list ref
 val ccobjs : string list ref
 val dllibs : string list ref
@@ -200,8 +203,8 @@ val keep_locs : bool ref
 val opaque : bool ref
 val default_timings_precision : int
 val timings_precision : int ref
-val profile_columns : Profile.column list ref
-val profile_granularity : Profile.granularity ref
+val profile_columns : profile_column list ref
+val profile_granularity : profile_granularity_level ref
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref
 val unbox_closures_factor : int ref

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -201,6 +201,7 @@ val opaque : bool ref
 val default_timings_precision : int
 val timings_precision : int ref
 val profile_columns : Profile.column list ref
+val profile_granularity : Profile.granularity ref
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref
 val unbox_closures_factor : int ref

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -205,6 +205,7 @@ val default_timings_precision : int
 val timings_precision : int ref
 val profile_columns : profile_column list ref
 val profile_granularity : profile_granularity_level ref
+val set_profile_granularity : string -> unit
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref
 val unbox_closures_factor : int ref

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -24,9 +24,10 @@ module String = Misc.Stdlib.String
 module Counters = struct
   type t = int String.Map.t
 
-  let get name t = String.Map.find name t
+  let opt_value = Option.value ~default:0
+  let get name t = String.Map.find_opt name t |> opt_value
   let set name count t = String.Map.add name count t
-  let increment name t = set name (get name t + 1) t
+  let increment name = String.Map.update name (fun x -> Some (opt_value x |> succ))
 
   let create ?(initial_names = []) () =
     List.fold_left (fun acc name -> set name 0 acc) String.Map.empty initial_names

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -33,8 +33,6 @@ module Counters = struct
 
   let is_empty = String.Map.is_empty
 
-
-
   let to_string t =
     t
     |> String.Map.bindings

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -16,7 +16,6 @@
 [@@@ocaml.warning "+a-18-40-42-48"]
 
 type file = string
-type granularity = File_level | Function_level
 
 module Int = Misc.Stdlib.Int
 module String = Misc.Stdlib.String
@@ -124,7 +123,11 @@ let _record_call ?(accumulate = false) ?counter_f name f =
   Misc.try_finally (
     match counter_f with
     | Some counter_f ->
-        fun () -> let result = f () in counters := counter_f result; result
+        fun () ->
+          let result = f () in
+          if List.mem `Counters !Clflags.profile_columns then
+            counters := counter_f result;
+          result
     | None -> f
     )
     ~always:(fun () ->
@@ -235,7 +238,6 @@ let compute_other_category (E table : hierarchy) (total : Measure_diff.t) =
   !r
 
 type row = R of string * (float * display) list * row list
-type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap | `Counters]
 
 let rec rows_of_hierarchy ~nesting make_row name measure_diff hierarchy env =
   let rows =

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -101,7 +101,7 @@ let hierarchy = ref (create ())
 let initial_measure = ref None
 let reset () = hierarchy := create (); initial_measure := None
 
-let _record_call ?(accumulate = false) ?counter_f name f =
+let record_call_internal ?(accumulate = false) ?counter_f name f =
   let E prev_hierarchy = !hierarchy in
   let start_measure = Measure.create () in
   if !initial_measure = None then initial_measure := Some start_measure;
@@ -137,12 +137,12 @@ let _record_call ?(accumulate = false) ?counter_f name f =
           Measure_diff.accumulate this_measure_diff start_measure end_measure in
         Hashtbl.add prev_hierarchy name (measure_diff, E this_table))
 
-let record_call = _record_call ?counter_f:None
+let record_call = record_call_internal ?counter_f:None
 
 let record ?accumulate pass f x = record_call ?accumulate pass (fun () -> f x)
 
 let record_with_counters ?accumulate ~counter_f pass f x =
-  _record_call ?accumulate ~counter_f pass (fun () -> f x)
+  record_call_internal ?accumulate ~counter_f pass (fun () -> f x)
 
 type display = {
   to_string : max:float -> width:int -> string;

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -16,6 +16,7 @@
 [@@@ocaml.warning "+a-18-40-42-48"]
 
 type file = string
+type granularity = File_level | Function_level
 type counters = (string * int) list
 
 external time_include_children: bool -> float = "caml_sys_time_include_children"

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -36,7 +36,7 @@ module Counters = struct
   let to_string t =
     t
     |> String.Map.bindings
-    |> List.map (fun (name, count) -> Printf.sprintf "%s = %s" name (string_of_int count))
+    |> List.map (fun (name, count) -> Printf.sprintf "%s = %d" name count)
     |> String.concat "; "
     |> Printf.sprintf "[%s]"
 end

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -23,16 +23,11 @@ module String = Misc.Stdlib.String
 module Counters = struct
   type t = int String.Map.t
 
-  let opt_value = Option.value ~default:0
-  let get name t = String.Map.find_opt name t |> opt_value
+  let create () = String.Map.empty
+  let get name t = String.Map.find_opt name t |> Option.value ~default:0
   let set name count t = String.Map.add name count t
-  let increment name = String.Map.update name (fun x -> Some (opt_value x |> succ))
   let is_empty = String.Map.is_empty
   let union = String.Map.union (fun _ count1 count2 -> Some (count1 + count2))
-
-  let create ?(initial_names = []) () =
-    List.fold_left (fun acc name -> set name 0 acc) String.Map.empty initial_names
-
   let to_string t =
     t
     |> String.Map.bindings

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -27,11 +27,11 @@ module Counters = struct
   let get name t = String.Map.find_opt name t |> opt_value
   let set name count t = String.Map.add name count t
   let increment name = String.Map.update name (fun x -> Some (opt_value x |> succ))
+  let is_empty = String.Map.is_empty
+  let union = String.Map.union (fun _ count1 count2 -> Some (count1 + count2))
 
   let create ?(initial_names = []) () =
     List.fold_left (fun acc name -> set name 0 acc) String.Map.empty initial_names
-
-  let is_empty = String.Map.is_empty
 
   let to_string t =
     t
@@ -86,7 +86,7 @@ module Measure_diff = struct
       t.allocated_words +. (m2.allocated_words -. m1.allocated_words);
     top_heap_words_increase =
       t.top_heap_words_increase + (m2.top_heap_words - m1.top_heap_words);
-    counters = m2.counters
+    counters = Counters.union t.counters m2.counters
   }
   let of_diff m1 m2 =
     accumulate (zero ()) m1 m2

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -31,7 +31,7 @@ val record_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 val record : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [record pass f arg] records the profile information of [f arg] *)
 
-type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
+type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap | `Counters ]
 
 val print : Format.formatter -> column list -> timings_precision:int -> unit
 (** Prints the selected recorded profiling information to the formatter. *)

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -30,6 +30,7 @@ module Counters : sig
   val increment : string -> t -> t
   val get : string -> t -> int
   val set : string -> int -> t -> t
+  val union : t -> t -> t
   val to_string : t -> string
 end
 

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -21,6 +21,7 @@
 *)
 
 type file = string
+type granularity = File_level | Function_level
 
 val reset : unit -> unit
 (** erase all recorded profile information *)

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -23,6 +23,17 @@
 type file = string
 type granularity = File_level | Function_level
 
+module Counters : sig
+  type t
+
+  val create : ?initial_names:(string list) -> unit -> t
+  val is_empty : t -> bool
+  val increment : string -> t -> t
+  val get : string -> t -> int
+  val set : string -> int -> t -> t
+  val to_string : t -> string
+end
+
 val reset : unit -> unit
 (** erase all recorded profile information *)
 
@@ -31,6 +42,11 @@ val record_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 
 val record : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [record pass f arg] records the profile information of [f arg] *)
+
+val record_with_counters :
+  ?accumulate:bool -> counter_f:('b -> Counters.t) -> string -> ('a -> 'b) -> 'a -> 'b
+(** [record_with_counters counter_f pass f arg] records the profile information of [f arg]
+  and records counter information given by calling [counter_f] on the result of [f arg] *)
 
 type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap | `Counters ]
 

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -21,7 +21,6 @@
 *)
 
 type file = string
-type granularity = File_level | Function_level
 
 module Counters : sig
   type t
@@ -48,15 +47,13 @@ val record_with_counters :
 (** [record_with_counters counter_f pass f arg] records the profile information of [f arg]
   and records counter information given by calling [counter_f] on the result of [f arg] *)
 
-type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap | `Counters ]
-
-val print : Format.formatter -> column list -> timings_precision:int -> unit
+val print : Format.formatter -> Clflags.profile_column list -> timings_precision:int -> unit
 (** Prints the selected recorded profiling information to the formatter. *)
 
 (** Command line flags *)
 
 val options_doc : string
-val all_columns : column list
+val all_columns : Clflags.profile_column list
 
 (** A few pass names that are needed in several places, and shared to
     avoid typos. *)

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -25,9 +25,8 @@ type file = string
 module Counters : sig
   type t
 
-  val create : ?initial_names:(string list) -> unit -> t
+  val create : unit -> t
   val is_empty : t -> bool
-  val increment : string -> t -> t
   val get : string -> t -> int
   val set : string -> int -> t -> t
   val union : t -> t -> t

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -74,6 +74,7 @@ let main() =
      "-dscheduling", Arg.Set dump_scheduling, "";
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
+     "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";
     ] compile_file usage
 
 let () =

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -75,7 +75,7 @@ let main() =
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
      "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";
-     "-dfunc_level", Arg.Unit (fun () -> profile_granularity := Profile.Function_level), "";
+     "-dfunc_level", Arg.Unit (fun () -> profile_granularity := Function_level), "";
     ] compile_file usage
 
 let () =

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -75,6 +75,7 @@ let main() =
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
      "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";
+     "-dfunc_level", Arg.Unit (fun () -> profile_granularity := Profile.Function_level), "";
     ] compile_file usage
 
 let () =

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -75,7 +75,7 @@ let main() =
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
      "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";
-     "-dfunc_level", Arg.Unit (fun () -> profile_granularity := Function_level), "";
+     "-dgranularity", Arg.Symbol (["file"; "func"], Clflags.set_profile_granularity), "";
     ] compile_file usage
 
 let () =


### PR DESCRIPTION
This PR introduces the ability to measure certain values as counters during passes of the compiler.

Options for API:
1. Existing `Profile.record` function with optional `?counter_f` argument
    - This function is used in many files so changing the signature could potentially mean implementations 
      no longer match interfaces.
2. New `Profile.record_with_counters` function
    - Shows intent better and gives hint about purpose of `couter_f` argument.
    - Allows providing specific documentation for this function.
    - New function so won't break any other files.
    - Intertwines logic for timing/memory profiling with counter profiling (these operate differently as 
      timing and memory are difference measures between the start and end of the stage and have a fixed 
      number of measures whereas counters are purely based on the result of a stage and there may be 
      many counters).
3. Completely separate function
    - No intertwining of logic for timing/memory profiling with counter profiling
    - May lead to code duplication (many aspects in common between these different types of profiling)
    - Harder to print all profile columns for `-dprofile` option (need to manage integration of the two profiling 
      mechanisms)

The current implementation uses option 2.