### PR TITLE
Port 10111 (allowing displaying multi-line backtrace locations in the same way as errors)

### DIFF
--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -186,12 +186,12 @@ let emit_frames a =
       lbl
   in
   let defnames = Hashtbl.create 7 in
-  let label_defname filename defname =
-    try snd (Hashtbl.find defnames (filename, defname))
+  let label_defname filename defname loc =
+    try snd (Hashtbl.find defnames (filename, defname, loc))
     with Not_found ->
       let file_lbl = label_filename filename in
       let def_lbl = Cmm.new_label () in
-      Hashtbl.add defnames (filename, defname) (file_lbl, def_lbl);
+      Hashtbl.add defnames (filename, defname, loc) (file_lbl, def_lbl);
       def_lbl
   in
   let module Label_table = Hashtbl.Make (struct
@@ -261,29 +261,57 @@ let emit_frames a =
     a.efa_def_label lbl;
     a.efa_string name
   in
-  let emit_defname (_filename, defname) (file_lbl, lbl) =
+  let emit_defname (_filename, defname, loc) (file_lbl, lbl) =
+    let emit_loc (start_chr, end_chr, end_offset) =
+      a.efa_16 start_chr;
+      a.efa_16 end_chr;
+      a.efa_32 (Int32.of_int end_offset)
+    in
     (* These must be 32-bit aligned, both because they contain a 32-bit value,
        and because emit_debuginfo assumes the low 2 bits of their addresses are
        0. *)
     a.efa_align 4;
     a.efa_def_label lbl;
     a.efa_label_rel file_lbl 0l;
+    (* Include the additional 64-bits of location information which didn't pack
+       in the main 64-bit word *)
+    Option.iter emit_loc loc;
     a.efa_string defname
   in
-  let pack_info fd_raise d has_next =
-    let line = min 0xFFFFF d.Debuginfo.dinfo_line
-    and char_start = min 0xFF d.Debuginfo.dinfo_char_start
-    and char_end = min 0x3FF d.Debuginfo.dinfo_char_end
+  let fully_pack_info fd_raise d has_next =
+    (* See format in caml_debuginfo_location in runtime/backtrace-nat.c *)
+    let open Debuginfo in
+    let kind = if fd_raise then 1 else 0
+    and has_next = if has_next then 1 else 0
+    and char_end = d.dinfo_char_end + d.dinfo_start_bol - d.dinfo_end_bol in
+    let char_end_offset = d.dinfo_end_bol - d.dinfo_start_bol in
+    Int64.(add (shift_left (of_int d.dinfo_line) 51)
+             (add (shift_left (of_int (d.dinfo_end_line - d.dinfo_line)) 48)
+                (add (shift_left (of_int d.dinfo_char_start) 42)
+                   (add (shift_left (of_int char_end) 35)
+                      (add (shift_left (of_int char_end_offset) 26)
+                         (add (shift_left (of_int kind) 1)
+                            (of_int has_next)))))))
+      in
+  let partially_pack_info fd_raise d has_next =
+    (* Partially packed debuginfo:
+       1lllllllllmmmmmmmmddddddddddddkn
+         1           - d points to a name_and_loc_info struct
+         l (19 bits) - start line number
+         m (18 bits) - offset of end line number from start
+         d (24 bits) - memory offset to name_and_loc_info struct
+         k (1 bit)   - fd_raise flag
+         n (1 bit)   - has_next flag *)
+    let open Debuginfo in
+    let start_line = Int.min 0x7FFFF d.dinfo_line
+    and end_line = Int.min 0x3FFFF (d.dinfo_end_line - d.dinfo_line)
     and kind = if fd_raise then 1 else 0
     and has_next = if has_next then 1 else 0 in
-    Int64.(
-      add
-        (shift_left (of_int line) 44)
-        (add
-           (shift_left (of_int char_start) 36)
-           (add
-              (shift_left (of_int char_end) 26)
-              (add (shift_left (of_int kind) 1) (of_int has_next)))))
+    Int64.(add (shift_left Int64.one 63)
+             (add (shift_left (of_int start_line) 44)
+                (add (shift_left (of_int end_line) 26)
+                   (add (shift_left (of_int kind) 1)
+                      (of_int has_next)))))
   in
   let emit_debuginfo (rs, dbg) lbl =
     let rdbg = dbg |> Debuginfo.Dbg.to_list |> List.rev in
@@ -294,9 +322,30 @@ let emit_frames a =
     a.efa_def_label lbl;
     let rec emit rs d rest =
       let open Debuginfo in
-      let info = pack_info rs d (rest <> []) in
       let defname = Scoped_location.string_of_scopes d.dinfo_scopes in
-      a.efa_label_rel (label_defname d.dinfo_file defname) (Int64.to_int32 info);
+      let char_end = d.dinfo_char_end + d.dinfo_start_bol - d.dinfo_end_bol in
+      let is_fully_packable =
+        d.dinfo_line <= 0xFFF
+        && d.dinfo_end_line - d.dinfo_line <= 0x7
+        && d.dinfo_char_start <= 0x3F
+        && char_end <= 0x7F
+        && d.dinfo_end_bol - d.dinfo_start_bol <= 0x1FF
+      in
+      let info =
+        if is_fully_packable then
+          fully_pack_info rs d (rest <> [])
+        else
+          partially_pack_info rs d (rest <> [])
+      in
+      let loc =
+        if is_fully_packable then
+          None
+        else
+          Some (Int.min 0xFFFF d.dinfo_char_start,   (* start_chr *)
+                Int.min 0xFFFF char_end,             (* end_chr *)
+                Int.min 0x3FFFFFFF d.dinfo_char_end) (* end_offset *)
+      in
+      a.efa_label_rel (label_defname d.dinfo_file defname loc) (Int64.to_int32 info);
       a.efa_32 (Int64.to_int32 (Int64.shift_right info 32));
       match rest with [] -> () | d :: rest -> emit false d rest
     in

--- a/ocaml/.gitattributes
+++ b/ocaml/.gitattributes
@@ -198,6 +198,7 @@ runtime/caml/sizeclasses.h typo.missing-header
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.
 testsuite/tests/backtrace/names.ml text eol=lf
+testsuite/tests/backtrace/print_location.ml text eol=lf
 testsuite/tests/basic-modules/anonymous.ml text eol=lf
 testsuite/tests/formatting/test_locations.ml text eol=lf
 testsuite/tests/functors/functors.ml text eol=lf

--- a/ocaml/asmcomp/emitaux.ml
+++ b/ocaml/asmcomp/emitaux.ml
@@ -155,13 +155,13 @@ let emit_frames a =
       lbl
   in
   let defnames = Hashtbl.create 7 in
-  let label_defname filename defname =
+  let label_defname filename defname loc =
     try
-      snd (Hashtbl.find defnames (filename, defname))
+      snd (Hashtbl.find defnames (filename, defname, loc))
     with Not_found ->
       let file_lbl = label_filename filename in
       let def_lbl = Cmm.new_label () in
-      Hashtbl.add defnames (filename, defname) (file_lbl, def_lbl);
+      Hashtbl.add defnames (filename, defname, loc) (file_lbl, def_lbl);
       def_lbl
   in
   let module Label_table =
@@ -241,24 +241,55 @@ let emit_frames a =
     a.efa_def_label lbl;
     a.efa_string name
   in
-  let emit_defname (_filename, defname) (file_lbl, lbl) =
+  let emit_defname (_filename, defname, loc) (file_lbl, lbl) =
+    let emit_loc (start_chr, end_chr, end_offset) =
+      a.efa_16 start_chr;
+      a.efa_16 end_chr;
+      a.efa_32 (Int32.of_int end_offset)
+    in
     (* These must be 32-bit aligned, both because they contain a
        32-bit value, and because emit_debuginfo assumes the low 2 bits
        of their addresses are 0. *)
     a.efa_align 4;
     a.efa_def_label lbl;
     a.efa_label_rel file_lbl 0l;
+    (* Include the additional 64-bits of location information which didn't pack
+       in the main 64-bit word *)
+    Option.iter emit_loc loc;
     a.efa_string defname
   in
-  let pack_info fd_raise d has_next =
-    let line = Int.min 0xFFFFF d.Debuginfo.dinfo_line
-    and char_start = Int.min 0xFF d.Debuginfo.dinfo_char_start
-    and char_end = Int.min 0x3FF d.Debuginfo.dinfo_char_end
+  let fully_pack_info fd_raise d has_next =
+    (* See format in caml_debuginfo_location in runtime/backtrace-nat.c *)
+    let open Debuginfo in
+    let kind = if fd_raise then 1 else 0
+    and has_next = if has_next then 1 else 0
+    and char_end = d.dinfo_char_end + d.dinfo_start_bol - d.dinfo_end_bol in
+    let char_end_offset = d.dinfo_end_bol - d.dinfo_start_bol in
+    Int64.(add (shift_left (of_int d.dinfo_line) 51)
+             (add (shift_left (of_int (d.dinfo_end_line - d.dinfo_line)) 48)
+                (add (shift_left (of_int d.dinfo_char_start) 42)
+                   (add (shift_left (of_int char_end) 35)
+                      (add (shift_left (of_int char_end_offset) 26)
+                         (add (shift_left (of_int kind) 1)
+                            (of_int has_next)))))))
+  in
+  let partially_pack_info fd_raise d has_next =
+    (* Partially packed debuginfo:
+       1lllllllllmmmmmmmmddddddddddddkn
+         1           - d points to a name_and_loc_info struct
+         l (19 bits) - start line number
+         m (18 bits) - offset of end line number from start
+         d (24 bits) - memory offset to name_and_loc_info struct
+         k (1 bit)   - fd_raise flag
+         n (1 bit)   - has_next flag *)
+    let open Debuginfo in
+    let start_line = Int.min 0x7FFFF d.dinfo_line
+    and end_line = Int.min 0x3FFFF (d.dinfo_end_line - d.dinfo_line)
     and kind = if fd_raise then 1 else 0
     and has_next = if has_next then 1 else 0 in
-    Int64.(add (shift_left (of_int line) 44)
-             (add (shift_left (of_int char_start) 36)
-                (add (shift_left (of_int char_end) 26)
+    Int64.(add (shift_left Int64.one 63)
+             (add (shift_left (of_int start_line) 44)
+                (add (shift_left (of_int end_line) 26)
                    (add (shift_left (of_int kind) 1)
                       (of_int has_next)))))
   in
@@ -271,10 +302,31 @@ let emit_frames a =
     a.efa_def_label lbl;
     let rec emit rs d rest =
       let open Debuginfo in
-      let info = pack_info rs d (rest <> []) in
       let defname = Scoped_location.string_of_scopes d.dinfo_scopes in
+      let char_end = d.dinfo_char_end + d.dinfo_start_bol - d.dinfo_end_bol in
+      let is_fully_packable =
+        d.dinfo_line <= 0xFFF
+        && d.dinfo_end_line - d.dinfo_line <= 0x7
+        && d.dinfo_char_start <= 0x3F
+        && char_end <= 0x7F
+        && d.dinfo_end_bol - d.dinfo_start_bol <= 0x1FF
+      in
+      let info =
+        if is_fully_packable then
+          fully_pack_info rs d (rest <> [])
+        else
+          partially_pack_info rs d (rest <> [])
+      in
+      let loc =
+        if is_fully_packable then
+          None
+        else
+          Some (Int.min 0xFFFF d.dinfo_char_start,   (* start_chr *)
+                Int.min 0xFFFF char_end,             (* end_chr *)
+                Int.min 0x3FFFFFFF d.dinfo_char_end) (* end_offset *)
+      in
       a.efa_label_rel
-        (label_defname d.dinfo_file defname)
+        (label_defname d.dinfo_file defname loc)
         (Int64.to_int32 info);
       a.efa_32 (Int64.to_int32 (Int64.shift_right info 32));
       match rest with

--- a/ocaml/runtime/backtrace.c
+++ b/ocaml/runtime/backtrace.c
@@ -90,8 +90,8 @@ static void print_location(struct caml_loc_info * li, int index)
     fprintf(stderr, "%s unknown location%s\n", info, inlined);
   } else {
     fprintf (stderr, "%s %s in file \"%s\"%s, line %d, characters %d-%d\n",
-             info, li->loc_defname, li->loc_filename, inlined, li->loc_lnum,
-             li->loc_startchr, li->loc_endchr);
+             info, li->loc_defname, li->loc_filename, inlined,
+             li->loc_start_lnum, li->loc_start_chr, li->loc_end_offset);
   }
 }
 
@@ -244,14 +244,16 @@ static value caml_convert_debuginfo(debuginfo dbg)
   if (li.loc_valid) {
     fname = caml_copy_string(li.loc_filename);
     dname = caml_copy_string(li.loc_defname);
-    p = caml_alloc_small(7, 0);
+    p = caml_alloc_small(9, 0);
     Field(p, 0) = Val_bool(li.loc_is_raise);
     Field(p, 1) = fname;
-    Field(p, 2) = Val_int(li.loc_lnum);
-    Field(p, 3) = Val_int(li.loc_startchr);
-    Field(p, 4) = Val_int(li.loc_endchr);
-    Field(p, 5) = Val_bool(li.loc_is_inlined);
-    Field(p, 6) = dname;
+    Field(p, 2) = Val_int(li.loc_start_lnum);
+    Field(p, 3) = Val_int(li.loc_start_chr);
+    Field(p, 4) = Val_int(li.loc_end_offset);
+    Field(p, 5) = Val_int(li.loc_end_lnum);
+    Field(p, 6) = Val_int(li.loc_end_chr);
+    Field(p, 7) = Val_bool(li.loc_is_inlined);
+    Field(p, 8) = dname;
   } else {
     p = caml_alloc_small(1, 1);
     Field(p, 0) = Val_bool(li.loc_is_raise);

--- a/ocaml/runtime/backtrace_byt.c
+++ b/ocaml/runtime/backtrace_byt.c
@@ -102,25 +102,27 @@ static int cmp_ev_info(const void *a, const void *b)
   int num_b;
 
   /* Perform a full lexicographic comparison to make sure the resulting order is
-     the same under all implementations of qsort (which is not stable). */
+     the same under all implementations of qsort (which is not stable).
+     NB a->ev_end_offset == b->ev_end_offset =>
+           a->ev_end_lnum == b->ev_end_lnum && a->ev_end_chr == b->ev_end_chr */
 
   if (pc_a > pc_b) return 1;
   if (pc_a < pc_b) return -1;
 
-  num_a = ev_a->ev_lnum;
-  num_b = ev_b->ev_lnum;
+  num_a = ev_a->ev_start_chr;
+  num_b = ev_b->ev_start_chr;
 
   if (num_a > num_b) return 1;
   if (num_a < num_b) return -1;
 
-  num_a = ev_a->ev_startchr;
-  num_b = ev_b->ev_startchr;
+  num_a = ev_a->ev_start_chr;
+  num_b = ev_b->ev_start_chr;
 
   if (num_a > num_b) return 1;
   if (num_a < num_b) return -1;
 
-  num_a = ev_a->ev_endchr;
-  num_b = ev_b->ev_endchr;
+  num_a = ev_a->ev_end_offset;
+  num_b = ev_b->ev_end_offset;
 
   if (num_a > num_b) return 1;
   if (num_a < num_b) return -1;
@@ -133,7 +135,7 @@ static struct ev_info *process_debug_events(code_t code_start,
                                             mlsize_t *num_events)
 {
   CAMLparam1(events_heap);
-  CAMLlocal3(l, ev, ev_start);
+  CAMLlocal4(l, ev, ev_start, ev_end);
   mlsize_t i, j;
   struct ev_info *events;
 
@@ -159,6 +161,7 @@ static struct ev_info *process_debug_events(code_t code_start,
                                  + Long_val(Field(ev, EV_POS)));
 
       ev_start = Field(Field(ev, EV_LOC), LOC_START);
+      ev_end = Field(Field(ev, EV_LOC), LOC_END);
 
       {
         const char *fname = String_val(Field(ev_start, POS_FNAME));
@@ -177,13 +180,14 @@ static struct ev_info *process_debug_events(code_t code_start,
         events[j].ev_defname = "<old bytecode>";
       }
 
-      events[j].ev_lnum = Int_val(Field(ev_start, POS_LNUM));
-      events[j].ev_startchr =
-        Int_val(Field(ev_start, POS_CNUM))
-        - Int_val(Field(ev_start, POS_BOL));
-      events[j].ev_endchr =
-        Int_val(Field(Field(Field(ev, EV_LOC), LOC_END), POS_CNUM))
-        - Int_val(Field(ev_start, POS_BOL));
+      events[j].ev_start_lnum = Int_val(Field(ev_start, POS_LNUM));
+      events[j].ev_start_chr =
+        Int_val(Field(ev_start, POS_CNUM)) - Int_val(Field(ev_start, POS_BOL));
+      events[j].ev_end_lnum = Int_val(Field(ev_end, POS_LNUM));
+      events[j].ev_end_chr =
+        Int_val(Field(ev_end, POS_CNUM)) - Int_val(Field(ev_end, POS_BOL));
+      events[j].ev_end_offset =
+        Int_val(Field(ev_end, POS_CNUM)) - Int_val(Field(ev_start, POS_BOL));
 
       j++;
     }
@@ -588,9 +592,11 @@ void caml_debuginfo_location(debuginfo dbg,
   li->loc_is_inlined = 0;
   li->loc_filename = event->ev_filename;
   li->loc_defname = event->ev_defname;
-  li->loc_lnum = event->ev_lnum;
-  li->loc_startchr = event->ev_startchr;
-  li->loc_endchr = event->ev_endchr;
+  li->loc_start_lnum = event->ev_start_lnum;
+  li->loc_start_chr = event->ev_start_chr;
+  li->loc_end_lnum = event->ev_end_lnum;
+  li->loc_end_chr = event->ev_end_chr;
+  li->loc_end_offset = event->ev_end_offset;
 }
 
 debuginfo caml_debuginfo_extract(backtrace_slot slot)

--- a/ocaml/runtime/backtrace_nat.c
+++ b/ocaml/runtime/backtrace_nat.c
@@ -369,11 +369,20 @@ struct name_info {
   char name[1];
 };
 
+/* Extended version of name_info including location fields which didn't fit
+   in the main debuginfo word. */
+struct name_and_loc_info {
+  int32_t filename_offs;
+  uint16_t start_chr;
+  uint16_t end_chr;
+  int32_t end_offset; /* End character position relative to start bol */
+  char name[1];
+};
+
 /* Extract location information for the given frame descriptor */
 void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
 {
   uint32_t info1, info2;
-  struct name_info * name_info;
 
   /* If no debugging information available, print nothing.
      When everything is compiled with -g, this corresponds to
@@ -387,28 +396,56 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
   /* Recover debugging info */
   info1 = ((uint32_t *)dbg)[0];
   info2 = ((uint32_t *)dbg)[1];
-  name_info = (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
+
   /* Format of the two info words:
-       llllllllllllllllllll aaaaaaaa bbbbbbbbbb ffffffffffffffffffffffff k n
-                         44       36         26                        2 1 0
-                       (32+12)    (32+4)
-     n ( 1 bit ): 0 if this is the final debuginfo
-                  1 if there's another following this one
-     k ( 1 bit ): 0 if it's a call
-                  1 if it's a raise
-     f (24 bits): offset (in 4-byte words) of file name relative to dbg
-     l (20 bits): line number
-     a ( 8 bits): beginning of character range
-     b (10 bits): end of character range */
+     Two possible formats based on value of bit 63:
+     Partially packed format
+       |------------- info2 ------------||------------- info1 -------------|
+       1 lllllllllllllllllll mmmmmmmmmmmmmmmmmm ffffffffffffffffffffffff k n
+      63                  44                 26                        2 1 0
+     Fully packed format:
+       |-------------- info2 --------------||------------- info1 -------------|
+       0 llllllllllll mmm aaaaaa bbbbbbb ooooooooo ffffffffffffffffffffffff k n
+      63           51  48     42      35        26                        2 1 0
+     n (    1 bit ): 0 if this is the final debuginfo
+                     1 if there's another following this one
+     k (    1 bit ): 0 if it's a call
+                     1 if it's a raise
+     f (   24 bits): offset (in 4-byte words) of struct relative to dbg. For
+                     partially packed format, f is struct name_and_loc_info;
+                     for fully packed format, f is struct name_info.
+     m ( 17/3 bits): difference between start line and end line
+     o (  0/9 bits): difference between start bol and end bol
+     a (  0/6 bits): beginning of character range (relative to start bol)
+     b (  0/7 bits): end of character range (relative to end bol)
+     l (19/12 bits): start line number
+   */
   li->loc_valid = 1;
   li->loc_is_raise = (info1 & 2) == 2;
   li->loc_is_inlined = caml_debuginfo_next(dbg) != NULL;
-  li->loc_defname = name_info->name;
-  li->loc_filename =
-    (char *)name_info + name_info->filename_offs;
-  li->loc_lnum = info2 >> 12;
-  li->loc_startchr = (info2 >> 4) & 0xFF;
-  li->loc_endchr = ((info2 & 0xF) << 6) | (info1 >> 26);
+  if (info2 & 0x80000000) {
+    struct name_and_loc_info * name_and_loc_info =
+      (struct name_and_loc_info*)((char *) dbg + (info1 & 0x3FFFFFC));
+    li->loc_defname = name_and_loc_info->name;
+    li->loc_filename =
+      (char *)name_and_loc_info + name_and_loc_info->filename_offs;
+    li->loc_start_lnum = li->loc_end_lnum = (info2 >> 12) & 0x7FFFF;
+    li->loc_end_lnum += ((info2 & 0xFFF) << 6) | (info1 >> 26);
+    li->loc_start_chr = name_and_loc_info->start_chr;
+    li->loc_end_chr = name_and_loc_info->end_chr;
+    li->loc_end_offset = name_and_loc_info->end_offset;
+  } else {
+    struct name_info * name_info =
+      (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
+    li->loc_defname = name_info->name;
+    li->loc_filename =
+      (char *)name_info + name_info->filename_offs;
+    li->loc_start_lnum = li->loc_end_lnum = info2 >> 19;
+    li->loc_end_lnum += (info2 >> 16) & 0x7;
+    li->loc_start_chr = (info2 >> 10) & 0x3F;
+    li->loc_end_chr = li->loc_end_offset = (info2 >> 3) & 0x7F;
+    li->loc_end_offset += (((info2 & 0x7) << 6) | (info1 >> 26));
+  }
 }
 
 value caml_add_debug_info(backtrace_slot start, value size, value events)

--- a/ocaml/runtime/caml/backtrace_prim.h
+++ b/ocaml/runtime/caml/backtrace_prim.h
@@ -37,9 +37,11 @@ struct caml_loc_info {
   int loc_is_raise;
   char * loc_filename;
   char * loc_defname;
-  int loc_lnum;
-  int loc_startchr;
-  int loc_endchr;
+  int loc_start_lnum;
+  int loc_start_chr;
+  int loc_end_lnum;
+  int loc_end_chr;
+  int loc_end_offset;
   int loc_is_inlined;
 };
 
@@ -110,9 +112,11 @@ struct ev_info {
   code_t ev_pc;
   char *ev_filename;
   char *ev_defname;
-  int ev_lnum;
-  int ev_startchr;
-  int ev_endchr;
+  int ev_start_lnum;
+  int ev_start_chr;  /* Relative to ev_start_lnum */
+  int ev_end_lnum;
+  int ev_end_chr;    /* Relative to ev_end_lnum */
+  int ev_end_offset; /* Relative to ev_start_lnum */
 };
 
 /* Find the event with the given pc. */

--- a/ocaml/runtime/instrtrace.c
+++ b/ocaml/runtime/instrtrace.c
@@ -56,7 +56,7 @@ caml_event_trace(code_t pc)
      Caml_state->id,
      (long) (pc - caml_start_code),
      evi->ev_defname, evi->ev_filename,
-     evi->ev_lnum, evi->ev_startchr, evi->ev_endchr);
+     evi->ev_start_lnum, evi->ev_start_chr, evi->ev_end_offset);
   fflush (stdout);
 }
 

--- a/ocaml/runtime4/caml/backtrace_prim.h
+++ b/ocaml/runtime4/caml/backtrace_prim.h
@@ -37,9 +37,6 @@ struct caml_loc_info {
   int loc_is_raise;
   char * loc_filename;
   char * loc_defname;
-  int loc_lnum;
-  int loc_startchr;
-  int loc_endchr;
   int loc_is_inlined;
 };
 

--- a/ocaml/stdlib/printexc.ml
+++ b/ocaml/stdlib/printexc.ml
@@ -116,25 +116,22 @@ external get_raw_backtrace:
 external raise_with_backtrace: exn -> raw_backtrace -> 'a
   = "%raise_with_backtrace"
 
-type backtrace_slot =
+(* Disable warning 37: values are constructed in the runtime *)
+type[@warning "-37"] backtrace_slot =
   | Known_location of {
-      is_raise    : bool;
-      filename    : string;
-      line_number : int;
-      start_char  : int;
-      end_char    : int;
-      is_inline   : bool;
-      defname     : string;
+      is_raise   : bool;
+      filename   : string;
+      start_lnum : int;
+      start_char : int;
+      end_offset : int; (* Relative to beginning of start_lnum *)
+      end_lnum   : int;
+      end_char   : int; (* Relative to beginning of end_lnum line *)
+      is_inline  : bool;
+      defname    : string;
     }
   | Unknown_location of {
       is_raise : bool
     }
-
-(* to avoid warning *)
-let _ = [Known_location { is_raise = false; filename = "";
-                          line_number = 0; start_char = 0; end_char = 0;
-                          is_inline = false; defname = "" };
-         Unknown_location { is_raise = false }]
 
 external convert_raw_backtrace_slot:
   raw_backtrace_slot -> backtrace_slot = "caml_convert_raw_backtrace_slot"
@@ -163,7 +160,7 @@ let format_backtrace_slot pos slot =
       Some (sprintf "%s %s in file \"%s\"%s, line %d, characters %d-%d"
               (info l.is_raise) l.defname l.filename
               (if l.is_inline then " (inlined)" else "")
-              l.line_number l.start_char l.end_char)
+              l.start_lnum l.start_char l.end_offset)
 
 let print_exception_backtrace outchan backtrace =
   match backtrace with
@@ -213,6 +210,8 @@ type location = {
   line_number : int;
   start_char : int;
   end_char : int;
+  end_line : int;
+  end_col : int;
 }
 
 let backtrace_slot_location = function
@@ -220,9 +219,11 @@ let backtrace_slot_location = function
   | Known_location l ->
     Some {
       filename    = l.filename;
-      line_number = l.line_number;
+      line_number = l.start_lnum;
       start_char  = l.start_char;
-      end_char    = l.end_char;
+      end_char    = l.end_offset;
+      end_line    = l.end_lnum;
+      end_col     = l.end_char;
     }
 
 let backtrace_slot_defname = function

--- a/ocaml/stdlib/printexc.mli
+++ b/ocaml/stdlib/printexc.mli
@@ -264,16 +264,17 @@ val backtrace_slots_of_raw_entry :
     @since 4.12
 *)
 
-
 type location = {
   filename : string;
   line_number : int;
   start_char : int;
   end_char : int;
+  end_line : int; (** @since 5.2 *)
+  end_col : int; (** @since 5.2 *)
 }
 (** The type of location information found in backtraces. [start_char]
-    and [end_char] are positions relative to the beginning of the
-    line.
+    and [end_char] are positions relative to the beginning of [line_number].
+    [end_col] is relative to the beginning of [end_line].
 
     @since 4.02
 *)


### PR DESCRIPTION
As per title - only runtime5 at this point.