### PR TITLE
Middle and backend parts of upstream PR12735

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4170,13 +4170,17 @@ let run_stack ~dbg ~stack ~f ~arg =
       [Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg); stack; f; arg],
       dbg )
 
-let resume ~dbg ~stack ~f ~arg =
+let resume ~dbg ~stack ~f ~arg ~last_fiber =
   (* Rc_normal is required here, because there are some uses of effects with
      repeated resumes, and these should consume O(1) stack space by tail-calling
      caml_resume. *)
   Cop
     ( Capply (typ_val, Rc_normal),
-      [Cconst_symbol (Cmm.global_symbol "caml_resume", dbg); stack; f; arg],
+      [ Cconst_symbol (Cmm.global_symbol "caml_resume", dbg);
+        stack;
+        f;
+        arg;
+        last_fiber ],
       dbg )
 
 let reperform ~dbg ~eff ~cont ~last_fiber =

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1014,6 +1014,7 @@ val resume :
   stack:expression ->
   f:expression ->
   arg:expression ->
+  last_fiber:expression ->
   expression
 
 val reperform :

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -855,8 +855,8 @@ let close_effect_primitive acc env ~dbg exn_continuation
   | Prunstack, [[stack]; [f]; [arg]] ->
     let call_kind = C.effect (E.run_stack ~stack ~f ~arg) in
     close call_kind
-  | Presume, [[stack]; [f]; [arg]] ->
-    let call_kind = C.effect (E.resume ~stack ~f ~arg) in
+  | Presume, [[stack]; [f]; [arg]; [last_fiber]] ->
+    let call_kind = C.effect (E.resume ~stack ~f ~arg ~last_fiber) in
     close call_kind
   | Preperform, [[eff]; [cont]; [last_fiber]] ->
     let call_kind = C.effect (E.reperform ~eff ~cont ~last_fiber) in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -1212,9 +1212,10 @@ let simplify_effect_op dacc apply (op : Call_kind.Effect.t) ~down_to_up =
     | Run_stack { stack; f; arg } ->
       E.run_stack ~stack:(simplify_simple stack) ~f:(simplify_simple f)
         ~arg:(simplify_simple arg)
-    | Resume { stack; f; arg } ->
+    | Resume { stack; f; arg; last_fiber } ->
       E.resume ~stack:(simplify_simple stack) ~f:(simplify_simple f)
         ~arg:(simplify_simple arg)
+        ~last_fiber:(simplify_simple last_fiber)
   in
   let apply = Apply.with_call_kind apply (Call_kind.effect op) in
   let dacc, use_id =

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -58,7 +58,8 @@ module Effect : sig
     | Resume of
         { stack : Simple.t;
           f : Simple.t;
-          arg : Simple.t
+          arg : Simple.t;
+          last_fiber : Simple.t
         }
 
   include Contains_names.S with type t := t
@@ -69,7 +70,8 @@ module Effect : sig
 
   val run_stack : stack:Simple.t -> f:Simple.t -> arg:Simple.t -> t
 
-  val resume : stack:Simple.t -> f:Simple.t -> arg:Simple.t -> t
+  val resume :
+    stack:Simple.t -> f:Simple.t -> arg:Simple.t -> last_fiber:Simple.t -> t
 end
 
 (* The allocation mode corresponds to the type of the function that is called:

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -334,7 +334,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       in
       let free_vars = BV.Set.union (BV.Set.union fv0 fv1) fv2 in
       C.run_stack ~dbg ~stack ~f ~arg, free_vars, env, res, Ece.all
-    | Resume { stack; f; arg } ->
+    | Resume { stack; f; arg; last_fiber } ->
       let { env; res; expr = { cmm = stack; free_vars = fv0; effs = _ } } =
         simple env res stack
       in
@@ -344,8 +344,13 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       let { env; res; expr = { cmm = arg; free_vars = fv2; effs = _ } } =
         simple env res arg
       in
-      let free_vars = BV.Set.union (BV.Set.union fv0 fv1) fv2 in
-      C.resume ~dbg ~stack ~f ~arg, free_vars, env, res, Ece.all)
+      let { env; res; expr = { cmm = last_fiber; free_vars = fv3; effs = _ } } =
+        simple env res last_fiber
+      in
+      let free_vars =
+        BV.Set.union (BV.Set.union fv0 fv1) (BV.Set.union fv2 fv3)
+      in
+      C.resume ~dbg ~stack ~f ~arg ~last_fiber, free_vars, env, res, Ece.all)
 
 (* Function calls that have an exn continuation with extra arguments must be
    wrapped with assignments for the mutable variables used to pass the extra


### PR DESCRIPTION
This just provides the new `last_fiber` argument to `resume`.  The remainder of ocaml/ocaml#12735 has arrived as part of the subtree merge.