### PR TITLE
Make pprintast handle new modes

### DIFF
--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -366,15 +366,9 @@ let maybe_modes_type pty ctxt f c =
 
 let modalities_type pty ctxt f pca =
   let modalities = Split_modalities.split_list pca.pca_modalities in
-  let space_if_legacies =
-    match modalities.legacy with
-    | [] -> ""
-    | _ :: _ -> " "
-  in
-  pp f "%a%s%a%a" legacy_modalities modalities.legacy
-                  space_if_legacies
-                  (pty ctxt) pca.pca_type
-                  maybe_atat_modalities modalities.nonlegacy
+  optional_legacy_modalities f modalities.legacy;
+  pty ctxt f pca.pca_type;
+  maybe_atat_modalities f modalities.nonlegacy
 
 (* c ['a,'b] *)
 let rec class_params_def ctxt f =  function

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -366,12 +366,15 @@ let maybe_modes_type pty ctxt f c =
 
 let modalities_type pty ctxt f pca =
   let modalities = Split_modalities.split_list pca.pca_modalities in
-  match modalities.legacy with
-  | [] -> pty ctxt f pca.pca_type
-  | _ :: _ ->
-    pp f "%a %a%a" legacy_modalities modalities.legacy
-                   (pty ctxt) pca.pca_type
-                   maybe_atat_modalities modalities.nonlegacy
+  let space_if_legacies =
+    match modalities.legacy with
+    | [] -> ""
+    | _ :: _ -> " "
+  in
+  pp f "%a%s%a%a" legacy_modalities modalities.legacy
+                  space_if_legacies
+                  (pty ctxt) pca.pca_type
+                  maybe_atat_modalities modalities.nonlegacy
 
 (* c ['a,'b] *)
 let rec class_params_def ctxt f =  function

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -22,11 +22,12 @@ module Example = struct
     "struct \
       type t = {global_ x : string;
                 global_ y : int @@ local many once shared unique portable nonportable
-                                   contended uncontended} \
+                                   contended uncontended;
+                z : bool @@ unique} \
      end"
   let modality_cstrarg = parse module_expr
     "struct \
-      type t = Foo of global_ string * global_ string @@ portable \
+      type t = Foo of global_ string * global_ string @@ portable * string @@ portable \
       type u = Foo : global_ string * global_ string -> u \
      end"
 

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -20,11 +20,13 @@ module Example = struct
 
   let modality_record  = parse module_expr
     "struct \
-      type t = {global_ x : string; global_ y : int} \
+      type t = {global_ x : string;
+                global_ y : int @@ local many once shared unique portable nonportable
+                                   contended uncontended} \
      end"
   let modality_cstrarg = parse module_expr
     "struct \
-      type t = Foo of global_ string * global_ string \
+      type t = Foo of global_ string * global_ string @@ portable \
       type u = Foo : global_ string * global_ string -> u \
      end"
 

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -1,14 +1,21 @@
 ##### All extensions enabled
 --------------------------------
 
-modality_record: struct type t = {
-                          global_ x: string ;
-                          global_ y: int } end
+modality_record:
+  struct
+    type t =
+      {
+      global_ x: string ;
+      global_ y:
+        int @@ local many once shared unique portable nonportable contended
+               uncontended
+        }
+  end
 
 modality_cstrarg:
   struct
     type t =
-      | Foo of global_ string * global_ string 
+      | Foo of global_ string * global_ string @@ portable 
     type u =
       | Foo: global_ string * global_ string -> u 
   end
@@ -102,14 +109,21 @@ mode: global
 ##### Extensions disallowed
 --------------------------------
 
-modality_record: struct type t = {
-                          global_ x: string ;
-                          global_ y: int } end
+modality_record:
+  struct
+    type t =
+      {
+      global_ x: string ;
+      global_ y:
+        int @@ local many once shared unique portable nonportable contended
+               uncontended
+        }
+  end
 
 modality_cstrarg:
   struct
     type t =
-      | Foo of global_ string * global_ string 
+      | Foo of global_ string * global_ string @@ portable 
     type u =
       | Foo: global_ string * global_ string -> u 
   end

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -9,13 +9,15 @@ modality_record:
       global_ y:
         int @@ local many once shared unique portable nonportable contended
                uncontended
-        }
+        ;
+      z: bool @@ unique }
   end
 
 modality_cstrarg:
   struct
     type t =
-      | Foo of global_ string * global_ string @@ portable 
+      | Foo of global_ string * global_ string @@ portable *
+      string @@ portable 
     type u =
       | Foo: global_ string * global_ string -> u 
   end
@@ -117,13 +119,15 @@ modality_record:
       global_ y:
         int @@ local many once shared unique portable nonportable contended
                uncontended
-        }
+        ;
+      z: bool @@ unique }
   end
 
 modality_cstrarg:
   struct
     type t =
-      | Foo of global_ string * global_ string @@ portable 
+      | Foo of global_ string * global_ string @@ portable *
+      string @@ portable 
     type u =
       | Foo: global_ string * global_ string -> u 
   end


### PR DESCRIPTION
Currently, printing the ast of `type a = { x : b @@ portable }` (or any other modality besides `global`) fails. This PR makes this succeed, while still printing global as a legacy modality. For example, `type a = { x : b @@ global portable }` prints as `type a = { x : global_ b @@ portable }`.