### PR TITLE
Initial implementation of the Capsule API

### DIFF
--- a/ocaml/otherlibs/stdlib_alpha/capsule.ml
+++ b/ocaml/otherlibs/stdlib_alpha/capsule.ml
@@ -87,30 +87,33 @@ module Data = struct
 
   external unsafe_get : ('a, 'k) t -> 'a @@ portable = "%identity"
 
-  let create f =
-    try unsafe_mk (f ()) with
-    | exn -> reraise (Contended exn)
+  let create f = unsafe_mk (f ())
 
   let map _ f t =
-    try unsafe_mk (f (unsafe_get t)) with
-    | exn -> reraise (Contended exn)
+    let v = unsafe_get t in
+    match f v with
+    | res -> unsafe_mk res
+    | exception exn -> reraise (Contended exn)
 
   let both t1 t2 = unsafe_mk (unsafe_get t1, unsafe_get t2)
 
   let extract _ f t =
-    try f (unsafe_get t) with
-    | exn -> reraise (Contended exn)
+    let v = unsafe_get t in
+    try f v with
+    |  exn -> reraise (Contended exn)
 
   let inject = unsafe_mk
 
   let project = unsafe_get
 
   let bind _ f t =
-    try f (unsafe_get t) with
+    let v = unsafe_get t in
+    try f v with
     | exn -> reraise (Contended exn)
 
   let iter _ f t =
-    try f (unsafe_get t) with
+    let v = unsafe_get t in
+    try f v with
     | exn -> reraise (Contended exn)
 
   let expose _ t = unsafe_get t

--- a/ocaml/otherlibs/stdlib_alpha/capsule.ml
+++ b/ocaml/otherlibs/stdlib_alpha/capsule.ml
@@ -1,0 +1,82 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                 Diana Kalinichenko, Jane Street, New York              *)
+(*                                                                        *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Password = struct
+  (* CR layouts v5: this should have layout [void], but
+     [void] can't be used for function argument and return types yet. *)
+  type 'k t = unit
+  let unsafe_mk () = ()
+end
+
+module M = Stdlib.Mutex
+
+module Mutex = struct
+
+  type 'k t = { mutex : M.t; mutable poisoned : bool }
+
+  type packed = P : 'k t -> packed
+
+  exception Poisoned
+
+  (* Cannot inline, otherwise flambda might move code around. *)
+  let[@inline never] with_lock t (f @ local) : 'a =
+    M.lock t.mutex;
+    match t.poisoned with
+    | true -> M.unlock t.mutex; raise Poisoned
+    | false ->
+      match f (Password.unsafe_mk ()) with
+      | x -> M.unlock t.mutex; x
+      | exception exn ->  t.poisoned <- true; raise exn
+
+  (* Cannot inline, otherwise flambda might move code around. *)
+  let[@inline never] destroy t =
+    M.lock t.mutex;
+    match t.poisoned with
+    | true ->
+      M.unlock t.mutex;
+      raise Poisoned
+    | false ->
+      M.unlock t.mutex;
+      t.poisoned <- true;
+      Password.unsafe_mk ()
+end
+
+let create_with_mutex () =
+  Mutex.P { mutex = M.create (); poisoned = false }
+
+module Ptr = struct
+  type ('a, 'k) t : value mod portable uncontended
+
+  external unsafe_mk : 'a -> ('a, 'k) t = "%identity"
+
+  external unsafe_get : ('a, 'k) t -> 'a = "%identity"
+
+  let create f = unsafe_mk (f ())
+
+  let map _ f t = unsafe_mk (f (unsafe_get t))
+
+  let both t1 t2 = unsafe_mk (unsafe_get t1, unsafe_get t2)
+
+  let extract _ f t = f (unsafe_get t)
+
+  let inject x = unsafe_mk x
+
+  let project t = unsafe_get t
+
+  let bind _ f t = f (unsafe_get t)
+
+  let iter _ f t = f (unsafe_get t)
+
+  let expose _ t = unsafe_get t
+end

--- a/ocaml/otherlibs/stdlib_alpha/capsule.mli
+++ b/ocaml/otherlibs/stdlib_alpha/capsule.mli
@@ -59,7 +59,9 @@ module Password : sig
 
 end
 
-  (** Mutual exclusion primtives for controlling uncontended access to a capsule. *)
+  (** Mutual exclusion primtives for controlling uncontended access to a capsule.
+
+      Requires OCaml 5 runtime. *)
 module Mutex : sig
 
     type 'k t

--- a/ocaml/otherlibs/stdlib_alpha/capsule.mli
+++ b/ocaml/otherlibs/stdlib_alpha/capsule.mli
@@ -100,13 +100,17 @@ val create_with_mutex : unit -> Mutex.packed @@ portable
 (** [create_with_mutex ()] creates a new capsule with an associated mutex. *)
 
 (** Pointers to data within a capsule. *)
-module Ptr : sig
+module Data : sig
 
     type ('a, 'k) t : value mod portable uncontended
     (** [('a, 'k) t] is the type of pointers to ['a]s in
         the capsule ['k]. It can be passed between domains.
         Operations on [('a, 'k) t] require a ['k Password.t],
         created from the ['k Mutex.t]. *)
+
+    exception Contended of exn @@ contended
+    (** If a function accessing the contents of the capsule raises an exception,
+        it is wrapped in [Contended] to avoid leaking access to the data. *)
 
     val create :
       (unit -> 'a) @ local portable

--- a/ocaml/otherlibs/stdlib_alpha/capsule.mli
+++ b/ocaml/otherlibs/stdlib_alpha/capsule.mli
@@ -80,18 +80,21 @@ module Mutex : sig
         'k t
         -> ('k Password.t @ local -> 'a) @ local
         -> 'a
+        @@ portable
     (** [with_lock m f] tries to acquire the mutex [m]. If [m] is already
         locked, blocks the current thread until it's unlocked. If successful,
         provides [f] a password for the capsule ['k] associated with [m].
 
-        If [f] raises an exception, the mutex is marked as poisoned. *)
+        If [f] raises an exception, the mutex is marked as poisoned.
 
-    val destroy : 'k t -> 'k Password.t
+        If [m] is already locked by the current thread, raises [Sys_error]. *)
+
+    val destroy : 'k t -> 'k Password.t @@ portable
     (** [destroy m] acquires the mutex [m] and leaks its password.
         It marks the lock as poisoned. *)
 end
 
-val create_with_mutex : unit -> Mutex.packed
+val create_with_mutex : unit -> Mutex.packed @@ portable
 (** [create_with_mutex ()] creates a new capsule with an associated mutex. *)
 
 (** Pointers to data within a capsule. *)
@@ -106,6 +109,7 @@ module Ptr : sig
     val create :
       (unit -> 'a) @ local portable
       -> ('a, 'k) t
+      @@ portable
     (** [create f] runs [f] within the capsule ['k] and creates
         a pointer to the result of [f]. *)
 
@@ -115,6 +119,7 @@ module Ptr : sig
       -> ('a -> 'b) @ local portable
       -> ('a, 'k) t
       -> ('b, 'k) t
+      @@ portable
     (** [map p f t] applies [f] to the value of [p] within the capsule ['k],
         creating a pointer to the result. *)
 
@@ -122,6 +127,7 @@ module Ptr : sig
       ('a, 'k) t
       -> ('b, 'k) t
       -> ('a * 'b, 'k) t
+      @@ portable
     (** [both t1 t2] is a pointer to a pair of the values of [t1] and [t2]. *)
 
     val extract :
@@ -129,6 +135,7 @@ module Ptr : sig
       -> ('a -> 'b @ portable contended) @ local portable
       -> ('a, 'k) t
       -> 'b @ portable contended
+      @@ portable
     (** [extract p f t] applies [f] to the value of [t] within
         the capsule ['k] and returns the result. The result is within ['k]
         so it must be [portable] and it is marked [contended]. *)
@@ -136,12 +143,14 @@ module Ptr : sig
     val inject :
       ('a : value mod uncontended) 'k.
       'a @ portable -> ('a, 'k) t
+      @@ portable
     (** [inject v] is a pointer to an immutable value [v] injected
         into the capsule ['k]. *)
 
     val project :
       ('a : value mod portable) 'k.
       ('a, 'k) t -> 'a @ contended
+      @@ portable
     (** [project t] returns the value of [t]. The result is within
         ['k] so it must be [portable] and it is marked [contended]. *)
 
@@ -150,6 +159,7 @@ module Ptr : sig
       -> ('a -> ('b, 'j) t) @ local portable
       -> ('a, 'k) t
       -> ('b, 'j) t
+      @@ portable
     (** [bind f t] is [project (map f t)]. *)
 
     val iter :
@@ -157,12 +167,14 @@ module Ptr : sig
       -> ('a -> unit) @ local portable
       -> ('a, 'k) t
       -> unit
+      @@ portable
     (** [iter] is [extract] with result type specialized to [unit]. *)
 
     val expose :
       'k Password.t
       -> ('a, 'k) t
       -> 'a
+      @@ portable
     (** [expose p t] retrieves the value stored by [Ptr.t]. It requires
         a [global] [Password.t] leaked by [Mutex.destroy]. *)
 

--- a/ocaml/otherlibs/stdlib_alpha/capsule.mli
+++ b/ocaml/otherlibs/stdlib_alpha/capsule.mli
@@ -1,0 +1,169 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                 Diana Kalinichenko, Jane Street, New York              *)
+(*                                                                        *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Capsules are a mechanism for safely having [uncontended]
+    access to mutable data from multiple domains. The interface
+    in this module ensures that only one domain can have [uncontended]
+    access to that data at a time.
+
+    We consider every piece of mutable data in the program to live
+    inside of some capsule. This might be an explicit capsule created
+    by the user using this interface, or an implicit capsule created
+    when a new domain is started. Whenever some thread is executing
+    a function it has uncontended access to a single capsule and any
+    new mutable data it creates is created within that capsule. We say
+    that the function is "running within" the capsule.
+
+    Capsules are only ever associated with threads from one domain at
+    a time, which ensures there are no data races in the program. The
+    implicit capsules created when a new domain is started are only ever
+    associated with threads in that domain. Explicit capsules can change
+    which domains have uncontended access to them using synchronization
+    primitives. Currently each explicit capsule has an associated mutex
+    that controls access to it. In the future there will also be other
+    synchronization mechanisms available to control access to explicit capsules.
+
+    Each explicit capsule is associated with a type "brand" -- written ['k]
+    throughout this interface -- which allows us to statically reason about
+    access to the capsule within the type system.  In the documentation of
+    this interface we will often use ['k] to refer to the capsule associated
+    with that brand. *)
+
+(** Passwords represent access to a capsule. *)
+module Password : sig
+
+    (* CR layouts v5: this should have layout [void], but
+       [void] can't be used for function argument and return types yet. *)
+    type 'k t
+    (** ['k t] is the type of "passwords" representing
+        the ability of the current domain to have [uncontended]
+        access to the capsule ['k]. They don't have a runtime representation,
+        and can't be passed between domains. Just as we don't share passwords
+        between people, we don't share [Password.t]s between domains.
+
+        Obtaining a ['k t] requires acquiring the mutex associated with ['k],
+        and modes prevent retaining the [t] after releasing the mutex. This
+        guarantees that uncontended access to the capsule is only granted
+        to a single domain at once. *)
+
+end
+
+  (** Mutual exclusion primtives for controlling uncontended access to a capsule. *)
+module Mutex : sig
+
+    type 'k t
+    (** ['k t] is the type of the mutex that controls access to
+        the capsule ['k]. This mutex is created when creating
+        the capsule ['k] using {!create_with_mutex}. *)
+
+    type packed = P : 'k t -> packed
+    (** [packed] is the type of a mutex for some unknown capsule.
+        Unpacking one provides a ['k Mutex.t] together with a fresh
+        existential type brand for ['k]. *)
+
+    exception Poisoned
+    (** Mutexes can get marked as poisoned. Any operations on a poisoned mutex
+        raise the [Poisoned] exception. *)
+
+    val with_lock :
+        'k t
+        -> ('k Password.t @ local -> 'a) @ local
+        -> 'a
+    (** [with_lock m f] tries to acquire the mutex [m]. If [m] is already
+        locked, blocks the current thread until it's unlocked. If successful,
+        provides [f] a password for the capsule ['k] associated with [m].
+
+        If [f] raises an exception, the mutex is marked as poisoned. *)
+
+    val destroy : 'k t -> 'k Password.t
+    (** [destroy m] acquires the mutex [m] and leaks its password.
+        It marks the lock as poisoned. *)
+end
+
+val create_with_mutex : unit -> Mutex.packed
+(** [create_with_mutex ()] creates a new capsule with an associated mutex. *)
+
+(** Pointers to data within a capsule. *)
+module Ptr : sig
+
+    type ('a, 'k) t : value mod portable uncontended
+    (** [('a, 'k) t] is the type of pointers to ['a]s in
+        the capsule ['k]. It can be passed between domains.
+        Operations on [('a, 'k) t] require a ['k Password.t],
+        created from the ['k Mutex.t]. *)
+
+    val create :
+      (unit -> 'a) @ local portable
+      -> ('a, 'k) t
+    (** [create f] runs [f] within the capsule ['k] and creates
+        a pointer to the result of [f]. *)
+
+
+    val map :
+      'k Password.t @ local
+      -> ('a -> 'b) @ local portable
+      -> ('a, 'k) t
+      -> ('b, 'k) t
+    (** [map p f t] applies [f] to the value of [p] within the capsule ['k],
+        creating a pointer to the result. *)
+
+    val both :
+      ('a, 'k) t
+      -> ('b, 'k) t
+      -> ('a * 'b, 'k) t
+    (** [both t1 t2] is a pointer to a pair of the values of [t1] and [t2]. *)
+
+    val extract :
+      'k Password.t @ local
+      -> ('a -> 'b @ portable contended) @ local portable
+      -> ('a, 'k) t
+      -> 'b @ portable contended
+    (** [extract p f t] applies [f] to the value of [t] within
+        the capsule ['k] and returns the result. The result is within ['k]
+        so it must be [portable] and it is marked [contended]. *)
+
+    val inject :
+      ('a : value mod uncontended) 'k.
+      'a @ portable -> ('a, 'k) t
+    (** [inject v] is a pointer to an immutable value [v] injected
+        into the capsule ['k]. *)
+
+    val project :
+      ('a : value mod portable) 'k.
+      ('a, 'k) t -> 'a @ contended
+    (** [project t] returns the value of [t]. The result is within
+        ['k] so it must be [portable] and it is marked [contended]. *)
+
+    val bind :
+      'k Password.t @ local
+      -> ('a -> ('b, 'j) t) @ local portable
+      -> ('a, 'k) t
+      -> ('b, 'j) t
+    (** [bind f t] is [project (map f t)]. *)
+
+    val iter :
+      'k Password.t @ local
+      -> ('a -> unit) @ local portable
+      -> ('a, 'k) t
+      -> unit
+    (** [iter] is [extract] with result type specialized to [unit]. *)
+
+    val expose :
+      'k Password.t
+      -> ('a, 'k) t
+      -> 'a
+    (** [expose p t] retrieves the value stored by [Ptr.t]. It requires
+        a [global] [Password.t] leaked by [Mutex.destroy]. *)
+
+  end

--- a/ocaml/otherlibs/stdlib_alpha/stdlib_alpha.ml
+++ b/ocaml/otherlibs/stdlib_alpha/stdlib_alpha.ml
@@ -1,1 +1,2 @@
+module Capsule = Capsule
 module Or_null = Or_null

--- a/ocaml/otherlibs/stdlib_alpha/stdlib_alpha.mli
+++ b/ocaml/otherlibs/stdlib_alpha/stdlib_alpha.mli
@@ -1,1 +1,2 @@
+module Capsule = Capsule
 module Or_null = Or_null

--- a/ocaml/testsuite/tests/capsule-api/basics.ml
+++ b/ocaml/testsuite/tests/capsule-api/basics.ml
@@ -20,22 +20,22 @@ let write_ref : ('a : value mod portable uncontended) .
 
 module Cell = struct
   type 'a t =
-    | Mk : 'k Capsule.Mutex.t * ('a myref, 'k) Capsule.Ptr.t -> 'a t
+    | Mk : 'k Capsule.Mutex.t * ('a myref, 'k) Capsule.Data.t -> 'a t
 
   let create x =
     let (P m) = Capsule.create_with_mutex () in
-    let p = Capsule.Ptr.create (fun () -> mk_ref x)  in
+    let p = Capsule.Data.create (fun () -> mk_ref x)  in
     Mk (m, p)
 
   let read t =
     let (Mk (m, p)) = t in
     Capsule.Mutex.with_lock m (fun k ->
-      Capsule.Ptr.extract k read_ref p)
+      Capsule.Data.extract k read_ref p)
 
   let write t x =
     let (Mk (m, p)) = t in
     Capsule.Mutex.with_lock m (fun k ->
-      Capsule.Ptr.iter k (write_ref x) p)
+      Capsule.Data.iter k (write_ref x) p)
 end
 
 let () =

--- a/ocaml/testsuite/tests/capsule-api/basics.ml
+++ b/ocaml/testsuite/tests/capsule-api/basics.ml
@@ -1,0 +1,42 @@
+(* TEST
+ include stdlib_alpha;
+ flags = "-extension-universe alpha";
+*)
+
+module Capsule = Stdlib_alpha.Capsule
+
+type 'a myref = { mutable v : 'a}
+
+(* We need extra annotations to convince the typechecker for examples below. *)
+let mk_ref : ('a : value mod portable uncontended) .
+  ('a -> 'a myref) @@ portable = fun v -> {v}
+let read_ref : ('a : value mod portable uncontended) .
+  ('a myref -> 'a @ portable contended) @@ portable = fun r -> r.v
+let write_ref : ('a : value mod portable uncontended) .
+  'a -> ('a myref -> unit) @ portable = fun v -> fun r -> r.v <- v
+
+module Cell = struct
+  type 'a t =
+    | Mk : 'k Capsule.Mutex.t * ('a myref, 'k) Capsule.Ptr.t -> 'a t
+
+  let create x =
+    let (P m) = Capsule.create_with_mutex () in
+    let p = Capsule.Ptr.create (fun () -> mk_ref x)  in
+    Mk (m, p)
+
+  let read t =
+    let (Mk (m, p)) = t in
+    Capsule.Mutex.with_lock m (fun k ->
+      Capsule.Ptr.extract k read_ref p)
+
+  let write t x =
+    let (Mk (m, p)) = t in
+    Capsule.Mutex.with_lock m (fun k ->
+      Capsule.Ptr.iter k (write_ref x) p)
+end
+
+let () =
+  let ptr = Cell.create 42 in
+  assert (Cell.read ptr = 42);
+  Cell.write ptr 45;
+  assert (Cell.read ptr = 45)

--- a/ocaml/testsuite/tests/capsule-api/basics.ml
+++ b/ocaml/testsuite/tests/capsule-api/basics.ml
@@ -1,6 +1,9 @@
 (* TEST
  include stdlib_alpha;
  flags = "-extension-universe alpha";
+ runtime5;
+ { bytecode; }
+ { native; }
 *)
 
 module Capsule = Stdlib_alpha.Capsule

--- a/ocaml/testsuite/tests/capsule-api/data.ml
+++ b/ocaml/testsuite/tests/capsule-api/data.ml
@@ -8,6 +8,8 @@
 
 module Capsule = Stdlib_alpha.Capsule
 
+external reraise : exn -> 'a @ portable @@ portable = "%reraise"
+
 type 'a myref = { mutable v : 'a}
 
 (* We need extra annotations to convince the typechecker for examples below. *)
@@ -19,9 +21,9 @@ let write_ref : ('a : value mod portable uncontended) .
   'a -> ('a myref -> unit) @ portable = fun v -> fun r -> r.v <- v
 
 type 'a guarded =
-  | Mk : 'k Capsule.Mutex.t * ('a, 'k) Capsule.Ptr.t -> 'a guarded
+  | Mk : 'k Capsule.Mutex.t * ('a, 'k) Capsule.Data.t -> 'a guarded
 
-let with_guarded x (f : 'k . 'k Capsule.Password.t @ local -> ('a, 'k) Capsule.Ptr.t -> 'b) =
+let with_guarded x (f : 'k . 'k Capsule.Password.t @ local -> ('a, 'k) Capsule.Data.t -> 'b) =
   let (Mk (m, p)) = x in
   Capsule.Mutex.with_lock m (fun k -> f k p)
 ;;
@@ -29,49 +31,60 @@ let with_guarded x (f : 'k . 'k Capsule.Password.t @ local -> ('a, 'k) Capsule.P
 (* [create]. *)
 let ptr =
   let (P m) = Capsule.create_with_mutex () in
-  Mk (m, Capsule.Ptr.create (fun () -> mk_ref 42))
+  Mk (m, Capsule.Data.create (fun () -> mk_ref 42))
 ;;
 
 (* [extract]. *)
 let () =
   with_guarded ptr (fun k p ->
-    assert (Capsule.Ptr.extract k read_ref p = 42))
+    assert (Capsule.Data.extract k read_ref p = 42))
 ;;
 
 let ptr' =
   let (Mk (m, p)) = ptr in
-  Mk (m, Capsule.Ptr.create (fun () -> mk_ref 2))
+  Mk (m, Capsule.Data.create (fun () -> mk_ref 2))
 
 (* [iter]. *)
 let () =
   with_guarded ptr (fun k p ->
-    Capsule.Ptr.iter k (write_ref 15) p)
+    Capsule.Data.iter k (write_ref 15) p)
 ;;
 
 let () =
   with_guarded ptr (fun k p ->
-    assert (Capsule.Ptr.extract k read_ref p = 15))
+    assert (Capsule.Data.extract k read_ref p = 15))
 ;;
 
 let () =
   with_guarded ptr' (fun k p ->
-    assert (Capsule.Ptr.extract k read_ref p = 2))
+    assert (Capsule.Data.extract k read_ref p = 2))
+;;
+
+exception Leak of int myref
+
+(* An exception raised from [iter] is marked as [contended]: *)
+let () =
+  with_guarded ptr (fun k p ->
+    match Capsule.Data.iter k (fun r -> reraise (Leak r)) p with
+    | exception Capsule.Data.Contended (Leak r) -> ()
+    | _ -> assert false)
 ;;
 
 (* [map], [both]. *)
 let ptr2 =
   let (Mk (m, p)) = ptr in
   let p' =
-    Capsule.Mutex.with_lock m (fun k -> Capsule.Ptr.map k (fun _ -> mk_ref 3) p)
+    Capsule.Mutex.with_lock m (fun k -> Capsule.Data.map k (fun _ -> mk_ref 3) p)
   in
-  Mk (m, Capsule.Ptr.both p p')
+  Mk (m, Capsule.Data.both p p')
 ;;
+
 
 (* [expose]. *)
 let () =
   let (Mk (m, p)) = ptr2 in
   let k = Capsule.Mutex.destroy m in
-  let (r1, r2) = Capsule.Ptr.expose k p in
+  let (r1, r2) = Capsule.Data.expose k p in
   assert (read_ref r1 = 15 && read_ref r2 = 3)
 ;;
 
@@ -95,8 +108,8 @@ let () =
 
 (* [inject], [project]. *)
 let () =
-  let ptr = Capsule.Ptr.inject 100 in
-  assert (Capsule.Ptr.project ptr = 100)
+  let ptr = Capsule.Data.inject 100 in
+  assert (Capsule.Data.project ptr = 100)
 ;;
 
 external (+) : int -> int -> int @@ portable = "%addint"
@@ -104,13 +117,13 @@ external (+) : int -> int -> int @@ portable = "%addint"
 type lost_capsule = |
 
 (* [bind]. *)
-let ptr' : (int, lost_capsule) Capsule.Ptr.t =
+let ptr' : (int, lost_capsule) Capsule.Data.t =
   let (P m) = Capsule.create_with_mutex () in
-  let ptr = Capsule.Ptr.inject 100 in
+  let ptr = Capsule.Data.inject 100 in
   Capsule.Mutex.with_lock m (fun k ->
-    Capsule.Ptr.bind k (fun x -> Capsule.Ptr.inject (((+) x) 11)) ptr)
+    Capsule.Data.bind k (fun x -> Capsule.Data.inject (((+) x) 11)) ptr)
 ;;
 
 let () =
-  assert (Capsule.Ptr.project ptr' = 111)
+  assert (Capsule.Data.project ptr' = 111)
 ;;

--- a/ocaml/testsuite/tests/capsule-api/poisoning.ml
+++ b/ocaml/testsuite/tests/capsule-api/poisoning.ml
@@ -1,0 +1,93 @@
+(* TEST
+ include stdlib_alpha;
+ flags = "-extension-universe alpha";
+*)
+
+module Capsule = Stdlib_alpha.Capsule
+
+let m = Capsule.create_with_mutex ()
+
+(* Normal execution. *)
+let () =
+  let x = ref 1 in
+  let (P m) = m in
+  Capsule.Mutex.with_lock m (fun _ ->
+    x := 2
+  );
+  assert (!x = 2)
+;;
+
+(* Trying to lock a mutex that is already locked from the same domain. *)
+let () =
+  let (P m) = m in
+  Capsule.Mutex.with_lock m (fun _ ->
+    match
+      Capsule.Mutex.with_lock m (fun _ -> ())
+    with
+    | exception Sys_error _ -> ()
+    | _ -> assert false
+  )
+;;
+
+(* Poisoning the mutex by raising an exception. *)
+let () =
+  let (P m) = m in
+  match
+    Capsule.Mutex.with_lock m (fun _ ->
+      raise Division_by_zero
+    )
+  with
+  | exception Division_by_zero -> ()
+  | _ -> assert false
+;;
+
+(* Operations on a poisoned mutex raise [Poisoned]. *)
+let () =
+  let (P m) = m in
+  match
+    Capsule.Mutex.with_lock m (fun _ ->
+      raise Division_by_zero
+    )
+  with
+  | exception Capsule.Mutex.Poisoned -> ()
+  | _ -> assert false
+;;
+
+(* Reset *)
+let m = Capsule.create_with_mutex ()
+
+let () =
+  let x = ref 1 in
+  let (P m) = m in
+  Capsule.Mutex.with_lock m (fun _ ->
+    x := 2
+  );
+  assert (!x = 2)
+;;
+
+(* Destroying the mutex leaks the password. *)
+let () =
+  let (P m) = m in
+  let _k : _ Capsule.Password.t = Capsule.Mutex.destroy m in
+  ()
+;;
+
+(* Destroyed mutex is poisoned. *)
+let () =
+  let (P m) = m in
+  match
+    Capsule.Mutex.with_lock m (fun _ ->
+      raise Division_by_zero
+    )
+  with
+  | exception Capsule.Mutex.Poisoned -> ()
+  | _ -> assert false
+;;
+
+(* Destroying a poisoned mutex raises [Poisoned]. *)
+let () =
+  let (P m) = m in
+  match Capsule.Mutex.destroy m with
+  | exception Capsule.Mutex.Poisoned -> ()
+  | _ -> assert false
+;;

--- a/ocaml/testsuite/tests/capsule-api/poisoning.ml
+++ b/ocaml/testsuite/tests/capsule-api/poisoning.ml
@@ -1,6 +1,9 @@
 (* TEST
  include stdlib_alpha;
  flags = "-extension-universe alpha";
+ runtime5;
+ { bytecode; }
+ { native; }
 *)
 
 module Capsule = Stdlib_alpha.Capsule

--- a/ocaml/testsuite/tests/capsule-api/ptr.ml
+++ b/ocaml/testsuite/tests/capsule-api/ptr.ml
@@ -1,0 +1,113 @@
+(* TEST
+ include stdlib_alpha;
+ flags = "-extension-universe alpha";
+*)
+
+module Capsule = Stdlib_alpha.Capsule
+
+type 'a myref = { mutable v : 'a}
+
+(* We need extra annotations to convince the typechecker for examples below. *)
+let mk_ref : ('a : value mod portable uncontended) .
+  ('a -> 'a myref) @@ portable = fun v -> {v}
+let read_ref : ('a : value mod portable uncontended) .
+  ('a myref -> 'a @ portable contended) @@ portable = fun r -> r.v
+let write_ref : ('a : value mod portable uncontended) .
+  'a -> ('a myref -> unit) @ portable = fun v -> fun r -> r.v <- v
+
+type 'a guarded =
+  | Mk : 'k Capsule.Mutex.t * ('a, 'k) Capsule.Ptr.t -> 'a guarded
+
+let with_guarded x (f : 'k . 'k Capsule.Password.t @ local -> ('a, 'k) Capsule.Ptr.t -> 'b) =
+  let (Mk (m, p)) = x in
+  Capsule.Mutex.with_lock m (fun k -> f k p)
+;;
+
+(* [create]. *)
+let ptr =
+  let (P m) = Capsule.create_with_mutex () in
+  Mk (m, Capsule.Ptr.create (fun () -> mk_ref 42))
+;;
+
+(* [extract]. *)
+let () =
+  with_guarded ptr (fun k p ->
+    assert (Capsule.Ptr.extract k read_ref p = 42))
+;;
+
+let ptr' =
+  let (Mk (m, p)) = ptr in
+  Mk (m, Capsule.Ptr.create (fun () -> mk_ref 2))
+
+(* [iter]. *)
+let () =
+  with_guarded ptr (fun k p ->
+    Capsule.Ptr.iter k (write_ref 15) p)
+;;
+
+let () =
+  with_guarded ptr (fun k p ->
+    assert (Capsule.Ptr.extract k read_ref p = 15))
+;;
+
+let () =
+  with_guarded ptr' (fun k p ->
+    assert (Capsule.Ptr.extract k read_ref p = 2))
+;;
+
+(* [map], [both]. *)
+let ptr2 =
+  let (Mk (m, p)) = ptr in
+  let p' =
+    Capsule.Mutex.with_lock m (fun k -> Capsule.Ptr.map k (fun _ -> mk_ref 3) p)
+  in
+  Mk (m, Capsule.Ptr.both p p')
+;;
+
+(* [expose]. *)
+let () =
+  let (Mk (m, p)) = ptr2 in
+  let k = Capsule.Mutex.destroy m in
+  let (r1, r2) = Capsule.Ptr.expose k p in
+  assert (read_ref r1 = 15 && read_ref r2 = 3)
+;;
+
+let () =
+  match with_guarded ptr (fun _ _ -> ()) with
+  | exception Capsule.Mutex.Poisoned -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match with_guarded ptr' (fun _ _ -> ()) with
+  | exception Capsule.Mutex.Poisoned -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match with_guarded ptr2 (fun _ _ -> ()) with
+  | exception Capsule.Mutex.Poisoned -> ()
+  | _ -> assert false
+;;
+
+(* [inject], [project]. *)
+let () =
+  let ptr = Capsule.Ptr.inject 100 in
+  assert (Capsule.Ptr.project ptr = 100)
+;;
+
+external (+) : int -> int -> int @@ portable = "%addint"
+
+type lost_capsule = |
+
+(* [bind]. *)
+let ptr' : (int, lost_capsule) Capsule.Ptr.t =
+  let (P m) = Capsule.create_with_mutex () in
+  let ptr = Capsule.Ptr.inject 100 in
+  Capsule.Mutex.with_lock m (fun k ->
+    Capsule.Ptr.bind k (fun x -> Capsule.Ptr.inject (((+) x) 11)) ptr)
+;;
+
+let () =
+  assert (Capsule.Ptr.project ptr' = 111)
+;;

--- a/ocaml/testsuite/tests/capsule-api/ptr.ml
+++ b/ocaml/testsuite/tests/capsule-api/ptr.ml
@@ -1,6 +1,9 @@
 (* TEST
  include stdlib_alpha;
  flags = "-extension-universe alpha";
+ runtime5;
+ { bytecode; }
+ { native; }
 *)
 
 module Capsule = Stdlib_alpha.Capsule

--- a/testsuite/tests/lib-extensions/alpha_exports.ml
+++ b/testsuite/tests/lib-extensions/alpha_exports.ml
@@ -10,6 +10,12 @@
 
 open Stdlib_alpha
 
+(* Test that [Capsule] is exported. *)
+let () =
+  let x = Capsule.Ptr.inject 5 in
+  assert (Capsule.Ptr.project x = 5)
+;;
+
 (* Test that [Or_null] is exported. *)
 
 let () =

--- a/testsuite/tests/lib-extensions/alpha_exports.ml
+++ b/testsuite/tests/lib-extensions/alpha_exports.ml
@@ -12,8 +12,8 @@ open Stdlib_alpha
 
 (* Test that [Capsule] is exported. *)
 let () =
-  let x = Capsule.Ptr.inject 5 in
-  assert (Capsule.Ptr.project x = 5)
+  let x = Capsule.Data.inject 5 in
+  assert (Capsule.Data.project x = 5)
 ;;
 
 (* Test that [Or_null] is exported. *)


### PR DESCRIPTION
Implement the Capsule API per the design doc. `Password.t`s are temporarily `value`s since `void` can't be used for function argument and return types yet. Mark every function in the interface as `portable`.

Test the Capsule API. Since domains are not supported yet, behavior in presence of multiple threads is not tested.