### PR TITLE
Parse arrow kinds in the jkind algebra

### DIFF
--- a/ocaml/parsing/ast_iterator.ml
+++ b/ocaml/parsing/ast_iterator.ml
@@ -1013,5 +1013,8 @@ let default_iterator =
         | With (t, ty) ->
           this.jkind_annotation this t;
           this.typ this ty
-        | Kind_of ty -> this.typ this ty);
+        | Kind_of ty -> this.typ this ty
+        | Arrow (args, result) ->
+          List.iter (this.jkind_annotation this) args;
+          this.jkind_annotation this result);
   }

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -1139,7 +1139,10 @@ let default_mapper =
         Mod (this.jkind_annotation this t, this.modes this mode_list)
       | With (t, ty) ->
         With (this.jkind_annotation this t, this.typ this ty)
-      | Kind_of ty -> Kind_of (this.typ this ty));
+      | Kind_of ty -> Kind_of (this.typ this ty)
+      | Arrow (args, result) -> Arrow
+        (List.map (this.jkind_annotation this) args,
+         this.jkind_annotation this result));
 
     expr_jane_syntax = E.map_jst;
     extension_constructor_jane_syntax = T.map_extension_constructor_jst;

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -1140,9 +1140,9 @@ let default_mapper =
       | With (t, ty) ->
         With (this.jkind_annotation this t, this.typ this ty)
       | Kind_of ty -> Kind_of (this.typ this ty)
-      | Arrow (args, result) -> Arrow
-        (List.map (this.jkind_annotation this) args,
-         this.jkind_annotation this result));
+      | Arrow (args, result) ->
+        Arrow (List.map (this.jkind_annotation this) args,
+               this.jkind_annotation this result));
 
     expr_jane_syntax = E.map_jst;
     extension_constructor_jane_syntax = T.map_extension_constructor_jst;

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -625,14 +625,18 @@ module Jkind = struct
       bind (Const.of_structure_item item) (fun c -> ret loc (Abbreviation c))
     | Some ("arrow", result :: args, loc) ->
       bind (of_structure_item result) (fun { txt = result } ->
-          let args = List.map of_structure_item args in
-          if List.for_all Option.is_some args
-          then
-            let args = List.map Option.get args in
-            let args = List.map (fun { txt } -> txt) args in
-            ret loc (Arrow (args, result))
-          else None)
+          bind (of_structure_item_list args) (fun args ->
+              let args = List.map (fun { txt } -> txt) args in
+              ret loc (Arrow (args, result))))
     | Some _ | None -> None
+
+  and of_structure_item_list items =
+    List.fold_right
+      Option.(
+        fun arg acc ->
+          bind acc (fun acc ->
+              Option.map (fun arg -> arg :: acc) (of_structure_item arg)))
+      items (Some [])
 end
 
 (** Jkind annotations' encoding as attribute payload, used in both n-ary

--- a/ocaml/parsing/jane_syntax.mli
+++ b/ocaml/parsing/jane_syntax.mli
@@ -214,6 +214,7 @@ module Jkind : sig
     | Mod of t * Mode_expr.t
     | With of t * Parsetree.core_type
     | Kind_of of Parsetree.core_type
+    | Arrow of t list * t
 
   type annotation = t Location.loc
 end

--- a/ocaml/parsing/lexer.mll
+++ b/ocaml/parsing/lexer.mll
@@ -707,6 +707,7 @@ rule token = parse
   | "*"  { STAR }
   | ","  { COMMA }
   | "->" { MINUSGREATER }
+  | "=>" { EQUALGREATER }
   | "."  { DOT }
   | ".." { DOTDOT }
   | "." (dotsymbolchar symbolchar* as op) { DOTOP op }

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -3872,8 +3872,6 @@ jkind_parameters:
 ;
 
 jkind_base:
-    (* not parsing this for now as e.g. mod doesn't seem to make sense *)
-    (* LPAREN k=jkind RPAREN { k } *)
     jkind_base MOD mkrhs(LIDENT)+ { (* LIDENTs here are for modes *)
       let mode_list =
         List.map

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -1114,6 +1114,7 @@ The precedences must be listed from low to high.
 %right    OR BARBAR                     /* expr (e || e || e) */
 %right    AMPERSAND AMPERAMPER          /* expr (e && e && e) */
 %nonassoc below_EQUAL
+%left     EQUALGREATER                  /* jkind (k => k => k) */
 %left     INFIXOP0 EQUAL LESS GREATER   /* expr (e OP e OP e) */
 %right    ATAT AT INFIXOP1              /* expr (e OP e OP e) */
 %nonassoc below_LBRACKETAT
@@ -4739,6 +4740,7 @@ operator:
   | STAR           {"*"}
   | PERCENT        {"%"}
   | EQUAL          {"="}
+  | EQUALGREATER  {"=>"}
   | LESS           {"<"}
   | GREATER        {">"}
   | OR            {"or"}

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -1012,6 +1012,7 @@ let unboxed_type sloc lident tys =
 %token MINUS                  "-"
 %token MINUSDOT               "-."
 %token MINUSGREATER           "->"
+%token EQUALGREATER           "=>"
 %token MOD                    "mod"
 %token MODULE                 "module"
 %token MUTABLE                "mutable"
@@ -3863,8 +3864,17 @@ type_parameters:
       { ps }
 ;
 
-jkind:
-    jkind MOD mkrhs(LIDENT)+ { (* LIDENTs here are for modes *)
+jkind_parameters:
+    p = jkind_base
+      { [p] }
+  | LPAREN ps = separated_nonempty_llist(COMMA, jkind) RPAREN (* ( jkind+ )  *)
+      { ps }
+;
+
+jkind_base:
+    (* not parsing this for now as e.g. mod doesn't seem to make sense *)
+    (* LPAREN k=jkind RPAREN { k } *)
+    jkind_base MOD mkrhs(LIDENT)+ { (* LIDENTs here are for modes *)
       let mode_list =
         List.map
           (fun {txt; loc} -> Jane_syntax.Mode_expr.Const.mk txt loc)
@@ -3872,7 +3882,7 @@ jkind:
       in
       Jane_syntax.Jkind.Mod ($1, mkrhs mode_list $loc($3))
     }
-  | jkind WITH core_type {
+  | jkind_base WITH core_type {
       Jane_syntax.Jkind.With ($1, $3)
     }
   | mkrhs(ident) {
@@ -3886,6 +3896,12 @@ jkind:
       Jane_syntax.Jkind.Default
     }
 ;
+
+jkind:
+    args=jkind_parameters EQUALGREATER result=jkind {
+      Jane_syntax.Jkind.Arrow (args, result)
+    }
+  | k=jkind_base { k }
 
 jkind_annotation: (* : jkind_annotation *)
   mkrhs(jkind) { $1 }

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -388,6 +388,9 @@ and jkind ctxt f k = match (k : Jane_syntax.Jkind.t) with
   | With (t, ty) ->
     pp f "%a with %a" (jkind ctxt) t (core_type ctxt) ty
   | Kind_of ty -> pp f "kind_of_ %a" (core_type ctxt) ty
+  | Arrow (args, result) ->
+      pp f "(%a) => %a" (list (jkind ctxt) ~sep:", ") args (jkind ctxt) result
+
 
 and jkind_annotation ctxt f annot = jkind ctxt f annot.txt
 

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -388,6 +388,8 @@ and jkind ctxt f k = match (k : Jane_syntax.Jkind.t) with
   | With (t, ty) ->
     pp f "%a with %a" (jkind ctxt) t (core_type ctxt) ty
   | Kind_of ty -> pp f "kind_of_ %a" (core_type ctxt) ty
+  | Arrow ([(Default | Abbreviation _ | Mod _ | With _ | Kind_of _) as arg], result) ->
+    pp f "%a => %a" (jkind ctxt) arg (jkind ctxt) result
   | Arrow (args, result) ->
       pp f "(%a) => %a" (list (jkind ctxt) ~sep:", ") args (jkind ctxt) result
 

--- a/ocaml/testsuite/tests/typing-higher-jkinds/arrow_infix_op_preserved.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/arrow_infix_op_preserved.ml
@@ -1,0 +1,15 @@
+(* TEST
+  expect;
+*)
+
+let (=>) x y = 2 * x + y
+
+(* Note that the language defines (=>) to be left-associative as = is first. *)
+(* left-associative:  2 * (2 * 5 + 3) + 1 = 2 * 13 + 1 = 27 *)
+(* right-associative: 2 * 5 + (2 * 3 + 1) = 10 + 6 + 1 = 17 *)
+let t = 5 => 3 => 1
+
+[%%expect{|
+val ( => ) : int -> int -> int = <fun>
+val t : int = 27
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
@@ -13,6 +13,8 @@ type s : (value, value mod local) => value
 type t : (value) => (value) => value
 
 [%%expect{|
-Uncaught exception: Failure("Arrow jkind (=>) syntax parsed, but annotations are not implemented")
-
+Line 1, characters 9-23:
+1 | type p : value => value
+             ^^^^^^^^^^^^^^
+Error: Arrow jkind (=>) syntax parsed, but annotations are not implemented
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
@@ -9,6 +9,7 @@ type s : (value, value) => value
 type t : (value => value, value) => value
 type u : (value, value mod local) => value
 type v : (value) => (value) => value
+type w : value => value => value
 
 [%%expect{|
 Line 1, characters 9-23:

--- a/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
@@ -1,0 +1,18 @@
+(* TEST
+  expect;
+  flags = "-g";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  check-ocamlc.byte-output;
+*)
+
+type p : value => value
+type q : (value, value) => value
+type r : (value => value, value) => value
+type s : (value, value mod local) => value
+type t : (value) => ((value) => value)
+
+[%%expect{|
+Uncaught exception: Jkind.Unexpected_higher_jkind("Arrow annotation parsing is not implemented yet")
+
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
@@ -1,6 +1,6 @@
 (* TEST
   expect;
-  flags = "-g";
+  ocamlc_byte_exit_status = "2";
   setup-ocamlc.byte-build-env;
   ocamlc.byte;
   check-ocamlc.byte-output;
@@ -10,9 +10,9 @@ type p : value => value
 type q : (value, value) => value
 type r : (value => value, value) => value
 type s : (value, value mod local) => value
-type t : (value) => ((value) => value)
+type t : (value) => (value) => value
 
 [%%expect{|
-Uncaught exception: Jkind.Unexpected_higher_jkind("Arrow annotation parsing is not implemented yet")
+Uncaught exception: Failure("Arrow jkind (=>) syntax parsed, but annotations are not implemented")
 
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
@@ -3,10 +3,12 @@
 *)
 
 type p : value => value
-type q : (value, value) => value
-type r : (value => value, value) => value
-type s : (value, value mod local) => value
-type t : (value) => (value) => value
+type q : (value) => value
+type r : (value => value) => value
+type s : (value, value) => value
+type t : (value => value, value) => value
+type u : (value, value mod local) => value
+type v : (value) => (value) => value
 
 [%%expect{|
 Line 1, characters 9-23:

--- a/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/parsing_arrows.ml
@@ -1,9 +1,5 @@
 (* TEST
   expect;
-  ocamlc_byte_exit_status = "2";
-  setup-ocamlc.byte-build-env;
-  ocamlc.byte;
-  check-ocamlc.byte-output;
 *)
 
 type p : value => value

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -632,7 +632,7 @@ module Type = struct
             }
         in
         List.fold_left meet_mode base parsed_modes
-      | Default | With _ | Kind_of _ -> Misc.fatal_error "XXX unimplemented"
+      | Default | With _ | Kind_of _ | Arrow _ -> Misc.fatal_error "XXX unimplemented"
 
     module Sort = Sort.Const
     module Layout = Layout.Const

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -632,7 +632,9 @@ module Type = struct
             }
         in
         List.fold_left meet_mode base parsed_modes
-      | Default | With _ | Kind_of _ | Arrow _ -> Misc.fatal_error "XXX unimplemented"
+      | Arrow _ ->
+        failwith "Arrow jkind (=>) syntax parsed, but annotations are not implemented"
+      | Default | With _ | Kind_of _ -> Misc.fatal_error "XXX unimplemented"
 
     module Sort = Sort.Const
     module Layout = Layout.Const

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -240,6 +240,7 @@ module Type = struct
           { from_annotation : const;
             from_attribute : const
           }
+      | Arrow_not_implemented
 
     exception User_error of Location.t * t
   end
@@ -550,7 +551,7 @@ module Type = struct
         List.map parse_mode modes
     end
 
-    let rec of_user_written_annotation_unchecked_level
+    let rec of_user_written_annotation_unchecked_level ~loc
         (jkind : Jane_syntax.Jkind.t) : t =
       match jkind with
       | Abbreviation const -> (
@@ -571,7 +572,7 @@ module Type = struct
         | "bits64" -> Primitive.bits64.jkind
         | _ -> raise ~loc (Unknown_jkind jkind))
       | Mod (jkind, modes) ->
-        let base = of_user_written_annotation_unchecked_level jkind in
+        let base = of_user_written_annotation_unchecked_level ~loc jkind in
         (* for each mode, lower the corresponding modal bound to be that mode *)
         let parsed_modes = ModeParser.parse_modes modes in
         let meet_mode jkind (mode : ModeParser.mode) =
@@ -632,9 +633,7 @@ module Type = struct
             }
         in
         List.fold_left meet_mode base parsed_modes
-      | Arrow _ ->
-        failwith
-          "Arrow jkind (=>) syntax parsed, but annotations are not implemented"
+      | Arrow _ -> raise ~loc Arrow_not_implemented
       | Default | With _ | Kind_of _ -> Misc.fatal_error "XXX unimplemented"
 
     module Sort = Sort.Const
@@ -910,7 +909,7 @@ module Type = struct
     }
 
   let const_of_user_written_annotation ~context Location.{ loc; txt = annot } =
-    let const = Const.of_user_written_annotation_unchecked_level annot in
+    let const = Const.of_user_written_annotation_unchecked_level ~loc annot in
     let required_layouts_level = get_required_layouts_level context const in
     if not (Language_extension.is_at_least Layouts required_layouts_level)
     then
@@ -1756,6 +1755,9 @@ module Type = struct
 
   (*** formatting user errors ***)
   let report_error ~loc : Error.t -> _ = function
+    | Arrow_not_implemented ->
+      Location.errorf ~loc
+        "Arrow jkind (=>) syntax parsed, but annotations are not implemented"
     | Unknown_jkind jkind ->
       Location.errorf ~loc
         (* CR layouts v2.9: use the context to produce a better error message.

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -633,7 +633,8 @@ module Type = struct
         in
         List.fold_left meet_mode base parsed_modes
       | Arrow _ ->
-        failwith "Arrow jkind (=>) syntax parsed, but annotations are not implemented"
+        failwith
+          "Arrow jkind (=>) syntax parsed, but annotations are not implemented"
       | Default | With _ | Kind_of _ -> Misc.fatal_error "XXX unimplemented"
 
     module Sort = Sort.Const

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1261,7 +1261,7 @@ let out_jkind_of_user_jkind (jkind : Jane_syntax.Jkind.annotation) =
           modes.txt
       in
       Ojkind_user_mod (base, modes)
-    | With _ | Kind_of _ -> failwith "XXX unimplemented jkind syntax"
+    | With _ | Kind_of _ | Arrow _ -> failwith "XXX unimplemented jkind syntax"
   in
   Ojkind_user (out_jkind_user_of_user_jkind jkind.txt)
 


### PR DESCRIPTION
- Extend the parser and lexer to support `=>` for arrow jkinds
- Support utilities around `Jane_syntax.Jkind` and the `annotation` type

Does not include translating such annotations to jkinds, as the type definition of `Jkind.t` is only extended in the next PR.

~~**Note:** Please exclude commits up to 5f2ac10 when comparing the diff.~~ Branch parent fixed after merge and force push (`higher-kinded-retypes`).