### PR TITLE
Fix parsing mls

### DIFF
--- a/ocaml/jane/build-resolved-files-for-ci
+++ b/ocaml/jane/build-resolved-files-for-ci
@@ -25,6 +25,19 @@ dune_targets=$(
   done
 )
 
+# ocamlcommon mls
+mls=$(
+  { echo ocaml/parsing/*.ml
+  } | tr ' ' '\n'
+)
+echo "$mls"
+dune_targets=$(
+  for ml in $mls; do
+    cmx=$(basename ${ml%.ml})
+    echo _build/default/ocaml/.ocamlcommon.objs/native/$cmx.cmx
+  done
+)
+
 # # ocamlbytecomp mlis
 # mlis=$(
 #   { echo driver/{errors,compile,maindriver}.mli

--- a/ocaml/parsing/ast_helper.ml
+++ b/ocaml/parsing/ast_helper.ml
@@ -114,7 +114,7 @@ module Typ = struct
            [Jane_syntax.Layouts.Ltyp_alias]), but the code here still has the
            correct behavior. *)
         | Ptyp_alias(core_type, alias) ->
-            check_variable var_names t.ptyp_loc alias.txt;
+            check_variable var_names alias.loc alias.txt;
             Ptyp_alias(loop core_type, alias)
         | Ptyp_variant(row_field_list, flag, lbl_lst_option) ->
             Ptyp_variant(List.map loop_row_field row_field_list,

--- a/ocaml/parsing/ast_helper.ml
+++ b/ocaml/parsing/ast_helper.ml
@@ -109,23 +109,13 @@ module Typ = struct
             Ptyp_object (List.map loop_object_field lst, o)
         | Ptyp_class (longident, lst) ->
             Ptyp_class (longident, List.map loop lst)
-<<<<<<< HEAD
         (* A Ptyp_alias might be a jkind annotation (that is, it might have
            attributes which mean it should be interpreted as a
            [Jane_syntax.Layouts.Ltyp_alias]), but the code here still has the
            correct behavior. *)
-        | Ptyp_alias(core_type, string) ->
-            check_variable var_names t.ptyp_loc string;
-            Ptyp_alias(loop core_type, string)
-||||||| 121bedcfd2
-        | Ptyp_alias(core_type, string) ->
-            check_variable var_names t.ptyp_loc string;
-            Ptyp_alias(loop core_type, string)
-=======
         | Ptyp_alias(core_type, alias) ->
-            check_variable var_names alias.loc alias.txt;
+            check_variable var_names t.ptyp_loc alias.txt;
             Ptyp_alias(loop core_type, alias)
->>>>>>> 5.2.0
         | Ptyp_variant(row_field_list, flag, lbl_lst_option) ->
             Ptyp_variant(List.map loop_row_field row_field_list,
                          flag, lbl_lst_option)

--- a/ocaml/parsing/ast_helper.mli
+++ b/ocaml/parsing/ast_helper.mli
@@ -139,7 +139,7 @@ module Exp:
     val let_: ?loc:loc -> ?attrs:attrs -> rec_flag -> value_binding list
               -> expression -> expression
     val function_ : ?loc:loc -> ?attrs:attrs -> function_param list
-                   -> type_constraint option -> function_body
+                   -> function_constraint option -> function_body
                    -> expression
     val apply: ?loc:loc -> ?attrs:attrs -> expression
                -> (arg_label * expression) list -> expression

--- a/ocaml/parsing/ast_invariants.ml
+++ b/ocaml/parsing/ast_invariants.ml
@@ -37,17 +37,9 @@ let empty_type loc = err loc "Type declarations cannot be empty."
 let complex_id loc = err loc "Functor application not allowed here."
 let module_type_substitution_missing_rhs loc =
   err loc "Module type substitution with no right hand side"
-<<<<<<< HEAD
 let empty_comprehension loc = err loc "Comprehension with no clauses"
-let no_val_params loc = err loc "Functions must have a value parameter."
-
-let non_jane_syntax_function loc =
-  err loc "Functions must be constructed using Jane Street syntax."
-||||||| 121bedcfd2
-=======
 let function_without_value_parameters loc =
   err loc "Function without any value parameters"
->>>>>>> 5.2.0
 
 let simple_longident id =
   let rec is_simple = function
@@ -122,23 +114,8 @@ let iterator =
       List.iter (fun (id, _) -> simple_longident id) fields
     | _ -> ()
   in
-  let n_ary_function loc (params, _constraint, body) =
-    let open Jane_syntax.N_ary_functions in
-    match body with
-    | Pfunction_cases _ -> ()
-    | Pfunction_body _ ->
-        if
-          not (
-            List.exists
-              (function
-                | { pparam_desc = Pparam_val _ } -> true
-                | { pparam_desc = Pparam_newtype _ } -> false)
-              params)
-        then no_val_params loc
-  in
   let jexpr _self loc (jexp : Jane_syntax.Expression.t) =
     match jexp with
-    | Jexp_n_ary_function n_ary -> n_ary_function loc n_ary
     | Jexp_comprehension
         ( Cexp_list_comprehension {clauses = []; body = _}
         | Cexp_array_comprehension (_, {clauses = []; body = _}) )
@@ -180,10 +157,6 @@ let iterator =
     | Pexp_new id -> simple_longident id
     | Pexp_record (fields, _) ->
       List.iter (fun (id, _) -> simple_longident id) fields
-<<<<<<< HEAD
-    | Pexp_fun _ | Pexp_function _ -> non_jane_syntax_function loc
-||||||| 121bedcfd2
-=======
     | Pexp_function (params, _, Pfunction_body _) ->
         if
           List.for_all
@@ -192,7 +165,6 @@ let iterator =
               | { pparam_desc = Pparam_val _ } -> false)
             params
         then function_without_value_parameters loc
->>>>>>> 5.2.0
     | _ -> ()
   in
   let extension_constructor self ec =
@@ -272,17 +244,6 @@ let iterator =
           "In object types, attaching attributes to inherited \
            subtypes is not allowed."
   in
-<<<<<<< HEAD
-  let attribute self attr =
-    (* The change to `self` here avoids registering attributes within attributes
-       for the purposes of warning 53, while keeping all the other invariant
-       checks for attribute payloads.  See comment on [attr_tracking_time] in
-       [builtin_attributes.mli]. *)
-    super.attribute { self with attribute = super.attribute } attr;
-    Builtin_attributes.(register_attr Invariant_check attr.attr_name)
-  in
-||||||| 121bedcfd2
-=======
   let attribute self attr =
     (* The change to `self` here avoids registering attributes within attributes
        for the purposes of warning 53, while keeping all the other invariant
@@ -291,7 +252,6 @@ let iterator =
     super.attribute { self with attribute = super.attribute } attr;
     Builtin_attributes.(register_attr Invariant_check attr.attr_name)
   in
->>>>>>> 5.2.0
   { super with
     type_declaration
   ; typ

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -686,7 +686,6 @@ module E = struct
     | Jexp_comprehension x -> Jexp_comprehension (map_cexp sub x)
     | Jexp_immutable_array x -> Jexp_immutable_array (map_iaexp sub x)
     | Jexp_layout x -> Jexp_layout (map_layout_exp sub x)
-    | Jexp_n_ary_function x -> Jexp_n_ary_function (map_n_ary_exp sub x)
     | Jexp_tuple ltexp -> Jexp_tuple (map_ltexp sub ltexp)
     | Jexp_modes mode_exp -> Jexp_modes (map_modes_exp sub mode_exp)
 

--- a/ocaml/parsing/attr_helper.ml
+++ b/ocaml/parsing/attr_helper.ml
@@ -24,21 +24,9 @@ type error =
 
 exception Error of Location.t * error
 
-<<<<<<< HEAD
-let get_no_payload_attribute alt_names attrs =
-  match
-    Builtin_attributes.filter_attributes
-      (Builtin_attributes.Attributes_filter.create [alt_names,true])
-      attrs
-  with
-||||||| 121bedcfd2
-let get_no_payload_attribute alt_names attrs =
-  match List.filter (fun a -> List.mem a.attr_name.txt alt_names) attrs with
-=======
 let get_no_payload_attribute nm attrs =
   let actions = [(nm, Builtin_attributes.Return)] in
   match Builtin_attributes.select_attributes actions attrs with
->>>>>>> 5.2.0
   | [] -> None
   | [ {attr_name = name; attr_payload = PStr []; attr_loc = _} ] -> Some name
   | [ {attr_name = name; _} ] ->

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -30,11 +30,7 @@ let mark_used t = Attribute_table.remove unused_attrs t
 (* [attr_order] is used to issue unused attribute warnings in the order the
    attributes occur in the file rather than the random order of the hash table
 *)
-let attr_order a1 a2 =
-  match String.compare a1.loc.loc_start.pos_fname a2.loc.loc_start.pos_fname
-  with
-  | 0 -> Int.compare a1.loc.loc_start.pos_cnum a2.loc.loc_start.pos_cnum
-  | n -> n
+let attr_order a1 a2 = Location.compare a1.loc a2.loc
 
 let unchecked_zero_alloc_attributes = Attribute_table.create 1
 let mark_zero_alloc_attribute_checked txt loc =
@@ -66,8 +62,7 @@ let warn_unused () =
   end
 
 (* These are the attributes that are tracked in the builtin_attrs table for
-   misplaced attribute warnings.  Explicitly excluded is [deprecated_mutable],
-   which is currently broken in the compiler *)
+   misplaced attribute warnings. *)
 let builtin_attrs =
   [ "inline"
   ; "inlined"
@@ -78,6 +73,7 @@ let builtin_attrs =
   ; "error"
   ; "alert"
   ; "deprecated"
+  ; "deprecated_mutable"
   ; "warning"
   ; "warnerror"
   ; "ppwarning"

--- a/ocaml/parsing/depend.ml
+++ b/ocaml/parsing/depend.ml
@@ -261,7 +261,7 @@ let rec add_expr bv exp =
       let bv = add_bindings rf bv pel in add_expr bv e
   | Pexp_function (params, constraint_, body) ->
       let bv = List.fold_left add_function_param bv params in
-      add_opt add_constraint bv constraint_;
+      add_opt add_function_constraint bv constraint_;
       add_function_body bv body
   | Pexp_apply(e, el) ->
       add_expr bv e; List.iter (fun (_,e) -> add_expr bv e) el
@@ -331,12 +331,10 @@ let rec add_expr bv exp =
   | Pexp_extension e -> handle_extension e
   | Pexp_unreachable -> ()
 
-<<<<<<< HEAD
 and add_expr_jane_syntax bv : Jane_syntax.Expression.t -> _ = function
   | Jexp_comprehension x -> add_comprehension_expr bv x
   | Jexp_immutable_array x -> add_immutable_array_expr bv x
   | Jexp_layout x -> add_layout_expr bv x
-  | Jexp_n_ary_function n_ary -> add_n_ary_function bv n_ary
   | Jexp_tuple x -> add_labeled_tuple_expr bv x
   | Jexp_modes x -> add_modes_expr bv x
 
@@ -387,44 +385,9 @@ and add_layout_expr bv : Jane_syntax.Layouts.expression -> _ = function
     add_jkind bv jkind;
     add_expr bv inner_expr
 
-and add_n_ary_function bv : Jane_syntax.N_ary_functions.expression -> _ =
-  fun (params, constraint_, body) ->
-    let bv = List.fold_left add_function_param bv params in
-    add_opt add_function_constraint bv constraint_;
-    add_function_body bv body
-
-and add_function_param bv : Jane_syntax.N_ary_functions.function_param -> _ =
-  fun { pparam_desc } ->
-    match pparam_desc with
-    | Pparam_val (_, opte, pat) ->
-      add_opt add_expr bv opte;
-      add_pattern bv pat
-    | Pparam_newtype _ -> bv
-
-and add_function_body bv : Jane_syntax.N_ary_functions.function_body -> _ =
-  function
-  | Pfunction_body e ->
-    add_expr bv e
-  | Pfunction_cases (cases, _, _) ->
-    add_cases bv cases
-
-and add_function_constraint bv
-    : Jane_syntax.N_ary_functions.function_constraint -> _ =
-  (* Enable warning 9 to ensure that the record pattern doesn't miss any field.
-  *)
-  fun[@ocaml.warning "+9"] { mode_annotations = _; type_constraint } ->
-    match type_constraint with
-    | Pconstraint ty ->
-      add_type bv ty
-    | Pcoerce (ty1, ty2) ->
-      add_opt add_type bv ty1;
-      add_type bv ty2
-
 and add_labeled_tuple_expr bv : Jane_syntax.Labeled_tuples.expression -> _ =
   function el -> List.iter (add_expr bv) (List.map snd el)
 
-||||||| 121bedcfd2
-=======
 and add_function_param bv param =
   match param.pparam_desc with
   | Pparam_val (_, opte, pat) ->
@@ -439,15 +402,14 @@ and add_function_body bv body =
   | Pfunction_cases (cases, _, _) ->
       add_cases bv cases
 
-and add_constraint bv constraint_ =
-  match constraint_ with
+and add_function_constraint bv { mode_annotations = _; type_constraint } =
+  match type_constraint with
   | Pconstraint ty ->
       add_type bv ty
   | Pcoerce (ty1, ty2) ->
       add_opt add_type bv ty1;
       add_type bv ty2
 
->>>>>>> 5.2.0
 and add_cases bv cases =
   List.iter (add_case bv) cases
 

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -39,22 +39,10 @@ end = struct
 end
 
 module Of_ast (Ext : Extension) : sig
-  module Desugaring_error : sig
-    type error =
-      | Not_this_embedding of Embedded_name.t
-      | Non_embedding
-  end
-
   type unwrapped := string list * payload * attributes
 
-  (* Find and remove a jane-syntax attribute marker, returning an error
+  (* Find and remove a jane-syntax attribute marker, throwing an error
      if the attribute name does not have the right format or extension. *)
-  val unwrap_jane_syntax_attributes :
-    attributes -> (unwrapped, Desugaring_error.error) result
-
-  (* The same as [unwrap_jane_syntax_attributes], except throwing
-     an exception instead of returning an error.
-  *)
   val unwrap_jane_syntax_attributes_exn :
     loc:Location.t -> attributes -> unwrapped
 end = struct
@@ -349,9 +337,7 @@ end
 
 module Mode_expr = struct
   module Const : sig
-    type raw = string
-
-    type t = private raw Location.loc
+    type t = Parsetree.mode_const_expression
 
     val mk : string -> Location.t -> t
 
@@ -379,7 +365,7 @@ module Mode_expr = struct
 
     let list_from_payload = Protocol.Decode.list_from_payload
 
-    type t = raw Location.loc
+    type t = Parsetree.mode_const_expression
 
     let mk txt loc : t = { txt; loc }
 
@@ -388,7 +374,7 @@ module Mode_expr = struct
       { txt; loc }
   end
 
-  type t = Const.t list Location.loc
+  type t = Parsetree.mode_expression
 
   let empty = Location.mknoloc []
 
@@ -490,9 +476,7 @@ end
 
 module Jkind = struct
   module Const : sig
-    type raw = string
-
-    type t = private raw loc
+    type t = Parsetree.jkind_const_annotation
 
     val mk : string -> Location.t -> t
 
@@ -521,7 +505,7 @@ module Jkind = struct
     let to_structure_item = Protocol.to_structure_item
   end
 
-  type t =
+  type t = Parsetree.jkind_annotation =
     | Default
     | Abbreviation of Const.t
     | Mod of t * Mode_expr.t
@@ -917,485 +901,6 @@ module Immutable_arrays = struct
     match pat.ppat_desc with
     | Ppat_array elts -> Iapat_immutable_array elts, pat.ppat_attributes
     | _ -> failwith "Malformed immutable array pattern"
-end
-
-module N_ary_functions = struct
-  module Ext = struct
-    let feature : Feature.t = Builtin
-  end
-
-  module Ast_of = Ast_of (Expression) (Ext)
-  module Of_ast = Of_ast (Ext)
-  open Ext
-
-  type function_body =
-    | Pfunction_body of expression
-    | Pfunction_cases of case list * Location.t * attributes
-
-  type function_param_desc =
-    | Pparam_val of arg_label * expression option * pattern
-    | Pparam_newtype of string loc * Jkind.annotation option
-
-  type function_param =
-    { pparam_desc : function_param_desc;
-      pparam_loc : Location.t
-    }
-
-  type type_constraint = Parsetree.type_constraint =
-    | Pconstraint of core_type
-    | Pcoerce of core_type option * core_type
-
-  type function_constraint =
-    { mode_annotations : Mode_expr.t;
-      type_constraint : type_constraint
-    }
-
-  type expression =
-    function_param list * function_constraint option * function_body
-
-  (** An attribute of the form [@jane.erasable._builtin.*] that's relevant
-      to n-ary functions. The "*" in the example is what we call the "suffix".
-      See the below BNF for the meaning of the attributes.
-  *)
-  module Attribute_node = struct
-    type after_fun =
-      | Cases
-      | Constraint_then_cases
-
-    type t =
-      | Top_level
-      | Fun_then of after_fun
-      | Mode_constraint of Mode_expr.t
-      | Jkind_annotation of Jkind.annotation
-
-    (* We return an [of_suffix_result] from [of_suffix] rather than having
-       [of_suffix] interpret the payload for two reasons:
-         1. It's nice to keep the string production / matching extremely
-            visually simple so it's easy to check that [to_suffix_and_payload]
-            and [of_suffix] correspond.
-         2. We want to raise a [Desugaring_error.Has_payload] in the case that
-            a [No_payload t] has an improper payload, but this creates a
-            dependency cycle between [Attribute_node] and [Desugaring_error].
-            Moving the interpretation of the payload to the caller of
-            [of_suffix] breaks this cycle.
-    *)
-
-    type of_suffix_result =
-      | No_payload of t
-      | Payload of (payload -> loc:Location.t -> t)
-      | Unknown_suffix
-
-    let to_suffix_and_payload = function
-      | Top_level -> [], None
-      | Fun_then Cases -> ["cases"], None
-      | Fun_then Constraint_then_cases -> ["constraint"; "cases"], None
-      | Mode_constraint modes ->
-        let payload = Mode_expr.payload_of modes in
-        ["mode_constraint"], payload
-      | Jkind_annotation jkind_annotation ->
-        let payload = Jkind_annotation.Encode.as_payload jkind_annotation in
-        ["jkind_annotation"], Some payload
-
-    let of_suffix suffix =
-      match suffix with
-      | [] -> No_payload Top_level
-      | ["cases"] -> No_payload (Fun_then Cases)
-      | ["constraint"; "cases"] -> No_payload (Fun_then Constraint_then_cases)
-      | ["mode_constraint"] ->
-        Payload
-          (fun payload ~loc ->
-            let modes = Mode_expr.of_payload payload ~loc in
-            Mode_constraint modes)
-      | ["jkind_annotation"] ->
-        Payload
-          (fun payload ~loc ->
-            assert_extension_enabled ~loc Layouts
-              (Stable : Language_extension.maturity);
-            let jkind_annotation =
-              Jkind_annotation.Decode.from_payload payload ~loc
-            in
-            Jkind_annotation jkind_annotation)
-      | _ -> Unknown_suffix
-
-    let format ppf t =
-      let suffix, _ = to_suffix_and_payload t in
-      Embedded_name.pp_quoted_name ppf (Embedded_name.of_feature feature suffix)
-  end
-
-  module Desugaring_error = struct
-    type error =
-      | Has_payload of payload
-      | Expected_constraint_or_coerce
-      | Expected_function_cases of Attribute_node.t
-      | Expected_fun_or_newtype of Attribute_node.t
-      | Expected_newtype_with_jkind_annotation of Jkind.annotation
-      | Parameterless_function
-
-    let report_error ~loc = function
-      | Has_payload payload ->
-        Location.errorf ~loc
-          "Syntactic arity attribute has an unexpected payload:@;%a"
-          (Printast.payload 0) payload
-      | Expected_constraint_or_coerce ->
-        Location.errorf ~loc
-          "Expected a Pexp_constraint or Pexp_coerce node at this position."
-      | Expected_function_cases attribute ->
-        Location.errorf ~loc
-          "Expected a Pexp_function node in this position, as the enclosing \
-           Pexp_fun is annotated with %a."
-          Attribute_node.format attribute
-      | Expected_fun_or_newtype attribute ->
-        Location.errorf ~loc
-          "Only Pexp_fun or Pexp_newtype may carry the attribute %a."
-          Attribute_node.format attribute
-      | Expected_newtype_with_jkind_annotation annotation ->
-        Location.errorf ~loc "Only Pexp_newtype may carry the attribute %a."
-          Attribute_node.format (Attribute_node.Jkind_annotation annotation)
-      | Parameterless_function ->
-        Location.errorf ~loc
-          "The expression is a Jane Syntax encoding of a function with no \
-           parameters, which is an invalid expression."
-
-    exception Error of Location.t * error
-
-    let () =
-      Location.register_error_of_exn (function
-        | Error (loc, err) -> Some (report_error ~loc err)
-        | _ -> None)
-
-    let raise_with_loc loc err = raise (Error (loc, err))
-
-    let raise expr err = raise (Error (expr.pexp_loc, err))
-  end
-
-  (* The desugared-to-OCaml version of an n-ary function is described by the
-     following BNF, where [{% '...' | expr %}] refers to the result of
-     [Expression.make_jane_syntax] (via n_ary_function_expr) as described at the
-     top of [jane_syntax_parsing.mli]. Within the '...' string, I use <...>
-     brackets to denote string interpolation.
-
-     {v
-         (* The entry point.
-
-            The encoding only puts attributes on:
-              - [fun] nodes
-              - constraint/coercion nodes, on the rare occasions
-                that a constraint should be interpreted at the [local] mode
-
-            This ensures that we rarely put attributes on the *body* of the
-            function, which means that ppxes that move or transform the body
-            of a function won't make Jane Syntax complain.
-         *)
-         n_ary_function ::=
-           | nested_n_ary_function
-           (* A function need not have [fun] params; it can be a function
-              or a constrained function. These need not have extra attributes,
-              except in the rare case that the function is constrained at the
-              local mode.
-           *)
-           | pexp_function
-           | constraint_with_mode_then(pexp_function)
-
-         nested_n_ary_function ::=
-           | fun_then(nested_n_ary_function)
-           | fun_then(constraint_with_mode_then(expression))
-           | {% '_builtin.cases' | fun_then(pexp_function) }
-           | {% '_builtin.constraint.cases' |
-               fun_then(constraint_with_mode_then(pexp_function)) }
-           | fun_then(expression)
-
-
-         fun_then(body) ::=
-           | 'fun' pattern '->' body (* Pexp_fun *)
-           | 'fun' '(' 'type' ident ')' '->' body (* Pexp_newtype *)
-           |{% '_builtin.jkind_annotation' |
-              'fun' '(' 'type' ident ')' '->' body %} (* Pexp_newtype *)
-
-         pexp_function ::=
-           | 'function' cases
-
-         constraint_then(ast) ::=
-           | ast (':' type)? ':>' type (* Pexp_coerce *)
-           | ast ':' type              (* Pexp_constraint *)
-
-         constraint_with_mode_then(ast) ::=
-           | constraint_then(ast)
-           | {% '_builtin.local_constraint' | constraint_then(ast) %}
-     v}
-  *)
-
-  let expand_n_ary_expr expr =
-    match Of_ast.unwrap_jane_syntax_attributes expr.pexp_attributes with
-    | Error (Not_this_embedding _ | Non_embedding) -> None
-    | Ok (suffix, payload, attributes) ->
-      let attribute_node =
-        match Attribute_node.of_suffix suffix, payload with
-        | No_payload t, PStr [] -> Some t
-        | Payload f, payload -> Some (f payload ~loc:expr.pexp_loc)
-        | No_payload _, payload ->
-          Desugaring_error.raise expr (Has_payload payload)
-        | Unknown_suffix, _ -> None
-      in
-      Option.map (fun x -> x, attributes) attribute_node
-
-  let require_function_cases expr ~arity_attribute =
-    match expr.pexp_desc with
-    | Pexp_function cases -> cases
-    | _ -> Desugaring_error.raise expr (Expected_function_cases arity_attribute)
-
-  let constraint_modes expr : Mode_expr.t =
-    match expand_n_ary_expr expr with
-    | Some (Mode_constraint modes, _) -> modes
-    | _ -> Mode_expr.empty
-
-  let check_constraint expr =
-    match expr.pexp_desc with
-    | Pexp_constraint (e, ty) ->
-      let mode_annotations = constraint_modes expr in
-      Some ({ mode_annotations; type_constraint = Pconstraint ty }, e)
-    | Pexp_coerce (e, ty1, ty2) ->
-      let mode_annotations = constraint_modes expr in
-      Some ({ mode_annotations; type_constraint = Pcoerce (ty1, ty2) }, e)
-    | _ -> None
-
-  let require_constraint expr =
-    match check_constraint expr with
-    | Some constraint_ -> constraint_
-    | None -> Desugaring_error.raise expr Expected_constraint_or_coerce
-
-  let check_param pexp_desc (pexp_loc : Location.t) ~jkind =
-    match pexp_desc, jkind with
-    | Pexp_fun (lbl, def, pat, body), None ->
-      let pparam_loc : Location.t =
-        { loc_ghost = true;
-          loc_start = pexp_loc.loc_start;
-          loc_end = pat.ppat_loc.loc_end
-        }
-      in
-      let pparam_desc = Pparam_val (lbl, def, pat) in
-      Some ({ pparam_desc; pparam_loc }, body)
-    | Pexp_newtype (newtype, body), jkind ->
-      (* This imperfectly estimates where a newtype parameter ends: it uses
-         the end of the type name rather than the closing paren. The closing
-         paren location is not tracked anywhere in the parsetree. We don't
-         think merlin is affected.
-      *)
-      let pparam_loc : Location.t =
-        { loc_ghost = true;
-          loc_start = pexp_loc.loc_start;
-          loc_end = newtype.loc.loc_end
-        }
-      in
-      let pparam_desc = Pparam_newtype (newtype, jkind) in
-      Some ({ pparam_desc; pparam_loc }, body)
-    | _, None -> None
-    | _, Some jkind ->
-      Desugaring_error.raise_with_loc pexp_loc
-        (Expected_newtype_with_jkind_annotation jkind)
-
-  let require_param pexp_desc pexp_loc ~arity_attribute ~jkind =
-    match check_param pexp_desc pexp_loc ~jkind with
-    | Some x -> x
-    | None ->
-      Desugaring_error.raise_with_loc pexp_loc
-        (Expected_fun_or_newtype arity_attribute)
-
-  (* Should only be called on [Pexp_fun] and [Pexp_newtype]. *)
-  let extract_fun_params =
-    let open struct
-      type continue_or_stop =
-        | Continue of Parsetree.expression
-        | Stop of function_constraint option * function_body
-    end in
-    (* Returns: the next parameter, together with whether there are possibly
-       more parameters available ("Continue") or whether all parameters have
-       been consumed ("Stop").
-
-       The returned attributes are the remaining unconsumed attributes on the
-       Pexp_fun or Pexp_newtype node.
-
-       The [jkind] parameter gives the jkind at which to interpret the type
-       introduced by [expr = Pexp_newtype _]. It is only supplied in a recursive
-       call to [extract_next_fun_param] in the event that it sees a
-       [Jkind_annotation] attribute.
-    *)
-    let rec extract_next_fun_param expr ~jkind :
-        (function_param * attributes) option * continue_or_stop =
-      match expand_n_ary_expr expr with
-      | None -> (
-        match check_param expr.pexp_desc expr.pexp_loc ~jkind with
-        | Some (param, body) ->
-          Some (param, expr.pexp_attributes), Continue body
-        | None -> None, Stop (None, Pfunction_body expr))
-      | Some (Top_level, _) -> None, Stop (None, Pfunction_body expr)
-      | Some (Jkind_annotation next_jkind, unconsumed_attributes) ->
-        extract_next_fun_param
-          { expr with pexp_attributes = unconsumed_attributes }
-          ~jkind:(Some next_jkind)
-      | Some (Mode_constraint _, _unconsumed_attributes) ->
-        (* We need not pass through any unconsumed attributes, as
-            [Mode_constraint _] isn't the outermost Jane Syntax node:
-            [extract_fun_params] took in [Pexp_fun] or [Pexp_newtype].
-        *)
-        let function_constraint, body = require_constraint expr in
-        None, Stop (Some function_constraint, Pfunction_body body)
-      | Some ((Fun_then after_fun as arity_attribute), unconsumed_attributes) ->
-        let param, body =
-          require_param expr.pexp_desc expr.pexp_loc ~arity_attribute ~jkind
-        in
-        let continue_or_stop =
-          match after_fun with
-          | Cases ->
-            let cases = require_function_cases body ~arity_attribute in
-            let function_body =
-              Pfunction_cases (cases, body.pexp_loc, body.pexp_attributes)
-            in
-            Stop (None, function_body)
-          | Constraint_then_cases ->
-            let function_constraint, body = require_constraint body in
-            let cases = require_function_cases body ~arity_attribute in
-            let function_body =
-              Pfunction_cases (cases, body.pexp_loc, body.pexp_attributes)
-            in
-            Stop (Some function_constraint, function_body)
-        in
-        Some (param, unconsumed_attributes), continue_or_stop
-    in
-    let rec loop expr ~rev_params =
-      let next_param, continue_or_stop =
-        extract_next_fun_param expr ~jkind:None
-      in
-      let rev_params =
-        match next_param with
-        | None -> rev_params
-        | Some (x, _) -> x :: rev_params
-      in
-      match continue_or_stop with
-      | Continue body -> loop body ~rev_params
-      | Stop (function_constraint, body) ->
-        let params = List.rev rev_params in
-        params, function_constraint, body
-    in
-    fun expr ->
-      (match expr.pexp_desc with
-      | Pexp_newtype _ | Pexp_fun _ -> ()
-      | _ -> Misc.fatal_error "called on something that isn't a newtype or fun");
-      let unconsumed_attributes =
-        match extract_next_fun_param expr ~jkind:None with
-        | Some (_, attributes), _ -> attributes
-        | None, _ -> Desugaring_error.raise expr Parameterless_function
-      in
-      loop expr ~rev_params:[], unconsumed_attributes
-
-  (* Returns remaining unconsumed attributes on outermost expression *)
-  let of_expr =
-    let function_without_additional_params cases constraint_ loc : expression =
-      (* If the outermost node is function cases, we place the
-          attributes on the function node as a whole rather than on the
-          [Pfunction_cases] body.
-      *)
-      [], constraint_, Pfunction_cases (cases, loc, [])
-    in
-    (* Hack: be more permissive toward a way that a ppx can mishandle an
-       attribute, which is to duplicate the top-level Jane Syntax
-       attribute.
-    *)
-    let rec remove_top_level_attributes expr =
-      match expand_n_ary_expr expr with
-      | Some (Top_level, unconsumed_attributes) ->
-        remove_top_level_attributes
-          { expr with pexp_attributes = unconsumed_attributes }
-      | _ -> expr
-    in
-    fun expr ->
-      let expr = remove_top_level_attributes expr in
-      match expr.pexp_desc with
-      | Pexp_fun _ | Pexp_newtype _ -> Some (extract_fun_params expr)
-      | Pexp_function cases ->
-        let n_ary =
-          function_without_additional_params cases None expr.pexp_loc
-        in
-        Some (n_ary, expr.pexp_attributes)
-      | _ -> (
-        match check_constraint expr with
-        | Some (constraint_, { pexp_desc = Pexp_function cases }) ->
-          let n_ary =
-            function_without_additional_params cases (Some constraint_)
-              expr.pexp_loc
-          in
-          Some (n_ary, expr.pexp_attributes)
-        | _ -> None)
-
-  let n_ary_function_expr ext x =
-    let suffix, payload = Attribute_node.to_suffix_and_payload ext in
-    Ast_of.wrap_jane_syntax ?payload suffix x
-
-  let expr_of =
-    let add_param ?after_fun_attribute { pparam_desc; pparam_loc } body =
-      let fun_ =
-        let loc =
-          { !Ast_helper.default_loc with loc_start = pparam_loc.loc_start }
-        in
-        match pparam_desc with
-        | Pparam_val (label, default, pat) ->
-          Ast_helper.Exp.fun_ label default pat body ~loc
-          [@alert "-prefer_jane_syntax"]
-        | Pparam_newtype (newtype, jkind) -> (
-          match jkind with
-          | None -> Ast_helper.Exp.newtype newtype body ~loc
-          | Some jkind ->
-            n_ary_function_expr (Jkind_annotation jkind)
-              (Ast_helper.Exp.newtype newtype body ~loc))
-      in
-      match after_fun_attribute with
-      | None -> fun_
-      | Some after_fun -> n_ary_function_expr (Fun_then after_fun) fun_
-    in
-    fun ~loc (params, constraint_, function_body) ->
-      (* See Note [Wrapping with make_entire_jane_syntax] *)
-      Expression.make_entire_jane_syntax ~loc feature (fun () ->
-          let body =
-            match function_body with
-            | Pfunction_body body -> body
-            | Pfunction_cases (cases, loc, attrs) ->
-              Ast_helper.Exp.function_ cases ~loc ~attrs
-              [@alert "-prefer_jane_syntax"]
-          in
-          let possibly_constrained_body =
-            match constraint_ with
-            | None -> body
-            | Some { mode_annotations; type_constraint } -> (
-              let constrained_body =
-                (* We can't call [Location.ghostify] here, as we need this file
-                   to build with the upstream compiler; see Note [Buildable with
-                   upstream] in jane_syntax.mli for details. *)
-                let loc = { body.pexp_loc with loc_ghost = true } in
-                match type_constraint with
-                | Pconstraint ty -> Ast_helper.Exp.constraint_ body ty ~loc
-                | Pcoerce (ty1, ty2) -> Ast_helper.Exp.coerce body ty1 ty2 ~loc
-              in
-              match mode_annotations.txt with
-              | _ :: _ ->
-                n_ary_function_expr (Mode_constraint mode_annotations)
-                  constrained_body
-              | [] -> constrained_body)
-          in
-          match params with
-          | [] -> possibly_constrained_body
-          | params ->
-            let init_params, last_param = Misc.split_last params in
-            let after_fun_attribute : Attribute_node.after_fun option =
-              match constraint_, function_body with
-              | Some _, Pfunction_cases _ -> Some Constraint_then_cases
-              | None, Pfunction_cases _ -> Some Cases
-              | Some _, Pfunction_body _ -> None
-              | None, Pfunction_body _ -> None
-            in
-            let body_with_last_param =
-              add_param last_param ?after_fun_attribute
-                possibly_constrained_body
-            in
-            List.fold_right add_param init_params body_with_last_param)
 end
 
 (** Labeled tuples *)
@@ -1827,7 +1332,9 @@ module Layouts = struct
             let has_name, inner_typ =
               match name with
               | None -> "anon", aliased_type
-              | Some name -> "named", Ast_helper.Typ.alias aliased_type name
+              | Some name ->
+                ( "named",
+                  Ast_helper.Typ.alias aliased_type (Location.mkloc name loc) )
             in
             Type_of.wrap_jane_syntax ["alias"; has_name] ~payload inner_typ)
     with No_wrap_necessary result_type -> result_type
@@ -1867,7 +1374,7 @@ module Layouts = struct
         let jkind = Decode.from_payload ~loc payload in
         match typ.ptyp_desc with
         | Ptyp_alias (inner_typ, name) ->
-          Ltyp_alias { aliased_type = inner_typ; name = Some name; jkind }
+          Ltyp_alias { aliased_type = inner_typ; name = Some name.txt; jkind }
         | _ -> Desugaring_error.raise ~loc (Unexpected_wrapped_type typ))
       | _ -> Desugaring_error.raise ~loc (Unexpected_attribute names)
     in
@@ -2119,7 +1626,6 @@ module Expression = struct
     | Jexp_comprehension of Comprehensions.expression
     | Jexp_immutable_array of Immutable_arrays.expression
     | Jexp_layout of Layouts.expression
-    | Jexp_n_ary_function of N_ary_functions.expression
     | Jexp_tuple of Labeled_tuples.expression
     | Jexp_modes of Modes.expression
 
@@ -2134,10 +1640,6 @@ module Expression = struct
     | Language_extension Layouts ->
       let expr, attrs = Layouts.of_expr expr in
       Some (Jexp_layout expr, attrs)
-    | Builtin -> (
-      match N_ary_functions.of_expr expr with
-      | Some (expr, attrs) -> Some (Jexp_n_ary_function expr, attrs)
-      | None -> None)
     | Language_extension Labeled_tuples ->
       let expr, attrs = Labeled_tuples.of_expr expr in
       Some (Jexp_tuple expr, attrs)
@@ -2154,7 +1656,6 @@ module Expression = struct
       | Jexp_comprehension x -> Comprehensions.expr_of ~loc x
       | Jexp_immutable_array x -> Immutable_arrays.expr_of ~loc x
       | Jexp_layout x -> Layouts.expr_of ~loc x
-      | Jexp_n_ary_function x -> N_ary_functions.expr_of ~loc x
       | Jexp_tuple x -> Labeled_tuples.expr_of ~loc x
       | Jexp_modes x -> Modes.expr_of ~loc x
     in

--- a/ocaml/parsing/jane_syntax.mli
+++ b/ocaml/parsing/jane_syntax.mli
@@ -131,17 +131,15 @@ module Mode_expr : sig
   module Const : sig
     (** Constant modes *)
 
-    type raw = string
-
     (** Represent a user-written mode constant, containing a string and its
         location *)
-    type t = private raw Location.loc
+    type t = Parsetree.mode_const_expression
 
     (** Constructs a mode constant mode *)
     val mk : string -> Location.t -> t
   end
 
-  type t = Const.t list Location.loc
+  type t = Parsetree.mode_expression
 
   (** The empty mode expression. *)
   val empty : t
@@ -198,17 +196,15 @@ module Jkind : sig
   module Const : sig
     (** Constant jkind *)
 
-    type raw = string
-
     (** Represent a user-written kind primitive/abbreviation,
         containing a string and its location *)
-    type t = private raw Location.loc
+    type t = Parsetree.jkind_const_annotation
 
     (** Constructs a jkind constant *)
     val mk : string -> Location.t -> t
   end
 
-  type t =
+  type t = Parsetree.jkind_annotation =
     | Default
     | Abbreviation of Const.t
     | Mod of t * Mode_expr.t
@@ -216,99 +212,6 @@ module Jkind : sig
     | Kind_of of Parsetree.core_type
 
   type annotation = t Location.loc
-end
-
-module N_ary_functions : sig
-  (** These types use the [P] prefix to match how they are represented in the
-      upstream compiler *)
-
-  (** See the comment on [expression]. *)
-  type function_body =
-    | Pfunction_body of Parsetree.expression
-    | Pfunction_cases of Parsetree.case list * Location.t * Parsetree.attributes
-        (** In [Pfunction_cases (_, loc, attrs)], the location extends from the
-        start of the [function] keyword to the end of the last case. The
-        compiler will only use typechecking-related attributes from [attrs],
-        e.g. enabling or disabling a warning.
-    *)
-
-  type function_param_desc =
-    | Pparam_val of
-        Asttypes.arg_label * Parsetree.expression option * Parsetree.pattern
-        (** [Pparam_val (lbl, exp0, P)] represents the parameter:
-        - [P]
-          when [lbl] is {{!Asttypes.arg_label.Nolabel}[Nolabel]}
-          and [exp0] is [None]
-        - [~l:P]
-          when [lbl] is {{!Asttypes.arg_label.Labelled}[Labelled l]}
-          and [exp0] is [None]
-        - [?l:P]
-          when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
-          and [exp0] is [None]
-        - [?l:(P = E0)]
-          when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
-          and [exp0] is [Some E0]
-
-        Note: If [E0] is provided, only
-        {{!Asttypes.arg_label.Optional}[Optional]} is allowed.
-    *)
-    | Pparam_newtype of string Asttypes.loc * Jkind.annotation option
-        (** [Pparam_newtype (x, jkind)] represents the parameter [(type x)].
-        [x] carries the location of the identifier, whereas [pparam_loc] is
-        the location of the [(type x)] as a whole.
-
-        [jkind] is the same as [Lexp_newtype]'s jkind.
-
-        Multiple parameters [(type a b c)] are represented as multiple
-        [Pparam_newtype] nodes, let's say:
-
-        {[ [ { pparam_desc = Pparam_newtype (a, _); pparam_loc = loc };
-             { pparam_desc = Pparam_newtype (b, _); pparam_loc = loc };
-             { pparam_desc = Pparam_newtype (c, _); pparam_loc = loc };
-           ]
-        ]}
-
-        Here, [loc] gives the location of [(type a b c)], but is marked as a
-        ghost location. The locations on [a], [b], [c], correspond to the
-        variables [a], [b], and [c] in the source code.
-    *)
-
-  type function_param =
-    { pparam_desc : function_param_desc;
-      pparam_loc : Location.t
-    }
-
-  type type_constraint = Parsetree.type_constraint =
-    | Pconstraint of Parsetree.core_type
-    | Pcoerce of Parsetree.core_type option * Parsetree.core_type
-
-  (** The mode annotation placed on a function let-binding when the function
-      has a type constraint on the body, e.g.
-      [let local_ f x : int -> int = ...].
-  *)
-  type function_constraint =
-    { mode_annotations : Mode_expr.t;
-      type_constraint : type_constraint
-    }
-
-  (** [([P1; ...; Pn], C, body)] represents any construct
-      involving [fun] or [function], including:
-      - [fun P1 ... Pn -> E]
-        when [body = Pfunction_body E]
-      - [fun P1 ... Pn -> function p1 -> e1 | ... | pm -> em]
-        when [body = Pfunction_cases [ p1 -> e1; ...; pm -> em ]]
-
-      [C] represents a type constraint or coercion placed immediately
-      before the arrow, e.g. [fun P1 ... Pn : t1 :> t2 -> ...]
-      when [C = Some (Pcoerce (Some t1, t2))].
-
-      A function must have parameters. [Pexp_function (params, _, body)] must
-      have non-empty [params] or a [Pfunction_cases _] body.
-  *)
-  type expression =
-    function_param list * function_constraint option * function_body
-
-  val expr_of : loc:Location.t -> expression -> Parsetree.expression
 end
 
 (** The ASTs for labeled tuples. When we merge this upstream, we'll replace
@@ -627,7 +530,6 @@ module Expression : sig
     | Jexp_comprehension of Comprehensions.expression
     | Jexp_immutable_array of Immutable_arrays.expression
     | Jexp_layout of Layouts.expression
-    | Jexp_n_ary_function of N_ary_functions.expression
     | Jexp_tuple of Labeled_tuples.expression
     | Jexp_modes of Modes.expression
 

--- a/ocaml/parsing/jane_syntax_parsing.ml
+++ b/ocaml/parsing/jane_syntax_parsing.ml
@@ -94,9 +94,7 @@ end
 (******************************************************************************)
 
 module Feature : sig
-  type t =
-    | Language_extension : _ Language_extension.t -> t
-    | Builtin
+  type t = Language_extension : _ Language_extension.t -> t
 
   type error =
     | Disabled_extension : _ Language_extension.t -> error
@@ -110,42 +108,29 @@ module Feature : sig
 
   val is_erasable : t -> bool
 end = struct
-  type t =
-    | Language_extension : _ Language_extension.t -> t
-    | Builtin
+  type t = Language_extension : _ Language_extension.t -> t
 
   type error =
     | Disabled_extension : _ Language_extension.t -> error
     | Unknown_extension of string
 
-  let builtin_component = "_builtin"
-
   let describe_uppercase = function
     | Language_extension ext ->
       "The extension \"" ^ Language_extension.to_string ext ^ "\""
-    | Builtin -> "Built-in syntax"
 
   let extension_component = function
     | Language_extension ext -> Language_extension.to_string ext
-    | Builtin -> builtin_component
 
   let of_component str =
-    if String.equal str builtin_component
-    then Ok Builtin
-    else
-      match Language_extension.of_string str with
-      | Some (Pack ext) ->
-        if Language_extension.is_enabled ext
-        then Ok (Language_extension ext)
-        else Error (Disabled_extension ext)
-      | None -> Error (Unknown_extension str)
+    match Language_extension.of_string str with
+    | Some (Pack ext) ->
+      if Language_extension.is_enabled ext
+      then Ok (Language_extension ext)
+      else Error (Disabled_extension ext)
+    | None -> Error (Unknown_extension str)
 
   let is_erasable = function
     | Language_extension ext -> Language_extension.is_erasable ext
-    (* Builtin syntax changes don't involve additions or changes to concrete
-       syntax and are always erasable.
-    *)
-    | Builtin -> true
 end
 
 (** Was this embedded as an [[%extension_node]] or an [[@attribute]]?  Not

--- a/ocaml/parsing/jane_syntax_parsing.mli
+++ b/ocaml/parsing/jane_syntax_parsing.mli
@@ -93,9 +93,7 @@
     language extension (separated out by which one) or the collection of all
     built-in features. *)
 module Feature : sig
-  type t =
-    | Language_extension : _ Language_extension.t -> t
-    | Builtin
+  type t = Language_extension : _ Language_extension.t -> t
 
   (** The component of an attribute or extension name that identifies the
       feature. This is third component.

--- a/ocaml/parsing/lexer.mll
+++ b/ocaml/parsing/lexer.mll
@@ -587,7 +587,6 @@ rule token = parse
   | "?" (lowercase_latin1 identchar_latin1 * as name) ':'
       { warn_latin1 lexbuf;
         OPTLABEL name }
-<<<<<<< HEAD
   (* Lowercase identifiers are split into 3 cases, and the order matters
      (longest to shortest).
   *)
@@ -599,11 +598,8 @@ rule token = parse
       (* See Note [Lexing hack for float#] *)
       { enqueue_hash_suffix_from_end_of_lexbuf_window lexbuf;
         lookup_keyword name }
-||||||| 121bedcfd2
-=======
   | raw_ident_escape (lowercase identchar * as name)
       { LIDENT name }
->>>>>>> 5.2.0
   | lowercase identchar * as name
       { lookup_keyword name }
   (* Lowercase latin1 identifiers are split into 3 cases, and the order matters

--- a/ocaml/parsing/location.ml
+++ b/ocaml/parsing/location.ml
@@ -261,16 +261,8 @@ let print_filename ppf file =
    Some of the information (filename, line number or characters numbers) in the
    location might be invalid; in which case we do not print it.
  *)
-<<<<<<< HEAD
 let print_loc ~capitalize_first ppf loc =
-  setup_colors ();
-||||||| 121bedcfd2
-let print_loc ppf loc =
-  setup_colors ();
-=======
-let print_loc ppf loc =
   setup_tags ();
->>>>>>> 5.2.0
   let file_valid = function
     | "_none_" ->
         (* This is a dummy placeholder, but we print it anyway to please editors

--- a/ocaml/parsing/parse.ml
+++ b/ocaml/parsing/parse.ml
@@ -163,25 +163,6 @@ let prepare_error err =
       in
       Location.errorf ~loc "invalid package type: %a" invalid ipt
   | Removed_string_set loc ->
-<<<<<<< HEAD
-    Location.errorf ~loc
-      "Syntax error: strings are immutable, there is no assignment \
-       syntax for them.\n\
-       @{<hint>Hint@}: Mutable sequences of bytes are available in \
-       the Bytes module.\n\
-       @{<hint>Hint@}: Did you mean to use 'Bytes.set'?"
-  | Missing_unboxed_literal_suffix loc ->
-    Location.errorf ~loc
-      "Syntax error: Unboxed integer literals require width suffixes."
-
-||||||| 121bedcfd2
-      Location.errorf ~loc
-        "Syntax error: strings are immutable, there is no assignment \
-         syntax for them.\n\
-         @{<hint>Hint@}: Mutable sequences of bytes are available in \
-         the Bytes module.\n\
-         @{<hint>Hint@}: Did you mean to use 'Bytes.set'?"
-=======
       Location.errorf ~loc
         "Syntax error: strings are immutable, there is no assignment \
          syntax for them.\n\
@@ -189,7 +170,10 @@ let prepare_error err =
          the Bytes module.\n\
          @{<hint>Hint@}: Did you mean to use %a?"
         Style.inline_code "Bytes.set"
->>>>>>> 5.2.0
+  | Missing_unboxed_literal_suffix loc ->
+      Location.errorf ~loc
+        "Syntax error: Unboxed integer literals require width suffixes."
+
 let () =
   Location.register_error_of_exn
     (function

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -33,7 +33,6 @@ open Parsetree
 open Ast_helper
 open Docstrings
 open Docstrings.WithMenhir
-module N_ary = Jane_syntax.N_ary_functions
 module Mode = Jane_syntax.Mode_expr
 
 let mkloc = Location.mkloc
@@ -152,10 +151,6 @@ let mkuplus ~oploc name arg =
   | _ ->
       Pexp_apply(mkoperator ~loc:oploc ("~" ^ name), [Nolabel, arg]), []
 
-let mk_attr ~loc name payload =
-  Builtin_attributes.(register_attr Parser name);
-  Attr.mk ~loc name payload
-
 let mkexp_with_modes ?(ghost=false) ~loc modes exp =
   let loc =
     if ghost then ghost_loc loc else make_loc loc
@@ -269,30 +264,15 @@ let rec mktailpat nilloc = let open Location in function
 let mkstrexp e attrs =
   { pstr_desc = Pstr_eval (e, attrs); pstr_loc = e.pexp_loc }
 
-<<<<<<< HEAD
-let mkexp_type_constraint ?(ghost=false) ~loc e t =
-  let desc =
-    match t with
-  | N_ary.Pconstraint t -> Pexp_constraint(e, t)
-  | N_ary.Pcoerce(t1, t2)  -> Pexp_coerce(e, t1, t2)
-  in
-  if ghost then ghexp ~loc desc
-  else mkexp ~loc desc
-||||||| 121bedcfd2
-let mkexp_constraint ~loc e (t1, t2) =
-  match t1, t2 with
-  | Some t, None -> mkexp ~loc (Pexp_constraint(e, t))
-  | _, Some t -> mkexp ~loc (Pexp_coerce(e, t1, t))
-  | None, None -> assert false
-=======
-let mkexp_desc_constraint e t =
+let mkexp_desc_type_constraint e t =
   match t with
   | Pconstraint t -> Pexp_constraint(e, t)
   | Pcoerce(t1, t2)  -> Pexp_coerce(e, t1, t2)
 
-let mkexp_constraint ~loc e t =
-  mkexp ~loc (mkexp_desc_constraint e t)
->>>>>>> 5.2.0
+let mkexp_type_constraint ?(ghost=false) ~loc e t =
+  let desc = mkexp_desc_type_constraint e t in
+  if ghost then ghexp ~loc desc
+  else mkexp ~loc desc
 
 let mkexp_opt_type_constraint ~loc e = function
   | None -> e
@@ -761,14 +741,12 @@ let class_of_let_bindings ~loc lbs body =
     assert (lbs.lbs_extension = None);
     mkclass ~loc (Pcl_let (lbs.lbs_rec, List.rev bindings, body))
 
-<<<<<<< HEAD
 (* If all the parameters are [Pparam_newtype x], then return [Some xs] where
    [xs] is the corresponding list of values [x]. This function is optimized for
    the common case, where a list of parameters contains at least one value
    parameter.
 *)
 let all_params_as_newtypes =
-  let open N_ary in
   let is_newtype { pparam_desc; _ } =
     match pparam_desc with
     | Pparam_newtype _ -> true
@@ -792,7 +770,7 @@ let mkghost_newtype_function_body newtypes body_constraint body ~loc =
   let wrapped_body =
     match body_constraint with
     | None -> body
-    | Some { N_ary.type_constraint; mode_annotations } ->
+    | Some { type_constraint; mode_annotations } ->
         let {Location.loc_start; loc_end} = body.pexp_loc in
         let loc = loc_start, loc_end in
         let body = mkexp_type_constraint ~ghost:true ~loc body type_constraint in
@@ -800,18 +778,16 @@ let mkghost_newtype_function_body newtypes body_constraint body ~loc =
   in
   mk_newtypes ~loc newtypes wrapped_body
 
-let n_ary_function expr ~attrs ~loc =
-  wrap_exp_attrs ~loc (N_ary.expr_of expr ~loc:(make_loc loc)) attrs
-
 let mkfunction ~loc ~attrs params body_constraint body =
   match body with
-  | N_ary.Pfunction_cases _ ->
-      n_ary_function (params, body_constraint, body) ~loc ~attrs
-  | N_ary.Pfunction_body body_exp -> begin
+  | Pfunction_cases _ ->
+      mkexp_attrs (Pexp_function (params, body_constraint, body)) attrs ~loc
+  | Pfunction_body body_exp -> begin
     (* If all the params are newtypes, then we don't create a function node;
-       we create a newtype node. *)
+       we create nested newtype nodes. *)
       match all_params_as_newtypes params with
-      | None -> n_ary_function (params, body_constraint, body) ~loc ~attrs
+      | None ->
+         mkexp_attrs (Pexp_function (params, body_constraint, body)) attrs ~loc
       | Some newtypes ->
           wrap_exp_attrs
             ~loc
@@ -820,67 +796,6 @@ let mkfunction ~loc ~attrs params body_constraint body =
             attrs
     end
 
-||||||| 121bedcfd2
-=======
-(* If all the parameters are [Pparam_newtype x], then return [Some xs] where
-   [xs] is the corresponding list of values [x]. This function is optimized for
-   the common case, where a list of parameters contains at least one value
-   parameter.
-*)
-let all_params_as_newtypes =
-  let is_newtype { pparam_desc; _ } =
-    match pparam_desc with
-    | Pparam_newtype _ -> true
-    | Pparam_val _ -> false
-  in
-  let as_newtype { pparam_desc; pparam_loc } =
-    match pparam_desc with
-    | Pparam_newtype x -> Some (x, pparam_loc)
-    | Pparam_val _ -> None
-  in
-  fun params ->
-    if List.for_all is_newtype params
-    then Some (List.filter_map as_newtype params)
-    else None
-
-(* Given a construct [fun (type a b c) : t -> e], we construct
-   [Pexp_newtype(a, Pexp_newtype(b, Pexp_newtype(c, Pexp_constraint(e, t))))]
-   rather than a [Pexp_function].
-*)
-let mkghost_newtype_function_body newtypes body_constraint body =
-  let wrapped_body =
-    match body_constraint with
-    | None -> body
-    | Some body_constraint ->
-        let loc = { body.pexp_loc with loc_ghost = true } in
-        Exp.mk (mkexp_desc_constraint body body_constraint) ~loc
-  in
-  let expr =
-    List.fold_right
-      (fun (newtype, newtype_loc) e ->
-         (* Mints a ghost location that approximates the newtype's "extent" as
-            being from the start of the newtype param until the end of the
-            function body.
-         *)
-         let loc = (newtype_loc.Location.loc_start, body.pexp_loc.loc_end) in
-         ghexp (Pexp_newtype (newtype, e)) ~loc)
-      newtypes
-      wrapped_body
-  in
-  expr.pexp_desc
-
-let mkfunction params body_constraint body =
-  match body with
-  | Pfunction_cases _ -> Pexp_function (params, body_constraint, body)
-  | Pfunction_body body_exp ->
-    (* If all the params are newtypes, then we don't create a function node;
-       we create nested newtype nodes. *)
-      match all_params_as_newtypes params with
-      | None -> Pexp_function (params, body_constraint, body)
-      | Some newtypes ->
-          mkghost_newtype_function_body newtypes body_constraint body_exp
-
->>>>>>> 5.2.0
 (* Alternatively, we could keep the generic module type in the Parsetree
    and extract the package type during type-checking. In that case,
    the assertions below should be turned into explicit checks. *)
@@ -1381,7 +1296,6 @@ reversed_nonempty_llist(X):
   xs = rev(reversed_nonempty_llist(X))
     { xs }
 
-<<<<<<< HEAD
 (* [reversed_nonempty_concat(X)] recognizes a nonempty sequence of [X]s (each of
     which is a list), and produces an OCaml list of their concatenation in
     reverse order -- that is, the last element of the last list in the input text
@@ -1402,30 +1316,6 @@ reversed_nonempty_concat(X):
   xs = rev(reversed_nonempty_concat(X))
     { xs }
 
-||||||| 121bedcfd2
-=======
-(* [reversed_nonempty_concat(X)] recognizes a nonempty sequence of [X]s (each of
-   which is a list), and produces an OCaml list of their concatenation in
-   reverse order -- that is, the last element of the last list in the input text
-   appears first in the list.
-*)
-reversed_nonempty_concat(X):
-  x = X
-    { List.rev x }
-| xs = reversed_nonempty_concat(X) x = X
-    { List.rev_append x xs }
-
-(* [nonempty_concat(X)] recognizes a nonempty sequence of [X]s
-   (each of which is a list), and produces an OCaml list of their concatenation
-   in direct order -- that is, the first element of the first list in the input
-   text appears first in the list.
-*)
-
-%inline nonempty_concat(X):
-  xs = rev(reversed_nonempty_concat(X))
-    { xs }
-
->>>>>>> 5.2.0
 (* [reversed_separated_nonempty_llist(separator, X)] recognizes a nonempty list
    of [X]s, separated with [separator]s, and produces an OCaml list in reverse
    order -- that is, the last element in the input text appears first in this
@@ -2668,36 +2558,6 @@ class_type_declarations:
 
 /* Core expressions */
 
-<<<<<<< HEAD
-%inline or_function(EXPR):
-  | EXPR
-      { $1 }
-  | FUNCTION ext_attributes match_cases
-      { let loc = make_loc $sloc in
-        let cases = $3 in
-        mkfunction [] None (Pfunction_cases (cases, loc, []))
-          ~loc:$sloc ~attrs:$2
-      }
-;
-
-(* [fun_seq_expr] (and [fun_expr]) are legal expression bodies of a function.
-   [seq_expr] (and [expr]) are expressions that appear in other contexts
-   (e.g. subexpressions of the expression body of a function).
-   [fun_seq_expr] can't be a bare [function _ -> ...]. [seq_expr] can.
-   This distinction exists because [function _ -> ...] is parsed as a *function
-   cases* body of a function, not an expression body. This so functions can be
-   parsed with the intended arity.
-*)
-fun_seq_expr:
-  | fun_expr    %prec below_SEMI  { $1 }
-  | fun_expr SEMI                 { $1 }
-  | mkexp(fun_expr SEMI seq_expr
-||||||| 121bedcfd2
-seq_expr:
-  | expr        %prec below_SEMI  { $1 }
-  | expr SEMI                     { $1 }
-  | mkexp(expr SEMI seq_expr
-=======
 %inline or_function(EXPR):
   | EXPR
       { $1 }
@@ -2711,17 +2571,15 @@ seq_expr:
            typechecking. For standalone function cases, we want the compiler to
            respect, e.g., [@inline] attributes.
         *)
-        let desc = mkfunction [] None (Pfunction_cases (cases, loc, [])) in
-        mkexp_attrs ~loc:$sloc desc $2
+        mkfunction [] None (Pfunction_cases (cases, loc, [])) ~attrs:$2
+          ~loc:$sloc
       }
 ;
 
 (* [fun_seq_expr] (and [fun_expr]) are legal expression bodies of a function.
    [seq_expr] (and [expr]) are expressions that appear in other contexts
    (e.g. subexpressions of the expression body of a function).
-
    [fun_seq_expr] can't be a bare [function _ -> ...]. [seq_expr] can.
-
    This distinction exists because [function _ -> ...] is parsed as a *function
    cases* body of a function, not an expression body. This so functions can be
    parsed with the intended arity.
@@ -2730,7 +2588,6 @@ fun_seq_expr:
   | fun_expr    %prec below_SEMI  { $1 }
   | fun_expr SEMI                 { $1 }
   | mkexp(fun_expr SEMI seq_expr
->>>>>>> 5.2.0
     { Pexp_sequence($1, $3) })
     { $1 }
   | fun_expr SEMI PERCENT attr_id seq_expr
@@ -2874,7 +2731,7 @@ fun_expr:
       MINUSGREATER fun_body
       { let body_constraint =
           Option.map
-            (fun x : N_ary.function_constraint ->
+            (fun x ->
               { type_constraint = Pconstraint x
               ; mode_annotations = Mode.empty
               })
@@ -2916,9 +2773,6 @@ fun_expr:
 %inline expr:
   | or_function(fun_expr) { $1 }
 ;
-%inline expr:
-  | or_function(fun_expr) { $1 }
-;
 %inline fun_expr_attrs:
   | LET MODULE ext_attributes mkrhs(module_name) module_binding_body IN seq_expr
       { Pexp_letmodule($4, $5, $7), $3 }
@@ -2928,23 +2782,6 @@ fun_expr:
       { let open_loc = make_loc ($startpos($2), $endpos($5)) in
         let od = Opn.mk $5 ~override:$3 ~loc:open_loc in
         Pexp_open(od, $7), $4 }
-<<<<<<< HEAD
-||||||| 121bedcfd2
-  | FUNCTION ext_attributes match_cases
-      { Pexp_function $3, $2 }
-  | FUN ext_attributes labeled_simple_pattern fun_def
-      { let (l,o,p) = $3 in
-        Pexp_fun(l, o, p, $4), $2 }
-  | FUN ext_attributes LPAREN TYPE lident_list RPAREN fun_def
-      { (mk_newtypes ~loc:$sloc $5 $7).pexp_desc, $2 }
-=======
-  /* Cf #5939: we used to accept (fun p when e0 -> e) */
-  | FUN ext_attributes fun_params preceded(COLON, atomic_type)?
-      MINUSGREATER fun_body
-      { let body_constraint = Option.map (fun x -> Pconstraint x) $4 in
-        mkfunction $3 body_constraint $6, $2
-      }
->>>>>>> 5.2.0
   | MATCH ext_attributes seq_expr WITH match_cases
       { Pexp_match($3, $5), $2 }
   | TRY ext_attributes seq_expr WITH match_cases
@@ -2985,27 +2822,9 @@ fun_expr:
   | mkrhs(constr_longident) simple_expr %prec below_HASH
       { mkexp ~loc:$sloc (Pexp_construct($1, Some $2)) }
   | name_tag simple_expr %prec below_HASH
-<<<<<<< HEAD
       { mkexp ~loc:$sloc (Pexp_variant($1, Some $2)) }
   | e1 = fun_expr op = op(infix_operator) e2 = expr
       { mkexp ~loc:$sloc (mkinfix e1 op e2) }
-||||||| 121bedcfd2
-      { Pexp_variant($1, Some $2) }
-  | e1 = expr op = op(infix_operator) e2 = expr
-      { mkinfix e1 op e2 }
-  | subtractive expr %prec prec_unary_minus
-      { mkuminus ~oploc:$loc($1) $1 $2 }
-  | additive expr %prec prec_unary_plus
-      { mkuplus ~oploc:$loc($1) $1 $2 }
-=======
-      { Pexp_variant($1, Some $2) }
-  | e1 = fun_expr op = op(infix_operator) e2 = expr
-      { mkinfix e1 op e2 }
-  | subtractive expr %prec prec_unary_minus
-      { mkuminus ~oploc:$loc($1) $1 $2 }
-  | additive expr %prec prec_unary_plus
-      { mkuplus ~oploc:$loc($1) $1 $2 }
->>>>>>> 5.2.0
 ;
 
 simple_expr:
@@ -3270,25 +3089,12 @@ let_binding_body_no_punning:
       { let v = $2 in (* PR#7344 *)
         let typ, modes1 = $3 in
         let t =
-<<<<<<< HEAD
           Option.map (function
-          | N_ary.Pconstraint t ->
-             Pvc_constraint { locally_abstract_univars = []; typ=t }
-          | N_ary.Pcoerce (ground, coercion) -> Pvc_coercion { ground; coercion}
-          ) typ
-||||||| 121bedcfd2
-          match $2 with
-            Some t, None -> t
-          | _, Some t -> t
-          | _ -> assert false
-=======
-          match $2 with
-            Pconstraint t ->
+          | Pconstraint t ->
              Pvc_constraint { locally_abstract_univars = []; typ=t }
           | Pcoerce (ground, coercion) -> Pvc_coercion { ground; coercion}
->>>>>>> 5.2.0
+          ) typ
         in
-<<<<<<< HEAD
         let modes = Mode.concat modes0 modes1 in
         let modes_ghost = Mode.ghostify modes in
         let exp = mkexp_with_modes ~ghost:true ~loc:$sloc modes_ghost $5 in
@@ -3332,32 +3138,7 @@ let_binding_body_no_punning:
         let exp = mkexp_with_modes ~ghost:true ~loc:$sloc modes_ghost exp in
         (ghpat ~loc (Ppat_constraint($1, poly)), exp, None, let_binding_mode_attrs modes)
        }
-||||||| 121bedcfd2
-        (v, $4, Some {locally_abstract_univars=[]; typ=t})
-        }
-  | let_ident COLON poly(core_type) EQUAL seq_expr
-    {
-      let t = ghtyp ~loc:($loc($3)) $3 in
-      ($1, $5, Some { locally_abstract_univars = []; typ = t})
-    }
-  | let_ident COLON TYPE lident_list DOT core_type EQUAL seq_expr
-      {  ($1, $8, Some { locally_abstract_univars = $4; typ = $6}) }
-=======
-        (v, $4, Some t)
-        }
-  | let_ident COLON poly(core_type) EQUAL seq_expr
-    {
-      let t = ghtyp ~loc:($loc($3)) $3 in
-      ($1, $5, Some (Pvc_constraint { locally_abstract_univars = []; typ=t }))
-    }
-  | let_ident COLON TYPE lident_list DOT core_type EQUAL seq_expr
-    { let constraint' =
-        Pvc_constraint { locally_abstract_univars=$4; typ = $6}
-      in
-      ($1, $8, Some constraint') }
->>>>>>> 5.2.0
   | pattern_no_exn EQUAL seq_expr
-<<<<<<< HEAD
       { ($1, $3, None, []) }
   | simple_pattern_not_ident pvc_modes EQUAL seq_expr
       {
@@ -3374,15 +3155,6 @@ let_binding_body_no_punning:
       { let modes_ghost = Mode.ghostify modes in
         ($2, mkexp_with_modes ~ghost:true ~loc:$sloc modes_ghost ($5 modes_ghost), None,
          let_binding_mode_attrs modes) }
-||||||| 121bedcfd2
-      { ($1, $3, None) }
-  | simple_pattern_not_ident COLON core_type EQUAL seq_expr
-      { ($1, $5, Some { locally_abstract_univars = []; typ=$3}) }
-=======
-      { ($1, $3, None) }
-  | simple_pattern_not_ident COLON core_type EQUAL seq_expr
-      { ($1, $5, Some(Pvc_constraint { locally_abstract_univars=[]; typ=$3 })) }
->>>>>>> 5.2.0
 ;
 let_binding_body:
   | let_binding_body_no_punning
@@ -3450,27 +3222,14 @@ letop_bindings:
         let and_ = {pbop_op; pbop_pat; pbop_exp; pbop_loc} in
         let_pat, let_exp, and_ :: rev_ands }
 ;
-<<<<<<< HEAD
 strict_binding_modes:
-||||||| 121bedcfd2
-fun_binding:
-    strict_binding
-      { $1 }
-  | type_constraint EQUAL seq_expr
-      { mkexp_constraint ~loc:$sloc $3 $1 }
-;
-strict_binding:
-=======
-strict_binding:
->>>>>>> 5.2.0
     EQUAL seq_expr
-<<<<<<< HEAD
       { fun _ -> $2 }
   | fun_params type_constraint? EQUAL fun_body
   (* CR zqian: The above [type_constraint] should be replaced by [constraint_]
     to support mode annotation *)
     { fun mode_annotations ->
-        let constraint_ : N_ary.function_constraint option =
+        let constraint_ : function_constraint option =
           match $2 with
           | None -> None
           | Some type_constraint -> Some { type_constraint; mode_annotations }
@@ -3487,41 +3246,15 @@ fun_body:
   | FUNCTION ext_attributes match_cases
       { let ext, attrs = $2 in
         match ext with
-        | None -> N_ary.Pfunction_cases ($3, make_loc $sloc, attrs)
-        | Some _ ->
-          (* function%foo extension nodes interrupt the arity *)
-          let cases = N_ary.Pfunction_cases ($3, make_loc $sloc, []) in
-          let function_ = mkfunction [] None cases ~loc:$sloc ~attrs:$2 in
-          N_ary.Pfunction_body function_
-      }
-  | fun_seq_expr
-      { N_ary.Pfunction_body $1 }
-||||||| 121bedcfd2
-      { $2 }
-  | labeled_simple_pattern fun_binding
-      { let (l, o, p) = $1 in ghexp ~loc:$sloc (Pexp_fun(l, o, p, $2)) }
-  | LPAREN TYPE lident_list RPAREN fun_binding
-      { mk_newtypes ~loc:$sloc $3 $5 }
-=======
-      { $2 }
-  | fun_params type_constraint? EQUAL fun_body
-      { ghexp ~loc:$sloc (mkfunction $1 $2 $4)
-      }
-;
-fun_body:
-  | FUNCTION ext_attributes match_cases
-      { let ext, attrs = $2 in
-        match ext with
         | None -> Pfunction_cases ($3, make_loc $sloc, attrs)
         | Some _ ->
           (* function%foo extension nodes interrupt the arity *)
-            let cases = Pfunction_cases ($3, make_loc $sloc, []) in
-            Pfunction_body
-              (mkexp_attrs ~loc:$sloc (mkfunction [] None cases) $2)
+          let cases = Pfunction_cases ($3, make_loc $sloc, []) in
+          let function_ = mkfunction [] None cases ~loc:$sloc ~attrs:$2 in
+          Pfunction_body function_
       }
   | fun_seq_expr
       { Pfunction_body $1 }
->>>>>>> 5.2.0
 ;
 %inline match_cases:
   xs = preceded_or_separated_nonempty_llist(BAR, match_case)
@@ -3535,7 +3268,6 @@ match_case:
   | pattern MINUSGREATER DOT
       { Exp.case $1 (Exp.unreachable ~loc:(make_loc $loc($3)) ()) }
 ;
-<<<<<<< HEAD
 fun_param_as_list:
   | LPAREN TYPE ty_params = newtypes RPAREN
       { (* We desugar (type a b c) to (type a) (type b) (type c).
@@ -3548,65 +3280,24 @@ fun_param_as_list:
         in
         List.map
           (fun (newtype, jkind) ->
-             { N_ary.pparam_loc = loc;
+             { pparam_loc = loc;
                pparam_desc = Pparam_newtype (newtype, jkind)
              })
           ty_params
       }
   | LPAREN TYPE mkrhs(LIDENT) COLON jkind_annotation RPAREN
-      { [ { N_ary.pparam_loc = make_loc $sloc;
+      { [ { pparam_loc = make_loc $sloc;
             pparam_desc = Pparam_newtype ($3, Some $5)
           }
         ]
       }
   | labeled_simple_pattern
       { let a, b, c = $1 in
-        [ { N_ary.pparam_loc = make_loc $sloc;
+        [ { pparam_loc = make_loc $sloc;
             pparam_desc = Pparam_val (a, b, c)
           }
         ]
-||||||| 121bedcfd2
-fun_def:
-    MINUSGREATER seq_expr
-      { $2 }
-  | mkexp(COLON atomic_type MINUSGREATER seq_expr
-      { Pexp_constraint ($4, $2) })
-      { $1 }
-/* Cf #5939: we used to accept (fun p when e0 -> e) */
-  | labeled_simple_pattern fun_def
-      {
-       let (l,o,p) = $1 in
-       ghexp ~loc:$sloc (Pexp_fun(l, o, p, $2))
-=======
-fun_param_as_list:
-  | LPAREN TYPE ty_params = lident_list RPAREN
-      { (* We desugar (type a b c) to (type a) (type b) (type c).
-           If we do this desugaring, the loc for each parameter is a ghost.
-        *)
-        let loc =
-          match ty_params with
-          | [] -> assert false (* lident_list is non-empty *)
-          | [_] -> make_loc $sloc
-          | _ :: _ :: _ -> ghost_loc $sloc
-        in
-        List.map
-          (fun x -> { pparam_loc = loc; pparam_desc = Pparam_newtype x })
-          ty_params
->>>>>>> 5.2.0
       }
-<<<<<<< HEAD
-||||||| 121bedcfd2
-  | LPAREN TYPE lident_list RPAREN fun_def
-      { mk_newtypes ~loc:$sloc $3 $5 }
-=======
-  | labeled_simple_pattern
-      { let a, b, c = $1 in
-        [ { pparam_loc = make_loc $sloc; pparam_desc = Pparam_val (a, b, c) } ]
-      }
-;
-fun_params:
-  | nonempty_concat(fun_param_as_list) { $1 }
->>>>>>> 5.2.0
 ;
 fun_params:
   | nonempty_concat(fun_param_as_list) { $1 }
@@ -3732,19 +3423,9 @@ record_expr_content:
     { es }
 ;
 type_constraint:
-<<<<<<< HEAD
-    COLON core_type                             { N_ary.Pconstraint $2 }
-  | COLON core_type COLONGREATER core_type      { N_ary.Pcoerce (Some $2, $4) }
-  | COLONGREATER core_type                      { N_ary.Pcoerce (None, $2) }
-||||||| 121bedcfd2
-    COLON core_type                             { (Some $2, None) }
-  | COLON core_type COLONGREATER core_type      { (Some $2, Some $4) }
-  | COLONGREATER core_type                      { (None, Some $2) }
-=======
     COLON core_type                             { Pconstraint $2 }
   | COLON core_type COLONGREATER core_type      { Pcoerce (Some $2, $4) }
   | COLONGREATER core_type                      { Pcoerce (None, $2) }
->>>>>>> 5.2.0
   | COLON error                                 { syntax_error() }
   | COLONGREATER error                          { syntax_error() }
 ;
@@ -4504,21 +4185,11 @@ with_type_binder:
 
 /* Polymorphic types */
 
-<<<<<<< HEAD
 %inline typevar: (* : string with_loc * jkind_annotation option *)
     QUOTE mkrhs(ident)
       { ($2, None) }
     | LPAREN QUOTE tyvar=mkrhs(ident) COLON jkind=jkind_annotation RPAREN
       { (tyvar, Some jkind) }
-||||||| 121bedcfd2
-%inline typevar:
-  QUOTE mkrhs(ident)
-    { $2 }
-=======
-%inline typevar:
-  QUOTE ident
-    { mkrhs $2 $sloc }
->>>>>>> 5.2.0
 ;
 %inline typevar_list:
   (* : (string with_loc * jkind_annotation option) list *)
@@ -4575,7 +4246,7 @@ alias_type:
     function_type
       { $1 }
   | mktyp(
-      ty = alias_type AS tyvar = typevar
+      ty = alias_type AS QUOTE tyvar = mkrhs(ident)
         { Ptyp_alias(ty, tyvar) }
    )
    { $1 }
@@ -4814,42 +4485,6 @@ tuple_type:
    - applications of type constructors:   int, int list, int option list
    - variant types:                       [`A]
  *)
-<<<<<<< HEAD
-atomic_type:
-  | LPAREN core_type RPAREN
-      { $2 }
-  | LPAREN MODULE ext_attributes package_type RPAREN
-      { wrap_typ_attrs ~loc:$sloc (reloc_typ ~loc:$sloc $4) $3 }
-  | mktyp( /* begin mktyp group */
-      QUOTE ident
-        { Ptyp_var $2 }
-    | UNDERSCORE
-        { Ptyp_any }
-    | tys = actual_type_parameters
-      tid = mkrhs(type_unboxed_longident)
-        { unboxed_type $loc(tid) tid.txt tys }
-    | tys = actual_type_parameters
-      tid = mkrhs(type_longident)
-        { Ptyp_constr(tid, tys) }
-    | LESS meth_list GREATER
-        { let (f, c) = $2 in Ptyp_object (f, c) }
-||||||| 121bedcfd2
-atomic_type:
-  | LPAREN core_type RPAREN
-      { $2 }
-  | LPAREN MODULE ext_attributes package_type RPAREN
-      { wrap_typ_attrs ~loc:$sloc (reloc_typ ~loc:$sloc $4) $3 }
-  | mktyp( /* begin mktyp group */
-      QUOTE ident
-        { Ptyp_var $2 }
-    | UNDERSCORE
-        { Ptyp_any }
-    | tys = actual_type_parameters
-      tid = mkrhs(type_longident)
-        { Ptyp_constr(tid, tys) }
-    | LESS meth_list GREATER
-        { let (f, c) = $2 in Ptyp_object (f, c) }
-=======
 
 
 (*
@@ -4904,7 +4539,6 @@ object_type:
   | mktyp(
       LESS meth_list = meth_list GREATER
         { let (f, c) = meth_list in Ptyp_object (f, c) }
->>>>>>> 5.2.0
     | LESS GREATER
         { Ptyp_object ([], Closed) }
   )
@@ -4933,6 +4567,9 @@ atomic_type:
       tys = actual_type_parameters
       tid = mkrhs(type_longident)
         { Ptyp_constr (tid, tys) }
+    | tys = actual_type_parameters
+      tid = mkrhs(type_unboxed_longident)
+        { unboxed_type $loc(tid) tid.txt tys }
     | tys = actual_type_parameters
       HASH
       cid = mkrhs(clty_longident)
@@ -4969,18 +4606,10 @@ atomic_type:
   | /* empty */
       { [] }
   | ty = atomic_type
-<<<<<<< HEAD
-      { [ty] }
+      { [ ty ] }
   | LPAREN
     tys = separated_nontrivial_llist(COMMA, one_type_parameter_of_several)
     RPAREN
-||||||| 121bedcfd2
-      { [ty] }
-  | LPAREN tys = separated_nontrivial_llist(COMMA, core_type) RPAREN
-=======
-      { [ ty ] }
-  | LPAREN tys = separated_nontrivial_llist(COMMA, core_type) RPAREN
->>>>>>> 5.2.0
       { tys }
 
 (* Layout annotations on type expressions typically require parens, as in [('a :

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -189,22 +189,11 @@ type ctxt = {
   functionrhs : bool;
 }
 
-<<<<<<< HEAD
-let reset_ctxt = { pipe=false; semi=false; ifthenelse=false; functionrhs=false}
-||||||| 121bedcfd2
-let reset_ctxt = { pipe=false; semi=false; ifthenelse=false }
-=======
 let reset_ctxt = { pipe=false; semi=false; ifthenelse=false; functionrhs=false }
->>>>>>> 5.2.0
 let under_pipe ctxt = { ctxt with pipe=true }
 let under_semi ctxt = { ctxt with semi=true }
 let under_ifthenelse ctxt = { ctxt with ifthenelse=true }
-<<<<<<< HEAD
-let under_functionrhs ctxt = { ctxt with functionrhs=true }
-||||||| 121bedcfd2
-=======
 let under_functionrhs ctxt = { ctxt with functionrhs = true }
->>>>>>> 5.2.0
 (*
 let reset_semi ctxt = { ctxt with semi=false }
 let reset_ifthenelse ctxt = { ctxt with ifthenelse=false }
@@ -395,10 +384,11 @@ let rec class_params_def ctxt f =  function
 
 and type_with_label ctxt f (label, c) =
   match label with
-<<<<<<< HEAD
   | Nolabel    -> maybe_modes_type core_type1 ctxt f c (* otherwise parenthesize *)
-  | Labelled s -> pp f "%s:%a" s (maybe_modes_type core_type1 ctxt) c
-  | Optional s -> pp f "?%s:%a" s (maybe_modes_type core_type1 ctxt) c
+  | Labelled s ->
+      pp f "%a:%a" ident_of_name s (maybe_modes_type core_type1 ctxt) c
+  | Optional s ->
+      pp f "?%a:%a" ident_of_name s (maybe_modes_type core_type1 ctxt) c
 
 and jkind ctxt f k = match (k : Jane_syntax.Jkind.t) with
   | Default -> pp f "_"
@@ -427,15 +417,6 @@ and tyvar_jkind_loc ctxt ~print_quote f (str,jkind) =
   match jkind with
   | None -> pptv f str.txt
   | Some lay -> pp f "(%a : %a)" pptv str.txt (jkind_annotation ctxt) lay
-||||||| 121bedcfd2
-  | Nolabel    -> core_type1 ctxt f c (* otherwise parenthesize *)
-  | Labelled s -> pp f "%s:%a" s (core_type1 ctxt) c
-  | Optional s -> pp f "?%s:%a" s (core_type1 ctxt) c
-=======
-  | Nolabel    -> core_type1 ctxt f c (* otherwise parenthesize *)
-  | Labelled s -> pp f "%a:%a" ident_of_name s (core_type1 ctxt) c
-  | Optional s -> pp f "?%a:%a" ident_of_name s (core_type1 ctxt) c
->>>>>>> 5.2.0
 
 and core_type ctxt f x =
   match Jane_syntax.Core_type.of_ast x with
@@ -451,13 +432,7 @@ and core_type ctxt f x =
         pp f "@[<2>%a@;->@;%a@]" (* FIXME remove parens later *)
           (type_with_label ctxt) (l,ct1) (return_type ctxt) ct2
     | Ptyp_alias (ct, s) ->
-<<<<<<< HEAD
-      pp f "@[<2>%a@;as@;%a@]" (core_type1 ctxt) ct tyvar s
-||||||| 121bedcfd2
-        pp f "@[<2>%a@;as@;%a@]" (core_type1 ctxt) ct tyvar s
-=======
         pp f "@[<2>%a@;as@;%a@]" (core_type1 ctxt) ct tyvar s.txt
->>>>>>> 5.2.0
     | Ptyp_poly ([], ct) ->
         core_type ctxt f ct
     | Ptyp_poly (sl, ct) ->
@@ -690,19 +665,11 @@ and labeled_pattern1 ctxt (f:Format.formatter) (label, x) : unit =
 
 and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
   if x.ppat_attributes <> [] then pattern ctxt f x
-<<<<<<< HEAD
   else match Jane_syntax.Pattern.of_ast x with
     | Some (jpat, attrs) -> pattern_jane_syntax ctxt attrs f jpat
     | None ->
     match x.ppat_desc with
-    | Ppat_construct (({txt=Lident ("()"|"[]" as x);_}), None) ->
-||||||| 121bedcfd2
-  else match x.ppat_desc with
-    | Ppat_construct (({txt=Lident ("()"|"[]" as x);_}), None) ->
-=======
-  else match x.ppat_desc with
     | Ppat_construct (({txt=Lident ("()"|"[]"|"true"|"false" as x);_}), None) ->
->>>>>>> 5.2.0
         pp f  "%s" x
     | Ppat_any -> pp f "_";
     | Ppat_var ({txt = txt;_}) -> ident_of_name f txt
@@ -795,54 +762,29 @@ and label_exp ctxt f (l,opt,p) =
       | {ppat_desc = Ppat_var {txt;_}; ppat_attributes = []}
         when txt = rest && Option.is_none m ->
           (match opt with
-<<<<<<< HEAD
-           | Some o -> pp f "?(%s=@;%a)" rest  (expression ctxt) o
-           | None -> pp f "?%s" rest)
-||||||| 121bedcfd2
-           | Some o -> pp f "?(%s=@;%a)@;" rest  (expression ctxt) o
-           | None -> pp f "?%s@ " rest)
-=======
            | Some o ->
-              pp f "?(%a=@;%a)@;" ident_of_name rest  (expression ctxt) o
-           | None -> pp f "?%a@ " ident_of_name rest)
->>>>>>> 5.2.0
+              pp f "?(%a=@;%a)" ident_of_name rest  (expression ctxt) o
+           | None -> pp f "?%a" ident_of_name rest)
       | _ ->
           (match opt with
            | Some o ->
-<<<<<<< HEAD
-               pp f "?%s:(%a%a=@;%a)"
-                 rest
+               pp f "?%a:(%a%a=@;%a)"
+                 ident_of_name rest
                  optional_legacy_modes m
                  (pattern1 ctxt) p (expression ctxt) o
-           | None -> pp f "?%s:%a" rest (maybe_modes_pat ctxt m) p)
-||||||| 121bedcfd2
-               pp f "?%s:(%a=@;%a)@;"
-                 rest (pattern1 ctxt) p (expression ctxt) o
-           | None -> pp f "?%s:%a@;" rest (simple_pattern ctxt) p)
-=======
-               pp f "?%a:(%a=@;%a)@;"
-                 ident_of_name rest (pattern1 ctxt) p (expression ctxt) o
-           | None -> pp f "?%a:%a@;" ident_of_name rest (simple_pattern ctxt) p)
->>>>>>> 5.2.0
+           | None ->
+               pp f "?%a:%a" ident_of_name rest (maybe_modes_pat ctxt m) p)
       end
   | Labelled l -> match p with
     | {ppat_desc  = Ppat_var {txt;_}; ppat_attributes = []}
       when txt = l ->
-<<<<<<< HEAD
         (match m with
         | Some m ->
-          pp f "~(%a %s)" legacy_modes m l
+          pp f "~(%a %a)" legacy_modes m ident_of_name l
         | None ->
-          pp f "~%s" l
+          pp f "~%a" ident_of_name l
         )
-    | _ ->  pp f "~%s:%a" l (maybe_modes_pat ctxt m) p
-||||||| 121bedcfd2
-        pp f "~%s@;" l
-    | _ ->  pp f "~%s:%a@;" l (simple_pattern ctxt) p
-=======
-        pp f "~%a@;" ident_of_name l
-    | _ ->  pp f "~%a:%a@;" ident_of_name l (simple_pattern ctxt) p
->>>>>>> 5.2.0
+    | _ ->  pp f "~%a:%a" ident_of_name l (maybe_modes_pat ctxt m) p
 
 and sugar_expr ctxt f e =
   if e.pexp_attributes <> [] then false
@@ -920,7 +862,47 @@ and sugar_expr ctxt f e =
     end
   | _ -> false
 
-<<<<<<< HEAD
+and function_param ctxt f { pparam_desc; pparam_loc = _ } =
+  match pparam_desc with
+  | Pparam_val (a, b, c) -> label_exp ctxt f (a, b, c)
+  | Pparam_newtype (ty, None) -> pp f "(type %s)" ty.txt
+  | Pparam_newtype (ty, Some annot) ->
+      pp f "(type %s : %a)" ty.txt (jkind_annotation ctxt) annot
+
+and function_body ctxt f x =
+  match x with
+  | Pfunction_body body -> expression ctxt f body
+  | Pfunction_cases (cases, _, attrs) ->
+    pp f "@[<hv>function%a%a@]"
+      (item_attributes ctxt) attrs
+      (case_list ctxt) cases
+
+and function_constraint ctxt f x =
+  (* We don't currently print [x.alloc_mode]; this would need
+     to go on the enclosing [let] binding.
+  *)
+  (* Enable warning 9 to ensure that the record pattern doesn't miss any field.
+  *)
+  match[@ocaml.warning "+9"] x with
+  | { type_constraint = Pconstraint ty; mode_annotations = _ } ->
+    pp f ":@;%a" (core_type ctxt) ty
+  | { type_constraint = Pcoerce (ty1, ty2); mode_annotations = _ } ->
+    pp f "%a:>@;%a"
+      (option ~first:":@;" (core_type ctxt)) ty1
+      (core_type ctxt) ty2
+
+and function_params_then_body ctxt f params constraint_ body ~delimiter =
+  let pp_params f =
+    match params with
+    | [] -> ()
+    | _ :: _ -> pp f "%a@;" (list (function_param ctxt) ~sep:"@ ") params
+  in
+  pp f "%t%a%s@;%a"
+    pp_params
+    (option (function_constraint ctxt) ~first:"@;") constraint_
+    delimiter
+    (function_body (under_functionrhs ctxt)) body
+
 (* Postcondition: If [x] has any non-Jane Syntax attributes, the output will
    be self-delimiting. (I.e., it will be wrapped in parens.)
 
@@ -928,47 +910,10 @@ and sugar_expr ctxt f e =
    expressions that aren't already self-delimiting.
 *)
 and expression ?(jane_syntax_parens = false) ctxt f x =
-  match Jane_syntax.Expression.of_ast x with
-  | Some (jexpr, attrs) ->
-      jane_syntax_expr ctxt attrs f jexpr ~parens:jane_syntax_parens
-  | None ->
-||||||| 121bedcfd2
-and expression ctxt f x =
-=======
-and function_param ctxt f param =
-  match param.pparam_desc with
-  | Pparam_val (a, b, c) -> label_exp ctxt f (a, b, c)
-  | Pparam_newtype ty -> pp f "(type %a)@;" ident_of_name ty.txt
-
-and function_body ctxt f function_body =
-  match function_body with
-  | Pfunction_body body -> expression ctxt f body
-  | Pfunction_cases (cases, _, attrs) ->
-      pp f "@[<hv>function%a%a@]"
-        (item_attributes ctxt) attrs
-        (case_list ctxt) cases
-
-and type_constraint ctxt f constraint_ =
-  match constraint_ with
-  | Pconstraint ty ->
-      pp f ":@;%a" (core_type ctxt) ty
-  | Pcoerce (ty1, ty2) ->
-      pp f "%a:>@;%a"
-        (option ~first:":@;" (core_type ctxt)) ty1
-        (core_type ctxt) ty2
-
-and function_params_then_body ctxt f params constraint_ body ~delimiter =
-  pp f "%a%a%s@;%a"
-    (list (function_param ctxt) ~sep:"") params
-    (option (type_constraint ctxt)) constraint_
-    delimiter
-    (function_body (under_functionrhs ctxt)) body
-
-and expression ctxt f x =
->>>>>>> 5.2.0
-  if x.pexp_attributes <> [] then
-    pp f "((%a)@,%a)" (expression ctxt) {x with pexp_attributes=[]}
-      (attributes ctxt) x.pexp_attributes
+    match Jane_syntax.Expression.of_ast x with
+    | Some (jexpr, attrs) ->
+        jane_syntax_expr ctxt attrs f jexpr ~parens:jane_syntax_parens
+    | None ->
   else match x.pexp_desc with
     | Pexp_function _ | Pexp_match _ | Pexp_try _ | Pexp_sequence _
     | Pexp_newtype _
@@ -980,30 +925,7 @@ and expression ctxt f x =
       | Pexp_letexception _ | Pexp_letop _
         when ctxt.semi ->
         paren true (expression reset_ctxt) f x
-<<<<<<< HEAD
-    | Pexp_fun (l, e0, p, e) ->
-        pp f "@[<2>fun@;%a@;%a@]"
-          (label_exp ctxt) (l, e0, p)
-          (pp_print_pexp_function ctxt "->") e
-||||||| 121bedcfd2
-    | Pexp_fun (l, e0, p, e) ->
-        pp f "@[<2>fun@;%a->@;%a@]"
-          (label_exp ctxt) (l, e0, p)
-          (expression ctxt) e
-=======
->>>>>>> 5.2.0
     | Pexp_newtype (lid, e) ->
-<<<<<<< HEAD
-        pp f "@[<2>fun@;(type@;%s)@;%a@]" lid.txt
-          (pp_print_pexp_function ctxt "->") e
-    | Pexp_function l ->
-        pp f "@[<hv>function%a@]" (case_list ctxt) l
-||||||| 121bedcfd2
-        pp f "@[<2>fun@;(type@;%s)@;->@;%a@]" lid.txt
-          (expression ctxt) e
-    | Pexp_function l ->
-        pp f "@[<hv>function%a@]" (case_list ctxt) l
-=======
         pp f "@[<2>fun@;(type@;%a)@;->@;%a@]" ident_of_name lid.txt
           (expression ctxt) e
     | Pexp_function (params, c, body) ->
@@ -1031,7 +953,6 @@ and expression ctxt f x =
             ();
 
         end
->>>>>>> 5.2.0
     | Pexp_match (e, l) ->
         pp f "@[<hv0>@[<hv0>@[<2>match %a@]@ with@]%a@]"
           (expression reset_ctxt) e (case_list ctxt) l
@@ -1719,7 +1640,7 @@ and payload ctxt f = function
       pp f " when "; expression ctxt f e
 
 and pp_print_pexp_function ctxt sep f x =
-  (* We go to some trouble to print nested [Pexp_newtype]/[Lexp_newtype] as
+  (* We go to some trouble to print nested [Lexp_newtype] as
      newtype parameters of the same "fun" (rather than printing several nested
      "fun (type a) -> ..."). This isn't necessary for round-tripping -- it just
      makes the pretty-printing a bit prettier. *)
@@ -1749,32 +1670,6 @@ and pp_print_pexp_function ctxt sep f x =
 (* transform [f = fun g h -> ..] to [f g h = ... ] could be improved *)
 and binding ctxt f {pvb_pat=p; pvb_expr=x; pvb_constraint = ct; _} =
   (* .pvb_attributes have already been printed by the caller, #bindings *)
-<<<<<<< HEAD
-||||||| 121bedcfd2
-  let rec pp_print_pexp_function f x =
-    if x.pexp_attributes <> [] then pp f "=@;%a" (expression ctxt) x
-    else match x.pexp_desc with
-      | Pexp_fun (label, eo, p, e) ->
-          if label=Nolabel then
-            pp f "%a@ %a" (simple_pattern ctxt) p pp_print_pexp_function e
-          else
-            pp f "%a@ %a"
-              (label_exp ctxt) (label,eo,p) pp_print_pexp_function e
-      | Pexp_newtype (str,e) ->
-          pp f "(type@ %s)@ %a" str.txt pp_print_pexp_function e
-      | _ -> pp f "=@;%a" (expression ctxt) x
-  in
-=======
-  let rec pp_print_pexp_function f x =
-    if x.pexp_attributes <> [] then pp f "=@;%a" (expression ctxt) x
-    else match x.pexp_desc with
-      | Pexp_function (params, c, body) ->
-          function_params_then_body ctxt f params c body ~delimiter:"="
-      | Pexp_newtype (str,e) ->
-          pp f "(type@ %a)@ %a" ident_of_name str.txt pp_print_pexp_function e
-      | _ -> pp f "=@;%a" (expression ctxt) x
-  in
->>>>>>> 5.2.0
   match ct with
   | Some (Pvc_constraint { locally_abstract_univars = []; typ }) ->
       pp f "%a@;:@;%a@;=@;%a"
@@ -1784,7 +1679,6 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; pvb_constraint = ct; _} =
         (simple_pattern ctxt) p (list pp_print_string ~sep:"@;")
         (List.map (fun x -> x.txt) vars)
         (core_type ctxt) typ (expression ctxt) x
-<<<<<<< HEAD
   | Some (Pvc_coercion {ground=None; coercion }) ->
       pp f "%a@;:>@;%a@;=@;%a"
         (simple_pattern ctxt) p (core_type ctxt) coercion (expression ctxt) x
@@ -1832,26 +1726,6 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; pvb_constraint = ct; _} =
           pp f "%a@;: type@;%a.@;%a@;=@;%a"
             (simple_pattern ctxt) p (list pp_print_string ~sep:"@;")
             (tyvars_str tyvars) (core_type ctxt) ct (expression ctxt) e
-||||||| 121bedcfd2
-  | None -> begin
-      match p with
-      | {ppat_desc=Ppat_var _; ppat_attributes=[]} ->
-          pp f "%a@ %a" (simple_pattern ctxt) p pp_print_pexp_function x
-=======
-  | Some (Pvc_coercion {ground=None; coercion }) ->
-      pp f "%a@;:>@;%a@;=@;%a"
-        (simple_pattern ctxt) p (core_type ctxt) coercion (expression ctxt) x
-  | Some (Pvc_coercion {ground=Some ground; coercion }) ->
-      pp f "%a@;:%a@;:>@;%a@;=@;%a"
-        (simple_pattern ctxt) p
-        (core_type ctxt) ground
-        (core_type ctxt) coercion
-        (expression ctxt) x
-  | None -> begin
-      match p with
-      | {ppat_desc=Ppat_var _; ppat_attributes=[]} ->
-          pp f "%a@ %a" (simple_pattern ctxt) p pp_print_pexp_function x
->>>>>>> 5.2.0
       | _ ->
         begin match p with
         | {ppat_desc=Ppat_var _; ppat_attributes=[]} ->
@@ -2010,17 +1884,9 @@ and structure_item ctxt f x =
         let args, constr, cl = extract_class_args x.pci_expr in
         pp f "@[<2>%s %a%a%a %a%a=@;%a@]%a" kwd
           virtual_flag x.pci_virt
-<<<<<<< HEAD
-          (class_params_def ctxt) ls txt
-          (list (label_exp ctxt) ~last:"@ ") args
-||||||| 121bedcfd2
-          (class_params_def ctxt) ls txt
-          (list (label_exp ctxt)) args
-=======
           (class_params_def ctxt) ls
           ident_of_name txt
-          (list (label_exp ctxt)) args
->>>>>>> 5.2.0
+          (list (label_exp ctxt) ~last:"@ ") args
           (option class_constraint) constr
           (class_expr ctxt) cl
           (item_attributes ctxt) x.pci_attributes
@@ -2091,7 +1957,6 @@ and type_def_list ctxt f (rf, exported, l) =
       else if exported then " ="
       else " :="
     in
-<<<<<<< HEAD
     let layout_annot, x =
       match Jane_syntax.Layouts.of_type_declaration x with
       | None -> Format.dprintf "", x
@@ -2100,22 +1965,9 @@ and type_def_list ctxt f (rf, exported, l) =
             (jkind_annotation ctxt) jkind,
           { x with ptype_attributes = remaining_attributes }
     in
-    pp f "@[<2>%s %a%a%s%t%s%a@]%a" kwd
-||||||| 121bedcfd2
-    pp f "@[<2>%s %a%a%s%s%a@]%a" kwd
-=======
-    pp f "@[<2>%s %a%a%a%s%a@]%a" kwd
->>>>>>> 5.2.0
-      nonrec_flag rf
-      (type_params ctxt) x.ptype_params
-<<<<<<< HEAD
-      x.ptype_name.txt layout_annot eq
-||||||| 121bedcfd2
-      x.ptype_name.txt eq
-=======
+    pp f "@[<2>%s %a%a%a%t%s%a@]%a" kwd
       ident_of_name x.ptype_name.txt
-      eq
->>>>>>> 5.2.0
+      layout_annot eq
       (type_declaration ctxt) x
       (item_attributes ctxt) x.ptype_attributes
   in
@@ -2128,22 +1980,10 @@ and type_def_list ctxt f (rf, exported, l) =
 
 and record_declaration ctxt f lbls =
   let type_record_field f pld =
-<<<<<<< HEAD
-    pp f "@[<2>%a%a%s:@;%a@;%a@]"
-||||||| 121bedcfd2
-    pp f "@[<2>%a%s:@;%a@;%a@]"
-=======
-    pp f "@[<2>%a%a:@;%a@;%a@]"
->>>>>>> 5.2.0
+    pp f "@[<2>%a%a%a:@;%a@;%a@]"
       mutable_flag pld.pld_mutable
-<<<<<<< HEAD
       optional_legacy_modalities pld.pld_modalities
-      pld.pld_name.txt
-||||||| 121bedcfd2
-      pld.pld_name.txt
-=======
       ident_of_name pld.pld_name.txt
->>>>>>> 5.2.0
       (core_type ctxt) pld.pld_type
       (attributes ctxt) pld.pld_attributes
   in
@@ -2417,80 +2257,6 @@ and unboxed_constant _ctxt f (x : Jane_syntax.Layouts.constant)
   | Integer (x, suffix) ->
     paren (first_is '-' x) (fun f (x, suffix) -> pp f "%s%c" x suffix) f
       (Misc.format_as_unboxed_literal x, suffix)
-
-and function_param ctxt f
-    ({ pparam_desc; pparam_loc = _ } :
-       Jane_syntax.N_ary_functions.function_param)
-  =
-  match pparam_desc with
-  | Pparam_val (a, b, c) -> label_exp ctxt f (a, b, c)
-  | Pparam_newtype (ty, None) -> pp f "(type %s)" ty.txt
-  | Pparam_newtype (ty, Some annot) ->
-      pp f "(type %s : %a)" ty.txt (jkind_annotation ctxt) annot
-
-and function_body ctxt f (x : Jane_syntax.N_ary_functions.function_body) =
-  match x with
-  | Pfunction_body body -> expression ctxt f body
-  | Pfunction_cases (cases, _, attrs) ->
-    pp f "@[<hv>function%a%a@]"
-      (item_attributes ctxt) attrs
-      (case_list ctxt) cases
-
-and function_constraint
-    ctxt f (x : Jane_syntax.N_ary_functions.function_constraint)
-  =
-  (* We don't currently print [x.alloc_mode]; this would need
-     to go on the enclosing [let] binding.
-  *)
-  (* Enable warning 9 to ensure that the record pattern doesn't miss any field.
-  *)
-  match[@ocaml.warning "+9"] x with
-  | { type_constraint = Pconstraint ty; mode_annotations = _ } ->
-    pp f ":@;%a" (core_type ctxt) ty
-  | { type_constraint = Pcoerce (ty1, ty2); mode_annotations = _ } ->
-    pp f "%a:>@;%a"
-      (option ~first:":@;" (core_type ctxt)) ty1
-      (core_type ctxt) ty2
-
-and function_params_then_body ctxt f params constraint_ body ~delimiter =
-  let pp_params f =
-    match params with
-    | [] -> ()
-    | _ :: _ -> pp f "%a@;" (list (function_param ctxt) ~sep:"@ ") params
-  in
-  pp f "%t%a%s@;%a"
-    pp_params
-    (option (function_constraint ctxt) ~first:"@;") constraint_
-    delimiter
-    (function_body (under_functionrhs ctxt)) body
-
-and n_ary_function_expr
-      ctxt
-      f
-      ((params, constraint_, body) as x : Jane_syntax.N_ary_functions.expression)
-  =
-  if ctxt.pipe || ctxt.semi then
-    paren true (n_ary_function_expr reset_ctxt) f x
-  else
-    match params, constraint_ with
-    (* Omit [fun] if there are no params. *)
-    | [], None ->
-        let should_paren =
-          match body with
-          | Pfunction_cases _ -> ctxt.functionrhs
-          | Pfunction_body _ -> false
-        in
-        let ctxt' = if should_paren then reset_ctxt else ctxt in
-        pp f "@[<2>%a@]" (paren should_paren (function_body ctxt')) body
-    | [], Some constraint_ ->
-      pp f "@[<2>(%a@;%a)@]"
-        (function_body ctxt) body
-        (function_constraint ctxt) constraint_
-    | _ :: _, _ ->
-      pp f "@[<2>fun@;%t@]"
-        (fun f ->
-          function_params_then_body
-            ctxt f params constraint_ body ~delimiter:"->")
 
 and labeled_tuple_expr ctxt f (x : Jane_syntax.Labeled_tuples.expression) =
   pp f "@[<hov2>(%a)@]" (list (tuple_component ctxt) ~sep:",@;") x

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -929,8 +929,8 @@ and expression ?(jane_syntax_parens = false) ctxt f x =
         when ctxt.semi ->
         paren true (expression reset_ctxt) f x
     | Pexp_newtype (lid, e) ->
-        pp f "@[<2>fun@;(type@;%a)@;->@;%a@]" ident_of_name lid.txt
-          (expression ctxt) e
+        pp f "@[<2>fun@;(type@;%s)@;%a@]" lid.txt
+          (pp_print_pexp_newtype ctxt "->") e
     | Pexp_function (params, c, body) ->
         begin match params, c with
         (* Omit [fun] if there are no params. *)

--- a/ocaml/parsing/pprintast.mli
+++ b/ocaml/parsing/pprintast.mli
@@ -50,31 +50,18 @@ val signature_item: Format.formatter -> Parsetree.signature_item -> unit
 val binding: Format.formatter -> Parsetree.value_binding -> unit
 val payload: Format.formatter -> Parsetree.payload -> unit
 
-<<<<<<< HEAD
 val class_signature: Format.formatter -> Parsetree.class_signature -> unit
 val type_declaration: Format.formatter -> Parsetree.type_declaration -> unit
 
-||||||| 121bedcfd2
-=======
 val tyvar_of_name : string -> string
   (** Turn a type variable name into a valid identifier, taking care of the
       special treatment required for the single quote character in second
       position, or for keywords by escaping them with \#. No-op on "_". *)
 
->>>>>>> 5.2.0
 val tyvar: Format.formatter -> string -> unit
-<<<<<<< HEAD
   (** Print a type variable name as a valid identifier, taking care of the
       special treatment required for the single quote character in second
       position, or for keywords by escaping them with \#. No-op on "_". *)
 
 val jkind : Format.formatter -> Jane_syntax.Jkind.t -> unit
 val mode : Format.formatter -> Jane_syntax.Mode_expr.Const.t -> unit
-||||||| 121bedcfd2
-  (** Print a type variable name, taking care of the special treatment
-      required for the single quote character in second position. *)
-=======
-  (** Print a type variable name as a valid identifier, taking care of the
-      special treatment required for the single quote character in second
-      position, or for keywords by escaping them with \#. No-op on "_". *)
->>>>>>> 5.2.0

--- a/ocaml/parsing/unit_info.ml
+++ b/ocaml/parsing/unit_info.ml
@@ -118,5 +118,5 @@ let is_cmi f = Filename.check_suffix (Artifact.filename f) ".cmi"
 
 let find_normalized_cmi f =
   let filename = modname f ^ ".cmi" in
-  let filename = Load_path.find_normalized filename in
+  let filename = Load_path.find_uncap filename in
   { Artifact.filename; modname = modname f; source_file = Some f.source_file  }


### PR DESCRIPTION
This is a combination of resolving conflicts and pulling in changes from #2780.

Testing: `make install` does not report any more build errors for parsing files. I'm working on getting CI set up better in a different branch.

Sorry, this is difficult to review because it's not merely conflict resolution. I don't see a better way of structuring this. #2780's changes are important to include here &mdash; without those changes, we'd have to devise a new Jane Syntax encoding for our functions on top of 5.2's parsetree.

Recommendations for review:
  * For changes that seem to be about n-ary functions, cross-reference #2780.
  * The hardest files to review will be `builtin_attributes.ml` and `parser.mly`.

@ccasin, could you please review the changes to builtin attributes? You will have the most informed opinion. It is mostly true that you wrote both sides of the diff.

@riaqn, could you please review the rest of the changes? They are either trivial merge conflict resolutions or parser changes.