### PR TITLE
Fix issues in the tree related to `Or_null`

### DIFF
--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1083,7 +1083,10 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
             match
               Ctype.check_type_jkind
                 e.exp_env (Ctype.correct_levels val_type)
-                (Jkind.Primitive.value ~why:Probe)
+              (* CR layouts v3: here we allow [value_or_null] because this check
+                 happens too late for the typecheker to infer [non_null]. Test that
+                 nothing breaks once we have null pointers. *)
+                (Jkind.Primitive.value_or_null ~why:Probe)
             with
             | Ok _ -> ()
             | Error _ -> raise (Error (e.exp_loc, Bad_probe_layout id))

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
@@ -685,7 +685,7 @@ end;;
 Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
-Error: This expression has type ('a : value)
+Error: This expression has type ('a : value_or_null)
        but an expression was expected of type t_bits32
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
@@ -687,7 +687,7 @@ end;;
 Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
-Error: This expression has type ('a : value)
+Error: This expression has type ('a : value_or_null)
        but an expression was expected of type t_bits64
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/probe.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/probe.ml
@@ -1,6 +1,7 @@
 (* TEST
  setup-ocamlopt.opt-build-env;
  arch_amd64;
+ not-macos;
  flags = "-extension layouts_alpha";
  compiler_reference2 = "${test_source_directory}/probe.reference";
  ocamlopt_opt_exit_status = "2";

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/probe.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/probe.ml
@@ -1,7 +1,6 @@
 (* TEST
  setup-ocamlopt.opt-build-env;
  arch_amd64;
- not-macos;
  flags = "-extension layouts_alpha";
  compiler_reference2 = "${test_source_directory}/probe.reference";
  ocamlopt_opt_exit_status = "2";

--- a/ocaml/testsuite/tests/typing-layouts-or-null/probe.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/probe.ml
@@ -1,8 +1,10 @@
 (* TEST
  setup-ocamlopt.opt-build-env;
- arch_amd64;
+ {
+  arch_amd64;
+  native;
+ }
  flags = "-extension layouts_alpha";
- compiler_reference2 = "${test_source_directory}/probe.reference";
  compile_only = "true";
  ocamlopt.opt;
  check-ocamlopt.opt-output;

--- a/ocaml/testsuite/tests/typing-layouts-or-null/probe.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/probe.ml
@@ -1,5 +1,6 @@
 (* TEST
  arch_amd64;
+ not-macos;
  ocamlopt_flags = "-extension-universe alpha";
  native;
  setup-ocamlopt.opt-build-env;

--- a/ocaml/testsuite/tests/typing-layouts-or-null/probe.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/probe.ml
@@ -1,11 +1,8 @@
 (* TEST
+ arch_amd64;
+ ocamlopt_flags = "-extension-universe alpha";
+ native;
  setup-ocamlopt.opt-build-env;
- {
-  arch_amd64;
-  native;
- }
- flags = "-extension layouts_alpha";
- compile_only = "true";
  ocamlopt.opt;
  check-ocamlopt.opt-output;
 *)

--- a/ocaml/testsuite/tests/typing-layouts-or-null/probe.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/probe.ml
@@ -1,0 +1,15 @@
+(* TEST
+ setup-ocamlopt.opt-build-env;
+ arch_amd64;
+ flags = "-extension layouts_alpha";
+ compile_only = "true";
+ ocamlopt.opt;
+ check-ocamlopt.opt-output;
+*)
+
+type t : value_or_null
+
+let[@warning "-26"] f (x : t) = [%probe "a" (
+  let f () = x in
+  ()
+)]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/probe.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/probe.ml
@@ -2,6 +2,7 @@
  setup-ocamlopt.opt-build-env;
  arch_amd64;
  flags = "-extension layouts_alpha";
+ compiler_reference2 = "${test_source_directory}/probe.reference";
  compile_only = "true";
  ocamlopt.opt;
  check-ocamlopt.opt-output;

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -397,3 +397,17 @@ Error: This type t_value_or_null dummy should be an instance of type 'a dummy
        But the kind of t_value_or_null must be a subkind of value
          because of the definition of constrained' at lines 1-2, characters 0-44.
 |}]
+
+(* Copied from the tree, should work. *)
+let should_work s =
+  let (a, b) =
+    Marshal.from_string s 0 in
+  ( object
+      method a = a
+      method b = b
+    end
+  )
+
+[%%expect{|
+val should_work : string -> < a : 'a; b : 'b > = <fun>
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
@@ -685,7 +685,7 @@ end;;
 Line 3, characters 17-19:
 3 |     let _ = f1_1 m1 in
                      ^^
-Error: This expression has type ('a : value)
+Error: This expression has type ('a : value_or_null)
        but an expression was expected of type t_word
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -3094,9 +3094,11 @@ let unboxed_type ~errors ~env ~loc ~lid ty =
   match ty with
   | None -> ()
   | Some ty ->
-    (* Sometimes, this function is called on a generalized type variable
-       when it actually should check the specialized one. This is sound,
-       but incomplete. *)
+    (* The type is the type of a variable in the environment. It thus is likely generic. Despite
+       the fact that instantiated variables work better in [constrain_type_jkind] (because they
+       can be assigned more specific jkinds), we actually want to work on these generic types
+       here. After all, it's the value in the environment that is getting captured by the object,
+       not a specific instance of that variable. *)
     match !constrain_type_jkind env ty Jkind.Primitive.(value_or_null ~why:Captured_in_object) with
     | Ok () -> ()
     | Result.Error err ->

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -3094,6 +3094,9 @@ let unboxed_type ~errors ~env ~loc ~lid ty =
   match ty with
   | None -> ()
   | Some ty ->
+    (* Sometimes, this function is called on a generalized type variable
+       when it actually should check the specialized one. This is sound,
+       but incomplete. *)
     match !constrain_type_jkind env ty Jkind.Primitive.(value_or_null ~why:Captured_in_object) with
     | Ok () -> ()
     | Result.Error err ->

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -3094,7 +3094,7 @@ let unboxed_type ~errors ~env ~loc ~lid ty =
   match ty with
   | None -> ()
   | Some ty ->
-    match !constrain_type_jkind env ty Jkind.Primitive.(value ~why:Captured_in_object) with
+    match !constrain_type_jkind env ty Jkind.Primitive.(value_or_null ~why:Captured_in_object) with
     | Ok () -> ()
     | Result.Error err ->
       may_lookup_error errors loc env (Non_value_used_in_object (lid, ty, err))

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1476,6 +1476,8 @@ module Format_history = struct
     | V1_safety_check ->
       fprintf ppf "it has to be value for the V1 safety check"
     | Probe -> format_with_notify_js ppf "it's a probe"
+    | Captured_in_object ->
+      fprintf ppf "it's the type of a variable captured in an object"
 
   let format_value_creation_reason ppf ~layout_or_kind :
       History.value_creation_reason -> _ = function
@@ -1522,8 +1524,6 @@ module Format_history = struct
     | Debug_printer_argument ->
       format_with_notify_js ppf
         "it's the type of an argument to a debugger printer function"
-    | Captured_in_object ->
-      fprintf ppf "it's the type of a variable captured in an object"
     | Recmod_fun_arg ->
       fprintf ppf
         "it's the type of the first argument to a function in a recursive \
@@ -1943,6 +1943,7 @@ module Debug_printers = struct
     | Structure_element -> fprintf ppf "Structure_element"
     | V1_safety_check -> fprintf ppf "V1_safety_check"
     | Probe -> fprintf ppf "Probe"
+    | Captured_in_object -> fprintf ppf "Captured_in_object"
 
   let value_creation_reason ppf : History.value_creation_reason -> _ = function
     | Class_let_binding -> fprintf ppf "Class_let_binding"
@@ -1972,7 +1973,6 @@ module Debug_printers = struct
     | Class_type_argument -> fprintf ppf "Class_type_argument"
     | Class_term_argument -> fprintf ppf "Class_term_argument"
     | Debug_printer_argument -> fprintf ppf "Debug_printer_argument"
-    | Captured_in_object -> fprintf ppf "Captured_in_object"
     | Recmod_fun_arg -> fprintf ppf "Recmod_fun_arg"
     | Unknown s -> fprintf ppf "Unknown %s" s
 

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1475,12 +1475,12 @@ module Format_history = struct
       fprintf ppf "it's the type of something stored in a module structure"
     | V1_safety_check ->
       fprintf ppf "it has to be value for the V1 safety check"
+    | Probe -> format_with_notify_js ppf "it's a probe"
 
   let format_value_creation_reason ppf ~layout_or_kind :
       History.value_creation_reason -> _ = function
     | Class_let_binding ->
       fprintf ppf "it's the type of a let-bound variable in a class expression"
-    | Probe -> format_with_notify_js ppf "it's a probe"
     | Object -> fprintf ppf "it's the type of an object"
     | Instance_variable -> fprintf ppf "it's the type of an instance variable"
     | Object_field -> fprintf ppf "it's the type of an object field"
@@ -1942,10 +1942,10 @@ module Debug_printers = struct
     | Polymorphic_variant_field -> fprintf ppf "Polymorphic_variant_field"
     | Structure_element -> fprintf ppf "Structure_element"
     | V1_safety_check -> fprintf ppf "V1_safety_check"
+    | Probe -> fprintf ppf "Probe"
 
   let value_creation_reason ppf : History.value_creation_reason -> _ = function
     | Class_let_binding -> fprintf ppf "Class_let_binding"
-    | Probe -> fprintf ppf "Probe"
     | Object -> fprintf ppf "Object"
     | Instance_variable -> fprintf ppf "Instance_variable"
     | Object_field -> fprintf ppf "Object_field"

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -196,10 +196,10 @@ module History = struct
     | Polymorphic_variant_field
     | Structure_element
     | V1_safety_check
+    | Probe
 
   type value_creation_reason =
     | Class_let_binding
-    | Probe
     | Object
     | Instance_variable
     | Object_field

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -197,6 +197,7 @@ module History = struct
     | Structure_element
     | V1_safety_check
     | Probe
+    | Captured_in_object
 
   type value_creation_reason =
     | Class_let_binding
@@ -229,7 +230,6 @@ module History = struct
     | Class_type_argument
     | Class_term_argument
     | Debug_printer_argument
-    | Captured_in_object
     | Recmod_fun_arg
     | Unknown of string (* CR layouts: get rid of these *)
 


### PR DESCRIPTION
Make `Probe`s and variables `Captured_in_object` `value_or_null`.

The check for probes happens too late to infer the right nullability for the jkind, so accept `or_null` for backwards compatibility. Leave a CR to check that this is sound with null pointers.

The check for captured variables similarly happens after generalizing variables in pattern matches on tuples. It should be fine to capture null pointers in objects, so do it.

