### PR TITLE
Zero alloc fix flambda2 invalid no return take2

### DIFF
--- a/backend/deadcode.ml
+++ b/backend/deadcode.ml
@@ -41,10 +41,6 @@ let rec deadcode i =
   | Iend | Ireturn _ | Iop(Itailcall_ind) | Iop(Itailcall_imm _) | Iraise _ ->
       let regs = Reg.add_set_array i.live i.arg in
       { i; regs; exits = Int.Set.empty; }
-  | Iop (Iextcall ({ func = "caml_flambda2_invalid"; _ }  as caml_flambda2_invalid)) ->
-      let regs = Reg.add_set_array i.live i.arg in
-      let desc = Iop (Iextcall { caml_flambda2_invalid with returns = false }) in
-      { i = { i with desc; next = Mach.end_instr () }; regs; exits = Int.Set.empty; }
   | Iop op ->
       let s = deadcode i.next in
       if operation_is_pure op                  (* no side effects *)

--- a/backend/deadcode.ml
+++ b/backend/deadcode.ml
@@ -41,6 +41,10 @@ let rec deadcode i =
   | Iend | Ireturn _ | Iop(Itailcall_ind) | Iop(Itailcall_imm _) | Iraise _ ->
       let regs = Reg.add_set_array i.live i.arg in
       { i; regs; exits = Int.Set.empty; }
+  | Iop (Iextcall ({ func = "caml_flambda2_invalid"; _ }  as caml_flambda2_invalid)) ->
+      let regs = Reg.add_set_array i.live i.arg in
+      let desc = Iop (Iextcall { caml_flambda2_invalid with returns = false }) in
+      { i = { i with desc; next = Mach.end_instr () }; regs; exits = Int.Set.empty; }
   | Iop op ->
       let s = deadcode i.next in
       if operation_is_pure op                  (* no side effects *)

--- a/tests/backend/zero_alloc_checker/t.ml
+++ b/tests/backend/zero_alloc_checker/t.ml
@@ -326,3 +326,18 @@ module Test1 = struct
       |> h |> List.hd  (* ignore this allocation *)
     | answer -> (answer * 2)
 end
+
+module Test_caml_flambda2_invalid = struct
+  external opaque : 'a -> 'a = "%opaque"
+  external box : float# -> (float[@local_opt]) = "%box_float"
+  external unbox : (float[@local_opt]) -> float# = "%unbox_float"
+
+  let f _ = assert false
+
+  let _test () =
+    let a = opaque 0.0 |> unbox in
+    List.iter
+      (fun [@zero_alloc] _ ->
+         let _ : float = box a +. 0.0 |> opaque in
+         f #0.0) []
+end


### PR DESCRIPTION
Fix compilation failure caused by the special treatment of `caml_flambda2_invalid` for `zero_alloc` (added in #2112) in the presence of unboxed types.  

The middle end generates `caml_flambda2_invalid` with `return=false` and return type set to `typ_void`. In `Selectgen`, we sometimes change it to `return=true` and `typ_int`, but the context may not be compatible with the return type of `int`. This should not matter because the code is unreachable, but it triggers an assertion:

```
>> Fatal error: Illegal move between registers of differing types (I/77[%rax] to F/78[%xmm0])
```
The proposed fix updates `return=false` at the end of `Zero_alloc_check` on all these special primitives. 
- For Cfg, we rerun dead code elimination pass if needed.  This is expensive but performed only when needed.
- For Mach, we rely on `Deadcode` pass to eliminate the illegal moves before register allocation. This is expensive because we reallocate all functions annotated with zero_alloc. An cheaper alternative (see reverted commit) is to directly change `Deadcode` pass. 

A proper fix would be to let the middle end eliminate dead functions even if they are annotated with zero_alloc assertions (i.e., revert https://github.com/ocaml-flambda/flambda-backend/pull/1378), and instead propagate zero_alloc assertions to instructions, similarly to the way we do for assume using debug info, but currently debug info may not reliable enough.

