### PR TITLE
Fix merge conflicts in some `typing/*.ml` files

### DIFF
--- a/ocaml/jane/build-resolved-files-for-ci
+++ b/ocaml/jane/build-resolved-files-for-ci
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd $(dirname $0)/../..
+
 set -euo pipefail
 
 make _build/_bootinstall
@@ -28,6 +30,7 @@ dune_targets=$(
 # ocamlcommon mls
 mls=$(
   { echo ocaml/parsing/*.ml
+    echo ocaml/typing/*.ml
   } | tr ' ' '\n'
 )
 echo "$mls"

--- a/ocaml/typing/btype.ml
+++ b/ocaml/typing/btype.ml
@@ -128,19 +128,13 @@ let newmarkedgenvar () =
 let is_Tvar ty = match get_desc ty with Tvar _ -> true | _ -> false
 let is_Tunivar ty = match get_desc ty with Tunivar _ -> true | _ -> false
 let is_Tconstr ty = match get_desc ty with Tconstr _ -> true | _ -> false
-<<<<<<< HEAD
 let is_Tpoly ty = match get_desc ty with Tpoly _ -> true | _ -> false
-let type_kind_is_abstract decl =
-  match decl.type_kind with Type_abstract _ -> true | _ -> false
-||||||| 121bedcfd2
-=======
 let type_kind_is_abstract decl =
   match decl.type_kind with Type_abstract _ -> true | _ -> false
 let type_origin decl =
   match decl.type_kind with
   | Type_abstract origin -> origin
   | Type_variant _ | Type_record _ | Type_open -> Definition
->>>>>>> 5.2.0
 
 let dummy_method = "*dummy method*"
 

--- a/ocaml/typing/cmt2annot.ml
+++ b/ocaml/typing/cmt2annot.ml
@@ -23,13 +23,7 @@ let variables_iterator scope =
   let super = default_iterator in
   let pat sub (type k) (p : k general_pattern) =
     begin match p.pat_desc with
-<<<<<<< HEAD
     | Tpat_var (id, _, _, _) | Tpat_alias (_, id, _, _, _) ->
-||||||| 121bedcfd2
-    | Tpat_var (id, _) | Tpat_alias (_, id, _) ->
-=======
-    | Tpat_var (id, _, _) | Tpat_alias (_, id, _, _) ->
->>>>>>> 5.2.0
         Stypes.record (Stypes.An_ident (p.pat_loc,
                                         Ident.name id,
                                         Annot.Idef scope))
@@ -60,20 +54,11 @@ let bind_cases l =
     )
     l
 
-<<<<<<< HEAD
 let bind_function_param loc fp =
   match fp.fp_kind with
   | Tparam_pat pat -> bind_variables loc pat
   | Tparam_optional_default (pat, _, _) -> bind_variables loc pat
 
-||||||| 121bedcfd2
-=======
-let bind_function_param loc fp =
-  match fp.fp_kind with
-  | Tparam_pat pat -> bind_variables loc pat
-  | Tparam_optional_default (pat, _) -> bind_variables loc pat
-
->>>>>>> 5.2.0
 let record_module_binding scope mb =
   Stypes.record (Stypes.An_ident
                    (mb.mb_name.loc,
@@ -119,14 +104,8 @@ let rec iterator ~scope rebuild_env =
         bind_cases f1
     | Texp_try (_, f) ->
         bind_cases f
-<<<<<<< HEAD
     | Texp_function { params; _ } ->
         List.iter (bind_function_param exp.exp_loc) params
-||||||| 121bedcfd2
-=======
-    | Texp_function (params, _) ->
-        List.iter (bind_function_param exp.exp_loc) params
->>>>>>> 5.2.0
     | Texp_letmodule (_, modname, _, _, body ) ->
         Stypes.record (Stypes.An_ident
                          (modname.loc,Option.value ~default:"_" modname.txt,

--- a/ocaml/typing/mtype.ml
+++ b/ocaml/typing/mtype.ml
@@ -82,19 +82,9 @@ and strengthen_lazy_sig' ~aliasable sg p =
   let open Subst.Lazy in
   match sg with
     [] -> []
-<<<<<<< HEAD
   | (Sig_value(_, _, _) as sigelt) :: rem ->
       sigelt :: strengthen_lazy_sig' ~aliasable rem p
   | Sig_type(id, {type_kind=Type_abstract _}, _, _) :: rem
-||||||| 121bedcfd2
-  | (SigL_value(_, _, _) as sigelt) :: rem ->
-      sigelt :: strengthen_lazy_sig' ~aliasable env rem p
-  | SigL_type(id, {type_kind=Type_abstract}, _, _) :: rem
-=======
-  | (SigL_value(_, _, _) as sigelt) :: rem ->
-      sigelt :: strengthen_lazy_sig' ~aliasable env rem p
-  | SigL_type(id, {type_kind=Type_abstract _}, _, _) :: rem
->>>>>>> 5.2.0
     when Btype.is_row_name (Ident.name id) ->
       strengthen_lazy_sig' ~aliasable rem p
   | Sig_type(id, decl, rs, vis) :: rem ->

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -197,13 +197,10 @@ let print_out_string ppf s =
   else
     fprintf ppf "%S" s
 
-<<<<<<< HEAD
 external float32_format : string -> Obj.t -> string = "caml_format_float32"
 
 let float32_to_string f = Stdlib.valid_float_lexem (float32_format "%.9g" f)
 
-||||||| 121bedcfd2
-=======
 let print_constr ppf name =
   match name with
   | Oide_ident {printed_name = ("true" | "false") as c} ->
@@ -212,7 +209,6 @@ let print_constr ppf name =
     fprintf ppf "%s" c
   | _ -> print_ident ppf name
 
->>>>>>> 5.2.0
 let print_out_value ppf tree =
   let rec print_tree_1 ppf =
     function
@@ -269,7 +265,6 @@ let print_out_value ppf tree =
         end
     | Oval_list tl ->
         fprintf ppf "@[<1>[%a]@]" (print_tree_list print_tree_1 ";") tl
-<<<<<<< HEAD
     | Oval_array (tl, am) ->
         let sigil = match am with
           | Mutable   -> '|'
@@ -277,19 +272,8 @@ let print_out_value ppf tree =
         in
         fprintf ppf "@[<2>[%c%a%c]@]"
           sigil (print_tree_list print_tree_1 ";") tl sigil
-    | Oval_constr (name, []) -> print_ident ppf name
-    | Oval_variant (name, None) -> fprintf ppf "`%s" name
-||||||| 121bedcfd2
-    | Oval_array tl ->
-        fprintf ppf "@[<2>[|%a|]@]" (print_tree_list print_tree_1 ";") tl
-    | Oval_constr (name, []) -> print_ident ppf name
-    | Oval_variant (name, None) -> fprintf ppf "`%s" name
-=======
-    | Oval_array tl ->
-        fprintf ppf "@[<2>[|%a|]@]" (print_tree_list print_tree_1 ";") tl
     | Oval_constr (name, []) -> print_constr ppf name
     | Oval_variant (name, None) -> fprintf ppf "`%a" print_lident name
->>>>>>> 5.2.0
     | Oval_stuff s -> pp_print_string ppf s
     | Oval_record fel ->
         fprintf ppf "@[<1>{%a}@]" (cautious (print_fields true)) fel
@@ -365,23 +349,8 @@ let rec print_out_jkind_const ppf (ojkind : Outcometree.out_jkind_const) =
   | Ojkind_const_with _ | Ojkind_const_kind_of _ ->
     failwith "XXX unimplemented jkind syntax"
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-let print_out_jkind ppf = function
-  | Ojkind_const { base; modal_bounds=[] } ->
-    fprintf ppf "%s" base
-  | Ojkind_const { base; modal_bounds=_::_ as modal_bounds } ->
-    print_jkind_with_modes ppf (fun ppf -> fprintf ppf "%s") base modal_bounds
-||||||| 2572783060
-let print_out_jkind ppf = function
-  | Ojkind_const { base; modal_bounds=[] } ->
-    fprintf ppf "%s" base
-  | Ojkind_const { base; modal_bounds=_::_ as modal_bounds } ->
-    print_jkind_with_modes ppf (fun ppf -> fprintf ppf "%s") base modal_bounds
-=======
 let print_out_jkind ppf ojkind =
   match ojkind with
->>>>>>> ocaml-jst/flambda-patches
   | Ojkind_var v -> fprintf ppf "%s" v
   | Ojkind_const jkind -> print_out_jkind_const ppf jkind
 
@@ -465,18 +434,14 @@ let partition_modalities l =
   | Ogf_new m -> Right m
   ) l
 
-let rec print_out_type_0 ppf =
-||||||| 121bedcfd2
-let rec print_out_type ppf =
-=======
-let print_arg_label ppf (lbl : Asttypes.arg_label) =
+let print_arg_label_and_out_type ppf (lbl : arg_label) ty ~print_type =
   match lbl with
-  | Nolabel -> ()
-  | Labelled s -> fprintf ppf "%a:" print_lident s
-  | Optional s -> fprintf ppf "?%a:" print_lident s
+  | Nolabel -> print_type ppf ty
+  | Labelled l -> fprintf ppf "%a:%a" print_lident l print_type ty
+  | Position l -> fprintf ppf "%a:[%%call_pos]" print_lident l
+  | Optional l -> fprintf ppf "?%a:%a" print_lident l print_type ty
 
-let rec print_out_type ppf =
->>>>>>> 5.2.0
+let rec print_out_type_0 ppf =
   function
   | Otyp_alias {non_gen; aliased; alias } ->
     fprintf ppf "@[%a@ as %a@]"
@@ -518,24 +483,7 @@ and print_out_type_1 ppf =
   function
   | Otyp_arrow (lab, am, ty1, rm, ty2) ->
       pp_open_box ppf 0;
-<<<<<<< HEAD
-      let print_type () = print_out_arg am ppf ty1 in
-      (match lab with
-      | Nolabel -> print_type ()
-      | Labelled l ->
-          pp_print_string ppf l; pp_print_char ppf ':'; print_type ()
-      | Position l ->
-          pp_print_string ppf l;
-          pp_print_string ppf ":[%call_pos]"
-      | Optional l ->
-          pp_print_string ppf ("?" ^ l); pp_print_char ppf ':'; print_type ());
-||||||| 121bedcfd2
-      if lab <> "" then (pp_print_string ppf lab; pp_print_char ppf ':');
-      print_out_type_2 ppf ty1;
-=======
-      print_arg_label ppf lab;
-      print_out_type_2 ppf ty1;
->>>>>>> 5.2.0
+      print_arg_label_and_out_type ppf lab ty1 ~print_type:(print_out_arg am);
       pp_print_string ppf " ->";
       pp_print_space ppf ();
       print_out_ret rm ppf ty2;
@@ -666,7 +614,6 @@ and print_typargs ppf =
       pp_print_char ppf ')';
       pp_close_box ppf ();
       pp_print_space ppf ()
-<<<<<<< HEAD
 and print_out_label ppf (name, mut, arg, gbl) =
   (* See the notes [NON-LEGACY MODES] *)
   let mut =
@@ -676,18 +623,10 @@ and print_out_label ppf (name, mut, arg, gbl) =
     | Om_mutable (Some s) -> "mutable(" ^ s ^ ") "
   in
   let m_legacy, m_new = partition_modalities gbl in
-  fprintf ppf "@[<2>%s%a%s :@ %a%a@];"
+  fprintf ppf "@[<2>%s%a%a :@ %a%a@];"
     mut
     print_out_modalities_legacy m_legacy
-    name
-||||||| 121bedcfd2
-and print_out_label ppf (name, mut, arg) =
-  fprintf ppf "@[<2>%s%s :@ %a@];" (if mut then "mutable " else "") name
-=======
-and print_out_label ppf (name, mut, arg) =
-  fprintf ppf "@[<2>%s%a :@ %a@];" (if mut then "mutable " else "")
     print_lident name
->>>>>>> 5.2.0
     print_out_type arg
     print_out_modalities_new m_new
 
@@ -708,15 +647,10 @@ let out_type_args = ref print_typargs
 let print_type_parameter ?(non_gen=false) ppf s =
   if s = "_" then fprintf ppf "_" else ty_var ~non_gen ppf s
 
-<<<<<<< HEAD
 let type_parameter ~in_parens ppf
-      { oparam_name = ty; oparam_variance = var;
-        oparam_injectivity = inj; oparam_jkind = lay } =
-||||||| 121bedcfd2
-let type_parameter ppf (ty, (var, inj)) =
-=======
-let type_parameter ppf {ot_non_gen=non_gen; ot_name=ty; ot_variance=var,inj} =
->>>>>>> 5.2.0
+    {ot_non_gen=non_gen; ot_name=ty; ot_variance=var,inj;
+     ot_jkind=lay; }
+  =
   let open Asttypes in
   let format_string : _ format = "%s%s%a%a" in
   let format_string : _ format = match lay with
@@ -726,14 +660,8 @@ let type_parameter ppf {ot_non_gen=non_gen; ot_name=ty; ot_variance=var,inj} =
   fprintf ppf format_string
     (match var with Covariant -> "+" | Contravariant -> "-" | NoVariance ->  "")
     (match inj with Injective -> "!" | NoInjectivity -> "")
-<<<<<<< HEAD
-    print_type_parameter ty
-    print_out_jkind_annot lay
-||||||| 121bedcfd2
-    print_type_parameter ty
-=======
     (print_type_parameter ~non_gen) ty
->>>>>>> 5.2.0
+    print_out_jkind_annot lay
 
 let print_out_class_params ppf =
   function
@@ -755,25 +683,10 @@ let rec print_out_class_type ppf =
       in
       fprintf ppf "@[%a%a@]" pr_tyl tyl print_ident id
   | Octy_arrow (lab, ty, cty) ->
-<<<<<<< HEAD
       let print_type = print_out_type_2 in
-      let label, print_type = match lab with
-        | Nolabel -> "", print_type
-        | Labelled l -> l ^ ":", print_type
-        | Position l -> l ^ ":", fun ppf _ -> pp_print_string ppf "[%call_pos]"
-        | Optional l -> "?" ^ l ^ ":", print_type
-      in
-      fprintf ppf "@[%s%a ->@ %a@]"
-        label
-        print_type ty
+      fprintf ppf "@[%t ->@ %a@]"
+        (fun ppf -> print_arg_label_and_out_type ppf lab ty ~print_type)
         print_out_class_type cty
-||||||| 121bedcfd2
-      fprintf ppf "@[%s%a ->@ %a@]" (if lab <> "" then lab ^ ":" else "")
-        print_out_type_2 ty print_out_class_type cty
-=======
-      fprintf ppf "@[%a%a ->@ %a@]" print_arg_label lab
-        print_out_type_2 ty print_out_class_type cty
->>>>>>> 5.2.0
   | Octy_signature (self_ty, csil) ->
       let pr_param ppf =
         function
@@ -1003,31 +916,14 @@ and print_out_type_decl kwd ppf td =
   in
   let type_defined ppf =
     match td.otype_params with
-<<<<<<< HEAD
-      [] -> pp_print_string ppf td.otype_name
-    | [param] -> fprintf ppf "@[%a@ %s@]"
-                   (type_parameter ~in_parens:false) param td.otype_name
-||||||| 121bedcfd2
-      [] -> pp_print_string ppf td.otype_name
-    | [param] -> fprintf ppf "@[%a@ %s@]" type_parameter param td.otype_name
-=======
       [] -> print_lident ppf td.otype_name
-    | [param] ->
-        fprintf ppf "@[%a@ %a@]" type_parameter param
-          print_lident td.otype_name
->>>>>>> 5.2.0
+    | [param] -> fprintf ppf "@[%a@ %a@]"
+                   (type_parameter ~in_parens:false) param
+                   print_lident td.otype_name
     | _ ->
-<<<<<<< HEAD
-        fprintf ppf "@[(@[%a)@]@ %s@]"
+        fprintf ppf "@[(@[%a)@]@ %a@]"
           (print_list (type_parameter ~in_parens:true)
              (fun ppf -> fprintf ppf ",@ "))
-||||||| 121bedcfd2
-        fprintf ppf "@[(@[%a)@]@ %s@]"
-          (print_list type_parameter (fun ppf -> fprintf ppf ",@ "))
-=======
-        fprintf ppf "@[(@[%a)@]@ %a@]"
-          (print_list type_parameter (fun ppf -> fprintf ppf ",@ "))
->>>>>>> 5.2.0
           td.otype_params
           print_lident td.otype_name
   in

--- a/ocaml/typing/parmatch.ml
+++ b/ocaml/typing/parmatch.ml
@@ -20,7 +20,6 @@ open Asttypes
 open Types
 open Typedtree
 
-<<<<<<< HEAD
 type error = Float32_match
 
 exception Error of error
@@ -44,26 +43,6 @@ let untyped_case { Parsetree.pc_lhs; pc_guard; pc_rhs } =
     has_guard = Option.is_some pc_guard;
     needs_refute = (pc_rhs.pexp_desc = Parsetree.Pexp_unreachable);
   }
-||||||| 121bedcfd2
-=======
-type 'pattern parmatch_case =
-  { pattern : 'pattern;
-    has_guard : bool;
-    needs_refute : bool;
-  }
-
-let typed_case { c_lhs; c_guard; c_rhs } =
-  { pattern = c_lhs;
-    has_guard = Option.is_some c_guard;
-    needs_refute = (c_rhs.exp_desc = Texp_unreachable);
-  }
-
-let untyped_case { Parsetree.pc_lhs; pc_guard; pc_rhs } =
-  { pattern = pc_lhs;
-    has_guard = Option.is_some pc_guard;
-    needs_refute = (pc_rhs.pexp_desc = Parsetree.Pexp_unreachable);
-  }
->>>>>>> 5.2.0
 
 (*************************************)
 (* Utilities for building patterns   *)
@@ -81,15 +60,8 @@ let omega_list = Patterns.omega_list
 
 let extra_pat =
   make_pat
-<<<<<<< HEAD
     (Tpat_var (Ident.create_local "+", mknoloc "+",
       Uid.internal_not_actually_unique, Mode.Value.disallow_right Mode.Value.max))
-||||||| 121bedcfd2
-    (Tpat_var (Ident.create_local "+", mknoloc "+"))
-=======
-    (Tpat_var (Ident.create_local "+", mknoloc "+",
-      Uid.internal_not_actually_unique))
->>>>>>> 5.2.0
     Ctype.none Env.empty
 
 
@@ -354,16 +326,8 @@ module Compat
   | ((Tpat_any|Tpat_var _),_)
   | (_,(Tpat_any|Tpat_var _)) -> true
 (* Structural induction *)
-<<<<<<< HEAD
   | Tpat_alias (p,_,_,_,_),_      -> compat p q
   | _,Tpat_alias (q,_,_,_,_)      -> compat p q
-||||||| 121bedcfd2
-  | Tpat_alias (p,_,_),_      -> compat p q
-  | _,Tpat_alias (q,_,_)      -> compat p q
-=======
-  | Tpat_alias (p,_,_,_),_      -> compat p q
-  | _,Tpat_alias (q,_,_,_)      -> compat p q
->>>>>>> 5.2.0
   | Tpat_or (p1,p2,_),_ ->
       (compat p1 q || compat p2 q)
   | _,Tpat_or (q1,q2,_) ->
@@ -1017,15 +981,8 @@ let build_other ext env =
           (* let c = {c with cstr_name = "*extension*"} in *) (* PR#7330 *)
           make_pat
             (Tpat_var (Ident.create_local "*extension*",
-<<<<<<< HEAD
                        {txt="*extension*"; loc = d.pat_loc},
                        Uid.internal_not_actually_unique, Mode.Value.disallow_right Mode.Value.max))
-||||||| 121bedcfd2
-                       {txt="*extension*"; loc = d.pat_loc}))
-=======
-                       {txt="*extension*"; loc = d.pat_loc},
-                       Uid.internal_not_actually_unique))
->>>>>>> 5.2.0
             Ctype.none Env.empty
       | Construct _ ->
           begin match ext with
@@ -1182,13 +1139,7 @@ let build_other ext env =
 let rec has_instance p = match p.pat_desc with
   | Tpat_variant (l,_,r) when is_absent l r -> false
   | Tpat_any | Tpat_var _ | Tpat_constant _ | Tpat_variant (_,None,_) -> true
-<<<<<<< HEAD
   | Tpat_alias (p,_,_,_,_) | Tpat_variant (_,Some p,_) -> has_instance p
-||||||| 121bedcfd2
-  | Tpat_alias (p,_,_) | Tpat_variant (_,Some p,_) -> has_instance p
-=======
-  | Tpat_alias (p,_,_,_) | Tpat_variant (_,Some p,_) -> has_instance p
->>>>>>> 5.2.0
   | Tpat_or (p1,p2,_) -> has_instance p1 || has_instance p2
   | Tpat_construct (_,_,ps, _) | Tpat_array (_, _, ps) ->
       has_instances ps
@@ -1644,13 +1595,7 @@ let is_var_column rs =
 (* Standard or-args for left-to-right matching *)
 let rec or_args p = match p.pat_desc with
 | Tpat_or (p1,p2,_) -> p1,p2
-<<<<<<< HEAD
 | Tpat_alias (p,_,_,_,_)  -> or_args p
-||||||| 121bedcfd2
-| Tpat_alias (p,_,_)  -> or_args p
-=======
-| Tpat_alias (p,_,_,_)  -> or_args p
->>>>>>> 5.2.0
 | _                 -> assert false
 
 (* Just remove current column *)
@@ -1830,16 +1775,8 @@ and every_both pss qs q1 q2 =
 let rec le_pat p q =
   match (p.pat_desc, q.pat_desc) with
   | (Tpat_var _|Tpat_any),_ -> true
-<<<<<<< HEAD
   | Tpat_alias(p,_,_,_,_), _ -> le_pat p q
   | _, Tpat_alias(q,_,_,_,_) -> le_pat p q
-||||||| 121bedcfd2
-  | Tpat_alias(p,_,_), _ -> le_pat p q
-  | _, Tpat_alias(q,_,_) -> le_pat p q
-=======
-  | Tpat_alias(p,_,_,_), _ -> le_pat p q
-  | _, Tpat_alias(q,_,_,_) -> le_pat p q
->>>>>>> 5.2.0
   | Tpat_constant(c1), Tpat_constant(c2) -> const_compare c1 c2 = 0
   | Tpat_construct(_,c1,ps,_), Tpat_construct(_,c2,qs,_) ->
       Types.equal_tag c1.cstr_tag c2.cstr_tag && le_pats ps qs
@@ -1890,16 +1827,8 @@ let get_mins le ps =
 *)
 
 let rec lub p q = match p.pat_desc,q.pat_desc with
-<<<<<<< HEAD
 | Tpat_alias (p,_,_,_,_),_      -> lub p q
 | _,Tpat_alias (q,_,_,_,_)      -> lub p q
-||||||| 121bedcfd2
-| Tpat_alias (p,_,_),_      -> lub p q
-| _,Tpat_alias (q,_,_)      -> lub p q
-=======
-| Tpat_alias (p,_,_,_),_      -> lub p q
-| _,Tpat_alias (q,_,_,_)      -> lub p q
->>>>>>> 5.2.0
 | (Tpat_any|Tpat_var _),_ -> q
 | _,(Tpat_any|Tpat_var _) -> p
 | Tpat_or (p1,p2,_),_     -> orlub p1 p2 q
@@ -2016,13 +1945,7 @@ let rec initial_matrix = function
 *)
 let rec initial_only_guarded = function
   | [] -> []
-<<<<<<< HEAD
   | { has_guard=false; _} :: rem ->
-||||||| 121bedcfd2
-  | { c_guard = None; _} :: rem ->
-=======
-  | { has_guard = false; _} :: rem ->
->>>>>>> 5.2.0
       initial_only_guarded rem
   | { pattern = pat; _ } :: rem ->
       [pat] :: initial_only_guarded rem
@@ -2036,13 +1959,7 @@ let rec initial_only_guarded = function
 let contains_extension pat =
   exists_pattern
     (function
-<<<<<<< HEAD
      | {pat_desc=Tpat_var (_, {txt="*extension*"}, _, _)} -> true
-||||||| 121bedcfd2
-     | {pat_desc=Tpat_var (_, {txt="*extension*"})} -> true
-=======
-     | {pat_desc=Tpat_var (_, {txt="*extension*"}, _)} -> true
->>>>>>> 5.2.0
      | _ -> false)
     pat
 
@@ -2127,14 +2044,8 @@ let rec collect_paths_from_pat r p = match p.pat_desc with
     List.fold_left
       (fun r (_, _, p) -> collect_paths_from_pat r p)
       r lps
-<<<<<<< HEAD
-| Tpat_variant (_, Some p, _) | Tpat_alias (p,_,_,_,_) -> collect_paths_from_pat r p
-||||||| 121bedcfd2
-| Tpat_variant (_, Some p, _) | Tpat_alias (p,_,_) -> collect_paths_from_pat r p
-=======
-| Tpat_variant (_, Some p, _) | Tpat_alias (p,_,_,_) ->
+| Tpat_variant (_, Some p, _) | Tpat_alias (p,_,_,_,_) ->
     collect_paths_from_pat r p
->>>>>>> 5.2.0
 | Tpat_or (p1,p2,_) ->
     collect_paths_from_pat (collect_paths_from_pat r p1) p2
 | Tpat_lazy p
@@ -2271,13 +2182,7 @@ let inactive ~partial pat =
             List.for_all (fun (_,p) -> loop p) ps
         | Tpat_construct (_, _, ps, _) | Tpat_array (Immutable, _, ps) ->
             List.for_all (fun p -> loop p) ps
-<<<<<<< HEAD
         | Tpat_alias (p,_,_,_,_) | Tpat_variant (_, Some p, _) ->
-||||||| 121bedcfd2
-        | Tpat_alias (p,_,_) | Tpat_variant (_, Some p, _) ->
-=======
-        | Tpat_alias (p,_,_,_) | Tpat_variant (_, Some p, _) ->
->>>>>>> 5.2.0
             loop p
         | Tpat_record (ldps,_) ->
             List.for_all
@@ -2396,21 +2301,9 @@ type amb_row = { row : pattern list ; varsets : Ident.Set.t list; }
 let simplify_head_amb_pat head_bound_variables varsets ~add_column p ps k =
   let rec simpl head_bound_variables varsets p ps k =
     match (Patterns.General.view p).pat_desc with
-<<<<<<< HEAD
     | `Alias (p,x,_,_,_) ->
-||||||| 121bedcfd2
-    | `Alias (p,x,_) ->
-=======
-    | `Alias (p,x,_,_) ->
->>>>>>> 5.2.0
       simpl (Ident.Set.add x head_bound_variables) varsets p ps k
-<<<<<<< HEAD
     | `Var (x, _, _, _) ->
-||||||| 121bedcfd2
-    | `Var (x, _) ->
-=======
-    | `Var (x,_,_) ->
->>>>>>> 5.2.0
       simpl (Ident.Set.add x head_bound_variables) varsets Patterns.omega ps k
     | `Or (p1,p2,_) ->
       simpl head_bound_variables varsets p1 ps

--- a/ocaml/typing/patterns.ml
+++ b/ocaml/typing/patterns.ml
@@ -79,38 +79,18 @@ end
 module General = struct
   type view = [
     | Half_simple.view
-<<<<<<< HEAD
     | `Var of Ident.t * string loc * Uid.t * Mode.Value.l
     | `Alias of pattern * Ident.t * string loc * Uid.t * Mode.Value.l
-||||||| 121bedcfd2
-    | `Var of Ident.t * string loc
-    | `Alias of pattern * Ident.t * string loc
-=======
-    | `Var of Ident.t * string loc * Uid.t
-    | `Alias of pattern * Ident.t * string loc * Uid.t
->>>>>>> 5.2.0
   ]
   type pattern = view pattern_data
 
   let view_desc = function
     | Tpat_any ->
        `Any
-<<<<<<< HEAD
     | Tpat_var (id, str, uid, mode) ->
        `Var (id, str, uid, mode)
     | Tpat_alias (p, id, str, uid, mode) ->
        `Alias (p, id, str, uid, mode)
-||||||| 121bedcfd2
-    | Tpat_var (id, str) ->
-       `Var (id, str)
-    | Tpat_alias (p, id, str) ->
-       `Alias (p, id, str)
-=======
-    | Tpat_var (id, str, uid) ->
-       `Var (id, str, uid)
-    | Tpat_alias (p, id, str, uid) ->
-       `Alias (p, id, str, uid)
->>>>>>> 5.2.0
     | Tpat_constant cst ->
        `Constant cst
     | Tpat_tuple ps ->
@@ -130,16 +110,8 @@ module General = struct
 
   let erase_desc = function
     | `Any -> Tpat_any
-<<<<<<< HEAD
     | `Var (id, str, uid, mode) -> Tpat_var (id, str, uid, mode)
     | `Alias (p, id, str, uid, mode) -> Tpat_alias (p, id, str, uid, mode)
-||||||| 121bedcfd2
-    | `Var (id, str) -> Tpat_var (id, str)
-    | `Alias (p, id, str) -> Tpat_alias (p, id, str)
-=======
-    | `Var (id, str, uid) -> Tpat_var (id, str, uid)
-    | `Alias (p, id, str, uid) -> Tpat_alias (p, id, str, uid)
->>>>>>> 5.2.0
     | `Constant cst -> Tpat_constant cst
     | `Tuple ps -> Tpat_tuple ps
     | `Construct (cstr, cst_descr, args) ->
@@ -157,13 +129,7 @@ module General = struct
 
   let rec strip_vars (p : pattern) : Half_simple.pattern =
     match p.pat_desc with
-<<<<<<< HEAD
     | `Alias (p, _, _, _, _) -> strip_vars (view p)
-||||||| 121bedcfd2
-    | `Alias (p, _, _) -> strip_vars (view p)
-=======
-    | `Alias (p, _, _, _) -> strip_vars (view p)
->>>>>>> 5.2.0
     | `Var _ -> { p with pat_desc = `Any }
     | #Half_simple.view as view -> { p with pat_desc = view }
 end

--- a/ocaml/typing/subst.ml
+++ b/ocaml/typing/subst.ml
@@ -261,7 +261,8 @@ let apply_type_function params args body =
       match get_desc ty with
       | Tsubst (ty, _) -> ty
       | Tvariant row ->
-          let t = newgenstub ~scope:(get_scope ty) in
+          let t = newgenstub ~scope:(get_scope ty)
+            (Jkind.Primitive.any ~why:Dummy_jkind) in
           For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
           let more = row_more row in
           assert (get_level more = generic_level);
@@ -304,7 +305,8 @@ let apply_type_function params args body =
           Transient_expr.set_stub_desc t desc';
           t
       | desc ->
-          let t = newgenstub ~scope:(get_scope ty) in
+          let t = newgenstub ~scope:(get_scope ty)
+            (Jkind.Primitive.any ~why:Dummy_jkind) in
           For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
           let desc' = copy_type_desc copy desc in
           Transient_expr.set_stub_desc t desc';

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -430,39 +430,52 @@ and function_param =
        [Total] otherwise.
     *)
     fp_kind: function_param_kind;
-    fp_newtypes: string loc list;
-      (** [fp_newtypes] are the new type declarations that come *after* that
-          parameter. The newtypes that come before the first parameter are
-          placed as exp_extras on the Texp_function node. This is just used in
-          {!Untypeast}. *)
+    fp_sort: Jkind.sort;
+    fp_mode: Mode.Alloc.l;
+    fp_curry: function_curry;
+    fp_newtypes: (string loc * Jkind.annotation option) list;
+    (** [fp_newtypes] are the new type declarations that come *after* that
+        parameter. The newtypes that come before the first parameter are
+        placed as exp_extras on the Texp_function node. This is just used in
+        {!Untypeast}. *)
     fp_loc: Location.t;
-      (** [fp_loc] is the location of the entire value parameter, not including
-          the [fp_newtypes].
-      *)
+    (** [fp_loc] is the location of the entire value parameter, not including
+        the [fp_newtypes].
+    *)
   }
 
 and function_param_kind =
   | Tparam_pat of pattern
   (** [Tparam_pat p] is a non-optional argument with pattern [p]. *)
-  | Tparam_optional_default of pattern * expression
-  (** [Tparam_optional_default (p, e)] is an optional argument [p] with default
-      value [e], i.e. [?x:(p = e)]. If the parameter is of type [a option], the
-      pattern and expression are of type [a]. *)
+  | Tparam_optional_default of pattern * expression * Jkind.sort
+  (** [Tparam_optional_default (p, e, sort)] is an optional argument [p] with
+      default value [e], i.e. [?x:(p = e)]. If the parameter is of type
+      [a option], the pattern and expression are of type [a]. [sort] is the
+      sort of [e]. *)
 
 and function_body =
   | Tfunction_body of expression
-  | Tfunction_cases of
-      { cases: value case list;
-        partial: partial;
-        param: Ident.t;
-        loc: Location.t;
-        exp_extra: exp_extra option;
-        attributes: attributes;
-        (** [attributes] is just used in untypeast. *)
-      }
+  | Tfunction_cases of function_cases
 (** The function body binds a final argument in [Tfunction_cases],
     and this argument is pattern-matched against the cases.
 *)
+
+and function_cases =
+  { fc_cases: value case list;
+    fc_env : Env.t;
+    (** [fc_env] contains entries from all parameters except
+        for the last one being matched by the cases.
+    *)
+    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_sort: Jkind.sort;
+    fc_ret_type : Types.type_expr;
+    fc_partial: partial;
+    fc_param: Ident.t;
+    fc_loc: Location.t;
+    fc_exp_extra: exp_extra option;
+    fc_attributes: attributes;
+    (** [fc_attributes] is just used in untypeast. *)
+  }
 
 and ident_kind =
   | Id_value

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -13,14 +13,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-<<<<<<< HEAD
-||||||| 121bedcfd2
-open Longident
-=======
 [@@@ocaml.warning "-60"] module Str = Ast_helper.Str (* For ocamldep *)
 [@@@ocaml.warning "+60"]
 
->>>>>>> 5.2.0
 open Asttypes
 open Parsetree
 open Ast_helper
@@ -352,14 +347,8 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
   match pat with
       { pat_extra=[Tpat_unpack, loc, _attrs]; pat_desc = Tpat_any; _ } ->
         Ppat_unpack { txt = None; loc  }
-<<<<<<< HEAD
-    | { pat_extra=[Tpat_unpack, _, _attrs]; pat_desc = Tpat_var (_,name,_,_); _ } ->
-||||||| 121bedcfd2
-    | { pat_extra=[Tpat_unpack, _, _attrs]; pat_desc = Tpat_var (_,name); _ } ->
-=======
     | { pat_extra=[Tpat_unpack, _, _attrs];
-        pat_desc = Tpat_var (_,name, _); _ } ->
->>>>>>> 5.2.0
+        pat_desc = Tpat_var (_,name, _, _); _ } ->
         Ppat_unpack { name with txt = Some name.txt }
     | { pat_extra=[Tpat_type (_path, lid), _, _attrs]; _ } ->
         Ppat_type (map_loc sub lid)
@@ -369,13 +358,7 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
     | _ ->
     match pat.pat_desc with
       Tpat_any -> Ppat_any
-<<<<<<< HEAD
     | Tpat_var (id, name,_,_) ->
-||||||| 121bedcfd2
-    | Tpat_var (id, name) ->
-=======
-    | Tpat_var (id, name, _) ->
->>>>>>> 5.2.0
         begin
           match (Ident.name id).[0] with
             'A'..'Z' ->
@@ -388,23 +371,11 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
        The compiler transforms (x:t) into (_ as x : t).
        This avoids transforming a warning 27 into a 26.
      *)
-<<<<<<< HEAD
     | Tpat_alias ({pat_desc = Tpat_any; pat_loc}, _id, name, _uid, _mode)
-||||||| 121bedcfd2
-    | Tpat_alias ({pat_desc = Tpat_any; pat_loc}, _id, name)
-=======
-    | Tpat_alias ({pat_desc = Tpat_any; pat_loc}, _id, name, _)
->>>>>>> 5.2.0
          when pat_loc = pat.pat_loc ->
        Ppat_var name
 
-<<<<<<< HEAD
     | Tpat_alias (pat, _id, name, _uid, _mode) ->
-||||||| 121bedcfd2
-    | Tpat_alias (pat, _id, name) ->
-=======
-    | Tpat_alias (pat, _id, name, _) ->
->>>>>>> 5.2.0
         Ppat_alias (sub.pat sub pat, name)
     | Tpat_constant cst ->
       begin match constant cst with
@@ -573,9 +544,7 @@ let expression sub exp =
         Pexp_let (rec_flag,
           List.map (sub.value_binding sub) list,
           sub.expr sub exp)
-<<<<<<< HEAD
     | Texp_function { params; body } ->
-        let open Jane_syntax.N_ary_functions in
         let body, constraint_ =
           match body with
           | Tfunction_body body ->
@@ -630,76 +599,9 @@ let expression sub exp =
                { pparam_desc; pparam_loc = fp.fp_loc } :: newtypes)
             params
         in
-        Jane_syntax.N_ary_functions.expr_of ~loc (params, constraint_, body)
-        |> add_jane_syntax_attributes
+        Pexp_function (params, constraint_, body)
     | Texp_apply (exp, list, _, _, _) ->
         let list = List.map (fun (arg_label, arg) -> label arg_label, arg) list in
-||||||| 121bedcfd2
-
-    (* Pexp_function can't have a label, so we split in 3 cases. *)
-    (* One case, no guard: It's a fun. *)
-    | Texp_function { arg_label; cases = [{c_lhs=p; c_guard=None; c_rhs=e}];
-          _ } ->
-        Pexp_fun (arg_label, None, sub.pat sub p, sub.expr sub e)
-    (* No label: it's a function. *)
-    | Texp_function { arg_label = Nolabel; cases; _; } ->
-        Pexp_function (List.map (sub.case sub) cases)
-    (* Mix of both, we generate `fun ~label:$name$ -> match $name$ with ...` *)
-    | Texp_function { arg_label = Labelled s | Optional s as label; cases;
-          _ } ->
-        let name = fresh_name s exp.exp_env in
-        Pexp_fun (label, None, Pat.var ~loc {loc;txt = name },
-          Exp.match_ ~loc (Exp.ident ~loc {loc;txt= Lident name})
-                          (List.map (sub.case sub) cases))
-    | Texp_apply (exp, list) ->
-=======
-    | Texp_function (params, body) ->
-        let body, constraint_ =
-          match body with
-          | Tfunction_body body ->
-              (* Unlike function cases, the [exp_extra] is placed on the body
-                 itself. *)
-              Pfunction_body (sub.expr sub body), None
-          | Tfunction_cases { cases; loc; exp_extra; attributes; _ } ->
-              let cases = List.map (sub.case sub) cases in
-              let constraint_ =
-                match exp_extra with
-                | Some (Texp_coerce (ty1, ty2)) ->
-                    Some
-                      (Pcoerce (Option.map (sub.typ sub) ty1, sub.typ sub ty2))
-                | Some (Texp_constraint ty) ->
-                    Some (Pconstraint (sub.typ sub ty))
-                | Some (Texp_poly _ | Texp_newtype _) | None -> None
-              in
-              Pfunction_cases (cases, loc, attributes), constraint_
-        in
-        let params =
-          List.concat_map
-            (fun fp ->
-               let pat, default_arg =
-                 match fp.fp_kind with
-                 | Tparam_pat pat -> pat, None
-                 | Tparam_optional_default (pat, expr) -> pat, Some expr
-               in
-               let pat = sub.pat sub pat in
-               let default_arg = Option.map (sub.expr sub) default_arg in
-               let newtypes =
-                 List.map
-                   (fun x ->
-                      { pparam_desc = Pparam_newtype x;
-                        pparam_loc = x.loc;
-                      })
-                   fp.fp_newtypes
-               in
-               let pparam_desc =
-                 Pparam_val (fp.fp_arg_label, default_arg, pat)
-               in
-               { pparam_desc; pparam_loc = fp.fp_loc } :: newtypes)
-            params
-        in
-        Pexp_function (params, constraint_, body)
-    | Texp_apply (exp, list) ->
->>>>>>> 5.2.0
         Pexp_apply (sub.expr sub exp,
           List.fold_right (fun (label, arg) list ->
               match arg with
@@ -1152,6 +1054,7 @@ let core_type sub ct =
     | Ttyp_alias (ct, Some s, None) ->
         Ptyp_alias (sub.typ sub ct, s)
     | Ttyp_alias (ct, s, Some (_, jkind_annotation)) ->
+        let s = Option.map Location.get_txt s in
         Jane_syntax.Layouts.type_of ~loc
           (Ltyp_alias { aliased_type = sub.typ sub ct; name = s;
                         jkind = jkind_annotation }) |>
@@ -1166,25 +1069,15 @@ let core_type sub ct =
           (Ltyp_poly { bound_vars; inner_type = sub.typ sub ct }) |>
         add_jane_syntax_attributes
     | Ttyp_package pack -> Ptyp_package (sub.package_type sub pack)
-<<<<<<< HEAD
+    | Ttyp_open (_path, mod_ident, t) -> Ptyp_open (mod_ident, sub.typ sub t)
     | Ttyp_call_pos ->
         Ptyp_extension call_pos_extension
-||||||| 121bedcfd2
-=======
-    | Ttyp_open (_path, mod_ident, t) -> Ptyp_open (mod_ident, sub.typ sub t)
->>>>>>> 5.2.0
   in
   Typ.mk ~loc ~attrs:!attrs desc
 
 let class_structure sub cs =
   let rec remove_self = function
-<<<<<<< HEAD
     | { pat_desc = Tpat_alias (p, id, _s, _uid, _mode) }
-||||||| 121bedcfd2
-    | { pat_desc = Tpat_alias (p, id, _s) }
-=======
-    | { pat_desc = Tpat_alias (p, id, _s, _) }
->>>>>>> 5.2.0
       when string_is_prefix "selfpat-" (Ident.name id) ->
         remove_self p
     | p -> p
@@ -1214,17 +1107,10 @@ let object_field sub {of_loc; of_desc; of_attributes;} =
   Of.mk ~loc ~attrs desc
 
 and is_self_pat = function
-<<<<<<< HEAD
   | { pat_desc = Tpat_alias(_pat, id, _, _uid, _mode) } ->
-||||||| 121bedcfd2
-  | { pat_desc = Tpat_alias(_pat, id, _) } ->
-=======
-  | { pat_desc = Tpat_alias(_pat, id, _, _) } ->
->>>>>>> 5.2.0
       string_is_prefix "self-" (Ident.name id)
   | _ -> false
 
-<<<<<<< HEAD
 (* [Typeclass] adds a [self] parameter to initializers and methods that isn't
    present in the source program.
 *)
@@ -1243,24 +1129,6 @@ let remove_fun_self exp =
        | _, _ -> { exp with exp_desc = Texp_function { fun_ with params } })
   | e -> e
 
-||||||| 121bedcfd2
-=======
-(* [Typeclass] adds a [self] parameter to initializers and methods that isn't
-   present in the source program.
-*)
-let remove_fun_self exp =
-  match exp with
-  | { exp_desc =
-        Texp_function
-          ({fp_arg_label = Nolabel; fp_kind = Tparam_pat pat} :: params, body)
-    }
-    when is_self_pat pat ->
-    (match params, body with
-     | [], Tfunction_body body -> body
-     | _, _ -> { exp with exp_desc = Texp_function (params, body) })
-  | e -> e
-
->>>>>>> 5.2.0
 let class_field sub cf =
   let loc = sub.location sub cf.cf_loc in
   let attrs = sub.attributes sub cf.cf_attributes in

--- a/ocaml/typing/value_rec_check.ml
+++ b/ocaml/typing/value_rec_check.ml
@@ -150,7 +150,6 @@ let classify_expression : Typedtree.expression -> sd =
     | Texp_let (rec_flag, vb, e) ->
         let env = classify_value_bindings rec_flag env vb in
         classify_expression env e
-<<<<<<< HEAD
     | Texp_letmodule (Some mid, _, _, mexp, e) ->
         (* Note on module presence:
            For absent modules (i.e. module aliases), the module being bound
@@ -161,38 +160,14 @@ let classify_expression : Typedtree.expression -> sd =
         let env = Ident.add mid size env in
         classify_expression env e
     | Texp_ident (path, _, _, _, _) ->
-||||||| 121bedcfd2
-    | Texp_ident (path, _, _) ->
-=======
-    | Texp_letmodule (Some mid, _, _, mexp, e) ->
-        (* Note on module presence:
-           For absent modules (i.e. module aliases), the module being bound
-           does not have a physical representation, but its size can still be
-           derived from the alias itself, so we can re-use the same code as
-           for modules that are present. *)
-        let size = classify_module_expression env mexp in
-        let env = Ident.add mid size env in
-        classify_expression env e
-    | Texp_ident (path, _, _) ->
->>>>>>> 5.2.0
         classify_path env path
 
     (* non-binding cases *)
     | Texp_open (_, e)
-<<<<<<< HEAD
     | Texp_letmodule (None, _, _, _, e)
     | Texp_sequence (_, _, e)
     | Texp_letexception (_, e)
     | Texp_exclave e ->
-||||||| 121bedcfd2
-    | Texp_letmodule (_, _, _, _, e)
-    | Texp_sequence (_, e)
-    | Texp_letexception (_, e) ->
-=======
-    | Texp_letmodule (None, _, _, _, e)
-    | Texp_sequence (_, e)
-    | Texp_letexception (_, e) ->
->>>>>>> 5.2.0
         classify_expression env e
 
     | Texp_construct (_, {cstr_repr = Variant_unboxed}, [e], _) ->
@@ -208,7 +183,6 @@ let classify_expression : Typedtree.expression -> sd =
     | Texp_record _ ->
         Static
 
-<<<<<<< HEAD
     | Texp_variant _
     | Texp_tuple _
     | Texp_extension_constructor _
@@ -232,27 +206,6 @@ let classify_expression : Typedtree.expression -> sd =
         Static
 
     | Texp_apply ({exp_desc = Texp_ident (_, _, vd, Id_prim _, _)}, _, _, _, _)
-||||||| 121bedcfd2
-    | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, _)
-=======
-    | Texp_variant _
-    | Texp_tuple _
-    | Texp_extension_constructor _
-    | Texp_constant _ ->
-        Static
-
-    | Texp_for _
-    | Texp_setfield _
-    | Texp_while _
-    | Texp_setinstvar _ ->
-        (* Unit-returning expressions *)
-        Static
-
-    | Texp_unreachable ->
-        Static
-
-    | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, _)
->>>>>>> 5.2.0
       when is_ref vd ->
         Static
     | Texp_apply (_, args, _, _, _)
@@ -315,13 +268,7 @@ let classify_expression : Typedtree.expression -> sd =
     let old_env = env in
     let add_value_binding env vb =
       match vb.vb_pat.pat_desc with
-<<<<<<< HEAD
       | Tpat_var (id, _loc, _uid, _mode) ->
-||||||| 121bedcfd2
-      | Tpat_var (id, _loc) ->
-=======
-      | Tpat_var (id, _loc, _uid) ->
->>>>>>> 5.2.0
           let size = classify_expression old_env vb.vb_expr in
           Ident.add id size env
       | _ ->
@@ -722,30 +669,7 @@ let rec expression : Typedtree.expression -> term_judg =
         G |- ref e: m
       *)
       expression arg << Guard
-<<<<<<< HEAD
     | Texp_apply (e, args, _, _, _)  ->
-        let arg (_, arg) =
-          match arg with
-          | Omitted _ -> empty
-          | Arg (e, _) -> expression e
-        in
-        let app_mode = if List.exists is_abstracted_arg args
-          then (* see the comment on Texp_apply in typedtree.mli;
-                  the non-abstracted arguments are bound to local
-                  variables, which corresponds to a Guard mode. *)
-            Guard
-          else Dereference
-||||||| 121bedcfd2
-    | Texp_apply (e, args)  ->
-        let arg (_, eo) = option expression eo in
-        let app_mode = if List.exists is_abstracted_arg args
-          then (* see the comment on Texp_apply in typedtree.mli;
-                  the non-abstracted arguments are bound to local
-                  variables, which corresponds to a Guard mode. *)
-            Guard
-          else Dereference
-=======
-    | Texp_apply (e, args)  ->
         (* [args] may contain omitted arguments, corresponding to labels in
            the function's type that were not passed in the actual application.
            The arguments before the first omitted argument are passed to the
@@ -757,16 +681,22 @@ let rec expression : Typedtree.expression -> term_judg =
            function is stored in the closure without being called. *)
         let rec split_args ~has_omitted_arg = function
           | [] -> [], []
-          | (_, None) :: rest -> split_args ~has_omitted_arg:true rest
-          | (_, Some arg) :: rest ->
+          | (_, Omitted _) :: rest -> split_args ~has_omitted_arg:true rest
+          | (_, Arg (arg, _)) :: rest ->
             let applied, delayed = split_args ~has_omitted_arg rest in
             if has_omitted_arg
             then applied, arg :: delayed
             else arg :: applied, delayed
->>>>>>> 5.2.0
         in
-<<<<<<< HEAD
-        join [expression e; list arg args] << app_mode
+        let applied, delayed = split_args ~has_omitted_arg:false args in
+        let function_mode =
+          match applied with
+          | [] -> Guard
+          | _ :: _ -> Dereference
+        in
+        join [expression e << function_mode;
+              list expression applied << Dereference;
+              list expression delayed << Guard]
     | Texp_tuple (exprs, _) ->
       list expression (List.map snd exprs) << Guard
     | Texp_array (_, elt_sort, exprs, _) ->
@@ -778,53 +708,6 @@ let rec expression : Typedtree.expression -> term_judg =
       join ((expression comp_body << array_mode exp elt_sort) ::
             comprehension_clauses comp_clauses)
     | Texp_construct (_, desc, exprs, _) ->
-||||||| 121bedcfd2
-        join [expression e; list arg args] << app_mode
-    | Texp_tuple exprs ->
-      list expression exprs << Guard
-    | Texp_array exprs ->
-      let array_mode = match Typeopt.array_kind exp with
-        | Lambda.Pfloatarray ->
-            (* (flat) float arrays unbox their elements *)
-            Dereference
-        | Lambda.Pgenarray ->
-            (* This is counted as a use, because constructing a generic array
-               involves inspecting to decide whether to unbox (PR#6939). *)
-            Dereference
-        | Lambda.Paddrarray | Lambda.Pintarray ->
-            (* non-generic, non-float arrays act as constructors *)
-            Guard
-      in
-      list expression exprs << array_mode
-    | Texp_construct (_, desc, exprs) ->
-=======
-        let applied, delayed = split_args ~has_omitted_arg:false args in
-        let function_mode =
-          match applied with
-          | [] -> Guard
-          | _ :: _ -> Dereference
-        in
-        join [expression e << function_mode;
-              list expression applied << Dereference;
-              list expression delayed << Guard]
-    | Texp_tuple exprs ->
-      list expression exprs << Guard
-    | Texp_array exprs ->
-      let array_mode = match Typeopt.array_kind exp with
-        | Lambda.Pfloatarray ->
-            (* (flat) float arrays unbox their elements *)
-            Dereference
-        | Lambda.Pgenarray ->
-            (* This is counted as a use, because constructing a generic array
-               involves inspecting to decide whether to unbox (PR#6939). *)
-            Dereference
-        | Lambda.Paddrarray | Lambda.Pintarray ->
-            (* non-generic, non-float arrays act as constructors *)
-            Guard
-      in
-      list expression exprs << array_mode
-    | Texp_construct (_, desc, exprs) ->
->>>>>>> 5.2.0
       let access_constructor =
         match desc.cstr_tag with
         | Extension (pth, _) ->
@@ -1015,13 +898,7 @@ let rec expression : Typedtree.expression -> term_judg =
         path pth << Dereference;
         list field fields << Dereference;
       ]
-<<<<<<< HEAD
     | Texp_function { params; body } ->
-||||||| 121bedcfd2
-    | Texp_function { cases } ->
-=======
-    | Texp_function (params, body) ->
->>>>>>> 5.2.0
       (*
          G      |-{body} b  : m[Delay]
          (Hj    |-{def}  Pj : m[Delay])^j
@@ -1030,7 +907,6 @@ let rec expression : Typedtree.expression -> term_judg =
          -----------------------------------
          G + H - ps |- fun (Pj)^j -> b : m
       *)
-<<<<<<< HEAD
         let param_pat param =
           (* param P ::=
               | ?(pat = expr)
@@ -1070,51 +946,6 @@ let rec expression : Typedtree.expression -> term_judg =
         (fun m ->
           let env = f m in
           remove_patlist patterns env)
-||||||| 121bedcfd2
-      let case_env c m = fst (case c m) in
-      list case_env cases << Delay
-=======
-      let param_pat param =
-        (* param P ::=
-            | ?(pat = expr)
-            | pat
-
-          Define pat(P) as
-              pat if P = ?(pat = expr)
-              pat if P = pat
-          *)
-        match param.fp_kind with
-        | Tparam_pat pat -> pat
-        | Tparam_optional_default (pat, _) -> pat
-      in
-      (* Optional argument defaults.
-
-          G |-{def} P : m
-      *)
-      let param_default param =
-        match param.fp_kind with
-        | Tparam_optional_default (_, default) ->
-          (*
-              G |- e : m
-              ------------------
-              G |-{def} ?(p=e) : m
-          *)
-            expression default
-        | Tparam_pat _ ->
-          (*
-              ------------------
-              . |-{def} p : m
-          *)
-            empty
-      in
-      let patterns = List.map param_pat params in
-      let defaults = List.map param_default params in
-      let body = function_body body in
-      let f = join (body :: defaults) << Delay in
-      (fun m ->
-         let env = f m in
-         remove_patlist patterns env)
->>>>>>> 5.2.0
     | Texp_lazy e ->
       (*
         G |- e: m[Delay]
@@ -1195,35 +1026,6 @@ and comprehension_clauses clauses =
       | Texp_comp_when guard ->
           [expression guard << Dereference])
     clauses
-
-(* Function bodies.
-
-    G |-{body} b : m
-*)
-and function_body body =
-  match body with
-  | Tfunction_body body ->
-    (*
-        G |- e : m
-        ------------------
-        G |-{body} e : m (**)
-
-      (**) The "e" here stands for [Tfunction_body] as opposed to
-           [Tfunction_cases].
-    *)
-      expression body
-  | Tfunction_cases { cases; _ } ->
-    (*
-        (Gi; _ |- pi -> ei : m)^i    (**)
-        ------------------
-        sum(Gi)^i |-{body} function (pi -> ei)^i : m
-
-      (**) Contrarily to match, the values that are pattern-matched
-           are bound locally, so the pattern modes do not influence
-           the final environment.
-    *)
-      List.map (fun c mode -> fst (case c mode)) cases
-      |> join
 
 and binding_op : Typedtree.binding_op -> term_judg =
   fun bop ->
@@ -1602,16 +1404,8 @@ and pattern : type k . k general_pattern -> Env.t -> mode = fun pat env ->
 and is_destructuring_pattern : type k . k general_pattern -> bool =
   fun pat -> match pat.pat_desc with
     | Tpat_any -> false
-<<<<<<< HEAD
     | Tpat_var (_, _, _, _) -> false
     | Tpat_alias (pat, _, _, _, _) -> is_destructuring_pattern pat
-||||||| 121bedcfd2
-    | Tpat_var (_, _) -> false
-    | Tpat_alias (pat, _, _) -> is_destructuring_pattern pat
-=======
-    | Tpat_var (_, _, _) -> false
-    | Tpat_alias (pat, _, _, _) -> is_destructuring_pattern pat
->>>>>>> 5.2.0
     | Tpat_constant _ -> true
     | Tpat_tuple _ -> true
     | Tpat_construct _ -> true


### PR DESCRIPTION
Fix easy typing conflicts. I'd review commit-by-commit; occasionally a commit has extra context about a relevant PR from upstream.

The files type-check. Running the script `ocaml/jane/build-resolved-files-for-ci` produces no type errors for these files.