### PR TITLE
Revert all depend files to our side

### DIFF
--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -48,7 +48,6 @@ utils/clflags.cmi : \
     utils/zero_alloc_annotations.cmi \
     utils/profile.cmi \
     utils/misc.cmi
-<<<<<<< HEAD
 utils/compilation_unit.cmo : \
     utils/misc.cmi \
     utils/int_replace_polymorphic_compare.cmi \
@@ -66,14 +65,6 @@ utils/compilation_unit.cmx : \
 utils/compilation_unit.cmi : \
     utils/identifiable.cmi \
     typing/ident.cmi
-||||||| 121bedcfd2
-=======
-utils/compression.cmo : \
-    utils/compression.cmi
-utils/compression.cmx : \
-    utils/compression.cmi
-utils/compression.cmi :
->>>>>>> 5.2.0
 utils/config.common.cmo :
 utils/config.common.cmx :
 utils/config.fixed.cmo :
@@ -402,14 +393,12 @@ parsing/asttypes.cmi : \
     parsing/location.cmi
 parsing/attr_helper.cmo : \
     parsing/parsetree.cmi \
-    utils/misc.cmi \
     parsing/location.cmi \
     parsing/builtin_attributes.cmi \
     parsing/asttypes.cmi \
     parsing/attr_helper.cmi
 parsing/attr_helper.cmx : \
     parsing/parsetree.cmi \
-    utils/misc.cmx \
     parsing/location.cmx \
     parsing/builtin_attributes.cmx \
     parsing/asttypes.cmi \
@@ -426,13 +415,8 @@ parsing/builtin_attributes.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-<<<<<<< HEAD
     utils/config.cmi \
     utils/clflags.cmi \
-||||||| 121bedcfd2
-=======
-    utils/clflags.cmi \
->>>>>>> 5.2.0
     parsing/asttypes.cmi \
     parsing/ast_iterator.cmi \
     parsing/ast_helper.cmi \
@@ -445,13 +429,8 @@ parsing/builtin_attributes.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
-<<<<<<< HEAD
     utils/config.cmx \
     utils/clflags.cmx \
-||||||| 121bedcfd2
-=======
-    utils/clflags.cmx \
->>>>>>> 5.2.0
     parsing/asttypes.cmi \
     parsing/ast_iterator.cmx \
     parsing/ast_helper.cmx \
@@ -600,7 +579,6 @@ parsing/parse.cmo : \
     parsing/syntaxerr.cmi \
     parsing/pprintast.cmi \
     parsing/parser.cmi \
-    utils/misc.cmi \
     parsing/location.cmi \
     parsing/lexer.cmi \
     parsing/docstrings.cmi \
@@ -609,7 +587,6 @@ parsing/parse.cmx : \
     parsing/syntaxerr.cmx \
     parsing/pprintast.cmx \
     parsing/parser.cmx \
-    utils/misc.cmx \
     parsing/location.cmx \
     parsing/lexer.cmx \
     parsing/docstrings.cmx \
@@ -664,13 +641,8 @@ parsing/pprintast.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-<<<<<<< HEAD
     utils/language_extension.cmi \
     parsing/jane_syntax.cmi \
-||||||| 121bedcfd2
-=======
-    parsing/lexer.cmi \
->>>>>>> 5.2.0
     parsing/asttypes.cmi \
     parsing/ast_helper.cmi \
     parsing/pprintast.cmi
@@ -679,13 +651,8 @@ parsing/pprintast.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
-<<<<<<< HEAD
     utils/language_extension.cmx \
     parsing/jane_syntax.cmx \
-||||||| 121bedcfd2
-=======
-    parsing/lexer.cmx \
->>>>>>> 5.2.0
     parsing/asttypes.cmi \
     parsing/ast_helper.cmx \
     parsing/pprintast.cmi
@@ -717,21 +684,6 @@ parsing/syntaxerr.cmx : \
     parsing/syntaxerr.cmi
 parsing/syntaxerr.cmi : \
     parsing/location.cmi
-parsing/unit_info.cmo : \
-    utils/warnings.cmi \
-    utils/misc.cmi \
-    parsing/location.cmi \
-    utils/load_path.cmi \
-    utils/config.cmi \
-    parsing/unit_info.cmi
-parsing/unit_info.cmx : \
-    utils/warnings.cmx \
-    utils/misc.cmx \
-    parsing/location.cmx \
-    utils/load_path.cmx \
-    utils/config.cmx \
-    parsing/unit_info.cmi
-parsing/unit_info.cmi :
 typing/annot.cmi : \
     parsing/location.cmi
 typing/btype.cmo : \
@@ -868,7 +820,6 @@ typing/datarepr.cmi : \
     utils/compilation_unit.cmi
 typing/env.cmo : \
     utils/warnings.cmi \
-    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/subst.cmi \
     typing/shape.cmi \
@@ -895,7 +846,6 @@ typing/env.cmo : \
     typing/env.cmi
 typing/env.cmx : \
     utils/warnings.cmx \
-    parsing/unit_info.cmx \
     typing/types.cmx \
     typing/subst.cmx \
     typing/shape.cmx \
@@ -922,7 +872,6 @@ typing/env.cmx : \
     typing/env.cmi
 typing/env.cmi : \
     utils/warnings.cmi \
-    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/subst.cmi \
     typing/shape.cmi \
@@ -942,7 +891,6 @@ typing/envaux.cmo : \
     typing/subst.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
-    utils/misc.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
     typing/env.cmi \
@@ -952,7 +900,6 @@ typing/envaux.cmx : \
     typing/subst.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \
-    utils/misc.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
     typing/env.cmx \
@@ -997,7 +944,6 @@ typing/includeclass.cmo : \
     typing/types.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
-    utils/misc.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
     typing/includeclass.cmi
@@ -1005,7 +951,6 @@ typing/includeclass.cmx : \
     typing/types.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \
-    utils/misc.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
     typing/includeclass.cmi
@@ -1270,23 +1215,13 @@ typing/mtype.cmi : \
 typing/oprint.cmo : \
     parsing/pprintast.cmi \
     typing/outcometree.cmi \
-<<<<<<< HEAD
     typing/jkind.cmi \
-||||||| 121bedcfd2
-=======
-    parsing/lexer.cmi \
->>>>>>> 5.2.0
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmx : \
     parsing/pprintast.cmx \
     typing/outcometree.cmi \
-<<<<<<< HEAD
     typing/jkind.cmx \
-||||||| 121bedcfd2
-=======
-    parsing/lexer.cmx \
->>>>>>> 5.2.0
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmi : \
@@ -1304,13 +1239,8 @@ typing/parmatch.cmo : \
     typing/predef.cmi \
     typing/patterns.cmi \
     typing/path.cmi \
-<<<<<<< HEAD
     parsing/parsetree.cmi \
     typing/mode.cmi \
-||||||| 121bedcfd2
-=======
-    parsing/parsetree.cmi \
->>>>>>> 5.2.0
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
@@ -1331,13 +1261,8 @@ typing/parmatch.cmx : \
     typing/predef.cmx \
     typing/patterns.cmx \
     typing/path.cmx \
-<<<<<<< HEAD
     parsing/parsetree.cmi \
     typing/mode.cmx \
-||||||| 121bedcfd2
-=======
-    parsing/parsetree.cmi \
->>>>>>> 5.2.0
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
@@ -1356,11 +1281,9 @@ typing/parmatch.cmi : \
     typing/env.cmi \
     parsing/asttypes.cmi
 typing/path.cmo : \
-    parsing/lexer.cmi \
     typing/ident.cmi \
     typing/path.cmi
 typing/path.cmx : \
-    parsing/lexer.cmx \
     typing/ident.cmx \
     typing/path.cmi
 typing/path.cmi : \
@@ -1399,13 +1322,8 @@ typing/patterns.cmi : \
     parsing/asttypes.cmi
 typing/persistent_env.cmo : \
     utils/warnings.cmi \
-<<<<<<< HEAD
     typing/subst.cmi \
     typing/shape.cmi \
-||||||| 121bedcfd2
-=======
-    parsing/unit_info.cmi \
->>>>>>> 5.2.0
     utils/misc.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
@@ -1419,13 +1337,8 @@ typing/persistent_env.cmo : \
     typing/persistent_env.cmi
 typing/persistent_env.cmx : \
     utils/warnings.cmx \
-<<<<<<< HEAD
     typing/subst.cmx \
     typing/shape.cmx \
-||||||| 121bedcfd2
-=======
-    parsing/unit_info.cmx \
->>>>>>> 5.2.0
     utils/misc.cmx \
     parsing/location.cmx \
     utils/load_path.cmx \
@@ -1438,15 +1351,8 @@ typing/persistent_env.cmx : \
     utils/clflags.cmx \
     typing/persistent_env.cmi
 typing/persistent_env.cmi : \
-<<<<<<< HEAD
     typing/subst.cmi \
     typing/shape.cmi \
-||||||| 121bedcfd2
-    typing/types.cmi \
-=======
-    parsing/unit_info.cmi \
-    typing/types.cmi \
->>>>>>> 5.2.0
     utils/misc.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
@@ -1528,13 +1434,11 @@ typing/printpat.cmi : \
     typing/typedtree.cmi
 typing/printtyp.cmo : \
     utils/warnings.cmi \
-    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/signature_group.cmi \
     typing/shape.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
-    parsing/pprintast.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
@@ -1555,13 +1459,11 @@ typing/printtyp.cmo : \
     typing/printtyp.cmi
 typing/printtyp.cmx : \
     utils/warnings.cmx \
-    parsing/unit_info.cmx \
     typing/types.cmx \
     typing/signature_group.cmx \
     typing/shape.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
-    parsing/pprintast.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
@@ -1642,7 +1544,6 @@ typing/shape.cmx : \
 typing/shape.cmi : \
     typing/path.cmi \
     utils/identifiable.cmi \
-<<<<<<< HEAD
     typing/ident.cmi \
     utils/compilation_unit.cmi
 typing/shape_reduce.cmo : \
@@ -1660,26 +1561,6 @@ typing/shape_reduce.cmx : \
 typing/shape_reduce.cmi : \
     typing/shape.cmi \
     typing/env.cmi
-||||||| 121bedcfd2
-    typing/ident.cmi
-=======
-    typing/ident.cmi
-typing/shape_reduce.cmo : \
-    typing/shape.cmi \
-    utils/local_store.cmi \
-    typing/ident.cmi \
-    typing/env.cmi \
-    typing/shape_reduce.cmi
-typing/shape_reduce.cmx : \
-    typing/shape.cmx \
-    utils/local_store.cmx \
-    typing/ident.cmx \
-    typing/env.cmx \
-    typing/shape_reduce.cmi
-typing/shape_reduce.cmi : \
-    typing/shape.cmi \
-    typing/env.cmi
->>>>>>> 5.2.0
 typing/signature_group.cmo : \
     typing/types.cmi \
     typing/ident.cmi \
@@ -1984,12 +1865,7 @@ typing/typedecl.cmo : \
     utils/warnings.cmi \
     typing/typetexp.cmi \
     typing/types.cmi \
-<<<<<<< HEAD
     typing/typemode.cmi \
-||||||| 121bedcfd2
-=======
-    typing/typeopt.cmi \
->>>>>>> 5.2.0
     typing/typedtree.cmi \
     typing/typedecl_variance.cmi \
     typing/typedecl_separability.cmi \
@@ -2006,14 +1882,9 @@ typing/typedecl.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-<<<<<<< HEAD
     utils/language_extension.cmi \
     typing/jkind.cmi \
     parsing/jane_syntax.cmi \
-||||||| 121bedcfd2
-=======
-    lambda/lambda.cmi \
->>>>>>> 5.2.0
     typing/includecore.cmi \
     typing/ident.cmi \
     typing/errortrace.cmi \
@@ -2032,12 +1903,7 @@ typing/typedecl.cmx : \
     utils/warnings.cmx \
     typing/typetexp.cmx \
     typing/types.cmx \
-<<<<<<< HEAD
     typing/typemode.cmx \
-||||||| 121bedcfd2
-=======
-    typing/typeopt.cmx \
->>>>>>> 5.2.0
     typing/typedtree.cmx \
     typing/typedecl_variance.cmx \
     typing/typedecl_separability.cmx \
@@ -2054,14 +1920,9 @@ typing/typedecl.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
-<<<<<<< HEAD
     utils/language_extension.cmx \
     typing/jkind.cmx \
     parsing/jane_syntax.cmx \
-||||||| 121bedcfd2
-=======
-    lambda/lambda.cmx \
->>>>>>> 5.2.0
     typing/includecore.cmx \
     typing/ident.cmx \
     typing/errortrace.cmx \
@@ -2081,14 +1942,7 @@ typing/typedecl.cmi : \
     typing/typedtree.cmi \
     typing/typedecl_variance.cmi \
     typing/typedecl_separability.cmi \
-<<<<<<< HEAD
     typing/shape.cmi \
-||||||| 121bedcfd2
-    typing/typedecl_immediacy.cmi \
-=======
-    typing/typedecl_immediacy.cmi \
-    typing/shape.cmi \
->>>>>>> 5.2.0
     typing/path.cmi \
     parsing/parsetree.cmi \
     typing/mode.cmi \
@@ -2178,13 +2032,8 @@ typing/typedecl_variance.cmi : \
     typing/env.cmi \
     parsing/asttypes.cmi
 typing/typedtree.cmo : \
-<<<<<<< HEAD
     utils/zero_alloc_utils.cmi \
     typing/value_rec_types.cmi \
-||||||| 121bedcfd2
-=======
-    typing/value_rec_types.cmi \
->>>>>>> 5.2.0
     typing/types.cmi \
     typing/shape.cmi \
     typing/primitive.cmi \
@@ -2201,13 +2050,8 @@ typing/typedtree.cmo : \
     parsing/asttypes.cmi \
     typing/typedtree.cmi
 typing/typedtree.cmx : \
-<<<<<<< HEAD
     utils/zero_alloc_utils.cmx \
     typing/value_rec_types.cmi \
-||||||| 121bedcfd2
-=======
-    typing/value_rec_types.cmi \
->>>>>>> 5.2.0
     typing/types.cmx \
     typing/shape.cmx \
     typing/primitive.cmx \
@@ -2224,13 +2068,8 @@ typing/typedtree.cmx : \
     parsing/asttypes.cmi \
     typing/typedtree.cmi
 typing/typedtree.cmi : \
-<<<<<<< HEAD
     utils/zero_alloc_utils.cmi \
     typing/value_rec_types.cmi \
-||||||| 121bedcfd2
-=======
-    typing/value_rec_types.cmi \
->>>>>>> 5.2.0
     typing/types.cmi \
     typing/shape.cmi \
     typing/primitive.cmi \
@@ -2247,11 +2086,9 @@ typing/typedtree.cmi : \
     parsing/asttypes.cmi
 typing/typemod.cmo : \
     utils/warnings.cmi \
-    parsing/unit_info.cmi \
     typing/typetexp.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
-    typing/typedecl_immediacy.cmi \
     typing/typedecl.cmi \
     typing/typecore.cmi \
     typing/typeclass.cmi \
@@ -2279,13 +2116,8 @@ typing/typemod.cmo : \
     typing/envaux.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
-<<<<<<< HEAD
     utils/config.cmi \
     utils/compilation_unit.cmi \
-||||||| 121bedcfd2
-    utils/config.cmi \
-=======
->>>>>>> 5.2.0
     file_formats/cmt_format.cmi \
     typing/cmt2annot.cmi \
     file_formats/cms_format.cmi \
@@ -2298,11 +2130,9 @@ typing/typemod.cmo : \
     typing/typemod.cmi
 typing/typemod.cmx : \
     utils/warnings.cmx \
-    parsing/unit_info.cmx \
     typing/typetexp.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
-    typing/typedecl_immediacy.cmx \
     typing/typedecl.cmx \
     typing/typecore.cmx \
     typing/typeclass.cmx \
@@ -2330,13 +2160,8 @@ typing/typemod.cmx : \
     typing/envaux.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
-<<<<<<< HEAD
     utils/config.cmx \
     utils/compilation_unit.cmx \
-||||||| 121bedcfd2
-    utils/config.cmx \
-=======
->>>>>>> 5.2.0
     file_formats/cmt_format.cmx \
     typing/cmt2annot.cmx \
     file_formats/cms_format.cmx \
@@ -2348,7 +2173,6 @@ typing/typemod.cmx : \
     parsing/asttypes.cmi \
     typing/typemod.cmi
 typing/typemod.cmi : \
-    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/typedecl.cmi \
@@ -2529,34 +2353,19 @@ typing/typetexp.cmi : \
     typing/jkind.cmi \
     parsing/jane_syntax.cmi \
     typing/errortrace.cmi \
-<<<<<<< HEAD
     typing/env.cmi \
     parsing/asttypes.cmi
 typing/uniqueness_analysis.cmo : \
     typing/types.cmi \
-||||||| 121bedcfd2
-    typing/env.cmi
-typing/untypeast.cmo : \
-=======
-    typing/env.cmi \
-    parsing/asttypes.cmi
-typing/untypeast.cmo : \
->>>>>>> 5.2.0
     typing/typedtree.cmi \
     typing/tast_iterator.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
-<<<<<<< HEAD
     typing/mode.cmi \
-||||||| 121bedcfd2
-    parsing/parsetree.cmi \
-    utils/misc.cmi \
-=======
-    parsing/parsetree.cmi \
->>>>>>> 5.2.0
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    typing/env.cmi \
     parsing/asttypes.cmi \
     typing/uniqueness_analysis.cmi
 typing/uniqueness_analysis.cmx : \
@@ -2565,17 +2374,11 @@ typing/uniqueness_analysis.cmx : \
     typing/tast_iterator.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \
-<<<<<<< HEAD
     typing/mode.cmx \
-||||||| 121bedcfd2
-    parsing/parsetree.cmi \
-    utils/misc.cmx \
-=======
-    parsing/parsetree.cmi \
->>>>>>> 5.2.0
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    typing/env.cmx \
     parsing/asttypes.cmi \
     typing/uniqueness_analysis.cmi
 typing/uniqueness_analysis.cmi : \
@@ -2616,18 +2419,9 @@ typing/untypeast.cmi : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-<<<<<<< HEAD
     parsing/jane_syntax.cmi
 typing/value_rec_check.cmo : \
     typing/value_rec_types.cmi \
-||||||| 121bedcfd2
-    parsing/asttypes.cmi
-bytecomp/bytegen.cmo : \
-=======
-    parsing/asttypes.cmi
-typing/value_rec_check.cmo : \
-    typing/value_rec_types.cmi \
->>>>>>> 5.2.0
     typing/types.cmi \
     typing/typeopt.cmi \
     typing/typedtree.cmi \
@@ -2720,23 +2514,13 @@ bytecomp/bytelink.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     bytecomp/instruct.cmi \
-<<<<<<< HEAD
     utils/import_info.cmi \
     typing/ident.cmi \
-||||||| 121bedcfd2
-    typing/ident.cmi \
-=======
->>>>>>> 5.2.0
     bytecomp/emitcode.cmi \
     bytecomp/dll.cmi \
     utils/consistbl.cmi \
     utils/config.cmi \
-<<<<<<< HEAD
     utils/compilation_unit.cmi \
-||||||| 121bedcfd2
-=======
-    utils/compression.cmi \
->>>>>>> 5.2.0
     file_formats/cmo_format.cmi \
     utils/clflags.cmi \
     utils/ccomp.cmi \
@@ -2749,23 +2533,13 @@ bytecomp/bytelink.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     bytecomp/instruct.cmx \
-<<<<<<< HEAD
     utils/import_info.cmx \
     typing/ident.cmx \
-||||||| 121bedcfd2
-    typing/ident.cmx \
-=======
->>>>>>> 5.2.0
     bytecomp/emitcode.cmx \
     bytecomp/dll.cmx \
     utils/consistbl.cmx \
     utils/config.cmx \
-<<<<<<< HEAD
     utils/compilation_unit.cmx \
-||||||| 121bedcfd2
-=======
-    utils/compression.cmx \
->>>>>>> 5.2.0
     file_formats/cmo_format.cmi \
     utils/clflags.cmx \
     utils/ccomp.cmx \
@@ -2778,10 +2552,8 @@ bytecomp/bytelink.cmi : \
     utils/compilation_unit.cmi \
     file_formats/cmo_format.cmi
 bytecomp/bytepackager.cmo : \
-    parsing/unit_info.cmi \
     typing/typemod.cmi \
     lambda/translmod.cmi \
-    bytecomp/symtable.cmi \
     typing/subst.cmi \
     lambda/simplif.cmi \
     lambda/printlambda.cmi \
@@ -2795,22 +2567,15 @@ bytecomp/bytepackager.cmo : \
     typing/env.cmi \
     bytecomp/emitcode.cmi \
     utils/config.cmi \
-<<<<<<< HEAD
     utils/compilation_unit.cmi \
-||||||| 121bedcfd2
-=======
-    utils/compression.cmi \
->>>>>>> 5.2.0
     file_formats/cmo_format.cmi \
     utils/clflags.cmi \
     bytecomp/bytelink.cmi \
     bytecomp/bytegen.cmi \
     bytecomp/bytepackager.cmi
 bytecomp/bytepackager.cmx : \
-    parsing/unit_info.cmx \
     typing/typemod.cmx \
     lambda/translmod.cmx \
-    bytecomp/symtable.cmx \
     typing/subst.cmx \
     lambda/simplif.cmx \
     lambda/printlambda.cmx \
@@ -2824,29 +2589,16 @@ bytecomp/bytepackager.cmx : \
     typing/env.cmx \
     bytecomp/emitcode.cmx \
     utils/config.cmx \
-<<<<<<< HEAD
     utils/compilation_unit.cmx \
-||||||| 121bedcfd2
-=======
-    utils/compression.cmx \
->>>>>>> 5.2.0
     file_formats/cmo_format.cmi \
     utils/clflags.cmx \
     bytecomp/bytelink.cmx \
     bytecomp/bytegen.cmx \
     bytecomp/bytepackager.cmi
 bytecomp/bytepackager.cmi : \
-<<<<<<< HEAD
     typing/ident.cmi \
     typing/env.cmi \
     utils/compilation_unit.cmi
-||||||| 121bedcfd2
-    typing/ident.cmi \
-    typing/env.cmi
-=======
-    typing/env.cmi \
-    file_formats/cmo_format.cmi
->>>>>>> 5.2.0
 bytecomp/bytesections.cmo : \
     utils/config.cmi \
     bytecomp/bytesections.cmi
@@ -2872,7 +2624,6 @@ bytecomp/dll.cmx : \
     bytecomp/dll.cmi
 bytecomp/dll.cmi :
 bytecomp/emitcode.cmo : \
-    parsing/unit_info.cmi \
     lambda/translmod.cmi \
     bytecomp/symtable.cmi \
     typing/primitive.cmi \
@@ -2883,19 +2634,13 @@ bytecomp/emitcode.cmo : \
     bytecomp/instruct.cmi \
     typing/env.cmi \
     utils/config.cmi \
-<<<<<<< HEAD
     utils/compilation_unit.cmi \
-||||||| 121bedcfd2
-=======
-    utils/compression.cmi \
->>>>>>> 5.2.0
     file_formats/cmo_format.cmi \
     utils/clflags.cmi \
     bytecomp/bytegen.cmi \
     typing/btype.cmi \
     bytecomp/emitcode.cmi
 bytecomp/emitcode.cmx : \
-    parsing/unit_info.cmx \
     lambda/translmod.cmx \
     bytecomp/symtable.cmx \
     typing/primitive.cmx \
@@ -2906,19 +2651,13 @@ bytecomp/emitcode.cmx : \
     bytecomp/instruct.cmx \
     typing/env.cmx \
     utils/config.cmx \
-<<<<<<< HEAD
     utils/compilation_unit.cmx \
-||||||| 121bedcfd2
-=======
-    utils/compression.cmx \
->>>>>>> 5.2.0
     file_formats/cmo_format.cmi \
     utils/clflags.cmx \
     bytecomp/bytegen.cmx \
     typing/btype.cmx \
     bytecomp/emitcode.cmi
 bytecomp/emitcode.cmi : \
-    parsing/unit_info.cmi \
     utils/misc.cmi \
     bytecomp/instruct.cmi \
     utils/compilation_unit.cmi \
@@ -2991,13 +2730,7 @@ bytecomp/symtable.cmo : \
     utils/config.cmi \
     file_formats/cmo_format.cmi \
     utils/clflags.cmi \
-<<<<<<< HEAD
     bytecomp/bytesections.cmi \
-||||||| 121bedcfd2
-    bytecomp/bytesections.cmi \
-    parsing/asttypes.cmi \
-=======
->>>>>>> 5.2.0
     bytecomp/symtable.cmi
 bytecomp/symtable.cmx : \
     lambda/runtimedef.cmx \
@@ -3012,13 +2745,7 @@ bytecomp/symtable.cmx : \
     utils/config.cmx \
     file_formats/cmo_format.cmi \
     utils/clflags.cmx \
-<<<<<<< HEAD
     bytecomp/bytesections.cmx \
-||||||| 121bedcfd2
-    bytecomp/bytesections.cmx \
-    parsing/asttypes.cmi \
-=======
->>>>>>> 5.2.0
     bytecomp/symtable.cmi
 bytecomp/symtable.cmi : \
     utils/misc.cmi \
@@ -3086,7 +2813,6 @@ asmcomp/arch.cmi : \
     asmcomp/x86_ast.cmi \
     lambda/lambda.cmi
 asmcomp/asmgen.cmo : \
-    parsing/unit_info.cmi \
     lambda/translmod.cmi \
     asmcomp/split.cmi \
     asmcomp/spill.cmi \
@@ -3130,7 +2856,6 @@ asmcomp/asmgen.cmo : \
     middle_end/backend_intf.cmi \
     asmcomp/asmgen.cmi
 asmcomp/asmgen.cmx : \
-    parsing/unit_info.cmx \
     lambda/translmod.cmx \
     asmcomp/split.cmx \
     asmcomp/spill.cmx \
@@ -3174,7 +2899,6 @@ asmcomp/asmgen.cmx : \
     middle_end/backend_intf.cmi \
     asmcomp/asmgen.cmi
 asmcomp/asmgen.cmi : \
-    parsing/unit_info.cmi \
     lambda/lambda.cmi \
     asmcomp/emitaux.cmi \
     utils/compilation_unit.cmi \
@@ -3209,12 +2933,7 @@ asmcomp/asmlibrarian.cmx : \
     asmcomp/asmlibrarian.cmi
 asmcomp/asmlibrarian.cmi :
 asmcomp/asmlink.cmo : \
-<<<<<<< HEAD
     utils/symbol.cmi \
-||||||| 121bedcfd2
-=======
-    asmcomp/thread_sanitizer.cmi \
->>>>>>> 5.2.0
     lambda/runtimedef.cmi \
     utils/profile.cmi \
     utils/misc.cmi \
@@ -3235,12 +2954,7 @@ asmcomp/asmlink.cmo : \
     asmcomp/asmgen.cmi \
     asmcomp/asmlink.cmi
 asmcomp/asmlink.cmx : \
-<<<<<<< HEAD
     utils/symbol.cmx \
-||||||| 121bedcfd2
-=======
-    asmcomp/thread_sanitizer.cmx \
->>>>>>> 5.2.0
     lambda/runtimedef.cmx \
     utils/profile.cmx \
     utils/misc.cmx \
@@ -3266,7 +2980,6 @@ asmcomp/asmlink.cmi : \
     utils/compilation_unit.cmi \
     file_formats/cmx_format.cmi
 asmcomp/asmpackager.cmo : \
-    parsing/unit_info.cmi \
     typing/typemod.cmi \
     lambda/translmod.cmi \
     utils/symbol.cmi \
@@ -3292,7 +3005,6 @@ asmcomp/asmpackager.cmo : \
     asmcomp/asmgen.cmi \
     asmcomp/asmpackager.cmi
 asmcomp/asmpackager.cmx : \
-    parsing/unit_info.cmx \
     typing/typemod.cmx \
     lambda/translmod.cmx \
     utils/symbol.cmx \
@@ -3442,12 +3154,6 @@ asmcomp/cmm_invariants.cmx : \
 asmcomp/cmm_invariants.cmi : \
     asmcomp/cmm.cmi
 asmcomp/cmmgen.cmo : \
-<<<<<<< HEAD
-||||||| 121bedcfd2
-    typing/types.cmi \
-=======
-    asmcomp/thread_sanitizer.cmi \
->>>>>>> 5.2.0
     middle_end/printclambda_primitives.cmi \
     typing/primitive.cmi \
     utils/misc.cmi \
@@ -3467,12 +3173,6 @@ asmcomp/cmmgen.cmo : \
     asmcomp/afl_instrument.cmi \
     asmcomp/cmmgen.cmi
 asmcomp/cmmgen.cmx : \
-<<<<<<< HEAD
-||||||| 121bedcfd2
-    typing/types.cmx \
-=======
-    asmcomp/thread_sanitizer.cmx \
->>>>>>> 5.2.0
     middle_end/printclambda_primitives.cmx \
     typing/primitive.cmx \
     utils/misc.cmx \
@@ -3617,33 +3317,21 @@ asmcomp/emit.cmi : \
     asmcomp/linear.cmi \
     asmcomp/cmm.cmi
 asmcomp/emitaux.cmo : \
-<<<<<<< HEAD
     utils/misc.cmi \
     asmcomp/linear.cmi \
-||||||| 121bedcfd2
-    asmcomp/linear.cmi \
-=======
->>>>>>> 5.2.0
     asmcomp/emitenv.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
-    middle_end/compilenv.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
     asmcomp/arch.cmi \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmx : \
-<<<<<<< HEAD
     utils/misc.cmx \
     asmcomp/linear.cmx \
-||||||| 121bedcfd2
-    asmcomp/linear.cmx \
-=======
->>>>>>> 5.2.0
     asmcomp/emitenv.cmi \
     lambda/debuginfo.cmx \
     utils/config.cmx \
-    middle_end/compilenv.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
     asmcomp/arch.cmx \
@@ -3702,8 +3390,8 @@ asmcomp/linear.cmi : \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi
 asmcomp/linearize.cmo : \
-    asmcomp/stackframe.cmi \
     asmcomp/reg.cmi \
+    asmcomp/proc.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     asmcomp/linear.cmi \
@@ -3711,8 +3399,8 @@ asmcomp/linearize.cmo : \
     asmcomp/cmm.cmi \
     asmcomp/linearize.cmi
 asmcomp/linearize.cmx : \
-    asmcomp/stackframe.cmx \
     asmcomp/reg.cmx \
+    asmcomp/proc.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     asmcomp/linear.cmx \
@@ -3971,6 +3659,7 @@ asmcomp/selectgen.cmo : \
     lambda/debuginfo.cmi \
     utils/config.cmi \
     asmcomp/cmm.cmi \
+    utils/clflags.cmi \
     middle_end/backend_var.cmi \
     parsing/asttypes.cmi \
     asmcomp/arch.cmi \
@@ -3986,6 +3675,7 @@ asmcomp/selectgen.cmx : \
     lambda/debuginfo.cmx \
     utils/config.cmx \
     asmcomp/cmm.cmx \
+    utils/clflags.cmx \
     middle_end/backend_var.cmx \
     parsing/asttypes.cmi \
     asmcomp/arch.cmx \
@@ -4053,31 +3743,6 @@ asmcomp/split.cmx : \
     asmcomp/split.cmi
 asmcomp/split.cmi : \
     asmcomp/mach.cmi
-asmcomp/stackframe.cmo : \
-    asmcomp/stackframegen.cmi \
-    asmcomp/mach.cmi \
-    utils/config.cmi \
-    asmcomp/stackframe.cmi
-asmcomp/stackframe.cmx : \
-    asmcomp/stackframegen.cmx \
-    asmcomp/mach.cmx \
-    utils/config.cmx \
-    asmcomp/stackframe.cmi
-asmcomp/stackframe.cmi : \
-    asmcomp/stackframegen.cmi \
-    asmcomp/mach.cmi
-asmcomp/stackframegen.cmo : \
-    asmcomp/mach.cmi \
-    lambda/lambda.cmi \
-    utils/clflags.cmi \
-    asmcomp/stackframegen.cmi
-asmcomp/stackframegen.cmx : \
-    asmcomp/mach.cmx \
-    lambda/lambda.cmx \
-    utils/clflags.cmx \
-    asmcomp/stackframegen.cmi
-asmcomp/stackframegen.cmi : \
-    asmcomp/mach.cmi
 asmcomp/strmatch.cmo : \
     lambda/lambda.cmi \
     lambda/debuginfo.cmi \
@@ -4096,22 +3761,6 @@ asmcomp/strmatch.cmx : \
     asmcomp/strmatch.cmi
 asmcomp/strmatch.cmi : \
     lambda/debuginfo.cmi \
-    asmcomp/cmm.cmi
-asmcomp/thread_sanitizer.cmo : \
-    lambda/debuginfo.cmi \
-    asmcomp/cmm_helpers.cmi \
-    asmcomp/cmm.cmi \
-    middle_end/backend_var.cmi \
-    parsing/asttypes.cmi \
-    asmcomp/thread_sanitizer.cmi
-asmcomp/thread_sanitizer.cmx : \
-    lambda/debuginfo.cmx \
-    asmcomp/cmm_helpers.cmx \
-    asmcomp/cmm.cmx \
-    middle_end/backend_var.cmx \
-    parsing/asttypes.cmi \
-    asmcomp/thread_sanitizer.cmi
-asmcomp/thread_sanitizer.cmi : \
     asmcomp/cmm.cmi
 asmcomp/x86_ast.cmi :
 asmcomp/x86_dsl.cmo : \
@@ -4150,7 +3799,6 @@ asmcomp/x86_proc.cmo : \
     asmcomp/x86_ast.cmi \
     utils/misc.cmi \
     utils/config.cmi \
-    middle_end/compilenv.cmi \
     utils/clflags.cmi \
     utils/ccomp.cmi \
     asmcomp/x86_proc.cmi
@@ -4158,7 +3806,6 @@ asmcomp/x86_proc.cmx : \
     asmcomp/x86_ast.cmi \
     utils/misc.cmx \
     utils/config.cmx \
-    middle_end/compilenv.cmx \
     utils/clflags.cmx \
     utils/ccomp.cmx \
     asmcomp/x86_proc.cmi
@@ -4571,7 +4218,6 @@ lambda/switch.cmx : \
 lambda/switch.cmi :
 lambda/tmc.cmo : \
     utils/warnings.cmi \
-    utils/misc.cmi \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
@@ -4579,7 +4225,6 @@ lambda/tmc.cmo : \
     lambda/tmc.cmi
 lambda/tmc.cmx : \
     utils/warnings.cmx \
-    utils/misc.cmx \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
@@ -4699,7 +4344,6 @@ lambda/translclass.cmo : \
     lambda/translobj.cmi \
     lambda/translcore.cmi \
     typing/path.cmi \
-    utils/misc.cmi \
     lambda/matching.cmi \
     parsing/location.cmi \
     lambda/lambda.cmi \
@@ -4719,7 +4363,6 @@ lambda/translclass.cmx : \
     lambda/translobj.cmx \
     lambda/translcore.cmx \
     typing/path.cmx \
-    utils/misc.cmx \
     lambda/matching.cmx \
     parsing/location.cmx \
     lambda/lambda.cmx \
@@ -4740,13 +4383,8 @@ lambda/translclass.cmi : \
     lambda/debuginfo.cmi \
     parsing/asttypes.cmi
 lambda/translcore.cmo : \
-<<<<<<< HEAD
     utils/zero_alloc_utils.cmi \
     lambda/value_rec_compiler.cmi \
-||||||| 121bedcfd2
-=======
-    lambda/value_rec_compiler.cmi \
->>>>>>> 5.2.0
     typing/types.cmi \
     typing/typeopt.cmi \
     typing/typedtree.cmi \
@@ -4763,15 +4401,10 @@ lambda/translcore.cmo : \
     typing/predef.cmi \
     parsing/pprintast.cmi \
     typing/path.cmi \
-<<<<<<< HEAD
     typing/mode.cmi \
-||||||| 121bedcfd2
-    parsing/parsetree.cmi \
-    typing/parmatch.cmi \
-=======
->>>>>>> 5.2.0
     utils/misc.cmi \
     lambda/matching.cmi \
+    parsing/longident.cmi \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/jkind.cmi \
@@ -4786,13 +4419,8 @@ lambda/translcore.cmo : \
     parsing/asttypes.cmi \
     lambda/translcore.cmi
 lambda/translcore.cmx : \
-<<<<<<< HEAD
     utils/zero_alloc_utils.cmx \
     lambda/value_rec_compiler.cmx \
-||||||| 121bedcfd2
-=======
-    lambda/value_rec_compiler.cmx \
->>>>>>> 5.2.0
     typing/types.cmx \
     typing/typeopt.cmx \
     typing/typedtree.cmx \
@@ -4809,15 +4437,10 @@ lambda/translcore.cmx : \
     typing/predef.cmx \
     parsing/pprintast.cmx \
     typing/path.cmx \
-<<<<<<< HEAD
     typing/mode.cmx \
-||||||| 121bedcfd2
-    parsing/parsetree.cmi \
-    typing/parmatch.cmx \
-=======
->>>>>>> 5.2.0
     utils/misc.cmx \
     lambda/matching.cmx \
+    parsing/longident.cmx \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/jkind.cmx \
@@ -4995,7 +4618,6 @@ lambda/translprim.cmi : \
     lambda/lambda.cmi \
     typing/jkind.cmi \
     typing/ident.cmi \
-<<<<<<< HEAD
     typing/env.cmi \
     utils/compilation_unit.cmi
 lambda/value_rec_compiler.cmo : \
@@ -5018,35 +4640,6 @@ lambda/value_rec_compiler.cmi : \
     typing/value_rec_types.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi
-||||||| 121bedcfd2
-    typing/env.cmi
-=======
-    typing/env.cmi
-lambda/value_rec_compiler.cmo : \
-    typing/value_rec_types.cmi \
-    typing/primitive.cmi \
-    utils/misc.cmi \
-    utils/lazy_backtrack.cmi \
-    lambda/lambda.cmi \
-    typing/ident.cmi \
-    lambda/debuginfo.cmi \
-    parsing/asttypes.cmi \
-    lambda/value_rec_compiler.cmi
-lambda/value_rec_compiler.cmx : \
-    typing/value_rec_types.cmi \
-    typing/primitive.cmx \
-    utils/misc.cmx \
-    utils/lazy_backtrack.cmx \
-    lambda/lambda.cmx \
-    typing/ident.cmx \
-    lambda/debuginfo.cmx \
-    parsing/asttypes.cmi \
-    lambda/value_rec_compiler.cmi
-lambda/value_rec_compiler.cmi : \
-    typing/value_rec_types.cmi \
-    lambda/lambda.cmi \
-    typing/ident.cmi
->>>>>>> 5.2.0
 file_formats/cmi_format.cmo : \
     typing/types.cmi \
     typing/subst.cmi \
@@ -5054,12 +4647,7 @@ file_formats/cmi_format.cmo : \
     parsing/location.cmi \
     utils/import_info.cmi \
     utils/config.cmi \
-<<<<<<< HEAD
     utils/compilation_unit.cmi \
-||||||| 121bedcfd2
-=======
-    utils/compression.cmi \
->>>>>>> 5.2.0
     file_formats/cmi_format.cmi
 file_formats/cmi_format.cmx : \
     typing/types.cmx \
@@ -5068,16 +4656,10 @@ file_formats/cmi_format.cmx : \
     parsing/location.cmx \
     utils/import_info.cmx \
     utils/config.cmx \
-<<<<<<< HEAD
     utils/compilation_unit.cmx \
-||||||| 121bedcfd2
-=======
-    utils/compression.cmx \
->>>>>>> 5.2.0
     file_formats/cmi_format.cmi
 file_formats/cmi_format.cmi : \
     typing/types.cmi \
-<<<<<<< HEAD
     typing/subst.cmi \
     utils/misc.cmi \
     utils/import_info.cmi \
@@ -5122,17 +4704,7 @@ file_formats/cms_format.cmi : \
     parsing/location.cmi \
     utils/compilation_unit.cmi \
     file_formats/cmt_format.cmi
-||||||| 121bedcfd2
-    utils/misc.cmi
-file_formats/cmo_format.cmi : \
-    utils/misc.cmi \
-    typing/ident.cmi
-=======
-    utils/misc.cmi
-file_formats/cmo_format.cmi :
->>>>>>> 5.2.0
 file_formats/cmt_format.cmo : \
-    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/tast_mapper.cmi \
@@ -5146,27 +4718,16 @@ file_formats/cmt_format.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     parsing/lexer.cmi \
-<<<<<<< HEAD
     utils/import_info.cmi \
     typing/ident.cmi \
-||||||| 121bedcfd2
-=======
-    typing/ident.cmi \
->>>>>>> 5.2.0
     typing/env.cmi \
     utils/config.cmi \
-<<<<<<< HEAD
     utils/compilation_unit.cmi \
-||||||| 121bedcfd2
-=======
-    utils/compression.cmi \
->>>>>>> 5.2.0
     file_formats/cmi_format.cmi \
     utils/clflags.cmi \
     typing/btype.cmi \
     file_formats/cmt_format.cmi
 file_formats/cmt_format.cmx : \
-    parsing/unit_info.cmx \
     typing/types.cmx \
     typing/typedtree.cmx \
     typing/tast_mapper.cmx \
@@ -5180,47 +4741,24 @@ file_formats/cmt_format.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     parsing/lexer.cmx \
-<<<<<<< HEAD
     utils/import_info.cmx \
     typing/ident.cmx \
-||||||| 121bedcfd2
-=======
-    typing/ident.cmx \
->>>>>>> 5.2.0
     typing/env.cmx \
     utils/config.cmx \
-<<<<<<< HEAD
     utils/compilation_unit.cmx \
-||||||| 121bedcfd2
-=======
-    utils/compression.cmx \
->>>>>>> 5.2.0
     file_formats/cmi_format.cmx \
     utils/clflags.cmx \
     typing/btype.cmx \
     file_formats/cmt_format.cmi
 file_formats/cmt_format.cmi : \
-    parsing/unit_info.cmi \
     typing/types.cmi \
     typing/typedtree.cmi \
     typing/shape_reduce.cmi \
     typing/shape.cmi \
-<<<<<<< HEAD
     parsing/longident.cmi \
-||||||| 121bedcfd2
-    utils/misc.cmi \
-=======
-    utils/misc.cmi \
-    parsing/longident.cmi \
->>>>>>> 5.2.0
     parsing/location.cmi \
-<<<<<<< HEAD
     utils/load_path.cmi \
     utils/import_info.cmi \
-||||||| 121bedcfd2
-=======
-    utils/load_path.cmi \
->>>>>>> 5.2.0
     typing/env.cmi \
     utils/compilation_unit.cmi \
     file_formats/cmi_format.cmi
@@ -5230,16 +4768,9 @@ file_formats/cmx_format.cmi : \
     middle_end/flambda/export_info.cmi \
     utils/compilation_unit.cmi \
     middle_end/clambda.cmi
-<<<<<<< HEAD
 file_formats/cmxs_format.cmi : \
     utils/import_info.cmi \
     utils/compilation_unit.cmi
-||||||| 121bedcfd2
-file_formats/cmxs_format.cmi : \
-    utils/misc.cmi
-=======
-file_formats/cmxs_format.cmi :
->>>>>>> 5.2.0
 file_formats/linear_format.cmo : \
     utils/misc.cmi \
     parsing/location.cmi \
@@ -6565,48 +6096,20 @@ middle_end/flambda/lift_constants.cmi : \
 middle_end/flambda/lift_let_to_initialize_symbol.cmo : \
     middle_end/variable.cmi \
     middle_end/flambda/base_types/tag.cmi \
-<<<<<<< HEAD
     middle_end/symbol_utils.cmi \
     utils/symbol.cmi \
-||||||| 121bedcfd2
-    middle_end/symbol.cmi \
-    middle_end/internal_variable_names.cmi \
-=======
-    middle_end/symbol.cmi \
->>>>>>> 5.2.0
     utils/int_replace_polymorphic_compare.cmi \
     middle_end/flambda/flambda_utils.cmi \
     middle_end/flambda/flambda.cmi \
-<<<<<<< HEAD
-||||||| 121bedcfd2
-    lambda/debuginfo.cmi \
-    parsing/asttypes.cmi \
-=======
-    parsing/asttypes.cmi \
->>>>>>> 5.2.0
     middle_end/flambda/lift_let_to_initialize_symbol.cmi
 middle_end/flambda/lift_let_to_initialize_symbol.cmx : \
     middle_end/variable.cmx \
     middle_end/flambda/base_types/tag.cmx \
-<<<<<<< HEAD
     middle_end/symbol_utils.cmx \
     utils/symbol.cmx \
-||||||| 121bedcfd2
-    middle_end/symbol.cmx \
-    middle_end/internal_variable_names.cmx \
-=======
-    middle_end/symbol.cmx \
->>>>>>> 5.2.0
     utils/int_replace_polymorphic_compare.cmx \
     middle_end/flambda/flambda_utils.cmx \
     middle_end/flambda/flambda.cmx \
-<<<<<<< HEAD
-||||||| 121bedcfd2
-    lambda/debuginfo.cmx \
-    parsing/asttypes.cmi \
-=======
-    parsing/asttypes.cmi \
->>>>>>> 5.2.0
     middle_end/flambda/lift_let_to_initialize_symbol.cmi
 middle_end/flambda/lift_let_to_initialize_symbol.cmi : \
     middle_end/flambda/flambda.cmi \
@@ -7244,7 +6747,6 @@ driver/compenv.cmx : \
 driver/compenv.cmi : \
     utils/clflags.cmi
 driver/compile.cmo : \
-    parsing/unit_info.cmi \
     typing/typedtree.cmi \
     lambda/translmod.cmi \
     lambda/simplif.cmi \
@@ -7261,7 +6763,6 @@ driver/compile.cmo : \
     parsing/builtin_attributes.cmi \
     driver/compile.cmi
 driver/compile.cmx : \
-    parsing/unit_info.cmx \
     typing/typedtree.cmx \
     lambda/translmod.cmx \
     lambda/simplif.cmx \
@@ -7285,7 +6786,6 @@ driver/compile.cmi : \
     utils/clflags.cmi
 driver/compile_common.cmo : \
     utils/warnings.cmi \
-    parsing/unit_info.cmi \
     typing/typemod.cmi \
     typing/typedtree.cmi \
     typing/typecore.cmi \
@@ -7299,21 +6799,16 @@ driver/compile_common.cmo : \
     utils/misc.cmi \
     typing/includemod.cmi \
     typing/env.cmi \
+    utils/config.cmi \
     driver/compmisc.cmi \
-<<<<<<< HEAD
     utils/compilation_unit.cmi \
     driver/compenv.cmi \
     file_formats/cmi_format.cmi \
-||||||| 121bedcfd2
-    driver/compenv.cmi \
-=======
->>>>>>> 5.2.0
     utils/clflags.cmi \
     parsing/builtin_attributes.cmi \
     driver/compile_common.cmi
 driver/compile_common.cmx : \
     utils/warnings.cmx \
-    parsing/unit_info.cmx \
     typing/typemod.cmx \
     typing/typedtree.cmx \
     typing/typecore.cmx \
@@ -7327,20 +6822,15 @@ driver/compile_common.cmx : \
     utils/misc.cmx \
     typing/includemod.cmx \
     typing/env.cmx \
+    utils/config.cmx \
     driver/compmisc.cmx \
-<<<<<<< HEAD
     utils/compilation_unit.cmx \
     driver/compenv.cmx \
     file_formats/cmi_format.cmx \
-||||||| 121bedcfd2
-    driver/compenv.cmx \
-=======
->>>>>>> 5.2.0
     utils/clflags.cmx \
     parsing/builtin_attributes.cmx \
     driver/compile_common.cmi
 driver/compile_common.cmi : \
-    parsing/unit_info.cmi \
     typing/typedtree.cmi \
     parsing/parsetree.cmi \
     typing/env.cmi \
@@ -7444,7 +6934,6 @@ driver/maindriver.cmx : \
     driver/maindriver.cmi
 driver/maindriver.cmi :
 driver/makedepend.cmo : \
-    parsing/unit_info.cmi \
     driver/pparse.cmi \
     parsing/parsetree.cmi \
     parsing/parser.cmi \
@@ -7459,7 +6948,6 @@ driver/makedepend.cmo : \
     utils/clflags.cmi \
     driver/makedepend.cmi
 driver/makedepend.cmx : \
-    parsing/unit_info.cmx \
     driver/pparse.cmx \
     parsing/parsetree.cmi \
     parsing/parser.cmx \
@@ -7475,7 +6963,6 @@ driver/makedepend.cmx : \
     driver/makedepend.cmi
 driver/makedepend.cmi :
 driver/optcompile.cmo : \
-    parsing/unit_info.cmi \
     typing/typedtree.cmi \
     lambda/translmod.cmi \
     lambda/simplif.cmi \
@@ -7493,7 +6980,6 @@ driver/optcompile.cmo : \
     asmcomp/asmgen.cmi \
     driver/optcompile.cmi
 driver/optcompile.cmx : \
-    parsing/unit_info.cmx \
     typing/typedtree.cmx \
     lambda/translmod.cmx \
     lambda/simplif.cmx \
@@ -7597,33 +7083,21 @@ driver/pparse.cmx : \
 driver/pparse.cmi : \
     parsing/parsetree.cmi
 toplevel/expunge.cmo : \
-    parsing/unit_info.cmi \
     bytecomp/symtable.cmi \
+    lambda/runtimedef.cmi \
     utils/misc.cmi \
-<<<<<<< HEAD
     utils/import_info.cmi \
     typing/ident.cmi \
     utils/compilation_unit.cmi \
-||||||| 121bedcfd2
-    typing/ident.cmi \
-=======
-    file_formats/cmo_format.cmi \
->>>>>>> 5.2.0
     bytecomp/bytesections.cmi \
     toplevel/expunge.cmi
 toplevel/expunge.cmx : \
-    parsing/unit_info.cmx \
     bytecomp/symtable.cmx \
+    lambda/runtimedef.cmx \
     utils/misc.cmx \
-<<<<<<< HEAD
     utils/import_info.cmx \
     typing/ident.cmx \
     utils/compilation_unit.cmx \
-||||||| 121bedcfd2
-    typing/ident.cmx \
-=======
-    file_formats/cmo_format.cmi \
->>>>>>> 5.2.0
     bytecomp/bytesections.cmx \
     toplevel/expunge.cmi
 toplevel/expunge.cmi :
@@ -7677,7 +7151,6 @@ toplevel/genprintval.cmi : \
     typing/outcometree.cmi \
     typing/env.cmi
 toplevel/topcommon.cmo : \
-    parsing/unit_info.cmi \
     typing/typedtree.cmi \
     bytecomp/symtable.cmi \
     parsing/printast.cmi \
@@ -7702,13 +7175,11 @@ toplevel/topcommon.cmo : \
     driver/compmisc.cmi \
     utils/compilation_unit.cmi \
     driver/compenv.cmi \
-    file_formats/cmo_format.cmi \
     utils/clflags.cmi \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmi \
     toplevel/topcommon.cmi
 toplevel/topcommon.cmx : \
-    parsing/unit_info.cmx \
     typing/typedtree.cmx \
     bytecomp/symtable.cmx \
     parsing/printast.cmx \
@@ -7733,7 +7204,6 @@ toplevel/topcommon.cmx : \
     driver/compmisc.cmx \
     utils/compilation_unit.cmx \
     driver/compenv.cmx \
-    file_formats/cmo_format.cmi \
     utils/clflags.cmx \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmx \
@@ -7903,6 +7373,7 @@ toplevel/byte/topeval.cmo : \
     typing/persistent_env.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
+    bytecomp/opcodes.cmi \
     utils/misc.cmi \
     bytecomp/meta.cmi \
     parsing/location.cmi \
@@ -7939,6 +7410,7 @@ toplevel/byte/topeval.cmx : \
     typing/persistent_env.cmx \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
+    bytecomp/opcodes.cmx \
     utils/misc.cmx \
     bytecomp/meta.cmx \
     parsing/location.cmx \
@@ -8050,7 +7522,6 @@ toplevel/native/topeval.cmo : \
     typing/includemod.cmi \
     typing/ident.cmi \
     typing/env.cmi \
-    otherlibs/dynlink/dynlink.cmi \
     utils/config.cmi \
     driver/compmisc.cmi \
     middle_end/compilenv.cmi \
@@ -8086,7 +7557,6 @@ toplevel/native/topeval.cmx : \
     typing/includemod.cmx \
     typing/ident.cmx \
     typing/env.cmx \
-    otherlibs/dynlink/dynlink.cmi \
     utils/config.cmx \
     driver/compmisc.cmx \
     middle_end/compilenv.cmx \
@@ -8104,7 +7574,6 @@ toplevel/native/tophooks.cmo : \
     lambda/lambda.cmi \
     middle_end/flambda/import_approx.cmi \
     middle_end/flambda/flambda_middle_end.cmi \
-    otherlibs/dynlink/dynlink.cmi \
     utils/config.cmi \
     middle_end/closure/closure_middle_end.cmi \
     utils/clflags.cmi \
@@ -8120,7 +7589,6 @@ toplevel/native/tophooks.cmx : \
     lambda/lambda.cmx \
     middle_end/flambda/import_approx.cmx \
     middle_end/flambda/flambda_middle_end.cmx \
-    otherlibs/dynlink/dynlink.cmi \
     utils/config.cmx \
     middle_end/closure/closure_middle_end.cmx \
     utils/clflags.cmx \
@@ -8316,8 +7784,8 @@ tools/dumpobj.cmo : \
     utils/misc.cmi \
     parsing/location.cmi \
     bytecomp/instruct.cmi \
+    typing/ident.cmi \
     utils/config.cmi \
-    utils/compression.cmi \
     file_formats/cmo_format.cmi \
     bytecomp/bytesections.cmi \
     tools/dumpobj.cmi
@@ -8328,8 +7796,8 @@ tools/dumpobj.cmx : \
     utils/misc.cmx \
     parsing/location.cmx \
     bytecomp/instruct.cmx \
+    typing/ident.cmx \
     utils/config.cmx \
-    utils/compression.cmx \
     file_formats/cmo_format.cmi \
     bytecomp/bytesections.cmx \
     tools/dumpobj.cmi
@@ -8347,8 +7815,6 @@ tools/eqparsetree.cmx : \
 tools/gen_sizeclasses.cmo :
 tools/gen_sizeclasses.cmx :
 tools/lintapidiff.cmo : \
-    parsing/unit_info.cmi \
-    otherlibs/str/str.cmi \
     typing/printtyp.cmi \
     driver/pparse.cmi \
     typing/path.cmi \
@@ -8360,8 +7826,6 @@ tools/lintapidiff.cmo : \
     typing/ident.cmi \
     tools/lintapidiff.cmi
 tools/lintapidiff.cmx : \
-    parsing/unit_info.cmx \
-    otherlibs/str/str.cmx \
     typing/printtyp.cmx \
     driver/pparse.cmx \
     typing/path.cmx \
@@ -8381,29 +7845,15 @@ tools/make_opcodes.cmi :
 tools/objinfo.cmo : \
     typing/typedtree.cmi \
     bytecomp/symtable.cmi \
-<<<<<<< HEAD
     utils/symbol.cmi \
     typing/shape_reduce.cmi \
-||||||| 121bedcfd2
-    middle_end/symbol.cmi \
-=======
-    middle_end/symbol.cmi \
-    typing/shape_reduce.cmi \
->>>>>>> 5.2.0
     typing/shape.cmi \
     middle_end/printclambda.cmi \
     parsing/pprintast.cmi \
     utils/misc.cmi \
-<<<<<<< HEAD
     parsing/location.cmi \
     lambda/lambda.cmi \
     utils/import_info.cmi \
-||||||| 121bedcfd2
-    middle_end/linkage_name.cmi \
-=======
-    parsing/location.cmi \
-    middle_end/linkage_name.cmi \
->>>>>>> 5.2.0
     typing/ident.cmi \
     middle_end/flambda/export_info.cmi \
     utils/compilation_unit.cmi \
@@ -8419,29 +7869,15 @@ tools/objinfo.cmo : \
 tools/objinfo.cmx : \
     typing/typedtree.cmx \
     bytecomp/symtable.cmx \
-<<<<<<< HEAD
     utils/symbol.cmx \
     typing/shape_reduce.cmx \
-||||||| 121bedcfd2
-    middle_end/symbol.cmx \
-=======
-    middle_end/symbol.cmx \
-    typing/shape_reduce.cmx \
->>>>>>> 5.2.0
     typing/shape.cmx \
     middle_end/printclambda.cmx \
     parsing/pprintast.cmx \
     utils/misc.cmx \
-<<<<<<< HEAD
     parsing/location.cmx \
     lambda/lambda.cmx \
     utils/import_info.cmx \
-||||||| 121bedcfd2
-    middle_end/linkage_name.cmx \
-=======
-    parsing/location.cmx \
-    middle_end/linkage_name.cmx \
->>>>>>> 5.2.0
     typing/ident.cmx \
     middle_end/flambda/export_info.cmx \
     utils/compilation_unit.cmx \
@@ -8555,10 +7991,8 @@ tools/ocamlprof.cmx : \
     tools/ocamlprof.cmi
 tools/ocamlprof.cmi :
 tools/ocamltex.cmo : \
-    otherlibs/unix/unix.cmi \
     toplevel/toploop.cmi \
     parsing/syntaxerr.cmi \
-    otherlibs/str/str.cmi \
     parsing/parsetree.cmi \
     parsing/parse.cmi \
     utils/misc.cmi \
@@ -8572,10 +8006,8 @@ tools/ocamltex.cmo : \
     parsing/ast_helper.cmi \
     tools/ocamltex.cmi
 tools/ocamltex.cmx : \
-    otherlibs/unix/unix.cmx \
     toplevel/toploop.cmx \
     parsing/syntaxerr.cmx \
-    otherlibs/str/str.cmx \
     parsing/parsetree.cmi \
     parsing/parse.cmx \
     utils/misc.cmx \
@@ -8619,2302 +8051,3 @@ tools/stripdebug.cmx : \
     bytecomp/bytesections.cmx \
     tools/stripdebug.cmi
 tools/stripdebug.cmi :
-debugger/breakpoints.cmo : \
-    debugger/symbols.cmi \
-    debugger/pos.cmi \
-    debugger/parameters.cmi \
-    utils/misc.cmi \
-    bytecomp/instruct.cmi \
-    debugger/exec.cmi \
-    debugger/events.cmi \
-    debugger/debugger_config.cmi \
-    debugger/debugcom.cmi \
-    debugger/checkpoints.cmi \
-    debugger/breakpoints.cmi
-debugger/breakpoints.cmx : \
-    debugger/symbols.cmx \
-    debugger/pos.cmx \
-    debugger/parameters.cmx \
-    utils/misc.cmx \
-    bytecomp/instruct.cmx \
-    debugger/exec.cmx \
-    debugger/events.cmx \
-    debugger/debugger_config.cmx \
-    debugger/debugcom.cmx \
-    debugger/checkpoints.cmx \
-    debugger/breakpoints.cmi
-debugger/breakpoints.cmi : \
-    debugger/events.cmi \
-    debugger/debugcom.cmi
-debugger/checkpoints.cmo : \
-    debugger/primitives.cmi \
-    debugger/int64ops.cmi \
-    debugger/debugcom.cmi \
-    debugger/checkpoints.cmi
-debugger/checkpoints.cmx : \
-    debugger/primitives.cmx \
-    debugger/int64ops.cmx \
-    debugger/debugcom.cmx \
-    debugger/checkpoints.cmi
-debugger/checkpoints.cmi : \
-    debugger/primitives.cmi \
-    debugger/debugcom.cmi
-debugger/command_line.cmo : \
-    debugger/unix_tools.cmi \
-    otherlibs/unix/unix.cmi \
-    parsing/unit_info.cmi \
-    typing/types.cmi \
-    debugger/time_travel.cmi \
-    debugger/symbols.cmi \
-    debugger/source.cmi \
-    debugger/show_source.cmi \
-    debugger/show_information.cmi \
-    debugger/question.cmi \
-    debugger/program_management.cmi \
-    debugger/program_loading.cmi \
-    debugger/printval.cmi \
-    debugger/primitives.cmi \
-    debugger/pos.cmi \
-    debugger/parser_aux.cmi \
-    debugger/parameters.cmi \
-    parsing/longident.cmi \
-    parsing/location.cmi \
-    debugger/loadprinter.cmi \
-    utils/load_path.cmi \
-    debugger/int64ops.cmi \
-    bytecomp/instruct.cmi \
-    debugger/input_handling.cmi \
-    debugger/history.cmi \
-    debugger/frames.cmi \
-    debugger/events.cmi \
-    debugger/eval.cmi \
-    typing/envaux.cmi \
-    typing/env.cmi \
-    debugger/debugger_parser.cmi \
-    debugger/debugger_lexer.cmi \
-    debugger/debugger_config.cmi \
-    debugger/debugcom.cmi \
-    driver/compmisc.cmi \
-    debugger/checkpoints.cmi \
-    debugger/breakpoints.cmi \
-    debugger/command_line.cmi
-debugger/command_line.cmx : \
-    debugger/unix_tools.cmx \
-    otherlibs/unix/unix.cmx \
-    parsing/unit_info.cmx \
-    typing/types.cmx \
-    debugger/time_travel.cmx \
-    debugger/symbols.cmx \
-    debugger/source.cmx \
-    debugger/show_source.cmx \
-    debugger/show_information.cmx \
-    debugger/question.cmx \
-    debugger/program_management.cmx \
-    debugger/program_loading.cmx \
-    debugger/printval.cmx \
-    debugger/primitives.cmx \
-    debugger/pos.cmx \
-    debugger/parser_aux.cmi \
-    debugger/parameters.cmx \
-    parsing/longident.cmx \
-    parsing/location.cmx \
-    debugger/loadprinter.cmx \
-    utils/load_path.cmx \
-    debugger/int64ops.cmx \
-    bytecomp/instruct.cmx \
-    debugger/input_handling.cmx \
-    debugger/history.cmx \
-    debugger/frames.cmx \
-    debugger/events.cmx \
-    debugger/eval.cmx \
-    typing/envaux.cmx \
-    typing/env.cmx \
-    debugger/debugger_parser.cmx \
-    debugger/debugger_lexer.cmx \
-    debugger/debugger_config.cmx \
-    debugger/debugcom.cmx \
-    driver/compmisc.cmx \
-    debugger/checkpoints.cmx \
-    debugger/breakpoints.cmx \
-    debugger/command_line.cmi
-debugger/command_line.cmi :
-debugger/debugcom.cmo : \
-    debugger/primitives.cmi \
-    utils/misc.cmi \
-    debugger/int64ops.cmi \
-    bytecomp/instruct.cmi \
-    debugger/input_handling.cmi \
-    debugger/debugcom.cmi
-debugger/debugcom.cmx : \
-    debugger/primitives.cmx \
-    utils/misc.cmx \
-    debugger/int64ops.cmx \
-    bytecomp/instruct.cmx \
-    debugger/input_handling.cmx \
-    debugger/debugcom.cmi
-debugger/debugcom.cmi : \
-    debugger/primitives.cmi \
-    bytecomp/instruct.cmi
-debugger/debugger_config.cmo : \
-    debugger/int64ops.cmi \
-    debugger/debugger_config.cmi
-debugger/debugger_config.cmx : \
-    debugger/int64ops.cmx \
-    debugger/debugger_config.cmi
-debugger/debugger_config.cmi :
-debugger/debugger_lexer.cmo : \
-    debugger/debugger_parser.cmi \
-    debugger/debugger_lexer.cmi
-debugger/debugger_lexer.cmx : \
-    debugger/debugger_parser.cmx \
-    debugger/debugger_lexer.cmi
-debugger/debugger_lexer.cmi : \
-    debugger/debugger_parser.cmi
-debugger/debugger_parser.cmo : \
-    debugger/parser_aux.cmi \
-    parsing/longident.cmi \
-    debugger/int64ops.cmi \
-    debugger/input_handling.cmi \
-    debugger/debugcom.cmi \
-    debugger/debugger_parser.cmi
-debugger/debugger_parser.cmx : \
-    debugger/parser_aux.cmi \
-    parsing/longident.cmx \
-    debugger/int64ops.cmx \
-    debugger/input_handling.cmx \
-    debugger/debugcom.cmx \
-    debugger/debugger_parser.cmi
-debugger/debugger_parser.cmi : \
-    debugger/parser_aux.cmi \
-    parsing/longident.cmi
-debugger/eval.cmo : \
-    typing/types.cmi \
-    bytecomp/symtable.cmi \
-    typing/subst.cmi \
-    debugger/printval.cmi \
-    typing/printtyp.cmi \
-    typing/predef.cmi \
-    typing/path.cmi \
-    debugger/parser_aux.cmi \
-    utils/misc.cmi \
-    parsing/longident.cmi \
-    bytecomp/instruct.cmi \
-    typing/ident.cmi \
-    debugger/frames.cmi \
-    debugger/events.cmi \
-    typing/env.cmi \
-    debugger/debugcom.cmi \
-    typing/ctype.cmi \
-    typing/btype.cmi \
-    debugger/eval.cmi
-debugger/eval.cmx : \
-    typing/types.cmx \
-    bytecomp/symtable.cmx \
-    typing/subst.cmx \
-    debugger/printval.cmx \
-    typing/printtyp.cmx \
-    typing/predef.cmx \
-    typing/path.cmx \
-    debugger/parser_aux.cmi \
-    utils/misc.cmx \
-    parsing/longident.cmx \
-    bytecomp/instruct.cmx \
-    typing/ident.cmx \
-    debugger/frames.cmx \
-    debugger/events.cmx \
-    typing/env.cmx \
-    debugger/debugcom.cmx \
-    typing/ctype.cmx \
-    typing/btype.cmx \
-    debugger/eval.cmi
-debugger/eval.cmi : \
-    typing/types.cmi \
-    typing/path.cmi \
-    debugger/parser_aux.cmi \
-    parsing/longident.cmi \
-    typing/ident.cmi \
-    debugger/events.cmi \
-    typing/env.cmi \
-    debugger/debugcom.cmi
-debugger/events.cmo : \
-    parsing/location.cmi \
-    bytecomp/instruct.cmi \
-    debugger/events.cmi
-debugger/events.cmx : \
-    parsing/location.cmx \
-    bytecomp/instruct.cmx \
-    debugger/events.cmi
-debugger/events.cmi : \
-    bytecomp/instruct.cmi
-debugger/exec.cmo : \
-    debugger/exec.cmi
-debugger/exec.cmx : \
-    debugger/exec.cmi
-debugger/exec.cmi :
-debugger/frames.cmo : \
-    debugger/symbols.cmi \
-    utils/misc.cmi \
-    bytecomp/instruct.cmi \
-    debugger/events.cmi \
-    debugger/debugcom.cmi \
-    debugger/frames.cmi
-debugger/frames.cmx : \
-    debugger/symbols.cmx \
-    utils/misc.cmx \
-    bytecomp/instruct.cmx \
-    debugger/events.cmx \
-    debugger/debugcom.cmx \
-    debugger/frames.cmi
-debugger/frames.cmi : \
-    debugger/events.cmi
-debugger/history.cmo : \
-    debugger/primitives.cmi \
-    debugger/int64ops.cmi \
-    debugger/debugger_config.cmi \
-    debugger/checkpoints.cmi \
-    debugger/history.cmi
-debugger/history.cmx : \
-    debugger/primitives.cmx \
-    debugger/int64ops.cmx \
-    debugger/debugger_config.cmx \
-    debugger/checkpoints.cmx \
-    debugger/history.cmi
-debugger/history.cmi :
-debugger/input_handling.cmo : \
-    otherlibs/unix/unix.cmi \
-    debugger/primitives.cmi \
-    debugger/parameters.cmi \
-    debugger/input_handling.cmi
-debugger/input_handling.cmx : \
-    otherlibs/unix/unix.cmx \
-    debugger/primitives.cmx \
-    debugger/parameters.cmx \
-    debugger/input_handling.cmi
-debugger/input_handling.cmi : \
-    debugger/primitives.cmi
-debugger/int64ops.cmo : \
-    debugger/int64ops.cmi
-debugger/int64ops.cmx : \
-    debugger/int64ops.cmi
-debugger/int64ops.cmi :
-debugger/loadprinter.cmo : \
-    parsing/unit_info.cmi \
-    typing/types.cmi \
-    toplevel/topprinters.cmi \
-    bytecomp/symtable.cmi \
-    debugger/printval.cmi \
-    typing/printtyp.cmi \
-    typing/path.cmi \
-    utils/misc.cmi \
-    parsing/longident.cmi \
-    utils/load_path.cmi \
-    typing/ident.cmi \
-    typing/env.cmi \
-    otherlibs/dynlink/dynlink.cmi \
-    typing/ctype.cmi \
-    file_formats/cmo_format.cmi \
-    debugger/loadprinter.cmi
-debugger/loadprinter.cmx : \
-    parsing/unit_info.cmx \
-    typing/types.cmx \
-    toplevel/topprinters.cmx \
-    bytecomp/symtable.cmx \
-    debugger/printval.cmx \
-    typing/printtyp.cmx \
-    typing/path.cmx \
-    utils/misc.cmx \
-    parsing/longident.cmx \
-    utils/load_path.cmx \
-    typing/ident.cmx \
-    typing/env.cmx \
-    otherlibs/dynlink/dynlink.cmi \
-    typing/ctype.cmx \
-    file_formats/cmo_format.cmi \
-    debugger/loadprinter.cmi
-debugger/loadprinter.cmi : \
-    parsing/longident.cmi \
-    otherlibs/dynlink/dynlink.cmi
-debugger/main.cmo : \
-    debugger/unix_tools.cmi \
-    otherlibs/unix/unix.cmi \
-    debugger/time_travel.cmi \
-    debugger/show_information.cmi \
-    debugger/question.cmi \
-    debugger/program_management.cmi \
-    debugger/primitives.cmi \
-    typing/persistent_env.cmi \
-    debugger/parameters.cmi \
-    utils/misc.cmi \
-    utils/load_path.cmi \
-    debugger/input_handling.cmi \
-    debugger/frames.cmi \
-    debugger/exec.cmi \
-    debugger/debugger_config.cmi \
-    utils/config.cmi \
-    driver/compmisc.cmi \
-    debugger/command_line.cmi \
-    file_formats/cmi_format.cmi \
-    utils/clflags.cmi \
-    debugger/checkpoints.cmi \
-    debugger/main.cmi
-debugger/main.cmx : \
-    debugger/unix_tools.cmx \
-    otherlibs/unix/unix.cmx \
-    debugger/time_travel.cmx \
-    debugger/show_information.cmx \
-    debugger/question.cmx \
-    debugger/program_management.cmx \
-    debugger/primitives.cmx \
-    typing/persistent_env.cmx \
-    debugger/parameters.cmx \
-    utils/misc.cmx \
-    utils/load_path.cmx \
-    debugger/input_handling.cmx \
-    debugger/frames.cmx \
-    debugger/exec.cmx \
-    debugger/debugger_config.cmx \
-    utils/config.cmx \
-    driver/compmisc.cmx \
-    debugger/command_line.cmx \
-    file_formats/cmi_format.cmx \
-    utils/clflags.cmx \
-    debugger/checkpoints.cmx \
-    debugger/main.cmi
-debugger/main.cmi :
-debugger/ocamldebug_entry.cmo : \
-    otherlibs/unix/unix.cmi \
-    debugger/ocamldebug_entry.cmi
-debugger/ocamldebug_entry.cmx : \
-    otherlibs/unix/unix.cmx \
-    debugger/ocamldebug_entry.cmi
-debugger/ocamldebug_entry.cmi :
-debugger/parameters.cmo : \
-    utils/load_path.cmi \
-    typing/envaux.cmi \
-    debugger/debugger_config.cmi \
-    utils/config.cmi \
-    debugger/parameters.cmi
-debugger/parameters.cmx : \
-    utils/load_path.cmx \
-    typing/envaux.cmx \
-    debugger/debugger_config.cmx \
-    utils/config.cmx \
-    debugger/parameters.cmi
-debugger/parameters.cmi :
-debugger/parser_aux.cmi : \
-    parsing/longident.cmi \
-    debugger/debugcom.cmi
-debugger/pos.cmo : \
-    parsing/location.cmi \
-    bytecomp/instruct.cmi \
-    debugger/events.cmi \
-    debugger/pos.cmi
-debugger/pos.cmx : \
-    parsing/location.cmx \
-    bytecomp/instruct.cmx \
-    debugger/events.cmx \
-    debugger/pos.cmi
-debugger/pos.cmi : \
-    debugger/events.cmi
-debugger/primitives.cmo : \
-    otherlibs/unix/unix.cmi \
-    debugger/primitives.cmi
-debugger/primitives.cmx : \
-    otherlibs/unix/unix.cmx \
-    debugger/primitives.cmi
-debugger/primitives.cmi : \
-    otherlibs/unix/unix.cmi
-debugger/printval.cmo : \
-    typing/types.cmi \
-    bytecomp/symtable.cmi \
-    typing/printtyp.cmi \
-    debugger/parser_aux.cmi \
-    typing/outcometree.cmi \
-    typing/oprint.cmi \
-    toplevel/genprintval.cmi \
-    typing/env.cmi \
-    debugger/debugcom.cmi \
-    debugger/printval.cmi
-debugger/printval.cmx : \
-    typing/types.cmx \
-    bytecomp/symtable.cmx \
-    typing/printtyp.cmx \
-    debugger/parser_aux.cmi \
-    typing/outcometree.cmi \
-    typing/oprint.cmx \
-    toplevel/genprintval.cmx \
-    typing/env.cmx \
-    debugger/debugcom.cmx \
-    debugger/printval.cmi
-debugger/printval.cmi : \
-    typing/types.cmi \
-    typing/path.cmi \
-    debugger/parser_aux.cmi \
-    typing/env.cmi \
-    debugger/debugcom.cmi
-debugger/program_loading.cmo : \
-    debugger/unix_tools.cmi \
-    otherlibs/unix/unix.cmi \
-    debugger/primitives.cmi \
-    debugger/parameters.cmi \
-    debugger/input_handling.cmi \
-    debugger/debugger_config.cmi \
-    debugger/program_loading.cmi
-debugger/program_loading.cmx : \
-    debugger/unix_tools.cmx \
-    otherlibs/unix/unix.cmx \
-    debugger/primitives.cmx \
-    debugger/parameters.cmx \
-    debugger/input_handling.cmx \
-    debugger/debugger_config.cmx \
-    debugger/program_loading.cmi
-debugger/program_loading.cmi : \
-    debugger/primitives.cmi
-debugger/program_management.cmo : \
-    debugger/unix_tools.cmi \
-    otherlibs/unix/unix.cmi \
-    debugger/time_travel.cmi \
-    debugger/symbols.cmi \
-    debugger/question.cmi \
-    debugger/program_loading.cmi \
-    debugger/primitives.cmi \
-    debugger/parameters.cmi \
-    utils/load_path.cmi \
-    debugger/int64ops.cmi \
-    debugger/input_handling.cmi \
-    debugger/history.cmi \
-    typing/envaux.cmi \
-    debugger/debugger_config.cmi \
-    debugger/debugcom.cmi \
-    driver/compmisc.cmi \
-    debugger/breakpoints.cmi \
-    debugger/program_management.cmi
-debugger/program_management.cmx : \
-    debugger/unix_tools.cmx \
-    otherlibs/unix/unix.cmx \
-    debugger/time_travel.cmx \
-    debugger/symbols.cmx \
-    debugger/question.cmx \
-    debugger/program_loading.cmx \
-    debugger/primitives.cmx \
-    debugger/parameters.cmx \
-    utils/load_path.cmx \
-    debugger/int64ops.cmx \
-    debugger/input_handling.cmx \
-    debugger/history.cmx \
-    typing/envaux.cmx \
-    debugger/debugger_config.cmx \
-    debugger/debugcom.cmx \
-    driver/compmisc.cmx \
-    debugger/breakpoints.cmx \
-    debugger/program_management.cmi
-debugger/program_management.cmi :
-debugger/question.cmo : \
-    debugger/primitives.cmi \
-    debugger/input_handling.cmi \
-    debugger/debugger_lexer.cmi \
-    debugger/question.cmi
-debugger/question.cmx : \
-    debugger/primitives.cmx \
-    debugger/input_handling.cmx \
-    debugger/debugger_lexer.cmx \
-    debugger/question.cmi
-debugger/question.cmi :
-debugger/show_information.cmo : \
-    debugger/symbols.cmi \
-    debugger/source.cmi \
-    debugger/show_source.cmi \
-    debugger/printval.cmi \
-    debugger/parameters.cmi \
-    utils/misc.cmi \
-    bytecomp/instruct.cmi \
-    debugger/frames.cmi \
-    debugger/events.cmi \
-    debugger/debugcom.cmi \
-    debugger/checkpoints.cmi \
-    debugger/breakpoints.cmi \
-    debugger/show_information.cmi
-debugger/show_information.cmx : \
-    debugger/symbols.cmx \
-    debugger/source.cmx \
-    debugger/show_source.cmx \
-    debugger/printval.cmx \
-    debugger/parameters.cmx \
-    utils/misc.cmx \
-    bytecomp/instruct.cmx \
-    debugger/frames.cmx \
-    debugger/events.cmx \
-    debugger/debugcom.cmx \
-    debugger/checkpoints.cmx \
-    debugger/breakpoints.cmx \
-    debugger/show_information.cmi
-debugger/show_information.cmi : \
-    debugger/events.cmi
-debugger/show_source.cmo : \
-    debugger/source.cmi \
-    debugger/primitives.cmi \
-    debugger/parameters.cmi \
-    parsing/location.cmi \
-    bytecomp/instruct.cmi \
-    debugger/events.cmi \
-    debugger/debugger_config.cmi \
-    debugger/show_source.cmi
-debugger/show_source.cmx : \
-    debugger/source.cmx \
-    debugger/primitives.cmx \
-    debugger/parameters.cmx \
-    parsing/location.cmx \
-    bytecomp/instruct.cmx \
-    debugger/events.cmx \
-    debugger/debugger_config.cmx \
-    debugger/show_source.cmi
-debugger/show_source.cmi : \
-    bytecomp/instruct.cmi
-debugger/source.cmo : \
-    debugger/primitives.cmi \
-    utils/misc.cmi \
-    utils/load_path.cmi \
-    debugger/debugger_config.cmi \
-    debugger/source.cmi
-debugger/source.cmx : \
-    debugger/primitives.cmx \
-    utils/misc.cmx \
-    utils/load_path.cmx \
-    debugger/debugger_config.cmx \
-    debugger/source.cmi
-debugger/source.cmi :
-debugger/symbols.cmo : \
-    bytecomp/symtable.cmi \
-    debugger/program_loading.cmi \
-    utils/misc.cmi \
-    bytecomp/instruct.cmi \
-    debugger/events.cmi \
-    debugger/debugger_config.cmi \
-    debugger/debugcom.cmi \
-    debugger/checkpoints.cmi \
-    bytecomp/bytesections.cmi \
-    debugger/symbols.cmi
-debugger/symbols.cmx : \
-    bytecomp/symtable.cmx \
-    debugger/program_loading.cmx \
-    utils/misc.cmx \
-    bytecomp/instruct.cmx \
-    debugger/events.cmx \
-    debugger/debugger_config.cmx \
-    debugger/debugcom.cmx \
-    debugger/checkpoints.cmx \
-    bytecomp/bytesections.cmx \
-    debugger/symbols.cmi
-debugger/symbols.cmi : \
-    bytecomp/instruct.cmi \
-    debugger/events.cmi \
-    debugger/debugcom.cmi
-debugger/time_travel.cmo : \
-    debugger/trap_barrier.cmi \
-    debugger/symbols.cmi \
-    debugger/question.cmi \
-    debugger/program_loading.cmi \
-    debugger/primitives.cmi \
-    utils/misc.cmi \
-    debugger/int64ops.cmi \
-    bytecomp/instruct.cmi \
-    debugger/input_handling.cmi \
-    debugger/exec.cmi \
-    debugger/events.cmi \
-    debugger/debugger_config.cmi \
-    debugger/debugcom.cmi \
-    debugger/checkpoints.cmi \
-    debugger/breakpoints.cmi \
-    debugger/time_travel.cmi
-debugger/time_travel.cmx : \
-    debugger/trap_barrier.cmx \
-    debugger/symbols.cmx \
-    debugger/question.cmx \
-    debugger/program_loading.cmx \
-    debugger/primitives.cmx \
-    utils/misc.cmx \
-    debugger/int64ops.cmx \
-    bytecomp/instruct.cmx \
-    debugger/input_handling.cmx \
-    debugger/exec.cmx \
-    debugger/events.cmx \
-    debugger/debugger_config.cmx \
-    debugger/debugcom.cmx \
-    debugger/checkpoints.cmx \
-    debugger/breakpoints.cmx \
-    debugger/time_travel.cmi
-debugger/time_travel.cmi : \
-    debugger/primitives.cmi
-debugger/trap_barrier.cmo : \
-    debugger/exec.cmi \
-    debugger/debugcom.cmi \
-    debugger/checkpoints.cmi \
-    debugger/trap_barrier.cmi
-debugger/trap_barrier.cmx : \
-    debugger/exec.cmx \
-    debugger/debugcom.cmx \
-    debugger/checkpoints.cmx \
-    debugger/trap_barrier.cmi
-debugger/trap_barrier.cmi : \
-    debugger/debugcom.cmi
-debugger/unix_tools.cmo : \
-    otherlibs/unix/unix.cmi \
-    utils/misc.cmi \
-    debugger/unix_tools.cmi
-debugger/unix_tools.cmx : \
-    otherlibs/unix/unix.cmx \
-    utils/misc.cmx \
-    debugger/unix_tools.cmi
-debugger/unix_tools.cmi : \
-    otherlibs/unix/unix.cmi
-ocamldoc/odoc.cmo : \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_info.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_gen.cmi \
-    ocamldoc/odoc_config.cmi \
-    ocamldoc/odoc_args.cmi \
-    ocamldoc/odoc_analyse.cmi \
-    otherlibs/dynlink/dynlink.cmi \
-    ocamldoc/odoc.cmi
-ocamldoc/odoc.cmx : \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_info.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_gen.cmx \
-    ocamldoc/odoc_config.cmx \
-    ocamldoc/odoc_args.cmx \
-    ocamldoc/odoc_analyse.cmx \
-    otherlibs/dynlink/dynlink.cmi \
-    ocamldoc/odoc.cmi
-ocamldoc/odoc.cmi :
-ocamldoc/odoc_analyse.cmo : \
-    utils/warnings.cmi \
-    parsing/unit_info.cmi \
-    typing/types.cmi \
-    typing/typemod.cmi \
-    typing/typedtree.cmi \
-    parsing/syntaxerr.cmi \
-    driver/pparse.cmi \
-    parsing/parse.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_text.cmi \
-    ocamldoc/odoc_sig.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_misc.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_merge.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_dep.cmi \
-    ocamldoc/odoc_cross.cmi \
-    ocamldoc/odoc_comments.cmi \
-    ocamldoc/odoc_class.cmi \
-    ocamldoc/odoc_ast.cmi \
-    parsing/location.cmi \
-    parsing/lexer.cmi \
-    typing/env.cmi \
-    driver/compmisc.cmi \
-    utils/clflags.cmi \
-    ocamldoc/odoc_analyse.cmi
-ocamldoc/odoc_analyse.cmx : \
-    utils/warnings.cmx \
-    parsing/unit_info.cmx \
-    typing/types.cmx \
-    typing/typemod.cmx \
-    typing/typedtree.cmx \
-    parsing/syntaxerr.cmx \
-    driver/pparse.cmx \
-    parsing/parse.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_text.cmx \
-    ocamldoc/odoc_sig.cmx \
-    ocamldoc/odoc_module.cmx \
-    ocamldoc/odoc_misc.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_merge.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_dep.cmx \
-    ocamldoc/odoc_cross.cmx \
-    ocamldoc/odoc_comments.cmx \
-    ocamldoc/odoc_class.cmx \
-    ocamldoc/odoc_ast.cmx \
-    parsing/location.cmx \
-    parsing/lexer.cmx \
-    typing/env.cmx \
-    driver/compmisc.cmx \
-    utils/clflags.cmx \
-    ocamldoc/odoc_analyse.cmi
-ocamldoc/odoc_analyse.cmi : \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_global.cmi
-ocamldoc/odoc_args.cmo : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_texi.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_man.cmi \
-    ocamldoc/odoc_latex.cmi \
-    ocamldoc/odoc_html.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_gen.cmi \
-    ocamldoc/odoc_dot.cmi \
-    ocamldoc/odoc_config.cmi \
-    driver/main_args.cmi \
-    utils/config.cmi \
-    driver/compenv.cmi \
-    ocamldoc/odoc_args.cmi
-ocamldoc/odoc_args.cmx : \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_texi.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_man.cmx \
-    ocamldoc/odoc_latex.cmx \
-    ocamldoc/odoc_html.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_gen.cmx \
-    ocamldoc/odoc_dot.cmx \
-    ocamldoc/odoc_config.cmx \
-    driver/main_args.cmx \
-    utils/config.cmx \
-    driver/compenv.cmx \
-    ocamldoc/odoc_args.cmi
-ocamldoc/odoc_args.cmi : \
-    ocamldoc/odoc_gen.cmi
-ocamldoc/odoc_ast.cmo : \
-    parsing/unit_info.cmi \
-    typing/types.cmi \
-    typing/typedtree.cmi \
-    typing/predef.cmi \
-    typing/path.cmi \
-    parsing/parsetree.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_sig.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_env.cmi \
-    ocamldoc/odoc_class.cmi \
-    parsing/location.cmi \
-    typing/ident.cmi \
-    typing/btype.cmi \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_ast.cmi
-ocamldoc/odoc_ast.cmx : \
-    parsing/unit_info.cmx \
-    typing/types.cmx \
-    typing/typedtree.cmx \
-    typing/predef.cmx \
-    typing/path.cmx \
-    parsing/parsetree.cmi \
-    ocamldoc/odoc_value.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_sig.cmx \
-    ocamldoc/odoc_parameter.cmx \
-    ocamldoc/odoc_module.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_extension.cmx \
-    ocamldoc/odoc_exception.cmx \
-    ocamldoc/odoc_env.cmx \
-    ocamldoc/odoc_class.cmx \
-    parsing/location.cmx \
-    typing/ident.cmx \
-    typing/btype.cmx \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_ast.cmi
-ocamldoc/odoc_ast.cmi : \
-    typing/types.cmi \
-    typing/typedtree.cmi \
-    parsing/parsetree.cmi \
-    ocamldoc/odoc_sig.cmi \
-    ocamldoc/odoc_name.cmi \
-    ocamldoc/odoc_module.cmi
-ocamldoc/odoc_class.cmo : \
-    typing/types.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_name.cmi \
-    ocamldoc/odoc_class.cmi
-ocamldoc/odoc_class.cmx : \
-    typing/types.cmx \
-    ocamldoc/odoc_value.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_parameter.cmx \
-    ocamldoc/odoc_name.cmx \
-    ocamldoc/odoc_class.cmi
-ocamldoc/odoc_class.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_name.cmi
-ocamldoc/odoc_comments.cmo : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_text.cmi \
-    ocamldoc/odoc_see_lexer.cmi \
-    ocamldoc/odoc_parser.cmi \
-    ocamldoc/odoc_misc.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_merge.cmi \
-    ocamldoc/odoc_lexer.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_cross.cmi \
-    ocamldoc/odoc_comments_global.cmi \
-    ocamldoc/odoc_comments.cmi
-ocamldoc/odoc_comments.cmx : \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_text.cmx \
-    ocamldoc/odoc_see_lexer.cmx \
-    ocamldoc/odoc_parser.cmx \
-    ocamldoc/odoc_misc.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_merge.cmx \
-    ocamldoc/odoc_lexer.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_cross.cmx \
-    ocamldoc/odoc_comments_global.cmx \
-    ocamldoc/odoc_comments.cmi
-ocamldoc/odoc_comments.cmi : \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_module.cmi
-ocamldoc/odoc_comments_global.cmo : \
-    ocamldoc/odoc_comments_global.cmi
-ocamldoc/odoc_comments_global.cmx : \
-    ocamldoc/odoc_comments_global.cmi
-ocamldoc/odoc_comments_global.cmi :
-ocamldoc/odoc_config.cmo : \
-    utils/config.cmi \
-    ocamldoc/odoc_config.cmi
-ocamldoc/odoc_config.cmx : \
-    utils/config.cmx \
-    ocamldoc/odoc_config.cmi
-ocamldoc/odoc_config.cmi :
-ocamldoc/odoc_cross.cmo : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_search.cmi \
-    ocamldoc/odoc_scan.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_name.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_misc.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi \
-    utils/misc.cmi \
-    ocamldoc/odoc_cross.cmi
-ocamldoc/odoc_cross.cmx : \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_value.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_search.cmx \
-    ocamldoc/odoc_scan.cmx \
-    ocamldoc/odoc_parameter.cmx \
-    ocamldoc/odoc_name.cmx \
-    ocamldoc/odoc_module.cmx \
-    ocamldoc/odoc_misc.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_extension.cmx \
-    ocamldoc/odoc_exception.cmx \
-    ocamldoc/odoc_class.cmx \
-    utils/misc.cmx \
-    ocamldoc/odoc_cross.cmi
-ocamldoc/odoc_cross.cmi : \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_module.cmi
-ocamldoc/odoc_dag2html.cmo : \
-    ocamldoc/odoc_info.cmi \
-    ocamldoc/odoc_dag2html.cmi
-ocamldoc/odoc_dag2html.cmx : \
-    ocamldoc/odoc_info.cmx \
-    ocamldoc/odoc_dag2html.cmi
-ocamldoc/odoc_dag2html.cmi : \
-    ocamldoc/odoc_info.cmi
-ocamldoc/odoc_dep.cmo : \
-    otherlibs/str/str.cmi \
-    parsing/parsetree.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_print.cmi \
-    ocamldoc/odoc_module.cmi \
-    utils/misc.cmi \
-    parsing/depend.cmi \
-    ocamldoc/odoc_dep.cmi
-ocamldoc/odoc_dep.cmx : \
-    otherlibs/str/str.cmx \
-    parsing/parsetree.cmi \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_print.cmx \
-    ocamldoc/odoc_module.cmx \
-    utils/misc.cmx \
-    parsing/depend.cmx \
-    ocamldoc/odoc_dep.cmi
-ocamldoc/odoc_dep.cmi : \
-    parsing/parsetree.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_module.cmi \
-    utils/misc.cmi
-ocamldoc/odoc_dot.cmo : \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_info.cmi \
-    ocamldoc/odoc_dot.cmi
-ocamldoc/odoc_dot.cmx : \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_info.cmx \
-    ocamldoc/odoc_dot.cmi
-ocamldoc/odoc_dot.cmi : \
-    ocamldoc/odoc_info.cmi
-ocamldoc/odoc_env.cmo : \
-    typing/types.cmi \
-    typing/predef.cmi \
-    typing/path.cmi \
-    ocamldoc/odoc_name.cmi \
-    typing/btype.cmi \
-    ocamldoc/odoc_env.cmi
-ocamldoc/odoc_env.cmx : \
-    typing/types.cmx \
-    typing/predef.cmx \
-    typing/path.cmx \
-    ocamldoc/odoc_name.cmx \
-    typing/btype.cmx \
-    ocamldoc/odoc_env.cmi
-ocamldoc/odoc_env.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_name.cmi
-ocamldoc/odoc_exception.cmo : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_name.cmi \
-    ocamldoc/odoc_exception.cmi
-ocamldoc/odoc_exception.cmx : \
-    typing/types.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_name.cmx \
-    ocamldoc/odoc_exception.cmi
-ocamldoc/odoc_exception.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_name.cmi
-ocamldoc/odoc_extension.cmo : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_name.cmi \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_extension.cmi
-ocamldoc/odoc_extension.cmx : \
-    typing/types.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_name.cmx \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_extension.cmi
-ocamldoc/odoc_extension.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_name.cmi \
-    parsing/asttypes.cmi
-ocamldoc/odoc_gen.cmo : \
-    ocamldoc/odoc_texi.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_man.cmi \
-    ocamldoc/odoc_latex.cmi \
-    ocamldoc/odoc_html.cmi \
-    ocamldoc/odoc_dot.cmi \
-    ocamldoc/odoc_gen.cmi
-ocamldoc/odoc_gen.cmx : \
-    ocamldoc/odoc_texi.cmx \
-    ocamldoc/odoc_module.cmx \
-    ocamldoc/odoc_man.cmx \
-    ocamldoc/odoc_latex.cmx \
-    ocamldoc/odoc_html.cmx \
-    ocamldoc/odoc_dot.cmx \
-    ocamldoc/odoc_gen.cmi
-ocamldoc/odoc_gen.cmi : \
-    ocamldoc/odoc_texi.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_man.cmi \
-    ocamldoc/odoc_latex.cmi \
-    ocamldoc/odoc_html.cmi \
-    ocamldoc/odoc_dot.cmi
-ocamldoc/odoc_global.cmo : \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_config.cmi \
-    utils/clflags.cmi \
-    ocamldoc/odoc_global.cmi
-ocamldoc/odoc_global.cmx : \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_config.cmx \
-    utils/clflags.cmx \
-    ocamldoc/odoc_global.cmi
-ocamldoc/odoc_global.cmi : \
-    ocamldoc/odoc_types.cmi
-ocamldoc/odoc_html.cmo : \
-    otherlibs/str/str.cmi \
-    middle_end/flambda/parameter.cmi \
-    ocamldoc/odoc_text.cmi \
-    ocamldoc/odoc_ocamlhtml.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_info.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_dag2html.cmi \
-    utils/misc.cmi \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_html.cmi
-ocamldoc/odoc_html.cmx : \
-    otherlibs/str/str.cmx \
-    middle_end/flambda/parameter.cmx \
-    ocamldoc/odoc_text.cmx \
-    ocamldoc/odoc_ocamlhtml.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_info.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_dag2html.cmx \
-    utils/misc.cmx \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_html.cmi
-ocamldoc/odoc_html.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_info.cmi \
-    ocamldoc/odoc_dag2html.cmi \
-    utils/misc.cmi
-ocamldoc/odoc_info.cmo : \
-    typing/printtyp.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_text.cmi \
-    ocamldoc/odoc_str.cmi \
-    ocamldoc/odoc_search.cmi \
-    ocamldoc/odoc_scan.cmi \
-    ocamldoc/odoc_print.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_name.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_misc.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_dep.cmi \
-    ocamldoc/odoc_config.cmi \
-    ocamldoc/odoc_comments.cmi \
-    ocamldoc/odoc_class.cmi \
-    ocamldoc/odoc_analyse.cmi \
-    parsing/location.cmi \
-    ocamldoc/odoc_info.cmi
-ocamldoc/odoc_info.cmx : \
-    typing/printtyp.cmx \
-    ocamldoc/odoc_value.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_text.cmx \
-    ocamldoc/odoc_str.cmx \
-    ocamldoc/odoc_search.cmx \
-    ocamldoc/odoc_scan.cmx \
-    ocamldoc/odoc_print.cmx \
-    ocamldoc/odoc_parameter.cmx \
-    ocamldoc/odoc_name.cmx \
-    ocamldoc/odoc_module.cmx \
-    ocamldoc/odoc_misc.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_extension.cmx \
-    ocamldoc/odoc_exception.cmx \
-    ocamldoc/odoc_dep.cmx \
-    ocamldoc/odoc_config.cmx \
-    ocamldoc/odoc_comments.cmx \
-    ocamldoc/odoc_class.cmx \
-    ocamldoc/odoc_analyse.cmx \
-    parsing/location.cmx \
-    ocamldoc/odoc_info.cmi
-ocamldoc/odoc_info.cmi : \
-    typing/types.cmi \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_search.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi \
-    parsing/location.cmi \
-    parsing/asttypes.cmi
-ocamldoc/odoc_latex.cmo : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_to_text.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_latex_style.cmi \
-    ocamldoc/odoc_info.cmi \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_latex.cmi
-ocamldoc/odoc_latex.cmx : \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_to_text.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_latex_style.cmx \
-    ocamldoc/odoc_info.cmx \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_latex.cmi
-ocamldoc/odoc_latex.cmi : \
-    typing/types.cmi \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_info.cmi
-ocamldoc/odoc_latex_style.cmo : \
-    ocamldoc/odoc_latex_style.cmi
-ocamldoc/odoc_latex_style.cmx : \
-    ocamldoc/odoc_latex_style.cmi
-ocamldoc/odoc_latex_style.cmi :
-ocamldoc/odoc_lexer.cmo : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_parser.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_comments_global.cmi \
-    ocamldoc/odoc_lexer.cmi
-ocamldoc/odoc_lexer.cmx : \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_parser.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_comments_global.cmx \
-    ocamldoc/odoc_lexer.cmi
-ocamldoc/odoc_lexer.cmi : \
-    ocamldoc/odoc_parser.cmi
-ocamldoc/odoc_man.cmo : \
-    otherlibs/str/str.cmi \
-    middle_end/flambda/parameter.cmi \
-    ocamldoc/odoc_str.cmi \
-    ocamldoc/odoc_print.cmi \
-    ocamldoc/odoc_misc.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_info.cmi \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_man.cmi
-ocamldoc/odoc_man.cmx : \
-    otherlibs/str/str.cmx \
-    middle_end/flambda/parameter.cmx \
-    ocamldoc/odoc_str.cmx \
-    ocamldoc/odoc_print.cmx \
-    ocamldoc/odoc_misc.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_info.cmx \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_man.cmi
-ocamldoc/odoc_man.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_info.cmi
-ocamldoc/odoc_merge.cmo : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi \
-    ocamldoc/odoc_merge.cmi
-ocamldoc/odoc_merge.cmx : \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_value.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_parameter.cmx \
-    ocamldoc/odoc_module.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_extension.cmx \
-    ocamldoc/odoc_exception.cmx \
-    ocamldoc/odoc_class.cmx \
-    ocamldoc/odoc_merge.cmi
-ocamldoc/odoc_merge.cmi : \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_module.cmi
-ocamldoc/odoc_messages.cmo : \
-    otherlibs/str/str.cmi \
-    utils/config.cmi \
-    ocamldoc/odoc_messages.cmi
-ocamldoc/odoc_messages.cmx : \
-    otherlibs/str/str.cmx \
-    utils/config.cmx \
-    ocamldoc/odoc_messages.cmi
-ocamldoc/odoc_messages.cmi :
-ocamldoc/odoc_misc.cmo : \
-    otherlibs/unix/unix.cmi \
-    typing/types.cmi \
-    typing/predef.cmi \
-    typing/path.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_messages.cmi \
-    parsing/longident.cmi \
-    typing/btype.cmi \
-    ocamldoc/odoc_misc.cmi
-ocamldoc/odoc_misc.cmx : \
-    otherlibs/unix/unix.cmx \
-    typing/types.cmx \
-    typing/predef.cmx \
-    typing/path.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_messages.cmx \
-    parsing/longident.cmx \
-    typing/btype.cmx \
-    ocamldoc/odoc_misc.cmi
-ocamldoc/odoc_misc.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    parsing/longident.cmi \
-    parsing/asttypes.cmi
-ocamldoc/odoc_module.cmo : \
-    typing/types.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_name.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi \
-    utils/misc.cmi \
-    ocamldoc/odoc_module.cmi
-ocamldoc/odoc_module.cmx : \
-    typing/types.cmx \
-    ocamldoc/odoc_value.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_name.cmx \
-    ocamldoc/odoc_extension.cmx \
-    ocamldoc/odoc_exception.cmx \
-    ocamldoc/odoc_class.cmx \
-    utils/misc.cmx \
-    ocamldoc/odoc_module.cmi
-ocamldoc/odoc_module.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_name.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi \
-    utils/misc.cmi
-ocamldoc/odoc_name.cmo : \
-    parsing/unit_info.cmi \
-    otherlibs/str/str.cmi \
-    typing/path.cmi \
-    ocamldoc/odoc_misc.cmi \
-    typing/ident.cmi \
-    ocamldoc/odoc_name.cmi
-ocamldoc/odoc_name.cmx : \
-    parsing/unit_info.cmx \
-    otherlibs/str/str.cmx \
-    typing/path.cmx \
-    ocamldoc/odoc_misc.cmx \
-    typing/ident.cmx \
-    ocamldoc/odoc_name.cmi
-ocamldoc/odoc_name.cmi : \
-    typing/path.cmi \
-    parsing/longident.cmi \
-    typing/ident.cmi
-ocamldoc/odoc_ocamlhtml.cmo : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_ocamlhtml.cmi
-ocamldoc/odoc_ocamlhtml.cmx : \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_ocamlhtml.cmi
-ocamldoc/odoc_ocamlhtml.cmi :
-ocamldoc/odoc_parameter.cmo : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_parameter.cmi
-ocamldoc/odoc_parameter.cmx : \
-    typing/types.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_parameter.cmi
-ocamldoc/odoc_parameter.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi
-ocamldoc/odoc_parser.cmo : \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_comments_global.cmi \
-    ocamldoc/odoc_parser.cmi
-ocamldoc/odoc_parser.cmx : \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_comments_global.cmx \
-    ocamldoc/odoc_parser.cmi
-ocamldoc/odoc_parser.cmi : \
-    ocamldoc/odoc_types.cmi
-ocamldoc/odoc_print.cmo : \
-    typing/types.cmi \
-    typing/printtyp.cmi \
-    typing/btype.cmi \
-    ocamldoc/odoc_print.cmi
-ocamldoc/odoc_print.cmx : \
-    typing/types.cmx \
-    typing/printtyp.cmx \
-    typing/btype.cmx \
-    ocamldoc/odoc_print.cmi
-ocamldoc/odoc_print.cmi : \
-    typing/types.cmi
-ocamldoc/odoc_scan.cmo : \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi \
-    ocamldoc/odoc_scan.cmi
-ocamldoc/odoc_scan.cmx : \
-    ocamldoc/odoc_value.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_module.cmx \
-    ocamldoc/odoc_extension.cmx \
-    ocamldoc/odoc_exception.cmx \
-    ocamldoc/odoc_class.cmx \
-    ocamldoc/odoc_scan.cmi
-ocamldoc/odoc_scan.cmi : \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi
-ocamldoc/odoc_search.cmo : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_misc.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi \
-    ocamldoc/odoc_search.cmi
-ocamldoc/odoc_search.cmx : \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_value.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_module.cmx \
-    ocamldoc/odoc_misc.cmx \
-    ocamldoc/odoc_extension.cmx \
-    ocamldoc/odoc_exception.cmx \
-    ocamldoc/odoc_class.cmx \
-    ocamldoc/odoc_search.cmi
-ocamldoc/odoc_search.cmi : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi
-ocamldoc/odoc_see_lexer.cmo : \
-    ocamldoc/odoc_parser.cmi \
-    ocamldoc/odoc_see_lexer.cmi
-ocamldoc/odoc_see_lexer.cmx : \
-    ocamldoc/odoc_parser.cmx \
-    ocamldoc/odoc_see_lexer.cmi
-ocamldoc/odoc_see_lexer.cmi : \
-    ocamldoc/odoc_parser.cmi
-ocamldoc/odoc_sig.cmo : \
-    parsing/unit_info.cmi \
-    typing/types.cmi \
-    typing/typedtree.cmi \
-    parsing/parsetree.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_misc.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_merge.cmi \
-    ocamldoc/odoc_global.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_env.cmi \
-    ocamldoc/odoc_class.cmi \
-    parsing/longident.cmi \
-    parsing/location.cmi \
-    typing/ident.cmi \
-    typing/ctype.cmi \
-    typing/btype.cmi \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_sig.cmi
-ocamldoc/odoc_sig.cmx : \
-    parsing/unit_info.cmx \
-    typing/types.cmx \
-    typing/typedtree.cmx \
-    parsing/parsetree.cmi \
-    ocamldoc/odoc_value.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_parameter.cmx \
-    ocamldoc/odoc_module.cmx \
-    ocamldoc/odoc_misc.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_merge.cmx \
-    ocamldoc/odoc_global.cmx \
-    ocamldoc/odoc_extension.cmx \
-    ocamldoc/odoc_exception.cmx \
-    ocamldoc/odoc_env.cmx \
-    ocamldoc/odoc_class.cmx \
-    parsing/longident.cmx \
-    parsing/location.cmx \
-    typing/ident.cmx \
-    typing/ctype.cmx \
-    typing/btype.cmx \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_sig.cmi
-ocamldoc/odoc_sig.cmi : \
-    typing/types.cmi \
-    typing/typedtree.cmi \
-    parsing/parsetree.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_name.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_env.cmi \
-    ocamldoc/odoc_class.cmi \
-    parsing/location.cmi
-ocamldoc/odoc_str.cmo : \
-    typing/types.cmi \
-    typing/printtyp.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_print.cmi \
-    ocamldoc/odoc_name.cmi \
-    ocamldoc/odoc_misc.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_str.cmi
-ocamldoc/odoc_str.cmx : \
-    typing/types.cmx \
-    typing/printtyp.cmx \
-    ocamldoc/odoc_value.cmx \
-    ocamldoc/odoc_type.cmx \
-    ocamldoc/odoc_print.cmx \
-    ocamldoc/odoc_name.cmx \
-    ocamldoc/odoc_misc.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_extension.cmx \
-    ocamldoc/odoc_exception.cmx \
-    ocamldoc/odoc_class.cmx \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_str.cmi
-ocamldoc/odoc_str.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_value.cmi \
-    ocamldoc/odoc_type.cmi \
-    ocamldoc/odoc_extension.cmi \
-    ocamldoc/odoc_exception.cmi \
-    ocamldoc/odoc_class.cmi
-ocamldoc/odoc_test.cmo : \
-    ocamldoc/odoc_info.cmi \
-    ocamldoc/odoc_gen.cmi \
-    ocamldoc/odoc_args.cmi \
-    ocamldoc/odoc_test.cmi
-ocamldoc/odoc_test.cmx : \
-    ocamldoc/odoc_info.cmx \
-    ocamldoc/odoc_gen.cmx \
-    ocamldoc/odoc_args.cmx \
-    ocamldoc/odoc_test.cmi
-ocamldoc/odoc_test.cmi :
-ocamldoc/odoc_texi.cmo : \
-    typing/types.cmi \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_to_text.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_info.cmi \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_texi.cmi
-ocamldoc/odoc_texi.cmx : \
-    typing/types.cmx \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_to_text.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_info.cmx \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_texi.cmi
-ocamldoc/odoc_texi.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_info.cmi
-ocamldoc/odoc_text.cmo : \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_text_parser.cmi \
-    ocamldoc/odoc_text_lexer.cmi \
-    ocamldoc/odoc_text.cmi
-ocamldoc/odoc_text.cmx : \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_text_parser.cmx \
-    ocamldoc/odoc_text_lexer.cmx \
-    ocamldoc/odoc_text.cmi
-ocamldoc/odoc_text.cmi : \
-    ocamldoc/odoc_types.cmi
-ocamldoc/odoc_text_lexer.cmo : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_text_parser.cmi \
-    ocamldoc/odoc_misc.cmi \
-    ocamldoc/odoc_text_lexer.cmi
-ocamldoc/odoc_text_lexer.cmx : \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_text_parser.cmx \
-    ocamldoc/odoc_misc.cmx \
-    ocamldoc/odoc_text_lexer.cmi
-ocamldoc/odoc_text_lexer.cmi : \
-    ocamldoc/odoc_text_parser.cmi
-ocamldoc/odoc_text_parser.cmo : \
-    otherlibs/str/str.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_misc.cmi \
-    ocamldoc/odoc_text_parser.cmi
-ocamldoc/odoc_text_parser.cmx : \
-    otherlibs/str/str.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_misc.cmx \
-    ocamldoc/odoc_text_parser.cmi
-ocamldoc/odoc_text_parser.cmi : \
-    ocamldoc/odoc_types.cmi
-ocamldoc/odoc_to_text.cmo : \
-    otherlibs/str/str.cmi \
-    middle_end/flambda/parameter.cmi \
-    ocamldoc/odoc_str.cmi \
-    ocamldoc/odoc_module.cmi \
-    ocamldoc/odoc_messages.cmi \
-    ocamldoc/odoc_info.cmi \
-    ocamldoc/odoc_to_text.cmi
-ocamldoc/odoc_to_text.cmx : \
-    otherlibs/str/str.cmx \
-    middle_end/flambda/parameter.cmx \
-    ocamldoc/odoc_str.cmx \
-    ocamldoc/odoc_module.cmx \
-    ocamldoc/odoc_messages.cmx \
-    ocamldoc/odoc_info.cmx \
-    ocamldoc/odoc_to_text.cmi
-ocamldoc/odoc_to_text.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_info.cmi
-ocamldoc/odoc_type.cmo : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_name.cmi \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_type.cmi
-ocamldoc/odoc_type.cmx : \
-    typing/types.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_name.cmx \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_type.cmi
-ocamldoc/odoc_type.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_name.cmi \
-    parsing/asttypes.cmi
-ocamldoc/odoc_types.cmo : \
-    ocamldoc/odoc_messages.cmi \
-    parsing/location.cmi \
-    ocamldoc/odoc_types.cmi
-ocamldoc/odoc_types.cmx : \
-    ocamldoc/odoc_messages.cmx \
-    parsing/location.cmx \
-    ocamldoc/odoc_types.cmi
-ocamldoc/odoc_types.cmi : \
-    parsing/location.cmi
-ocamldoc/odoc_value.cmo : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_name.cmi \
-    ocamldoc/odoc_misc.cmi \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_value.cmi
-ocamldoc/odoc_value.cmx : \
-    typing/types.cmx \
-    ocamldoc/odoc_types.cmx \
-    ocamldoc/odoc_parameter.cmx \
-    ocamldoc/odoc_name.cmx \
-    ocamldoc/odoc_misc.cmx \
-    parsing/asttypes.cmi \
-    ocamldoc/odoc_value.cmi
-ocamldoc/odoc_value.cmi : \
-    typing/types.cmi \
-    ocamldoc/odoc_types.cmi \
-    ocamldoc/odoc_parameter.cmi \
-    ocamldoc/odoc_name.cmi
-ocamltest/actions.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/result.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/actions.cmi
-ocamltest/actions.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/result.cmx \
-    ocamltest/environments.cmx \
-    ocamltest/actions.cmi
-ocamltest/actions.cmi : \
-    ocamltest/variables.cmi \
-    ocamltest/result.cmi \
-    ocamltest/environments.cmi
-ocamltest/actions_helpers.cmo : \
-    ocamltest/variables.cmi \
-    otherlibs/unix/unix.cmi \
-    ocamltest/strace.cmi \
-    ocamltest/run_command.cmi \
-    ocamltest/result.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/modifier_parser.cmi \
-    ocamltest/filecompare.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/builtin_variables.cmi \
-    ocamltest/actions.cmi \
-    ocamltest/actions_helpers.cmi
-ocamltest/actions_helpers.cmx : \
-    ocamltest/variables.cmx \
-    otherlibs/unix/unix.cmx \
-    ocamltest/strace.cmx \
-    ocamltest/run_command.cmx \
-    ocamltest/result.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/modifier_parser.cmx \
-    ocamltest/filecompare.cmx \
-    ocamltest/environments.cmx \
-    ocamltest/builtin_variables.cmx \
-    ocamltest/actions.cmx \
-    ocamltest/actions_helpers.cmi
-ocamltest/actions_helpers.cmi : \
-    ocamltest/variables.cmi \
-    ocamltest/result.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/actions.cmi
-ocamltest/builtin_actions.cmo : \
-    otherlibs/unix/unix.cmi \
-    ocamltest/result.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocamltest_config.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/builtin_variables.cmi \
-    ocamltest/actions_helpers.cmi \
-    ocamltest/actions.cmi \
-    ocamltest/builtin_actions.cmi
-ocamltest/builtin_actions.cmx : \
-    otherlibs/unix/unix.cmx \
-    ocamltest/result.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocamltest_config.cmx \
-    ocamltest/environments.cmx \
-    ocamltest/builtin_variables.cmx \
-    ocamltest/actions_helpers.cmx \
-    ocamltest/actions.cmx \
-    ocamltest/builtin_actions.cmi
-ocamltest/builtin_actions.cmi : \
-    ocamltest/actions.cmi
-ocamltest/builtin_variables.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/builtin_variables.cmi
-ocamltest/builtin_variables.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/builtin_variables.cmi
-ocamltest/builtin_variables.cmi : \
-    ocamltest/variables.cmi
-ocamltest/environments.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/environments.cmi
-ocamltest/environments.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/environments.cmi
-ocamltest/environments.cmi : \
-    ocamltest/variables.cmi
-ocamltest/filecompare.cmo : \
-    ocamltest/run_command.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocamltest_config.cmi \
-    ocamltest/filecompare.cmi
-ocamltest/filecompare.cmx : \
-    ocamltest/run_command.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocamltest_config.cmx \
-    ocamltest/filecompare.cmi
-ocamltest/filecompare.cmi :
-ocamltest/main.cmo : \
-    ocamltest/variables.cmi \
-    otherlibs/unix/unix.cmi \
-    ocamltest/tsl_semantics.cmi \
-    ocamltest/tsl_parser.cmi \
-    ocamltest/tsl_lexer.cmi \
-    ocamltest/tsl_ast.cmi \
-    ocamltest/translate.cmi \
-    ocamltest/tests.cmi \
-    ocamltest/result.cmi \
-    ocamltest/options.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocaml_actions.cmi \
-    parsing/location.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/builtin_variables.cmi \
-    ocamltest/actions_helpers.cmi \
-    ocamltest/actions.cmi \
-    ocamltest/main.cmi
-ocamltest/main.cmx : \
-    ocamltest/variables.cmx \
-    otherlibs/unix/unix.cmx \
-    ocamltest/tsl_semantics.cmx \
-    ocamltest/tsl_parser.cmx \
-    ocamltest/tsl_lexer.cmx \
-    ocamltest/tsl_ast.cmx \
-    ocamltest/translate.cmx \
-    ocamltest/tests.cmx \
-    ocamltest/result.cmx \
-    ocamltest/options.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocaml_actions.cmx \
-    parsing/location.cmx \
-    ocamltest/environments.cmx \
-    ocamltest/builtin_variables.cmx \
-    ocamltest/actions_helpers.cmx \
-    ocamltest/actions.cmx \
-    ocamltest/main.cmi
-ocamltest/main.cmi :
-ocamltest/modifier_parser.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/tsl_lexer.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/modifier_parser.cmi
-ocamltest/modifier_parser.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/tsl_lexer.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/environments.cmx \
-    ocamltest/modifier_parser.cmi
-ocamltest/modifier_parser.cmi : \
-    ocamltest/environments.cmi
-ocamltest/ocaml_actions.cmo : \
-    ocamltest/result.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocamltest_config.cmi \
-    ocamltest/ocaml_variables.cmi \
-    ocamltest/ocaml_toplevels.cmi \
-    ocamltest/ocaml_tools.cmi \
-    ocamltest/ocaml_modifiers.cmi \
-    ocamltest/ocaml_flags.cmi \
-    ocamltest/ocaml_filetypes.cmi \
-    ocamltest/ocaml_files.cmi \
-    ocamltest/ocaml_directories.cmi \
-    ocamltest/ocaml_compilers.cmi \
-    ocamltest/ocaml_commands.cmi \
-    ocamltest/ocaml_backends.cmi \
-    utils/misc.cmi \
-    ocamltest/filecompare.cmi \
-    ocamltest/environments.cmi \
-    utils/config.cmi \
-    file_formats/cmo_format.cmi \
-    utils/clflags.cmi \
-    ocamltest/builtin_variables.cmi \
-    ocamltest/actions_helpers.cmi \
-    ocamltest/actions.cmi \
-    ocamltest/ocaml_actions.cmi
-ocamltest/ocaml_actions.cmx : \
-    ocamltest/result.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocamltest_config.cmx \
-    ocamltest/ocaml_variables.cmx \
-    ocamltest/ocaml_toplevels.cmx \
-    ocamltest/ocaml_tools.cmx \
-    ocamltest/ocaml_modifiers.cmx \
-    ocamltest/ocaml_flags.cmx \
-    ocamltest/ocaml_filetypes.cmx \
-    ocamltest/ocaml_files.cmx \
-    ocamltest/ocaml_directories.cmx \
-    ocamltest/ocaml_compilers.cmx \
-    ocamltest/ocaml_commands.cmx \
-    ocamltest/ocaml_backends.cmx \
-    utils/misc.cmx \
-    ocamltest/filecompare.cmx \
-    ocamltest/environments.cmx \
-    utils/config.cmx \
-    file_formats/cmo_format.cmi \
-    utils/clflags.cmx \
-    ocamltest/builtin_variables.cmx \
-    ocamltest/actions_helpers.cmx \
-    ocamltest/actions.cmx \
-    ocamltest/ocaml_actions.cmi
-ocamltest/ocaml_actions.cmi : \
-    ocamltest/actions.cmi
-ocamltest/ocaml_backends.cmo : \
-    ocamltest/ocaml_backends.cmi
-ocamltest/ocaml_backends.cmx : \
-    ocamltest/ocaml_backends.cmi
-ocamltest/ocaml_backends.cmi :
-ocamltest/ocaml_commands.cmo : \
-    ocamltest/ocaml_files.cmi \
-    ocamltest/ocaml_commands.cmi
-ocamltest/ocaml_commands.cmx : \
-    ocamltest/ocaml_files.cmx \
-    ocamltest/ocaml_commands.cmi
-ocamltest/ocaml_commands.cmi :
-ocamltest/ocaml_compilers.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocaml_variables.cmi \
-    ocamltest/ocaml_tools.cmi \
-    ocamltest/ocaml_files.cmi \
-    ocamltest/ocaml_commands.cmi \
-    ocamltest/ocaml_backends.cmi \
-    ocamltest/builtin_variables.cmi \
-    ocamltest/ocaml_compilers.cmi
-ocamltest/ocaml_compilers.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocaml_variables.cmx \
-    ocamltest/ocaml_tools.cmx \
-    ocamltest/ocaml_files.cmx \
-    ocamltest/ocaml_commands.cmx \
-    ocamltest/ocaml_backends.cmx \
-    ocamltest/builtin_variables.cmx \
-    ocamltest/ocaml_compilers.cmi
-ocamltest/ocaml_compilers.cmi : \
-    ocamltest/variables.cmi \
-    ocamltest/ocaml_tools.cmi \
-    ocamltest/ocaml_backends.cmi
-ocamltest/ocaml_directories.cmo : \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocamltest_config.cmi \
-    ocamltest/ocaml_directories.cmi
-ocamltest/ocaml_directories.cmx : \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocamltest_config.cmx \
-    ocamltest/ocaml_directories.cmi
-ocamltest/ocaml_directories.cmi :
-ocamltest/ocaml_files.cmo : \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocamltest_config.cmi \
-    ocamltest/ocaml_directories.cmi \
-    ocamltest/ocaml_files.cmi
-ocamltest/ocaml_files.cmx : \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocamltest_config.cmx \
-    ocamltest/ocaml_directories.cmx \
-    ocamltest/ocaml_files.cmi
-ocamltest/ocaml_files.cmi :
-ocamltest/ocaml_filetypes.cmo : \
-    ocamltest/ocamltest_config.cmi \
-    ocamltest/ocaml_backends.cmi \
-    ocamltest/ocaml_filetypes.cmi
-ocamltest/ocaml_filetypes.cmx : \
-    ocamltest/ocamltest_config.cmx \
-    ocamltest/ocaml_backends.cmx \
-    ocamltest/ocaml_filetypes.cmi
-ocamltest/ocaml_filetypes.cmi : \
-    ocamltest/ocaml_backends.cmi
-ocamltest/ocaml_flags.cmo : \
-    ocamltest/ocaml_variables.cmi \
-    ocamltest/ocaml_files.cmi \
-    ocamltest/ocaml_directories.cmi \
-    ocamltest/ocaml_backends.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/ocaml_flags.cmi
-ocamltest/ocaml_flags.cmx : \
-    ocamltest/ocaml_variables.cmx \
-    ocamltest/ocaml_files.cmx \
-    ocamltest/ocaml_directories.cmx \
-    ocamltest/ocaml_backends.cmx \
-    ocamltest/environments.cmx \
-    ocamltest/ocaml_flags.cmi
-ocamltest/ocaml_flags.cmi : \
-    ocamltest/ocaml_backends.cmi \
-    ocamltest/environments.cmi
-ocamltest/ocaml_modifiers.cmo : \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocamltest_config.cmi \
-    ocamltest/ocaml_variables.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/ocaml_modifiers.cmi
-ocamltest/ocaml_modifiers.cmx : \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocamltest_config.cmx \
-    ocamltest/ocaml_variables.cmx \
-    ocamltest/environments.cmx \
-    ocamltest/ocaml_modifiers.cmi
-ocamltest/ocaml_modifiers.cmi : \
-    ocamltest/environments.cmi
-ocamltest/ocaml_tests.cmo : \
-    ocamltest/tests.cmi \
-    ocamltest/ocamltest_config.cmi \
-    ocamltest/ocaml_actions.cmi \
-    ocamltest/builtin_actions.cmi \
-    ocamltest/actions_helpers.cmi \
-    ocamltest/ocaml_tests.cmi
-ocamltest/ocaml_tests.cmx : \
-    ocamltest/tests.cmx \
-    ocamltest/ocamltest_config.cmx \
-    ocamltest/ocaml_actions.cmx \
-    ocamltest/builtin_actions.cmx \
-    ocamltest/actions_helpers.cmx \
-    ocamltest/ocaml_tests.cmi
-ocamltest/ocaml_tests.cmi : \
-    ocamltest/tests.cmi
-ocamltest/ocaml_tools.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocaml_variables.cmi \
-    ocamltest/ocaml_files.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/actions_helpers.cmi \
-    ocamltest/ocaml_tools.cmi
-ocamltest/ocaml_tools.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocaml_variables.cmx \
-    ocamltest/ocaml_files.cmx \
-    ocamltest/environments.cmx \
-    ocamltest/actions_helpers.cmx \
-    ocamltest/ocaml_tools.cmi
-ocamltest/ocaml_tools.cmi : \
-    ocamltest/variables.cmi \
-    ocamltest/environments.cmi
-ocamltest/ocaml_toplevels.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocaml_variables.cmi \
-    ocamltest/ocaml_tools.cmi \
-    ocamltest/ocaml_files.cmi \
-    ocamltest/ocaml_compilers.cmi \
-    ocamltest/ocaml_commands.cmi \
-    ocamltest/ocaml_backends.cmi \
-    ocamltest/ocaml_toplevels.cmi
-ocamltest/ocaml_toplevels.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocaml_variables.cmx \
-    ocamltest/ocaml_tools.cmx \
-    ocamltest/ocaml_files.cmx \
-    ocamltest/ocaml_compilers.cmx \
-    ocamltest/ocaml_commands.cmx \
-    ocamltest/ocaml_backends.cmx \
-    ocamltest/ocaml_toplevels.cmi
-ocamltest/ocaml_toplevels.cmi : \
-    ocamltest/variables.cmi \
-    ocamltest/ocaml_tools.cmi \
-    ocamltest/ocaml_compilers.cmi \
-    ocamltest/ocaml_backends.cmi
-ocamltest/ocaml_variables.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/ocaml_variables.cmi
-ocamltest/ocaml_variables.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/ocaml_variables.cmi
-ocamltest/ocaml_variables.cmi : \
-    ocamltest/variables.cmi
-ocamltest/ocamltest_config.cmo : \
-    ocamltest/ocamltest_config.cmi
-ocamltest/ocamltest_config.cmx : \
-    ocamltest/ocamltest_config.cmi
-ocamltest/ocamltest_config.cmi :
-ocamltest/ocamltest_stdlib.cmo : \
-    ocamltest/ocamltest_unix.cmi \
-    ocamltest/ocamltest_config.cmi \
-    utils/misc.cmi \
-    ocamltest/ocamltest_stdlib.cmi
-ocamltest/ocamltest_stdlib.cmx : \
-    ocamltest/ocamltest_unix.cmx \
-    ocamltest/ocamltest_config.cmx \
-    utils/misc.cmx \
-    ocamltest/ocamltest_stdlib.cmi
-ocamltest/ocamltest_stdlib.cmi : \
-    ocamltest/ocamltest_unix.cmi \
-    utils/misc.cmi
-ocamltest/ocamltest_unix.cmo : \
-    otherlibs/unix/unix.cmi \
-    ocamltest/ocamltest_unix.cmi
-ocamltest/ocamltest_unix.cmx : \
-    otherlibs/unix/unix.cmx \
-    ocamltest/ocamltest_unix.cmi
-ocamltest/ocamltest_unix.cmi :
-ocamltest/ocamltest_unix_dummy.cmo :
-ocamltest/ocamltest_unix_dummy.cmx :
-ocamltest/ocamltest_unix_real.cmo : \
-    otherlibs/unix/unix.cmi
-ocamltest/ocamltest_unix_real.cmx : \
-    otherlibs/unix/unix.cmx
-ocamltest/options.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/translate.cmi \
-    ocamltest/tests.cmi \
-    ocamltest/actions.cmi \
-    ocamltest/options.cmi
-ocamltest/options.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/translate.cmx \
-    ocamltest/tests.cmx \
-    ocamltest/actions.cmx \
-    ocamltest/options.cmi
-ocamltest/options.cmi : \
-    ocamltest/translate.cmi
-ocamltest/result.cmo : \
-    ocamltest/result.cmi
-ocamltest/result.cmx : \
-    ocamltest/result.cmi
-ocamltest/result.cmi :
-ocamltest/run_command.cmo : \
-    ocamltest/ocamltest_stdlib.cmi \
-    ocamltest/run_command.cmi
-ocamltest/run_command.cmx : \
-    ocamltest/ocamltest_stdlib.cmx \
-    ocamltest/run_command.cmi
-ocamltest/run_command.cmi :
-ocamltest/strace.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/strace.cmi
-ocamltest/strace.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/strace.cmi
-ocamltest/strace.cmi : \
-    ocamltest/variables.cmi
-ocamltest/tests.cmo : \
-    ocamltest/result.cmi \
-    ocamltest/actions.cmi \
-    ocamltest/tests.cmi
-ocamltest/tests.cmx : \
-    ocamltest/result.cmx \
-    ocamltest/actions.cmx \
-    ocamltest/tests.cmi
-ocamltest/tests.cmi : \
-    ocamltest/result.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/actions.cmi
-ocamltest/translate.cmo : \
-    ocamltest/tsl_semantics.cmi \
-    ocamltest/tsl_parser.cmi \
-    ocamltest/tsl_lexer.cmi \
-    ocamltest/tsl_ast.cmi \
-    parsing/location.cmi \
-    ocamltest/translate.cmi
-ocamltest/translate.cmx : \
-    ocamltest/tsl_semantics.cmx \
-    ocamltest/tsl_parser.cmx \
-    ocamltest/tsl_lexer.cmx \
-    ocamltest/tsl_ast.cmx \
-    parsing/location.cmx \
-    ocamltest/translate.cmi
-ocamltest/translate.cmi :
-ocamltest/tsl_ast.cmo : \
-    parsing/location.cmi \
-    ocamltest/tsl_ast.cmi
-ocamltest/tsl_ast.cmx : \
-    parsing/location.cmx \
-    ocamltest/tsl_ast.cmi
-ocamltest/tsl_ast.cmi : \
-    parsing/location.cmi
-ocamltest/tsl_lexer.cmo : \
-    ocamltest/tsl_parser.cmi \
-    ocamltest/tsl_lexer.cmi
-ocamltest/tsl_lexer.cmx : \
-    ocamltest/tsl_parser.cmx \
-    ocamltest/tsl_lexer.cmi
-ocamltest/tsl_lexer.cmi : \
-    ocamltest/tsl_parser.cmi
-ocamltest/tsl_parser.cmo : \
-    ocamltest/tsl_ast.cmi \
-    parsing/location.cmi \
-    ocamltest/tsl_parser.cmi
-ocamltest/tsl_parser.cmx : \
-    ocamltest/tsl_ast.cmx \
-    parsing/location.cmx \
-    ocamltest/tsl_parser.cmi
-ocamltest/tsl_parser.cmi : \
-    ocamltest/tsl_ast.cmi
-ocamltest/tsl_semantics.cmo : \
-    ocamltest/variables.cmi \
-    ocamltest/tsl_ast.cmi \
-    ocamltest/tests.cmi \
-    parsing/location.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/actions.cmi \
-    ocamltest/tsl_semantics.cmi
-ocamltest/tsl_semantics.cmx : \
-    ocamltest/variables.cmx \
-    ocamltest/tsl_ast.cmx \
-    ocamltest/tests.cmx \
-    parsing/location.cmx \
-    ocamltest/environments.cmx \
-    ocamltest/actions.cmx \
-    ocamltest/tsl_semantics.cmi
-ocamltest/tsl_semantics.cmi : \
-    ocamltest/tsl_ast.cmi \
-    ocamltest/tests.cmi \
-    ocamltest/environments.cmi \
-    ocamltest/actions.cmi
-ocamltest/variables.cmo : \
-    ocamltest/variables.cmi
-ocamltest/variables.cmx : \
-    ocamltest/variables.cmi
-ocamltest/variables.cmi :
-testsuite/lib/lib.cmo : \
-    testsuite/lib/lib.cmi
-testsuite/lib/lib.cmx : \
-    testsuite/lib/lib.cmi
-testsuite/lib/lib.cmi :
-testsuite/lib/testing.cmo : \
-    testsuite/lib/testing.cmi
-testsuite/lib/testing.cmx : \
-    testsuite/lib/testing.cmi
-testsuite/lib/testing.cmi :
-testsuite/tools/codegen_main.cmo : \
-    utils/profile.cmi \
-    testsuite/tools/parsecmmaux.cmi \
-    testsuite/tools/parsecmm.cmi \
-    testsuite/tools/lexcmm.cmi \
-    asmcomp/emitaux.cmi \
-    asmcomp/emit.cmi \
-    middle_end/compilenv.cmi \
-    utils/clflags.cmi \
-    asmcomp/asmgen.cmi \
-    testsuite/tools/codegen_main.cmi
-testsuite/tools/codegen_main.cmx : \
-    utils/profile.cmx \
-    testsuite/tools/parsecmmaux.cmx \
-    testsuite/tools/parsecmm.cmx \
-    testsuite/tools/lexcmm.cmx \
-    asmcomp/emitaux.cmx \
-    asmcomp/emit.cmx \
-    middle_end/compilenv.cmx \
-    utils/clflags.cmx \
-    asmcomp/asmgen.cmx \
-    testsuite/tools/codegen_main.cmi
-testsuite/tools/codegen_main.cmi :
-testsuite/tools/expect.cmo : \
-    utils/warnings.cmi \
-    toplevel/toploop.cmi \
-    parsing/printast.cmi \
-    parsing/pprintast.cmi \
-    parsing/parsetree.cmi \
-    parsing/parse.cmi \
-    utils/misc.cmi \
-    driver/main_args.cmi \
-    parsing/location.cmi \
-    utils/load_path.cmi \
-    driver/compmisc.cmi \
-    driver/compenv.cmi \
-    utils/clflags.cmi \
-    typing/btype.cmi \
-    parsing/asttypes.cmi \
-    parsing/ast_mapper.cmi \
-    testsuite/tools/expect.cmi
-testsuite/tools/expect.cmx : \
-    utils/warnings.cmx \
-    toplevel/toploop.cmx \
-    parsing/printast.cmx \
-    parsing/pprintast.cmx \
-    parsing/parsetree.cmi \
-    parsing/parse.cmx \
-    utils/misc.cmx \
-    driver/main_args.cmx \
-    parsing/location.cmx \
-    utils/load_path.cmx \
-    driver/compmisc.cmx \
-    driver/compenv.cmx \
-    utils/clflags.cmx \
-    typing/btype.cmx \
-    parsing/asttypes.cmi \
-    parsing/ast_mapper.cmx \
-    testsuite/tools/expect.cmi
-testsuite/tools/expect.cmi : \
-    parsing/location.cmi
-testsuite/tools/lexcmm.cmo : \
-    testsuite/tools/parsecmm.cmi \
-    utils/misc.cmi \
-    parsing/location.cmi \
-    lambda/lambda.cmi \
-    testsuite/tools/lexcmm.cmi
-testsuite/tools/lexcmm.cmx : \
-    testsuite/tools/parsecmm.cmx \
-    utils/misc.cmx \
-    parsing/location.cmx \
-    lambda/lambda.cmx \
-    testsuite/tools/lexcmm.cmi
-testsuite/tools/lexcmm.cmi : \
-    testsuite/tools/parsecmm.cmi
-testsuite/tools/parsecmm.cmo : \
-    testsuite/tools/parsecmmaux.cmi \
-    utils/misc.cmi \
-    parsing/location.cmi \
-    lambda/lambda.cmi \
-    lambda/debuginfo.cmi \
-    utils/config.cmi \
-    asmcomp/cmm.cmi \
-    parsing/asttypes.cmi \
-    asmcomp/arch.cmi \
-    testsuite/tools/parsecmm.cmi
-testsuite/tools/parsecmm.cmx : \
-    testsuite/tools/parsecmmaux.cmx \
-    utils/misc.cmx \
-    parsing/location.cmx \
-    lambda/lambda.cmx \
-    lambda/debuginfo.cmx \
-    utils/config.cmx \
-    asmcomp/cmm.cmx \
-    parsing/asttypes.cmi \
-    asmcomp/arch.cmx \
-    testsuite/tools/parsecmm.cmi
-testsuite/tools/parsecmm.cmi : \
-    parsing/location.cmi \
-    lambda/lambda.cmi \
-    asmcomp/cmm.cmi
-testsuite/tools/parsecmmaux.cmo : \
-    parsing/location.cmi \
-    lambda/lambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/backend_var.cmi \
-    testsuite/tools/parsecmmaux.cmi
-testsuite/tools/parsecmmaux.cmx : \
-    parsing/location.cmx \
-    lambda/lambda.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/backend_var.cmx \
-    testsuite/tools/parsecmmaux.cmi
-testsuite/tools/parsecmmaux.cmi : \
-    parsing/location.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/backend_var.cmi

--- a/ocaml/.depend.menhir
+++ b/ocaml/.depend.menhir
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 parsing/parser.cmo : \
     parsing/syntaxerr.cmi \
     parsing/parsetree.cmi \
@@ -10,24 +9,7 @@ parsing/parser.cmo : \
     parsing/builtin_attributes.cmi \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmi \
-||||||| 121bedcfd2
-parsing/parser.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
-    parsing/longident.cmi parsing/location.cmi parsing/docstrings.cmi \
-    utils/clflags.cmi parsing/asttypes.cmi parsing/ast_helper.cmi \
-=======
-parsing/parser.cmo : \
-    parsing/syntaxerr.cmi \
-    parsing/parsetree.cmi \
-    parsing/longident.cmi \
-    parsing/location.cmi \
-    parsing/docstrings.cmi \
-    utils/clflags.cmi \
-    parsing/builtin_attributes.cmi \
-    parsing/asttypes.cmi \
-    parsing/ast_helper.cmi \
->>>>>>> 5.2.0
     parsing/parser.cmi
-<<<<<<< HEAD
 parsing/parser.cmx : \
     parsing/syntaxerr.cmx \
     parsing/parsetree.cmi \
@@ -39,32 +21,10 @@ parsing/parser.cmx : \
     parsing/builtin_attributes.cmx \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmx \
-||||||| 121bedcfd2
-parsing/parser.cmx : parsing/syntaxerr.cmx parsing/parsetree.cmi \
-    parsing/longident.cmx parsing/location.cmx parsing/docstrings.cmx \
-    utils/clflags.cmx parsing/asttypes.cmi parsing/ast_helper.cmx \
-=======
-parsing/parser.cmx : \
-    parsing/syntaxerr.cmx \
-    parsing/parsetree.cmi \
-    parsing/longident.cmx \
-    parsing/location.cmx \
-    parsing/docstrings.cmx \
-    utils/clflags.cmx \
-    parsing/builtin_attributes.cmx \
-    parsing/asttypes.cmi \
-    parsing/ast_helper.cmx \
->>>>>>> 5.2.0
     parsing/parser.cmi
 parsing/parser.cmi : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
     parsing/docstrings.cmi
-<<<<<<< HEAD
 parsing/parser.ml parsing/parser.mli: parsing/ast_helper.cmi parsing/asttypes.cmi parsing/builtin_attributes.cmi utils/clflags.cmi parsing/docstrings.cmi parsing/jane_syntax.cmi parsing/location.cmi parsing/longident.cmi parsing/parsetree.cmi parsing/syntaxerr.cmi
-||||||| 121bedcfd2
-parsing/parser.ml parsing/parser.mli: parsing/ast_helper.cmi parsing/asttypes.cmi utils/clflags.cmi parsing/docstrings.cmi parsing/location.cmi parsing/longident.cmi parsing/parsetree.cmi parsing/syntaxerr.cmi
-=======
-parsing/parser.ml parsing/parser.mli: parsing/ast_helper.cmi parsing/asttypes.cmi parsing/builtin_attributes.cmi utils/clflags.cmi parsing/docstrings.cmi parsing/location.cmi parsing/longident.cmi parsing/parsetree.cmi parsing/syntaxerr.cmi
->>>>>>> 5.2.0

--- a/ocaml/stdlib/.depend
+++ b/ocaml/stdlib/.depend
@@ -254,25 +254,13 @@ stdlib__Condition.cmi : condition.mli \
     stdlib__Mutex.cmi
 stdlib__Digest.cmo : digest.ml \
     stdlib__String.cmi \
-<<<<<<< HEAD
     stdlib.cmi \
-||||||| 121bedcfd2
-=======
-    stdlib__Int.cmi \
-    stdlib__In_channel.cmi \
->>>>>>> 5.2.0
     stdlib__Char.cmi \
     stdlib__Bytes.cmi \
     stdlib__Digest.cmi
 stdlib__Digest.cmx : digest.ml \
     stdlib__String.cmx \
-<<<<<<< HEAD
     stdlib.cmx \
-||||||| 121bedcfd2
-=======
-    stdlib__Int.cmx \
-    stdlib__In_channel.cmx \
->>>>>>> 5.2.0
     stdlib__Char.cmx \
     stdlib__Bytes.cmx \
     stdlib__Digest.cmi
@@ -293,59 +281,11 @@ stdlib__Domain.cmx : domain.ml \
     stdlib__Array.cmx \
     stdlib__Domain.cmi
 stdlib__Domain.cmi : domain.mli
-<<<<<<< HEAD
 effect.cmo : \
     effect.cmi
 effect.cmx : \
     effect.cmi
 effect.cmi :
-||||||| 121bedcfd2
-stdlib__Effect.cmo : effect.ml \
-    stdlib__Printf.cmi \
-    stdlib__Printexc.cmi \
-    stdlib__Obj.cmi \
-    stdlib__Callback.cmi \
-    stdlib__Effect.cmi
-stdlib__Effect.cmx : effect.ml \
-    stdlib__Printf.cmx \
-    stdlib__Printexc.cmx \
-    stdlib__Obj.cmx \
-    stdlib__Callback.cmx \
-    stdlib__Effect.cmi
-stdlib__Effect.cmi : effect.mli \
-    stdlib__Printexc.cmi
-=======
-stdlib__Dynarray.cmo : dynarray.ml \
-    stdlib__Sys.cmi \
-    stdlib__Seq.cmi \
-    stdlib__Printf.cmi \
-    stdlib__List.cmi \
-    stdlib__Array.cmi \
-    stdlib__Dynarray.cmi
-stdlib__Dynarray.cmx : dynarray.ml \
-    stdlib__Sys.cmx \
-    stdlib__Seq.cmx \
-    stdlib__Printf.cmx \
-    stdlib__List.cmx \
-    stdlib__Array.cmx \
-    stdlib__Dynarray.cmi
-stdlib__Dynarray.cmi : dynarray.mli \
-    stdlib__Seq.cmi
-stdlib__Effect.cmo : effect.ml \
-    stdlib__Printf.cmi \
-    stdlib__Printexc.cmi \
-    stdlib__Obj.cmi \
-    stdlib__Callback.cmi \
-    stdlib__Effect.cmi
-stdlib__Effect.cmx : effect.ml \
-    stdlib__Printf.cmx \
-    stdlib__Printexc.cmx \
-    stdlib__Obj.cmx \
-    stdlib__Callback.cmx \
-    stdlib__Effect.cmi
-stdlib__Effect.cmi : effect.mli \
-    stdlib__Printexc.cmi
->>>>>>> 5.2.0
 stdlib__Either.cmo : either.ml \
     stdlib__Either.cmi
 stdlib__Either.cmx : either.ml \
@@ -473,7 +413,6 @@ stdlib__Gc.cmo : gc.ml \
     stdlib__Printf.cmi \
     stdlib__Printexc.cmi \
     stdlib__Fun.cmi \
-    stdlib__Domain.cmi \
     stdlib__Atomic.cmi \
     stdlib__Gc.cmi
 stdlib__Gc.cmx : gc.ml \
@@ -483,7 +422,6 @@ stdlib__Gc.cmx : gc.ml \
     stdlib__Printf.cmx \
     stdlib__Printexc.cmx \
     stdlib__Fun.cmx \
-    stdlib__Domain.cmx \
     stdlib__Atomic.cmx \
     stdlib__Gc.cmi
 stdlib__Gc.cmi : gc.mli \
@@ -521,18 +459,15 @@ stdlib__In_channel.cmo : in_channel.ml \
     stdlib.cmi \
     stdlib__Fun.cmi \
     stdlib__Bytes.cmi \
-    stdlib__Bigarray.cmi \
     stdlib__In_channel.cmi
 stdlib__In_channel.cmx : in_channel.ml \
     stdlib__Sys.cmx \
     stdlib.cmx \
     stdlib__Fun.cmx \
     stdlib__Bytes.cmx \
-    stdlib__Bigarray.cmx \
     stdlib__In_channel.cmi
 stdlib__In_channel.cmi : in_channel.mli \
-    stdlib.cmi \
-    stdlib__Bigarray.cmi
+    stdlib.cmi
 stdlib__Int.cmo : int.ml \
     stdlib.cmi \
     stdlib__Int.cmi
@@ -630,23 +565,13 @@ stdlib__Map.cmi : map.mli \
     stdlib.cmi \
     stdlib__Seq.cmi
 stdlib__Marshal.cmo : marshal.ml \
-<<<<<<< HEAD
     stdlib__String.cmi \
     stdlib.cmi \
-||||||| 121bedcfd2
-    stdlib__String.cmi \
-=======
->>>>>>> 5.2.0
     stdlib__Bytes.cmi \
     stdlib__Marshal.cmi
 stdlib__Marshal.cmx : marshal.ml \
-<<<<<<< HEAD
     stdlib__String.cmx \
     stdlib.cmx \
-||||||| 121bedcfd2
-    stdlib__String.cmx \
-=======
->>>>>>> 5.2.0
     stdlib__Bytes.cmx \
     stdlib__Marshal.cmi
 stdlib__Marshal.cmi : marshal.mli \
@@ -686,24 +611,14 @@ stdlib__Nativeint.cmi : nativeint.mli \
     stdlib.cmi
 stdlib__Obj.cmo : obj.ml \
     stdlib__Sys.cmi \
-<<<<<<< HEAD
     stdlib.cmi \
     stdlib__Nativeint.cmi \
-||||||| 121bedcfd2
-    stdlib__Nativeint.cmi \
-=======
->>>>>>> 5.2.0
     stdlib__Int32.cmi \
     stdlib__Obj.cmi
 stdlib__Obj.cmx : obj.ml \
     stdlib__Sys.cmx \
-<<<<<<< HEAD
     stdlib.cmx \
     stdlib__Nativeint.cmx \
-||||||| 121bedcfd2
-    stdlib__Nativeint.cmx \
-=======
->>>>>>> 5.2.0
     stdlib__Int32.cmx \
     stdlib__Obj.cmi
 stdlib__Obj.cmi : obj.mli \
@@ -734,16 +649,13 @@ stdlib__Option.cmi : option.mli \
 stdlib__Out_channel.cmo : out_channel.ml \
     stdlib.cmi \
     stdlib__Fun.cmi \
-    stdlib__Bigarray.cmi \
     stdlib__Out_channel.cmi
 stdlib__Out_channel.cmx : out_channel.ml \
     stdlib.cmx \
     stdlib__Fun.cmx \
-    stdlib__Bigarray.cmx \
     stdlib__Out_channel.cmi
 stdlib__Out_channel.cmi : out_channel.mli \
-    stdlib.cmi \
-    stdlib__Bigarray.cmi
+    stdlib.cmi
 stdlib__Parsing.cmo : parsing.ml \
     stdlib.cmi \
     stdlib__Obj.cmi \


### PR DESCRIPTION
These probably aren't needed for the flambda-backend build process at all, but currently the Makefiles (parts of which we still use) want them in a non-conflicted state.