### PR TITLE
Allow `string` to mode cross

### DIFF
--- a/ocaml/testsuite/tests/typing-immediate/immediate.ml
+++ b/ocaml/testsuite/tests/typing-immediate/immediate.ml
@@ -143,8 +143,8 @@ end;;
 Line 2, characters 2-31:
 2 |   type t = string [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type string is value
-         because it is the primitive value type string.
+Error: The kind of type string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of type string must be a subkind of immediate
          because of the definition of t at line 2, characters 2-31.
 |}];;
@@ -213,8 +213,8 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value
-         because it is the primitive value type string.
+       The kind of the first is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of the first must be a subkind of immediate
          because of the definition of t at line 1, characters 15-35.
 |}];;
@@ -231,8 +231,8 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value
-         because it is the primitive value type string.
+       The kind of the first is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of the first must be a subkind of immediate
          because of the definition of t at line 1, characters 20-40.
 |}];;
@@ -248,8 +248,8 @@ Error: Modules do not match: sig type t = string end is not included in
        type t = string
      is not included in
        type t : immediate
-     The kind of the first is value
-       because it is the primitive value type string.
+     The kind of the first is immutable_data
+       because it is the primitive immutable_data type string.
      But the kind of the first must be a subkind of immediate
        because of the definition of t at line 1, characters 20-40.
 |}];;
@@ -263,8 +263,8 @@ end;;
 Line 2, characters 2-26:
 2 |   type t = s [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type s is value
-         because it is the primitive value type string.
+Error: The kind of type s is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of type s must be a subkind of immediate
          because of the definition of t at line 2, characters 2-26.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -160,7 +160,7 @@ Line 1, characters 40-45:
 Error: This expression has type string but an expression was expected of type
          ('a : void)
        The layout of string is value
-         because it is the primitive value type string.
+         because it is the primitive immutable_data type string.
        But the layout of string must be a sublayout of void
          because of the annotation on the type variable 'a.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/a.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/a.ml
@@ -1,5 +1,11 @@
 (* CR layouts v2.5: The commented out code in this file uses void, but could
    use any non-value layout. *)
 type a_imm = A
-type a_value = string
+
+module Value : sig
+  type t
+end = struct
+  type t = unit
+end
+type a_value = Value.t
 (* type a_void : void *)

--- a/ocaml/testsuite/tests/typing-layouts/allow_illegal_crossing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/allow_illegal_crossing.ml
@@ -166,14 +166,14 @@ val my_str : string = ""
 val y : t = {a = ""}
 |}]
 
-type t : value mod portable = { a : string }
-let my_str : string @@ nonportable = ""
-let y : t @@ portable = { a = my_str }
+type t : value mod portable = { a : string -> string }
+let my_fun @ nonportable = fun x -> x
+let y : t @@ portable = { a = my_fun }
 [%%expect {|
-type t : value mod portable = { a : string; }
-val my_str : string = ""
+type t : value mod portable = { a : string -> string; }
+val my_fun : 'a -> 'a = <fun>
 Line 3, characters 30-36:
-3 | let y : t @@ portable = { a = my_str }
+3 | let y : t @@ portable = { a = my_fun }
                                   ^^^^^^
 Error: This value is nonportable but expected to be portable.
 |}]
@@ -219,14 +219,14 @@ val make_value : unit -> t_value = <fun>
 val f : unit -> unit = <fun>
 |}]
 
-type t : value mod portable = { a : string }
-let my_str : string @@ nonportable = ""
-let y = ({ a = my_str } : _ @@ portable)
+type t : value mod portable = { a : string -> string }
+let my_fun : _ @@ nonportable = fun x -> x
+let y = ({ a = my_fun } : _ @@ portable)
 [%%expect {|
-type t : value mod portable = { a : string; }
-val my_str : string = ""
+type t : value mod portable = { a : string -> string; }
+val my_fun : 'a -> 'a = <fun>
 Line 3, characters 15-21:
-3 | let y = ({ a = my_str } : _ @@ portable)
+3 | let y = ({ a = my_fun } : _ @@ portable)
                    ^^^^^^
 Error: This value is nonportable but expected to be portable.
 |}]
@@ -348,27 +348,27 @@ Error: The kind of type a/2 is value
 module A : sig
   type t
 end = struct
-  type t : value mod many = private string
+  type t : value mod many = private t_value
 end
 [%%expect {|
-Line 4, characters 2-42:
-4 |   type t : value mod many = private string
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type string is value
-         because it is the primitive value type string.
-       But the kind of type string must be a subkind of value mod many
-         because of the definition of t at line 4, characters 2-42.
+Line 4, characters 2-43:
+4 |   type t : value mod many = private t_value
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of value mod many
+         because of the definition of t at line 4, characters 2-43.
 |}]
 
-type t : value mod external_ = private string
+type t : value mod external_ = private t_value
 [%%expect {|
-Line 1, characters 0-45:
-1 | type t : value mod external_ = private string
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type string is value
-         because it is the primitive value type string.
-       But the kind of type string must be a subkind of value mod external_
-         because of the definition of t at line 1, characters 0-45.
+Line 1, characters 0-46:
+1 | type t : value mod external_ = private t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of value mod external_
+         because of the definition of t at line 1, characters 0-46.
 |}]
 
 type t : value mod global = { a : int; b : int }
@@ -567,13 +567,14 @@ end = struct
 end
 type t : value mod portable = Foo.t
 [%%expect {|
-Line 4, characters 2-38:
-4 |   type t : value mod portable = string
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type string is value
-         because it is the primitive value type string.
-       But the kind of type string must be a subkind of value mod portable
-         because of the definition of t at line 4, characters 2-38.
+module Foo : sig type t end
+Line 6, characters 0-35:
+6 | type t : value mod portable = Foo.t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type Foo.t is value
+         because of the definition of t at line 2, characters 2-8.
+       But the kind of type Foo.t must be a subkind of value mod portable
+         because of the definition of t at line 6, characters 0-35.
 |}]
 
 type a = { foo : string }
@@ -629,17 +630,17 @@ Error: The kind of type a is value
 |}]
 
 type ('a : value mod uncontended) of_uncontended
-type t = string of_uncontended
+type t = t_value of_uncontended
 [%%expect {|
 type ('a : value mod uncontended) of_uncontended
-Line 2, characters 9-15:
-2 | type t = string of_uncontended
-             ^^^^^^
-Error: This type string should be an instance of type
+Line 2, characters 9-16:
+2 | type t = t_value of_uncontended
+             ^^^^^^^
+Error: This type t_value should be an instance of type
          ('a : value mod uncontended)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of value mod uncontended
+       The kind of t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of t_value must be a subkind of value mod uncontended
          because of the definition of of_uncontended at line 1, characters 0-48.
 |}]
 
@@ -660,32 +661,31 @@ Error: This type t should be an instance of type ('a : value mod portable)
 |}]
 
 let f : ('a : value mod portable). 'a -> 'a = fun x -> x
-let _ = f "hello"
+let _ = f (fun x -> x)
 [%%expect {|
 val f : ('a : value mod portable). 'a -> 'a = <fun>
-Line 2, characters 10-17:
-2 | let _ = f "hello"
-              ^^^^^^^
-Error: This expression has type string but an expression was expected of type
-         ('a : value mod portable)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of value mod portable
+Line 2, characters 10-22:
+2 | let _ = f (fun x -> x)
+              ^^^^^^^^^^^^
+Error:
+       The kind of 'a -> 'b is value
+         because it's a function type.
+       But the kind of 'a -> 'b must be a subkind of value mod portable
          because of the definition of f at line 1, characters 4-5.
 |}]
 
 let f : ('a : value mod uncontended). 'a -> 'a = fun x -> x
-let _ = f "hello"
+let _ = f (ref 10)
 [%%expect {|
 val f : ('a : value mod uncontended). 'a -> 'a = <fun>
-Line 2, characters 10-17:
-2 | let _ = f "hello"
-              ^^^^^^^
-Error: This expression has type string but an expression was expected of type
-         ('a : value mod uncontended)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of value mod uncontended
+Line 2, characters 10-18:
+2 | let _ = f (ref 10)
+              ^^^^^^^^
+Error: This expression has type int ref
+       but an expression was expected of type ('a : value mod uncontended)
+       The kind of int ref is value
+         because of kind requirements from an imported definition.
+       But the kind of int ref must be a subkind of value mod uncontended
          because of the definition of f at line 1, characters 4-5.
 |}]
 
@@ -700,60 +700,72 @@ val f : ('a : value mod uncontended portable). 'a -> 'a = <fun>
 (*****************************************)
 (* Test 5: values cannot illegally cross *)
 
-let x : _ as (_ : value mod portable) = "hello world"
+(* Used for below testing *)
+module Value : sig
+  type t
+  val mk : t
+end = struct
+  type t = unit
+  let mk = ()
+end
 [%%expect {|
-Line 1, characters 40-53:
-1 | let x : _ as (_ : value mod portable) = "hello world"
-                                            ^^^^^^^^^^^^^
-Error: This expression has type string but an expression was expected of type
-         ('a : value mod portable)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of value mod portable
+module Value : sig type t val mk : t end
+|}]
+
+let x : _ as (_ : value mod portable) = Value.mk
+[%%expect {|
+Line 1, characters 40-48:
+1 | let x : _ as (_ : value mod portable) = Value.mk
+                                            ^^^^^^^^
+Error: This expression has type Value.t
+       but an expression was expected of type ('a : value mod portable)
+       The kind of Value.t is value
+         because of the definition of t at line 2, characters 2-8.
+       But the kind of Value.t must be a subkind of value mod portable
          because of the annotation on the wildcard _ at line 1, characters 18-36.
 |}]
 
-type t = { str : string }
-let f _ : _ as (_ : value mod uncontended) = { str = "hello world" }
+type t = { v : Value.t }
+let f _ : _ as (_ : value mod uncontended) = { v = Value.mk }
 [%%expect {|
-type t = { str : string; }
-Line 2, characters 45-68:
-2 | let f _ : _ as (_ : value mod uncontended) = { str = "hello world" }
-                                                 ^^^^^^^^^^^^^^^^^^^^^^^
+type t = { v : Value.t; }
+Line 2, characters 45-61:
+2 | let f _ : _ as (_ : value mod uncontended) = { v = Value.mk }
+                                                 ^^^^^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod uncontended)
        The kind of t is value
-         because of the definition of t at line 1, characters 0-25.
+         because of the definition of t at line 1, characters 0-24.
        But the kind of t must be a subkind of value mod uncontended
          because of the annotation on the wildcard _ at line 2, characters 20-41.
 |}]
 
-type t = Foo of string
-let f : ('a : value mod portable). 'a -> 'a = fun _ -> Foo "hello world"
+type t = Foo of Value.t
+let f : ('a : value mod portable). 'a -> 'a = fun _ -> Foo Value.mk
 [%%expect {|
-type t = Foo of string
-Line 2, characters 55-72:
-2 | let f : ('a : value mod portable). 'a -> 'a = fun _ -> Foo "hello world"
-                                                           ^^^^^^^^^^^^^^^^^
+type t = Foo of Value.t
+Line 2, characters 55-67:
+2 | let f : ('a : value mod portable). 'a -> 'a = fun _ -> Foo Value.mk
+                                                           ^^^^^^^^^^^^
 Error: This expression has type t but an expression was expected of type
          ('a : value mod portable)
        The kind of t is value
-         because of the definition of t at line 1, characters 0-22.
+         because of the definition of t at line 1, characters 0-23.
        But the kind of t must be a subkind of value mod portable
          because of the annotation on the universal variable 'a.
 |}]
 
-type t = string
-let x : ('a : value mod uncontended) = ("hello world" : t)
+type t = Value.t
+let x : ('a : value mod uncontended) = (Value.mk : t)
 [%%expect {|
-type t = string
-Line 2, characters 39-58:
-2 | let x : ('a : value mod uncontended) = ("hello world" : t)
-                                           ^^^^^^^^^^^^^^^^^^^
-Error: This expression has type t = string
+type t = Value.t
+Line 2, characters 39-53:
+2 | let x : ('a : value mod uncontended) = (Value.mk : t)
+                                           ^^^^^^^^^^^^^^
+Error: This expression has type t = Value.t
        but an expression was expected of type ('a : value mod uncontended)
        The kind of t is value
-         because it is the primitive value type string.
+         because of the definition of t at line 2, characters 2-8.
        But the kind of t must be a subkind of value mod uncontended
          because of the annotation on the type variable 'a.
 |}]
@@ -885,16 +897,16 @@ Error: The kind of type a is value mod global unique many external_
 module A : sig
   type t
 end = struct
-  type t : value mod portable = private string
+  type t : value mod portable = private t_value
 end
 [%%expect {|
-Line 4, characters 2-46:
-4 |   type t : value mod portable = private string
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type string is value
-         because it is the primitive value type string.
-       But the kind of type string must be a subkind of value mod portable
-         because of the definition of t at line 4, characters 2-46.
+Line 4, characters 2-47:
+4 |   type t : value mod portable = private t_value
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type t_value is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type t_value must be a subkind of value mod portable
+         because of the definition of t at line 4, characters 2-47.
 |}]
 
 type a : value mod portable uncontended = private b

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -286,8 +286,8 @@ Line 1, characters 9-15:
 1 | type t = string t2_imm
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of t2_imm at line 1, characters 0-28.
 |}]
@@ -299,8 +299,8 @@ Line 1, characters 9-15:
 1 | type t = string t2_global
              ^^^^^^
 Error: This type string should be an instance of type ('a : value mod global)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of value mod global
          because of the definition of t2_global at line 8, characters 0-38.
 |}]
@@ -542,8 +542,8 @@ Line 1, characters 24-31:
                             ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of r at line 1, characters 0-47.
 |}]
@@ -556,8 +556,8 @@ Line 1, characters 26-33:
                               ^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of value mod global
          because of the definition of rg at line 1, characters 0-56.
 |}]
@@ -571,7 +571,7 @@ Line 1, characters 26-33:
 Error: This expression has type string but an expression was expected of type
          ('a : word mod many external_)
        The layout of string is value
-         because it is the primitive value type string.
+         because it is the primitive immutable_data type string.
        But the layout of string must be a sublayout of word
          because of the definition of rc at line 1, characters 0-70.
 |}]
@@ -966,8 +966,8 @@ Line 1, characters 43-51:
                                                ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the annotation on the universal variable 'a.
 |}]
@@ -980,8 +980,8 @@ Line 1, characters 50-58:
                                                       ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod global)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of value mod global
          because of the annotation on the universal variable 'a.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -504,8 +504,8 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of imm_id at line 1, characters 0-33.
 |}];;
@@ -527,8 +527,8 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of id_for_imms at line 1, characters 16-35.
 |}]
@@ -543,8 +543,8 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the annotation on 'a in the declaration of the type t4.
 |}];;
@@ -557,8 +557,8 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the annotation on 'a in the declaration of the type t4.
 |}]
@@ -590,8 +590,8 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of s5 is value
-         because it is the primitive value type string.
+       The kind of s5 is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of s5 must be a subkind of immediate
          because of the annotation on 'a in the declaration of the type t4.
 |}]
@@ -915,8 +915,8 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of x at line 8, characters 10-26.
 |}];;
@@ -956,8 +956,8 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of x at line 8, characters 10-26.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -246,8 +246,8 @@ Line 1, characters 19-25:
 1 | let string_id (x : string imm_id) = x;;
                        ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of imm_id at line 1, characters 0-33.
 |}];;
@@ -269,8 +269,8 @@ Line 1, characters 33-46:
                                      ^^^^^^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          'a imm_id = ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of id_for_imms at line 1, characters 16-35.
 |}]
@@ -285,8 +285,8 @@ Line 2, characters 9-15:
 2 | and s4 = string t4;;
              ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the annotation on 'a in the declaration of the type t4.
 |}];;
@@ -299,8 +299,8 @@ Line 1, characters 10-16:
 1 | type s4 = string t4
               ^^^^^^
 Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the annotation on 'a in the declaration of the type t4.
 |}]
@@ -332,8 +332,8 @@ Line 3, characters 0-15:
 3 | and s5 = string;;
     ^^^^^^^^^^^^^^^
 Error:
-       The kind of s5 is value
-         because it is the primitive value type string.
+       The kind of s5 is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of s5 must be a subkind of immediate
          because of the annotation on 'a in the declaration of the type t4.
 |}]
@@ -749,8 +749,8 @@ Error: Signature mismatch:
        is not included in
          val x : string
        The type ('a : immediate) is not compatible with the type string
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of x at line 8, characters 10-26.
 |}];;
@@ -790,8 +790,8 @@ Error: Signature mismatch:
          val x : string
        The type 'a t = ('a : immediate) is not compatible with the type
          string
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of x at line 8, characters 10-26.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -232,8 +232,8 @@ Line 1, characters 22-23:
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
        custom message
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the annotation on the wildcard _ at line 1, characters 26-41.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -482,8 +482,8 @@ Line 2, characters 25-33:
                              ^^^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : value mod unique)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of value mod unique
          because of the definition of t at line 1, characters 0-54.
 |}]
@@ -787,8 +787,7 @@ Line 2, characters 0-77:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type t is value
          because it's a boxed record type.
-       But the kind of type t must be a subkind of
-         value mod many uncontended portable
+       But the kind of type t must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: This should be accepted *)
@@ -1126,13 +1125,13 @@ type t : value mod uncontended = Foo of int [@@unboxed]
 type t : value mod external_ = Foo of int [@@unboxed]
 |}]
 
-type t : any mod portable = Foo of string [@@unboxed]
+type t : any mod portable = Foo of t_value [@@unboxed]
 [%%expect {|
-Line 1, characters 0-53:
-1 | type t : any mod portable = Foo of string [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-54:
+1 | type t : any mod portable = Foo of t_value [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type t is value
-         because it is the primitive value type string.
+         because of the definition of t_value at line 1, characters 0-20.
        But the kind of type t must be a subkind of any mod portable
          because of the annotation on the declaration of the type t.
 |}]
@@ -1151,7 +1150,7 @@ Error: The kind of type t is value
          because it instantiates an unannotated type parameter of t,
          defaulted to kind value.
        But the kind of type t must be a subkind of
-         value mod global unique many uncontended portable
+         immutable_data mod global unique
          because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1166,7 +1165,7 @@ Error: The kind of type t is value
          because it instantiates an unannotated type parameter of t,
          defaulted to kind value.
        But the kind of type t must be a subkind of
-         value mod global unique many uncontended portable
+         immutable_data mod global unique
          because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
@@ -86,7 +86,7 @@ Line 4, characters 63-68:
 Error: This expression has type string but an expression was expected of type
          ('a : float64)
        The layout of string is value
-         because it is the primitive value type string.
+         because it is the primitive immutable_data type string.
        But the layout of string must be a sublayout of float64
          because of the definition of id' at line 2, characters 10-18.
 |}]
@@ -310,7 +310,7 @@ Line 1, characters 36-41:
 Error: This expression has type string but an expression was expected of type
          ('a : float64)
        The layout of string is value
-         because it is the primitive value type string.
+         because it is the primitive immutable_data type string.
        But the layout of string must be a sublayout of float64
          because of the definition of id at line 2, characters 2-35.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -188,8 +188,8 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of t at line 2, characters 2-25.
 |}]
@@ -450,8 +450,8 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of f at line 3, characters 2-20.
 |}]
@@ -466,8 +466,8 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The kind of type string is value
-         because it is the primitive value type string.
+Error: The kind of type string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of type string must be a subkind of immediate
          because of the definition of t at line 2, characters 2-20.
 |}]
@@ -553,8 +553,8 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value
-         because it is the primitive value type string.
+       The kind of the first is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of the first must be a subkind of immediate
          because of the definition of t at line 2, characters 2-20.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -133,8 +133,8 @@ Line 5, characters 25-30:
                              ^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of t at line 2, characters 2-25.
 |}]
@@ -376,8 +376,8 @@ Line 14, characters 17-23:
                       ^^^^^^
 Error: This expression has type string but an expression was expected of type
          ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
+       The kind of string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of string must be a subkind of immediate
          because of the definition of f at line 3, characters 2-20.
 |}]
@@ -392,8 +392,8 @@ module type S3_2 = sig type t : immediate end
 Line 5, characters 30-46:
 5 | module type S3_2' = S3_2 with type t := string;;
                                   ^^^^^^^^^^^^^^^^
-Error: The kind of type string is value
-         because it is the primitive value type string.
+Error: The kind of type string is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of type string must be a subkind of immediate
          because of the definition of t at line 2, characters 2-20.
 |}]
@@ -466,8 +466,8 @@ Error: In this `with' constraint, the new definition of t
          type t = string
        is not included in
          type t : immediate
-       The kind of the first is value
-         because it is the primitive value type string.
+       The kind of the first is immutable_data
+         because it is the primitive immutable_data type string.
        But the kind of the first must be a subkind of immediate
          because of the definition of t at line 2, characters 2-20.
 |}];;

--- a/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
@@ -271,12 +271,8 @@ Error: This value escapes its region.
 
 let string_duplicate = let once_ x : string = "hello" in Fun.id x
 
-(* CR layouts v2.8: this should succeed *)
 [%%expect{|
-Line 1, characters 64-65:
-1 | let string_duplicate = let once_ x : string = "hello" in Fun.id x
-                                                                    ^
-Error: This value is once but expected to be many.
+val string_duplicate : string = "hello"
 |}]
 
 let int_duplicate = let once_ x : int = 5 in Fun.id x

--- a/ocaml/testsuite/tests/typing-modal-kinds/expected_mode.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/expected_mode.ml
@@ -183,11 +183,13 @@ Line 2, characters 11-12:
 Error: This value escapes its region.
 |}]
 
-let string_duplicate : once_ _ -> string = fun x -> x
+type t_value
+let value_duplicate : once_ _ -> t_value = fun x -> x
 
 [%%expect{|
-Line 1, characters 52-53:
-1 | let string_duplicate : once_ _ -> string = fun x -> x
+type t_value
+Line 2, characters 52-53:
+2 | let value_duplicate : once_ _ -> t_value = fun x -> x
                                                         ^
 Error: This value is once but expected to be many.
 |}]
@@ -198,11 +200,11 @@ let int_duplicate : once_ _ -> int = fun x -> x
 val int_duplicate : once_ int -> int = <fun>
 |}]
 
-let string_list_duplicate : once_ _ -> string list = fun x -> x
+let value_list_duplicate : once_ _ -> t_value list = fun x -> x
 
 [%%expect{|
 Line 1, characters 62-63:
-1 | let string_list_duplicate : once_ _ -> string list = fun x -> x
+1 | let value_list_duplicate : once_ _ -> t_value list = fun x -> x
                                                                   ^
 Error: This value is once but expected to be many.
 |}]

--- a/ocaml/testsuite/tests/typing-modes/class.ml
+++ b/ocaml/testsuite/tests/typing-modes/class.ml
@@ -61,7 +61,7 @@ Error: This value escapes its region.
 
 (* instance variables are available as legacy to methods *)
 class cla = object
-    val x = ("world" : _ @@ portable)
+    val x = (fun y -> y : _ @@ portable)
 
     method foo = portable_use x
 end
@@ -114,15 +114,15 @@ Error: This value is nonportable but expected to be portable.
 
 (* for methods, arguments can be of any modes *)
 class cla = object
-    method foo (x : string) = portable_use x
+    method foo (x : unit -> unit) = portable_use x
 end
 [%%expect{|
-class cla : object method foo : string @ portable -> unit end
+class cla : object method foo : (unit -> unit) @ portable -> unit end
 |}]
 
 (* the argument mode is soundly required during application *)
 let foo () =
-    let x @ nonportable = "hello" in
+    let x @ nonportable = fun x -> x in
     let o = new cla in
     o#foo x
 [%%expect{|

--- a/ocaml/testsuite/tests/typing-modes/val_modalities.ml
+++ b/ocaml/testsuite/tests/typing-modes/val_modalities.ml
@@ -275,6 +275,7 @@ module Close_over_value :
   end
 |}]
 
+(* CR mode-crossing: this should use mutable record *)
 module Close_over_value_monadic = struct
   module M = struct
     let r @ uncontended = fun x -> x

--- a/ocaml/testsuite/tests/typing-modules/package_constraint.ml
+++ b/ocaml/testsuite/tests/typing-modules/package_constraint.ml
@@ -2,6 +2,12 @@
  expect;
 *)
 
+(* A type with kind value, used for the below tests *)
+type t_value
+[%%expect {|
+type t_value
+|}]
+
 (* You may constrain abstract types in packages. *)
 module type S = sig
   type t
@@ -43,21 +49,21 @@ module type S = sig
 end
 
 type m1 = (module S with type t = int)
-type m2 = (module S with type t = string);;
+type m2 = (module S with type t = t_value);;
 [%%expect{|
 module type S = sig type t : immediate end
 type m1 = (module S with type t = int)
-Line 6, characters 10-41:
-6 | type m2 = (module S with type t = string);;
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 6, characters 10-42:
+6 | type m2 = (module S with type t = t_value);;
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this `with' constraint, the new definition of t
        does not match its original definition in the constrained signature:
        Type declarations do not match:
-         type t = string
+         type t = t_value
        is not included in
          type t : immediate
        The kind of the first is value
-         because it is the primitive value type string.
+         because of the definition of t_value at line 1, characters 0-12.
        But the kind of the first must be a subkind of immediate
          because of the definition of t at line 2, characters 2-22.
 |}];;
@@ -67,12 +73,12 @@ module type S = sig
   type t = int
 end
 
-type m = (module S with type t = string);;
+type m = (module S with type t = t_value);;
 [%%expect{|
 module type S = sig type t = int end
-Line 5, characters 9-40:
-5 | type m = (module S with type t = string);;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 5, characters 9-41:
+5 | type m = (module S with type t = t_value);;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the constrained signature, type t is defined to be int.
        Package `with' constraints may only be used on abstract types.
 |}];;
@@ -133,15 +139,15 @@ module type S = sig
 end
 
 type t1 = (module S with type t = t2)
-and t2 = string;;
+and t2 = t_value;;
 [%%expect{|
 module type S = sig type t : immediate end
-Line 6, characters 0-15:
-6 | and t2 = string;;
-    ^^^^^^^^^^^^^^^
+Line 6, characters 0-16:
+6 | and t2 = t_value;;
+    ^^^^^^^^^^^^^^^^
 Error:
        The kind of t2 is value
-         because it is the primitive value type string.
+         because of the definition of t_value at line 1, characters 0-12.
        But the kind of t2 must be a subkind of immediate
          because of the definition of t at line 2, characters 2-22.
 |}];;
@@ -180,7 +186,7 @@ module type S = sig
   type t [@@immediate]
 end
 
-type t1 = (module S with type t = string t2)
+type t1 = (module S with type t = t_value t2)
 and 'a t2 = 'a;;
 [%%expect{|
 module type S = sig type t : immediate end
@@ -318,17 +324,17 @@ end
 type 'a t = (module S with type t = 'a)
 
 type t1 = int t
-type t2 = string t
+type t2 = t_value t
 [%%expect{|
 module type S = sig type t : immediate end
 type ('a : immediate) t = (module S with type t = 'a)
 type t1 = int t
-Line 8, characters 10-16:
-8 | type t2 = string t
-              ^^^^^^
-Error: This type string should be an instance of type ('a : immediate)
-       The kind of string is value
-         because it is the primitive value type string.
-       But the kind of string must be a subkind of immediate
+Line 8, characters 10-17:
+8 | type t2 = t_value t
+              ^^^^^^^
+Error: This type t_value should be an instance of type ('a : immediate)
+       The kind of t_value is value
+         because of the definition of t_value at line 1, characters 0-12.
+       But the kind of t_value must be a subkind of immediate
          because of the definition of t at line 5, characters 0-39.
 |}];;

--- a/ocaml/testsuite/tests/typing-unique/unique_analysis.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique_analysis.ml
@@ -555,14 +555,26 @@ let foo () =
 val foo : unit -> unit = <fun>
 |}]
 
+(* This will be used by below tests *)
+module Value : sig
+  type t
+  val mk : unit -> t @ unique
+end = struct
+  type t = unit
+  let mk : unit -> t @ unique = fun () -> ()
+end
+[%%expect {|
+module Value : sig type t val mk : unit -> unique_ t end
+|}]
+
 (* Testing modalities in records *)
-type r_shared = {x : string; y : string @@ shared many}
+type r_shared = {x : Value.t; y : Value.t @@ shared many}
 [%%expect{|
-type r_shared = { x : string; y : string @@ many shared; }
+type r_shared = { x : Value.t; y : Value.t @@ many shared; }
 |}]
 
 let foo () =
-  let r = {x = "hello"; y = "world"} in
+  let r = {x = Value.mk (); y = Value.mk ()} in
   ignore (shared_id r.y);
   (* the following is allowed, because using r uniquely implies using r.x
      shared *)
@@ -573,7 +585,7 @@ val foo : unit -> unit = <fun>
 
  (* Similarly for linearity *)
 let foo () =
-  let r = once_ {x = "hello"; y = "world"} in
+  let r = once_ {x = Value.mk (); y = Value.mk ()} in
   ignore_once r.y;
   ignore_once r;
 [%%expect{|
@@ -581,7 +593,7 @@ val foo : unit -> unit = <fun>
 |}]
 
 let foo () =
-  let r = once_ {x = "hello"; y = "world"} in
+  let r = once_ {x = Value.mk (); y = Value.mk ()} in
   ignore_once r.x;
   ignore_once r;
 [%%expect{|
@@ -597,7 +609,7 @@ Line 3, characters 14-17:
 |}]
 
 let foo () =
-  let r = {x = "hello"; y = "world"} in
+  let r = {x = Value.mk (); y = Value.mk ()} in
   ignore (shared_id r.x);
   (* doesn't work for normal fields *)
   ignore (unique_id r)
@@ -615,8 +627,8 @@ Line 3, characters 20-23:
 
 (* testing record update in the presense of modalities *)
 let foo () =
-  let r = {x = "hello"; y = "world"} in
-  ignore (unique_ {r with x = "hello agin"});
+  let r = {x = Value.mk (); y = Value.mk ()} in
+  ignore (unique_ {r with x = Value.mk ()});
   (* r.y has been used shared; in the following we will use r as unique *)
   ignore (unique_id r)
 [%%expect{|
@@ -624,8 +636,8 @@ val foo : unit -> unit = <fun>
 |}]
 
 let foo () =
-  let r = {x = "hello"; y = "world"} in
-  ignore (unique_ {r with y = "world again"});
+  let r = {x = Value.mk (); y = Value.mk ()} in
+  ignore (unique_ {r with y = Value.mk ()});
   (* r.x has been used unique; in the following we will use r as unique *)
   ignore (unique_id r)
 [%%expect{|
@@ -635,19 +647,19 @@ Line 5, characters 20-21:
 Error: This value is used here,
        but part of it has already been used as unique:
 Line 3, characters 19-20:
-3 |   ignore (unique_ {r with y = "world again"});
+3 |   ignore (unique_ {r with y = Value.mk ()});
                        ^
 
 |}]
 
 (* testing modalities in constructors *)
-type r_shared = R_shared of string * string @@ shared many
+type r_shared = R_shared of Value.t * Value.t @@ shared many
 [%%expect{|
-type r_shared = R_shared of string * string @@ many shared
+type r_shared = R_shared of Value.t * Value.t @@ many shared
 |}]
 
 let foo () =
-  let r = R_shared ("hello", "world") in
+  let r = R_shared (Value.mk (), Value.mk ()) in
   let R_shared (_, y) = r in
   ignore (shared_id y);
   (* the following is allowed, because using r uniquely implies using r.x
@@ -659,7 +671,7 @@ val foo : unit -> unit = <fun>
 
  (* Similarly for linearity *)
 let foo () =
-  let r = once_ (R_shared ("hello", "world")) in
+  let r = once_ (R_shared (Value.mk (), Value.mk ())) in
   let R_shared (_, y) = r in
   ignore_once y;
   ignore_once r;
@@ -668,7 +680,7 @@ val foo : unit -> unit = <fun>
 |}]
 
 let foo () =
-  let r = once_ (R_shared ("hello", "world")) in
+  let r = once_ (R_shared (Value.mk (), Value.mk ())) in
   let R_shared (x, _) = r in
   ignore_once x;
   ignore_once r;
@@ -685,7 +697,7 @@ Line 4, characters 14-15:
 |}]
 
 let foo () =
-  let r = R_shared ("hello", "world") in
+  let r = R_shared (Value.mk (), Value.mk ()) in
   let R_shared (x, _) = r in
   ignore (shared_id x);
   (* doesn't work for normal fields *)

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -388,6 +388,22 @@ module Const = struct
         name = "value"
       }
 
+    let immutable_data =
+      { jkind =
+          { layout = Sort Value;
+            modes_upper_bounds =
+              { linearity = Linearity.Const.min;
+                contention = Contention.Const.min;
+                portability = Portability.Const.min;
+                uniqueness = Uniqueness.Const.max;
+                areality = Locality.Const.max
+              };
+            externality_upper_bound = Externality.max;
+            nullability_upper_bound = Nullability.Non_null
+          };
+        name = "immutable_data"
+      }
+
     (* CR layouts v3: change to [or_null] when separability is implemented. *)
     let void =
       { jkind =
@@ -484,6 +500,7 @@ module Const = struct
         any_non_null;
         value_or_null;
         value;
+        immutable_data;
         void;
         immediate;
         immediate64;
@@ -499,6 +516,7 @@ module Const = struct
         { any_non_null with name = "any" };
         { value_or_null with name = "value" };
         value;
+        immutable_data;
         void;
         immediate;
         immediate64;
@@ -940,6 +958,8 @@ module Jkind_desc = struct
 
     let void = of_const Const.Primitive.void.jkind
 
+    let immutable_data = of_const Const.Primitive.immutable_data.jkind
+
     (* [immediate64] describes types that are stored directly (no indirection)
        on 64-bit platforms but indirectly on 32-bit platforms. The key question:
        along which modes should a [immediate64] cross? As of today, all of them,
@@ -1071,6 +1091,10 @@ module Primitive = struct
 
   let value ~(why : History.value_creation_reason) =
     fresh_jkind Jkind_desc.Primitive.value ~why:(Value_creation why)
+
+  let immutable_data ~why =
+    fresh_jkind Jkind_desc.Primitive.immutable_data
+      ~why:(Immutable_data_creation why)
 
   let immediate64 ~why =
     fresh_jkind Jkind_desc.Primitive.immediate64 ~why:(Immediate64_creation why)
@@ -1535,6 +1559,11 @@ module Format_history = struct
         "unknown @[(please alert the Jane Street@;\
          compilers team with this message: %s)@]" s
 
+  let format_immutable_data_creation_reason ppf :
+      History.immutable_data_creation_reason -> _ = function
+    | Primitive id ->
+      fprintf ppf "it is the primitive immutable_data type %s" (Ident.name id)
+
   let format_float64_creation_reason ppf : History.float64_creation_reason -> _
       = function
     | Primitive id ->
@@ -1577,6 +1606,8 @@ module Format_history = struct
       format_value_or_null_creation_reason ppf value
     | Value_creation value ->
       format_value_creation_reason ppf ~layout_or_kind value
+    | Immutable_data_creation float ->
+      format_immutable_data_creation_reason ppf float
     | Float64_creation float -> format_float64_creation_reason ppf float
     | Float32_creation float -> format_float32_creation_reason ppf float
     | Word_creation word -> format_word_creation_reason ppf word
@@ -1979,6 +2010,10 @@ module Debug_printers = struct
     | Recmod_fun_arg -> fprintf ppf "Recmod_fun_arg"
     | Unknown s -> fprintf ppf "Unknown %s" s
 
+  let immutable_data_creation_reason ppf :
+      History.immutable_data_creation_reason -> _ = function
+    | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
+
   let float64_creation_reason ppf : History.float64_creation_reason -> _ =
     function
     | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
@@ -2017,6 +2052,9 @@ module Debug_printers = struct
     | Value_creation value ->
       fprintf ppf "Value_creation %a" value_creation_reason value
     | Void_creation _ -> .
+    | Immutable_data_creation immutable_data ->
+      fprintf ppf "Immutable_data_creation %a" immutable_data_creation_reason
+        immutable_data
     | Float64_creation float ->
       fprintf ppf "Float64_creation %a" float64_creation_reason float
     | Float32_creation float ->

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -209,6 +209,9 @@ module Const : sig
     (** This is the jkind of normal ocaml values *)
     val value : t
 
+    (** This is the jkind of normal immutable ocaml values *)
+    val immutable_data : t
+
     (** Values of types of this jkind are immediate on 64-bit platforms; on other
     platforms, we know nothing other than that it's a value. *)
     val immediate64 : t
@@ -264,6 +267,11 @@ module Primitive : sig
 
   (** This is the jkind of normal ocaml values *)
   val value : why:History.value_creation_reason -> t
+
+  (* CR layouts v2.8: remove this in PR #2676 *)
+
+  (** This is the jkind of normal immutable ocaml values *)
+  val immutable_data : why:History.immutable_data_creation_reason -> t
 
   (** Values of types of this jkind are immediate on 64-bit platforms; on other
     platforms, we know nothing other than that it's a value. *)

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -259,6 +259,8 @@ module History = struct
 
   type any_non_null_creation_reason = Array_type_argument
 
+  type immutable_data_creation_reason = Primitive of Ident.t
+  
   type float64_creation_reason = Primitive of Ident.t
 
   type float32_creation_reason = Primitive of Ident.t
@@ -279,6 +281,7 @@ module History = struct
     | Void_creation of void_creation_reason
     | Any_creation of any_creation_reason
     | Any_non_null_creation of any_non_null_creation_reason
+    | Immutable_data_creation of immutable_data_creation_reason
     | Float64_creation of float64_creation_reason
     | Float32_creation of float32_creation_reason
     | Word_creation of word_creation_reason

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -260,7 +260,7 @@ module History = struct
   type any_non_null_creation_reason = Array_type_argument
 
   type immutable_data_creation_reason = Primitive of Ident.t
-  
+
   type float64_creation_reason = Primitive of Ident.t
 
   type float32_creation_reason = Primitive of Ident.t

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -415,6 +415,8 @@ let build_initial_env add_type add_extension empty_env =
        )
        ~jkind:(Jkind.Primitive.value ~why:Boxed_record)
   |> add_type ident_string
+       ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_string))
+       ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type ident_unboxed_float
        ~jkind:(Jkind.Primitive.float64 ~why:(Primitive ident_unboxed_float))
        ~jkind_annotation:Jkind.Const.Primitive.float64


### PR DESCRIPTION
Modify the definition of `string` in predef to allow crossing along linearity, contention, and portability.