### PR TITLE
Fix more cases of `zero_alloc` / modality variables getting into signatures

### DIFF
--- a/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/ocaml/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -1259,9 +1259,7 @@ module M_outer : sig module M_inner : sig type t val f : unit -> unit end end
 module type M_outer_strong = sig module M_inner = M_outer.M_inner end
 module type M_outer_subst =
   sig module M_inner : sig val f : unit -> unit end end
->> Fatal error: zero_alloc: variable constraint
-Uncaught exception: Misc.Fatal_error
-
+module M : M_outer_subst
 |}]
 
 (********************************************)
@@ -1300,9 +1298,7 @@ module M_outer :
 module type S_outer_strong = sig module M_inner = M_outer.M_inner end
 module type S_outer_subst =
   sig module M_inner : sig val f : unit -> unit end end
->> Fatal error: zero_alloc: variable constraint
-Uncaught exception: Misc.Fatal_error
-
+module M : S_outer_subst
 |}]
 
 (*************************************************)
@@ -1341,7 +1337,5 @@ module M_outer :
 module type S_outer_strong = sig module M_inner = M_outer.M_inner end
 module type S_outer_subst =
   sig module M_inner : sig val f : unit -> unit end end
->> Fatal error: zero_alloc: variable constraint
-Uncaught exception: Misc.Fatal_error
-
+module M : S_outer_subst
 |}]

--- a/ocaml/tools/debug_printers.ml
+++ b/ocaml/tools/debug_printers.ml
@@ -6,3 +6,4 @@ let ctype_global_state = Ctype.print_global_state
 let sort = Jkind.Sort.Debug_printers.t
 let sort_var = Jkind.Sort.Debug_printers.var
 let jkind = Jkind.Debug_printers.t
+let zero_alloc_var = Zero_alloc.debug_printer

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -826,6 +826,13 @@ let merge_constraint initial_env loc sg lid constr =
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
         let sg = extract_sig sig_env loc md.md_type in
         let ((path, _, tcstr), newsg) = merge_signature sig_env sg namelist in
+        let newsg =
+          if destructive_substitution then
+            remove_modality_and_zero_alloc_variables_sg sig_env
+              ~zap_modality:Mode.Modality.Value.zap_to_id newsg
+          else
+            newsg
+        in
         let path = path_concat id path in
         real_ids := path :: !real_ids;
         let item =

--- a/ocaml/typing/zero_alloc.ml
+++ b/ocaml/typing/zero_alloc.ml
@@ -37,6 +37,24 @@ type t =
   | Const of const
   | Var of var
 
+let debug_printer ppf t =
+  let head c = match c with
+    | Default_zero_alloc -> "Default"
+    | Ignore_assert_all -> "Ignore"
+    | Check _ -> "Check"
+    | Assume _ -> "Assume"
+  in
+  match t with
+  | Const c -> Format.fprintf ppf "Const %s" (head c)
+  | Var v ->
+    let print_desc ppf desc =
+      match desc with
+      | None -> Format.fprintf ppf "None"
+      | Some desc ->
+        Format.fprintf ppf "{ strict = %b; opt = %b }" desc.strict desc.opt
+    in
+    Format.fprintf ppf "Var { arity = %d; desc = %a }" v.arity print_desc v.desc
+
 (* For backtracking *)
 type change = desc option * var
 let undo_change (d, v) = v.desc <- d

--- a/ocaml/typing/zero_alloc.mli
+++ b/ocaml/typing/zero_alloc.mli
@@ -53,3 +53,5 @@ val print_error : Format.formatter -> error -> unit
    zero_alloc check t2. It returns [Ok ()] if so, and [Error e] if not.  If [t1]
    is a variable, it may be set to make the relation hold. *)
 val sub : t -> t -> (unit, error) Result.t
+
+val debug_printer : Format.formatter -> t -> unit


### PR DESCRIPTION
These cases have to do with destructive substitution and module alias types.  When we expand an `Mty_alias` into its definition, we must make the variables rigid if the new module type can be used to constrain something.  To quote the tests:
```ocaml
module M_outer = struct
  module M_inner = struct
    type t
    let f () = () (* this has a zero_alloc variable (and a modality variable) *)
  end
end

(* In [M_outer_strong], the type of [M_inner] will be
   [Mty_alias M_outer.M_inner] *)
module type M_outer_strong =  sig
  module M_inner = M_outer.M_inner
end

(* As a result of the destructive substition, we'll eliminate the alias.  When
   this happens, we shouldn't keep the zero_alloc variables on [f] *)
module type M_outer_subst = M_outer_strong
  with type M_inner.t := M_outer.M_inner.t

(* If we had kept the zero_alloc or modality variables, this would give an
   error. *)
module M : M_outer_subst = struct
  module M_inner = struct
    let f () = ()
  end
end
```

We should think a little harder about other ways this might happen - in particular other uses of `Typemod.extract_sig` or `Mtype.scrape_alias`.  I've taken a quick scan, and will think about it some more (as the reviewer of this PR might do) but don't want to delay getting this PR in.

This PR has three commits:
* The first one just adds some debug printers I was tired of not having.
* The second adds some tests that fail
* The third fixes the bug and, correspondingly, the tests