### PR TITLE
Fix conflicts in `typing/typetexp.ml`

### DIFF
--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -1155,7 +1155,7 @@ module Layouts = struct
         }
     | Ltyp_alias of
         { aliased_type : core_type;
-          name : string option;
+          name : string loc option;
           jkind : Jkind.annotation
         }
 
@@ -1332,9 +1332,7 @@ module Layouts = struct
             let has_name, inner_typ =
               match name with
               | None -> "anon", aliased_type
-              | Some name ->
-                ( "named",
-                  Ast_helper.Typ.alias aliased_type (Location.mkloc name loc) )
+              | Some name -> "named", Ast_helper.Typ.alias aliased_type name
             in
             Type_of.wrap_jane_syntax ["alias"; has_name] ~payload inner_typ)
     with No_wrap_necessary result_type -> result_type
@@ -1374,7 +1372,7 @@ module Layouts = struct
         let jkind = Decode.from_payload ~loc payload in
         match typ.ptyp_desc with
         | Ptyp_alias (inner_typ, name) ->
-          Ltyp_alias { aliased_type = inner_typ; name = Some name.txt; jkind }
+          Ltyp_alias { aliased_type = inner_typ; name = Some name; jkind }
         | _ -> Desugaring_error.raise ~loc (Unexpected_wrapped_type typ))
       | _ -> Desugaring_error.raise ~loc (Unexpected_attribute names)
     in

--- a/ocaml/parsing/jane_syntax.mli
+++ b/ocaml/parsing/jane_syntax.mli
@@ -335,7 +335,7 @@ module Layouts : sig
        intervening [type_desc]. *)
     | Ltyp_alias of
         { aliased_type : Parsetree.core_type;
-          name : string option;
+          name : string Location.loc option;
           jkind : Jkind.annotation
         }
 

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -4252,11 +4252,12 @@ alias_type:
    { $1 }
   | aliased_type = alias_type AS
              LPAREN
-             name = tyvar_name_or_underscore
+             name = mkrhs(tyvar_name_or_underscore)
              COLON
              jkind = jkind_annotation
              RPAREN
-        { Jane_syntax.Layouts.type_of ~loc:(make_loc $sloc)
+        { let name = Option.map (fun x -> mkloc x name.loc) name.txt in
+          Jane_syntax.Layouts.type_of ~loc:(make_loc $sloc)
               (Ltyp_alias { aliased_type; name; jkind }) }
 ;
 

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -540,7 +540,7 @@ and core_type_jane_syntax ctxt attrs f (x : Jane_syntax.Core_type.t) =
   | Jtyp_layout (Ltyp_alias { aliased_type; name; jkind }) ->
     pp f "@[<2>%a@;as@;(%a :@ %a)@]"
       (core_type1 ctxt) aliased_type
-      tyvar_option name
+      tyvar_option (Option.map Location.get_txt name)
       (jkind_annotation ctxt) jkind
   | Jtyp_layout (Ltyp_poly {bound_vars = []; inner_type}) ->
     core_type ctxt f inner_type

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -642,6 +642,7 @@ let transl_bound_vars : (_, _) Either.t -> _ =
   | Right vars_jkinds -> TyVarEnv.make_poly_univars_jkinds
                            ~context:(fun v -> Univar ("'" ^ v)) vars_jkinds
 
+(* Forward declaration (set in Typemod.type_open) *)
 let type_open :
   (?used_slot:bool ref -> override_flag -> Env.t -> Location.t ->
    Longident.t loc -> Path.t * Env.t)

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -1053,10 +1053,9 @@ let core_type sub ct =
         Ptyp_class (map_loc sub lid, List.map (sub.typ sub) list)
     | Ttyp_alias (ct, Some s, None) ->
         Ptyp_alias (sub.typ sub ct, s)
-    | Ttyp_alias (ct, s, Some (_, jkind_annotation)) ->
-        let s = Option.map Location.get_txt s in
+    | Ttyp_alias (ct, name, Some (_, jkind_annotation)) ->
         Jane_syntax.Layouts.type_of ~loc
-          (Ltyp_alias { aliased_type = sub.typ sub ct; name = s;
+          (Ltyp_alias { aliased_type = sub.typ sub ct; name;
                         jkind = jkind_annotation }) |>
         add_jane_syntax_attributes
     | Ttyp_alias (_, None, None) ->


### PR DESCRIPTION
A few things to note about this one:
  * I add `Style.as_inline_code` for the error messages we added, to match upstream.
  * I modify the Jane Syntax-encoded parsetree for type aliases with layout annotations (`Ltyp_alias`) to add a location, to match the change to `Ptyp_alias` in https://github.com/ocaml/ocaml/pull/12639.

Otherwise, this PR generally takes our side of the diff.