### PR TITLE
Add substitution for Pstr_include

### DIFF
--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -850,27 +850,28 @@ end = struct
   module type C = _
 end
 
-(* CR selee: This should be fixed by supporting substitution for includes *)
 [%%expect {|
 module A : sig module type B = sig type t = int end end
-Lines 13-17, characters 6-3:
-13 | ......struct
-14 |   include A
-15 |
-16 |   module type C = _
-17 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig module type B = A.B module type C = B/2 end
-       is not included in
-         sig module type B = sig type t = int end module type C = B end
-       Module type declarations do not match:
-         module type C = B/2
-       does not match
-         module type C = B/1
-       At position module type C = <here>
-       Module types do not match: B/2 is not equal to B/1
+module M : sig module type B = sig type t = int end module type C = B end
+|}]
 
-       Lines 2-4, characters 2-5:
-         Definition of module type B/1
+module A = struct
+  module type B = sig
+    type t = int
+  end
+end
+
+module M : sig
+  include module type of A
+
+  module type C = B
+end = struct
+  include A
+
+  module type C = _
+end
+
+[%%expect {|
+module A : sig module type B = sig type t = int end end
+module M : sig module type B = sig type t = int end module type C = B end
 |}]

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -2923,6 +2923,19 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
         end
   in
 
+  let add_expected_include_to_subst expected_sig actual_sig subst =
+    let add_item subst = function
+      | Sig_type (id, _, _, _) ->
+          add_expected_type_to_subst expected_sig [id] subst
+      | Sig_module (id, _, _, _, _) ->
+          add_expected_module_to_subst expected_sig (Some id) subst
+      | Sig_modtype (id, _, _) ->
+          add_expected_modtype_to_subst expected_sig id subst
+      | Sig_value _ | Sig_typext _ | Sig_class _ | Sig_class_type _ -> subst
+    in
+    List.fold_left add_item subst actual_sig
+  in
+
   let type_str_include ~functor_ ~loc env subst shape_map sincl sig_acc =
     let smodl = sincl.pincl_mod in
     let modl, modl_shape =
@@ -2959,7 +2972,7 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
     sg,
     shape,
     new_env,
-    subst
+    add_expected_include_to_subst expected_sig sg subst
   in
 
   let type_str_include_functor ~loc env subst shape_map ifincl sig_acc =


### PR DESCRIPTION
Previously, structure items added by `include` weren't included in the substitution between the expected signature items and the actual items, meaning it would fail in cases such as:

```ocaml
module A = struct
  module type B = sig
    type t = int
  end
end

module M : sig
  module type B = sig
    type t = int
  end

  module type C = B
end = struct
  include A

  module type C = _
end
```

This PR fixes this.