### PR TITLE
Fix missing inlined debuginfo in switch arms

### DIFF
--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -571,6 +571,9 @@ let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
       |> Flambda_arity.create_singletons
     in
     let action = Apply_cont.update_args action ~args in
+    let dbg = AC.debuginfo action in
+    let dbg = DE.add_inlined_debuginfo (DA.denv dacc) dbg in
+    let action = AC.with_debuginfo action ~dbg in
     let dacc =
       DA.map_flow_acc dacc
         ~f:


### PR DESCRIPTION
The stack frame of `g` was otherwise missing in the following test by @ncik-roberts:
```ocaml
let[@inline always] f x = if x = 1 then failwith "f"

let[@inline never] g x =
  let y = x + 1 in
  f y [@nontail]

let () = g 0
```