### PR TITLE
Add option to dump profile output to CSV

### DIFF
--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -183,4 +183,10 @@ let main unix argv ppf ~flambda2 =
       Format.fprintf Format.std_formatter "    %i major\n" stats.major_collections;
     end;
     Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
+    if !Clflags.dump_into_csv then begin
+      let output_csv ppf_file = Profile.output_to_csv
+        ppf_file !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision
+      in
+      Compmisc.with_ppf_file ~file_prefix:"profile" ~file_extension:".csv" output_csv
+    end;
     0

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -154,40 +154,40 @@ let main unix argv ppf ~flambda2 =
     Location.report_exception ppf x;
     2
   | () ->
-    if !Flambda_backend_flags.gc_timings then begin
-      let minor = Gc_timings.gc_minor_ns () in
-      let major = Gc_timings.gc_major_ns () in
-      let stats = Gc.quick_stat () in
-      let secs x = x *. 1e-9 in
-      let precision = !Clflags.timings_precision in
-      let w2b n = n * (Sys.word_size / 8) in
-      let fw2b x = w2b (Float.to_int x) in
-      Format.fprintf Format.std_formatter "%0.*fs gc\n" precision (secs (minor +. major));
-      Format.fprintf Format.std_formatter "  %0.*fs minor\n" precision (secs minor);
-      Format.fprintf Format.std_formatter "  %0.*fs major\n" precision (secs major);
-      Format.fprintf Format.std_formatter "- heap\n";
-      (* Having minor + major + promoted = total alloc make more sense for
-         hierarchical stats. *)
-      Format.fprintf Format.std_formatter "  %ib alloc\n"
-        (fw2b stats.minor_words + (fw2b stats.major_words - fw2b stats.promoted_words));
-      Format.fprintf Format.std_formatter "    %ib minor\n"
-        (fw2b stats.minor_words - fw2b stats.promoted_words);
-      Format.fprintf Format.std_formatter "    %ib major\n"
-        (fw2b stats.major_words - fw2b stats.promoted_words);
-      Format.fprintf Format.std_formatter "    %ib promoted\n"
-        (fw2b stats.promoted_words);
-      Format.fprintf Format.std_formatter "  %ib top\n" (w2b stats.top_heap_words);
-      Format.fprintf Format.std_formatter "  %i collections\n"
-        (stats.minor_collections + stats.major_collections);
-      Format.fprintf Format.std_formatter "    %i minor\n" stats.minor_collections;
-      Format.fprintf Format.std_formatter "    %i major\n" stats.major_collections;
-    end;
     if !Clflags.dump_into_csv then
       let output_csv ppf_file = Profile.output_to_csv
         ppf_file !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision
       in
       Compmisc.with_ppf_file ~file_prefix:"profile" ~file_extension:".csv" output_csv
     else
+      if !Flambda_backend_flags.gc_timings then begin
+        let minor = Gc_timings.gc_minor_ns () in
+        let major = Gc_timings.gc_major_ns () in
+        let stats = Gc.quick_stat () in
+        let secs x = x *. 1e-9 in
+        let precision = !Clflags.timings_precision in
+        let w2b n = n * (Sys.word_size / 8) in
+        let fw2b x = w2b (Float.to_int x) in
+        Format.fprintf Format.std_formatter "%0.*fs gc\n" precision (secs (minor +. major));
+        Format.fprintf Format.std_formatter "  %0.*fs minor\n" precision (secs minor);
+        Format.fprintf Format.std_formatter "  %0.*fs major\n" precision (secs major);
+        Format.fprintf Format.std_formatter "- heap\n";
+        (* Having minor + major + promoted = total alloc make more sense for
+           hierarchical stats. *)
+        Format.fprintf Format.std_formatter "  %ib alloc\n"
+          (fw2b stats.minor_words + (fw2b stats.major_words - fw2b stats.promoted_words));
+        Format.fprintf Format.std_formatter "    %ib minor\n"
+          (fw2b stats.minor_words - fw2b stats.promoted_words);
+        Format.fprintf Format.std_formatter "    %ib major\n"
+          (fw2b stats.major_words - fw2b stats.promoted_words);
+        Format.fprintf Format.std_formatter "    %ib promoted\n"
+          (fw2b stats.promoted_words);
+        Format.fprintf Format.std_formatter "  %ib top\n" (w2b stats.top_heap_words);
+        Format.fprintf Format.std_formatter "  %i collections\n"
+          (stats.minor_collections + stats.major_collections);
+        Format.fprintf Format.std_formatter "    %i minor\n" stats.minor_collections;
+        Format.fprintf Format.std_formatter "    %i major\n" stats.major_collections;
+      end;
       Profile.print
         Format.std_formatter
         !Clflags.profile_columns

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -182,11 +182,14 @@ let main unix argv ppf ~flambda2 =
       Format.fprintf Format.std_formatter "    %i minor\n" stats.minor_collections;
       Format.fprintf Format.std_formatter "    %i major\n" stats.major_collections;
     end;
-    Profile.print Format.std_formatter !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision;
-    if !Clflags.dump_into_csv then begin
+    if !Clflags.dump_into_csv then
       let output_csv ppf_file = Profile.output_to_csv
         ppf_file !Clflags.profile_columns ~timings_precision:!Clflags.timings_precision
       in
       Compmisc.with_ppf_file ~file_prefix:"profile" ~file_extension:".csv" output_csv
-    end;
+    else
+      Profile.print
+        Format.std_formatter
+        !Clflags.profile_columns
+        ~timings_precision:!Clflags.timings_precision;
     0

--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -507,6 +507,7 @@ let read_one_param ppf position name v =
       | Some pass -> set_save_ir_after pass true
     end
   | "dump-into-file" -> Clflags.dump_into_file := true
+  | "dump-into-csv" -> Clflags.dump_into_csv := true
   | "dump-dir" -> Clflags.dump_dir := Some v
 
   | "extension" -> Language_extension.enable_of_string_exn v

--- a/ocaml/driver/compmisc.ml
+++ b/ocaml/driver/compmisc.ml
@@ -129,4 +129,4 @@ let with_ppf_dump ?stdout ~file_prefix f =
     let formatter =
       if Option.is_some stdout then Format.std_formatter else Format.err_formatter in
     Misc.try_finally (fun () -> f formatter)
-  | _ -> with_ppf_file ~file_prefix ~file_extension:".dump" f
+  | true -> with_ppf_file ~file_prefix ~file_extension:".dump" f

--- a/ocaml/driver/compmisc.mli
+++ b/ocaml/driver/compmisc.mli
@@ -21,6 +21,9 @@ val initial_env : unit -> Env.t
 val set_from_env : 'a option ref -> 'a Clflags.env_reader -> unit
 val read_clflags_from_env : unit -> unit
 
+val with_ppf_file :
+  file_prefix:string -> file_extension:string -> (Format.formatter -> 'a) -> 'a
+
 val with_ppf_dump : ?stdout:unit ->
   file_prefix:string -> (Format.formatter -> 'a) -> 'a
 

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -686,6 +686,9 @@ let mk_dump_into_file f =
   "-dump-into-file", Arg.Unit f, " dump output like -dlambda into <target>.dump"
 ;;
 
+let mk_dump_into_csv f =
+  "-dump-into-csv", Arg.Unit f, " Dump profile information to CSV file"
+
 let mk_extension f =
   let available_extensions =
     Language_extension.Exist.(List.concat_map to_command_line_strings all)
@@ -1044,6 +1047,7 @@ module type Compiler_options = sig
   val _dprofile : unit -> unit
   val _dgranularity : string -> unit
   val _dump_into_file : unit -> unit
+  val _dump_into_csv : unit -> unit
   val _dump_dir : string -> unit
 
   val _args: string -> string array
@@ -1319,6 +1323,7 @@ struct
     mk_dprofile F._dprofile;
     mk_dgranularity F._dgranularity;
     mk_dump_into_file F._dump_into_file;
+    mk_dump_into_csv F._dump_into_csv;
     mk_dump_dir F._dump_dir;
     mk_debug_ocaml F._debug_ocaml;
 
@@ -1587,6 +1592,7 @@ struct
     mk_dprofile F._dprofile;
     mk_dgranularity F._dgranularity;
     mk_dump_into_file F._dump_into_file;
+    mk_dump_into_csv F._dump_into_csv;
     mk_dump_dir F._dump_dir;
     mk_dump_pass F._dump_pass;
     mk_debug_ocaml F._debug_ocaml;
@@ -2031,6 +2037,7 @@ module Default = struct
     let _dcounters () = profile_columns := [`Counters]
     let _dgranularity = Clflags.set_profile_granularity
     let _dump_into_file = set dump_into_file
+    let _dump_into_csv = set dump_into_csv
     let _dump_dir s = dump_dir := Some s
     let _for_pack s = for_package := (Some (String.capitalize_ascii s))
     let _g = set debug

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -144,6 +144,7 @@ module type Compiler_options = sig
   val _dprofile : unit -> unit
   val _dgranularity : string -> unit
   val _dump_into_file : unit -> unit
+  val _dump_into_csv : unit -> unit
   val _dump_dir : string -> unit
 
   val _args: string -> string array

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -405,6 +405,7 @@ let set_dumped_pass s enabled =
   end
 
 let dump_into_file = ref false (* -dump-into-file *)
+let dump_into_csv = ref false (* -dump-into-csv *)
 let dump_dir: string option ref = ref None (* -dump-dir *)
 
 type 'a env_reader = {

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -230,6 +230,7 @@ val dumped_pass : string -> bool
 val set_dumped_pass : string -> bool -> unit
 
 val dump_into_file : bool ref
+val dump_into_csv : bool ref
 val dump_dir : string option ref
 
 (* Support for flags that can also be set from an environment variable *)

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -323,6 +323,7 @@ let output_rows
     ~(output_row : prefix:string -> cell_strings:string list -> name:string -> unit)
     ~(new_prefix : prev:string -> curr_name:string -> string)
     ?(always_output_ancestors = true)
+    ?(pad_empty = true)
     rows
   =
   let n_columns =
@@ -335,7 +336,7 @@ let output_rows
     let display_cell = c.worth_displaying ~max:maxs.(i) in
     display_cell, if display_cell
                   then c.to_string ~max:maxs.(i) ~width
-                  else String.make width '-'
+                  else if pad_empty then String.make width '-' else ""
   in
   let widths = width_by_column ~n_columns ~display_cell rows in
   (* We track print row functions in a queue to ensure ancestors not worth displaying have
@@ -386,6 +387,7 @@ let output_to_csv ppf_file =
       Format.fprintf ppf_file "%s%s\n" prefix (to_csv (name :: cell_strings)))
     ~new_prefix:(fun ~prev ~curr_name -> Format.sprintf "%s%s/" prev curr_name)
     ~always_output_ancestors:false
+    ~pad_empty:false
   |> output_columns
 
 let column_mapping = [

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -379,9 +379,11 @@ let print ppf =
   |> output_columns
 
 let output_to_csv ppf_file =
+  let sanitise = String.map (fun c -> if c = ',' then '_' else c) in
+  let to_csv l = l |> List.map sanitise |> String.concat "," in
   output_rows
     ~output_row:(fun ~prefix ~cell_strings ~name ->
-      Format.fprintf ppf_file "%s%s,%s\n" prefix name (String.concat "," cell_strings))
+      Format.fprintf ppf_file "%s%s\n" prefix (to_csv (name :: cell_strings)))
     ~new_prefix:(fun ~prev ~curr_name -> Format.sprintf "%s%s/" prev curr_name)
     ~always_output_ancestors:false
   |> output_columns

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -393,7 +393,7 @@ let output_to_csv ppf columns =
   let sanitise = String.map (fun c -> if c = ',' then '_' else c) in
   let to_csv cell_strings = cell_strings |> List.map sanitise |> String.concat "," in
   let string_columns = List.map (fun col -> List.assoc col column_mapping) columns in
-  Format.fprintf ppf "%s\n" (to_csv ("stage name" :: string_columns));
+  Format.fprintf ppf "%s\n" (to_csv ("pass name" :: string_columns));
   let output_row_f = output_rows
     ~output_row:(fun ~prefix ~cell_strings ~name ->
       Format.fprintf ppf "%s%s\n" prefix (to_csv (name :: cell_strings)))

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -393,10 +393,10 @@ let output_to_csv ppf columns =
   let sanitise = String.map (fun c -> if c = ',' then '_' else c) in
   let to_csv cell_strings = cell_strings |> List.map sanitise |> String.concat "," in
   let string_columns = List.map (fun col -> List.assoc col column_mapping) columns in
-  Format.fprintf ppf "%s\n" (to_csv ("pass name" :: string_columns));
+  Format.fprintf ppf "%s@\n" (to_csv ("pass name" :: string_columns));
   let output_row_f = output_rows
     ~output_row:(fun ~prefix ~cell_strings ~name ->
-      Format.fprintf ppf "%s%s\n" prefix (to_csv (name :: cell_strings)))
+      Format.fprintf ppf "%s%s@\n" prefix (to_csv (name :: cell_strings)))
     ~new_prefix:(fun ~prev ~curr_name -> Format.sprintf "%s%s/" prev curr_name)
     ~always_output_ancestors:false
     ~pad_empty:false

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -387,14 +387,14 @@ let column_mapping = [
   `Counters, "counters"
 ]
 
-let output_to_csv ppf_file columns =
+let output_to_csv ppf columns =
   let sanitise = String.map (fun c -> if c = ',' then '_' else c) in
   let to_csv cell_strings = cell_strings |> List.map sanitise |> String.concat "," in
   let string_columns = List.map (fun col -> List.assoc col column_mapping) columns in
-  Format.fprintf ppf_file "%s\n" (to_csv ("stage name" :: string_columns));
+  Format.fprintf ppf "%s\n" (to_csv ("stage name" :: string_columns));
   let output_row_f = output_rows
     ~output_row:(fun ~prefix ~cell_strings ~name ->
-      Format.fprintf ppf_file "%s%s\n" prefix (to_csv (name :: cell_strings)))
+      Format.fprintf ppf "%s%s\n" prefix (to_csv (name :: cell_strings)))
     ~new_prefix:(fun ~prev ~curr_name -> Format.sprintf "%s%s/" prev curr_name)
     ~always_output_ancestors:false
     ~pad_empty:false

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -322,6 +322,7 @@ let width_by_column ~n_columns ~display_cell rows =
 let output_rows
     ~(output_row : prefix:string -> cell_strings:string list -> name:string -> unit)
     ~(new_prefix : prev:string -> curr_name:string -> string)
+    ?(always_output_ancestors = true)
     rows
   =
   let n_columns =
@@ -350,7 +351,7 @@ let output_rows
       let cell_strings = if should_output_row then cell_strings else [] in
       output_row ~prefix ~cell_strings ~name
     in
-    output_stack := output_current :: !output_stack;
+    output_stack := output_current :: (if always_output_ancestors then !output_stack else []);
     if should_output_row then
       (List.rev !output_stack |> List.iter (fun f -> f ()); output_stack := []);
     List.iter (loop ~prefix:(new_prefix ~prev:prefix ~curr_name:name) ~output_stack) rows;
@@ -382,6 +383,7 @@ let output_to_csv ppf_file =
     ~output_row:(fun ~prefix ~cell_strings ~name ->
       Format.fprintf ppf_file "%s%s,%s\n" prefix name (String.concat "," cell_strings))
     ~new_prefix:(fun ~prev ~curr_name -> Format.sprintf "%s%s/" prev curr_name)
+    ~always_output_ancestors:false
   |> output_columns
 
 let column_mapping = [

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -322,8 +322,8 @@ let width_by_column ~n_columns ~display_cell rows =
 let output_rows
     ~(output_row : prefix:string -> cell_strings:string list -> name:string -> unit)
     ~(new_prefix : prev:string -> curr_name:string -> string)
-    ?(always_output_ancestors = true)
-    ?(pad_empty = true)
+    ~(always_output_ancestors : bool)
+    ~(pad_empty : bool)
     rows
   =
   let n_columns =
@@ -377,6 +377,8 @@ let print ppf =
     ~output_row:(fun ~prefix ~cell_strings ~name ->
       Format.fprintf ppf "%s%s %s@\n" prefix (String.concat " " cell_strings) name)
     ~new_prefix:(fun ~prev ~curr_name:_ -> "  " ^ prev)
+    ~always_output_ancestors:true
+    ~pad_empty:true
   |> output_columns
 
 let column_mapping = [

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -379,34 +379,35 @@ let print ppf =
     ~new_prefix:(fun ~prev ~curr_name:_ -> "  " ^ prev)
   |> output_columns
 
-let output_to_csv ppf_file =
+let column_mapping = [
+  `Time, "time";
+  `Alloc, "alloc";
+  `Top_heap, "top-heap";
+  `Abs_top_heap, "absolute-top-heap";
+  `Counters, "counters"
+]
+
+let output_to_csv ppf_file columns =
   let sanitise = String.map (fun c -> if c = ',' then '_' else c) in
-  let to_csv l = l |> List.map sanitise |> String.concat "," in
-  output_rows
+  let to_csv cell_strings = cell_strings |> List.map sanitise |> String.concat "," in
+  let string_columns = List.map (fun col -> List.assoc col column_mapping) columns in
+  Format.fprintf ppf_file "%s\n" (to_csv ("stage name" :: string_columns));
+  let output_row_f = output_rows
     ~output_row:(fun ~prefix ~cell_strings ~name ->
       Format.fprintf ppf_file "%s%s\n" prefix (to_csv (name :: cell_strings)))
     ~new_prefix:(fun ~prev ~curr_name -> Format.sprintf "%s%s/" prev curr_name)
     ~always_output_ancestors:false
     ~pad_empty:false
-  |> output_columns
+  in output_columns output_row_f columns
 
-let column_mapping = [
-  "time", `Time;
-  "alloc", `Alloc;
-  "top-heap", `Top_heap;
-  "absolute-top-heap", `Abs_top_heap;
-  "counters", `Counters;
-]
-
-let column_names = List.map fst column_mapping
+let all_columns = List.map fst column_mapping
+let column_names = List.map snd column_mapping
 
 let options_doc =
   Printf.sprintf
     " Print performance information for each pass\
    \n    The columns are: %s."
     (String.concat " " column_names)
-
-let all_columns = List.map snd column_mapping
 
 let generate = "generate"
 let transl = "transl"

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -52,7 +52,7 @@ val print : Format.formatter -> Clflags.profile_column list -> timings_precision
 
 val output_to_csv :
 Format.formatter -> Clflags.profile_column list -> timings_precision:int -> unit
-(** Outputs the selected recorded profiling information to given CSV file formatter. *)
+(** Outputs the selected recorded profiling information in CSV format to the formatter. *)
 
 (** Command line flags *)
 

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -50,6 +50,10 @@ val record_with_counters :
 val print : Format.formatter -> Clflags.profile_column list -> timings_precision:int -> unit
 (** Prints the selected recorded profiling information to the formatter. *)
 
+val output_to_csv :
+Format.formatter -> Clflags.profile_column list -> timings_precision:int -> unit
+(** Outputs the selected recorded profiling information to given CSV file formatter. *)
+
 (** Command line flags *)
 
 val options_doc : string


### PR DESCRIPTION
Adds a `-dump-into-csv` command line flag that outputs the profile information in CSV format.

# Design choices
The main design choice was concerning whether to store counters as a single CSV field or multiple. In the end, the choice was made to have a single `counters` field as the number of counters is variable and not all counters apply to every stage. This single field can easily be divided into the constituent individual counters by scripts using these generated CSV files. 

# Example outputs
## `-dprofile -dump-into-csv`
```
stage name,time,alloc,top-heap,absolute-top-heap,counters
a.ml,0.065s,54.4MB,8.21MB,11.2MB,
a.ml/parsing,0.001s,1.05MB,0.46MB,3.47MB,
a.ml/parsing/parser,0.001s,1.04MB,0.46MB,3.47MB,
a.ml/typing,0.008s,8.63MB,1.81MB,5.29MB,
a.ml/typing/infer,0.007s,7.70MB,1.12MB,4.60MB,
a.ml/typing/check_sig,,0.38MB,0.69MB,5.29MB,
a.ml/typing/save_cmi,,0.07MB,,,
a.ml/typing/save_cmt,,0.11MB,,,
a.ml/typing/other,,0.35MB,,,
a.ml/transl,0.004s,2.77MB,,,
a.ml/generate,0.052s,42.0MB,5.93MB,11.2MB,
a.ml/generate/flambda2,0.034s,30.2MB,2.72MB,8.02MB,
a.ml/generate/flambda2/lambda_to_flambda,0.002s,1.90MB,,,
a.ml/generate/flambda2/simplify,0.031s,25.5MB,1.45MB,6.74MB,
a.ml/generate/flambda2/simplify/data_flow,0.009s,4.76MB,,,
a.ml/generate/flambda2/simplify/other,0.021s,20.7MB,1.45MB,6.74MB,
a.ml/generate/flambda2/flambda_to_cmm,0.001s,1.28MB,,,
a.ml/generate/flambda2/other,0.001s,1.51MB,1.27MB,8.02MB,
a.ml/generate/compile_phrases,0.008s,9.37MB,1.46MB,9.48MB,
a.ml/generate/compile_phrases/selection,,0.43MB,,,
a.ml/generate/compile_phrases/zero_alloc_checker,,0.10MB,,,
a.ml/generate/compile_phrases/zero_alloc_checker/check zero_alloc,,0.08MB,,,
a.ml/generate/compile_phrases/zero_alloc_checker/other,,0.01MB,,,
a.ml/generate/compile_phrases/comballoc,,0.06MB,,,
a.ml/generate/compile_phrases/cse,,0.12MB,,,
a.ml/generate/compile_phrases/regalloc,0.006s,8.22MB,1.46MB,9.48MB,
a.ml/generate/compile_phrases/regalloc/cfg,0.006s,8.20MB,1.46MB,9.48MB,
a.ml/generate/compile_phrases/regalloc/cfg/cfgize,0.001s,0.87MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfgize/register_preds,,0.02MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfgize/optimizations,,0.56MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfgize/other,,0.28MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_deadcode,,0.31MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc,0.003s,3.16MB,,,[reload = 30; spill = 30]
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc/split,0.001s,1.13MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc/split/state,,0.56MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc/split/compute_substitutions,,0.06MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc/split/insert_spills,,0.03MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc/split/insert_reloads,,0.02MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc/split/cfg_deadcode,0.001s,0.38MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc/split/other,,0.05MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc/stack_slots_optimize,,0.21MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc/other,0.001s,1.81MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_validate_description,0.002s,2.63MB,1.46MB,9.48MB,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_simplify,,0.50MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/peephole_optimize_cfg,,0.09MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/cfg_to_linear,,0.16MB,,,
a.ml/generate/compile_phrases/regalloc/cfg/other,,0.42MB,,,
a.ml/generate/compile_phrases/regalloc/other,,0.01MB,,,
a.ml/generate/compile_phrases/emit_fundecl,,0.19MB,,,
a.ml/generate/compile_phrases/emit_fundecl/emit,,0.18MB,,,
a.ml/generate/compile_phrases/emit_fundecl/other,,0.01MB,,,
a.ml/generate/compile_phrases/other,0.001s,0.19MB,,,
a.ml/generate/write_asm,0.001s,0.69MB,,,
a.ml/generate/assemble,0.007s,,,,
a.ml/generate/other,0.002s,1.71MB,1.74MB,11.2MB,
other,0.009s,7.87MB,3.00MB,,
```
## `-dcounters -dump-into-csv`
```
stage name,counters
a.ml/generate/compile_phrases/regalloc/cfg/cfg_irc,[reload = 30; spill = 30]
```
