### PR TITLE
Unboxed tuples fixes

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1607,6 +1607,8 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
     | Some ids -> ids
     | None -> Lambda.free_variables body
   in
+  let unboxed_product_components_in_scope = Env.get_unboxed_product_components_in_scope env in
+  let unboxed_product_components_in_scope = Ident.Map.filter (fun id _ -> Ident.Set.mem id free_idents_of_body) unboxed_product_components_in_scope in
   let free_idents_of_body =
     Ident.Set.fold
       (fun id acc ->
@@ -1623,7 +1625,7 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
   in
   let new_env =
     Env.with_unboxed_product_components_in_scope new_env
-      (Env.get_unboxed_product_components_in_scope env)
+      unboxed_product_components_in_scope
   in
   let exn_continuation : IR.exn_continuation =
     { exn_handler = body_exn_cont; extra_args = [] }

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -450,7 +450,7 @@ let let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler
               (Flambda_arity.unarize arity)
           in
           let handler_env =
-            Env.register_unboxed_product handler_env ~unboxed_product:id
+            Env.register_unboxed_product_with_kinds handler_env ~unboxed_product:id
               ~before_unarization:arity_component ~fields
           in
           let new_params_rev =
@@ -912,7 +912,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
               let arity = Flambda_arity.create [arity_component] in
               let fields = Flambda_arity.fresh_idents_unarized ~id arity in
               let env =
-                Env.register_unboxed_product env ~unboxed_product:id
+                Env.register_unboxed_product_with_kinds env ~unboxed_product:id
                   ~before_unarization:arity_component ~fields
               in
               env, fields
@@ -1085,7 +1085,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                   let before_unarization =
                     Flambda_arity.Component_for_creation.from_lambda layout
                   in
-                  ( Env.register_unboxed_product handler_env
+                  ( Env.register_unboxed_product_with_kinds handler_env
                       ~unboxed_product:arg ~before_unarization ~fields,
                     fields ))
               handler_env
@@ -1607,25 +1607,20 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
     | Some ids -> ids
     | None -> Lambda.free_variables body
   in
-  let unboxed_product_components_in_scope = Env.get_unboxed_product_components_in_scope env in
-  let unboxed_product_components_in_scope = Ident.Map.filter (fun id _ -> Ident.Set.mem id free_idents_of_body) unboxed_product_components_in_scope in
-  let free_idents_of_body =
-    Ident.Set.fold
-      (fun id acc ->
-        match Env.get_unboxed_product_fields env id with
-        | None -> Ident.Set.add id acc
-        | Some (_, fields) ->
-          List.fold_left (fun acc id -> Ident.Set.add id acc) acc fields)
-      free_idents_of_body Ident.Set.empty
-  in
   let my_region = Ident.create_local "my_region" in
   let new_env =
     Env.create ~current_unit:(Env.current_unit env)
       ~return_continuation:body_cont ~exn_continuation:body_exn_cont ~my_region
   in
-  let new_env =
-    Env.with_unboxed_product_components_in_scope new_env
-      unboxed_product_components_in_scope
+  let new_env, free_idents_of_body =
+    Ident.Set.fold
+      (fun id (new_env, free_idents_of_body) ->
+        match Env.get_unboxed_product_fields env id with
+        | None -> (new_env, Ident.Set.add id free_idents_of_body)
+        | Some (before_unarization, fields) ->
+          Env.register_unboxed_product new_env ~unboxed_product:id ~before_unarization ~fields,
+          Ident.Set.union free_idents_of_body (Ident.Set.of_list fields))
+      free_idents_of_body (new_env, Ident.Set.empty)
   in
   let exn_continuation : IR.exn_continuation =
     { exn_handler = body_exn_cont; extra_args = [] }
@@ -1678,7 +1673,7 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
     let new_env =
       Ident.Map.fold
         (fun unboxed_product (before_unarization, fields) new_env ->
-          Env.register_unboxed_product new_env ~unboxed_product
+          Env.register_unboxed_product_with_kinds new_env ~unboxed_product
             ~before_unarization ~fields)
         unboxed_products new_env
     in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1730,7 +1730,7 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
           in
           let k = restore_continuation_context_for_switch_arm env k in
           let consts_rev =
-            (arm, k, Debuginfo.none, None, IR.Var var :: extra_args)
+            (arm, k, Debuginfo.none, None, get_unarized_vars var env @ extra_args)
             :: consts_rev
           in
           consts_rev, wrappers

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
@@ -111,10 +111,10 @@ let register_unboxed_product t ~unboxed_product ~before_unarization ~fields =
         (before_unarization, Array.of_list fields)
         t.unboxed_product_components_in_scope
   }
-
+(*
 let unboxed_product_components_in_scope t =
   Ident.Map.keys t.unboxed_product_components_in_scope
-
+*)
 let get_unboxed_product_components_in_scope t =
   t.unboxed_product_components_in_scope
 
@@ -147,8 +147,8 @@ let add_continuation t cont ~push_to_try_stack ~pop_region
         t.mutables_needed_by_continuations
     in
     let unboxed_product_components_needed_by_continuations =
-      Continuation.Map.add cont
-        (unboxed_product_components_in_scope t)
+(*      Continuation.Map.add cont
+        (unboxed_product_components_in_scope t) *)
         t.unboxed_product_components_needed_by_continuations
     in
     let try_stack =
@@ -167,12 +167,12 @@ let add_continuation t cont ~push_to_try_stack ~pop_region
       t.current_values_of_mutables_in_scope
   in
   let unboxed_product_components_in_scope =
-    Ident.Map.map
+(*    Ident.Map.map
       (fun (before_unarization, fields) ->
         let fields =
           Array.map (fun (field, layout) -> Ident.rename field, layout) fields
         in
-        before_unarization, fields)
+        before_unarization, fields) *)
       t.unboxed_product_components_in_scope
   in
   let handler_env =
@@ -191,9 +191,9 @@ let add_continuation t cont ~push_to_try_stack ~pop_region
       region_stack
     }
   in
-  let extra_params_for_unboxed_products =
+  let extra_params_for_unboxed_products = [] (*
     Ident.Map.data handler_env.unboxed_product_components_in_scope
-    |> List.map snd |> List.map Array.to_list |> List.concat
+    |> List.map snd |> List.map Array.to_list |> List.concat *)
   in
   let extra_params =
     Ident.Map.data handler_env.current_values_of_mutables_in_scope
@@ -262,8 +262,8 @@ let extra_args_for_continuation_with_kinds t cont =
           | current_value, kind -> current_value, kind)
         mutables
   in
-  let for_unboxed_products =
-    match
+  let for_unboxed_products = []
+(*    match
       Continuation.Map.find cont
         t.unboxed_product_components_needed_by_continuations
     with
@@ -280,7 +280,7 @@ let extra_args_for_continuation_with_kinds t cont =
             Misc.fatal_errorf "No field list registered for unboxed product %a"
               Ident.print unboxed_product
           | _, fields -> Array.to_list fields)
-        unboxed_products
+        unboxed_products *)
   in
   for_mutables @ for_unboxed_products
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
@@ -115,6 +115,13 @@ let register_unboxed_product t ~unboxed_product ~before_unarization ~fields =
 let unboxed_product_components_in_scope t =
   Ident.Map.keys t.unboxed_product_components_in_scope
 
+let get_unboxed_product_components_in_scope t =
+  t.unboxed_product_components_in_scope
+
+let with_unboxed_product_components_in_scope t
+    unboxed_product_components_in_scope =
+  { t with unboxed_product_components_in_scope }
+
 type add_continuation_result =
   { body_env : t;
     handler_env : t;

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
@@ -42,6 +42,13 @@ val register_unboxed_product :
   t ->
   unboxed_product:Ident.t ->
   before_unarization:[`Complex] Flambda_arity.Component_for_creation.t ->
+  fields:Ident.t list ->
+  t
+
+val register_unboxed_product_with_kinds :
+  t ->
+  unboxed_product:Ident.t ->
+  before_unarization:[`Complex] Flambda_arity.Component_for_creation.t ->
   fields:(Ident.t * Flambda_kind.With_subkind.t) list ->
   t
 
@@ -49,19 +56,6 @@ val get_unboxed_product_fields :
   t ->
   Ident.t ->
   ([`Complex] Flambda_arity.Component_for_creation.t * Ident.t list) option
-
-val get_unboxed_product_components_in_scope :
-  t ->
-  ([`Complex] Flambda_arity.Component_for_creation.t
-  * (Ident.t * Flambda_kind.With_subkind.t) array)
-  Ident.Map.t
-
-val with_unboxed_product_components_in_scope :
-  t ->
-  ([`Complex] Flambda_arity.Component_for_creation.t
-  * (Ident.t * Flambda_kind.With_subkind.t) array)
-  Ident.Map.t ->
-  t
 
 type add_continuation_result = private
   { body_env : t;

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
@@ -50,6 +50,19 @@ val get_unboxed_product_fields :
   Ident.t ->
   ([`Complex] Flambda_arity.Component_for_creation.t * Ident.t list) option
 
+val get_unboxed_product_components_in_scope :
+  t ->
+  ([`Complex] Flambda_arity.Component_for_creation.t
+  * (Ident.t * Flambda_kind.With_subkind.t) array)
+  Ident.Map.t
+
+val with_unboxed_product_components_in_scope :
+  t ->
+  ([`Complex] Flambda_arity.Component_for_creation.t
+  * (Ident.t * Flambda_kind.With_subkind.t) array)
+  Ident.Map.t ->
+  t
+
 type add_continuation_result = private
   { body_env : t;
     handler_env : t;


### PR DESCRIPTION
Unboxed tuples appearing in free variables of closures were previously failing. This PR can be tested with https://github.com/Ekdohibs/flambda-backend/commit/dcd99956a757e4d4fb45e473e96151f7a01013d9 which sits on top of the unboxed tuples frontend work.
Example code that was previously failing:
```ocaml
type t = #(int * int)

let id_t (x : t) = x

let app f (x : t) = f x

let f y = app (fun _ -> id_t y) y
```