### PR TITLE
Fix unboxing EPA of wrong kind

### DIFF
--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -373,12 +373,11 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
     Tag.Scannable.Map.mapi
       (fun tag_decision (shape, block_fields) ->
         (* See doc/unboxing.md about invalid constants, poison and aliases. *)
-        let poison_const = Const.const_int (Targetint_31_63.of_int 0xbaba) in
         let new_fields_decisions, _ =
           List.fold_left
             (fun (new_decisions, field_nth)
                  ({ epa; decision; kind } : U.field_decision) ->
-              let bak, _const =
+              let bak, poison_const =
                 access_kind_and_dummy_const
                   (Tag.Scannable.to_tag tag_decision)
                   shape block_fields


### PR DESCRIPTION
It still used a poison const independent of kind.
Was failing on:
```ocaml
type t =
  | A of float#
  | B

let evaluate () =
  let[@inline] get () =
    let p = if Sys.opaque_identity true then A (Sys.opaque_identity #4.0) else B in
    match p with
    | A x -> x
    | B   -> assert false
  in
  let x = get () in
  x
;;
```