### PR TITLE
Improve error message for unbound path in inferred type

### DIFF
--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -698,35 +698,36 @@ end = struct
   module type A = _
 end
 
-(* CR selee: Give a better error message later *)
 [%%expect{|
-Lines 9-13, characters 6-3:
- 9 | ......struct
+Line 10, characters 2-19:
 10 |   module type B = _
-11 |
-12 |   module type A = _
-13 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module type B = A
-           module type A = sig type t val foo : t -> t end
-         end
-       is not included in
-         sig
-           module type A = sig type t val foo : t -> t end
-           module type B = A
-         end
-       Module type declarations do not match:
-         module type B = A/2
-       does not match
-         module type B = A/1
-       At position module type B = <here>
-       Module types do not match: A/2 is not equal to A/1
-
-       Line 12, characters 2-19:
-         Definition of module type A/1
+       ^^^^^^^^^^^^^^^^^
+Error: Unbound path A in inferred module type.
 |}]
+
+module M : sig
+  module A : sig
+    type t
+  end
+
+  module type B = sig
+    val f : A.t -> A.t
+  end
+end = struct
+  module type B = _
+
+  module A = struct
+    type t = int
+  end
+end
+
+[%%expect {|
+Line 10, characters 2-19:
+10 |   module type B = _
+       ^^^^^^^^^^^^^^^^^
+Error: Unbound path A.t in inferred module type.
+|}]
+
 
 module M : sig
   type 'a t
@@ -795,15 +796,35 @@ end = struct
   module type A = _
 end
 
-(* CR selee: This needs to be fixed *)
 [%%expect {|
-Line 14, characters 12-17:
-14 |     let _ = X.foo 42
-                 ^^^^^
-Error: The module X is abstract, it cannot have any components
+Line 11, characters 2-19:
+11 |   module type B = _
+       ^^^^^^^^^^^^^^^^^
+Error: Unbound path A in inferred module type.
 |}]
 
-(* CR selee: Surely this error message should be improved? *)
+module M : sig
+  module type A = sig
+    type 'a t
+
+    val foo : int t -> int t
+  end
+
+  module type B = A -> A
+
+end = struct
+  module type B = _
+
+  module type A = _
+end
+
+[%%expect {|
+Line 11, characters 2-19:
+11 |   module type B = _
+       ^^^^^^^^^^^^^^^^^
+Error: Unbound path A in inferred module type.
+|}]
+
 module M : sig
   type 'a t
 
@@ -822,17 +843,11 @@ end = struct
   type t = string
 end
 
-(* CR selee: This needs to be fixed *)
 [%%expect {|
-Line 13, characters 18-22:
-13 |     let _ = X.foo "hi"
-                       ^^^^
-Error: Function arguments and returns must be representable.
-       The layout of int t is any, because
-         the .cmi file for t is missing.
-       But the layout of int t must be representable, because
-         we must know concretely how to pass a function argument.
-       No .cmi file found containing t.
+Line 10, characters 2-19:
+10 |   module type S = _
+       ^^^^^^^^^^^^^^^^^
+Error: Unbound path t in inferred module type.
 |}]
 
 module M : sig

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -702,7 +702,7 @@ end
 Line 10, characters 2-19:
 10 |   module type B = _
        ^^^^^^^^^^^^^^^^^
-Error: Unbound path A in inferred module type.
+Error: The inferred module type refers to module type A, which is unbound here.
 |}]
 
 module M : sig
@@ -725,7 +725,7 @@ end
 Line 10, characters 2-19:
 10 |   module type B = _
        ^^^^^^^^^^^^^^^^^
-Error: Unbound path A.t in inferred module type.
+Error: The inferred module type refers to type A.t, which is unbound here.
 |}]
 
 
@@ -800,7 +800,7 @@ end
 Line 11, characters 2-19:
 11 |   module type B = _
        ^^^^^^^^^^^^^^^^^
-Error: Unbound path A in inferred module type.
+Error: The inferred module type refers to module type A, which is unbound here.
 |}]
 
 module M : sig
@@ -822,7 +822,7 @@ end
 Line 11, characters 2-19:
 11 |   module type B = _
        ^^^^^^^^^^^^^^^^^
-Error: Unbound path A in inferred module type.
+Error: The inferred module type refers to module type A, which is unbound here.
 |}]
 
 module M : sig
@@ -847,7 +847,7 @@ end
 Line 10, characters 2-19:
 10 |   module type S = _
        ^^^^^^^^^^^^^^^^^
-Error: Unbound path t in inferred module type.
+Error: The inferred module type refers to type t, which is unbound here.
 |}]
 
 module M : sig

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1180,3 +1180,37 @@ module M :
       end
   end
 |}]
+
+module M : sig
+  module A : sig type t end
+  module type S = sig type t = A.t -> A.t end
+end = struct
+  module A = struct end
+  module type S = _
+end
+
+(* CR selee: Currently our boundness check relies on the compatibility check.
+   As this branch doesn't have the compatibility check, it doesn't error properly
+   in this case. This should error properly before inclusion checking *)
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   module A = struct end
+6 |   module type S = _
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           module A : sig end
+           module type S = sig type t = A.t -> A.t end
+         end
+       is not included in
+         sig
+           module A : sig type t end
+           module type S = sig type t = A.t -> A.t end
+         end
+       In module A:
+       Modules do not match: sig end is not included in sig type t end
+       In module A:
+       The type `t' is required but not provided
+|}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1180,3 +1180,17 @@ module M :
       end
   end
 |}]
+
+
+module M : sig
+  module type S = sig
+    val either : 'a -> ('a, 'b) Either.t
+  end
+end = struct
+  module type S = _
+end
+
+[%%expect {|
+module M :
+  sig module type S = sig val either : 'a -> ('a, 'b) Either.t end end
+|}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1180,17 +1180,3 @@ module M :
       end
   end
 |}]
-
-
-module M : sig
-  module type S = sig
-    val either : 'a -> ('a, 'b) Either.t
-  end
-end = struct
-  module type S = _
-end
-
-[%%expect {|
-module M :
-  sig module type S = sig val either : 'a -> ('a, 'b) Either.t end end
-|}]

--- a/ocaml/toplevel/topdirs.ml
+++ b/ocaml/toplevel/topdirs.ml
@@ -442,7 +442,7 @@ let is_nonrec_type id td =
   *)
   let recursive_use = ref false in
   let nonrecursive_use = ref false in
-  let it_path = function
+  let it_path _f = function
     | Path.Pident id' when Ident.name id' = Ident.name id ->
         if Ident.same id id' then
           recursive_use := true
@@ -553,8 +553,8 @@ let () =
 
 let is_rec_module id md =
   let exception Exit in
-  let rec it_path = function
-    | Path.Pdot(root, _ ) -> it_path root
+  let rec it_path _path_type = function
+    | Path.Pdot(root, _ ) -> it_path Btype.Path_module root
     | Path.Pident id' -> if (Ident.same id id') then raise Exit
     | _ -> ()
   in

--- a/ocaml/typing/btype.ml
+++ b/ocaml/typing/btype.ml
@@ -246,7 +246,9 @@ type path_kind =
   | Path_module
   | Path_modtype
   | Path_class
+  | Path_class_lhs
   | Path_classtype
+  | Path_classtype_lhs
 
 let fold_row f init row =
   let result =
@@ -380,11 +382,11 @@ let type_iterators =
     List.iter (it.it_type_expr it) cd.cty_params;
     it.it_class_type it cd.cty_type;
     Option.iter (it.it_type_expr it) cd.cty_new;
-    it.it_path Path_classtype cd.cty_path
+    it.it_path Path_class_lhs cd.cty_path
   and it_class_type_declaration it ctd =
     List.iter (it.it_type_expr it) ctd.clty_params;
     it.it_class_type it ctd.clty_type;
-    it.it_path Path_classtype ctd.clty_path
+    it.it_path Path_classtype_lhs ctd.clty_path
   and it_functor_param it = function
     | Unit -> ()
     | Named (_, mt) -> it.it_module_type it mt

--- a/ocaml/typing/btype.ml
+++ b/ocaml/typing/btype.ml
@@ -250,6 +250,16 @@ type path_kind =
   | Path_classtype
   | Path_classtype_lhs
 
+let print_path_kind ppf = function
+  | Path_value -> Format.fprintf ppf "value"
+  | Path_type -> Format.fprintf ppf "type"
+  | Path_module -> Format.fprintf ppf "module"
+  | Path_modtype -> Format.fprintf ppf "module type"
+  | Path_class -> Format.fprintf ppf "class"
+  | Path_class_lhs -> Format.fprintf ppf "class"
+  | Path_classtype -> Format.fprintf ppf "class type"
+  | Path_classtype_lhs -> Format.fprintf ppf "class type"
+
 let fold_row f init row =
   let result =
     List.fold_left

--- a/ocaml/typing/btype.ml
+++ b/ocaml/typing/btype.ml
@@ -239,6 +239,15 @@ let set_static_row_name decl path =
                   (*  Utilities for type traversal  *)
                   (**********************************)
 
+(* Kinds of paths *)
+type path_kind =
+  | Path_value
+  | Path_type
+  | Path_module
+  | Path_modtype
+  | Path_class
+  | Path_classtype
+
 let fold_row f init row =
   let result =
     List.fold_left
@@ -315,7 +324,7 @@ type type_iterators =
     it_type_kind: type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: type_iterators -> type_expr -> unit;
     it_type_expr: type_iterators -> type_expr -> unit;
-    it_path: Path.t -> unit; }
+    it_path: path_kind -> Path.t -> unit; }
 
 let iter_type_expr_cstr_args f = function
   | Cstr_tuple tl -> List.iter (fun ca -> f ca.ca_type) tl
@@ -359,7 +368,7 @@ let type_iterators =
     Option.iter (it.it_type_expr it) td.type_manifest;
     it.it_type_kind it td.type_kind
   and it_extension_constructor it td =
-    it.it_path td.ext_type_path;
+    it.it_path Path_type td.ext_type_path;
     List.iter (it.it_type_expr it) td.ext_type_params;
     iter_type_expr_cstr_args (it.it_type_expr it) td.ext_args;
     Option.iter (it.it_type_expr it) td.ext_ret_type
@@ -371,27 +380,27 @@ let type_iterators =
     List.iter (it.it_type_expr it) cd.cty_params;
     it.it_class_type it cd.cty_type;
     Option.iter (it.it_type_expr it) cd.cty_new;
-    it.it_path cd.cty_path
+    it.it_path Path_classtype cd.cty_path
   and it_class_type_declaration it ctd =
     List.iter (it.it_type_expr it) ctd.clty_params;
     it.it_class_type it ctd.clty_type;
-    it.it_path ctd.clty_path
+    it.it_path Path_classtype ctd.clty_path
   and it_functor_param it = function
     | Unit -> ()
     | Named (_, mt) -> it.it_module_type it mt
   and it_module_type it = function
-      Mty_ident p
-    | Mty_alias p -> it.it_path p
+      Mty_ident p -> it.it_path Path_modtype p
+    | Mty_alias p -> it.it_path Path_module p
     | Mty_signature sg -> it.it_signature it sg
     | Mty_functor (p, mt) ->
         it.it_functor_param it p;
         it.it_module_type it mt
     | Mty_strengthen (mty, p, _) ->
         it.it_module_type it mty;
-        it.it_path p
+        it.it_path Path_module p
   and it_class_type it = function
       Cty_constr (p, tyl, cty) ->
-        it.it_path p;
+        it.it_path Path_classtype p;
         List.iter (it.it_type_expr it) tyl;
         it.it_class_type it cty
     | Cty_signature cs ->
@@ -408,13 +417,14 @@ let type_iterators =
     iter_type_expr (it.it_type_expr it) ty;
     match get_desc ty with
       Tconstr (p, _, _)
-    | Tobject (_, {contents=Some (p, _)})
+    | Tobject (_, {contents=Some (p, _)}) ->
+        it.it_path Path_type p
     | Tpackage (p, _) ->
-        it.it_path p
+        it.it_path Path_module p
     | Tvariant row ->
-        Option.iter (fun (p,_) -> it.it_path p) (row_name row)
+        Option.iter (fun (p,_) -> it.it_path Path_type p) (row_name row)
     | _ -> ()
-  and it_path _p = ()
+  and it_path _f _p = ()
   in
   { it_path; it_type_expr = it_do_type_expr; it_do_type_expr;
     it_type_kind; it_class_type; it_functor_param; it_module_type;

--- a/ocaml/typing/btype.mli
+++ b/ocaml/typing/btype.mli
@@ -127,6 +127,15 @@ val set_static_row_name: type_declaration -> Path.t -> unit
 
 (**** Utilities for type traversal ****)
 
+(* Kinds in paths *)
+type path_kind =
+  | Path_value
+  | Path_type
+  | Path_module
+  | Path_modtype
+  | Path_class
+  | Path_classtype
+
 val iter_type_expr: (type_expr -> unit) -> type_expr -> unit
         (* Iteration on types *)
 val fold_type_expr: ('a -> type_expr -> 'a) -> 'a -> type_expr -> 'a
@@ -159,7 +168,7 @@ type type_iterators =
     it_type_kind: type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: type_iterators -> type_expr -> unit;
     it_type_expr: type_iterators -> type_expr -> unit;
-    it_path: Path.t -> unit; }
+    it_path: path_kind -> Path.t -> unit; }
 val type_iterators: type_iterators
         (* Iteration on arbitrary type information.
            [it_type_expr] calls [mark_node] to avoid loops. *)

--- a/ocaml/typing/btype.mli
+++ b/ocaml/typing/btype.mli
@@ -134,7 +134,9 @@ type path_kind =
   | Path_module
   | Path_modtype
   | Path_class
+  | Path_class_lhs
   | Path_classtype
+  | Path_classtype_lhs
 
 val iter_type_expr: (type_expr -> unit) -> type_expr -> unit
         (* Iteration on types *)

--- a/ocaml/typing/btype.mli
+++ b/ocaml/typing/btype.mli
@@ -138,6 +138,8 @@ type path_kind =
   | Path_classtype
   | Path_classtype_lhs
 
+val print_path_kind: Format.formatter -> path_kind -> unit
+
 val iter_type_expr: (type_expr -> unit) -> type_expr -> unit
         (* Iteration on types *)
 val fold_type_expr: ('a -> type_expr -> 'a) -> 'a -> type_expr -> 'a

--- a/ocaml/typing/mtype.ml
+++ b/ocaml/typing/mtype.ml
@@ -700,7 +700,7 @@ let collect_arg_paths mty =
   and bindings = ref Ident.empty in
   (* let rt = Ident.create "Root" in
      and prefix = ref (Path.Pident rt) in *)
-  let it_path p = paths := Path.Set.union (get_arg_paths p) !paths
+  let it_path _type p = paths := Path.Set.union (get_arg_paths p) !paths
   and it_signature_item it si =
     type_iterators.it_signature_item it si;
     match si with

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -1674,7 +1674,8 @@ let check_no_unbound_paths env loc sig_map str_map mty =
             in
             check_error path in_sig in_str;
         | Pdot _ | Papply _ | Pextra_ty _ ->
-            let rec check p = match p with
+            let rec check p =
+              match p with
               | Pident id ->
                   let name = Ident.name id in
                   let in_sig = Sig_map.has_module name sig_map in
@@ -1689,10 +1690,10 @@ let check_no_unbound_paths env loc sig_map str_map mty =
   match mty with
   | None -> ()
   | Some mty ->
-    begin
-      iterator.it_module_type iterator mty;
-      Btype.(unmark_iterators.it_module_type unmark_iterators) mty
-    end
+      begin
+        iterator.it_module_type iterator mty;
+        Btype.(unmark_iterators.it_module_type unmark_iterators) mty
+      end
 
 let rec transl_modtype env smty =
   Builtin_attributes.warning_scope smty.pmty_attributes
@@ -2045,8 +2046,7 @@ and transl_signature env (sg : Parsetree.signature) =
         sig_items,
         newenv
     | Psig_modtype pmtd ->
-        let newenv, mtd, decl =
-          transl_modtype_decl ~context:In_signature env pmtd in
+        let newenv, mtd, decl = transl_modtype_decl ~context:In_signature env pmtd in
         Signature_names.check_modtype names pmtd.pmtd_loc mtd.mtd_id;
         mksig (Tsig_modtype mtd) env loc,
         [Sig_modtype (mtd.mtd_id, decl, Exported)],
@@ -2168,8 +2168,7 @@ and transl_modtype_decl_aux ~context env
     | Pmtd_underscore ->
       begin match context with
         | In_signature -> raise (Error (pmtd_loc, env, Underscore_not_allowed_in_signature))
-        | In_structure None ->
-            raise (Error (pmtd_loc, env, Cannot_infer_module_type))
+        | In_structure None -> raise (Error (pmtd_loc, env, Cannot_infer_module_type))
         | In_structure Some ({ expected = mtd; sig_map; str_map }) ->
             check_no_unbound_paths env pmtd_loc sig_map str_map mtd.Types.mtd_type;
             Tmtd_underscore, mtd.Types.mtd_type

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -1640,7 +1640,11 @@ let check_no_unbound_paths env loc mty =
   in
   match mty with
   | None -> ()
-  | Some mty -> iterator.it_module_type iterator mty
+  | Some mty ->
+    begin
+      iterator.it_module_type iterator mty;
+      Btype.(unmark_iterators.it_module_type unmark_iterators) mty
+    end
 
 let rec transl_modtype env smty =
   Builtin_attributes.warning_scope smty.pmty_attributes

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -176,6 +176,8 @@ module Sig_map = struct
   let find_class_type name map = String.Map.find_opt name map.class_types
 end
 
+
+
 open Typedtree
 
 let rec path_concat head p =

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -169,15 +169,32 @@ module Sig_map = struct
     List.fold_left add_item map sg
 
   let find_type name map = String.Map.find_opt name map.types
-
   let find_module name map = String.Map.find_opt name map.modules
-
   let find_module_type name map = String.Map.find_opt name map.module_types
 
   let find_class_type name map = String.Map.find_opt name map.class_types
+
+  let has_value name map = Option.is_some (find_value name map)
+  let has_type name map = Option.is_some (find_type name map)
+  let has_module name map = Option.is_some (find_module name map)
+  let has_module_type name map = Option.is_some (find_module_type name map)
+  let has_class name map = Option.is_some (find_class name map)
+  let has_class_type name map = Option.is_some (find_class_type name map)
 end
 
+type modtype_decl_expected = {
+  expected: modtype_declaration;
+  sig_map: Sig_map.t;
+  str_map: Sig_map.t;
+}
 
+type modtype_decl_context =
+  | In_signature
+  (** We are checking a signature. *)
+  | In_structure of modtype_decl_expected option
+  (** We are checking a struct, with a given expected signature (used for inferring
+      module types when we see a [module type S = _]). [sig_map] contains all the names
+      in the signature, and [str_map] contains all the names seen in the struct so far. *)
 
 open Typedtree
 
@@ -1612,31 +1629,61 @@ let mksig desc env loc =
     substitution from the paths appearing in the signature to the paths appearing in
     the structure. If after the substitution we encounter a [Path.t] not recognised by
     the env of the struct, this means the module type being inferred has a symbol not yet
-    included in the env of the struct, and so we should error out. This avoids having
-    confusing error messages later. *)
-let check_no_unbound_paths env loc mty =
-  let env, super = iterator_with_env env in
+    included in the struct, and so we should error out. This avoids having confusing
+    error messages later.
+
+    We do this check by checking if the head name (e.g [A] in [A.t]) doesn't appear
+    in the current structure but does appear in the signature. If it does appear in the
+    current structure, then all is well; if it doesn't appear in the signature, then it
+    was declared somewhere outside so it can't be unbound. This way, we avoid expensive
+    [Env.t] queries.*)
+let check_no_unbound_paths env loc sig_map str_map mty =
+  let check_error path in_sig in_str =
+    if in_sig && (not in_str) then
+      raise (Error (loc, env, Unbound_path_in_inferred_type path))
+  in
   let iterator =
-    { super with
+    { Btype.type_iterators with
       Btype.it_path = (fun path_kind path ->
-        let env = Lazy.force (!env) in
-        try
-          match path_kind with
-          | Path_value ->
-              ignore (Env.find_value path env);
-          | Path_type ->
-              ignore (Env.find_type path env);
-          | Path_module ->
-              ignore (Env.find_module_lazy path env);
-          | Path_modtype ->
-              ignore (Env.find_modtype_lazy path env);
-          | Path_class ->
-              ignore (Env.find_class path env);
-          | Path_classtype ->
-              ignore (Env.find_cltype path env);
-          | Path_class_lhs | Path_classtype_lhs -> ()
-        with
-        | Not_found -> raise (Error (loc, env, Unbound_path_in_inferred_type path))
+        match path with
+        | Pident id ->
+            let name = Ident.name id in
+            let (in_sig, in_str) =
+              begin match path_kind with
+                | Path_value ->
+                    Sig_map.has_value name sig_map,
+                    Sig_map.has_value name str_map
+                | Path_type ->
+                    Sig_map.has_type name sig_map,
+                    Sig_map.has_type name str_map
+                | Path_module ->
+                    Sig_map.has_module name sig_map,
+                    Sig_map.has_module name str_map
+                | Path_modtype ->
+                    Sig_map.has_module_type name sig_map,
+                    Sig_map.has_module_type name str_map
+                | Path_class ->
+                    Sig_map.has_class name sig_map,
+                    Sig_map.has_class name str_map
+                | Path_classtype ->
+                    Sig_map.has_class_type name sig_map,
+                    Sig_map.has_class_type name str_map
+                | Path_class_lhs | Path_classtype_lhs ->
+                    (true, true)
+              end
+            in
+            check_error path in_sig in_str;
+        | Pdot _ | Papply _ | Pextra_ty _ ->
+            let rec check p = match p with
+              | Pident id ->
+                  let name = Ident.name id in
+                  let in_sig = Sig_map.has_module name sig_map in
+                  let in_str = Sig_map.has_module name str_map in
+                  check_error path in_sig in_str
+              | Pdot (p, _) | Pextra_ty (p, _) -> check p
+              | Papply (p1, p2) -> check p1; check p2
+            in
+            check path
       );}
   in
   match mty with
@@ -1998,7 +2045,8 @@ and transl_signature env (sg : Parsetree.signature) =
         sig_items,
         newenv
     | Psig_modtype pmtd ->
-        let newenv, mtd, decl = transl_modtype_decl ~context:In_signature env pmtd in
+        let newenv, mtd, decl =
+          transl_modtype_decl ~context:In_signature env pmtd in
         Signature_names.check_modtype names pmtd.pmtd_loc mtd.mtd_id;
         mksig (Tsig_modtype mtd) env loc,
         [Sig_modtype (mtd.mtd_id, decl, Exported)],
@@ -2108,7 +2156,7 @@ and transl_signature env (sg : Parsetree.signature) =
 
 and transl_modtype_decl ~context env pmtd =
   Builtin_attributes.warning_scope pmtd.pmtd_attributes
-    (fun () -> transl_modtype_decl_aux env pmtd ~context)
+    (fun () -> transl_modtype_decl_aux ~context env pmtd)
 
 and transl_modtype_decl_aux ~context env
     {pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc} =
@@ -2120,10 +2168,11 @@ and transl_modtype_decl_aux ~context env
     | Pmtd_underscore ->
       begin match context with
         | In_signature -> raise (Error (pmtd_loc, env, Underscore_not_allowed_in_signature))
-        | In_structure None -> raise (Error (pmtd_loc, env, Cannot_infer_module_type))
-        | In_structure (Some mtd) ->
-          check_no_unbound_paths env pmtd_loc mtd.Types.mtd_type;
-          Tmtd_underscore, mtd.Types.mtd_type
+        | In_structure None ->
+            raise (Error (pmtd_loc, env, Cannot_infer_module_type))
+        | In_structure Some ({ expected = mtd; sig_map; str_map }) ->
+            check_no_unbound_paths env pmtd_loc sig_map str_map mtd.Types.mtd_type;
+            Tmtd_underscore, mtd.Types.mtd_type
       end
   in
   let decl =
@@ -3042,7 +3091,7 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
     List.fold_left add_item subst actual_sig
   in
 
-  let type_str_include ~functor_ ~loc env subst shape_map sincl sig_acc =
+  let type_str_include ~functor_ ~loc env subst str_map shape_map sincl sig_acc =
     let smodl = sincl.pincl_mod in
     let modl, modl_shape =
       Builtin_attributes.warning_scope sincl.pincl_attributes
@@ -3078,33 +3127,38 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
     sg,
     shape,
     new_env,
-    add_expected_include_to_subst expected_sig sg subst
+    add_expected_include_to_subst expected_sig sg subst,
+    Sig_map.add_signature sg str_map
   in
 
-  let type_str_include_functor ~loc env subst shape_map ifincl sig_acc =
+  let type_str_include_functor ~loc env subst str_map shape_map ifincl sig_acc =
     match (ifincl : Jane_syntax.Include_functor.structure_item) with
     | Ifstr_include_functor incl ->
-        type_str_include ~functor_:true ~loc env subst shape_map incl sig_acc
+        type_str_include ~functor_:true ~loc env subst str_map shape_map incl sig_acc
   in
 
-  let type_str_item_jst ~loc env subst shape_map jitem sig_acc =
+  let type_str_item_jst ~loc env subst str_map shape_map jitem sig_acc =
     match (jitem : Jane_syntax.Structure_item.t) with
     | Jstr_include_functor ifincl ->
-        type_str_include_functor ~loc env subst shape_map ifincl sig_acc
+        type_str_include_functor ~loc env subst str_map shape_map ifincl sig_acc
     | Jstr_layout (Lstr_kind_abbrev _) ->
         Misc.fatal_error "kind_abbrev not supported!"
   in
 
   let type_str_item
-        env subst shape_map ({pstr_loc = loc; pstr_desc = desc} as item) sig_acc =
+        env subst str_map shape_map ({pstr_loc = loc; pstr_desc = desc} as item) sig_acc =
     (* [subst] is a running [Subst] object. For every type, module and module type we
        have seen in the [struct] so far also present in [expected_sig], [subst] contains
        a mapping from its Ident.t to its corresponding definition within the struct.
-       It is used for module type inferrence with the underscore syntax. *)
+       It is used for module type inferrence with the underscore syntax.
+
+       [str_map] is a running [Sig_map.t] object, containing every name we've seen
+        in the [struct] so far. It is used for boundness checks before filling in a
+        [Pstr_underscore]. *)
     let md_mode = Mode.Value.legacy in
     match Jane_syntax.Structure_item.of_ast item with
     | Some jitem ->
-        type_str_item_jst ~loc env subst shape_map jitem sig_acc
+        type_str_item_jst ~loc env subst str_map shape_map jitem sig_acc
     | None ->
     match desc with
     | Pstr_eval (sexpr, attrs) ->
@@ -3116,7 +3170,7 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
             (fun () -> Typecore.type_representable_expression
                          ~why:Structure_item_expression env sexpr)
         in
-        Tstr_eval (expr, sort, attrs), [], shape_map, env, subst
+        Tstr_eval (expr, sort, attrs), [], shape_map, env, subst, str_map
     | Pstr_value(rec_flag, sdefs) ->
         let force_toplevel =
           (* Values bound by '_' still escape in the toplevel, because
@@ -3131,9 +3185,9 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
         in
         (* Note: Env.find_value does not trigger the value_used event. Values
            will be marked as being used during the signature inclusion test. *)
-        let items, shape_map =
+        let items, shape_map, str_map =
           List.fold_left
-            (fun (acc, shape_map) (id, id_info, zero_alloc) ->
+            (fun (acc, shape_map, str_map) (id, id_info, zero_alloc) ->
               List.iter
                 (fun (loc, _mode, sort) ->
                    (* CR layouts v5: this jkind check has the effect of
@@ -3170,16 +3224,18 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
                   val_modalities = modalities }
               in
               Sig_value(id, vd, Exported) :: acc,
-              Shape.Map.add_value shape_map id vd.val_uid
+              Shape.Map.add_value shape_map id vd.val_uid,
+              Sig_map.add_value id vd str_map
             )
-            ([], shape_map)
+            ([], shape_map, str_map)
             (let_bound_idents_with_modes_sorts_and_checks defs)
         in
         Tstr_value(rec_flag, defs),
         List.rev items,
         shape_map,
         newenv,
-        subst
+        subst,
+        str_map
     | Pstr_primitive sdesc ->
         let (desc, newenv) = Typedecl.transl_value_decl env loc sdesc in
         Signature_names.check_value names desc.val_loc desc.val_id;
@@ -3187,7 +3243,8 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
         [Sig_value(desc.val_id, desc.val_val, Exported)],
         Shape.Map.add_value shape_map desc.val_id desc.val_val.val_uid,
         newenv,
-        subst
+        subst,
+        Sig_map.add_value desc.val_id desc.val_val str_map
     | Pstr_type (rec_flag, sdecls) ->
         let (decls, newenv, shapes) =
           Typedecl.transl_type_decl env rec_flag sdecls
@@ -3206,6 +3263,10 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
           decls
           shapes
         in
+        let str_map = List.fold_left
+          (fun map { typ_id; typ_type; _ } -> Sig_map.add_type typ_id typ_type map)
+          str_map decls
+        in
         let idents =
           List.map (fun { typ_id; _ } -> typ_id) decls
         in
@@ -3213,7 +3274,8 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
         items,
         shape_map,
         enrich_type_decls anchor decls env newenv,
-        add_expected_type_to_subst expected_sig idents subst
+        add_expected_type_to_subst expected_sig idents subst,
+        str_map
     | Pstr_typext styext ->
         let (tyext, newenv, shapes) =
           Typedecl.transl_type_extension true env loc styext
@@ -3230,7 +3292,8 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
            constructors,
          shape_map,
          newenv,
-         subst)
+         subst,
+         str_map)
     | Pstr_exception sext ->
         let (ext, newenv, shape) = Typedecl.transl_type_exception env sext in
         let constructor = ext.tyexn_constructor in
@@ -3245,7 +3308,8 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
           constructor.ext_id
           shape,
         newenv,
-        subst
+        subst,
+        str_map
     | Pstr_module {pmb_name = name; pmb_expr = smodl; pmb_attributes = attrs;
                    pmb_loc;
                   } ->
@@ -3307,13 +3371,18 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
           | Some id -> Shape.Map.add_module shape_map id md_shape
           | None -> shape_map
         in
+        let str_map = match id with
+          | Some id -> Sig_map.add_module id md str_map
+          | None -> str_map
+        in
         Tstr_module {mb_id=id; mb_name=name; mb_uid = md.md_uid;
                      mb_expr=modl; mb_presence=pres; mb_attributes=attrs;
                      mb_loc=pmb_loc; },
         sg,
         shape_map,
         newenv,
-        add_expected_module_to_subst expected_sig id subst
+        add_expected_module_to_subst expected_sig id subst,
+        str_map
     | Pstr_recmodule sbind ->
         let sbind =
           List.map
@@ -3356,11 +3425,11 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
                in
                (id, name, mty, modl, mty', attrs, loc, shape, uid))
             decls sbind in
-        let newenv = (* allow aliasing recursive modules from outside *)
+        let (newenv, str_map) = (* allow aliasing recursive modules from outside *)
           List.fold_left
-            (fun env (id_opt, _, mty, _, _, attrs, loc, shape, uid) ->
+            (fun (env, map) (id_opt, _, mty, _, _, attrs, loc, shape, uid) ->
                match id_opt with
-               | None -> env
+               | None -> env, map
                | Some id ->
                    let mdecl =
                      {
@@ -3371,9 +3440,10 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
                      }
                    in
                    Env.add_module_declaration ~check:true ~shape
-                     id Mp_present mdecl env
+                     id Mp_present mdecl env,
+                   Sig_map.add_module id mdecl map
             )
-            env bindings1
+            (env, str_map) bindings1
         in
         let bindings2 =
           check_recmodule_inclusion newenv bindings1 in
@@ -3401,17 +3471,22 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
            mbs [],
         shape_map,
         newenv,
-        add_expected_rec_modules_to_subst expected_sig idents subst
+        add_expected_rec_modules_to_subst expected_sig idents subst,
+        str_map
     | Pstr_modtype pmtd ->
         let context =
           match expected_sig with
           | None -> In_structure None
           | Some expected_sig ->
-              begin match Sig_map.find_module_type pmtd.pmtd_name.txt expected_sig with
-                | None -> In_structure None
-                | Some (_, decl) ->
-                    In_structure (Some (Subst.modtype_declaration Keep subst decl))
-              end
+            begin match Sig_map.find_module_type pmtd.pmtd_name.txt expected_sig with
+              | None -> In_structure None
+              | Some (_, decl) ->
+                  In_structure (Some ({
+                    expected = Subst.modtype_declaration Keep subst decl;
+                    sig_map = expected_sig;
+                    str_map;
+                  }))
+            end
         in
         (* check that it is non-abstract *)
         let newenv, mtd, decl = transl_modtype_decl env pmtd ~context in
@@ -3422,13 +3497,14 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
         [Sig_modtype (id, decl, Exported)],
         map,
         newenv,
-        add_expected_modtype_to_subst expected_sig id subst
+        add_expected_modtype_to_subst expected_sig id subst,
+        Sig_map.add_module_type id decl str_map
     | Pstr_open sod ->
         let toplevel = Option.is_some toplevel in
         let (od, sg, newenv) =
           type_open_decl ~toplevel funct_body names env sod
         in
-        Tstr_open od, sg, shape_map, newenv, subst
+        Tstr_open od, sg, shape_map, newenv, subst, str_map
     | Pstr_class cl ->
         let (classes, new_env) = Typeclass.class_declarations env cl in
         let shape_map = List.fold_left (fun acc cls ->
@@ -3443,6 +3519,13 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
             |> map Shape.Map.add_class_type cls.cls_ty_id uid
             |> map Shape.Map.add_type cls.cls_obj_id (Shape.leaf uid)
           ) shape_map classes
+        in
+        let str_map = List.fold_left (fun map cls ->
+            let open Typeclass in
+            Sig_map.add_class cls.cls_id cls.cls_decl map
+            |> Sig_map.add_class_type cls.cls_ty_id cls.cls_ty_decl
+            |> Sig_map.add_type cls.cls_obj_id cls.cls_obj_abbr
+          ) str_map classes
         in
         let clty_ids = List.map (fun cl -> cl.Typeclass.cls_ty_id) classes in
         let ty_ids = List.map (fun cl -> cl.Typeclass.cls_obj_id) classes in
@@ -3461,7 +3544,8 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
              classes []),
         shape_map,
         new_env,
-        add_expected_class_type_to_subst expected_sig clty_ids ty_ids subst
+        add_expected_class_type_to_subst expected_sig clty_ids ty_ids subst,
+        str_map
     | Pstr_class_type cl ->
         let (classes, new_env) = Typeclass.class_type_declarations env cl in
         let shape_map = List.fold_left (fun acc decl ->
@@ -3474,6 +3558,12 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
             map Shape.Map.add_class_type decl.clsty_ty_id uid acc
             |> map Shape.Map.add_type decl.clsty_obj_id (Shape.leaf uid)
           ) shape_map classes
+        in
+        let str_map = List.fold_left (fun map decl ->
+            let open Typeclass in
+            Sig_map.add_class_type decl.clsty_ty_id decl.clsty_ty_decl map
+            |> Sig_map.add_type decl.clsty_obj_id decl.clsty_obj_abbr
+          ) str_map classes
         in
         let clty_ids = List.map (fun cl -> cl.Typeclass.clsty_ty_id) classes in
         let ty_ids = List.map (fun cl -> cl.Typeclass.clsty_obj_id) classes in
@@ -3493,38 +3583,39 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
              classes []),
         shape_map,
         new_env,
-        add_expected_class_type_to_subst expected_sig clty_ids ty_ids subst
+        add_expected_class_type_to_subst expected_sig clty_ids ty_ids subst,
+        str_map
     | Pstr_include sincl ->
-        type_str_include ~functor_:false ~loc env subst shape_map sincl sig_acc
+        type_str_include ~functor_:false ~loc env subst str_map shape_map sincl sig_acc
     | Pstr_extension (ext, _attrs) ->
         raise (Error_forward (Builtin_attributes.error_of_extension ext))
     | Pstr_attribute attr ->
         Builtin_attributes.parse_standard_implementation_attributes attr;
         Builtin_attributes.mark_alert_used attr;
-        Tstr_attribute attr, [], shape_map, env, subst
+        Tstr_attribute attr, [], shape_map, env, subst, str_map
   in
   let toplevel_sig = Option.value toplevel ~default:[] in
-  let rec type_struct env subst shape_map sstr str_acc sig_acc
+  let rec type_struct env subst str_map shape_map sstr str_acc sig_acc
             sig_acc_include_functor =
     match sstr with
     | [] ->
-      (List.rev str_acc, List.rev sig_acc, shape_map, env, subst)
+      (List.rev str_acc, List.rev sig_acc, shape_map, env, subst, str_map)
     | pstr :: srem ->
         let previous_saved_types = Cmt_format.get_saved_types () in
-        let desc, sg, shape_map, new_env, new_subst =
-          type_str_item env subst shape_map pstr sig_acc_include_functor
+        let desc, sg, shape_map, new_env, new_subst, str_map =
+          type_str_item env subst str_map shape_map pstr sig_acc_include_functor
         in
         let str = { str_desc = desc; str_loc = pstr.pstr_loc; str_env = env } in
         Cmt_format.set_saved_types (Cmt_format.Partial_structure_item str
                                     :: previous_saved_types);
-        type_struct new_env new_subst shape_map srem (str :: str_acc)
+        type_struct new_env new_subst str_map shape_map srem (str :: str_acc)
           (List.rev_append sg sig_acc)
           (List.rev_append sg sig_acc_include_functor)
   in
   let previous_saved_types = Cmt_format.get_saved_types () in
   let run () =
-    let (items, sg, shape_map, final_env, _final_subst) =
-      type_struct env Subst.identity Shape.Map.empty sstr [] [] toplevel_sig
+    let (items, sg, shape_map, final_env, _final_subst, _str_map) =
+      type_struct env Subst.identity Sig_map.empty Shape.Map.empty sstr [] [] toplevel_sig
     in
     let str = { str_items = items; str_type = sg; str_final_env = final_env } in
     Cmt_format.set_saved_types

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -1634,6 +1634,7 @@ let check_no_unbound_paths env loc mty =
               ignore (Env.find_class path env);
           | Path_classtype ->
               ignore (Env.find_cltype path env);
+          | Path_class_lhs | Path_classtype_lhs -> ()
         with
         | Not_found -> raise (Error (loc, env, Unbound_path_in_inferred_type path))
       );}

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -107,15 +107,6 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-type modtype_decl_context =
-  | In_signature
-  (** We are checking a signature. *)
-  | In_structure of modtype_declaration option
-  (** We are checking a struct, with a given expected signature (used for inferring
-      module types when we see a [module type S = _]). The expected signature would have
-      been gone through substitution from the elements in the signature to the elements
-      in the struct seen so far.*)
-
 (** Map of items in a signature (similar to an [Env.t] after [Env.add_signature]), but
     only indexed by the item's name as a string. This avoids us having to iterate through
     an [expected_sig] to find the declaration we are looking for in [type_str_item]. *)
@@ -168,10 +159,11 @@ module Sig_map = struct
     in
     List.fold_left add_item map sg
 
+  let find_value name map = String.Map.find_opt name map.values
   let find_type name map = String.Map.find_opt name map.types
   let find_module name map = String.Map.find_opt name map.modules
   let find_module_type name map = String.Map.find_opt name map.module_types
-
+  let find_class name map = String.Map.find_opt name map.classes
   let find_class_type name map = String.Map.find_opt name map.class_types
 
   let has_value name map = Option.is_some (find_value name map)
@@ -193,8 +185,9 @@ type modtype_decl_context =
   (** We are checking a signature. *)
   | In_structure of modtype_decl_expected option
   (** We are checking a struct, with a given expected signature (used for inferring
-      module types when we see a [module type S = _]). [sig_map] contains all the names
-      in the signature, and [str_map] contains all the names seen in the struct so far. *)
+      module types when we see a [module type S = _]). The expected signature would have
+      been gone through substitution from the elements in the signature to the elements
+      in the struct seen so far.*)
 
 open Typedtree
 

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -166,6 +166,7 @@ type error =
   | Submode_failed of Mode.Value.error
   | Underscore_not_allowed_in_signature
   | Cannot_infer_module_type
+  | Unbound_path_in_inferred_type of Path.t
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -166,7 +166,7 @@ type error =
   | Submode_failed of Mode.Value.error
   | Underscore_not_allowed_in_signature
   | Cannot_infer_module_type
-  | Unbound_path_in_inferred_type of Path.t
+  | Unbound_path_in_inferred_type of Btype.path_kind * Path.t
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error


### PR DESCRIPTION
Previously, if the module type being inferred (via the underscore syntax) contains a path that hasn't yet been encountered in the struct, it led to very confusing error messages (and different error messages in slightly different contexts, though it has the same root problem). This PR introduces a check to error out early if we see an unbound path.