### PR TITLE
Fix initialisation of type parameter jkinds from annotations

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -176,7 +176,7 @@ type ('a : bits32) t4_6 = 'a * 'a
 Line 1, characters 26-28:
 1 | type ('a : bits32) t4_6 = 'a * 'a
                               ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits32)
+Error: Tuple element types must have layout value.
        The layout of 'a is bits32
          because of the annotation on 'a in the declaration of the type t4_6.
        But the layout of 'a must overlap with value
@@ -186,15 +186,14 @@ Error: This type ('a : value) should be an instance of type ('a0 : bits32)
 (* check for layout propagation *)
 type ('a : bits32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
 [%%expect{|
-Line 1, characters 31-33:
+Line 1, characters 45-47:
 1 | type ('a : bits32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
-                                   ^^
-Error: This type ('b : value) should be an instance of type ('a : bits32)
+                                                 ^^
+Error: Tuple element types must have layout value.
        The layout of 'a is bits32
          because of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value
-         because it instantiates an unannotated type parameter of t4_7,
-         defaulted to layout value.
+         because it's the type of a tuple element.
 |}]
 
 (*********************************************************)
@@ -371,7 +370,7 @@ type ('a : bits32) f7_5 = [ `A of 'a ];;
 Line 1, characters 34-36:
 1 | type ('a : bits32) f7_5 = [ `A of 'a ];;
                                       ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits32)
+Error: Polymorphic variant constructor argument types must have layout value.
        The layout of 'a is bits32
          because of the annotation on 'a in the declaration of the type f7_5.
        But the layout of 'a must overlap with value
@@ -576,10 +575,10 @@ Error: Object field types must have layout value.
 
 type ('a : bits32) t12_2 = < x : 'a >;;
 [%%expect{|
-Line 1, characters 33-35:
+Line 1, characters 29-35:
 1 | type ('a : bits32) t12_2 = < x : 'a >;;
-                                     ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits32)
+                                 ^^^^^^
+Error: Object field types must have layout value.
        The layout of 'a is bits32
          because of the annotation on 'a in the declaration of the type t12_2.
        But the layout of 'a must overlap with value
@@ -606,7 +605,7 @@ end;;
 Line 2, characters 13-15:
 2 |   method x : 'a t_bits32_id -> 'a t_bits32_id = assert false
                  ^^
-Error: This type ('a : bits32) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : bits32)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with bits32
@@ -656,7 +655,7 @@ end
 Line 2, characters 10-12:
 2 |   val x : 'a t_bits32_id -> 'a t_bits32_id
               ^^
-Error: This type ('a : bits32) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : bits32)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with bits32

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
@@ -174,8 +174,7 @@ type ('a : bits32) t4_6 = 'a * 'a
 Line 1, characters 26-28:
 1 | type ('a : bits32) t4_6 = 'a * 'a
                               ^^
-Error: This type ('a : value_or_null) should be an instance of type
-         ('a0 : bits32)
+Error: Tuple element types must have layout value.
        The layout of 'a is bits32
          because of the annotation on 'a in the declaration of the type t4_6.
        But the layout of 'a must overlap with value
@@ -185,15 +184,14 @@ Error: This type ('a : value_or_null) should be an instance of type
 (* check for layout propagation *)
 type ('a : bits32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
 [%%expect{|
-Line 1, characters 31-33:
+Line 1, characters 45-47:
 1 | type ('a : bits32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
-                                   ^^
-Error: This type ('b : value) should be an instance of type ('a : bits32)
+                                                 ^^
+Error: Tuple element types must have layout value.
        The layout of 'a is bits32
          because of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value
-         because it instantiates an unannotated type parameter of t4_7,
-         defaulted to layout value.
+         because it's the type of a tuple element.
 |}]
 
 (*********************************************************)
@@ -361,8 +359,7 @@ type ('a : bits32) f7_5 = [ `A of 'a ];;
 Line 1, characters 34-36:
 1 | type ('a : bits32) f7_5 = [ `A of 'a ];;
                                       ^^
-Error: This type ('a : value_or_null) should be an instance of type
-         ('a0 : bits32)
+Error: Polymorphic variant constructor argument types must have layout value.
        The layout of 'a is bits32
          because of the annotation on 'a in the declaration of the type f7_5.
        But the layout of 'a must overlap with value
@@ -567,10 +564,10 @@ Error: Object field types must have layout value.
 
 type ('a : bits32) t12_2 = < x : 'a >;;
 [%%expect{|
-Line 1, characters 33-35:
+Line 1, characters 29-35:
 1 | type ('a : bits32) t12_2 = < x : 'a >;;
-                                     ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits32)
+                                 ^^^^^^
+Error: Object field types must have layout value.
        The layout of 'a is bits32
          because of the annotation on 'a in the declaration of the type t12_2.
        But the layout of 'a must overlap with value
@@ -597,7 +594,7 @@ end;;
 Line 2, characters 13-15:
 2 |   method x : 'a t_bits32_id -> 'a t_bits32_id = assert false
                  ^^
-Error: This type ('a : bits32) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : bits32)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with bits32
@@ -647,7 +644,7 @@ end
 Line 2, characters 10-12:
 2 |   val x : 'a t_bits32_id -> 'a t_bits32_id
               ^^
-Error: This type ('a : bits32) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : bits32)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with bits32

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -176,7 +176,7 @@ type ('a : bits64) t4_6 = 'a * 'a
 Line 1, characters 26-28:
 1 | type ('a : bits64) t4_6 = 'a * 'a
                               ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits64)
+Error: Tuple element types must have layout value.
        The layout of 'a is bits64
          because of the annotation on 'a in the declaration of the type t4_6.
        But the layout of 'a must overlap with value
@@ -186,15 +186,14 @@ Error: This type ('a : value) should be an instance of type ('a0 : bits64)
 (* check for layout propagation *)
 type ('a : bits64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
 [%%expect{|
-Line 1, characters 31-33:
+Line 1, characters 45-47:
 1 | type ('a : bits64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
-                                   ^^
-Error: This type ('b : value) should be an instance of type ('a : bits64)
+                                                 ^^
+Error: Tuple element types must have layout value.
        The layout of 'a is bits64
          because of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value
-         because it instantiates an unannotated type parameter of t4_7,
-         defaulted to layout value.
+         because it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -371,7 +370,7 @@ type ('a : bits64) f7_5 = [ `A of 'a ];;
 Line 1, characters 34-36:
 1 | type ('a : bits64) f7_5 = [ `A of 'a ];;
                                       ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits64)
+Error: Polymorphic variant constructor argument types must have layout value.
        The layout of 'a is bits64
          because of the annotation on 'a in the declaration of the type f7_5.
        But the layout of 'a must overlap with value
@@ -578,10 +577,10 @@ Error: Object field types must have layout value.
 
 type ('a : bits64) t12_2 = < x : 'a >;;
 [%%expect{|
-Line 1, characters 33-35:
+Line 1, characters 29-35:
 1 | type ('a : bits64) t12_2 = < x : 'a >;;
-                                     ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits64)
+                                 ^^^^^^
+Error: Object field types must have layout value.
        The layout of 'a is bits64
          because of the annotation on 'a in the declaration of the type t12_2.
        But the layout of 'a must overlap with value
@@ -608,7 +607,7 @@ end;;
 Line 2, characters 13-15:
 2 |   method x : 'a t_bits64_id -> 'a t_bits64_id = assert false
                  ^^
-Error: This type ('a : bits64) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : bits64)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with bits64
@@ -658,7 +657,7 @@ end
 Line 2, characters 10-12:
 2 |   val x : 'a t_bits64_id -> 'a t_bits64_id
               ^^
-Error: This type ('a : bits64) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : bits64)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with bits64

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
@@ -174,8 +174,7 @@ type ('a : bits64) t4_6 = 'a * 'a
 Line 1, characters 26-28:
 1 | type ('a : bits64) t4_6 = 'a * 'a
                               ^^
-Error: This type ('a : value_or_null) should be an instance of type
-         ('a0 : bits64)
+Error: Tuple element types must have layout value.
        The layout of 'a is bits64
          because of the annotation on 'a in the declaration of the type t4_6.
        But the layout of 'a must overlap with value
@@ -185,15 +184,14 @@ Error: This type ('a : value_or_null) should be an instance of type
 (* check for layout propagation *)
 type ('a : bits64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
 [%%expect{|
-Line 1, characters 31-33:
+Line 1, characters 45-47:
 1 | type ('a : bits64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
-                                   ^^
-Error: This type ('b : value) should be an instance of type ('a : bits64)
+                                                 ^^
+Error: Tuple element types must have layout value.
        The layout of 'a is bits64
          because of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value
-         because it instantiates an unannotated type parameter of t4_7,
-         defaulted to layout value.
+         because it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -361,8 +359,7 @@ type ('a : bits64) f7_5 = [ `A of 'a ];;
 Line 1, characters 34-36:
 1 | type ('a : bits64) f7_5 = [ `A of 'a ];;
                                       ^^
-Error: This type ('a : value_or_null) should be an instance of type
-         ('a0 : bits64)
+Error: Polymorphic variant constructor argument types must have layout value.
        The layout of 'a is bits64
          because of the annotation on 'a in the declaration of the type f7_5.
        But the layout of 'a must overlap with value
@@ -569,10 +566,10 @@ Error: Object field types must have layout value.
 
 type ('a : bits64) t12_2 = < x : 'a >;;
 [%%expect{|
-Line 1, characters 33-35:
+Line 1, characters 29-35:
 1 | type ('a : bits64) t12_2 = < x : 'a >;;
-                                     ^^
-Error: This type ('a : value) should be an instance of type ('a0 : bits64)
+                                 ^^^^^^
+Error: Object field types must have layout value.
        The layout of 'a is bits64
          because of the annotation on 'a in the declaration of the type t12_2.
        But the layout of 'a must overlap with value
@@ -599,7 +596,7 @@ end;;
 Line 2, characters 13-15:
 2 |   method x : 'a t_bits64_id -> 'a t_bits64_id = assert false
                  ^^
-Error: This type ('a : bits64) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : bits64)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with bits64
@@ -649,7 +646,7 @@ end
 Line 2, characters 10-12:
 2 |   val x : 'a t_bits64_id -> 'a t_bits64_id
               ^^
-Error: This type ('a : bits64) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : bits64)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with bits64

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/annots.ml
@@ -32,7 +32,7 @@ type ('a : void) t = 'a value
 Line 1, characters 21-23:
 1 | type ('a : void) t = 'a value
                          ^^
-Error: This type ('a : value) should be an instance of type ('a0 : void)
+Error: This type ('a : void) should be an instance of type ('b : value)
        The layout of 'a is void
          because of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must overlap with value

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/value.ml
@@ -346,7 +346,7 @@ end
 Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
-Error: This type ('a : void) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : void)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with void

--- a/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
@@ -174,7 +174,7 @@ type ('a : float32) t4_6 = 'a * 'a
 Line 1, characters 27-29:
 1 | type ('a : float32) t4_6 = 'a * 'a
                                ^^
-Error: This type ('a : value) should be an instance of type ('a0 : float32)
+Error: Tuple element types must have layout value.
        The layout of 'a is float32
          because of the annotation on 'a in the declaration of the type t4_6.
        But the layout of 'a must overlap with value
@@ -184,15 +184,14 @@ Error: This type ('a : value) should be an instance of type ('a0 : float32)
 (* check for layout propagation *)
 type ('a : float32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
 [%%expect{|
-Line 1, characters 32-34:
+Line 1, characters 46-48:
 1 | type ('a : float32, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
-                                    ^^
-Error: This type ('b : value) should be an instance of type ('a : float32)
+                                                  ^^
+Error: Tuple element types must have layout value.
        The layout of 'a is float32
          because of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value
-         because it instantiates an unannotated type parameter of t4_7,
-         defaulted to layout value.
+         because it's the type of a tuple element.
 |}]
 
 (*****************************************)
@@ -393,7 +392,7 @@ type ('a : float32) f7_5 = [ `A of 'a ];;
 Line 1, characters 35-37:
 1 | type ('a : float32) f7_5 = [ `A of 'a ];;
                                        ^^
-Error: This type ('a : value) should be an instance of type ('a0 : float32)
+Error: Polymorphic variant constructor argument types must have layout value.
        The layout of 'a is float32
          because of the annotation on 'a in the declaration of the type f7_5.
        But the layout of 'a must overlap with value
@@ -624,10 +623,10 @@ Error: Object field types must have layout value.
 
 type ('a : float32) t12_2 = < x : 'a >;;
 [%%expect{|
-Line 1, characters 34-36:
+Line 1, characters 30-36:
 1 | type ('a : float32) t12_2 = < x : 'a >;;
-                                      ^^
-Error: This type ('a : value) should be an instance of type ('a0 : float32)
+                                  ^^^^^^
+Error: Object field types must have layout value.
        The layout of 'a is float32
          because of the annotation on 'a in the declaration of the type t12_2.
        But the layout of 'a must overlap with value
@@ -654,7 +653,7 @@ end;;
 Line 2, characters 13-15:
 2 |   method x : 'a t_float32_id -> 'a t_float32_id = assert false
                  ^^
-Error: This type ('a : float32) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : float32)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with float32
@@ -705,7 +704,7 @@ end
 Line 2, characters 10-12:
 2 |   val x : 'a t_float32_id -> 'a t_float32_id
               ^^
-Error: This type ('a : float32) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : float32)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with float32

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -174,7 +174,7 @@ type ('a : float64) t4_6 = 'a * 'a
 Line 1, characters 27-29:
 1 | type ('a : float64) t4_6 = 'a * 'a
                                ^^
-Error: This type ('a : value) should be an instance of type ('a0 : float64)
+Error: Tuple element types must have layout value.
        The layout of 'a is float64
          because of the annotation on 'a in the declaration of the type t4_6.
        But the layout of 'a must overlap with value
@@ -184,15 +184,14 @@ Error: This type ('a : value) should be an instance of type ('a0 : float64)
 (* check for layout propagation *)
 type ('a : float64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
 [%%expect{|
-Line 1, characters 32-34:
+Line 1, characters 46-48:
 1 | type ('a : float64, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
-                                    ^^
-Error: This type ('b : value) should be an instance of type ('a : float64)
+                                                  ^^
+Error: Tuple element types must have layout value.
        The layout of 'a is float64
          because of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value
-         because it instantiates an unannotated type parameter of t4_7,
-         defaulted to layout value.
+         because it's the type of a tuple element.
 |}]
 
 (*****************************************)
@@ -398,7 +397,7 @@ type ('a : float64) f7_5 = [ `A of 'a ];;
 Line 1, characters 35-37:
 1 | type ('a : float64) f7_5 = [ `A of 'a ];;
                                        ^^
-Error: This type ('a : value) should be an instance of type ('a0 : float64)
+Error: Polymorphic variant constructor argument types must have layout value.
        The layout of 'a is float64
          because of the annotation on 'a in the declaration of the type f7_5.
        But the layout of 'a must overlap with value
@@ -633,10 +632,10 @@ Error: Object field types must have layout value.
 
 type ('a : float64) t12_2 = < x : 'a >;;
 [%%expect{|
-Line 1, characters 34-36:
+Line 1, characters 30-36:
 1 | type ('a : float64) t12_2 = < x : 'a >;;
-                                      ^^
-Error: This type ('a : value) should be an instance of type ('a0 : float64)
+                                  ^^^^^^
+Error: Object field types must have layout value.
        The layout of 'a is float64
          because of the annotation on 'a in the declaration of the type t12_2.
        But the layout of 'a must overlap with value
@@ -663,7 +662,7 @@ end;;
 Line 2, characters 13-15:
 2 |   method x : 'a t_float64_id -> 'a t_float64_id = assert false
                  ^^
-Error: This type ('a : float64) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : float64)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with float64
@@ -713,7 +712,7 @@ end
 Line 2, characters 10-12:
 2 |   val x : 'a t_float64_id -> 'a t_float64_id
               ^^
-Error: This type ('a : float64) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : float64)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with float64

--- a/ocaml/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -134,7 +134,7 @@ type ('a : float64) t = 'a or_null [@@or_null_reexport]
 Line 1, characters 24-26:
 1 | type ('a : float64) t = 'a or_null [@@or_null_reexport]
                             ^^
-Error: This type ('a : value) should be an instance of type ('a0 : float64)
+Error: This type ('a : float64) should be an instance of type ('b : value)
        The layout of 'a is float64
          because of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must overlap with value

--- a/ocaml/testsuite/tests/typing-layouts-word/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics.ml
@@ -176,7 +176,7 @@ type ('a : word) t4_6 = 'a * 'a
 Line 1, characters 24-26:
 1 | type ('a : word) t4_6 = 'a * 'a
                             ^^
-Error: This type ('a : value) should be an instance of type ('a0 : word)
+Error: Tuple element types must have layout value.
        The layout of 'a is word
          because of the annotation on 'a in the declaration of the type t4_6.
        But the layout of 'a must overlap with value
@@ -186,15 +186,14 @@ Error: This type ('a : value) should be an instance of type ('a0 : word)
 (* check for layout propagation *)
 type ('a : word, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
 [%%expect{|
-Line 1, characters 29-31:
+Line 1, characters 43-45:
 1 | type ('a : word, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
-                                 ^^
-Error: This type ('b : value) should be an instance of type ('a : word)
+                                               ^^
+Error: Tuple element types must have layout value.
        The layout of 'a is word
          because of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value
-         because it instantiates an unannotated type parameter of t4_7,
-         defaulted to layout value.
+         because it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -370,7 +369,7 @@ type ('a : word) f7_5 = [ `A of 'a ];;
 Line 1, characters 32-34:
 1 | type ('a : word) f7_5 = [ `A of 'a ];;
                                     ^^
-Error: This type ('a : value) should be an instance of type ('a0 : word)
+Error: Polymorphic variant constructor argument types must have layout value.
        The layout of 'a is word
          because of the annotation on 'a in the declaration of the type f7_5.
        But the layout of 'a must overlap with value
@@ -576,10 +575,10 @@ Error: Object field types must have layout value.
 
 type ('a : word) t12_2 = < x : 'a >;;
 [%%expect{|
-Line 1, characters 31-33:
+Line 1, characters 27-33:
 1 | type ('a : word) t12_2 = < x : 'a >;;
-                                   ^^
-Error: This type ('a : value) should be an instance of type ('a0 : word)
+                               ^^^^^^
+Error: Object field types must have layout value.
        The layout of 'a is word
          because of the annotation on 'a in the declaration of the type t12_2.
        But the layout of 'a must overlap with value
@@ -605,7 +604,7 @@ end;;
 Line 2, characters 13-15:
 2 |   method x : 'a t_word_id -> 'a t_word_id = assert false
                  ^^
-Error: This type ('a : word) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : word)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with word
@@ -656,7 +655,7 @@ end
 Line 2, characters 10-12:
 2 |   val x : 'a t_word_id -> 'a t_word_id
               ^^
-Error: This type ('a : word) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : word)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with word

--- a/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
@@ -174,8 +174,7 @@ type ('a : word) t4_6 = 'a * 'a
 Line 1, characters 24-26:
 1 | type ('a : word) t4_6 = 'a * 'a
                             ^^
-Error: This type ('a : value_or_null) should be an instance of type
-         ('a0 : word)
+Error: Tuple element types must have layout value.
        The layout of 'a is word
          because of the annotation on 'a in the declaration of the type t4_6.
        But the layout of 'a must overlap with value
@@ -185,15 +184,14 @@ Error: This type ('a : value_or_null) should be an instance of type
 (* check for layout propagation *)
 type ('a : word, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
 [%%expect{|
-Line 1, characters 29-31:
+Line 1, characters 43-45:
 1 | type ('a : word, 'b) t4_7 = ('a as 'b) -> ('b * 'b);;
-                                 ^^
-Error: This type ('b : value) should be an instance of type ('a : word)
+                                               ^^
+Error: Tuple element types must have layout value.
        The layout of 'a is word
          because of the annotation on 'a in the declaration of the type t4_7.
        But the layout of 'a must overlap with value
-         because it instantiates an unannotated type parameter of t4_7,
-         defaulted to layout value.
+         because it's the type of a tuple element.
 |}]
 
 (****************************************************)
@@ -360,8 +358,7 @@ type ('a : word) f7_5 = [ `A of 'a ];;
 Line 1, characters 32-34:
 1 | type ('a : word) f7_5 = [ `A of 'a ];;
                                     ^^
-Error: This type ('a : value_or_null) should be an instance of type
-         ('a0 : word)
+Error: Polymorphic variant constructor argument types must have layout value.
        The layout of 'a is word
          because of the annotation on 'a in the declaration of the type f7_5.
        But the layout of 'a must overlap with value
@@ -567,10 +564,10 @@ Error: Object field types must have layout value.
 
 type ('a : word) t12_2 = < x : 'a >;;
 [%%expect{|
-Line 1, characters 31-33:
+Line 1, characters 27-33:
 1 | type ('a : word) t12_2 = < x : 'a >;;
-                                   ^^
-Error: This type ('a : value) should be an instance of type ('a0 : word)
+                               ^^^^^^
+Error: Object field types must have layout value.
        The layout of 'a is word
          because of the annotation on 'a in the declaration of the type t12_2.
        But the layout of 'a must overlap with value
@@ -596,7 +593,7 @@ end;;
 Line 2, characters 13-15:
 2 |   method x : 'a t_word_id -> 'a t_word_id = assert false
                  ^^
-Error: This type ('a : word) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : word)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with word
@@ -647,7 +644,7 @@ end
 Line 2, characters 10-12:
 2 |   val x : 'a t_word_id -> 'a t_word_id
               ^^
-Error: This type ('a : word) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : word)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with word

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -1142,7 +1142,7 @@ end
 Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
-Error: This type ('a : float64) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : float64)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with float64
@@ -1161,7 +1161,7 @@ end;;
 Line 6, characters 26-28:
 6 |       method void_id (a : 'a t) : 'a t = a
                               ^^
-Error: This type ('a : float64) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : float64)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with float64
@@ -1181,7 +1181,7 @@ end;;
 Line 5, characters 4-6:
 5 |     'a t ->
         ^^
-Error: This type ('a : float64) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : float64)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with float64
@@ -1777,7 +1777,7 @@ let f #poly_var = "hello"
 Line 1, characters 44-46:
 1 | type ('a : float64) poly_var = [`A of int * 'a | `B]
                                                 ^^
-Error: This type ('a : value) should be an instance of type ('a0 : float64)
+Error: Tuple element types must have layout value.
        The layout of 'a is float64
          because of the annotation on 'a in the declaration of the type
                                       poly_var.

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -954,7 +954,7 @@ end
 Line 6, characters 24-26:
 6 |       val virtual baz : 'a t
                             ^^
-Error: This type ('a : void) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : void)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with void
@@ -973,7 +973,7 @@ end;;
 Line 6, characters 29-31:
 6 |       method void_id (A a) : 'a t = a
                                  ^^
-Error: This type ('a : void) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : void)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with void
@@ -993,7 +993,7 @@ end;;
 Line 5, characters 4-6:
 5 |     'a t ->
         ^^
-Error: This type ('a : void) should be an instance of type ('a0 : value)
+Error: This type ('a : value) should be an instance of type ('b : void)
        The layout of 'a is value
          because it's a type argument to a class constructor.
        But the layout of 'a must overlap with void
@@ -1748,8 +1748,7 @@ let f #poly_var = "hello"
 Line 1, characters 41-43:
 1 | type ('a : void) poly_var = [`A of int * 'a | `B]
                                              ^^
-Error: This type ('a : value_or_null) should be an instance of type
-         ('a0 : void)
+Error: Tuple element types must have layout value.
        The layout of 'a is void
          because of the annotation on 'a in the declaration of the type
                                       poly_var.

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -1270,14 +1270,14 @@ type ('a : bits32 mod global unique) t = 'a
 
 type ('a : bits32) t = ('a : word)
 [%%expect {|
-Line 1, characters 23-34:
+Line 1, characters 29-33:
 1 | type ('a : bits32) t = ('a : word)
-                           ^^^^^^^^^^^
-Error: This type ('a : word) should be an instance of type ('a0 : bits32)
-       The layout of 'a is bits32
-         because of the annotation on 'a in the declaration of the type t.
-       But the layout of 'a must overlap with word
-         because of the annotation on the type variable 'a.
+                                 ^^^^
+Error: Bad layout annotation:
+         The layout of 'a is bits32
+           because of the annotation on 'a in the declaration of the type t.
+         But the layout of 'a must overlap with word
+           because of the annotation on the type variable 'a.
 |}]
 
 let f : ('a : any mod global unique) -> ('a: any mod uncontended) = fun x -> x

--- a/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts/parsing_alpha.compilers.reference
@@ -3,7 +3,7 @@ type ('a : immediate) t0 = 'a list
 Line 2, characters 22-24:
 2 | type ('a : void) t0 = 'a list;;
                           ^^
-Error: This type ('a : value) should be an instance of type ('a0 : void)
+Error: This type ('a : void) should be an instance of type ('b : value)
        The layout of 'a is void
          because of the annotation on 'a in the declaration of the type t0.
        But the layout of 'a must overlap with value


### PR DESCRIPTION
A simple fix for jkind assignment for type variables, which cleans up many error messages and is necessary for higher jkinds to work later down the line.

When type parameters are encountered within `Typetexp.transl_type_var`, their jkind is initialised anew, even when an annotation is available. This PR looks up whether a parameter of the same name had an annotation and uses that instead. 
This is fine as the type variable itself is still initialised as distinct, but we know the jkinds will be consistent across all instances.
