### PR TITLE
Fix ocamlformat CI

### DIFF
--- a/middle_end/flambda2/algorithms/container_types.ml
+++ b/middle_end/flambda2/algorithms/container_types.ml
@@ -14,6 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+
 include Container_types_intf
 
 module Pair (A : Thing) (B : Thing) : Thing with type t = A.t * B.t = struct


### PR DESCRIPTION
The ocamlformat CI doesn't actually detect poorly formatted files in the flambda2 and cfg codebases. 