### PR TITLE
Extra args for continuations should be computed after restore_continuation_context

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -546,13 +546,13 @@ let restore_continuation_context_for_switch_arm env cont =
     continuation_closing_region
 
 let apply_cont_with_extra_args acc env ccenv ~dbg cont traps args =
-  let extra_args =
-    List.map
-      (fun var : IR.simple -> Var var)
-      (Env.extra_args_for_continuation env cont)
-  in
   restore_continuation_context acc env ccenv cont
     ~close_current_region_early:false (fun acc ccenv cont ->
+      let extra_args =
+        List.map
+          (fun var : IR.simple -> Var var)
+          (Env.extra_args_for_continuation env cont)
+      in
       CC.close_apply_cont acc ~dbg ccenv cont traps (args @ extra_args))
 
 let wrap_return_continuation acc env ccenv (apply : IR.apply) =
@@ -1774,12 +1774,12 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
         match action with
         | Lvar var ->
           assert (not (Env.is_mutable env var));
+          let k = restore_continuation_context_for_switch_arm env k in
           let extra_args =
             List.map
               (fun arg : IR.simple -> Var arg)
               (Env.extra_args_for_continuation env k)
           in
-          let k = restore_continuation_context_for_switch_arm env k in
           let consts_rev =
             ( arm,
               k,
@@ -1790,12 +1790,12 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
           in
           consts_rev, wrappers
         | Lconst cst ->
+          let k = restore_continuation_context_for_switch_arm env k in
           let extra_args =
             List.map
               (fun arg : IR.simple -> Var arg)
               (Env.extra_args_for_continuation env k)
           in
-          let k = restore_continuation_context_for_switch_arm env k in
           let consts_rev =
             (arm, k, Debuginfo.none, None, IR.Const cst :: extra_args)
             :: consts_rev

--- a/ocaml/testsuite/tests/typing-local/pr2848.ml
+++ b/ocaml/testsuite/tests/typing-local/pr2848.ml
@@ -1,0 +1,10 @@
+(* TEST *)
+
+let f (x : int) y =
+  let h (y : int) =
+    let _ = local_ (x, y) in
+    if y < 42 then failwith "foo"
+  in
+  let _m = ref 42 in
+  let l = local_ (x, x) in
+  h (fst l)

--- a/ocaml/testsuite/tests/typing-local/pr2848.ml
+++ b/ocaml/testsuite/tests/typing-local/pr2848.ml
@@ -1,7 +1,7 @@
 (* TEST *)
 
 let f (x : int) y =
-  let h (y : int) =
+  let[@local always] h (y : int) =
     let _ = local_ (x, y) in
     if y < 42 then failwith "foo"
   in


### PR DESCRIPTION
IMPORTANT: I think this PR fixes an error in lambda_to_flambda, but I am not sure about that and it needs a careful review.

Currently when generating an `apply_cont` in lambda_to_flambda, we first compute the extra args before calling `restore_continuation_context`, which can change the continuation being called and thus the extra args that are needed. It seems to me it should be the other way around, but there could be subtleties I'm missing.

Unfortunately, the only way I know to trigger the bug is to use a WIP version of unboxed products, in which the strange treatment we currently have of those (passing them to every continuation like mutable variables) has not been undone, which is available here: https://github.com/Ekdohibs/flambda-backend/commit/0abdaa8b1e3c6ef3dfbbb5fbe0926bcff8c63854 .

With that commit and `-extension layouts_beta` options, this program (found by @ccasin) crashes flambda due to continuations with incorrect number of arguments, while it works with this commit on top:
```ocaml
let rec f6_2 n (tup : #(int * int)) =
  if (Sys.opaque_identity fst) n = 0 then tup
  else tup
```
I tried to produce a similar version with mutable variables, but have not succeeded yet.