### PR TITLE
An array of iarrays is an addr array, not a genarray

### DIFF
--- a/ocaml/testsuite/tests/lib-array/test_iarray_typeopt.ml
+++ b/ocaml/testsuite/tests/lib-array/test_iarray_typeopt.ml
@@ -1,0 +1,12 @@
+(* TEST
+   flags = "-dlambda";
+   expect;
+*)
+
+let _ = [: [: :] :];;
+
+[%%expect {|
+(makearray_imm[gen] (makearray_imm[gen]))
+- : 'a iarray iarray = [:[::]:]
+|}]
+

--- a/ocaml/testsuite/tests/lib-array/test_iarray_typeopt.ml
+++ b/ocaml/testsuite/tests/lib-array/test_iarray_typeopt.ml
@@ -3,10 +3,21 @@
    expect;
 *)
 
+(* Regression test showing that an [i]array of iarrays
+   has element kind [addr].
+ *)
+
 let _ = [: [: :] :];;
 
 [%%expect {|
-(makearray_imm[gen] (makearray_imm[gen]))
+(makearray_imm[addr] (makearray_imm[gen]))
 - : 'a iarray iarray = [:[::]:]
+|}]
+
+let _ = [| [: :] |];;
+
+[%%expect {|
+(makearray[addr] (makearray_imm[gen]))
+- : '_weak1 iarray array = [|[::]|]
 |}]
 

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -136,6 +136,7 @@ let classify env loc ty sort : classification =
       else if Path.same p Predef.path_string
            || Path.same p Predef.path_bytes
            || Path.same p Predef.path_array
+           || Path.same p Predef.path_iarray
            || Path.same p Predef.path_nativeint
            || Path.same p Predef.path_float32
            || Path.same p Predef.path_int32


### PR DESCRIPTION
As title. This helps the optimizer elide "is it a float?" checks when operating over arrays of iarrays (and iarrays of iarrays).

The first commit adds a regression test that shows the old output, and the second commit fixes the omission that led to the bug.