### PR TITLE
Make all register allocation parameters optional

### DIFF
--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -49,6 +49,8 @@ module Priority_heuristics = struct
     | Interval_length
     | Random_for_testing
 
+  let default = Interval_length
+
   let all = [Interval_length; Random_for_testing]
 
   let to_string = function
@@ -64,11 +66,7 @@ module Priority_heuristics = struct
     in
     lazy
       (match find_param_value "GI_PRIORITY_HEURISTICS" with
-      | None ->
-        fatal
-          "the GI_PRIORITY_HEURISTICS parameter is not set (possible values: \
-           %s)"
-          (available_heuristics ())
+      | None -> default
       | Some id -> (
         match String.lowercase_ascii id with
         | "interval_length" | "interval-length" -> Interval_length
@@ -85,6 +83,8 @@ module Selection_heuristics = struct
     | Best_fit
     | Worst_fit
     | Random_for_testing
+
+  let default = First_available
 
   let all = [First_available; Best_fit; Worst_fit; Random_for_testing]
 
@@ -110,11 +110,7 @@ module Selection_heuristics = struct
     in
     lazy
       (match find_param_value "GI_SELECTION_HEURISTICS" with
-      | None ->
-        fatal
-          "the GI_SELECTION_HEURISTICS parameter is not set (possible values: \
-           %s)"
-          (available_heuristics ())
+      | None -> default
       | Some id -> (
         match String.lowercase_ascii id with
         | "first_available" | "first-available" -> First_available
@@ -132,6 +128,8 @@ module Spilling_heuristics = struct
     | Hierarchical_uses
     | Random_for_testing
 
+  let default = Flat_uses
+
   let all = [Flat_uses; Hierarchical_uses; Random_for_testing]
 
   let to_string = function
@@ -148,11 +146,7 @@ module Spilling_heuristics = struct
     in
     lazy
       (match find_param_value "GI_SPILLING_HEURISTICS" with
-      | None ->
-        fatal
-          "the GI_SPILLING_HEURISTICS parameter is not set (possible values: \
-           %s)"
-          (available_heuristics ())
+      | None -> default
       | Some id -> (
         match String.lowercase_ascii id with
         | "flat_uses" | "flat-uses" -> Flat_uses

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -167,6 +167,8 @@ module Spilling_heuristics = struct
     | Flat_uses
     | Hierarchical_uses
 
+  let default = Flat_uses
+
   let all = [Set_choose; Flat_uses; Hierarchical_uses]
 
   let to_string = function
@@ -181,11 +183,7 @@ module Spilling_heuristics = struct
     in
     lazy
       (match find_param_value "IRC_SPILLING_HEURISTICS" with
-      | None ->
-        fatal
-          "the IRC_SPILLING_HEURISTICS parameter is not set (possible values: \
-           %s)"
-          (available_heuristics ())
+      | None -> default
       | Some id -> (
         match String.lowercase_ascii id with
         | "set_choose" | "set-choose" -> Set_choose


### PR DESCRIPTION
As per title.

(Having mandatory parameters is useful for
the developer, ensuring everything is explicit
set, but of course this instead puts the burden
on the user.)