### PR TITLE
Bump magic numbers for 5.1.1minus-20

### DIFF
--- a/ocaml/runtime/caml/exec.h
+++ b/ocaml/runtime/caml/exec.h
@@ -60,7 +60,7 @@ struct exec_trailer {
 
 /* Magic number for this release */
 
-#define EXEC_MAGIC "Caml1999X533"
+#define EXEC_MAGIC "Caml1999X534"
 
 #endif /* CAML_INTERNALS */
 

--- a/ocaml/runtime4/caml/exec.h
+++ b/ocaml/runtime4/caml/exec.h
@@ -60,7 +60,7 @@ struct exec_trailer {
 
 /* Magic number for this release */
 
-#define EXEC_MAGIC "Caml1999X533"
+#define EXEC_MAGIC "Caml1999X534"
 
 #endif /* CAML_INTERNALS */
 

--- a/ocaml/utils/config.common.ml
+++ b/ocaml/utils/config.common.ml
@@ -31,28 +31,28 @@ let standard_library =
 (* When artifacts are incompatible with upstream OCaml, ocaml-jst uses
    magic numbers ending in 5xx. (The AST remains
    compatible, so use upstream numbers) *)
-let exec_magic_number = "Caml1999X533"
+let exec_magic_number = "Caml1999X534"
     (* exec_magic_number is duplicated in runtime/caml/exec.h *)
-and cmi_magic_number = "Caml1999I533"
-and cmo_magic_number = "Caml1999O533"
-and cma_magic_number = "Caml1999A533"
+and cmi_magic_number = "Caml1999I534"
+and cmo_magic_number = "Caml1999O534"
+and cma_magic_number = "Caml1999A534"
 and cmx_magic_number =
   if flambda || flambda2 then
-    "Caml2021y534"
+    "Caml2021y535"
   else
-    "Caml2021Y533"
+    "Caml2021Y534"
 and cmxa_magic_number =
   if flambda || flambda2 then
-    "Caml2021z534"
+    "Caml2021z535"
   else
-    "Caml2021Z533"
-and ast_impl_magic_number = "Caml1999M533"
-and ast_intf_magic_number = "Caml1999N533"
-and cmxs_magic_number = "Caml1999D533"
-and cmt_magic_number = "Caml1999T533"
-and cms_magic_number = "Caml1999S533"
-and linear_magic_number = "Caml1999L533"
-and cfg_magic_number = "Caml2021G533"
+    "Caml2021Z534"
+and ast_impl_magic_number = "Caml1999M534"
+and ast_intf_magic_number = "Caml1999N534"
+and cmxs_magic_number = "Caml1999D534"
+and cmt_magic_number = "Caml1999T534"
+and cms_magic_number = "Caml1999S534"
+and linear_magic_number = "Caml1999L534"
+and cfg_magic_number = "Caml2021G534"
 
 let safe_string = true
 let default_safe_string = true


### PR DESCRIPTION
The tag in this case will be performed from a microbranch so that we can only include #2780. But this PR reflects the magic number bump back onto `main`.

**Please do not merge this yet.** I will merge.