### PR TITLE
Fix float32 to/of bits comments

### DIFF
--- a/ocaml/otherlibs/stdlib_beta/amd64/float32.mli
+++ b/ocaml/otherlibs/stdlib_beta/amd64/float32.mli
@@ -199,14 +199,14 @@ external to_int64 : (t[@local_opt]) -> int64
 external of_bits : (int32[@local_opt]) -> t
   = "caml_float32_of_bits_bytecode" "caml_float32_of_bits"
   [@@unboxed] [@@noalloc] [@@builtin]
-(** Convert a 32-bit float to a 32-bit integer, preserving the value's
+(** Convert a 32-bit integer to a 32-bit float, preserving the value's
     bit pattern.
     The amd64 flambda-backend compiler translates this call to MOVD. *)
 
 external to_bits : (t[@local_opt]) -> int32
   = "caml_float32_to_bits_bytecode" "caml_float32_to_bits"
   [@@unboxed] [@@noalloc] [@@builtin]
-(** Convert a 32-bit integer to a 32-bit float, preserving the value's
+(** Convert a 32-bit float to a 32-bit integer, preserving the value's
     bit pattern.
     The amd64 flambda-backend compiler translates this call to MOVD. *)
 

--- a/ocaml/otherlibs/stdlib_beta/amd64/float32_u.mli
+++ b/ocaml/otherlibs/stdlib_beta/amd64/float32_u.mli
@@ -151,12 +151,14 @@ val to_float : t -> float#
 (** Convert a 32-bit float to a 64-bit float. *)
 
 val of_bits : int32# -> t
-(** Convert a 32-bit float to a 32-bit integer, preserving the value's
-    bit pattern. *)
+(** Convert a 32-bit integer to a 32-bit float, preserving the value's
+    bit pattern.
+    The amd64 flambda-backend compiler translates this call to MOVD. *)
 
 val to_bits : t -> int32#
-(** Convert a 32-bit integer to a 32-bit float, preserving the value's
-    bit pattern. *)
+(** Convert a 32-bit float to a 32-bit integer, preserving the value's
+    bit pattern.
+    The amd64 flambda-backend compiler translates this call to MOVD. *)
 
 val of_string : string -> t
 (** Convert the given string to a float.  The string is read in decimal


### PR DESCRIPTION
The doc comments for `Float32.to_bits` and `Float32.of_bits` were flipped.