### PR TITLE
Tracking histories for higher jkinds

### DIFF
--- a/ocaml/testsuite/tests/typing-higher-jkinds/applied.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/applied.ml
@@ -57,7 +57,8 @@ Line 1, characters 9-10:
 1 | type p = t t
              ^
 Error: This type t should be an instance of type ('a : value)
-       The kind of t is ((value) => value) (...??)
+       The kind of t is ((value) => value)
+         because of the definition of t at line 1, characters 0-23.
        But the kind of t must be a subkind of value
          because of the definition of t at line 1, characters 0-23.
 |}]
@@ -115,7 +116,8 @@ Line 4, characters 10-15:
 Error: This type int s should be an instance of type ('a : value => value)
        The kind of int s is value
          because of the definition of s at line 3, characters 2-25.
-       But the kind of int s must be a subkind of ((value) => value) (...??)
+       But the kind of int s must be a subkind of ((value) => value)
+         because of the definition of r at line 2, characters 2-36.
 |}]
 
 type t : value => value

--- a/ocaml/testsuite/tests/typing-higher-jkinds/equalities.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/equalities.ml
@@ -43,7 +43,8 @@ Error: Signature mismatch:
          type a : value => value
        The kind of the first is value
          because of the definition of a at line 4, characters 2-16.
-       But the kind of the first must be a subkind of ((value) => value) (...??)
+       But the kind of the first must be a subkind of ((value) => value)
+         because of the definition of a at line 2, characters 2-25.
 |}]
 
 module M : sig
@@ -65,7 +66,8 @@ Error: Signature mismatch:
          type a : value => value
        is not included in
          type a : value
-       The kind of the first is ((value) => value) (...??)
+       The kind of the first is ((value) => value)
+         because of the definition of a at line 4, characters 2-25.
        But the kind of the first must be a subkind of value
          because of the definition of a at line 2, characters 2-16.
 |}]
@@ -98,9 +100,11 @@ Error: Signature mismatch:
          type a : value => value
        is not included in
          type a : (value, value) => value
-       The kind of the first is ((value) => value) (...??)
+       The kind of the first is ((value) => value)
+         because of the definition of a at line 4, characters 2-25.
        But the kind of the first must be a subkind of
-         ((value, value) => value) (...??)
+         ((value, value) => value)
+         because of the definition of a at line 2, characters 2-34.
 |}]
 
 module M : sig
@@ -122,8 +126,10 @@ Error: Signature mismatch:
          type a : value => any
        is not included in
          type a : value => value
-       The kind of the first is ((value) => any) (...??)
-       But the kind of the first must be a subkind of ((value) => value) (...??)
+       The kind of the first is ((value) => any)
+         because of the definition of a at line 4, characters 2-23.
+       But the kind of the first must be a subkind of ((value) => value)
+         because of the definition of a at line 2, characters 2-25.
 |}]
 
 module M : sig
@@ -154,8 +160,10 @@ Error: Signature mismatch:
          type a : value => value
        is not included in
          type a : any => value
-       The kind of the first is ((value) => value) (...??)
-       But the kind of the first must be a subkind of ((any) => value) (...??)
+       The kind of the first is ((value) => value)
+         because of the definition of a at line 4, characters 2-25.
+       But the kind of the first must be a subkind of ((any) => value)
+         because of the definition of a at line 2, characters 2-23.
 |}]
 
 module M : sig
@@ -195,6 +203,8 @@ Error: Signature mismatch:
          type a : immediate => value
        is not included in
          type a : value => value
-       The kind of the first is ((immediate) => value) (...??)
-       But the kind of the first must be a subkind of ((value) => value) (...??)
+       The kind of the first is ((immediate) => value)
+         because of the definition of a at line 4, characters 2-29.
+       But the kind of the first must be a subkind of ((value) => value)
+         because of the definition of a at line 2, characters 2-25.
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/sharp_corners.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/sharp_corners.ml
@@ -112,6 +112,14 @@ type ('a : float64) t = Foo of 'a
 type ('f : value => value) s
 let foo (x : t s) = x
 [%%expect{|
-Uncaught exception: Invalid_argument("List.combine")
-
+type ('a : float64) t = Foo of 'a
+type ('f : value => value) s
+Line 3, characters 13-14:
+3 | let foo (x : t s) = x
+                 ^
+Error: This type t should be an instance of type ('a : value => value)
+       The kind of t is ((float64) => value)
+         because of the definition of t at line 1, characters 0-33.
+       But the kind of t must be a subkind of ((value) => value)
+         because of the definition of s at line 2, characters 0-28.
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/sharp_corners.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/sharp_corners.ml
@@ -65,7 +65,8 @@ end
 Line 2, characters 2-12:
 2 |   type t = l
       ^^^^^^^^^^
-Error: The kind of type l is ((value) => value) (...??)
+Error: The kind of type l is ((value) => value)
+         because of the definition of l at line 1, characters 0-23.
        But the kind of type l must be a subkind of any
          because of the definition of t at line 2, characters 2-12.
 |}]
@@ -78,7 +79,8 @@ end
 Line 4, characters 2-12:
 4 |   type t = l
       ^^^^^^^^^^
-Error: The kind of type l is ((value) => value) (...??)
+Error: The kind of type l is ((value) => value)
+         because of the definition of l at line 1, characters 0-23.
        But the kind of type l must be a subkind of any
          because of the definition of t at line 4, characters 2-12.
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/sharp_corners.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/sharp_corners.ml
@@ -107,3 +107,11 @@ let f x = (x : int l :> l)
 Uncaught exception: Invalid_argument("List.combine")
 
 |}]
+
+type ('a : float64) t = Foo of 'a
+type ('f : value => value) s
+let foo (x : t s) = x
+[%%expect{|
+Uncaught exception: Invalid_argument("List.combine")
+
+|}]

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2126,7 +2126,10 @@ let rec jkind_of_decl_unapplied env (decl : type_declaration) =
   | 0 -> Some decl.type_jkind
   | _ when is_datatype_decl decl.type_kind ->
     Some (Jkind.of_arrow
-      ~history:decl.type_jkind.history
+      ~history:(Projection {
+        reason = Unapplied;
+        history = decl.type_jkind.history;
+        jkind = decl.type_jkind.desc })
       ~args:(List.map (type_jkind env) decl.type_params)
       ~result:decl.type_jkind)
   | _ -> None

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -889,19 +889,20 @@ let update_scope_for tr_exn scope ty =
 *)
 
 let applied_params_of_decl decl =
-  match decl.type_arity, decl.type_jkind with
+  match decl.type_arity, Jkind.get decl.type_jkind with
   | 0, Type _ -> []
-  | 0, Arrow { args; result = _ } -> List.map Btype.newgenvar args
+  | 0, Arrow { args; result = _ } ->
+    List.map Btype.newgenvar args
   | _ -> decl.type_params
 
 let applied_variance_of_decl decl =
-  match decl.type_arity, decl.type_jkind with
+  match decl.type_arity, Jkind.get decl.type_jkind with
   | 0, Type _ -> []
   | 0, Arrow { args; result = _ } -> Variance.unknown_signature ~injective:true ~arity:(List.length args)
   | _ -> decl.type_variance
 
 let applied_separability_of_decl decl =
-  match decl.type_arity, decl.type_jkind with
+  match decl.type_arity, Jkind.get decl.type_jkind with
   | 0, Type _ -> []
   | 0, Arrow { args; result = _ } -> Separability.default_signature ~arity:(List.length args)
   | _ -> decl.type_separability
@@ -2119,18 +2120,19 @@ let is_datatype_decl (k : type_decl_kind) =
   | Type_record _ | Type_variant _ | Type_open -> true
   | Type_abstract _ -> false
 
-let rec jkind_of_decl_unapplied env (decl : type_declaration) : jkind option =
+let rec jkind_of_decl_unapplied env (decl : type_declaration) =
   (* FIXME jbachurski: Shouldn't we look at type_variance and type_separability here? *)
   match decl.type_arity with
   | 0 -> Some decl.type_jkind
   | _ when is_datatype_decl decl.type_kind ->
-    Some (Arrow
-    { args = List.map (type_jkind env) decl.type_params
-    ; result = decl.type_jkind })
+    Some (Jkind.of_arrow
+      ~history:decl.type_jkind.history
+      ~args:(List.map (type_jkind env) decl.type_params)
+      ~result:decl.type_jkind)
   | _ -> None
 
-and type_jkind_for_app (app_jkind : jkind) app_arity tys : jkind option =
-  match tys, app_jkind with
+and type_jkind_for_app app_jkind app_arity tys =
+  match tys, Jkind.get app_jkind with
   | Unapplied, _ when app_arity = 0 -> Some app_jkind
   | Unapplied, _ -> None
   | Applied tys, _ when app_arity > 0 ->
@@ -2155,8 +2157,7 @@ and type_jkind_for_app_decl env decl tys =
 and type_jkind_for_app_path env path tys =
   match Env.find_type path env with
   | decl -> type_jkind_for_app_decl env decl tys
-  | exception Not_found ->
-    Some (Jkind.Type.Primitive.any ~why:(Missing_cmi path) |> Jkind.of_type_jkind)
+  | exception Not_found -> Some (Jkind.Type.Primitive.any ~why:(Missing_cmi path) |> Jkind.of_type_jkind)
 
 (* We assume here that [get_unboxed_type_representation] has already been
    called, if the type is a Tconstr.  This allows for some optimization by
@@ -2204,7 +2205,7 @@ and estimate_type_jkind env ty =
   | Tpoly (ty, _) -> estimate_type_jkind env ty
   | Tpackage _ -> Jkind (Type.Primitive.value ~why:First_class_module |> Jkind.of_type_jkind)
 
-and type_jkind env ty =
+and type_jkind env ty : Jkind.t =
   jkind_of_result (estimate_type_jkind env (get_unboxed_type_approximation env ty))
 
 (**** checking jkind relationships ****)
@@ -2387,17 +2388,19 @@ let unification_jkind_check env ty jkind =
 
 let check_and_update_generalized_ty_jkind ?name ~loc ty =
   let immediacy_check jkind =
-    let is_immediate jkind =
+    let is_immediate jkind = match Jkind.get jkind with
       (* Just check externality and layout, because that's what actually matters
          for upstream code. We check both for a known value and something that
          might turn out later to be value. This is the conservative choice. *)
-      Jkind.Type.(Externality.le (get_externality_upper_bound jkind) External64 &&
-             match get_layout jkind with
+      | Type ty ->
+      Jkind.Type.(Externality.le (get_externality_upper_bound ty) External64 &&
+             match get_layout ty with
                | Some (Sort Value) | None -> true
                | _ -> false)
+      | Arrow _ -> false
     in
     if Language_extension.erasable_extensions_only ()
-      && is_immediate jkind && not (Jkind.Type.History.has_warned jkind)
+      && is_immediate jkind && not (Jkind.History.has_warned jkind)
     then
       let id =
         match name with
@@ -2406,28 +2409,26 @@ let check_and_update_generalized_ty_jkind ?name ~loc ty =
       in
       Location.prerr_warning loc (Warnings.Incompatible_with_upstream
         (Warnings.Immediate_erasure id));
-      Jkind.Type.History.with_warning jkind
+      Jkind.History.with_warning jkind
     else jkind
   in
   let generalization_check level jkind =
     if level = generic_level then
-      Jkind.Type.History.(update_reason jkind (Generalized (name, loc)))
+      Jkind.History.(update_reason jkind (Generalized (name, loc)))
     else jkind
   in
   let rec inner ty =
     let level = get_level ty in
     if try_mark_node ty then begin
       begin match get_desc ty with
-      (* FIXME jbachurski: This just seems to be an interaction with extension levels
-         and histories *)
-      | Tvar ({ jkind = Type jkind; _ } as r) ->
+      | Tvar ({ jkind; _ } as r) ->
         let new_jkind = immediacy_check jkind in
         let new_jkind = generalization_check level new_jkind in
-        set_type_desc ty (Tvar {r with jkind = Jkind.of_type_jkind new_jkind})
-      | Tunivar ({ jkind = Type jkind; _ } as r) ->
+        set_type_desc ty (Tvar {r with jkind = new_jkind})
+      | Tunivar ({ jkind; _ } as r) ->
         let new_jkind = immediacy_check jkind in
         let new_jkind = generalization_check level new_jkind in
-        set_type_desc ty (Tunivar {r with jkind = Jkind.of_type_jkind new_jkind})
+        set_type_desc ty (Tunivar {r with jkind = new_jkind})
       | _ -> ()
       end;
       iter_type_expr inner ty

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -80,7 +80,7 @@ val newvar: ?name:string -> Jkind.t -> type_expr
 
 val new_rep_var
   : ?name:string
-  -> why:Jkind_intf.History.concrete_creation_reason
+  -> why:Jkind.History.concrete_creation_reason
   -> unit
   -> type_expr * Jkind.Type.sort
         (* Return a fresh representable variable, along with its sort *)
@@ -566,13 +566,13 @@ val type_jkind_purely : Env.t -> type_expr -> jkind
 (* Find a type's sort (constraining it to be an arbitrary sort variable, if
    needed) *)
 val type_sort :
-  why:Jkind_intf.History.concrete_creation_reason ->
+  why:Jkind.History.concrete_creation_reason ->
   Env.t -> type_expr -> (Jkind.Type.sort, Jkind.Violation.t) result
 
 (* As [type_sort], but constrain the jkind to be non-null.
    Used for checking array elements. *)
 val type_legacy_sort :
-  why:Jkind_intf.History.concrete_legacy_creation_reason ->
+  why:Jkind.History.concrete_legacy_creation_reason ->
   Env.t -> type_expr -> (Jkind.Type.sort, Jkind.Violation.t) result
 
 (* Jkind checking. [constrain_type_jkind] will update the jkind of type

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -80,7 +80,7 @@ val newvar: ?name:string -> Jkind.t -> type_expr
 
 val new_rep_var
   : ?name:string
-  -> why:Jkind.Type.History.concrete_creation_reason
+  -> why:Jkind_intf.History.concrete_creation_reason
   -> unit
   -> type_expr * Jkind.Type.sort
         (* Return a fresh representable variable, along with its sort *)
@@ -566,13 +566,13 @@ val type_jkind_purely : Env.t -> type_expr -> jkind
 (* Find a type's sort (constraining it to be an arbitrary sort variable, if
    needed) *)
 val type_sort :
-  why:Jkind.Type.History.concrete_creation_reason ->
+  why:Jkind_intf.History.concrete_creation_reason ->
   Env.t -> type_expr -> (Jkind.Type.sort, Jkind.Violation.t) result
 
 (* As [type_sort], but constrain the jkind to be non-null.
    Used for checking array elements. *)
 val type_legacy_sort :
-  why:Jkind.Type.History.concrete_legacy_creation_reason ->
+  why:Jkind_intf.History.concrete_legacy_creation_reason ->
   Env.t -> type_expr -> (Jkind.Type.sort, Jkind.Violation.t) result
 
 (* Jkind checking. [constrain_type_jkind] will update the jkind of type

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1511,7 +1511,6 @@ module Type = struct
         fprintf ppf "Generalized (%s, %a)"
           (match id with Some id -> Ident.unique_name id | None -> "")
           Location.print_loc loc
-      | Temporary -> fprintf ppf "Temporary"
 
     let project_reason ppf : History.project_reason -> _ = function
       | Arrow_argument i -> fprintf ppf "Arrow_argument %d" i
@@ -2105,7 +2104,6 @@ module Format_history = struct
       in
       fprintf ppf "of the definition%a at %a" format_id id
         Location.print_loc_in_lowercase loc
-    | Temporary -> fprintf ppf "it is an intermediate created by an operation"
 
   let format_interact_reason ppf : History.interact_reason -> _ = function
     | Gadt_equation name ->

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1542,6 +1542,8 @@ type desc = type_expr Jkind_types.Jkind_desc.t
 type nonrec t = type_expr jkind
 
 module History = struct
+  include Jkind_intf.History
+
   let has_imported_history t : bool =
     match t.history with Creation Imported -> true | _ -> false
 
@@ -2436,7 +2438,7 @@ let has_intersection t t' =
   Result.is_ok
     (intersection_or_error
      (* This reason is just used as a dummy for the test *)
-       ~reason:Jkind_intf.History.Subjkind t t')
+       ~reason:Subjkind t t')
 
 let rec check_sub (t : t) (t' : t) : Misc.Le_result.t =
   match get t, get t' with

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1514,6 +1514,7 @@ module Type = struct
     let project_reason ppf : History.project_reason -> _ = function
       | Arrow_argument i -> fprintf ppf "Arrow_argument %d" i
       | Arrow_result -> fprintf ppf "Arrow_result"
+      | Unapplied -> fprintf ppf "Unapplied"
 
     let interact_reason ppf : History.interact_reason -> _ = function
       | Gadt_equation p -> fprintf ppf "Gadt_equation %a" Path.print p
@@ -2113,6 +2114,7 @@ module Format_history = struct
   let format_project_reason ppf : History.project_reason -> _ = function
     | Arrow_argument i -> fprintf ppf "in an application at position %d to" i
     | Arrow_result -> fprintf ppf "result of an application to"
+    | Unapplied -> fprintf ppf "unapplied constructor"
 
   (* CR layouts: An older implementation of format_flattened_history existed
       which displays more information not limited to one layout and one creation_reason

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1267,6 +1267,8 @@ module Type = struct
   (*********************************)
   (* pretty printing *)
 
+  let format ppf (t : t) = Jkind_desc.format ppf t.jkind
+
   module Report_missing_cmi : sig
     (* used both in format_history and in Violation.report_general *)
     val report_missing_cmi : Format.formatter -> Path.t option -> unit

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -342,9 +342,13 @@ type t = Types.type_expr Jkind_types.t
 type desc = Types.type_expr Jkind_types.Jkind_desc.t
 
 module History : sig
+  include module type of struct
+    include Jkind_intf.History
+  end
+
   val has_imported_history : t -> bool
 
-  val update_reason : t -> Jkind_intf.History.creation_reason -> t
+  val update_reason : t -> creation_reason -> t
 
   (* Mark the jkind as having produced a compiler warning. *)
   val with_warning : t -> t
@@ -368,7 +372,7 @@ end
 
 module Primitive : sig
   (** Top element of the jkind lattice, including higher jkinds *)
-  val top : why:Jkind_intf.History.any_creation_reason -> t
+  val top : why:History.any_creation_reason -> t
 end
 
 (******************************)
@@ -379,30 +383,27 @@ val to_const : t -> Const.t option
 
 (** Create a fresh sort variable, packed into a jkind, returning both
     the resulting kind and the sort. *)
-val of_new_sort_var :
-  why:Jkind_intf.History.concrete_creation_reason -> t * Type.sort
+val of_new_sort_var : why:History.concrete_creation_reason -> t * Type.sort
 
 (** Create a fresh sort variable, packed into a jkind. *)
-val of_new_sort : why:Jkind_intf.History.concrete_creation_reason -> t
+val of_new_sort : why:History.concrete_creation_reason -> t
 
-val of_const : why:Jkind_intf.History.creation_reason -> Const.t -> t
+val of_const : why:History.creation_reason -> Const.t -> t
 
 val const_of_user_written_annotation :
-  context:Jkind_intf.History.annotation_context ->
-  Jane_syntax.Jkind.annotation ->
-  Const.t
+  context:History.annotation_context -> Jane_syntax.Jkind.annotation -> Const.t
 
 (** The typed jkind together with its user-written annotation. *)
 type annotation = Types.type_expr Jkind_types.annotation
 
 val of_annotation :
-  context:Jkind_intf.History.annotation_context ->
+  context:History.annotation_context ->
   Jane_syntax.Jkind.annotation ->
   t * annotation
 
 val of_annotation_option_default :
   default:t ->
-  context:Jkind_intf.History.annotation_context ->
+  context:History.annotation_context ->
   Jane_syntax.Jkind.annotation option ->
   t * annotation option
 
@@ -420,7 +421,7 @@ val of_annotation_option_default :
     Raises if a disallowed or unknown jkind is present.
 *)
 val of_type_decl :
-  context:Jkind_intf.History.annotation_context ->
+  context:History.annotation_context ->
   Parsetree.type_declaration ->
   (t * annotation * Parsetree.attributes) option
 
@@ -430,7 +431,7 @@ val of_type_decl :
     Raises if a disallowed or unknown jkind is present.
 *)
 val of_type_decl_default :
-  context:Jkind_intf.History.annotation_context ->
+  context:History.annotation_context ->
   default:t ->
   Parsetree.type_declaration ->
   t * annotation option * Parsetree.attributes
@@ -551,10 +552,7 @@ val has_intersection : t -> t -> bool
     it should be thought of as modifying the first jkind to be the
     intersection of the two, not something that modifies the second jkind. *)
 val intersection_or_error :
-  reason:Jkind_intf.History.interact_reason ->
-  t ->
-  t ->
-  (t, Violation.t) Result.t
+  reason:History.interact_reason -> t -> t -> (t, Violation.t) Result.t
 
 (** [sub t1 t2] says whether [t1] is a subjkind of [t2]. Might update
     either [t1] or [t2] to make their layouts equal.*)

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -328,6 +328,11 @@ module Type : sig
   val set_externality_upper_bound : t -> Externality.t -> t
 
   (*********************************)
+  (* pretty printing *)
+
+  val format : Format.formatter -> t -> unit
+
+  (*********************************)
   (* debugging *)
 
   module Debug_printers : sig

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -99,25 +99,9 @@ module Type : sig
   (** A Jkind.Type.t is a full description of the runtime representation of values
       of a given type. It includes sorts, but also the abstract top jkind
       [Any] and subjkinds of other sorts, such as [Immediate]. *)
-  type t = Types.type_expr Jkind_types.Type.t
+  type t = Types.type_expr Jkind_types.type_jkind
 
-  module History : sig
-    include module type of struct
-      include Jkind_intf.History
-    end
-
-    (* history *)
-
-    val has_imported_history : t -> bool
-
-    val update_reason : t -> creation_reason -> t
-
-    (* Mark the jkind as having produced a compiler warning. *)
-    val with_warning : t -> t
-
-    (* Whether this jkind has produced a compiler warning. *)
-    val has_warned : t -> bool
-  end
+  type desc = Types.type_expr Jkind_types.Type.Jkind_desc.t
 
   (******************************)
   (* constants *)
@@ -210,6 +194,8 @@ module Type : sig
   end
 
   module Primitive : sig
+    open Jkind_intf
+
     (** This jkind is the top of the *type* jkind lattice. All types have
       jkind [any]. But we cannot compile run-time manipulations of values of
       types with jkind [any]. *)
@@ -266,23 +252,25 @@ module Type : sig
 
   (** Create a fresh sort variable, packed into a jkind, returning both
       the resulting kind and the sort. *)
-  val of_new_sort_var : why:History.concrete_creation_reason -> t * sort
+  val of_new_sort_var :
+    why:Jkind_intf.History.concrete_creation_reason -> t * sort
 
   (** Create a fresh sort variable, packed into a jkind. *)
-  val of_new_sort : why:History.concrete_creation_reason -> t
+  val of_new_sort : why:Jkind_intf.History.concrete_creation_reason -> t
 
   (** Same as [of_new_sort_var], but the jkind is lowered to [Non_null]
     to mirror "legacy" OCaml values.
     Defaulting the sort variable produces exactly [value].  *)
   val of_new_legacy_sort_var :
-    why:History.concrete_legacy_creation_reason -> t * sort
+    why:Jkind_intf.History.concrete_legacy_creation_reason -> t * sort
 
   (** Same as [of_new_sort], but the jkind is lowered to [Non_null]
     to mirror "legacy" OCaml values.
     Defaulting the sort variable produces exactly [value].  *)
-  val of_new_legacy_sort : why:History.concrete_legacy_creation_reason -> t
+  val of_new_legacy_sort :
+    why:Jkind_intf.History.concrete_legacy_creation_reason -> t
 
-  val of_const : why:History.creation_reason -> Const.t -> t
+  val of_const : why:Jkind_intf.History.creation_reason -> Const.t -> t
 
   (** Choose an appropriate jkind for a boxed record type, given whether
       all of its fields are [void]. *)
@@ -340,19 +328,6 @@ module Type : sig
   val set_externality_upper_bound : t -> Externality.t -> t
 
   (*********************************)
-  (* pretty printing *)
-
-  val format : Format.formatter -> t -> unit
-
-  (** Format the history of this jkind: what interactions it has had and why
-      it is the jkind that it is. Might be a no-op: see [display_histories]
-      in the implementation of the [Jkind] module.
-
-      The [intro] is something like "The jkind of t is". *)
-  val format_history :
-    intro:(Format.formatter -> unit) -> Format.formatter -> t -> unit
-
-  (*********************************)
   (* debugging *)
 
   module Debug_printers : sig
@@ -364,10 +339,18 @@ end
     case is a zeroth-order kind of runtime-representable types (Jkind.Type.t). *)
 type t = Types.type_expr Jkind_types.t
 
+type desc = Types.type_expr Jkind_types.Jkind_desc.t
+
 module History : sig
   val has_imported_history : t -> bool
 
-  val update_reason : t -> Type.History.creation_reason -> t
+  val update_reason : t -> Jkind_intf.History.creation_reason -> t
+
+  (* Mark the jkind as having produced a compiler warning. *)
+  val with_warning : t -> t
+
+  (* Whether this jkind has produced a compiler warning. *)
+  val has_warned : t -> bool
 end
 
 (******************************)
@@ -385,7 +368,7 @@ end
 
 module Primitive : sig
   (** Top element of the jkind lattice, including higher jkinds *)
-  val top : why:Type.History.any_creation_reason -> t
+  val top : why:Jkind_intf.History.any_creation_reason -> t
 end
 
 (******************************)
@@ -396,15 +379,16 @@ val to_const : t -> Const.t option
 
 (** Create a fresh sort variable, packed into a jkind, returning both
     the resulting kind and the sort. *)
-val of_new_sort_var : why:Type.History.concrete_creation_reason -> t * Type.sort
+val of_new_sort_var :
+  why:Jkind_intf.History.concrete_creation_reason -> t * Type.sort
 
 (** Create a fresh sort variable, packed into a jkind. *)
-val of_new_sort : why:Type.History.concrete_creation_reason -> t
+val of_new_sort : why:Jkind_intf.History.concrete_creation_reason -> t
 
-val of_const : why:Type.History.creation_reason -> Const.t -> t
+val of_const : why:Jkind_intf.History.creation_reason -> Const.t -> t
 
 val const_of_user_written_annotation :
-  context:Type.History.annotation_context ->
+  context:Jkind_intf.History.annotation_context ->
   Jane_syntax.Jkind.annotation ->
   Const.t
 
@@ -412,13 +396,13 @@ val const_of_user_written_annotation :
 type annotation = Types.type_expr Jkind_types.annotation
 
 val of_annotation :
-  context:Type.History.annotation_context ->
+  context:Jkind_intf.History.annotation_context ->
   Jane_syntax.Jkind.annotation ->
   t * annotation
 
 val of_annotation_option_default :
   default:t ->
-  context:Type.History.annotation_context ->
+  context:Jkind_intf.History.annotation_context ->
   Jane_syntax.Jkind.annotation option ->
   t * annotation option
 
@@ -436,7 +420,7 @@ val of_annotation_option_default :
     Raises if a disallowed or unknown jkind is present.
 *)
 val of_type_decl :
-  context:Type.History.annotation_context ->
+  context:Jkind_intf.History.annotation_context ->
   Parsetree.type_declaration ->
   (t * annotation * Parsetree.attributes) option
 
@@ -446,7 +430,7 @@ val of_type_decl :
     Raises if a disallowed or unknown jkind is present.
 *)
 val of_type_decl_default :
-  context:Type.History.annotation_context ->
+  context:Jkind_intf.History.annotation_context ->
   default:t ->
   Parsetree.type_declaration ->
   t * annotation option * Parsetree.attributes
@@ -456,6 +440,10 @@ val to_type_jkind : t -> Type.t
 
 (** Convert a type jkind into a general jkind *)
 val of_type_jkind : Type.t -> t
+
+(** Construct the jkind from an arrow with a given history *)
+val of_arrow :
+  history:Types.type_expr Jkind_types.history -> args:t list -> result:t -> t
 
 (******************************)
 (* elimination and defaulting *)
@@ -563,7 +551,10 @@ val has_intersection : t -> t -> bool
     it should be thought of as modifying the first jkind to be the
     intersection of the two, not something that modifies the second jkind. *)
 val intersection_or_error :
-  reason:Type.History.interact_reason -> t -> t -> (t, Violation.t) Result.t
+  reason:Jkind_intf.History.interact_reason ->
+  t ->
+  t ->
+  (t, Violation.t) Result.t
 
 (** [sub t1 t2] says whether [t1] is a subjkind of [t2]. Might update
     either [t1] or [t2] to make their layouts equal.*)

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -306,6 +306,7 @@ module History = struct
   type project_reason =
     | Arrow_argument of int
     | Arrow_result
+    | Unapplied
 
   type interact_reason =
     | Gadt_equation of Path.t

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -302,6 +302,11 @@ module History = struct
         }
     (* [position] is 1-indexed *)
     | Generalized of Ident.t option * Location.t
+    | Temporary
+
+  type project_reason =
+    | Arrow_argument of int
+    | Arrow_result
 
   type interact_reason =
     | Gadt_equation of Path.t

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -302,7 +302,6 @@ module History = struct
         }
     (* [position] is 1-indexed *)
     | Generalized of Ident.t option * Location.t
-    | Temporary
 
   type project_reason =
     | Arrow_argument of int

--- a/ocaml/typing/jkind_types.ml
+++ b/ocaml/typing/jkind_types.ml
@@ -414,13 +414,13 @@ end
 type 'type_expr history = 'type_expr History.t
 
 type 'type_expr type_jkind =
-  { jkind : 'type_expr Type.Jkind_desc.t;
+  { desc : 'type_expr Type.Jkind_desc.t;
     history : 'type_expr history;
     has_warned : bool
   }
 
 type 'type_expr t =
-  { jkind : 'type_expr Jkind_desc.t;
+  { desc : 'type_expr Jkind_desc.t;
     history : 'type_expr history;
     has_warned : bool
   }

--- a/ocaml/typing/jkind_types.ml
+++ b/ocaml/typing/jkind_types.ml
@@ -12,36 +12,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module History = struct
-  type 'desc t =
-    | Interact of
-        { reason : Jkind_intf.History.interact_reason;
-          lhs_jkind : 'desc;
-          lhs_history : 'desc t;
-          rhs_jkind : 'desc;
-          rhs_history : 'desc t
-        }
-    | Projection of
-        { reason : Jkind_intf.History.project_reason;
-          jkind : 'desc;
-          history : 'desc t
-        }
-    | Creation of Jkind_intf.History.creation_reason
-
-  let rec desc_map f = function
-    | Interact { reason; lhs_jkind; lhs_history; rhs_jkind; rhs_history } ->
-      Interact
-        { reason;
-          lhs_jkind = f lhs_jkind;
-          lhs_history = desc_map f lhs_history;
-          rhs_jkind = f rhs_jkind;
-          rhs_history = desc_map f rhs_history
-        }
-    | Projection { reason; jkind; history } ->
-      Projection { reason; jkind = f jkind; history = desc_map f history }
-    | Creation why -> Creation why
-end
-
 module Type = struct
   module Sort = struct
     type const =
@@ -424,7 +394,24 @@ module Jkind_desc = struct
         }
 end
 
-type 'type_expr history = 'type_expr Jkind_desc.t History.t
+module History = struct
+  type 'type_expr t =
+    | Interact of
+        { reason : Jkind_intf.History.interact_reason;
+          lhs_jkind : 'type_expr Jkind_desc.t;
+          lhs_history : 'type_expr t;
+          rhs_jkind : 'type_expr Jkind_desc.t;
+          rhs_history : 'type_expr t
+        }
+    | Projection of
+        { reason : Jkind_intf.History.project_reason;
+          jkind : 'type_expr Jkind_desc.t;
+          history : 'type_expr t
+        }
+    | Creation of Jkind_intf.History.creation_reason
+end
+
+type 'type_expr history = 'type_expr History.t
 
 type 'type_expr type_jkind =
   { jkind : 'type_expr Type.Jkind_desc.t;

--- a/ocaml/typing/jkind_types.mli
+++ b/ocaml/typing/jkind_types.mli
@@ -41,6 +41,25 @@
 
    All definitions here are commented in jkind.ml or jkind.mli. *)
 
+module History : sig
+  type 'desc t =
+    | Interact of
+        { reason : Jkind_intf.History.interact_reason;
+          lhs_jkind : 'desc;
+          lhs_history : 'desc t;
+          rhs_jkind : 'desc;
+          rhs_history : 'desc t
+        }
+    | Projection of
+        { reason : Jkind_intf.History.project_reason;
+          jkind : 'desc;
+          history : 'desc t
+        }
+    | Creation of Jkind_intf.History.creation_reason
+
+  val desc_map : ('a -> 'b) -> 'a t -> 'b t
+end
+
 module Type : sig
   module Sort : sig
     (* We need to expose these details for use in [Jkind] *)
@@ -135,22 +154,6 @@ module Type : sig
       }
   end
 
-  type 'type_expr history =
-    | Interact of
-        { reason : Jkind_intf.History.interact_reason;
-          lhs_jkind : 'type_expr Jkind_desc.t;
-          lhs_history : 'type_expr history;
-          rhs_jkind : 'type_expr Jkind_desc.t;
-          rhs_history : 'type_expr history
-        }
-    | Creation of Jkind_intf.History.creation_reason
-
-  type 'type_expr t =
-    { jkind : 'type_expr Jkind_desc.t;
-      history : 'type_expr history;
-      has_warned : bool
-    }
-
   module Const : sig
     type 'type_expr t =
       { layout : Layout.Const.t;
@@ -163,12 +166,28 @@ module Type : sig
   type 'type_expr annotation = 'type_expr Const.t * Jane_syntax.Jkind.annotation
 end
 
+module Jkind_desc : sig
+  type 'type_expr t =
+    | Type of 'type_expr Type.Jkind_desc.t
+    | Arrow of
+        { args : 'type_expr t list;
+          result : 'type_expr t
+        }
+end
+
+type 'type_expr history = 'type_expr Jkind_desc.t History.t
+
+type 'type_expr type_jkind =
+  { jkind : 'type_expr Type.Jkind_desc.t;
+    history : 'type_expr history;
+    has_warned : bool
+  }
+
 type 'type_expr t =
-  | Type of 'type_expr Type.t
-  | Arrow of
-      { args : 'type_expr t list;
-        result : 'type_expr t
-      }
+  { jkind : 'type_expr Jkind_desc.t;
+    history : 'type_expr history;
+    has_warned : bool
+  }
 
 module Const : sig
   type 'type_expr t =

--- a/ocaml/typing/jkind_types.mli
+++ b/ocaml/typing/jkind_types.mli
@@ -176,13 +176,13 @@ end
 type 'type_expr history = 'type_expr History.t
 
 type 'type_expr type_jkind =
-  { jkind : 'type_expr Type.Jkind_desc.t;
+  { desc : 'type_expr Type.Jkind_desc.t;
     history : 'type_expr history;
     has_warned : bool
   }
 
 type 'type_expr t =
-  { jkind : 'type_expr Jkind_desc.t;
+  { desc : 'type_expr Jkind_desc.t;
     history : 'type_expr history;
     has_warned : bool
   }

--- a/ocaml/typing/jkind_types.mli
+++ b/ocaml/typing/jkind_types.mli
@@ -41,25 +41,6 @@
 
    All definitions here are commented in jkind.ml or jkind.mli. *)
 
-module History : sig
-  type 'desc t =
-    | Interact of
-        { reason : Jkind_intf.History.interact_reason;
-          lhs_jkind : 'desc;
-          lhs_history : 'desc t;
-          rhs_jkind : 'desc;
-          rhs_history : 'desc t
-        }
-    | Projection of
-        { reason : Jkind_intf.History.project_reason;
-          jkind : 'desc;
-          history : 'desc t
-        }
-    | Creation of Jkind_intf.History.creation_reason
-
-  val desc_map : ('a -> 'b) -> 'a t -> 'b t
-end
-
 module Type : sig
   module Sort : sig
     (* We need to expose these details for use in [Jkind] *)
@@ -175,7 +156,24 @@ module Jkind_desc : sig
         }
 end
 
-type 'type_expr history = 'type_expr Jkind_desc.t History.t
+module History : sig
+  type 'type_expr t =
+    | Interact of
+        { reason : Jkind_intf.History.interact_reason;
+          lhs_jkind : 'type_expr Jkind_desc.t;
+          lhs_history : 'type_expr t;
+          rhs_jkind : 'type_expr Jkind_desc.t;
+          rhs_history : 'type_expr t
+        }
+    | Projection of
+        { reason : Jkind_intf.History.project_reason;
+          jkind : 'type_expr Jkind_desc.t;
+          history : 'type_expr t
+        }
+    | Creation of Jkind_intf.History.creation_reason
+end
+
+type 'type_expr history = 'type_expr History.t
 
 type 'type_expr type_jkind =
   { jkind : 'type_expr Type.Jkind_desc.t;

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1283,8 +1283,8 @@ let out_jkind_of_user_jkind (jkind : Jane_syntax.Jkind.annotation) =
 let out_jkind_of_const_jkind jkind =
   Ojkind_const (Jkind.Type.Const.to_out_jkind_const jkind)
 
-let rec out_jkind_of_jkind ~sort_var_names t =
-  match Jkind.get t with
+let rec out_jkind_of_jkind ~sort_var_names jkind =
+  match Jkind.get jkind with
   | Type ty -> begin match Jkind.Type.get ty with
     | Const clay -> out_jkind_of_const_jkind clay
     | Var v      -> Ojkind_var (if sort_var_names then Jkind.Type.Sort.Var.name v else "_")
@@ -1296,7 +1296,8 @@ let rec out_jkind_of_jkind ~sort_var_names t =
 
 (* returns None for [value], according to (C2.1) from
    Note [When to print jkind annotations] *)
-let out_jkind_option_of_jkind t = match Jkind.get t with
+let out_jkind_option_of_jkind t =
+  match Jkind.get t with
   | Type ty -> begin
     match Jkind.Type.get ty with
     | Const jkind ->

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1283,8 +1283,8 @@ let out_jkind_of_user_jkind (jkind : Jane_syntax.Jkind.annotation) =
 let out_jkind_of_const_jkind jkind =
   Ojkind_const (Jkind.Type.Const.to_out_jkind_const jkind)
 
-let rec out_jkind_of_jkind ~sort_var_names jkind =
-  match Jkind.get jkind with
+let rec out_jkind_of_jkind ~sort_var_names t =
+  match Jkind.get t with
   | Type ty -> begin match Jkind.Type.get ty with
     | Const clay -> out_jkind_of_const_jkind clay
     | Var v      -> Ojkind_var (if sort_var_names then Jkind.Type.Sort.Var.name v else "_")
@@ -1296,8 +1296,7 @@ let rec out_jkind_of_jkind ~sort_var_names jkind =
 
 (* returns None for [value], according to (C2.1) from
    Note [When to print jkind annotations] *)
-let out_jkind_option_of_jkind jkind =
-  match Jkind.get jkind with
+let out_jkind_option_of_jkind t = match Jkind.get t with
   | Type ty -> begin
     match Jkind.Type.get ty with
     | Const jkind ->
@@ -1318,7 +1317,7 @@ let out_jkind_option_of_jkind jkind =
       else None
     end
   (* We ignore the rules above for arrows, which should always be printed *)
-  | _ -> Some (out_jkind_of_jkind ~sort_var_names:!Clflags.verbose_types jkind)
+  | _ -> Some (out_jkind_of_jkind ~sort_var_names:!Clflags.verbose_types t)
 
 let alias_nongen_row mode px ty =
     match get_desc ty with

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -176,7 +176,7 @@ let typevars ppf vs =
   List.iter (typevar_jkind ~print_quote:true ppf) vs
 
 let jkind_array i ppf jkinds =
-  array (i+1) (fun _ ppf l -> fprintf ppf "%a;@ " Jkind.Type.format l)
+  array (i+1) (fun _ ppf l -> fprintf ppf "%a;@ " Jkind.format (Jkind.of_type_jkind l))
     ppf jkinds
 
 let tag ppf = let open Types in function

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -176,7 +176,7 @@ let typevars ppf vs =
   List.iter (typevar_jkind ~print_quote:true ppf) vs
 
 let jkind_array i ppf jkinds =
-  array (i+1) (fun _ ppf l -> fprintf ppf "%a;@ " Jkind.format (Jkind.of_type_jkind l))
+  array (i+1) (fun _ ppf l -> fprintf ppf "%a;@ " Jkind.Type.format l)
     ppf jkinds
 
 let tag ppf = let open Types in function

--- a/ocaml/typing/subst.ml
+++ b/ocaml/typing/subst.ml
@@ -84,7 +84,7 @@ let with_additional_action =
   let builtins =
     Jkind.Type.Const.Primitive.all
     |> List.map (fun (builtin : Jkind.Type.Const.Primitive.t) ->
-          builtin.jkind, Jkind.Type.of_const builtin.jkind ~why:Jkind.Type.History.Imported)
+          builtin.jkind, Jkind.Type.of_const builtin.jkind ~why:Jkind_intf.History.Imported)
   in
   fun (config : additional_action_config) s ->
   (* CR layouts: it would be better to put all this stuff outside this
@@ -109,8 +109,8 @@ let with_additional_action =
                 Jkind.Const.equal const (Jkind.Const.of_type_jkind builtin)) builtins
             in
             begin match builtin with
-            | Some (__, jkind) -> (Type jkind : jkind)
-            | None -> Jkind.of_const const ~why:Jkind.Type.History.Imported
+            | Some (__, jkind) -> (Jkind.of_type_jkind jkind : jkind)
+            | None -> Jkind.of_const const ~why:Jkind_intf.History.Imported
             end
           | None -> raise(Error (loc, Unconstrained_jkind_variable))
         in

--- a/ocaml/typing/subst.ml
+++ b/ocaml/typing/subst.ml
@@ -84,7 +84,7 @@ let with_additional_action =
   let builtins =
     Jkind.Type.Const.Primitive.all
     |> List.map (fun (builtin : Jkind.Type.Const.Primitive.t) ->
-          builtin.jkind, Jkind.Type.of_const builtin.jkind ~why:Jkind_intf.History.Imported)
+          builtin.jkind, Jkind.Type.of_const builtin.jkind ~why:Jkind.History.Imported)
   in
   fun (config : additional_action_config) s ->
   (* CR layouts: it would be better to put all this stuff outside this
@@ -110,7 +110,7 @@ let with_additional_action =
             in
             begin match builtin with
             | Some (__, jkind) -> (Jkind.of_type_jkind jkind : jkind)
-            | None -> Jkind.of_const const ~why:Jkind_intf.History.Imported
+            | None -> Jkind.of_const const ~why:Jkind.History.Imported
             end
           | None -> raise(Error (loc, Unconstrained_jkind_variable))
         in

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -9026,7 +9026,7 @@ and type_comprehension_expr
         (* CR layouts v4: When this changes from [value], you will also have to
            update the use of [transl_exp] in transl_array_comprehension.ml. See
            a companion CR layouts v4 at the point of interest in that file. *)
-        Jkind.Type.Primitive.value ~why:Jkind_intf.History.Array_comprehension_element |> Jkind.of_type_jkind
+        Jkind.Type.Primitive.value ~why:Jkind.History.Array_comprehension_element |> Jkind.of_type_jkind
   in
   let element_ty =
     with_local_level_if_principal begin fun () ->

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -9026,7 +9026,7 @@ and type_comprehension_expr
         (* CR layouts v4: When this changes from [value], you will also have to
            update the use of [transl_exp] in transl_array_comprehension.ml. See
            a companion CR layouts v4 at the point of interest in that file. *)
-        Jkind.Type.Primitive.value ~why:Jkind.Type.History.Array_comprehension_element |> Jkind.of_type_jkind
+        Jkind.Type.Primitive.value ~why:Jkind_intf.History.Array_comprehension_element |> Jkind.of_type_jkind
   in
   let element_ty =
     with_local_level_if_principal begin fun () ->

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -128,7 +128,7 @@ val type_let:
 val type_expression:
         Env.t -> Parsetree.expression -> Typedtree.expression
 val type_representable_expression:
-        why:Jkind_intf.History.concrete_creation_reason ->
+        why:Jkind.History.concrete_creation_reason ->
         Env.t -> Parsetree.expression -> Typedtree.expression * Jkind.Type.sort
 val type_class_arg_pattern:
         string -> Env.t -> Env.t -> arg_label -> Parsetree.pattern ->

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -128,7 +128,7 @@ val type_let:
 val type_expression:
         Env.t -> Parsetree.expression -> Typedtree.expression
 val type_representable_expression:
-        why:Jkind.Type.History.concrete_creation_reason ->
+        why:Jkind_intf.History.concrete_creation_reason ->
         Env.t -> Parsetree.expression -> Typedtree.expression * Jkind.Type.sort
 val type_class_arg_pattern:
         string -> Env.t -> Env.t -> arg_label -> Parsetree.pattern ->

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1661,7 +1661,7 @@ let update_decls_jkind_reason decls =
        List.iter update_generalized decl.type_params;
        Btype.iter_type_expr_kind update_generalized decl.type_kind;
        Option.iter update_generalized decl.type_manifest;
-       let reason = Jkind_intf.History.Generalized (Some id, decl.type_loc) in
+       let reason = Jkind.History.Generalized (Some id, decl.type_loc) in
        let new_decl = {decl with type_jkind =
                                    Jkind.History.update_reason decl.type_jkind reason} in
        (id, new_decl)

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1661,7 +1661,7 @@ let update_decls_jkind_reason decls =
        List.iter update_generalized decl.type_params;
        Btype.iter_type_expr_kind update_generalized decl.type_kind;
        Option.iter update_generalized decl.type_manifest;
-       let reason = Jkind.Type.History.Generalized (Some id, decl.type_loc) in
+       let reason = Jkind_intf.History.Generalized (Some id, decl.type_loc) in
        let new_decl = {decl with type_jkind =
                                    Jkind.History.update_reason decl.type_jkind reason} in
        (id, new_decl)

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -102,7 +102,7 @@ and _ commutable_gen =
   | Cunknown : [> `none] commutable_gen
   | Cvar : {mutable commu: any commutable_gen} -> [> `var] commutable_gen
 
-and type_jkind = type_expr Jkind_types.Type.t
+and type_jkind = type_expr Jkind_types.type_jkind
 and jkind = type_expr Jkind_types.t
 
 (* jkind depends on types defined in this file, but Jkind.Type.equal is required

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -228,7 +228,7 @@ and abbrev_memo =
 
 (** Jkinds classify types. *)
 (* CR layouts v2.8: Say more here. *)
-and type_jkind = type_expr Jkind_types.Type.t
+and type_jkind = type_expr Jkind_types.type_jkind
 and jkind = type_expr Jkind_types.t
 
 (* jkind depends on types defined in this file, but Jkind.Type.equal is required

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -119,7 +119,7 @@ module TyVarEnv : sig
   (* a version of [make_poly_univars_jkinds] that doesn't take jkinds *)
 
   val make_poly_univars_jkinds :
-    context:(string -> Jkind.Type.History.annotation_context) ->
+    context:(string -> Jkind_intf.History.annotation_context) ->
     (string Location.loc * Jane_syntax.Jkind.annotation option) list -> poly_univars
   (* see mli file *)
 
@@ -629,7 +629,7 @@ let transl_label_from_pat (label : Parsetree.arg_label)
 
 let enrich_with_attributes attrs annotation_context =
   match Builtin_attributes.error_message_attr attrs with
-  | Some msg -> Jkind.Type.History.With_error_message (msg, annotation_context)
+  | Some msg -> Jkind_intf.History.With_error_message (msg, annotation_context)
   | None -> annotation_context
 
 let jkind_of_annotation annotation_context attrs jkind =
@@ -645,7 +645,7 @@ let check_arity_matches_decl ~loc ~txt env decl arity =
       | Some _ -> true
     end
     | m, 0 -> begin
-      match decl.type_jkind with
+      match Jkind.get decl.type_jkind with
       | Type _ -> false
       | Arrow { args = kind_args; result = _ } -> List.length kind_args = m
     end
@@ -767,7 +767,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
                 of a performance impact: compiling [types.ml] resulted in 13k
                 extra alloc (~0.01% increase) and building the core library had
                 no statistically significant increase in build time. *)
-             let reason = Jkind.Type.History.Imported_type_argument
+             let reason = Jkind_intf.History.Imported_type_argument
                             {parent_path = path; position = idx + 1; arity} in
              Types.set_var_jkind ty' (Jkind.History.update_reason jkind reason)
            | _ -> ()

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -119,7 +119,7 @@ module TyVarEnv : sig
   (* a version of [make_poly_univars_jkinds] that doesn't take jkinds *)
 
   val make_poly_univars_jkinds :
-    context:(string -> Jkind_intf.History.annotation_context) ->
+    context:(string -> Jkind.History.annotation_context) ->
     (string Location.loc * Jane_syntax.Jkind.annotation option) list -> poly_univars
   (* see mli file *)
 
@@ -629,7 +629,7 @@ let transl_label_from_pat (label : Parsetree.arg_label)
 
 let enrich_with_attributes attrs annotation_context =
   match Builtin_attributes.error_message_attr attrs with
-  | Some msg -> Jkind_intf.History.With_error_message (msg, annotation_context)
+  | Some msg -> Jkind.History.With_error_message (msg, annotation_context)
   | None -> annotation_context
 
 let jkind_of_annotation annotation_context attrs jkind =
@@ -767,7 +767,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
                 of a performance impact: compiling [types.ml] resulted in 13k
                 extra alloc (~0.01% increase) and building the core library had
                 no statistically significant increase in build time. *)
-             let reason = Jkind_intf.History.Imported_type_argument
+             let reason = Jkind.History.Imported_type_argument
                             {parent_path = path; position = idx + 1; arity} in
              Types.set_var_jkind ty' (Jkind.History.update_reason jkind reason)
            | _ -> ()

--- a/ocaml/typing/typetexp.mli
+++ b/ocaml/typing/typetexp.mli
@@ -36,7 +36,7 @@ module TyVarEnv : sig
         without jkind annotations *)
 
   val make_poly_univars_jkinds :
-    context:(string -> Jkind.Type.History.annotation_context) ->
+    context:(string -> Jkind_intf.History.annotation_context) ->
     (string Location.loc * Jane_syntax.Jkind.annotation option) list ->
     poly_univars
     (** remember that a list of strings connotes univars; this must

--- a/ocaml/typing/typetexp.mli
+++ b/ocaml/typing/typetexp.mli
@@ -36,7 +36,7 @@ module TyVarEnv : sig
         without jkind annotations *)
 
   val make_poly_univars_jkinds :
-    context:(string -> Jkind_intf.History.annotation_context) ->
+    context:(string -> Jkind.History.annotation_context) ->
     (string Location.loc * Jane_syntax.Jkind.annotation option) list ->
     poly_univars
     (** remember that a list of strings connotes univars; this must


### PR DESCRIPTION
The initial implementation of higher jkinds only kept track of histories at type jkinds (as they were before), which isn't sufficient to provide useful error messages, and also just unexpected with the existing logic. 

This PR amends this by moving out the type structure (from the perspective of pre-`higher-kinded`):
```ocaml
module Jkind_desc = struct
  type t = (* structure of a jkind, without history *)
end
type history = (* ... *)
type t = (* a [Jkind_desc.t] with history *)
```
to 
```ocaml
module Type = struct
  module Jkind_desc = struct
    type t = (* structure of a *type* jkind, without [history] *)
  end
  (* cannot define [Type.t] here yet, as history might involve higher kinds *)
end

module Jkind_desc = struct
  type t = (* structure of a general jkind, without history *)
end
type history = (* ... *)
type t = (* [Jkind_desc.t] with history *)
type type_jkind = (* now, [Type.Jkind_desc.t] with [history] *)
```
This is a bit unsatisfying in that it seems there is no sensible way by which `type_jkind` lives in `Jkind.Type.t`, but this seems to make sense - it has now become dependent on `Jkind.t` through `history`, which contains them.

Thanks to the introduction of histories there gave a point to a `Jkind.get`, which e.g. for arrows creates a `Jkind.t Arrow.t` as opposed to the actually stored `Jkind_desc.t Arrow.t`. This refactors some things, usually for the better.

Unfortunately, due to move of histories from `Jkind.Type` to `Jkind`, the diff is slightly messy in `jkind.ml`.