### PR TITLE
Implement the `Top` of the (higher) jkind lattice

### DIFF
--- a/ocaml/testsuite/tests/typing-higher-jkinds/top.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/top.ml
@@ -1,0 +1,66 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+type t : top
+[%%expect {|
+type t : top
+|}]
+
+type t : top => value
+[%%expect {|
+type t : top => value
+|}]
+
+module M : sig
+  type t : top
+end = struct
+  type t : top
+end
+[%%expect {|
+module M : sig type t : top end
+|}]
+
+module M : sig
+  type t : top
+end = struct
+  type t : value
+end
+[%%expect {|
+module M : sig type t : top end
+|}]
+
+module M : sig
+  type t : value => value
+end = struct
+  type t : value => top
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t : value => top
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t : value => top end
+       is not included in
+         sig type t : value => value end
+       Type declarations do not match:
+         type t : value => top
+       is not included in
+         type t : value => value
+       The layout of the first is ((value) => top), because
+         of the definition of t at line 4, characters 2-23.
+       But the layout of the first must be a sublayout of ((value) => value), because
+         of the definition of t at line 2, characters 2-25.
+|}]
+
+module M : sig
+  type t : value => top
+end = struct
+  type t : value => value
+end
+[%%expect {|
+module M : sig type t : value => top end
+|}]

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -5725,6 +5725,11 @@ let build_submode posi m =
   if posi then build_submode_pos (Alloc.allow_left m)
   else build_submode_neg (Alloc.allow_right m)
 
+let subtype_error ~env ~trace ~unification_trace =
+  raise (Subtype (Subtype.error
+                    ~trace:(expand_subtype_trace env (List.rev trace))
+                    ~unification_trace))
+
 (* CR layouts v2.8: merge with Typecore.mode_cross_left when [Value] and
    [Alloc] get unified *)
 let mode_cross_left env ty mode =
@@ -5733,6 +5738,10 @@ let mode_cross_left env ty mode =
      are bad when checking for principality. Really, I'm surprised that
      the types here aren't principal. In any case, leaving the check out
      now; will return and figure this out later. *)
+  let () = match constrain_type_jkind env ty (Jkind.of_type_jkind (Jkind.Type.Primitive.any ~why:Dummy_jkind)) with
+    | Ok () -> ()
+    | Error _ -> subtype_error ~env ~trace:[] ~unification_trace:[]
+  in
   let jkind = type_jkind_purely env ty in
   let upper_bounds = Jkind.Type.get_modal_upper_bounds (Jkind.to_type_jkind jkind) in
   Alloc.meet_const upper_bounds mode
@@ -5742,6 +5751,10 @@ let mode_cross_left env ty mode =
 let mode_cross_right env ty mode =
   (* CR layouts v2.8: This should probably check for principality. See
      similar comment in [mode_cross_left]. *)
+  let () = match constrain_type_jkind env ty (Jkind.of_type_jkind (Jkind.Type.Primitive.any ~why:Dummy_jkind)) with
+    | Ok () -> ()
+    | Error _ -> subtype_error ~env ~trace:[] ~unification_trace:[]
+  in
   let jkind = type_jkind_purely env ty in
   let upper_bounds = Jkind.Type.get_modal_upper_bounds (Jkind.to_type_jkind jkind) in
   Alloc.imply upper_bounds mode
@@ -5969,11 +5982,6 @@ let enlarge_type env ty =
 *)
 
 let subtypes = TypePairs.create 17
-
-let subtype_error ~env ~trace ~unification_trace =
-  raise (Subtype (Subtype.error
-                    ~trace:(expand_subtype_trace env (List.rev trace))
-                    ~unification_trace))
 
 let subtype_alloc_mode env trace a1 a2 =
   match Alloc.submode a1 a2 with

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2133,6 +2133,7 @@ let rec jkind_of_decl_unapplied env (decl : type_declaration) =
 
 and type_jkind_for_app app_jkind app_arity tys =
   match tys, Jkind.get app_jkind with
+  | _, Top -> Some app_jkind
   | Unapplied, _ when app_arity = 0 -> Some app_jkind
   | Unapplied, _ -> None
   | Applied tys, _ when app_arity > 0 ->
@@ -2219,6 +2220,7 @@ let arity_matches_decl env decl t = match t, decl.type_arity with
     match Jkind.get decl.type_jkind with
     | Type _ -> false
     | Arrow { args = kind_args; result = _ } -> List.length kind_args = m
+    | Top -> true
   end
   | m, n -> m = n
 
@@ -2406,6 +2408,7 @@ let check_and_update_generalized_ty_jkind ?name ~loc ty =
                | Some (Sort Value) | None -> true
                | _ -> false)
       | Arrow _ -> false
+      | Top -> false
     in
     if Language_extension.erasable_extensions_only ()
       && is_immediate jkind && not (Jkind.History.has_warned jkind)

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -558,23 +558,23 @@ module Type = struct
     end
 
     let of_user_written_abbreviation ~jkind (const : Jane_syntax.Jkind.Const.t)
-        : t =
+        =
       let { txt = name; loc } =
         (const : Jane_syntax.Jkind.Const.t :> _ Location.loc)
       in
       (* CR layouts 2.8: move this to predef *)
       match name with
-      | "any" -> Primitive.any.jkind
-      | "value" -> Primitive.value.jkind
-      | "void" -> Primitive.void.jkind
-      | "immediate64" -> Primitive.immediate64.jkind
-      | "immediate" -> Primitive.immediate.jkind
-      | "float64" -> Primitive.float64.jkind
-      | "float32" -> Primitive.float32.jkind
-      | "word" -> Primitive.word.jkind
-      | "bits32" -> Primitive.bits32.jkind
-      | "bits64" -> Primitive.bits64.jkind
-      | _ -> user_raise ~loc (Unknown_jkind jkind)
+      | "any" -> Ok Primitive.any.jkind
+      | "value" -> Ok Primitive.value.jkind
+      | "void" -> Ok Primitive.void.jkind
+      | "immediate64" -> Ok Primitive.immediate64.jkind
+      | "immediate" -> Ok Primitive.immediate.jkind
+      | "float64" -> Ok Primitive.float64.jkind
+      | "float32" -> Ok Primitive.float32.jkind
+      | "word" -> Ok Primitive.word.jkind
+      | "bits32" -> Ok Primitive.bits32.jkind
+      | "bits64" -> Ok Primitive.bits64.jkind
+      | _ -> Error (loc, (Unknown_jkind jkind : Error.t))
 
     let meet_mode_in_parse jkind (mode : ModeParser.mode) =
       (* for each mode, lower the corresponding modal bound to be that mode *)
@@ -1296,11 +1296,25 @@ module Const = struct
     | Immediate -> of_type_jkind Type.Const.Primitive.immediate.jkind
     | Immediate64 -> of_type_jkind Type.Const.Primitive.immediate64.jkind
 
+  let of_user_written_abbreviation ~jkind const =
+    let { txt = name; loc = _ } =
+      (const : Jane_syntax.Jkind.Const.t :> _ Location.loc)
+    in
+    (* CR layouts 2.8: move this to predef
+       jbachurski: (CC from Type.Const.of_user_written_abbreviation) *)
+    match name with
+    | "top" -> Ok Jkind_types.Const.Top
+    | _ ->
+      Result.map of_type_jkind
+        (Type.Const.of_user_written_abbreviation ~jkind const)
+
   let rec of_user_written_annotation_unchecked_level
       (jkind : Jane_syntax.Jkind.t) : t =
     match jkind with
-    | Abbreviation const ->
-      Type (Type.Const.of_user_written_abbreviation ~jkind const)
+    | Abbreviation const -> (
+      match of_user_written_abbreviation ~jkind const with
+      | Ok k -> k
+      | Error (loc, err) -> user_raise ~loc err)
     | Mod (jkind, modes) ->
       (* jbachurski: We coerce here - in the future, the syntax should not permit
          mod on arrows. Such expressions are not parsed currently. *)

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -411,6 +411,7 @@ module Desc : sig
   type nonrec t =
     | Type of Type.t
     | Arrow of t Jkind_types.Arrow.t
+    | Top
 end
 
 (** [default_to_value_and_get] extracts the jkind as a `const`.  If it's a sort

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -326,7 +326,7 @@ end
 
 module Primitive : sig
   (** Top element of the jkind lattice, including higher jkinds *)
-  val top : why:Jkind_intf.History.any_creation_reason -> t
+  val top : why:Jkind_intf.History.top_creation_reason -> t
 end
 
 (******************************)

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -275,6 +275,7 @@ module History = struct
     | Bits32_creation of bits32_creation_reason
     | Bits64_creation of bits64_creation_reason
     | Concrete_creation of concrete_jkind_reason
+    | Top_creation of top_creation_reason
     | Imported
     | Imported_type_argument of
         { parent_path : Path.t;

--- a/ocaml/typing/jkind_types.ml
+++ b/ocaml/typing/jkind_types.ml
@@ -416,6 +416,7 @@ module Jkind_desc = struct
   type 'type_expr t =
     | Type of 'type_expr Type.Jkind_desc.t
     | Arrow of 'type_expr t Arrow.t
+    | Top
 end
 
 type 'type_expr history = 'type_expr Jkind_desc.t History.t
@@ -436,6 +437,7 @@ module Const = struct
   type 'type_expr t =
     | Type of 'type_expr Type.Const.t
     | Arrow of 'type_expr t Arrow.t
+    | Top
 end
 
 type 'type_expr const = 'type_expr Const.t

--- a/ocaml/typing/jkind_types.mli
+++ b/ocaml/typing/jkind_types.mli
@@ -166,6 +166,7 @@ module Jkind_desc : sig
   type 'type_expr t =
     | Type of 'type_expr Type.Jkind_desc.t
     | Arrow of 'type_expr t Arrow.t
+    | Top
 end
 
 type 'type_expr history = 'type_expr Jkind_desc.t History.t
@@ -186,6 +187,7 @@ module Const : sig
   type 'type_expr t =
     | Type of 'type_expr Type.Const.t
     | Arrow of 'type_expr t Arrow.t
+    | Top
 end
 
 type 'type_expr annotation = 'type_expr Const.t * Jane_syntax.Jkind.annotation

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -347,6 +347,7 @@ let rec print_out_jkind ppf = function
   | Ojkind_const { base; modal_bounds=_::_ as modal_bounds } ->
     print_jkind_with_modes ppf (fun ppf -> fprintf ppf "%s") base modal_bounds
   | Ojkind_var v -> fprintf ppf "%s" v
+  | Ojkind_top -> fprintf ppf "top"
   | Ojkind_user jkind ->
     let rec print_out_jkind_user ppf = function
       | Ojkind_user_default -> fprintf ppf "_"

--- a/ocaml/typing/outcometree.mli
+++ b/ocaml/typing/outcometree.mli
@@ -117,6 +117,7 @@ and out_jkind =
   | Ojkind_const of out_jkind_const
   | Ojkind_var of string
   | Ojkind_arrow of out_jkind Jkind_types.Arrow.t
+  | Ojkind_top
 
 and out_type_param =
   { oparam_name : string;

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1286,6 +1286,7 @@ let rec out_jkind_of_jkind t = match Jkind.get t with
     Ojkind_arrow
       { args = List.map out_jkind_of_jkind args;
         result = out_jkind_of_jkind result }
+  | Top -> Ojkind_top
 
 (* returns None for [value], according to (C2.1) from
    Note [When to print jkind annotations] *)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -812,7 +812,11 @@ let actual_mode_cross_left env ty (actual_mode : Env.actual_mode)
 
 (** Mode cross a mode whose monadic fragment is a right mode, and whose comonadic
     fragment is a left mode. *)
-let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
+let alloc_mode_cross_to_max_min ~loc env ty { monadic; comonadic } =
+  let () = match constrain_type_jkind env ty (Jkind.of_type_jkind (Jkind.Type.Primitive.any ~why:Dummy_jkind)) with
+    | Ok () -> ()
+    | Error err -> raise (Error (loc, env, Not_a_value(err, None)))
+  in
   let monadic = Alloc.Monadic.disallow_left monadic in
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
   if not (is_principal ty) then { monadic; comonadic } else
@@ -824,8 +828,12 @@ let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
   { monadic; comonadic }
 
 (** Mode cross a right mode *)
-let expect_mode_cross env ty (expected_mode : expected_mode) =
+let expect_mode_cross ~loc env ty (expected_mode : expected_mode) =
   if not (is_principal ty) then expected_mode else
+  let () = match constrain_type_jkind env ty (Jkind.of_type_jkind (Jkind.Type.Primitive.any ~why:Dummy_jkind)) with
+    | Ok () -> ()
+    | Error err -> raise (Error (loc, env, Not_a_value(err, None)))
+  in
   let jkind = type_jkind_purely env ty in
   let upper_bounds = Jkind.Type.get_modal_upper_bounds (Jkind.to_type_jkind jkind) in
   let upper_bounds = Const.alloc_as_value upper_bounds in
@@ -4921,7 +4929,7 @@ let split_function_ty
           | Error _ -> raise (Error (loc_fun, env, Function_returns_local))
         end
       in
-      let ret_value_mode = expect_mode_cross env ty_ret ret_value_mode in
+      let ret_value_mode = expect_mode_cross ~loc:loc_fun env ty_ret ret_value_mode in
       ret_value_mode
   in
   let ty_arg_mono =
@@ -6842,7 +6850,7 @@ and type_function
                      uses the [arg_mode.comonadic] as a left mode, and
                      [arg_mode.monadic] as a right mode, hence they need to be
                      mode-crossed differently. *)
-                  let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
+                  let arg_mode = alloc_mode_cross_to_max_min ~loc env ty_arg arg_mode in
                   begin match
                     Alloc.submode (Alloc.close_over arg_mode) fun_alloc_mode
                   with
@@ -7564,7 +7572,7 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
       end
       end
   | None ->
-      let mode = expect_mode_cross env ty_expected' mode in
+      let mode = expect_mode_cross ~loc:sarg.pexp_loc env ty_expected' mode in
       let texp = type_expect ?recarg env mode sarg
         (mk_expected ?explanation ty_expected') in
       unify_exp env texp ty_expected;
@@ -7767,7 +7775,7 @@ and type_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
     List.map2
       (fun (label, body) ((_, ty), argument_mode) ->
         let argument_mode = mode_default argument_mode in
-        let argument_mode = expect_mode_cross env ty argument_mode in
+        let argument_mode = expect_mode_cross ~loc env ty argument_mode in
           (label, type_expect env argument_mode body (mk_expected ty)))
       sexpl types_and_modes
   in
@@ -8782,7 +8790,7 @@ and type_generic_array
   let to_unify = type_ ty in
   with_explanation explanation (fun () ->
     unify_exp_types loc env to_unify (generic_instance ty_expected));
-  let argument_mode = expect_mode_cross env ty argument_mode in
+  let argument_mode = expect_mode_cross ~loc env ty argument_mode in
   let argl =
     List.map
       (fun sarg -> type_expect env argument_mode sarg (mk_expected ty))


### PR DESCRIPTION
Adds `Top` to the jkind lattice, which is required where a jkind is to be inferred, but it is insufficient to bound it with `Any` as it may be a higher jkind.

Additionally, to preserve the behaviour of existing inference (and not break tests), this constrains some type expressions to `any` at (hopefully) appropriate sites. This is where most of the diff outside `jkind.ml` comes from - besides the small changes in `Ctype` related to type application logic.