### PR TITLE
Add `[@@or_null_reexport]`

### DIFF
--- a/ocaml/otherlibs/stdlib_alpha/or_null.ml
+++ b/ocaml/otherlibs/stdlib_alpha/or_null.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type 'a t : value_or_null = 'a or_null = Null | This of 'a
+type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
 
 let null = Null
 let this v = This v

--- a/ocaml/otherlibs/stdlib_alpha/or_null.mli
+++ b/ocaml/otherlibs/stdlib_alpha/or_null.mli
@@ -24,9 +24,7 @@
 (* CR layouts: enable ocamlformat for this module when it starts supporting
    jkind annotations. *)
 
-type 'a t : value_or_null = 'a or_null =
-  | Null
-  | This of 'a
+type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
       (** The type of nullable values. Either [Null] or a value [This v].
           ['a or_null] has a non-standard layout [value_or_null],
           preventing the type constructor from being nested. *)

--- a/ocaml/otherlibs/stdlib_alpha/or_null.mli
+++ b/ocaml/otherlibs/stdlib_alpha/or_null.mli
@@ -29,58 +29,58 @@ type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
           ['a or_null] has a non-standard layout [value_or_null],
           preventing the type constructor from being nested. *)
 
-val null : 'a or_null
+val null : 'a t
 (** [null] is [Null]. *)
 
-val this : 'a -> 'a or_null
+val this : 'a -> 'a t
 (** [this v] is [This v]. *)
 
-val value : 'a or_null -> default:'a -> 'a
+val value : 'a t -> default:'a -> 'a
 (** [value o ~default] is [v] if [o] is [This v] and [default] otherwise. *)
 
-val get : 'a or_null -> 'a
+val get : 'a t -> 'a
 (** [get o] is [v] if [o] is [This v] and raise otherwise. *)
 
-val bind : 'a or_null -> ('a -> 'b or_null) -> 'b or_null
+val bind : 'a t -> ('a -> 'b or_null) -> 'b or_null
 (** [bind o f] is [f v] if [o] is [This v] and [Null] if [o] is [Null]. *)
 
-val map : ('a -> 'b) -> 'a or_null -> 'b or_null
+val map : ('a -> 'b) -> 'a t -> 'b or_null
 (** [map f o] is [Null] if [o] is [Null] and [This v] if [o] is [This v]. *)
 
 val fold : null:'a -> this:('b -> 'a) -> 'b or_null -> 'a
 (** [fold ~null ~this o] is [null] if [o] is [Null] and [this v]
     if [o] is [This v]. *)
 
-val iter : ('a -> unit) -> 'a or_null -> unit
+val iter : ('a -> unit) -> 'a t -> unit
 (** [iter f o] is [f v] if [o] is [This v] and [()] otherwise. *)
 
-val is_null : 'a or_null -> bool
+val is_null : 'a t -> bool
 (** [is_null o] is [true] if [o] is [Null] and [false] otherwise. *)
 
-val is_this : 'a or_null -> bool
+val is_this : 'a t -> bool
 (** [is_this o] is [true] if [o] is [This v] and [false] otherwise. *)
 
-val equal : ('a -> 'a -> bool) -> 'a or_null -> 'a or_null -> bool
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 (** [equal eq o0 o1] is [true] if and only if [o0] and [o1] are both [Null]
     or if they are [This v0] and [This v1] and [eq v0 v1] is [true]. *)
 
-val compare : ('a -> 'a -> int) -> 'a or_null -> 'a or_null -> int
+val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
 (** [compare f o o'] is a total order on [or_null] using [cmp] to compare
     values wrapped by [This _]. [Null] is smaller than [This _] values. *)
 
-val to_result : null:'e -> 'a or_null -> ('a, 'e) result
+val to_result : null:'e -> 'a t -> ('a, 'e) result
 (** [to_result ~null o] is [Ok v] if [o] is [This v] and
     [Error null] otherwise. *)
 
-val to_list : 'a or_null -> 'a list
+val to_list : 'a t -> 'a list
 (** [to_list] is [[]] if [o] is [Null] and [[v]] if [o] is [This v]. *)
 
-val to_seq : 'a or_null -> 'a Seq.t
+val to_seq : 'a t -> 'a Seq.t
 (** [to_seq o] is [o] as a sequence. [Null] is the empty sequence and
     [This v] is the singleton sequence containing [v]. *)
 
-val to_option : 'a or_null -> 'a option
+val to_option : 'a t -> 'a option
 (** [to_option o] is [Some v] if [o] is [This v] and [None] otherwise. *)
 
-val of_option : 'a option -> 'a or_null
+val of_option : 'a option -> 'a t
 (** [of_option o] is [This v] if [o] is [Some v] and [Null] otherwise. *)

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -648,6 +648,9 @@ let has_curry attrs =
   has_attribute
     [Jane_syntax.Arrow_curry.curry_attr_name; "ocaml.curry"; "curry"] attrs
 
+let has_or_null_reexport attrs =
+  has_attribute ["ocaml.or_null_reexport"; "or_null_reexport"] attrs
+
 let tailcall attr =
   let has_nontail = has_attribute ["ocaml.nontail"; "nontail"] attr in
   let tail_attrs = filter_attributes [["ocaml.tail";"tail"], true] attr in

--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -110,6 +110,7 @@ let builtin_attrs =
   ; "error_message"; "ocaml.error_message"
   ; "layout_poly"; "ocaml.layout_poly"
   ; "no_mutable_implied_modalities"; "ocaml.no_mutable_implied_modalities"
+  ; "or_null_reexport"; "ocaml.or_null_reexport"
   ]
 
 (* nroberts: When we upstream the builtin-attribute whitelisting, we shouldn't

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -182,6 +182,7 @@ val has_no_mutable_implied_modalities: Parsetree.attributes -> bool
 val has_local_opt: Parsetree.attributes -> bool
 val has_layout_poly: Parsetree.attributes -> bool
 val has_curry: Parsetree.attributes -> bool
+val has_or_null_reexport : Parsetree.attributes -> bool
 
 val tailcall : Parsetree.attributes ->
     ([`Tail|`Nontail|`Tail_if_possible] option, [`Conflict]) result

--- a/ocaml/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -284,6 +284,33 @@ Error: In this definition, expected parameter variances are not satisfied.
        but it is injective covariant.
 |}]
 
+(* The type's arity must be exactly the same. *)
+
+type ('a, 'b) t = 'b or_null [@@or_null_reexport]
+
+[%%expect{|
+Line 1, characters 0-49:
+1 | type ('a, 'b) t = 'b or_null [@@or_null_reexport]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         'b or_null
+       They have different arities.
+|}]
+
+(* The type parameter must be actually used. *)
+
+type 'a t = int or_null [@@or_null_reexport]
+[%%expect{|
+Line 1, characters 0-44:
+1 | type 'a t = int or_null [@@or_null_reexport]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         int or_null
+       Their parameters differ:
+       The type int is not equal to the type 'a
+|}]
+
+
 (* [@@or_null_reexport] handles shadowing correctly. *)
 
 type 'a or_null : value = Null | This of 'a

--- a/ocaml/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -260,6 +260,30 @@ type 'a t1 = 'a or_null = Null | This of 'a
 type 'a t2 = 'a t1 = Null | This of 'a
 |}]
 
+(* Correct injectivity and variance annotations are accepted. *)
+
+type !'a t = 'a or_null [@@or_null_reexport]
+
+type +'a t = 'a or_null [@@or_null_reexport]
+
+[%%expect{|
+type 'a t = 'a or_null = Null | This of 'a
+type 'a t = 'a or_null = Null | This of 'a
+|}]
+
+(* Incorrect variance annotation fails. *)
+
+type -'a t = 'a or_null [@@or_null_reexport]
+
+[%%expect{|
+Line 1, characters 0-44:
+1 | type -'a t = 'a or_null [@@or_null_reexport]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this definition, expected parameter variances are not satisfied.
+       The 1st type parameter was expected to be contravariant,
+       but it is injective covariant.
+|}]
+
 (* [@@or_null_reexport] handles shadowing correctly. *)
 
 type 'a or_null : value = Null | This of 'a

--- a/ocaml/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -1,0 +1,234 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+(* CR layouts v3: ['a or_null] can't be re-exported normally,
+   because users can't define their own [Null]-like constructors. *)
+module Or_null = struct
+  type ('a : value) t : value_or_null = 'a or_null =
+    | Null
+    | This of 'a
+end
+
+[%%expect{|
+Lines 2-4, characters 2-16:
+2 | ..type ('a : value) t : value_or_null = 'a or_null =
+3 |     | Null
+4 |     | This of 'a
+Error: The kind of type 'a or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of type 'a or_null must be a subkind of value
+         because of the definition of t at lines 2-4, characters 2-16.
+|}]
+
+module Or_null = struct
+  type ('a : value) t : value_or_null = 'a or_null
+end
+
+[%%expect{|
+module Or_null : sig type 'a t = 'a or_null end
+|}]
+
+(* Omitting the type representation leaves constructors unexported. *)
+
+let n = Or_null.Null
+
+[%%expect{|
+Line 1, characters 8-20:
+1 | let n = Or_null.Null
+            ^^^^^^^^^^^^
+Error: Unbound constructor Or_null.Null
+|}]
+
+let t v = Or_null.This v
+
+[%%expect{|
+Line 1, characters 10-22:
+1 | let t v = Or_null.This v
+              ^^^^^^^^^^^^
+Error: Unbound constructor Or_null.This
+|}]
+
+(* [@@or_null_reexport] re-exports those constructors. *)
+
+module Or_null = struct
+  type ('a : value) t : value_or_null = 'a or_null [@@or_null_reexport]
+end
+let n = Or_null.Null
+let t v = Or_null.This v
+
+[%%expect{|
+module Or_null : sig type 'a t = 'a or_null = Null | This of 'a end
+val n : 'a Or_null.t = Or_null.Null
+val t : 'a -> 'a Or_null.t = <fun>
+|}]
+
+(* The jkind of [Or_null] is still correctly [value_or_null]. *)
+let fail = Or_null.This (Or_null.This 5)
+
+[%%expect{|
+Line 1, characters 24-40:
+1 | let fail = Or_null.This (Or_null.This 5)
+                            ^^^^^^^^^^^^^^^^
+Error: This expression has type 'a Or_null.t = 'a or_null
+       but an expression was expected of type ('b : value)
+       The kind of 'a Or_null.t is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of 'a Or_null.t must be a subkind of value
+         because of the definition of t at line 2, characters 2-71.
+|}]
+
+(* Type annotations are not required. *)
+
+module Or_null = struct
+  type 'a t = 'a or_null [@@or_null_reexport]
+end
+let fail = Or_null.This (Or_null.This 5)
+
+[%%expect{|
+module Or_null : sig type 'a t = 'a or_null = Null | This of 'a end
+Line 4, characters 24-40:
+4 | let fail = Or_null.This (Or_null.This 5)
+                            ^^^^^^^^^^^^^^^^
+Error: This expression has type 'a Or_null.t = 'a or_null
+       but an expression was expected of type ('b : value)
+       The kind of 'a Or_null.t is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of 'a Or_null.t must be a subkind of value
+         because of the definition of t at line 2, characters 2-45.
+|}]
+
+(* Incorrect annotations still cause errors. *)
+
+type 'a t : value = 'a or_null [@@or_null_reexport]
+
+[%%expect{|
+Line 1, characters 0-51:
+1 | type 'a t : value = 'a or_null [@@or_null_reexport]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type 'a or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of type 'a or_null must be a subkind of value
+         because of the definition of t at line 1, characters 0-51.
+|}]
+
+type 'a t : float64 = 'a or_null [@@or_null_reexport]
+
+[%%expect{|
+Line 1, characters 0-53:
+1 | type 'a t : float64 = 'a or_null [@@or_null_reexport]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type 'a or_null is value
+         because it is the primitive value_or_null type or_null.
+       But the layout of type 'a or_null must be a sublayout of float64
+         because of the definition of t at line 1, characters 0-53.
+|}]
+
+type ('a : float64) t = 'a or_null [@@or_null_reexport]
+
+[%%expect{|
+Line 1, characters 24-26:
+1 | type ('a : float64) t = 'a or_null [@@or_null_reexport]
+                            ^^
+Error: This type ('a : value) should be an instance of type ('a0 : float64)
+       The layout of 'a is float64
+         because of the annotation on 'a in the declaration of the type t.
+       But the layout of 'a must overlap with value
+         because the type argument of or_null has layout value.
+|}]
+
+(* The behavior here is correct but confusing: ['a] is restricted to [value],
+   which is a subjkind of [value_or_null]. *)
+
+module Or_null = struct
+  type ('a : value_or_null) t = 'a or_null [@@or_null_reexport]
+end
+let fail = Or_null.This (Or_null.This 5)
+
+[%%expect{|
+module Or_null : sig type 'a t = 'a or_null = Null | This of 'a end
+Line 4, characters 24-40:
+4 | let fail = Or_null.This (Or_null.This 5)
+                            ^^^^^^^^^^^^^^^^
+Error: This expression has type 'a Or_null.t = 'a or_null
+       but an expression was expected of type ('b : value)
+       The kind of 'a Or_null.t is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of 'a Or_null.t must be a subkind of value
+         because of the definition of t at line 2, characters 2-63.
+|}]
+
+(* This fails, just as [type t = int option = None | Some of int] would. *)
+
+type t = int or_null [@@or_null_reexport]
+
+[%%expect{|
+Line 1, characters 0-41:
+1 | type t = int or_null [@@or_null_reexport]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         int or_null
+       They have different arities.
+|}]
+
+(* [@@or_null_reexport] requires a manifest. *)
+
+type 'a t [@@or_null_reexport]
+
+[%%expect{|
+Line 1, characters 0-30:
+1 | type 'a t [@@or_null_reexport]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid reexport declaration.
+       Type t must be defined to be equal to or_null
+       with no explicit representation.
+|}]
+
+(* [@@or_null_reexport] forbids explicit representation. *)
+
+type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport]
+
+[%%expect{|
+Line 1, characters 0-63:
+1 | type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid reexport declaration.
+       Type t must be defined to be equal to or_null
+       with no explicit representation.
+|}]
+
+(* [@@or_null_reexport] requires the type to be equal to ['a null]. *)
+
+type 'a t = 'a option [@@or_null_reexport]
+
+[%%expect{|
+Line 1, characters 0-42:
+1 | type 'a t = 'a option [@@or_null_reexport]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid reexport declaration.
+       Type t must be defined to be equal to or_null
+       with no explicit representation.
+|}]
+
+(* [@@or_null_reexport] behaves sanely in corner cases. *)
+
+type 'a t = 'a or_null [@@or_null_reexport]
+and t' = int or_null
+
+[%%expect{|
+type 'a t = 'a or_null = Null | This of 'a
+and t' = int or_null
+|}]
+
+type 'a t = 'b or_null constraint 'b = int * 'a [@@or_null_reexport]
+
+[%%expect{|
+Line 1, characters 0-68:
+1 | type 'a t = 'b or_null constraint 'b = int * 'a [@@or_null_reexport]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         (int * 'a) or_null
+       Their parameters differ:
+       The type int * 'a is not equal to the type 'a
+|}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/reexport_attr_unused.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/reexport_attr_unused.compilers.reference
@@ -1,0 +1,9 @@
+File "reexport_attr_unused.ml", line 9, characters 5-21:
+9 | let[@or_null_reexport] x = 5
+         ^^^^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "or_null_reexport" attribute cannot appear in this context
+
+File "reexport_attr_unused.ml", line 12, characters 6-22:
+12 |   [@@@or_null_reexport]
+           ^^^^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "or_null_reexport" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/typing-layouts-or-null/reexport_attr_unused.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/reexport_attr_unused.ml
@@ -1,0 +1,14 @@
+(* TEST
+ flags = "-extension-universe alpha";
+ ocamlc_byte_exit_status = "0";
+ setup-ocamlc.byte-build-env;
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+*)
+
+let[@or_null_reexport] x = 5
+
+module A = struct
+  [@@@or_null_reexport]
+  type t = int
+end

--- a/ocaml/testsuite/tests/typing-layouts-or-null/stdlib_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/stdlib_or_null.ml
@@ -14,8 +14,8 @@ let _ = Or_null.null
 let _ = Or_null.this 3.14
 
 [%%expect{|
-- : 'a or_null = Null
-- : float or_null = This 3.14
+- : 'a Or_null.t = Or_null.Null
+- : float Or_null.t = Or_null.This 3.14
 |}]
 
 let _ = Or_null.value Null ~default:3
@@ -150,6 +150,6 @@ let _ = Or_null.of_option (Some "test")
 [%%expect{|
 - : 'a option = None
 - : int option = Some 5
-- : 'a or_null = Null
-- : string or_null = This "test"
+- : 'a Or_null.t = Or_null.Null
+- : string Or_null.t = Or_null.This "test"
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -3,9 +3,7 @@
  expect;
 *)
 
-type ('a : value) t : value_or_null = 'a or_null =
-  | Null
-  | This of 'a
+type ('a : value) t : value_or_null = 'a or_null [@@or_null_reexport]
 
 [%%expect{|
 type 'a t = 'a or_null = Null | This of 'a
@@ -118,7 +116,7 @@ Error: This expression has type 'a t = 'a or_null
        The kind of 'a t is value_or_null
          because it is the primitive value_or_null type or_null.
        But the kind of 'a t must be a subkind of value
-         because of the definition of t at lines 1-3, characters 0-14.
+         because of the definition of t at line 1, characters 0-69.
 |}]
 
 let should_also_fail = This Null
@@ -132,7 +130,7 @@ Error: This expression has type 'a t = 'a or_null
        The kind of 'a t is value_or_null
          because it is the primitive value_or_null type or_null.
        But the kind of 'a t must be a subkind of value
-         because of the definition of t at lines 1-3, characters 0-14.
+         because of the definition of t at line 1, characters 0-69.
 |}]
 
 let mk' n = `Foo (This n)

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -476,6 +476,12 @@ let add_small_number_extension_types add_type env =
        ~jkind:(Jkind.Primitive.float32 ~why:(Primitive ident_unboxed_float32))
        ~jkind_annotation:Jkind.Const.Primitive.float32
 
+let or_null_kind tvar =
+  variant [cstr ident_null []; cstr ident_this [unrestricted tvar]]
+  [| Constructor_uniform_value, [| |];
+      Constructor_uniform_value, [| or_null_argument_jkind |];
+  |]
+
 let add_or_null add_type env =
   let add_type1 = mk_add_type1 add_type in
   env
@@ -489,11 +495,7 @@ let add_or_null add_type env =
      For now, we mark the type argument as [Separability.Ind] to permit
      the most argument types, and forbid arrays from accepting [or_null]s.
      In the future, we will track separability in the jkind system. *)
-  ~kind:(fun tvar ->
-    variant [cstr ident_null []; cstr ident_this [unrestricted tvar]]
-      [| Constructor_uniform_value, [| |];
-          Constructor_uniform_value, [| or_null_argument_jkind |];
-      |])
+  ~kind:or_null_kind
   ~jkind:(Jkind.Primitive.value_or_null ~why:(Primitive ident_or_null))
 
 let builtin_values =

--- a/ocaml/typing/predef.mli
+++ b/ocaml/typing/predef.mli
@@ -99,6 +99,8 @@ val ident_cons : Ident.t
 val ident_none : Ident.t
 val ident_some : Ident.t
 
+val ident_or_null : Ident.t
+
 (* The jkind used for optional function argument types *)
 val option_argument_jkind : Jkind.t
 (* The jkind used for list argument types *)

--- a/ocaml/typing/predef.mli
+++ b/ocaml/typing/predef.mli
@@ -128,6 +128,11 @@ val add_small_number_extension_types :
 val add_or_null :
    (Ident.t -> type_declaration -> 'a -> 'a) -> 'a -> 'a
 
+(* Construct the [type_kind] of [or_null]. For re-exporting [or_null]
+   while users can't define their own types with null constructors. *)
+(* CR layouts v3.5: remove this when users can define null constructors. *)
+val or_null_kind : type_expr -> ('a, constructor_declaration) type_kind
+
 (* To initialize linker tables *)
 
 val builtin_values: (string * Ident.t) list

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -181,6 +181,7 @@ type error =
       { definition: Path.t
       ; expected: Path.t
       }
+  | Non_abstract_reexport of Path.t
 
 exception Error of Location.t * error
 

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -177,6 +177,10 @@ type error =
   | Zero_alloc_attr_unsupported of Builtin_attributes.zero_alloc_attribute
   | Zero_alloc_attr_non_function
   | Zero_alloc_attr_bad_user_arity
+  | Invalid_reexport of
+      { definition: Path.t
+      ; expected: Path.t
+      }
 
 exception Error of Location.t * error
 


### PR DESCRIPTION
Add `[@@or_null_reexport]`, an attribute for re-exporting the constructors of `'a or_null`, because they can't be defined by users.

Between `type 'a t [@@or_null_reexport]` and `type 'a t = 'a or_null [@@or_null_reexport]` this PR chooses the latter to avoid unnecessary work in `typedecl.ml`. With the manifest set by user, we can delay updating `type_kind` until relatively late in typechecking.

Also fix `or_null.mli` to use `'a t` instead of `'a or_null`.