### PR TITLE
Add `Variant_with_null` and `Null` variant constructors

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1965,6 +1965,8 @@ let get_expr_args_constr ~scopes head (arg, _mut, sort, layout) rem =
           cstr.cstr_args
         @ rem
     | Variant_unboxed -> (arg, str, sort, layout) :: rem
+    | Variant_with_null ->
+      Misc.fatal_error "[Variant_with_null] not implemented yet"
     | Variant_extensible ->
         List.mapi
           (fun i { ca_sort } ->
@@ -2379,6 +2381,7 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
             in
             Lprim (Pmixedfield (lbl.lbl_pos, read, shape, sem), [ arg ], loc),
             lbl.lbl_sort, lbl_layout
+        | Record_inlined (_, _, Variant_with_null) -> assert false
       in
       let str = if Types.is_mutable lbl.lbl_mut then StrictOpt else Alias in
       let str = add_barrier_to_let_kind ubr str in
@@ -3197,7 +3200,7 @@ let split_cases tag_lambda_list =
           ((runtime_tag, act) :: consts, nonconsts)
         | Ordinary {runtime_tag}, Variant_boxed _ ->
           (consts, (runtime_tag, act) :: nonconsts)
-        | _, Variant_extensible -> assert false
+        | _, (Variant_extensible | Variant_with_null) -> assert false
         | Extension _, _ -> assert false
       )
   in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3202,6 +3202,7 @@ let split_cases tag_lambda_list =
           (consts, (runtime_tag, act) :: nonconsts)
         | _, (Variant_extensible | Variant_with_null) -> assert false
         | Extension _, _ -> assert false
+        | Null, _ -> Misc.fatal_error "[Null] constructors not implemented"
       )
   in
   let const, nonconst = split_rec tag_lambda_list in
@@ -3225,7 +3226,7 @@ let split_extension_cases tag_lambda_list =
        match cstr_constant, cstr_tag with
        | true, Extension path -> Left (path, act)
        | false, Extension path -> Right (path, act)
-       | _, Ordinary _ -> assert false)
+       | _, (Ordinary _ | Null) -> assert false)
     tag_lambda_list
 
 let transl_match_on_option value_kind arg loc ~if_some ~if_none =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -536,6 +536,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         | [x] -> x
         | _ -> assert false
       end else begin match cstr.cstr_tag, cstr.cstr_repr with
+      | Null, _ -> Misc.fatal_error "[Null] constructors not implemented yet"
       | Ordinary _, Variant_with_null ->
         Misc.fatal_error "[Variant_with_null] not implemented yet"
       | Ordinary {runtime_tag}, _ when cstr.cstr_constant ->
@@ -755,7 +756,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
              { value_prefix_len; flat_suffix }
            in
            Psetmixedfield(lbl.lbl_pos, write, shape, mode)
-        end
+          end
         | Record_inlined (_, _, Variant_with_null) -> assert false
       in
       Lprim(access, [transl_exp ~scopes Jkind.Sort.Const.for_record arg;
@@ -2043,7 +2044,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
             *)
             raise Not_constant
         | Record_inlined (_, _, (Variant_extensible | Variant_with_null))
-        | Record_inlined (Extension _, _, _) ->
+        | Record_inlined ((Extension _ | Null), _, _) ->
             raise Not_constant
       with Not_constant ->
         let loc = of_location ~scopes loc in
@@ -2088,6 +2089,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
             Lprim (Pmakemixedblock (runtime_tag, mut, shape, Option.get mode),
                    ll, loc)
         | Record_inlined (_, _, Variant_with_null) -> assert false
+        | Record_inlined (Null, _, _) -> assert false
     in
     begin match opt_init_expr with
       None -> lam

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -237,7 +237,8 @@ let compute_static_size lam =
                           (Variant_boxed _ | Variant_extensible))
         | Record_mixed shape ->
             Block (Mixed_record (size, Lambda.transl_mixed_product_shape shape))
-        | Record_unboxed | Record_ufloat | Record_inlined (_, _, Variant_unboxed) ->
+        | Record_unboxed | Record_ufloat
+        | Record_inlined (_, _, (Variant_unboxed | Variant_with_null)) ->
             Misc.fatal_error "size_of_primitive"
         end
     | Pmakeblock _ ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1469,7 +1469,10 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
           (* CR layouts v5.9: support this *)
           Misc.fatal_error "Mixed blocks extensible variants are not supported")
       | Record_inlined (Extension _, _, _)
-      | Record_inlined (Ordinary _, _, (Variant_unboxed | Variant_extensible))
+      | Record_inlined
+          ( Ordinary _,
+            _,
+            (Variant_unboxed | Variant_extensible | Variant_with_null) )
       | Record_unboxed ->
         Misc.fatal_errorf "Cannot handle record kind for Pduprecord: %a"
           Printlambda.primitive prim

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1473,7 +1473,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
           ( Ordinary _,
             _,
             (Variant_unboxed | Variant_extensible | Variant_with_null) )
-      | Record_unboxed ->
+      | Record_unboxed
+      | Record_inlined (Null, _, _) ->
         Misc.fatal_errorf "Cannot handle record kind for Pduprecord: %a"
           Printlambda.primitive prim
     in

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -335,3 +335,17 @@ let[@or_null_reexport] foo = 5
 [%%expect{|
 val foo : int = 5
 |}]
+
+(* [private] re-export fails. *)
+
+module Or_null = struct
+  type ('a : value) t : value_or_null = private 'a or_null [@@or_null_reexport]
+end
+
+[%%expect{|
+Line 2, characters 2-79:
+2 |   type ('a : value) t : value_or_null = private 'a or_null [@@or_null_reexport]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid reexport declaration.
+       Type t must be defined equal to the primitive type or_null.
+|}]

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -448,6 +448,10 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                       match rep with
                       | Variant_unboxed -> true
                       | Variant_boxed _ | Variant_extensible -> false
+                      | Variant_with_null ->
+                        (* CR layouts v3.0: fix this. *)
+                        Misc.fatal_error "[Variant_with_null] not implemented\
+                          in bytecode"
                     in
                     begin
                       match cd_args with

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -482,7 +482,7 @@ let is_exception_constructor env type_expr =
 
 let is_extension_constructor = function
   | Extension _ -> true
-  | Ordinary _ -> false
+  | Ordinary _ | Null -> false
 
 let () =
   (* This show_prim function will only show constructor types

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -129,6 +129,12 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
       end
     | Variant_unboxed, ([] | _ :: _) ->
       Misc.fatal_error "Multiple or 0 constructors in [@@unboxed] variant"
+    | Variant_with_null, _ ->
+      (* CR layouts v3.5: this hardcodes ['a or_null]. Fix when we allow
+         users to write their own null constructors. *)
+      (* CR layouts v3.3: generalize to [any]. *)
+      [| Constructor_uniform_value, [| |]
+       ; Constructor_uniform_value, [| Jkind.Sort.Const.value |] |]
   in
   let all_void sorts = Array.for_all Jkind.Sort.Const.(equal void) sorts in
   let num_consts = ref 0 and num_nonconsts = ref 0 in

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -161,7 +161,11 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
       then const_tag, 1 + const_tag, nonconst_tag
       else nonconst_tag, const_tag, 1 + nonconst_tag
     in
-    let cstr_tag = Ordinary {src_index; runtime_tag} in
+    let cstr_tag =
+      match rep, cstr_constant with
+      | Variant_with_null, true -> Null
+      | _, _ ->  Ordinary {src_index; runtime_tag}
+    in
     let cstr_existentials, cstr_args, cstr_inlined =
       (* This is the representation of the inner record, IF there is one *)
       let record_repr = Record_inlined (cstr_tag, cstr_shape, rep) in
@@ -279,7 +283,7 @@ let find_constr ~constant tag cstrs =
       (function
         | ({cstr_tag=Ordinary {runtime_tag=tag'}; cstr_constant},_) ->
           tag' = tag && cstr_constant = constant
-        | ({cstr_tag=Extension _},_) -> false)
+        | ({cstr_tag=(Extension _ | Null)},_) -> false)
       cstrs
   with
   | Not_found -> raise Constr_not_found

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -306,6 +306,7 @@ type type_mismatch =
   | Variant_mismatch of variant_change list
   | Unboxed_representation of position * attributes
   | Extensible_representation of position
+  | With_null_representation of position
   | Jkind of Jkind.Violation.t
 
 let report_modality_sub_error first second ppf e =
@@ -634,6 +635,10 @@ let report_type_mismatch first second decl env ppf err =
       pr "Their internal representations differ:@ %s %s %s."
          (choose ord first second) decl
          "is extensible"
+  | With_null_representation ord ->
+      pr "Their internal representations differ:@ %s %s %s."
+         (choose ord first second) decl
+         "has a null constructor"
   | Jkind v ->
       Jkind.Violation.report_with_name ~name:first ppf v
 
@@ -989,7 +994,8 @@ module Variant_diffing = struct
     match err, rep1, rep2 with
     | None, Variant_unboxed, Variant_unboxed
     | None, Variant_boxed _, Variant_boxed _
-    | None, Variant_extensible, Variant_extensible -> None
+    | None, Variant_extensible, Variant_extensible
+    | None, Variant_with_null, Variant_with_null -> None
     | Some err, _, _ ->
         Some (Variant_mismatch err)
     | None, Variant_unboxed, Variant_boxed _ ->
@@ -1000,6 +1006,10 @@ module Variant_diffing = struct
       Some (Extensible_representation First)
     | None, _, Variant_extensible ->
       Some (Extensible_representation Second)
+    | None, Variant_with_null, _ ->
+      Some (With_null_representation First)
+    | None, _, Variant_with_null ->
+      Some (With_null_representation Second)
 end
 
 (* Inclusion between "private" annotations *)

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -119,6 +119,7 @@ type type_mismatch =
   | Variant_mismatch of variant_change list
   | Unboxed_representation of position * attributes
   | Extensible_representation of position
+  | With_null_representation of position
   | Jkind of Jkind.Violation.t
 
 type mmodes =

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -976,6 +976,11 @@ and print_out_type_decl kwd ppf td =
   let print_unboxed ppf =
     if td.otype_unboxed then fprintf ppf " [%@%@unboxed]" else ()
   in
+  let print_or_null_reexport ppf =
+    if td.otype_or_null_reexport then
+      fprintf ppf " [%@%@or_null_reexport]"
+    else ()
+  in
   let print_out_tkind ppf = function
   | Otyp_abstract -> ()
   | Otyp_record lbls ->
@@ -1001,12 +1006,13 @@ and print_out_type_decl kwd ppf td =
         print_private td.otype_private
         !out_type ty
   in
-  fprintf ppf "@[<2>@[<hv 2>%t%a%a@]%t%t@]"
+  fprintf ppf "@[<2>@[<hv 2>%t%a%a@]%t%t%t@]"
     print_name_params
     print_out_jkind_annot td.otype_jkind
     print_out_tkind ty
     print_constraints
     print_unboxed
+    print_or_null_reexport
 
 and print_simple_out_gf_type ppf (ty, gf) =
   let m_legacy, m_new = partition_modalities gf in

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -204,6 +204,7 @@ and out_type_decl =
     otype_jkind: out_jkind option;
 
     otype_unboxed: bool;
+    otype_or_null_reexport: bool;
     otype_cstrs: (out_type * out_type) list }
 and out_extension_constructor =
   { oext_name: string;

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -923,7 +923,7 @@ let should_extend ext env = match ext with
   | (p,_)::_ ->
       let open Patterns.Head in
       begin match p.pat_desc with
-      | Construct {cstr_tag=Ordinary _} ->
+      | Construct {cstr_tag=Ordinary _ | Null} ->
           let path = get_constructor_type_path p.pat_type p.pat_env in
           Path.same path ext
       | Construct {cstr_tag=Extension _} -> false
@@ -2129,7 +2129,7 @@ let extendable_path path =
     Path.same path Predef.path_option)
 
 let rec collect_paths_from_pat r p = match p.pat_desc with
-| Tpat_construct(_, {cstr_tag=Ordinary _}, ps, _) ->
+| Tpat_construct(_, {cstr_tag=Ordinary _ | Null}, ps, _) ->
     let path = get_constructor_type_path p.pat_type p.pat_env in
     List.fold_left
       collect_paths_from_pat

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -477,6 +477,8 @@ let add_small_number_beta_extension_types add_type env =
   |> add_type ident_int16 ~jkind:Jkind.Const.Builtin.immediate
 
 let or_null_kind tvar =
+  (* CR layouts v3: use [Variant_with_null] when it's supported
+     in the backend. *)
   variant [cstr ident_null [];
            cstr ident_this [unrestricted tvar or_null_argument_sort]]
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1934,35 +1934,46 @@ let tree_of_type_decl id decl =
   in
   let (name, args) = type_defined decl in
   let constraints = tree_of_constraints params in
-  let ty, priv, unboxed =
+  let ty, priv, unboxed, or_null_reexport =
     match decl.type_kind with
     | Type_abstract _ ->
         begin match ty_manifest with
-        | None -> (Otyp_abstract, Public, false)
+        | None -> (Otyp_abstract, Public, false, false)
         | Some ty ->
-            tree_of_typexp Type ty, decl.type_private, false
+            tree_of_typexp Type ty, decl.type_private, false, false
         end
     | Type_variant (cstrs, rep) ->
         let unboxed =
           match rep with
           | Variant_unboxed -> true
-          | Variant_boxed _ | Variant_extensible -> false
+          | Variant_boxed _ | Variant_extensible | Variant_with_null -> false
+        in
+        (* CR layouts v3.5: remove when [Variant_with_null] is merged into
+           [Variant_unboxed]. *)
+        let or_null_reexport =
+          match rep with
+          | Variant_with_null -> true
+          | Variant_boxed _ | Variant_unboxed | Variant_extensible -> false
         in
         tree_of_manifest (Otyp_sum (List.map tree_of_constructor_in_decl cstrs)),
         decl.type_private,
-        unboxed
+        unboxed,
+        or_null_reexport
     | Type_record(lbls, rep) ->
         tree_of_manifest (Otyp_record (List.map tree_of_label lbls)),
         decl.type_private,
-        (match rep with Record_unboxed -> true | _ -> false)
+        (match rep with Record_unboxed -> true | _ -> false),
+        false
     | Type_record_unboxed_product(lbls, Record_unboxed_product) ->
         tree_of_manifest
           (Otyp_record_unboxed_product (List.map tree_of_label lbls)),
         decl.type_private,
+        false,
         false
     | Type_open ->
         tree_of_manifest Otyp_open,
         decl.type_private,
+        false,
         false
   in
   (* The algorithm for setting [lay] here is described as Case (C1) in
@@ -1984,6 +1995,7 @@ let tree_of_type_decl id decl =
       otype_private = priv;
       otype_jkind;
       otype_unboxed = unboxed;
+      otype_or_null_reexport = or_null_reexport;
       otype_cstrs = constraints }
 
 let add_type_decl_to_preparation id decl =

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -198,6 +198,7 @@ let variant_representation i ppf = let open Types in function
          sort_array (i+1) ppf sorts))
       cstrs
   | Variant_extensible -> line i ppf "Variant_inlined\n"
+  | Variant_with_null -> line i ppf "Variant_with_null\n"
 
 let flat_element i ppf flat_element =
   line i ppf "%s\n" (Types.flat_element_to_string flat_element)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -188,6 +188,7 @@ let tag ppf = let open Types in function
   | Ordinary {src_index;runtime_tag} ->
       fprintf ppf "Ordinary {index: %d; tag: %d}" src_index runtime_tag
   | Extension p -> fprintf ppf "Extension %a" fmt_path p
+  | Null -> fprintf ppf "Null"
 
 let variant_representation i ppf = let open Types in function
   | Variant_unboxed ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8453,8 +8453,10 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
     begin match constr.cstr_repr with
     | Variant_extensible ->
         raise(Error(loc, env, Private_constructor (constr, ty_res)))
-    | Variant_boxed _ | Variant_unboxed | Variant_with_null ->
+    | Variant_boxed _ | Variant_unboxed ->
         raise (Error(loc, env, Private_type ty_res));
+    | Variant_with_null -> assert false
+      (* [Variant_with_null] can't be made private due to [or_null_reexport]. *)
     end;
   (* NOTE: shouldn't we call "re" on this final expression? -- AF *)
   { texp with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5417,7 +5417,9 @@ and type_expect_
             (rep : rep) =
         match record_form with
         | Legacy -> begin match rep with
-          | Record_unboxed | Record_inlined (_, _, Variant_unboxed) -> false
+          | Record_unboxed
+          | Record_inlined (_, _, (Variant_unboxed | Variant_with_null))
+            -> false
           | Record_boxed _ | Record_float | Record_ufloat | Record_mixed _
           | Record_inlined (_, _, (Variant_boxed _ | Variant_extensible))
             -> true
@@ -8416,7 +8418,7 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
   in
   let (argument_mode, alloc_mode) =
     match constr.cstr_repr with
-    | Variant_unboxed -> expected_mode, None
+    | Variant_unboxed | Variant_with_null -> expected_mode, None
     | Variant_boxed _ when constr.cstr_constant -> expected_mode, None
     | Variant_boxed _ | Variant_extensible ->
        let alloc_mode, argument_mode = register_allocation expected_mode in
@@ -8451,7 +8453,7 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
     begin match constr.cstr_repr with
     | Variant_extensible ->
         raise(Error(loc, env, Private_constructor (constr, ty_res)))
-    | Variant_boxed _ | Variant_unboxed ->
+    | Variant_boxed _ | Variant_unboxed | Variant_with_null ->
         raise (Error(loc, env, Private_type ty_res));
     end;
   (* NOTE: shouldn't we call "re" on this final expression? -- AF *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1664,6 +1664,11 @@ let update_decl_jkind env dpath decl =
   let update_variant_kind cstrs rep =
     (* CR layouts: factor out duplication *)
     match cstrs, rep with
+    | _, Variant_with_null ->
+      (* CR layouts v3.5: this case only happens with [or_null_reexport].
+         Change when we allow users to write their own null constructors. *)
+      (* CR layouts v3.3: use [any_non_null]. *)
+      cstrs, rep, Jkind.Builtin.value_or_null ~why:(Primitive Predef.ident_or_null)
     | [{Types.cd_args} as cstr], Variant_unboxed -> begin
         match cd_args with
         | Cstr_tuple [{ca_type=ty; _} as arg] -> begin
@@ -1738,8 +1743,7 @@ let update_decl_jkind env dpath decl =
                   type_jkind;
                   type_has_illegal_crossings },
       type_jkind
-    (* CR layouts v3.0: handle this case in [update_variant_jkind] when
-       [Variant_with_null] introduced.
+    (* CR layouts v3.0: remove this once [or_null] is [Variant_with_null].
 
        No updating required for [or_null_reexport], and we must not
        incorrectly override the jkind to [non_null].

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -1124,6 +1124,11 @@ let iter_pattern_full ~of_sort ~of_const_sort ~both_sides_of_or f sort pat =
           let sorts =
             match cstr.cstr_repr with
             | Variant_unboxed -> [ sort ]
+            (* CR layouts v3.5: this hardcodes ['a or_null]. Fix when we allow
+               users to write their own null constructors. *)
+            | Variant_with_null when cstr.cstr_constant -> []
+            (* CR layouts v3.3: allow all sorts. *)
+            | Variant_with_null -> [ value ]
             | Variant_boxed _ | Variant_extensible ->
               (List.map (fun { ca_sort } -> of_const_sort ca_sort )
                  cstr.cstr_args)

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -783,6 +783,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
           | Record_mixed _ ->
             [0, fields]
           | Record_unboxed -> assert false
+          | Record_inlined (Null, _, _) -> assert false
         in
         (num_nodes_visited, mk_nn (Pvariant { consts = []; non_consts }))
     end

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -560,6 +560,8 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
       (cstrs : Types.constructor_declaration list) rep =
   match rep with
   | Variant_extensible -> assert false
+  | Variant_with_null ->
+    num_nodes_visited + 1, { raw_kind = Pgenval; nullable = Nullable }
   | Variant_unboxed -> begin
       (* CR layouts v1.5: This should only be reachable in the case of a missing
          cmi, according to the comment on scrape_ty.  Reevaluate whether it's
@@ -701,6 +703,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ld_type
       | [] | _ :: _ :: _ -> assert false
     end
+  | Record_inlined (_, _, Variant_with_null) -> assert false
   | Record_inlined (_, _, (Variant_boxed _ | Variant_extensible))
   | Record_boxed _ | Record_float | Record_ufloat | Record_mixed _ -> begin
       let is_mutable =

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -286,6 +286,7 @@ and ('lbl, 'lbl_flat, 'cstr) type_kind =
 and tag = Ordinary of {src_index: int;     (* Unique name (per type) *)
                        runtime_tag: int}   (* The runtime tag *)
         | Extension of Path.t
+        | Null
 
 and type_origin =
     Definition
@@ -607,15 +608,19 @@ let equal_tag t1 t2 =
   | Ordinary {src_index=i1}, Ordinary {src_index=i2} ->
     i2 = i1 (* If i1 = i2, the runtime_tags will also be equal *)
   | Extension path1, Extension path2 -> Path.same path1 path2
-  | (Ordinary _ | Extension _), _ -> false
+  | Null, Null -> true
+  | (Ordinary _ | Extension _ | Null), _ -> false
 
 let compare_tag t1 t2 =
   match (t1, t2) with
   | Ordinary {src_index=i1}, Ordinary {src_index=i2} ->
     Int.compare i1 i2
   | Extension path1, Extension path2 -> Path.compare path1 path2
-  | Ordinary _, Extension _ -> -1
-  | Extension _, Ordinary _ -> 1
+  | Null, Null -> 0
+  | Ordinary _, (Extension _ | Null) -> -1
+  | (Extension _ | Null), Ordinary _ -> 1
+  | Extension _, Null -> -1
+  | Null, Extension _ -> 1
 
 let equal_flat_element e1 e2 =
   match e1, e2 with

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -324,6 +324,7 @@ and variant_representation =
   | Variant_boxed of (constructor_representation *
                       Jkind_types.Sort.Const.t array) array
   | Variant_extensible
+  | Variant_with_null
 
 and constructor_representation =
   | Constructor_uniform_value
@@ -669,7 +670,8 @@ let equal_variant_representation r1 r2 = r1 == r2 || match r1, r2 with
         cstrs_and_sorts2
   | Variant_extensible, Variant_extensible ->
       true
-  | (Variant_unboxed | Variant_boxed _ | Variant_extensible), _ ->
+  | Variant_with_null, Variant_with_null -> true
+  | (Variant_unboxed | Variant_boxed _ | Variant_extensible | Variant_with_null), _ ->
       false
 
 let equal_record_representation r1 r2 = match r1, r2 with
@@ -745,15 +747,14 @@ let find_unboxed_type decl =
   | Type_record_unboxed_product
                 ([{ld_type = arg; _}], Record_unboxed_product)
   | Type_variant ([{cd_args = Cstr_tuple [{ca_type = arg; _}]; _}], Variant_unboxed)
-  | Type_variant ([{cd_args = Cstr_record [{ld_type = arg; _}]; _}],
-                  Variant_unboxed) ->
+  | Type_variant ([{cd_args = Cstr_record [{ld_type = arg; _}]; _}], Variant_unboxed) ->
     Some arg
   | Type_record (_, ( Record_inlined _ | Record_unboxed
                     | Record_boxed _ | Record_float | Record_ufloat
                     | Record_mixed _))
   | Type_record_unboxed_product (_, Record_unboxed_product)
   | Type_variant (_, ( Variant_boxed _ | Variant_unboxed
-                     | Variant_extensible ))
+                     | Variant_extensible | Variant_with_null))
   | Type_abstract _ | Type_open ->
     None
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -570,6 +570,7 @@ and ('lbl, 'lbl_flat, 'cstr) type_kind =
 and tag = Ordinary of {src_index: int;  (* Unique name (per type) *)
                        runtime_tag: int}    (* The runtime tag *)
         | Extension of Path.t
+        | Null (* Null pointer *)
 
 (* A mixed product contains a possibly-empty prefix of values followed by a
    non-empty suffix of "flat" elements. Intuitively, a flat element is one that

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -634,6 +634,11 @@ and variant_representation =
      [Constructor_mixed] if the inlined record has any unboxed fields.
   *)
   | Variant_extensible
+  | Variant_with_null
+  (* CR layouts v3.5: A custom variant representation for ['a or_null].
+     Eventually, it should likely be merged into [Variant_unboxed], with
+     [Variant_unboxed] allowing either one ordinary constructor, or one
+     ordinary non-null and one [Null] constructor. *)
 
 and constructor_representation =
   | Constructor_uniform_value

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -735,7 +735,7 @@ let rec expression : Typedtree.expression -> term_judg =
         | _ -> empty
       in
       let arg_mode i = match desc.cstr_repr with
-        | Variant_unboxed ->
+        | Variant_unboxed | Variant_with_null ->
           Return
         | Variant_boxed _ | Variant_extensible ->
            (match desc.cstr_shape with


### PR DESCRIPTION
Add `Variant_with_null` and `Null` variant constructors to the compiler frontend. Hardcode involved jkinds for `'a or_null`.

This PR will be tested by future changes connecting `or_null` to the middle-end.