### PR TITLE
Ensure GC logs are printed atomically

### DIFF
--- a/ocaml/runtime/caml/osdeps.h
+++ b/ocaml/runtime/caml/osdeps.h
@@ -103,8 +103,12 @@ extern char_os *caml_secure_getenv(char_os const *var);
    cannot be determined, return -1. */
 extern int caml_num_rows_fd(int fd);
 
-/* Print a timestamp for verbose GC logs */
-extern void caml_print_timestamp(FILE* channel, int formatted);
+/* Print a timestamp for verbose GC logs.
+
+   Arguments as per snprintf: takes a buf and size, returns the length
+   of the formatted string (which may be greater than sz, in which
+   case the string is truncated) */
+extern int caml_format_timestamp(char* buf, size_t sz, int formatted);
 
 /* Memory management platform-specific operations */
 

--- a/ocaml/runtime/unix.c
+++ b/ocaml/runtime/unix.c
@@ -475,12 +475,12 @@ int caml_num_rows_fd(int fd)
 #endif
 }
 
-void caml_print_timestamp(FILE* channel, int formatted)
+int caml_format_timestamp(char* buf, size_t sz, int formatted)
 {
   struct timeval tv;
   gettimeofday(&tv, NULL);
   if (!formatted) {
-    fprintf(channel, "%ld.%06d ", (long)tv.tv_sec, (int)tv.tv_usec);
+    return snprintf(buf, sz, "%ld.%06d ", (long)tv.tv_sec, (int)tv.tv_usec);
   } else {
     struct tm tm;
     char tz[64] = "Z";
@@ -491,7 +491,7 @@ void caml_print_timestamp(FILE* channel, int formatted)
       if (tzmin < 0) {tzmin += 60; tzhour--;}
       sprintf(tz, "%+03ld:%02ld", tzhour, tzmin);
     }
-    fprintf(channel,
+    return snprintf(buf, sz,
             "[%04d-%02d-%02d %02d:%02d:%02d.%06d%s] ",
             1900 + tm.tm_year,
             tm.tm_mon + 1,

--- a/ocaml/runtime/win32.c
+++ b/ocaml/runtime/win32.c
@@ -1107,9 +1107,10 @@ int caml_num_rows_fd(int fd)
   return -1;
 }
 
-void caml_print_timestamp(FILE* channel, int formatted)
+int caml_format_timestamp(char* buf, size_t sz, int formatted)
 {
   /* unimplemented */
+  return 0;
 }
 
 /* UCRT clock function returns wall-clock time */


### PR DESCRIPTION
Multi-domain GC logging can currently interleave timestamps and messages, making them hard to read. This patch formats the message into a local buffer before writing it in a single call to `fwrite`, which makes the output nicer.