### PR TITLE
Draft `or_null` implementation

### DIFF
--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -524,15 +524,15 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         | [x] -> x
         | _ -> assert false
       end else begin match cstr.cstr_tag, cstr.cstr_repr with
-      | Null, _ -> Misc.fatal_error "[Null] constructors not implemented yet"
-      | Ordinary _, Variant_with_null ->
-        Misc.fatal_error "[Variant_with_null] not implemented yet"
+      | Null, Variant_with_null -> Lconst Const_null
+      | Null, (Variant_boxed _ | Variant_unboxed | Variant_extensible) ->
+        assert false
       | Ordinary {runtime_tag}, _ when cstr.cstr_constant ->
           assert (args_with_sorts = []);
           (* CR layouts v5: This could have void args, but for now we've ruled
              that out by checking that the sort list is empty *)
           Lconst(const_int runtime_tag)
-      | Ordinary _, (Variant_unboxed) ->
+      | Ordinary _, (Variant_unboxed | Variant_with_null) ->
           (match ll with [v] -> v | _ -> assert false)
       | Ordinary {runtime_tag}, Variant_boxed _ ->
           let constant =

--- a/ocaml/otherlibs/stdlib_alpha/or_null.ml
+++ b/ocaml/otherlibs/stdlib_alpha/or_null.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
+(* type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
 
 let null = Null
 let this v = This v
@@ -42,4 +42,4 @@ let to_result ~null = function Null -> Error null | This v -> Ok v
 let to_list = function Null -> [] | This v -> [ v ]
 let to_seq = function Null -> Seq.empty | This v -> Seq.return v
 let to_option = function Null -> None | This v -> Some v
-let of_option = function None -> Null | Some v -> This v
+let of_option = function None -> Null | Some v -> This v *)

--- a/ocaml/otherlibs/stdlib_alpha/or_null.mli
+++ b/ocaml/otherlibs/stdlib_alpha/or_null.mli
@@ -24,7 +24,7 @@
 (* CR layouts: enable ocamlformat for this module when it starts supporting
    jkind annotations. *)
 
-type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
+(* type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
       (** The type of nullable values. Either [Null] or a value [This v].
           ['a or_null] has a non-standard layout [value_or_null],
           preventing the type constructor from being nested. *)
@@ -83,4 +83,4 @@ val to_option : 'a t -> 'a option
 (** [to_option o] is [Some v] if [o] is [This v] and [None] otherwise. *)
 
 val of_option : 'a option -> 'a t
-(** [of_option o] is [This v] if [o] is [Some v] and [Null] otherwise. *)
+* [of_option o] is [This v] if [o] is [Some v] and [Null] otherwise. *)

--- a/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/ocaml/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -104,11 +104,11 @@ let _ = fun a b -> match a, b with
 [%%expect {|
 (function {nlocal = 0} a/291[int] b/292
   [(consts ()) (non_consts ([0: [int], *]))](let
-                                              (p/293 =a[(consts ())
+                                              (p/294 =a[(consts ())
                                                         (non_consts (
                                                         [0: [int], *]))]
                                                  (makeblock 0 a/291 b/292))
-                                              p/293))
+                                              p/294))
 (function {nlocal = 0} a/291[int] b/292
   [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/291 b/292))
 - : bool -> 'a -> bool * 'a = <fun>
@@ -140,11 +140,11 @@ let _ = fun a b -> match a, b with
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
   (let
-    (x/303 =a[int] a/301
-     p/304 =a[(consts ()) (non_consts ([0: [int], *]))]
+    (x/305 =a[int] a/301
+     p/306 =a[(consts ()) (non_consts ([0: [int], *]))]
        (makeblock 0 a/301 b/302))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/303
-      p/304)))
+    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/305
+      p/306)))
 (function {nlocal = 0} a/301[int] b/302
   [(consts ())
    (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/runtime.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/runtime.ml
@@ -1,0 +1,151 @@
+(* TEST
+   flags = "-extension layouts_alpha";
+   runtime5;
+   native;
+*)
+
+let x = Null
+
+let () =
+  match x with
+  | Null -> ()
+  | This _ -> assert false
+;;
+
+let y = This 3
+
+let () =
+  match y with
+  | This 3 -> ()
+  | _ -> assert false
+;;
+
+
+external int_as_pointer : int -> int or_null = "%int_as_pointer"
+
+let n = int_as_pointer 0
+
+let () =
+  match n with
+  | Null -> ()
+  | _ -> assert false
+;;
+
+external int_as_int : int -> int or_null = "%identity"
+
+let m = int_as_int 5
+
+let () =
+  match m with
+  | This 5 -> ()
+  | This _ -> assert false
+  | Null -> assert false
+;;
+
+let x = (Null, This "bar")
+
+let () =
+  match x with
+  | Null, This "foo" -> assert false
+  | Null, This "bar" -> ()
+  | _, This "bar" -> assert false
+  | Null, _ -> assert false
+  | _, _ -> assert false
+;;
+
+let y a = fun () -> This a
+
+let d = y 5
+
+let () =
+  match d () with
+  | This 5 -> ()
+  | _ -> assert false
+;;
+
+external to_bytes : ('a : value_or_null) . 'a -> int list -> bytes = "caml_output_value_to_bytes"
+
+external from_bytes_unsafe : ('a : value_or_null) . bytes -> int -> 'a = "caml_input_value_from_bytes"
+
+let z = to_bytes (This "foo") []
+
+let () =
+  match from_bytes_unsafe z 0 with
+    | This "foo" -> ()
+    | This _ -> assert false
+    | Null -> assert false
+;;
+
+let w = to_bytes Null []
+
+let () =
+  match from_bytes_unsafe w 0 with
+    | Null -> ()
+    | This _ -> assert false
+;;
+
+external evil : 'a or_null -> 'a = "%identity"
+
+let e = This (evil Null)
+
+let () =
+  match e with
+  | Null -> ()
+  | This _ -> assert false
+;;
+
+let e' = evil (This 4)
+
+let () =
+  match e' with
+  | 4 -> ()
+  | _ -> assert false
+;;
+
+let f a = fun () ->
+  match a with
+  | This x -> x ^ "bar"
+  | Null -> "foo"
+;;
+
+let g = f (This "xxx")
+
+let () =
+  match g () with
+  | "xxxbar" -> ()
+  | _ -> assert false
+;;
+
+let h = f Null
+
+let () =
+  match h () with
+  | "foo" -> ()
+  | _ -> assert false
+;;
+
+type 'a nref = { mutable v : 'a or_null }
+
+let x : string nref = { v = Null }
+
+let () =
+  match x.v with
+  | Null -> ()
+  | _ -> assert false
+;;
+
+let () = x.v <- This "foo"
+
+let () =
+  match x.v with
+  | This "foo" -> ()
+  | _ -> assert false
+;;
+
+let () = x.v <- Null
+
+let () =
+  match x.v with
+  | Null -> ()
+  | _ -> assert false
+;;

--- a/ocaml/testsuite/tests/typing-layouts-or-null/runtime.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/runtime.ml
@@ -149,3 +149,10 @@ let () =
   | Null -> ()
   | _ -> assert false
 ;;
+
+let[@warning "-11"] () =
+  match Null with
+  | Null -> ()
+  | Null -> assert false
+  | _ -> assert false
+;;

--- a/ocaml/testsuite/tests/typing-layouts-or-null/stdlib_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/stdlib_or_null.ml
@@ -1,4 +1,6 @@
 (* TEST
+ reason = "testing";
+ skip;
  flags = "-extension layouts_alpha";
  include stdlib_alpha;
  expect;

--- a/ocaml/typing/datarepr.ml
+++ b/ocaml/typing/datarepr.ml
@@ -147,7 +147,11 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
       then const_tag, 1 + const_tag, nonconst_tag
       else nonconst_tag, const_tag, 1 + nonconst_tag
     in
-    let cstr_tag = Ordinary {src_index; runtime_tag} in
+    let cstr_tag =
+      match rep, cstr_constant with
+      | Variant_with_null, true -> Null
+      | _, _ ->  Ordinary {src_index; runtime_tag}
+    in
     let cstr_existentials, cstr_args, cstr_inlined =
       (* This is the representation of the inner record, IF there is one *)
       let record_repr = Record_inlined (cstr_tag, cstr_shape, rep) in

--- a/testsuite/tests/lib-extensions/alpha_exports.ml
+++ b/testsuite/tests/lib-extensions/alpha_exports.ml
@@ -17,9 +17,9 @@ let () =
 ;;
 
 (* Test that [Or_null] is exported. *)
-
+(*
 let () =
   match Or_null.null with
   | Null -> ()
   | This _ -> assert false
-;;
+;; *)


### PR DESCRIPTION
Implement constructors and pattern matching for `or_null`, in the native backend, on runtime 5. Temporarily disable `Stdlib_alpha.Or_null` due to issues in bytecode.