### PR TITLE
Improve the modes in `predef.ml`

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-or-null/array.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/array.ml
@@ -37,3 +37,36 @@ Error: This type t_value_or_null should be an instance of type
        But the kind of t_value_or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
+
+type t_any : any
+
+type should_fail = t_any iarray
+
+[%%expect{|
+type t_any : any
+Line 3, characters 19-24:
+3 | type should_fail = t_any iarray
+                       ^^^^^
+Error: This type t_any should be an instance of type ('a : any_non_null)
+       The kind of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the kind of t_any must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}]
+
+type t_value_or_null : value_or_null
+
+type should_fail = t_value_or_null iarray
+
+[%%expect{|
+type t_value_or_null : value_or_null
+Line 3, characters 19-34:
+3 | type should_fail = t_value_or_null iarray
+                       ^^^^^^^^^^^^^^^
+Error: This type t_value_or_null should be an instance of type
+         ('a : any_non_null)
+       The kind of t_value_or_null is value_or_null
+         because of the definition of t_value_or_null at line 1, characters 0-36.
+       But the kind of t_value_or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/datatypes.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes.ml
@@ -339,8 +339,8 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The kind of float is value
-         because it is the primitive value type float.
+       The kind of float is immutable_data
+         because it is the primitive immutable_data type float.
        But the kind of float must be a subkind of immediate
          because of the definition of s6 at line 2, characters 0-35.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -325,8 +325,8 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type float but an expression was expected of type
          ('a : immediate)
-       The kind of float is value
-         because it is the primitive value type float.
+       The kind of float is immutable_data
+         because it is the primitive immutable_data type float.
        But the kind of float must be a subkind of immediate
          because of the definition of s6 at line 2, characters 0-35.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -975,7 +975,7 @@ Line 1, characters 0-70:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type t is value
          because it's a boxed record type.
-       But the kind of type t must be a subkind of value mod many portable
+       But the kind of type t must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)

--- a/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
@@ -699,6 +699,25 @@ val take_strong_mutable_data : 'a @ portable -> unit = <fun>
 |}]
 
 (* mode crossing on the right *)
+let ref_immutable_data_right x =
+  take_strong_immutable_data (weaken_immutable_data x : float ref);
+[%%expect{|
+Line 2, characters 30-53:
+2 |   take_strong_immutable_data (weaken_immutable_data x : float ref);
+                                  ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is once but expected to be many.
+|}]
+
+let ref_immutable_data_left x =
+  let x : float ref = weaken_immutable_data x in
+  take_strong_immutable_data x
+[%%expect{|
+Line 3, characters 29-30:
+3 |   take_strong_immutable_data x
+                                 ^
+Error: This value is once but expected to be many.
+|}]
+
 let float_immutable_data_right x =
   take_strong_immutable_data (weaken_immutable_data x : float);
 [%%expect{|

--- a/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
@@ -754,6 +754,12 @@ let float32_immutable_data_right x =
 val float32_immutable_data_right : float32 -> unit = <fun>
 |}]
 
+let int64x2_immutable_data_right x =
+  take_strong_immutable_data (weaken_immutable_data x : int64x2)
+[%%expect{|
+val int64x2_immutable_data_right : int64x2 -> unit = <fun>
+|}]
+
 let floatarray_mutable_data_right x =
   take_strong_mutable_data (weaken_mutable_data x : floatarray)
 [%%expect{|
@@ -807,6 +813,13 @@ let float32_immutable_data_left x =
   take_strong_immutable_data x
 [%%expect{|
 val float32_immutable_data_left : float32 -> unit = <fun>
+|}]
+
+let int64x2_immutable_data_left x =
+  let x : int64x2 = weaken_immutable_data x in
+  take_strong_immutable_data x
+[%%expect{|
+val int64x2_immutable_data_left : int64x2 -> unit = <fun>
 |}]
 
 let floatarray_mutable_data_left x =

--- a/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
@@ -680,9 +680,6 @@ let foo : (string -> string) -> (string -> string) @ unique
 val foo : (string -> string) -> unique_ (string -> string) = <fun>
 |}]
 
-(* CR layouts: maybe use the helper function below to refactor the tests above,
-   as well as [expected_mode.ml]. *)
-
 let weaken_immutable_data : 'a -> 'a @ contended once nonportable =
   fun a -> a
 

--- a/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
@@ -345,12 +345,8 @@ Error: This value is once but expected to be many.
 
 let float_duplicate = let once_ x : float = 3.14 in Fun.id x
 
-(* CR layouts v2.8: this should succeed *)
 [%%expect{|
-Line 1, characters 59-60:
-1 | let float_duplicate = let once_ x : float = 3.14 in Fun.id x
-                                                               ^
-Error: This value is once but expected to be many.
+val float_duplicate : float = 3.14
 |}]
 
 let float_u_duplicate () = let once_ x : float# = #3.14 in Float_u.id x
@@ -682,4 +678,131 @@ let foo : (string -> string) -> (string -> string) @ unique
   = fun f -> f
 [%%expect{|
 val foo : (string -> string) -> unique_ (string -> string) = <fun>
+|}]
+
+(* CR layouts: maybe use the helper function below to refactor the tests above,
+   as well as [expected_mode.ml]. *)
+
+let weaken_immutable_data : 'a -> 'a @ contended once nonportable =
+  fun a -> a
+
+let take_strong_immutable_data (x @ uncontended many portable) = ()
+[%%expect{|
+val weaken_immutable_data : 'a -> once_ 'a @ contended = <fun>
+val take_strong_immutable_data : 'a @ portable -> unit = <fun>
+|}]
+
+let weaken_mutable_data : 'a -> 'a @ once nonportable =
+  fun a -> a
+
+let take_strong_mutable_data (x @ many portable) = ()
+[%%expect{|
+val weaken_mutable_data : 'a -> once_ 'a = <fun>
+val take_strong_mutable_data : 'a @ portable -> unit = <fun>
+|}]
+
+(* mode crossing on the right *)
+let float_immutable_data_right x =
+  take_strong_immutable_data (weaken_immutable_data x : float);
+[%%expect{|
+val float_immutable_data_right : float -> unit = <fun>
+|}]
+
+let int32_immutable_data_right x =
+  take_strong_immutable_data (weaken_immutable_data x : int32)
+[%%expect{|
+val int32_immutable_data_right : int32 -> unit = <fun>
+|}]
+
+let int64_immutable_data_right x =
+  take_strong_immutable_data (weaken_immutable_data x : int64)
+[%%expect{|
+val int64_immutable_data_right : int64 -> unit = <fun>
+|}]
+
+let nativeint_immutable_data_right x =
+  take_strong_immutable_data (weaken_immutable_data x : nativeint)
+[%%expect{|
+val nativeint_immutable_data_right : nativeint -> unit = <fun>
+|}]
+
+let string_immutable_data_right x =
+  take_strong_immutable_data (weaken_immutable_data x : string)
+[%%expect{|
+val string_immutable_data_right : string -> unit = <fun>
+|}]
+
+let float32_immutable_data_right x =
+  take_strong_immutable_data (weaken_immutable_data x : float32)
+[%%expect{|
+val float32_immutable_data_right : float32 -> unit = <fun>
+|}]
+
+let floatarray_mutable_data_right x =
+  take_strong_mutable_data (weaken_mutable_data x : floatarray)
+[%%expect{|
+val floatarray_mutable_data_right : floatarray -> unit = <fun>
+|}]
+
+let bytes_mutable_data_right x =
+  take_strong_mutable_data (weaken_mutable_data x : bytes)
+[%%expect{|
+val bytes_mutable_data_right : bytes -> unit = <fun>
+|}]
+
+(* mode crossing on the left *)
+let float_immutable_data_left x =
+  let x : float = weaken_immutable_data x in
+  take_strong_immutable_data x
+[%%expect{|
+val float_immutable_data_left : float -> unit = <fun>
+|}]
+
+let int32_immutable_data_left x =
+  let x : int32 = weaken_immutable_data x in
+  take_strong_immutable_data x
+[%%expect{|
+val int32_immutable_data_left : int32 -> unit = <fun>
+|}]
+
+let int64_immutable_data_left x =
+  let x : int64 = weaken_immutable_data x in
+  take_strong_immutable_data x
+[%%expect{|
+val int64_immutable_data_left : int64 -> unit = <fun>
+|}]
+
+let nativeint_immutable_data_left x =
+  let x : nativeint = weaken_immutable_data x in
+  take_strong_immutable_data x
+[%%expect{|
+val nativeint_immutable_data_left : nativeint -> unit = <fun>
+|}]
+
+let string_immutable_data_left x =
+  let x : string = weaken_immutable_data x in
+  take_strong_immutable_data x
+[%%expect{|
+val string_immutable_data_left : string -> unit = <fun>
+|}]
+
+let float32_immutable_data_left x =
+  let x : float32 = weaken_immutable_data x in
+  take_strong_immutable_data x
+[%%expect{|
+val float32_immutable_data_left : float32 -> unit = <fun>
+|}]
+
+let floatarray_mutable_data_left x =
+  let x : floatarray = weaken_mutable_data x in
+  take_strong_mutable_data x
+[%%expect{|
+val floatarray_mutable_data_left : floatarray -> unit = <fun>
+|}]
+
+let bytes_mutable_data_left x =
+  let x : bytes = weaken_mutable_data x in
+  take_strong_mutable_data x
+[%%expect{|
+val bytes_mutable_data_left : bytes -> unit = <fun>
 |}]

--- a/ocaml/testsuite/tests/typing-modal-kinds/expected_mode.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/expected_mode.ml
@@ -248,10 +248,7 @@ val hidden_int_duplicate : once_ Hidden_int.t -> Hidden_int.t = <fun>
 let float_duplicate : once_ _ -> float = fun x -> x
 
 [%%expect{|
-Line 1, characters 50-51:
-1 | let float_duplicate : once_ _ -> float = fun x -> x
-                                                      ^
-Error: This value is once but expected to be many.
+val float_duplicate : once_ float -> float = <fun>
 |}]
 
 let float_u_duplicate : once_ _ -> float# = fun x -> x

--- a/ocaml/testsuite/tests/typing-modes/portable-contend.ml
+++ b/ocaml/testsuite/tests/typing-modes/portable-contend.ml
@@ -66,11 +66,11 @@ Line 1, characters 4-33:
 Error: This value is contended but expected to be uncontended.
 |}]
 
-let x @ portable = best_bytes ()
+let x @ portable = fun a -> a
 
 let y @ portable = x
 [%%expect{|
-val x : bytes = Bytes.of_string ""
+val x : 'a -> 'a = <fun>
 Line 3, characters 19-20:
 3 | let y @ portable = x
                        ^

--- a/ocaml/testsuite/tests/typing-unique/unique_analysis.ml
+++ b/ocaml/testsuite/tests/typing-unique/unique_analysis.ml
@@ -32,17 +32,17 @@ val update : unique_ box -> unique_ box = <fun>
 
 (* testing Texp_ifthenelse  *)
 
-let branching (unique_ x : float) = unique_ if true then x else x
+let branching (unique_ x) = unique_ if true then x else x
 [%%expect{|
-val branching : unique_ float -> float = <fun>
+val branching : unique_ 'a -> 'a = <fun>
 |}]
 
 (* whether we constrain uniqueness or linearity is irrelavant
    for testing uniqueness analysis. Therefore, in the rest we
    will only constrain uniqueness *)
-let branching (once_ x : float) = if true then x else x
+let branching (once_ x) = if true then x else x
 [%%expect{|
-val branching : once_ float -> once_ float = <fun>
+val branching : once_ 'a -> once_ 'a = <fun>
 |}]
 
 let branching b =
@@ -53,15 +53,15 @@ let branching b =
 val branching : bool -> box = <fun>
 |}]
 
-let sequence (unique_ x : float) = unique_ let y = x in (x, y)
+let sequence (unique_ x) = unique_ let y = x in (x, y)
 [%%expect{|
-Line 1, characters 60-61:
-1 | let sequence (unique_ x : float) = unique_ let y = x in (x, y)
-                                                                ^
+Line 1, characters 52-53:
+1 | let sequence (unique_ x) = unique_ let y = x in (x, y)
+                                                        ^
 Error: This value is used here, but it has already been used as unique:
-Line 1, characters 57-58:
-1 | let sequence (unique_ x : float) = unique_ let y = x in (x, y)
-                                                             ^
+Line 1, characters 49-50:
+1 | let sequence (unique_ x) = unique_ let y = x in (x, y)
+                                                     ^
 
 |}]
 

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1521,8 +1521,6 @@ module Format_history = struct
       History.immediate64_creation_reason -> _ = function
     | Separability_check ->
       fprintf ppf "the check that a type is definitely not `float`"
-    | Primitive id ->
-      fprintf ppf "it is the primitive immediate64 type %s" (Ident.name id)
 
   let format_value_or_null_creation_reason ppf :
       History.value_or_null_creation_reason -> _ = function
@@ -2010,7 +2008,6 @@ module Debug_printers = struct
   let immediate64_creation_reason ppf : History.immediate64_creation_reason -> _
       = function
     | Separability_check -> fprintf ppf "Separability_check"
-    | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
 
   let value_or_null_creation_reason ppf :
       History.value_or_null_creation_reason -> _ = function

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -209,8 +209,11 @@ module Const : sig
     (** This is the jkind of normal ocaml values *)
     val value : t
 
-    (** This is the jkind of normal immutable ocaml values *)
+    (** Immutable values that don't contain functions. *)
     val immutable_data : t
+
+    (** Mutable values that don't contain functions. *)
+    val mutable_data : t
 
     (** Values of types of this jkind are immediate on 64-bit platforms; on other
     platforms, we know nothing other than that it's a value. *)
@@ -270,8 +273,11 @@ module Primitive : sig
 
   (* CR layouts v2.8: remove this in PR #2676 *)
 
-  (** This is the jkind of normal immutable ocaml values *)
+  (** Immutable values that don't contain functions. *)
   val immutable_data : why:History.immutable_data_creation_reason -> t
+
+  (** Mutable values that don't contain functions. *)
+  val mutable_data : why:History.mutable_data_creation_reason -> t
 
   (** Values of types of this jkind are immediate on 64-bit platforms; on other
     platforms, we know nothing other than that it's a value. *)

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -240,9 +240,7 @@ module History = struct
     | Primitive of Ident.t
     | Immediate_polymorphic_variant
 
-  type immediate64_creation_reason =
-    | Separability_check
-    | Primitive of Ident.t
+  type immediate64_creation_reason = Separability_check
 
   (* CR layouts v5: make new void_creation_reasons *)
   type void_creation_reason = |

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -240,7 +240,9 @@ module History = struct
     | Primitive of Ident.t
     | Immediate_polymorphic_variant
 
-  type immediate64_creation_reason = Separability_check
+  type immediate64_creation_reason =
+    | Separability_check
+    | Primitive of Ident.t
 
   (* CR layouts v5: make new void_creation_reasons *)
   type void_creation_reason = |
@@ -260,6 +262,8 @@ module History = struct
   type any_non_null_creation_reason = Array_type_argument
 
   type immutable_data_creation_reason = Primitive of Ident.t
+
+  type mutable_data_creation_reason = Primitive of Ident.t
 
   type float64_creation_reason = Primitive of Ident.t
 
@@ -282,6 +286,7 @@ module History = struct
     | Any_creation of any_creation_reason
     | Any_non_null_creation of any_non_null_creation_reason
     | Immutable_data_creation of immutable_data_creation_reason
+    | Mutable_data_creation of mutable_data_creation_reason
     | Float64_creation of float64_creation_reason
     | Float32_creation of float32_creation_reason
     | Word_creation of word_creation_reason

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -342,23 +342,35 @@ let build_initial_env add_type add_extension empty_env =
   |> add_type1 ident_iarray
        ~variance:Variance.covariant
        ~separability:Separability.Ind
+       ~param_jkind:(Jkind.Primitive.any_non_null ~why:Array_type_argument)
   |> add_type ident_bool
        ~kind:(variant [ cstr ident_false []; cstr ident_true []]
                 [| Constructor_uniform_value, [| |];
                    Constructor_uniform_value, [| |] |])
        ~jkind:(Jkind.Primitive.immediate ~why:Enumeration)
-  |> add_type ident_char ~jkind:(Jkind.Primitive.immediate ~why:(Primitive ident_char))
+       ~jkind_annotation:Jkind.Const.Primitive.immediate
+  |> add_type ident_char
+      ~jkind:(Jkind.Primitive.immediate ~why:(Primitive ident_char))
       ~jkind_annotation:Jkind.Const.Primitive.immediate
   |> add_type ident_exn
        ~kind:Type_open
        ~jkind:(Jkind.Primitive.value ~why:Extensible_variant)
   |> add_type ident_extension_constructor
   |> add_type ident_float
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_float))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type ident_floatarray
-  |> add_type ident_int ~jkind:(Jkind.Primitive.immediate ~why:(Primitive ident_int))
+      ~jkind:(Jkind.Primitive.mutable_data ~why:(Primitive ident_floatarray))
+      ~jkind_annotation:Jkind.Const.Primitive.mutable_data
+  |> add_type ident_int
+      ~jkind:(Jkind.Primitive.immediate ~why:(Primitive ident_int))
       ~jkind_annotation:Jkind.Const.Primitive.immediate
   |> add_type ident_int32
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_int32))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type ident_int64
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_int64))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type1 ident_lazy_t
        ~variance:Variance.covariant
        ~separability:Separability.Ind
@@ -377,6 +389,8 @@ let build_initial_env add_type add_extension empty_env =
            |] )
        ~jkind:(Jkind.Primitive.value ~why:Boxed_variant)
   |> add_type ident_nativeint
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_nativeint))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type1 ident_option
        ~variance:Variance.covariant
        ~separability:Separability.Ind
@@ -430,11 +444,14 @@ let build_initial_env add_type add_extension empty_env =
        ~jkind:(Jkind.add_mode_crossing (Jkind.Primitive.bits64 ~why:(Primitive ident_unboxed_int64)))
        ~jkind_annotation:Jkind.Const.Primitive.bits64
   |> add_type ident_bytes
+      ~jkind:(Jkind.Primitive.mutable_data ~why:(Primitive ident_bytes))
+      ~jkind_annotation:Jkind.Const.Primitive.mutable_data
   |> add_type ident_unit
        ~kind:(variant
                 [cstr ident_void []]
                 [| Constructor_uniform_value, [| |] |])
        ~jkind:(Jkind.Primitive.immediate ~why:Enumeration)
+       ~jkind_annotation:Jkind.Const.Primitive.immediate
   (* Predefined exceptions - alphabetical order *)
   |> add_extension ident_assert_failure
        [newgenty (Ttuple[None, type_string; None, type_int; None, type_int])]
@@ -472,6 +489,8 @@ let add_small_number_extension_types add_type env =
   let add_type = mk_add_type add_type in
   env
   |> add_type ident_float32
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_float32))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type ident_unboxed_float32
        ~jkind:(Jkind.Primitive.float32 ~why:(Primitive ident_unboxed_float32))
        ~jkind_annotation:Jkind.Const.Primitive.float32
@@ -495,6 +514,7 @@ let add_or_null add_type env =
           Constructor_uniform_value, [| or_null_argument_jkind |];
       |])
   ~jkind:(Jkind.Primitive.value_or_null ~why:(Primitive ident_or_null))
+  ~jkind_annotation:Jkind.Const.Primitive.value_or_null
 
 let builtin_values =
   List.map (fun id -> (Ident.name id, id)) all_predef_exns

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -479,11 +479,23 @@ let add_simd_extension_types add_type env =
   let add_type = mk_add_type add_type in
   env
   |> add_type ident_int8x16
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_int8x16))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type ident_int16x8
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_int16x8))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type ident_int32x4
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_int32x4))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type ident_int64x2
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_int64x2))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type ident_float32x4
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_float32x4))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
   |> add_type ident_float64x2
+      ~jkind:(Jkind.Primitive.immutable_data ~why:(Primitive ident_float64x2))
+      ~jkind_annotation:Jkind.Const.Primitive.immutable_data
 
 let add_small_number_extension_types add_type env =
   let add_type = mk_add_type add_type in

--- a/ocaml/typing/typemode.ml
+++ b/ocaml/typing/typemode.ml
@@ -16,19 +16,29 @@ let transl_mode_annots modes =
         Language_extension.Stable;
       let acc : Alloc.Const.Option.t =
         match txt with
-        (* CR zqian: We should interpret other mode names (global, shared, once)
-           as well. We can't do that yet because of the CR below. *)
         | "local" -> (
           match acc.areality with
           | None -> { acc with areality = Some Local }
+          | Some _ -> raise (Error (loc, Duplicated_mode Areality)))
+        | "global" -> (
+          match acc.areality with
+          | None -> { acc with areality = Some Global }
           | Some _ -> raise (Error (loc, Duplicated_mode Areality)))
         | "unique" -> (
           match acc.uniqueness with
           | None -> { acc with uniqueness = Some Unique }
           | Some _ -> raise (Error (loc, Duplicated_mode Uniqueness)))
+        | "shared" -> (
+          match acc.uniqueness with
+          | None -> { acc with uniqueness = Some Shared }
+          | Some _ -> raise (Error (loc, Duplicated_mode Uniqueness)))
         | "once" -> (
           match acc.linearity with
           | None -> { acc with linearity = Some Once }
+          | Some _ -> raise (Error (loc, Duplicated_mode Linearity)))
+        | "many" -> (
+          match acc.linearity with
+          | None -> { acc with linearity = Some Many }
           | Some _ -> raise (Error (loc, Duplicated_mode Linearity)))
         | "nonportable" -> (
           match acc.portability with


### PR DESCRIPTION
This PR improves the modes in `predef.ml`. Please review by commits:

- The first commit adds the interpretation of more mode annotation, to allow tests
- The second commit adds the jkind `mutable_data`.
- The third commit fixes up `predef.ml` in the following ways:
  - Add `~jkind` to allow more mode crossing.
  - Add `~jkind_annotation` when the corresponding `~jkind` is not `value`
  - Add `~param_jkind` to `iarray`, to require elements of `iarray` to be non-null.
  - Also some reformatting to avoid long lines.