### PR TITLE
Fix conflicts in `typing/env.ml` and `typing/persistent_env.ml`

### DIFF
--- a/ocaml/parsing/unit_info.ml
+++ b/ocaml/parsing/unit_info.ml
@@ -123,5 +123,5 @@ let is_cmi f = Filename.check_suffix (Artifact.filename f) ".cmi"
 
 let find_normalized_cmi f =
   let filename = modname f ^ ".cmi" in
-  let filename = Load_path.find_uncap filename in
+  let filename = Load_path.find_normalized filename in
   { Artifact.filename; modname = modname f; source_file = Some f.source_file  }

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -2196,7 +2196,6 @@ and store_extension ~check ~rebind id addr ext shape env =
       cda_shape = shape }
   in
   Builtin_attributes.mark_alerts_used ext.ext_attributes;
-  Builtin_attributes.mark_alerts_used cstr.cstr_attributes;
   Builtin_attributes.mark_warn_on_literal_pattern_used cstr.cstr_attributes;
   Builtin_attributes.warning_scope ext.ext_attributes (fun () ->
   if check && not loc.Location.loc_ghost &&
@@ -4114,7 +4113,8 @@ let report_lookup_error _loc env ppf = function
            "but modules are not module types"
     end
   | Unbound_cltype lid ->
-      fprintf ppf "Unbound class type %a" !print_longident lid;
+      fprintf ppf "Unbound class type %a"
+        (Style.as_inline_code !print_longident) lid;
       spellcheck ppf extract_cltypes env lid
   | Unbound_instance_variable s ->
       fprintf ppf "Unbound instance variable %a" Style.inline_code s;
@@ -4148,7 +4148,8 @@ let report_lookup_error _loc env ppf = function
         (Style.as_inline_code !print_longident) lid
   | Functor_used_as_structure lid ->
       fprintf ppf "@[The module %a is a functor, \
-                   it cannot have any components@]" !print_longident lid
+                   it cannot have any components@]"
+        (Style.as_inline_code !print_longident) lid
   | Abstract_used_as_structure lid ->
       fprintf ppf "@[The module %a is abstract, \
                    it cannot have any components@]"

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -772,7 +772,6 @@ let error err = raise (Error err)
 let lookup_error loc env err =
   error (Lookup_error(loc, env, err))
 
-<<<<<<< HEAD
 type actual_mode = {
   mode : Mode.Value.l;
   context : shared_context option
@@ -783,14 +782,11 @@ let mode_default mode = {
   context = None
 }
 
-||||||| 121bedcfd2
-=======
 let same_type_declarations e1 e2 =
   e1.types == e2.types &&
   e1.modules == e2.modules &&
   e1.local_constraints == e2.local_constraints
 
->>>>>>> 5.2.0
 let same_constr = ref (fun _ _ _ -> assert false)
 
 let constrain_type_jkind = ref (fun _ _ _ -> assert false)
@@ -1070,25 +1066,13 @@ let imports () = Persistent_env.imports !persistent_env
 let import_crcs ~source crcs =
   Persistent_env.import_crcs !persistent_env ~source crcs
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-||||||| 2572783060
-=======
 let runtime_parameters () = Persistent_env.runtime_parameters !persistent_env
 
 let parameters () = Persistent_env.parameters !persistent_env
 
->>>>>>> ocaml-jst/flambda-patches
-let read_pers_mod modname filename ~add_binding =
-  Persistent_env.read !persistent_env read_sign_of_cmi modname filename
+let read_pers_mod modname cmi ~add_binding =
+  Persistent_env.read !persistent_env read_sign_of_cmi modname cmi
     ~add_binding
-||||||| 121bedcfd2
-let read_pers_mod modname filename =
-  Persistent_env.read !persistent_env read_sign_of_cmi modname filename
-=======
-let read_pers_mod cmi =
-  Persistent_env.read !persistent_env read_sign_of_cmi cmi
->>>>>>> 5.2.0
 
 let find_pers_mod name =
   Persistent_env.find !persistent_env read_sign_of_cmi name
@@ -1186,13 +1170,7 @@ let find_ident_module id env =
   match find_same_module id env.modules with
   | Mod_local data -> data
   | Mod_unbound _ -> raise Not_found
-<<<<<<< HEAD
   | Mod_persistent -> find_pers_mod ~allow_hidden:true (id |> modname_of_ident)
-||||||| 121bedcfd2
-  | Mod_persistent -> find_pers_mod (Ident.name id)
-=======
-  | Mod_persistent -> find_pers_mod ~allow_hidden:true (Ident.name id)
->>>>>>> 5.2.0
 
 let rec find_module_components path env =
   match path with
@@ -1294,13 +1272,7 @@ let rec find_type_data path env =
   | decl ->
     {
       tda_declaration = decl;
-<<<<<<< HEAD
-      tda_descriptions = Type_abstract Abstract_def;
-||||||| 121bedcfd2
-      tda_descriptions = Type_abstract;
-=======
       tda_descriptions = Type_abstract (Btype.type_origin decl);
->>>>>>> 5.2.0
       tda_shape = Shape.leaf decl.type_uid;
     }
   | exception Not_found -> begin
@@ -2148,14 +2120,12 @@ and store_label ~check type_decl type_id lbl_id lbl env =
                      loc (Warnings.Unused_field(name, complaint)))
               (label_usage_complaint priv mut used))
   end);
-<<<<<<< HEAD
   Builtin_attributes.mark_alerts_used lbl.lbl_attributes;
-||||||| 121bedcfd2
-=======
-  Builtin_attributes.mark_alerts_used lbl.lbl_attributes;
-  if lbl.lbl_mut = Mutable then
-    Builtin_attributes.mark_deprecated_mutable_used lbl.lbl_attributes;
->>>>>>> 5.2.0
+  begin match lbl.lbl_mut with
+    | Mutable _ ->
+      Builtin_attributes.mark_deprecated_mutable_used lbl.lbl_attributes;
+    | Immutable -> ()
+  end;
   { env with
     labels = TycompTbl.add lbl_id lbl env.labels;
   }
@@ -2207,13 +2177,7 @@ and store_type_infos ~tda_shape id info env =
   let tda =
     {
       tda_declaration = info;
-<<<<<<< HEAD
-      tda_descriptions = Type_abstract Abstract_def;
-||||||| 121bedcfd2
-      tda_descriptions = Type_abstract;
-=======
       tda_descriptions = Type_abstract (Btype.type_origin info);
->>>>>>> 5.2.0
       tda_shape
     }
   in
@@ -2231,15 +2195,9 @@ and store_extension ~check ~rebind id addr ext shape env =
       cda_address = Some addr;
       cda_shape = shape }
   in
-<<<<<<< HEAD
   Builtin_attributes.mark_alerts_used ext.ext_attributes;
   Builtin_attributes.mark_alerts_used cstr.cstr_attributes;
   Builtin_attributes.mark_warn_on_literal_pattern_used cstr.cstr_attributes;
-||||||| 121bedcfd2
-=======
-  Builtin_attributes.mark_alerts_used ext.ext_attributes;
-  Builtin_attributes.mark_warn_on_literal_pattern_used ext.ext_attributes;
->>>>>>> 5.2.0
   Builtin_attributes.warning_scope ext.ext_attributes (fun () ->
   if check && not loc.Location.loc_ghost &&
     Warnings.is_active (Warnings.Unused_extension ("", false, Unused))
@@ -2272,17 +2230,9 @@ and store_module ?(update_summary=true) ~check
   let open Subst.Lazy in
   let loc = md.md_loc in
   Option.iter
-<<<<<<< HEAD
     (fun f -> check_usage loc id md.md_uid f !module_declarations) check;
+  Builtin_attributes.mark_alerts_used md.md_attributes;
   let alerts = Builtin_attributes.alerts_of_attrs md.md_attributes in
-||||||| 121bedcfd2
-    (fun f -> check_usage loc id md.mdl_uid f !module_declarations) check;
-  let alerts = Builtin_attributes.alerts_of_attrs md.mdl_attributes in
-=======
-    (fun f -> check_usage loc id md.mdl_uid f !module_declarations) check;
-  Builtin_attributes.mark_alerts_used md.mdl_attributes;
-  let alerts = Builtin_attributes.alerts_of_attrs md.mdl_attributes in
->>>>>>> 5.2.0
   let comps =
     components_of_module ~alerts ~uid:md.md_uid
       env Subst.identity (Pident id) addr md.md_type shape
@@ -2301,12 +2251,7 @@ and store_module ?(update_summary=true) ~check
     summary }
 
 and store_modtype ?(update_summary=true) id info shape env =
-<<<<<<< HEAD
   Builtin_attributes.mark_alerts_used info.Subst.Lazy.mtd_attributes;
-||||||| 121bedcfd2
-=======
-  Builtin_attributes.mark_alerts_used info.Subst.Lazy.mtdl_attributes;
->>>>>>> 5.2.0
   let mtda = { mtda_declaration = info; mtda_shape = shape } in
   let summary =
     if not update_summary then env.summary
@@ -2445,31 +2390,9 @@ let add_module_lazy ~update_summary id presence mty env =
 let add_module ?arg ?shape id presence mty env =
   add_module_declaration ~check:false ?arg ?shape id presence (md mty) env
 
-<<<<<<< HEAD
-let add_local_type path info env =
+let add_local_constraint path info env =
   (* CR layouts: there should be a safety check for extension universe when the type's
      kind allows mode crossing *)
-||||||| 121bedcfd2
-let add_module_lazy ~update_summary id presence mty env =
-  let md = Subst.Lazy.{mdl_type = mty;
-                       mdl_attributes = [];
-                       mdl_loc = Location.none;
-                       mdl_uid = Uid.internal_not_actually_unique}
-  in
-  add_module_declaration_lazy ~update_summary id presence md env
-
-let add_local_type path info env =
-=======
-let add_module_lazy ~update_summary id presence mty env =
-  let md = Subst.Lazy.{mdl_type = mty;
-                       mdl_attributes = [];
-                       mdl_loc = Location.none;
-                       mdl_uid = Uid.internal_not_actually_unique}
-  in
-  add_module_declaration_lazy ~update_summary id presence md env
-
-let add_local_constraint path info env =
->>>>>>> 5.2.0
   { env with
     local_constraints = Path.Map.add path info env.local_constraints }
 
@@ -2635,17 +2558,9 @@ let enter_signature ?mod_shape ~scope sg env =
 let enter_signature_and_shape ~scope ~parent_shape mod_shape sg env =
   enter_signature_and_shape ~scope ~parent_shape (Some mod_shape) sg env
 
-<<<<<<< HEAD
 let add_value_lazy = add_value_lazy ?shape:None
 let add_value ?check ~mode id vd =
   add_value_lazy ?check ~mode id (Subst.Lazy.of_value_description vd)
-||||||| 121bedcfd2
-let add_value = add_value ?shape:None
-let add_type = add_type ?shape:None
-let add_extension = add_extension ?shape:None
-=======
-let add_value = add_value ?shape:None
->>>>>>> 5.2.0
 let add_class = add_class ?shape:None
 let add_cltype = add_cltype ?shape:None
 let add_modtype_lazy = add_modtype_lazy ?shape:None
@@ -2820,36 +2735,12 @@ let open_signature
   else open_signature None root env
 
 (* Read a signature from a file *)
-<<<<<<< HEAD
-let read_signature modname filename ~add_binding =
-  let mty = read_pers_mod modname filename ~add_binding in
+let read_signature modname cmi ~add_binding =
+  let mty = read_pers_mod modname cmi ~add_binding in
   Subst.Lazy.force_signature mty
 
-<<<<<<< HEAD
-let register_parameter_import import =
-  Persistent_env.register_parameter_import !persistent_env import
-||||||| 121bedcfd2
-let read_signature modname filename =
-  let mda = read_pers_mod modname filename in
-  let md = Subst.Lazy.force_module_decl mda.mda_declaration in
-  match md.md_type with
-  | Mty_signature sg -> sg
-  | Mty_ident _ | Mty_functor _ | Mty_alias _ -> assert false
-=======
-let read_signature u =
-  let mda = read_pers_mod u in
-  let md = Subst.Lazy.force_module_decl mda.mda_declaration in
-  match md.md_type with
-  | Mty_signature sg -> sg
-  | Mty_ident _ | Mty_functor _ | Mty_alias _ -> assert false
->>>>>>> 5.2.0
-||||||| 2572783060
-let register_parameter_import import =
-  Persistent_env.register_parameter_import !persistent_env import
-=======
 let register_parameter modname =
   Persistent_env.register_parameter !persistent_env modname
->>>>>>> ocaml-jst/flambda-patches
 
 
 let unit_name_of_filename fn =
@@ -2867,14 +2758,8 @@ let persistent_structures_of_dir dir =
   |> String.Set.of_seq
 
 (* Save a signature to a file *)
-<<<<<<< HEAD
 let save_signature_with_transform cmi_transform ~alerts sg modname kind
-      filename =
-||||||| 121bedcfd2
-let save_signature_with_transform cmi_transform ~alerts sg modname filename =
-=======
-let save_signature_with_transform cmi_transform ~alerts sg cmi_info =
->>>>>>> 5.2.0
+      cmi_info =
   Btype.cleanup_abbrev ();
   Subst.reset_additional_action_type_id ();
   let sg = Subst.Lazy.of_signature sg
@@ -2882,63 +2767,21 @@ let save_signature_with_transform cmi_transform ~alerts sg cmi_info =
         (Subst.with_additional_action Prepare_for_saving Subst.identity)
   in
   let cmi =
-<<<<<<< HEAD
     Persistent_env.make_cmi !persistent_env modname kind sg alerts
-||||||| 121bedcfd2
-    Persistent_env.make_cmi !persistent_env modname sg alerts
-=======
-    Persistent_env.make_cmi !persistent_env
-      (Unit_info.Artifact.modname cmi_info) sg alerts
->>>>>>> 5.2.0
     |> cmi_transform in
-<<<<<<< HEAD
+  let filename = Unit_info.Artifact.filename cmi_info in
   let pers_sig =
     Persistent_env.Persistent_signature.{ filename; cmi; visibility = Visible }
   in
   Persistent_env.save_cmi !persistent_env pers_sig;
-||||||| 121bedcfd2
-  let pm = save_sign_of_cmi
-      { Persistent_env.Persistent_signature.cmi; filename } in
-  Persistent_env.save_cmi !persistent_env
-    { Persistent_env.Persistent_signature.filename; cmi } pm;
-=======
-  let filename = Unit_info.Artifact.filename cmi_info in
-  let pers_sig =
-    Persistent_env.Persistent_signature.{ cmi; filename; visibility = Visible }
-  in
-  let pm = save_sign_of_cmi pers_sig in
-  Persistent_env.save_cmi !persistent_env pers_sig pm;
->>>>>>> 5.2.0
   cmi
 
-<<<<<<< HEAD
-let save_signature ~alerts sg modname cu filename =
-  save_signature_with_transform (fun cmi -> cmi) ~alerts sg modname cu filename
-||||||| 121bedcfd2
-let save_signature ~alerts sg modname filename =
-  save_signature_with_transform (fun cmi -> cmi)
-    ~alerts sg modname filename
-=======
-let save_signature ~alerts sg cmi =
-  save_signature_with_transform (fun cmi -> cmi) ~alerts sg cmi
->>>>>>> 5.2.0
+let save_signature ~alerts sg modname cu cmi =
+  save_signature_with_transform (fun cmi -> cmi) ~alerts sg modname cu cmi
 
-<<<<<<< HEAD
-let save_signature_with_imports ~alerts sg modname cu filename imports =
-||||||| 121bedcfd2
-let save_signature_with_imports ~alerts sg modname filename imports =
-=======
-let save_signature_with_imports ~alerts sg cmi imports =
->>>>>>> 5.2.0
+let save_signature_with_imports ~alerts sg modname cu cmi imports =
   let with_imports cmi = { cmi with cmi_crcs = imports } in
-<<<<<<< HEAD
-  save_signature_with_transform with_imports ~alerts sg modname cu filename
-||||||| 121bedcfd2
-  save_signature_with_transform with_imports
-    ~alerts sg modname filename
-=======
-  save_signature_with_transform with_imports ~alerts sg cmi
->>>>>>> 5.2.0
+  save_signature_with_transform with_imports ~alerts sg modname cu cmi
 
 (* Make the initial environment, without language extensions *)
 let initial =
@@ -3174,24 +3017,10 @@ let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
       let name = s |> Compilation_unit.Name.of_string in
       match load with
       | Don't_load ->
-<<<<<<< HEAD
           check_pers_mod ~allow_hidden:false ~loc name;
           path, locks, (() : a)
-||||||| 121bedcfd2
-          check_pers_mod ~loc s;
-          path, (() : a)
-=======
-          check_pers_mod ~allow_hidden:false ~loc s;
-          path, (() : a)
->>>>>>> 5.2.0
       | Load -> begin
-<<<<<<< HEAD
           match find_pers_mod ~allow_hidden:false name with
-||||||| 121bedcfd2
-          match find_pers_mod s with
-=======
-          match find_pers_mod ~allow_hidden:false s with
->>>>>>> 5.2.0
           | mda ->
               use_module ~use ~loc path mda;
               path, locks, (mda : a)
@@ -3871,16 +3700,10 @@ let bound_module name env =
   | Error _ ->
       if Current_unit_name.is name then false
       else begin
-<<<<<<< HEAD
         match
           find_pers_mod ~allow_hidden:false
             (name |> Compilation_unit.Name.of_string)
         with
-||||||| 121bedcfd2
-        match find_pers_mod name with
-=======
-        match find_pers_mod ~allow_hidden:false name with
->>>>>>> 5.2.0
         | _ -> true
         | exception Not_found -> false
       end
@@ -4160,7 +3983,6 @@ let extract_instance_variables env =
        | Val_ivar _ -> name :: acc
        | _ -> acc) None env []
 
-<<<<<<< HEAD
 let string_of_escaping_context : escaping_context -> string =
   function
   | Letop -> "a letop"
@@ -4224,13 +4046,11 @@ let print_lock_item ppf (item, lid) =
   match item with
   | Module -> fprintf ppf "Modules are"
   | Class -> fprintf ppf "Classes are"
-  | Value -> fprintf ppf "The value %a is" !print_longident lid
+  | Value -> fprintf ppf "The value %a is"
+      (Style.as_inline_code !print_longident) lid
 
-||||||| 121bedcfd2
-=======
 module Style = Misc.Style
 
->>>>>>> 5.2.0
 let report_lookup_error _loc env ppf = function
   | Unbound_value(lid, hint) -> begin
       fprintf ppf "Unbound value %a"
@@ -4294,17 +4114,8 @@ let report_lookup_error _loc env ppf = function
            "but modules are not module types"
     end
   | Unbound_cltype lid ->
-<<<<<<< HEAD
       fprintf ppf "Unbound class type %a" !print_longident lid;
       spellcheck ppf extract_cltypes env lid
-||||||| 121bedcfd2
-      fprintf ppf "Unbound class type %a" !print_longident lid;
-      spellcheck ppf extract_cltypes env lid;
-=======
-      fprintf ppf "Unbound class type %a"
-        (Style.as_inline_code !print_longident) lid;
-      spellcheck ppf extract_cltypes env lid;
->>>>>>> 5.2.0
   | Unbound_instance_variable s ->
       fprintf ppf "Unbound instance variable %a" Style.inline_code s;
       spellcheck_name ppf extract_instance_variables env s;
@@ -4353,8 +4164,8 @@ let report_lookup_error _loc env ppf = function
       in
       fprintf ppf
         "The module %a is an alias for module %a, which %s"
-<<<<<<< HEAD
-        !print_longident lid !print_path p cause
+        (Style.as_inline_code !print_longident) lid
+        (Style.as_inline_code !print_path) p cause
   | Local_value_escaping (item, lid, context) ->
       fprintf ppf
         "@[%a local, so cannot be used \
@@ -4392,15 +4203,9 @@ let report_lookup_error _loc env ppf = function
   | Non_value_used_in_object (lid, typ, err) ->
       fprintf ppf "@[%a must have a type of layout value because it is \
                    captured by an object.@ %a@]"
-        !print_longident lid
+        (Style.as_inline_code !print_longident) lid
         (Jkind.Violation.report_with_offender
            ~offender:(fun ppf -> !print_type_expr ppf typ)) err
-||||||| 121bedcfd2
-        !print_longident lid !print_path p cause
-=======
-        (Style.as_inline_code !print_longident) lid
-        (Style.as_inline_code !print_path) p cause
->>>>>>> 5.2.0
 
 let report_error ppf = function
   | Missing_module(_, path1, path2) ->

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -491,7 +491,7 @@ val save_signature_with_imports:
            file name, imported units with their CRCs. *)
 
 (* Register a module as a parameter to this unit. *)
-val register_parameter_import: Compilation_unit.Name.t -> unit
+val register_parameter: Compilation_unit.Name.t -> unit
 
 (* Return the CRC of the interface of the given compilation unit *)
 val crc_of_unit: Compilation_unit.Name.t -> Digest.t

--- a/ocaml/typing/persistent_env.ml
+++ b/ocaml/typing/persistent_env.ml
@@ -51,7 +51,7 @@ module Persistent_signature = struct
 
   let load = ref (fun ~allow_hidden ~unit_name ->
     let unit_name = CU.Name.to_string unit_name in
-    match Load_path.find_uncap_with_visibility (unit_name ^ ".cmi") with
+    match Load_path.find_normalized_with_visibility (unit_name ^ ".cmi") with
     | filename, visibility when allow_hidden ->
       Some { filename; cmi = read_cmi_lazy filename; visibility}
     | filename, Visible ->
@@ -634,7 +634,7 @@ let report_error ppf =
       fprintf ppf
         "@[<hov>The file %a@ contains the interface of a parameter.@ \
          %a is not declared as a parameter for the current unit (-parameter %a).@]"
-        Location.print_filename filename
+        (Style.as_inline_code Location.print_filename) filename
         (Style.as_inline_code CU.Name.print) modname
         (Style.as_inline_code CU.Name.print) modname
   | Not_compiled_as_parameter(modname, filename) ->
@@ -642,7 +642,7 @@ let report_error ppf =
         "@[<hov>The module %a@ is specified as a parameter, but %a@ \
          was not compiled with -as-parameter.@]"
         (Style.as_inline_code CU.Name.print) modname
-        Location.print_filename filename
+        (Style.as_inline_code Location.print_filename) filename
   | Direct_reference_from_wrong_package(unit, filename, prefix) ->
       fprintf ppf
         "@[<hov>Invalid reference to %a (in file %s) from %a.@ %s]"

--- a/ocaml/typing/persistent_env.ml
+++ b/ocaml/typing/persistent_env.ml
@@ -46,17 +46,9 @@ let error err = raise (Error err)
 module Persistent_signature = struct
   type t =
     { filename : string;
-<<<<<<< HEAD
       cmi : Cmi_format.cmi_infos_lazy;
       visibility : Load_path.visibility }
-||||||| 121bedcfd2
-      cmi : Cmi_format.cmi_infos }
-=======
-      cmi : Cmi_format.cmi_infos;
-      visibility : Load_path.visibility }
->>>>>>> 5.2.0
 
-<<<<<<< HEAD
   let load = ref (fun ~allow_hidden ~unit_name ->
     let unit_name = CU.Name.to_string unit_name in
     match Load_path.find_uncap_with_visibility (unit_name ^ ".cmi") with
@@ -66,28 +58,12 @@ module Persistent_signature = struct
       Some { filename; cmi = read_cmi_lazy filename; visibility = Visible}
     | _, Hidden
     | exception Not_found -> None)
-||||||| 121bedcfd2
-  let load = ref (fun ~unit_name ->
-      match Load_path.find_uncap (unit_name ^ ".cmi") with
-      | filename -> Some { filename; cmi = read_cmi filename }
-      | exception Not_found -> None)
-=======
-  let load = ref (fun ~allow_hidden ~unit_name ->
-    match Load_path.find_normalized_with_visibility (unit_name ^ ".cmi") with
-    | filename, visibility when allow_hidden ->
-      Some { filename; cmi = read_cmi filename; visibility}
-    | filename, Visible ->
-      Some { filename; cmi = read_cmi filename; visibility = Visible}
-    | _, Hidden
-    | exception Not_found -> None)
->>>>>>> 5.2.0
 end
 
 type can_load_cmis =
   | Can_load_cmis
   | Cannot_load_cmis of Lazy_backtrack.log
 
-<<<<<<< HEAD
 (* Data relating directly to a .cmi *)
 type import = {
   imp_is_param : bool;
@@ -99,20 +75,6 @@ type import = {
   imp_visibility: Load_path.visibility;
   imp_crcs : Import_info.Intf.t array;
   imp_flags : Cmi_format.pers_flags list;
-||||||| 121bedcfd2
-type pers_struct = {
-  ps_name: string;
-  ps_crcs: (string * Digest.t option) list;
-  ps_filename: string;
-  ps_flags: pers_flags list;
-=======
-type pers_struct = {
-  ps_name: string;
-  ps_crcs: (string * Digest.t option) list;
-  ps_filename: string;
-  ps_flags: pers_flags list;
-  ps_visibility: Load_path.visibility;
->>>>>>> 5.2.0
 }
 
 (* If a .cmi file is missing (or invalid), we
@@ -285,7 +247,6 @@ let save_import penv crc modname impl flags filename =
   Consistbl.check crc_units modname impl crc filename;
   add_import penv modname
 
-<<<<<<< HEAD
 (* Add an import to the hash table. Checks that we are allowed to access
    this .cmi. *)
 
@@ -293,47 +254,15 @@ let acknowledge_import penv ~check modname pers_sig =
   let { Persistent_signature.filename; cmi; visibility } = pers_sig in
   let found_name = cmi.cmi_name in
   let kind = cmi.cmi_kind in
-<<<<<<< HEAD
-||||||| 121bedcfd2
-let acknowledge_pers_struct penv check modname pers_sig pm =
-  let { Persistent_signature.filename; cmi } = pers_sig in
-  let name = cmi.cmi_name in
-=======
-let acknowledge_pers_struct penv check modname pers_sig pm =
-  let { Persistent_signature.filename; cmi; visibility } = pers_sig in
-  let name = cmi.cmi_name in
->>>>>>> 5.2.0
-||||||| 2572783060
-=======
   let params = cmi.cmi_params in
->>>>>>> ocaml-jst/flambda-patches
   let crcs = cmi.cmi_crcs in
   let flags = cmi.cmi_flags in
-<<<<<<< HEAD
   let sign =
     (* Freshen identifiers bound by signature *)
     Subst.Lazy.signature Make_local Subst.identity cmi.cmi_sign
   in
   if not (CU.Name.equal modname found_name) then
     error (Illegal_renaming(modname, found_name, filename));
-||||||| 121bedcfd2
-  let ps = { ps_name = name;
-             ps_crcs = crcs;
-             ps_filename = filename;
-             ps_flags = flags;
-           } in
-  if ps.ps_name <> modname then
-    error (Illegal_renaming(modname, ps.ps_name, filename));
-=======
-  let ps = { ps_name = name;
-             ps_crcs = crcs;
-             ps_filename = filename;
-             ps_flags = flags;
-             ps_visibility = visibility;
-           } in
-  if ps.ps_name <> modname then
-    error (Illegal_renaming(modname, ps.ps_name, filename));
->>>>>>> 5.2.0
   List.iter
     (function
         | Rectypes ->
@@ -379,35 +308,13 @@ let acknowledge_pers_struct penv check modname pers_sig pm =
   Hashtbl.add imports modname (Found import);
   import
 
-<<<<<<< HEAD
-let read_import penv ~check modname filename =
-||||||| 121bedcfd2
-let read_pers_struct penv val_of_pers_sig check modname filename =
-=======
-let read_pers_struct penv val_of_pers_sig check cmi =
-  let modname = Unit_info.Artifact.modname cmi in
+let read_import penv ~check modname cmi =
   let filename = Unit_info.Artifact.filename cmi in
->>>>>>> 5.2.0
   add_import penv modname;
-<<<<<<< HEAD
   let cmi = read_cmi_lazy filename in
   let pers_sig = { Persistent_signature.filename; cmi; visibility = Visible } in
   acknowledge_import penv ~check modname pers_sig
-||||||| 121bedcfd2
-  let cmi = read_cmi filename in
-  let pers_sig = { Persistent_signature.filename; cmi } in
-  let pm = val_of_pers_sig pers_sig in
-  let ps = acknowledge_pers_struct penv check modname pers_sig pm in
-  (ps, pm)
-=======
-  let cmi = read_cmi filename in
-  let pers_sig = { Persistent_signature.filename; cmi; visibility = Visible } in
-  let pm = val_of_pers_sig pers_sig in
-  let ps = acknowledge_pers_struct penv check modname pers_sig pm in
-  (ps, pm)
->>>>>>> 5.2.0
 
-<<<<<<< HEAD
 let check_visibility ~allow_hidden imp =
   if not allow_hidden && imp.imp_visibility = Load_path.Hidden then raise Not_found
 
@@ -416,24 +323,8 @@ let find_import ~allow_hidden penv ~check modname =
   if CU.Name.equal modname CU.Name.predef_exn then raise Not_found;
   match Hashtbl.find imports modname with
   | Found imp -> check_visibility ~allow_hidden imp; imp
-||||||| 121bedcfd2
-let find_pers_struct penv val_of_pers_sig check name =
-  let {persistent_structures; _} = penv in
-  if name = "*predef*" then raise Not_found;
-  match Hashtbl.find persistent_structures name with
-  | Found (ps, pm) -> (ps, pm)
-=======
-let find_pers_struct ~allow_hidden penv val_of_pers_sig check name =
-  let {persistent_structures; _} = penv in
-  if name = "*predef*" then raise Not_found;
-  match Hashtbl.find persistent_structures name with
-  | Found (ps, pm) when allow_hidden || ps.ps_visibility = Load_path.Visible ->
-    (ps, pm)
-  | Found _ -> raise Not_found
->>>>>>> 5.2.0
   | Missing -> raise Not_found
   | exception Not_found ->
-<<<<<<< HEAD
       match can_load_cmis penv with
       | Cannot_load_cmis _ -> raise Not_found
       | Can_load_cmis ->
@@ -531,8 +422,8 @@ let acknowledge_pers_struct penv modname import val_of_pers_sig =
   Hashtbl.add persistent_structures modname ps;
   ps
 
-let read_pers_struct penv val_of_pers_sig check modname filename ~add_binding =
-  let import = read_import penv ~check modname filename in
+let read_pers_struct penv val_of_pers_sig check modname cmi ~add_binding =
+  let import = read_import penv ~check modname cmi in
   if add_binding then
     ignore
       (acknowledge_pers_struct penv modname import val_of_pers_sig
@@ -552,48 +443,11 @@ let describe_prefix ppf prefix =
     Format.fprintf ppf "outside of any package"
   else
     Format.fprintf ppf "package %a" CU.Prefix.print prefix
-||||||| 121bedcfd2
-    match can_load_cmis penv with
-    | Cannot_load_cmis _ -> raise Not_found
-    | Can_load_cmis ->
-        let psig =
-          match !Persistent_signature.load ~unit_name:name with
-          | Some psig -> psig
-          | None ->
-            Hashtbl.add persistent_structures name Missing;
-            raise Not_found
-        in
-        add_import penv name;
-        let pm = val_of_pers_sig psig in
-        let ps = acknowledge_pers_struct penv check name psig pm in
-        (ps, pm)
-=======
-    match can_load_cmis penv with
-    | Cannot_load_cmis _ -> raise Not_found
-    | Can_load_cmis ->
-        let psig =
-          match !Persistent_signature.load ~allow_hidden ~unit_name:name with
-          | Some psig -> psig
-          | None ->
-            if allow_hidden then Hashtbl.add persistent_structures name Missing;
-            raise Not_found
-        in
-        add_import penv name;
-        let pm = val_of_pers_sig psig in
-        let ps = acknowledge_pers_struct penv check name psig pm in
-        (ps, pm)
->>>>>>> 5.2.0
 
 module Style = Misc.Style
 (* Emits a warning if there is no valid cmi for name *)
-<<<<<<< HEAD
 let check_pers_struct ~allow_hidden penv f ~loc name =
   let name_as_string = CU.Name.to_string name in
-||||||| 121bedcfd2
-let check_pers_struct penv f ~loc name =
-=======
-let check_pers_struct ~allow_hidden penv f ~loc name =
->>>>>>> 5.2.0
   try
     ignore (find_pers_struct ~allow_hidden penv f false name)
   with
@@ -610,26 +464,15 @@ let check_pers_struct ~allow_hidden penv f ~loc name =
         | Illegal_renaming(name, ps_name, filename) ->
             Format.asprintf
               " %a@ contains the compiled interface for @ \
-<<<<<<< HEAD
-               %a when %a was expected"
-              Location.print_filename filename
-              CU.Name.print ps_name
-              CU.Name.print name
-||||||| 121bedcfd2
-               %s when %s was expected"
-              Location.print_filename filename ps_name name
-=======
                %a when %a was expected"
               (Style.as_inline_code Location.print_filename) filename
-              Style.inline_code ps_name
-              Style.inline_code name
->>>>>>> 5.2.0
+              (Style.as_inline_code CU.Name.print) ps_name
+              (Style.as_inline_code CU.Name.print) name
         | Inconsistent_import _ -> assert false
         | Need_recursive_types name ->
-<<<<<<< HEAD
             Format.asprintf
               "%a uses recursive types"
-              CU.Name.print name
+              (Style.as_inline_code CU.Name.print) name
         | Inconsistent_package_declaration_between_imports _ -> assert false
         | Direct_reference_from_wrong_package (unit, _filename, prefix) ->
             Format.asprintf "%a is inaccessible from %a"
@@ -637,45 +480,16 @@ let check_pers_struct ~allow_hidden penv f ~loc name =
               describe_prefix prefix
         | Illegal_import_of_parameter _ -> assert false
         | Not_compiled_as_parameter _ -> assert false
-<<<<<<< HEAD
-||||||| 121bedcfd2
-            Format.sprintf
-              "%s uses recursive types"
-              name
-=======
-            Format.asprintf
-              "%a uses recursive types"
-              Style.inline_code name
->>>>>>> 5.2.0
-||||||| 2572783060
-=======
         | Imported_module_has_unset_parameter _ -> assert false
->>>>>>> ocaml-jst/flambda-patches
       in
       let warn = Warnings.No_cmi_file(name_as_string, Some msg) in
         Location.prerr_warning loc warn
 
-<<<<<<< HEAD
-let read penv f modname filename ~add_binding =
-  read_pers_struct penv f true modname filename ~add_binding
-||||||| 121bedcfd2
-let read penv f modname filename =
-  snd (read_pers_struct penv f true modname filename)
-=======
-let read penv f a =
-  snd (read_pers_struct penv f true a)
->>>>>>> 5.2.0
+let read penv f modname a ~add_binding =
+  read_pers_struct penv f true modname a ~add_binding
 
-<<<<<<< HEAD
 let find ~allow_hidden penv f name =
   (find_pers_struct ~allow_hidden penv f true name).ps_val
-||||||| 121bedcfd2
-let find penv f name =
-  snd (find_pers_struct penv f true name)
-=======
-let find ~allow_hidden penv f name =
-  snd (find_pers_struct ~allow_hidden penv f true name)
->>>>>>> 5.2.0
 
 let check ~allow_hidden penv f ~loc name =
   let {persistent_structures; _} = penv in
@@ -689,24 +503,6 @@ let check ~allow_hidden penv f ~loc name =
         (fun () -> check_pers_struct ~allow_hidden penv f ~loc name)
   end
 
-<<<<<<< HEAD
-(* CR mshinwell: delete this having moved to 4.14 build compilers *)
-module Array = struct
-  include Array
-
-  (* From stdlib/array.ml *)
-  let find_opt p a =
-    let n = Array.length a in
-    let rec loop i =
-      if i = n then None
-      else
-        let x = Array.unsafe_get a i in
-        if p x then Some x
-        else loop (succ i)
-    in
-    loop 0
-end
-
 let crc_of_unit penv name =
   match Consistbl.find penv.crc_units name with
   | Some (_impl, crc) -> crc
@@ -718,31 +514,6 @@ let crc_of_unit penv name =
       match Import_info.crc import_info with
       | None -> assert false
       | Some crc -> crc
-||||||| 121bedcfd2
-let crc_of_unit penv f name =
-  let (ps, _pm) = find_pers_struct penv f true name in
-  let crco =
-    try
-      List.assoc name ps.ps_crcs
-    with Not_found ->
-      assert false
-  in
-    match crco with
-      None -> assert false
-    | Some crc -> crc
-=======
-let crc_of_unit penv f name =
-  let (ps, _pm) = find_pers_struct ~allow_hidden:true penv f true name in
-  let crco =
-    try
-      List.assoc name ps.ps_crcs
-    with Not_found ->
-      assert false
-  in
-    match crco with
-      None -> assert false
-    | Some crc -> crc
->>>>>>> 5.2.0
 
 let imports {imported_units; crc_units; _} =
   let imports =
@@ -804,16 +575,8 @@ let make_cmi penv modname kind sign alerts =
     cmi_flags = flags
   }
 
-<<<<<<< HEAD
 let save_cmi penv psig =
   let { Persistent_signature.filename; cmi; _ } = psig in
-||||||| 121bedcfd2
-let save_cmi penv psig pm =
-  let { Persistent_signature.filename; cmi } = psig in
-=======
-let save_cmi penv psig pm =
-  let { Persistent_signature.filename; cmi; visibility } = psig in
->>>>>>> 5.2.0
   Misc.try_finally (fun () ->
       let {
         cmi_name = modname;
@@ -828,31 +591,12 @@ let save_cmi penv psig pm =
           (fun temp_filename oc -> output_cmi temp_filename oc cmi) in
       (* Enter signature in consistbl so that imports()
          will also return its crc *)
-<<<<<<< HEAD
       let data : Import_info.Intf.Nonalias.Kind.t =
         match kind with
         | Normal { cmi_impl } -> Normal cmi_impl
         | Parameter -> Parameter
       in
       save_import penv crc modname data flags filename
-||||||| 121bedcfd2
-      let ps =
-        { ps_name = modname;
-          ps_crcs = (cmi.cmi_name, Some crc) :: imports;
-          ps_filename = filename;
-          ps_flags = flags;
-        } in
-      save_pers_struct penv crc ps pm
-=======
-      let ps =
-        { ps_name = modname;
-          ps_crcs = (cmi.cmi_name, Some crc) :: imports;
-          ps_filename = filename;
-          ps_flags = flags;
-          ps_visibility = visibility
-        } in
-      save_pers_struct penv crc ps pm
->>>>>>> 5.2.0
     )
     ~exceptionally:(fun () -> remove_file filename)
 
@@ -864,79 +608,48 @@ let report_error ppf =
   function
   | Illegal_renaming(modname, ps_name, filename) -> fprintf ppf
       "Wrong file naming: %a@ contains the compiled interface for@ \
-<<<<<<< HEAD
-       %a when %a was expected"
-      Location.print_filename filename
-      CU.Name.print ps_name
-      CU.Name.print modname
-||||||| 121bedcfd2
-       %s when %s was expected"
-      Location.print_filename filename ps_name modname
-=======
        %a when %a was expected"
       (Style.as_inline_code Location.print_filename) filename
-      Style.inline_code ps_name
-      Style.inline_code modname
->>>>>>> 5.2.0
+      (Style.as_inline_code CU.Name.print) ps_name
+      (Style.as_inline_code CU.Name.print) modname
   | Inconsistent_import(name, source1, source2) -> fprintf ppf
       "@[<hov>The files %a@ and %a@ \
-<<<<<<< HEAD
-              make inconsistent assumptions@ over interface %a@]"
-      Location.print_filename source1 Location.print_filename source2
-      CU.Name.print name
-||||||| 121bedcfd2
-              make inconsistent assumptions@ over interface %s@]"
-      Location.print_filename source1 Location.print_filename source2 name
-=======
               make inconsistent assumptions@ over interface %a@]"
       (Style.as_inline_code Location.print_filename) source1
       (Style.as_inline_code Location.print_filename) source2
-      Style.inline_code name
->>>>>>> 5.2.0
+      (Style.as_inline_code CU.Name.print) name
   | Need_recursive_types(import) ->
       fprintf ppf
-<<<<<<< HEAD
-        "@[<hov>Invalid import of %a, which uses recursive types.@ %s@]"
-        CU.Name.print import
-        "The compilation flag -rectypes is required"
+        "@[<hov>Invalid import of %a, which uses recursive types.@ \
+         The compilation flag %a is required@]"
+        (Style.as_inline_code CU.Name.print) import
+        Style.inline_code "-rectypes"
   | Inconsistent_package_declaration_between_imports (filename, unit1, unit2) ->
       fprintf ppf
         "@[<hov>The file %s@ is imported both as %a@ and as %a.@]"
         filename
-        CU.print unit1
-        CU.print unit2
+        (Style.as_inline_code CU.print) unit1
+        (Style.as_inline_code CU.print) unit2
   | Illegal_import_of_parameter(modname, filename) ->
       fprintf ppf
         "@[<hov>The file %a@ contains the interface of a parameter.@ \
          %a is not declared as a parameter for the current unit (-parameter %a).@]"
         Location.print_filename filename
-        CU.Name.print modname
-        CU.Name.print modname
+        (Style.as_inline_code CU.Name.print) modname
+        (Style.as_inline_code CU.Name.print) modname
   | Not_compiled_as_parameter(modname, filename) ->
       fprintf ppf
         "@[<hov>The module %a@ is specified as a parameter, but %a@ \
          was not compiled with -as-parameter.@]"
-        CU.Name.print modname
+        (Style.as_inline_code CU.Name.print) modname
         Location.print_filename filename
   | Direct_reference_from_wrong_package(unit, filename, prefix) ->
       fprintf ppf
         "@[<hov>Invalid reference to %a (in file %s) from %a.@ %s]"
-        CU.print unit
+        (Style.as_inline_code CU.print) unit
         filename
         describe_prefix prefix
         "Can only access members of this library's package or a containing package"
-<<<<<<< HEAD
-||||||| 121bedcfd2
-        "@[<hov>Invalid import of %s, which uses recursive types.@ %s@]"
-        import "The compilation flag -rectypes is required"
-=======
-        "@[<hov>Invalid import of %a, which uses recursive types.@ \
-         The compilation flag %a is required@]"
-        Style.inline_code import
-        Style.inline_code "-rectypes"
->>>>>>> 5.2.0
-||||||| 2572783060
-=======
   | Imported_module_has_unset_parameter
         { imported = modname; parameter = param } ->
       fprintf ppf
@@ -945,11 +658,10 @@ let report_error ppf =
          @[<hov>@{<hint>Hint@}: \
            @[<hov>Pass `-parameter %a`@ to add %a@ as a parameter@ \
            of the current unit.@]@]"
-        CU.Name.print modname
-        CU.Name.print param
-        CU.Name.print param
-        CU.Name.print param
->>>>>>> ocaml-jst/flambda-patches
+        (Style.as_inline_code CU.Name.print) modname
+        (Style.as_inline_code CU.Name.print) param
+        (Style.as_inline_code CU.Name.print) param
+        (Style.as_inline_code CU.Name.print) param
 
 let () =
   Location.register_error_of_exn

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -271,7 +271,6 @@ type type_declaration =
 and type_decl_kind = (label_declaration, constructor_declaration) type_kind
 
 and ('lbl, 'cstr) type_kind =
-    Type_abstract of abstract_reason
     Type_abstract of type_origin
   | Type_record of 'lbl list * record_representation
   | Type_variant of 'cstr list * variant_representation

--- a/ocaml/utils/load_path.ml
+++ b/ocaml/utils/load_path.ml
@@ -31,7 +31,7 @@ module Dir : sig
   val create_libloc : hidden:bool -> libloc:string -> string -> t
 
   val find : t -> string -> string option
-  val find_uncap : t -> string -> string option
+  val find_normalized : t -> string -> string option
 end = struct
   type entry = {
     basename : string;
@@ -56,10 +56,10 @@ end = struct
       else
         None) t.files
 
-  let find_uncap t fn =
-    let fn = String.uncapitalize_ascii fn in
+  let find_normalized t fn =
+    let fn = Misc.normalized_unit_filename fn in
     let search { basename; path } =
-      if String.uncapitalize_ascii basename = fn then
+      if Misc.normalized_unit_filename basename = fn then
         Some path
       else
         None
@@ -149,7 +149,7 @@ end = struct
     List.iter (fun ({ basename = base; path = fn } : Dir.entry) ->
         if Dir.hidden dir then begin
           STbl.replace !hidden_files base fn;
-          STbl.replace !hidden_files_uncap (String.uncapitalize_ascii base) fn
+          STbl.replace !hidden_files_uncap (Misc.normalized_unit_filename base) fn
         end else begin
           STbl.replace !visible_files base fn;
           STbl.replace !visible_files_uncap (String.uncapitalize_ascii base) fn
@@ -166,7 +166,7 @@ end = struct
     List.iter
       (fun ({ basename = base; path = fn }: Dir.entry) ->
          update base fn visible_files hidden_files;
-         let ubase = String.uncapitalize_ascii base in
+         let ubase = Misc.normalized_unit_filename base in
          update ubase fn visible_files_uncap hidden_files_uncap)
       (Dir.files dir)
 
@@ -296,7 +296,7 @@ let find fn =
   with Not_found ->
     !auto_include_callback Dir.find fn
 
-let find_uncap_with_visibility fn =
+let find_normalized_with_visibility fn =
   assert (not Config.merlin || Local_store.is_bound ());
   try
     if is_basename fn && not !Sys.interactive then
@@ -311,4 +311,4 @@ let find_uncap_with_visibility fn =
     let fn_uncap = String.uncapitalize_ascii fn in
     (!auto_include_callback Dir.find_uncap fn_uncap, Visible)
 
-let find_uncap fn = fst (find_uncap_with_visibility fn)
+let find_normalized fn = fst (find_normalized_with_visibility fn)

--- a/ocaml/utils/load_path.mli
+++ b/ocaml/utils/load_path.mli
@@ -83,15 +83,16 @@ val find : string -> string
     filename is a basename, i.e. doesn't contain a directory
     separator. *)
 
-val find_uncap : string -> string
-(** Same as [find], but search also for uncapitalized name, i.e.  if
-    name is Foo.ml, allow /path/Foo.ml and /path/foo.ml to match. *)
+val find_normalized : string -> string
+(** Same as [find], but search also for normalized unit name (see
+    {!Misc.normalized_unit_filename}), i.e. if name is [Foo.ml], allow
+    [/path/Foo.ml] and [/path/foo.ml] to match. *)
 
 type visibility = Visible | Hidden
 
-val find_uncap_with_visibility : string -> string * visibility
-(** Same as [find_uncap], but also reports whether the cmi was found in a -I
-    directory (Visible) or a -H directory (Hidden) *)
+val find_normalized_with_visibility : string -> string * visibility
+(** Same as [find_normalized], but also reports whether the cmi was found in a
+    -I directory (Visible) or a -H directory (Hidden) *)
 
 val[@deprecated] add : Dir.t -> unit
 (** Old name for {!append_dir} *)


### PR DESCRIPTION
Main changes:
  * See note below about `Unit_info.Artifact.t`, etc.
  * We style more error messages as inline code to match upstream
  * Sometimes, the two implementations of attribute-marking differ a little. These seem easy enough to resolve, but I don't have a ton of context so may have made the wrong decision in some cases.

### `Unit_info.Artifact.t` and `Compilation_unit.Name.t`

See https://github.com/ocaml-flambda/flambda-backend/wiki/Strategy-for-5.2.0-Unit_info-and-compunit.

There are many case of this form:
  * `flambda-backend` takes a `modname : Compilation_unit.Name.t` and `filename : string` argument
  * upstream takes a `cmi : Unit_info.Artifact.t` argument

We resolve these by taking both `modname : Compilation_unit.Name.t` and `cmi : Unit_info.Artifact.t`, and projecting out filename from `Unit_info.Artifact.t`. We should add our internal notion of `modnam` to `Unit_info.Artifact.t` so we can get rid of this extra argument, but we haven't done this yet.