### PR TITLE
`Regalloc_split`: slightly generalize the code

### DIFF
--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -226,12 +226,10 @@ let insert_spills_in_block :
  fun state ~block_subst ~stack_subst block cell live_at_destruction_point ->
   insert_splills_or_reloads_in_block state ~make_spill_or_reload:make_spill
     ~occur_check:(fun instr reg ->
-      (* We assume `new_reg` has no location yet (we are before register
-         allocation, but selection uses fixed registers in various places). If
-         the assertion does not hold, we need to look at the registers destroyed
-         by the instruction. *)
-      assert (Reg.is_unknown reg);
-      occurs_array instr.res reg)
+      (* We have reached the insertion point not only if the register is
+         explicitly set, but also if it is destroyed by the instruction. *)
+      occurs_array instr.res reg
+      || occurs_array (Proc.destroyed_at_basic instr.desc) reg)
     ~insert:DLL.insert_after
     ~copy_default:
       (match DLL.hd block.body with


### PR DESCRIPTION
As noted in the original pull request [1],
the move should not cross a destruction
of the register. This cannot happen right
now, because the registers being moved
all have their location set to unknown,
but I intend to use this code in situations
where this restriction does not hold.


[1] https://github.com/ocaml-flambda/flambda-backend/pull/1739#discussion_r1297165422