### PR TITLE
Fix conflicts in `typing/typemod.ml`

### DIFF
--- a/ocaml/file_formats/cms_format.ml
+++ b/ocaml/file_formats/cms_format.ml
@@ -91,11 +91,13 @@ let uid_tables_of_binary_annots binary_annots =
     );
   cms_uid_to_loc, cms_uid_to_attributes
 
-let save_cms filename modname binary_annots sourcefile shape =
+let save_cms target modname binary_annots shape =
   if (!Clflags.binary_annotations_cms && not !Clflags.print_types) then begin
     Misc.output_to_file_via_temporary
-       ~mode:[Open_binary] filename
+       ~mode:[Open_binary] (Unit_info.Artifact.filename target)
        (fun _temp_file_name oc ->
+
+        let sourcefile = Unit_info.Artifact.source_file target in
         let source_digest = Option.map Digest.file sourcefile in
         let cms_ident_occurrences =
           if !Clflags.store_occurrences then

--- a/ocaml/file_formats/cms_format.mli
+++ b/ocaml/file_formats/cms_format.mli
@@ -43,10 +43,9 @@ val read : string -> cms_infos
 (** [save_cms filename modname sourcefile shape]
     writes a cms(i) file.  *)
 val save_cms :
-  string ->  (* filename.cms to generate *)
+  Unit_info.Artifact.t ->
   Compilation_unit.t ->  (* module name *)
   Cmt_format.binary_annots ->
-  string option ->  (* source file *)
   Shape.t option ->
   unit
 

--- a/ocaml/parsing/unit_info.ml
+++ b/ocaml/parsing/unit_info.ml
@@ -105,10 +105,13 @@ let cmx f = mk_artifact ".cmx" f
 let obj f = mk_artifact Config.ext_obj f
 let cmt f = mk_artifact ".cmt" f
 let cmti f = mk_artifact ".cmti" f
+let cms f = mk_artifact ".cms" f
+let cmsi f = mk_artifact ".cmsi" f
 let annot f = mk_artifact ".annot" f
 
 let companion_obj f = companion_artifact Config.ext_obj f
 let companion_cmt f = companion_artifact ".cmt" f
+let companion_cms f = companion_artifact ".cms" f
 
 let companion_cmi f =
   let prefix = Misc.chop_extensions f.Artifact.filename in

--- a/ocaml/parsing/unit_info.mli
+++ b/ocaml/parsing/unit_info.mli
@@ -120,6 +120,8 @@ val cmx: t -> Artifact.t
 val obj: t -> Artifact.t
 val cmt: t -> Artifact.t
 val cmti: t -> Artifact.t
+val cms: t -> Artifact.t
+val cmsi: t -> Artifact.t
 val annot: t -> Artifact.t
 
 (** The functions below change the type of an artifact by updating the
@@ -128,6 +130,7 @@ val annot: t -> Artifact.t
     to track which artifacts are assumed to be bundled together. *)
 val companion_obj: Artifact.t -> Artifact.t
 val companion_cmt: Artifact.t -> Artifact.t
+val companion_cms: Artifact.t -> Artifact.t
 
 val companion_cmi: Artifact.t -> Artifact.t
 (** Beware that [companion_cmi a] strips all extensions from the

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -626,15 +626,8 @@ type with_info =
 let merge_constraint initial_env loc sg lid constr =
   let destructive_substitution =
     match constr with
-<<<<<<< HEAD
-    | With_type _ | With_type_package _ | With_module _
-    | With_modtype _ -> false
-||||||| 121bedcfd2
-    | With_type _ | With_module _ | With_modtype _ -> false
-=======
     | With_type _ | With_module _ | With_modtype _
     | With_type_package _ -> false
->>>>>>> 5.2.0
     | With_typesubst _ | With_modsubst _ | With_modtypesubst _  -> true
   in
   let real_ids = ref [] in
@@ -666,15 +659,9 @@ let merge_constraint initial_env loc sg lid constr =
                 (fun _ -> Btype.newgenvar (Jkind.Primitive.any ~why:Dummy_jkind))
                 sdecl.ptype_params;
             type_arity = arity;
-<<<<<<< HEAD
-            type_kind = Type_abstract Abstract_def;
+            type_kind = Type_abstract Definition;
             type_jkind = Jkind.Primitive.value ~why:(Unknown "merge_constraint");
             type_jkind_annotation = None;
-||||||| 121bedcfd2
-            type_kind = Type_abstract;
-=======
-            type_kind = Type_abstract Definition;
->>>>>>> 5.2.0
             type_private = Private;
             type_manifest = None;
             type_variance =
@@ -742,7 +729,6 @@ let merge_constraint initial_env loc sg lid constr =
             return ~ghosts ~replace_by:None
               (Pident id, lid, Some (Twith_typesubst tdecl))
         end
-<<<<<<< HEAD
     | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
       when Ident.name id = s ->
         begin match sig_decl.type_manifest with
@@ -778,23 +764,6 @@ let merge_constraint initial_env loc sg lid constr =
         let tdecl = { tdecl with type_manifest = None } in
         return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
           (Pident id, lid, None)
-||||||| 121bedcfd2
-=======
-    | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
-      when Ident.name id = s ->
-        begin match sig_decl.type_manifest with
-        | None -> ()
-        | Some ty ->
-          raise (Error(loc, outer_sig_env, With_package_manifest (lid.txt, ty)))
-        end;
-        let tdecl =
-          Typedecl.transl_package_constraint ~loc outer_sig_env cty.ctyp_type
-        in
-        check_type_decl outer_sig_env sg_for_env loc id None tdecl sig_decl;
-        let tdecl = { tdecl with type_manifest = None } in
-        return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
-          (Pident id, lid, None)
->>>>>>> 5.2.0
     | Sig_modtype(id, mtd, priv), [s],
       (With_modtype mty | With_modtypesubst mty)
       when Ident.name id = s ->
@@ -886,122 +855,32 @@ let merge_constraint initial_env loc sg lid constr =
     if destructive_substitution then
       check_usage_after_substitution ~loc ~lid initial_env !real_ids
         !unpackable_modtype sg;
-<<<<<<< HEAD
     let sub = match tcstr with
       | (_, _, Some (Twith_typesubst tdecl)) ->
-        let how_to_extend_subst =
-          let sdecl =
-            match constr with
-            | With_typesubst sdecl -> sdecl
-            | _ -> assert false
+          let how_to_extend_subst =
+            let sdecl =
+              match constr with
+              | With_typesubst sdecl -> sdecl
+              | _ -> assert false
+            in
+            match type_decl_is_alias sdecl with
+            | Some lid ->
+                let replacement, _ =
+                  try Env.find_type_by_name lid.txt initial_env
+                  with Not_found -> assert false
+                in
+                fun s path -> Subst.add_type_path path replacement s
+            | None ->
+                let body = Option.get tdecl.typ_type.type_manifest in
+                let params = tdecl.typ_type.type_params in
+                if params_are_constrained params
+                then raise(Error(loc, initial_env,
+                                With_cannot_remove_constrained_type));
+                fun s path -> Subst.add_type_function path ~params ~body s
           in
-          match type_decl_is_alias sdecl with
-          | Some lid ->
-              let replacement, _ =
-                try Env.find_type_by_name lid.txt initial_env
-                with Not_found -> assert false
-              in
-              fun s path -> Subst.add_type_path path replacement s
-          | None ->
-              let body = Option.get tdecl.typ_type.type_manifest in
-              let params = tdecl.typ_type.type_params in
-              if params_are_constrained params
-              then raise(Error(loc, initial_env,
-                              With_cannot_remove_constrained_type));
-              fun s path -> Subst.add_type_function path ~params ~body s
-        in
-||||||| 121bedcfd2
-    let sg =
-    match tcstr with
-    | (_, _, Twith_typesubst tdecl) ->
-       let how_to_extend_subst =
-         let sdecl =
-           match constr with
-           | With_typesubst sdecl -> sdecl
-           | _ -> assert false
-         in
-         match type_decl_is_alias sdecl with
-         | Some lid ->
-            let replacement, _ =
-              try Env.find_type_by_name lid.txt initial_env
-              with Not_found -> assert false
-            in
-            fun s path -> Subst.add_type_path path replacement s
-         | None ->
-            let body = Option.get tdecl.typ_type.type_manifest in
-            let params = tdecl.typ_type.type_params in
-            if params_are_constrained params
-            then raise(Error(loc, initial_env,
-                             With_cannot_remove_constrained_type));
-            fun s path -> Subst.add_type_function path ~params ~body s
-       in
-       let sub = Subst.change_locs Subst.identity loc in
-       let sub = List.fold_left how_to_extend_subst sub !real_ids in
-       (* This signature will not be used directly, it will always be freshened
-          by the caller. So what we do with the scope doesn't really matter. But
-          making it local makes it unlikely that we will ever use the result of
-          this function unfreshened without issue. *)
-       Subst.signature Make_local sub sg
-    | (_, _, Twith_modsubst (real_path, _)) ->
-       let sub = Subst.change_locs Subst.identity loc in
-       let sub =
-         List.fold_left
-           (fun s path -> Subst.add_module_path path real_path s)
-           sub
-           !real_ids
-       in
-       (* See explanation in the [Twith_typesubst] case above. *)
-       Subst.signature Make_local sub sg
-    | (_, _, Twith_modtypesubst tmty) ->
-        let add s p = Subst.add_modtype_path p tmty.mty_type s in
-=======
-    let sg =
-    match tcstr with
-    | (_, _, Some (Twith_typesubst tdecl)) ->
-       let how_to_extend_subst =
-         let sdecl =
-           match constr with
-           | With_typesubst sdecl -> sdecl
-           | _ -> assert false
-         in
-         match type_decl_is_alias sdecl with
-         | Some lid ->
-            let replacement, _ =
-              try Env.find_type_by_name lid.txt initial_env
-              with Not_found -> assert false
-            in
-            fun s path -> Subst.add_type_path path replacement s
-         | None ->
-            let body = Option.get tdecl.typ_type.type_manifest in
-            let params = tdecl.typ_type.type_params in
-            if params_are_constrained params
-            then raise(Error(loc, initial_env,
-                             With_cannot_remove_constrained_type));
-            fun s path -> Subst.add_type_function path ~params ~body s
-       in
-       let sub = Subst.change_locs Subst.identity loc in
-       let sub = List.fold_left how_to_extend_subst sub !real_ids in
-       (* This signature will not be used directly, it will always be freshened
-          by the caller. So what we do with the scope doesn't really matter. But
-          making it local makes it unlikely that we will ever use the result of
-          this function unfreshened without issue. *)
-       Subst.signature Make_local sub sg
-    | (_, _, Some (Twith_modsubst (real_path, _))) ->
-       let sub = Subst.change_locs Subst.identity loc in
-       let sub =
-         List.fold_left
-           (fun s path -> Subst.add_module_path path real_path s)
-           sub
-           !real_ids
-       in
-       (* See explanation in the [Twith_typesubst] case above. *)
-       Subst.signature Make_local sub sg
-    | (_, _, Some (Twith_modtypesubst tmty)) ->
-        let add s p = Subst.add_modtype_path p tmty.mty_type s in
->>>>>>> 5.2.0
-        let sub = Subst.change_locs Subst.identity loc in
-        let sub = List.fold_left how_to_extend_subst sub !real_ids in
-        Some sub
+          let sub = Subst.change_locs Subst.identity loc in
+          let sub = List.fold_left how_to_extend_subst sub !real_ids in
+          Some sub
       | (_, _, Some (Twith_modsubst (real_path, _))) ->
         let sub = Subst.change_locs Subst.identity loc in
         let sub =
@@ -1039,28 +918,6 @@ let merge_constraint initial_env loc sg lid constr =
   with Includemod.Error explanation ->
     raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
 
-<<<<<<< HEAD
-let merge_package_constraint initial_env loc sg lid cty =
-  let _, s = merge_constraint initial_env loc sg lid (With_type_package cty) in
-  s
-
-let check_package_with_type_constraints loc env mty constraints =
-  let sg = extract_sig env loc mty in
-  let sg =
-    List.fold_left
-      (fun sg (lid, cty) -> merge_package_constraint env loc sg lid cty)
-      sg constraints
-  in
-  let scope = Ctype.create_scope () in
-  Mtype.freshen ~scope (Mty_signature sg)
-
-let () =
-  Typetexp.check_package_with_type_constraints :=
-    check_package_with_type_constraints
-
-
-||||||| 121bedcfd2
-=======
 let merge_package_constraint initial_env loc sg lid cty =
   let _, s = merge_constraint initial_env loc sg lid (With_type_package cty) in
   s
@@ -1080,7 +937,6 @@ let () =
   Typetexp.check_package_with_type_constraints :=
     check_package_with_type_constraints
 
->>>>>>> 5.2.0
 (* Add recursion flags on declarations arising from a mutually recursive
    block. *)
 
@@ -1793,15 +1649,8 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
 
 
 
-<<<<<<< HEAD
-and transl_signature env (sg : Parsetree.signature) =
-||||||| 121bedcfd2
-and transl_signature env sg =
-=======
 and transl_signature ?(toplevel = false) env sg =
->>>>>>> 5.2.0
   let names = Signature_names.create () in
-<<<<<<< HEAD
 
   let transl_include ~functor_ ~loc env sig_acc sincl =
     let smty = sincl.pincl_mod in
@@ -1894,116 +1743,7 @@ and transl_signature ?(toplevel = false) env sg =
                   ~params
                   ~body:(Option.get td.typ_type.type_manifest)
                   Subst.identity
-||||||| 121bedcfd2
-  let rec transl_sig env sg =
-    match sg with
-      [] -> [], [], env
-    | item :: srem ->
-        let loc = item.psig_loc in
-        match item.psig_desc with
-        | Psig_value sdesc ->
-            let (tdesc, newenv) =
-              Typedecl.transl_value_decl env item.psig_loc sdesc
-            in
-            Signature_names.check_value names tdesc.val_loc tdesc.val_id;
-            Env.register_uid tdesc.val_val.val_uid tdesc.val_loc;
-            let (trem,rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_value tdesc) env loc :: trem,
-            Sig_value(tdesc.val_id, tdesc.val_val, Exported) :: rem,
-              final_env
-        | Psig_type (rec_flag, sdecls) ->
-            let (decls, newenv) =
-              Typedecl.transl_type_decl env rec_flag sdecls
-            in
-            List.iter (fun td ->
-              Signature_names.check_type names td.typ_loc td.typ_id;
-              if not (Btype.is_row_name (Ident.name td.typ_id)) then
-                Env.register_uid td.typ_type.type_uid td.typ_loc
-            ) decls;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            let sg =
-              map_rec_type_with_row_types ~rec_flag
-                (fun rs td -> Sig_type(td.typ_id, td.typ_type, rs, Exported))
-                decls rem
-            in
-            mksig (Tsig_type (rec_flag, decls)) env loc :: trem,
-            sg,
-            final_env
-        | Psig_typesubst sdecls ->
-            let (decls, newenv) =
-              Typedecl.transl_type_decl env Nonrecursive sdecls
-            in
-            List.iter (fun td ->
-              if td.typ_kind <> Ttype_abstract || td.typ_manifest = None ||
-                 td.typ_private = Private
-              then
-                raise (Error (td.typ_loc, env, Invalid_type_subst_rhs));
-              let params = td.typ_type.type_params in
-              if params_are_constrained params
-              then raise(Error(loc, env, With_cannot_remove_constrained_type));
-              let info =
-                  let subst =
-                    Subst.add_type_function (Pident td.typ_id)
-                      ~params
-                      ~body:(Option.get td.typ_type.type_manifest)
-                      Subst.identity
-                  in
-                  Some (`Substituted_away subst)
-=======
-  let rec transl_sig env sg =
-    match sg with
-      [] -> [], [], env
-    | item :: srem ->
-        let loc = item.psig_loc in
-        match item.psig_desc with
-        | Psig_value sdesc ->
-            let (tdesc, newenv) =
-              Typedecl.transl_value_decl env item.psig_loc sdesc
-            in
-            Signature_names.check_value names tdesc.val_loc tdesc.val_id;
-            let (trem,rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_value tdesc) env loc :: trem,
-            Sig_value(tdesc.val_id, tdesc.val_val, Exported) :: rem,
-              final_env
-        | Psig_type (rec_flag, sdecls) ->
-            let (decls, newenv, _) =
-              Typedecl.transl_type_decl env rec_flag sdecls
-            in
-            List.iter (fun td ->
-              Signature_names.check_type names td.typ_loc td.typ_id;
-            ) decls;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            let sg =
-              map_rec_type_with_row_types ~rec_flag
-                (fun rs td -> Sig_type(td.typ_id, td.typ_type, rs, Exported))
-                decls rem
-            in
-            mksig (Tsig_type (rec_flag, decls)) env loc :: trem,
-            sg,
-            final_env
-        | Psig_typesubst sdecls ->
-            let (decls, newenv, _) =
-              Typedecl.transl_type_decl env Nonrecursive sdecls
-            in
-            List.iter (fun td ->
-              if td.typ_kind <> Ttype_abstract || td.typ_manifest = None ||
-                 td.typ_private = Private
-              then
-                raise (Error (td.typ_loc, env, Invalid_type_subst_rhs));
-              let params = td.typ_type.type_params in
-              if params_are_constrained params
-              then raise(Error(loc, env, With_cannot_remove_constrained_type));
-              let info =
-                  let subst =
-                    Subst.add_type_function (Pident td.typ_id)
-                      ~params
-                      ~body:(Option.get td.typ_type.type_manifest)
-                      Subst.identity
-                  in
-                  Some (`Substituted_away subst)
->>>>>>> 5.2.0
               in
-<<<<<<< HEAD
               Some (`Substituted_away subst)
           in
           Signature_names.check_type ?info names td.typ_loc td.typ_id
@@ -2058,20 +1798,7 @@ and transl_signature ?(toplevel = false) env sg =
           | Some name ->
             let id, newenv =
               Env.enter_module_declaration ~scope name pres md env
-||||||| 121bedcfd2
-              Signature_names.check_type ?info names td.typ_loc td.typ_id;
-              Env.register_uid td.typ_type.type_uid td.typ_loc
-            ) decls;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            let sg = rem
-=======
-              Signature_names.check_type ?info names td.typ_loc td.typ_id
-            ) decls;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            let sg = rem
->>>>>>> 5.2.0
             in
-<<<<<<< HEAD
             Signature_names.check_module names pmd.pmd_name.loc id;
             Some id, newenv
         in
@@ -2103,104 +1830,8 @@ and transl_signature ?(toplevel = false) env sg =
             { md_type = Mty_alias path;
               md_attributes = pms.pms_attributes;
               md_loc = pms.pms_loc;
-||||||| 121bedcfd2
-            mksig (Tsig_typesubst decls) env loc :: trem,
-            sg,
-            final_env
-        | Psig_typext styext ->
-            let (tyext, newenv) =
-              Typedecl.transl_type_extension false env item.psig_loc styext
-            in
-            let constructors = tyext.tyext_constructors in
-            List.iter (fun ext ->
-              Signature_names.check_typext names ext.ext_loc ext.ext_id;
-              Env.register_uid ext.ext_type.ext_uid ext.ext_loc
-            ) constructors;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-              mksig (Tsig_typext tyext) env loc :: trem,
-              map_ext (fun es ext ->
-                Sig_typext(ext.ext_id, ext.ext_type, es, Exported)
-              ) constructors rem,
-              final_env
-        | Psig_exception sext ->
-            let (ext, newenv) = Typedecl.transl_type_exception env sext in
-            let constructor = ext.tyexn_constructor in
-            Signature_names.check_typext names constructor.ext_loc
-              constructor.ext_id;
-            Env.register_uid
-              constructor.ext_type.ext_uid
-              constructor.ext_loc;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_exception ext) env loc :: trem,
-            Sig_typext(constructor.ext_id,
-                       constructor.ext_type,
-                       Text_exception,
-                       Exported) :: rem,
-            final_env
-        | Psig_module pmd ->
-            let scope = Ctype.create_scope () in
-            let tmty =
-              Builtin_attributes.warning_scope pmd.pmd_attributes
-                (fun () -> transl_modtype env pmd.pmd_type)
-            in
-            let pres =
-              match tmty.mty_type with
-              | Mty_alias _ -> Mp_absent
-              | _ -> Mp_present
-            in
-            let md = {
-              md_type=tmty.mty_type;
-              md_attributes=pmd.pmd_attributes;
-              md_loc=pmd.pmd_loc;
-=======
-            mksig (Tsig_typesubst decls) env loc :: trem,
-            sg,
-            final_env
-        | Psig_typext styext ->
-            let (tyext, newenv, _shapes) =
-              Typedecl.transl_type_extension false env item.psig_loc styext
-            in
-            let constructors = tyext.tyext_constructors in
-            List.iter (fun ext ->
-              Signature_names.check_typext names ext.ext_loc ext.ext_id
-            ) constructors;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-              mksig (Tsig_typext tyext) env loc :: trem,
-              map_ext (fun es ext ->
-                Sig_typext(ext.ext_id, ext.ext_type, es, Exported)
-              ) constructors rem,
-              final_env
-        | Psig_exception sext ->
-            let (ext, newenv, _s) = Typedecl.transl_type_exception env sext in
-            let constructor = ext.tyexn_constructor in
-            Signature_names.check_typext names constructor.ext_loc
-              constructor.ext_id;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_exception ext) env loc :: trem,
-            Sig_typext(constructor.ext_id,
-                       constructor.ext_type,
-                       Text_exception,
-                       Exported) :: rem,
-            final_env
-        | Psig_module pmd ->
-            let scope = Ctype.create_scope () in
-            let tmty =
-              Builtin_attributes.warning_scope pmd.pmd_attributes
-                (fun () -> transl_modtype env pmd.pmd_type)
-            in
-            let pres =
-              match tmty.mty_type with
-              | Mty_alias _ -> Mp_absent
-              | _ -> Mp_present
-            in
-            let md = {
-              md_type=tmty.mty_type;
-              md_attributes=pmd.pmd_attributes;
-              md_loc=pmd.pmd_loc;
->>>>>>> 5.2.0
               md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
             }
-<<<<<<< HEAD
         in
         let pres =
           match md.md_type with
@@ -2327,7 +1958,8 @@ and transl_signature ?(toplevel = false) env sg =
         typedtree, tsg, newenv
     | Psig_attribute attr ->
         Builtin_attributes.parse_standard_interface_attributes attr;
-        Builtin_attributes.mark_alert_used attr;
+        if toplevel || not (Warnings.is_active (Misplaced_attribute ""))
+        then Builtin_attributes.mark_alert_used attr;
         mksig (Tsig_attribute attr) env loc, [], env
     | Psig_extension (ext, _attrs) ->
         raise (Error_forward (Builtin_attributes.error_of_extension ext))
@@ -2340,416 +1972,6 @@ and transl_signature ?(toplevel = false) env sg =
         (new_item :: sig_items)
         (List.rev_append new_types sig_type)
         srem
-||||||| 121bedcfd2
-            in
-            let id, newenv =
-              match pmd.pmd_name.txt with
-              | None -> None, env
-              | Some name ->
-                let id, newenv =
-                  Env.enter_module_declaration ~scope name pres md env
-                in
-                Signature_names.check_module names pmd.pmd_name.loc id;
-                Some id, newenv
-            in
-            Env.register_uid md.md_uid md.md_loc;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_module {md_id=id; md_name=pmd.pmd_name;
-                                md_presence=pres; md_type=tmty;
-                                md_loc=pmd.pmd_loc;
-                                md_attributes=pmd.pmd_attributes})
-              env loc :: trem,
-            (match id with
-             | None -> rem
-             | Some id -> Sig_module(id, pres, md, Trec_not, Exported) :: rem),
-            final_env
-        | Psig_modsubst pms ->
-            let scope = Ctype.create_scope () in
-            let path, md =
-              Env.lookup_module ~loc:pms.pms_manifest.loc
-                pms.pms_manifest.txt env
-            in
-            let aliasable = not (Env.is_functor_arg path env) in
-            let md =
-              if not aliasable then
-                md
-              else
-                { md_type = Mty_alias path;
-                  md_attributes = pms.pms_attributes;
-                  md_loc = pms.pms_loc;
-                  md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
-                }
-            in
-            let pres =
-              match md.md_type with
-              | Mty_alias _ -> Mp_absent
-              | _ -> Mp_present
-            in
-            let id, newenv =
-              Env.enter_module_declaration ~scope pms.pms_name.txt pres md env
-            in
-            let info =
-              `Substituted_away (Subst.add_module id path Subst.identity)
-            in
-            Signature_names.check_module ~info names pms.pms_name.loc id;
-            Env.register_uid md.md_uid md.md_loc;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_modsubst {ms_id=id; ms_name=pms.pms_name;
-                                  ms_manifest=path; ms_txt=pms.pms_manifest;
-                                  ms_loc=pms.pms_loc;
-                                  ms_attributes=pms.pms_attributes})
-              env loc :: trem,
-            rem,
-            final_env
-        | Psig_recmodule sdecls ->
-            let (tdecls, newenv) =
-              transl_recmodule_modtypes env sdecls in
-            let decls =
-              List.filter_map (fun (md, uid, _) ->
-                match md.md_id with
-                | None -> None
-                | Some id -> Some (id, md, uid)
-              ) tdecls
-            in
-            List.iter (fun (id, md, uid) ->
-              Signature_names.check_module names md.md_loc id;
-              Env.register_uid uid md.md_loc
-            ) decls;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_recmodule (List.map (fun (md, _, _) -> md) tdecls))
-              env loc :: trem,
-            map_rec (fun rs (id, md, uid) ->
-                let d = {Types.md_type = md.md_type.mty_type;
-                         md_attributes = md.md_attributes;
-                         md_loc = md.md_loc;
-                         md_uid = uid;
-                        } in
-                Sig_module(id, Mp_present, d, rs, Exported))
-              decls rem,
-            final_env
-        | Psig_modtype pmtd ->
-            let newenv, mtd, decl = transl_modtype_decl env pmtd in
-            Signature_names.check_modtype names pmtd.pmtd_loc mtd.mtd_id;
-            Env.register_uid decl.mtd_uid mtd.mtd_loc;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_modtype mtd) env loc :: trem,
-            Sig_modtype (mtd.mtd_id, decl, Exported) :: rem,
-            final_env
-        | Psig_modtypesubst pmtd ->
-            let newenv, mtd, decl = transl_modtype_decl env pmtd in
-            let info =
-              let mty = match mtd.mtd_type with
-                | Some tmty -> tmty.mty_type
-                | None ->
-                    (* parsetree invariant, see Ast_invariants *)
-                    assert false
-              in
-              let subst = Subst.add_modtype mtd.mtd_id mty Subst.identity in
-              match mty with
-              | Mty_ident _ -> `Substituted_away subst
-              | _ -> `Unpackable_modtype_substituted_away (mtd.mtd_id,subst)
-            in
-            Signature_names.check_modtype ~info names pmtd.pmtd_loc mtd.mtd_id;
-            Env.register_uid decl.mtd_uid mtd.mtd_loc;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_modtypesubst mtd) env loc :: trem,
-            rem,
-            final_env
-        | Psig_open sod ->
-            let (od, newenv) = type_open_descr env sod in
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_open od) env loc :: trem,
-            rem, final_env
-        | Psig_include sincl ->
-            let smty = sincl.pincl_mod in
-            let tmty =
-              Builtin_attributes.warning_scope sincl.pincl_attributes
-                (fun () -> transl_modtype env smty)
-            in
-            let mty = tmty.mty_type in
-            let scope = Ctype.create_scope () in
-            let sg, newenv = Env.enter_signature ~scope
-                       (extract_sig env smty.pmty_loc mty) env in
-            Signature_group.iter
-              (Signature_names.check_sig_item names item.psig_loc)
-              sg;
-            let incl =
-              { incl_mod = tmty;
-                incl_type = sg;
-                incl_attributes = sincl.pincl_attributes;
-                incl_loc = sincl.pincl_loc;
-              }
-            in
-            let (trem, rem, final_env) = transl_sig newenv srem  in
-            mksig (Tsig_include incl) env loc :: trem,
-            sg @ rem,
-            final_env
-        | Psig_class cl ->
-            let (classes, newenv) = Typeclass.class_descriptions env cl in
-            List.iter (fun cls ->
-              let open Typeclass in
-              let loc = cls.cls_id_loc.Location.loc in
-              Signature_names.check_type names loc cls.cls_obj_id;
-              Signature_names.check_class names loc cls.cls_id;
-              Signature_names.check_class_type names loc cls.cls_ty_id;
-              Env.register_uid cls.cls_decl.cty_uid cls.cls_decl.cty_loc;
-            ) classes;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            let sg =
-              map_rec (fun rs cls ->
-                let open Typeclass in
-                [Sig_class(cls.cls_id, cls.cls_decl, rs, Exported);
-                 Sig_class_type(cls.cls_ty_id, cls.cls_ty_decl, rs, Exported);
-                 Sig_type(cls.cls_obj_id, cls.cls_obj_abbr, rs, Exported)
-                ]
-              ) classes [rem]
-              |> List.flatten
-            in
-            let typedtree =
-              mksig (Tsig_class
-                       (List.map (fun decr ->
-                          decr.Typeclass.cls_info) classes)) env loc
-              :: trem
-            in
-            typedtree, sg, final_env
-        | Psig_class_type cl ->
-            let (classes, newenv) = Typeclass.class_type_declarations env cl in
-            List.iter (fun decl ->
-              let open Typeclass in
-              let loc = decl.clsty_id_loc.Location.loc in
-              Signature_names.check_class_type names loc decl.clsty_ty_id;
-              Signature_names.check_type names loc decl.clsty_obj_id;
-              Env.register_uid
-                decl.clsty_ty_decl.clty_uid
-                decl.clsty_ty_decl.clty_loc;
-            ) classes;
-            let (trem,rem, final_env) = transl_sig newenv srem in
-            let sg =
-              map_rec (fun rs decl ->
-                let open Typeclass in
-                [Sig_class_type(decl.clsty_ty_id, decl.clsty_ty_decl, rs,
-                                Exported);
-                 Sig_type(decl.clsty_obj_id, decl.clsty_obj_abbr, rs, Exported);
-                ]
-              ) classes [rem]
-              |> List.flatten
-            in
-            let typedtree =
-              mksig
-                (Tsig_class_type
-                   (List.map (fun decl -> decl.Typeclass.clsty_info) classes))
-                env loc
-              :: trem
-            in
-            typedtree, sg, final_env
-        | Psig_attribute x ->
-            Builtin_attributes.warning_attribute x;
-            let (trem,rem, final_env) = transl_sig env srem in
-            mksig (Tsig_attribute x) env loc :: trem, rem, final_env
-        | Psig_extension (ext, _attrs) ->
-            raise (Error_forward (Builtin_attributes.error_of_extension ext))
-=======
-            in
-            let id, newenv =
-              match pmd.pmd_name.txt with
-              | None -> None, env
-              | Some name ->
-                let id, newenv =
-                  Env.enter_module_declaration ~scope name pres md env
-                in
-                Signature_names.check_module names pmd.pmd_name.loc id;
-                Some id, newenv
-            in
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_module {md_id=id; md_name=pmd.pmd_name;
-                                md_uid=md.md_uid; md_presence=pres;
-                                md_type=tmty; md_loc=pmd.pmd_loc;
-                                md_attributes=pmd.pmd_attributes})
-              env loc :: trem,
-            (match id with
-             | None -> rem
-             | Some id -> Sig_module(id, pres, md, Trec_not, Exported) :: rem),
-            final_env
-        | Psig_modsubst pms ->
-            let scope = Ctype.create_scope () in
-            let path, md =
-              Env.lookup_module ~loc:pms.pms_manifest.loc
-                pms.pms_manifest.txt env
-            in
-            let aliasable = not (Env.is_functor_arg path env) in
-            let md =
-              if not aliasable then
-                md
-              else
-                { md_type = Mty_alias path;
-                  md_attributes = pms.pms_attributes;
-                  md_loc = pms.pms_loc;
-                  md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
-                }
-            in
-            let pres =
-              match md.md_type with
-              | Mty_alias _ -> Mp_absent
-              | _ -> Mp_present
-            in
-            let id, newenv =
-              Env.enter_module_declaration ~scope pms.pms_name.txt pres md env
-            in
-            let info =
-              `Substituted_away (Subst.add_module id path Subst.identity)
-            in
-            Signature_names.check_module ~info names pms.pms_name.loc id;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_modsubst {ms_id=id; ms_name=pms.pms_name;
-                                  ms_uid=md.md_uid; ms_manifest=path;
-                                  ms_txt=pms.pms_manifest; ms_loc=pms.pms_loc;
-                                  ms_attributes=pms.pms_attributes})
-              env loc :: trem,
-            rem,
-            final_env
-        | Psig_recmodule sdecls ->
-            let (tdecls, newenv) =
-              transl_recmodule_modtypes env sdecls in
-            let decls =
-              List.filter_map (fun (md, uid, _) ->
-                match md.md_id with
-                | None -> None
-                | Some id -> Some (id, md, uid)
-              ) tdecls
-            in
-            List.iter (fun (id, md, _uid) ->
-              Signature_names.check_module names md.md_loc id;
-            ) decls;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_recmodule (List.map (fun (md, _, _) -> md) tdecls))
-              env loc :: trem,
-            map_rec (fun rs (id, md, uid) ->
-                let d = {Types.md_type = md.md_type.mty_type;
-                         md_attributes = md.md_attributes;
-                         md_loc = md.md_loc;
-                         md_uid = uid;
-                        } in
-                Sig_module(id, Mp_present, d, rs, Exported))
-              decls rem,
-            final_env
-        | Psig_modtype pmtd ->
-            let newenv, mtd, decl = transl_modtype_decl env pmtd in
-            Signature_names.check_modtype names pmtd.pmtd_loc mtd.mtd_id;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_modtype mtd) env loc :: trem,
-            Sig_modtype (mtd.mtd_id, decl, Exported) :: rem,
-            final_env
-        | Psig_modtypesubst pmtd ->
-            let newenv, mtd, _decl = transl_modtype_decl env pmtd in
-            let info =
-              let mty = match mtd.mtd_type with
-                | Some tmty -> tmty.mty_type
-                | None ->
-                    (* parsetree invariant, see Ast_invariants *)
-                    assert false
-              in
-              let subst = Subst.add_modtype mtd.mtd_id mty Subst.identity in
-              match mty with
-              | Mty_ident _ -> `Substituted_away subst
-              | _ -> `Unpackable_modtype_substituted_away (mtd.mtd_id,subst)
-            in
-            Signature_names.check_modtype ~info names pmtd.pmtd_loc mtd.mtd_id;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_modtypesubst mtd) env loc :: trem,
-            rem,
-            final_env
-        | Psig_open sod ->
-            let (od, newenv) = type_open_descr env sod in
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            mksig (Tsig_open od) env loc :: trem,
-            rem, final_env
-        | Psig_include sincl ->
-            let smty = sincl.pincl_mod in
-            let tmty =
-              Builtin_attributes.warning_scope sincl.pincl_attributes
-                (fun () -> transl_modtype env smty)
-            in
-            let mty = tmty.mty_type in
-            let scope = Ctype.create_scope () in
-            let sg, newenv = Env.enter_signature ~scope
-                       (extract_sig env smty.pmty_loc mty) env in
-            Signature_group.iter
-              (Signature_names.check_sig_item names item.psig_loc)
-              sg;
-            let incl =
-              { incl_mod = tmty;
-                incl_type = sg;
-                incl_attributes = sincl.pincl_attributes;
-                incl_loc = sincl.pincl_loc;
-              }
-            in
-            let (trem, rem, final_env) = transl_sig newenv srem  in
-            mksig (Tsig_include incl) env loc :: trem,
-            sg @ rem,
-            final_env
-        | Psig_class cl ->
-            let (classes, newenv) = Typeclass.class_descriptions env cl in
-            List.iter (fun cls ->
-              let open Typeclass in
-              let loc = cls.cls_id_loc.Location.loc in
-              Signature_names.check_type names loc cls.cls_obj_id;
-              Signature_names.check_class names loc cls.cls_id;
-              Signature_names.check_class_type names loc cls.cls_ty_id;
-            ) classes;
-            let (trem, rem, final_env) = transl_sig newenv srem in
-            let sg =
-              map_rec (fun rs cls ->
-                let open Typeclass in
-                [Sig_class(cls.cls_id, cls.cls_decl, rs, Exported);
-                 Sig_class_type(cls.cls_ty_id, cls.cls_ty_decl, rs, Exported);
-                 Sig_type(cls.cls_obj_id, cls.cls_obj_abbr, rs, Exported)
-                ]
-              ) classes [rem]
-              |> List.flatten
-            in
-            let typedtree =
-              mksig (Tsig_class
-                       (List.map (fun decr ->
-                          decr.Typeclass.cls_info) classes)) env loc
-              :: trem
-            in
-            typedtree, sg, final_env
-        | Psig_class_type cl ->
-            let (classes, newenv) = Typeclass.class_type_declarations env cl in
-            List.iter (fun decl ->
-              let open Typeclass in
-              let loc = decl.clsty_id_loc.Location.loc in
-              Signature_names.check_class_type names loc decl.clsty_ty_id;
-              Signature_names.check_type names loc decl.clsty_obj_id;
-            ) classes;
-            let (trem,rem, final_env) = transl_sig newenv srem in
-            let sg =
-              map_rec (fun rs decl ->
-                let open Typeclass in
-                [Sig_class_type(decl.clsty_ty_id, decl.clsty_ty_decl, rs,
-                                Exported);
-                 Sig_type(decl.clsty_obj_id, decl.clsty_obj_abbr, rs, Exported);
-                ]
-              ) classes [rem]
-              |> List.flatten
-            in
-            let typedtree =
-              mksig
-                (Tsig_class_type
-                   (List.map (fun decl -> decl.Typeclass.clsty_info) classes))
-                env loc
-              :: trem
-            in
-            typedtree, sg, final_env
-        | Psig_attribute x ->
-            Builtin_attributes.warning_attribute x;
-            if toplevel || not (Warnings.is_active (Misplaced_attribute ""))
-            then Builtin_attributes.mark_alert_used x;
-            let (trem,rem, final_env) = transl_sig env srem in
-            mksig (Tsig_attribute x) env loc :: trem, rem, final_env
-        | Psig_extension (ext, _attrs) ->
-            raise (Error_forward (Builtin_attributes.error_of_extension ext))
->>>>>>> 5.2.0
   in
   let previous_saved_types = Cmt_format.get_saved_types () in
   Builtin_attributes.warning_scope []
@@ -3107,9 +2329,7 @@ let rec package_constraints_sig env loc sg constrs =
       | Sig_type (id, ({type_params=[]} as td), rs, priv)
         when List.mem_assoc [Ident.name id] constrs ->
           let ty = List.assoc [Ident.name id] constrs in
-          let td = {td with type_manifest = Some ty} in
-          let type_immediate = Typedecl_immediacy.compute_decl env td in
-          Sig_type (id, {td with type_immediate}, rs, priv)
+          Sig_type (id, {td with type_manifest = Some ty}, rs, priv)
       | Sig_module (id, pres, md, rs, priv) ->
           let rec aux = function
             | (m :: ((_ :: _) as l), t) :: rest when m = Ident.name id ->
@@ -3532,7 +2752,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
     end
   | Mty_alias path ->
       raise(Error(app_view.f_loc, env, Cannot_scrape_alias path))
-  | Mty_ident _ | Mty_signature _  ->
+  | Mty_ident _ | Mty_signature _ | Mty_strengthen _ ->
       let args = List.map simplify_app_summary args in
       let mty_f = md_f.mod_type in
       let app_name = match sfunct.pmod_desc with
@@ -3680,27 +2900,15 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
           Option.is_some toplevel
         in
         let (defs, newenv) =
-<<<<<<< HEAD
           Typecore.type_binding env rec_flag ~force_toplevel sdefs in
         let defs = match rec_flag with
           | Recursive -> Typecore.annotate_recursive_bindings env defs
           | Nonrecursive -> defs
-||||||| 121bedcfd2
-          Typecore.type_binding env rec_flag sdefs in
-        let () = if rec_flag = Recursive then
-          Typecore.check_recursive_bindings env defs
-=======
-          Typecore.type_binding env rec_flag sdefs in
-        let defs = match rec_flag with
-          | Recursive -> Typecore.annotate_recursive_bindings env defs
-          | Nonrecursive -> defs
->>>>>>> 5.2.0
         in
         (* Note: Env.find_value does not trigger the value_used event. Values
            will be marked as being used during the signature inclusion test. *)
         let items, shape_map =
           List.fold_left
-<<<<<<< HEAD
             (fun (acc, shape_map) (id, id_info, zero_alloc) ->
               List.iter
                 (fun (loc, _mode, sort) ->
@@ -3737,16 +2945,6 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
                   val_zero_alloc = zero_alloc;
                   val_modalities = modalities }
               in
-||||||| 121bedcfd2
-            (fun (acc, shape_map) (id, { Asttypes.loc; _ }, _typ)->
-              Signature_names.check_value names loc id;
-              let vd =  Env.find_value (Pident id) newenv in
-              Env.register_uid vd.val_uid vd.val_loc;
-=======
-            (fun (acc, shape_map) (id, { Asttypes.loc; _ }, _typ, _uid)->
-              Signature_names.check_value names loc id;
-              let vd =  Env.find_value (Pident id) newenv in
->>>>>>> 5.2.0
               Sig_value(id, vd, Exported) :: acc,
               Shape.Map.add_value shape_map id vd.val_uid
             )
@@ -3775,25 +2973,9 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
           (fun rs info -> Sig_type(info.typ_id, info.typ_type, rs, Exported))
           decls
         in
-<<<<<<< HEAD
-        let shape_map = List.fold_left2
-          (fun map { typ_id; _} shape ->
-              Shape.Map.add_type map typ_id shape)
-||||||| 121bedcfd2
-        let shape_map = List.fold_left
-          (fun shape_map -> function
-            | Sig_type (id, vd, _, _) ->
-              if not (Btype.is_row_name (Ident.name id)) then begin
-                Env.register_uid vd.type_uid vd.type_loc;
-                Shape.Map.add_type shape_map id vd.type_uid
-              end else shape_map
-            | _ -> assert false
-          )
-=======
         let shape_map = List.fold_left2
           (fun map { typ_id; _} shape ->
             Shape.Map.add_type map typ_id shape)
->>>>>>> 5.2.0
           shape_map
           decls
           shapes
@@ -4046,22 +3228,12 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
         type_str_include ~functor_:false ~loc env shape_map sincl sig_acc
     | Pstr_extension (ext, _attrs) ->
         raise (Error_forward (Builtin_attributes.error_of_extension ext))
-<<<<<<< HEAD
-    | Pstr_attribute attr ->
-        Builtin_attributes.parse_standard_implementation_attributes attr;
-        Builtin_attributes.mark_alert_used attr;
-        Tstr_attribute attr, [], shape_map, env
-||||||| 121bedcfd2
     | Pstr_attribute x ->
-        Builtin_attributes.warning_attribute x;
-        Tstr_attribute x, [], shape_map, env
-=======
-    | Pstr_attribute x ->
-        Builtin_attributes.warning_attribute x;
-        if toplevel || not (Warnings.is_active (Misplaced_attribute "")) then
+        Builtin_attributes.parse_standard_implementation_attributes x;
+        if Option.is_some toplevel
+        || not (Warnings.is_active (Misplaced_attribute "")) then
           Builtin_attributes.mark_alert_used x;
         Tstr_attribute x, [], shape_map, env
->>>>>>> 5.2.0
   in
   let toplevel_sig = Option.value toplevel ~default:[] in
   let rec type_struct env shape_map sstr str_acc sig_acc
@@ -4316,7 +3488,6 @@ let gen_annot target annots =
     ~use_summaries:false
     annots
 
-<<<<<<< HEAD
 let cms_register_toplevel_attributes ~sourcefile ~uid ~f ast =
   (* Cms files do not store the typetree. This can be a problem for Merlin has
     it uses attributes - which is why we manually construct a mapping from uid
@@ -4359,8 +3530,9 @@ let check_argument_type_if_given env sourcefile actual_sig arg_module_opt =
         with Not_found ->
           raise(Error(Location.none, Env.empty,
                       Cannot_find_argument_type arg_module)) in
+      let arg_cmi = Unit_info.Artifact.from_filename arg_filename in
       let arg_sig =
-        Env.read_signature arg_module arg_filename ~add_binding:false in
+        Env.read_signature arg_module arg_cmi ~add_binding:false in
       if not (Env.is_parameter_unit arg_import) then
         raise (Error (Location.none, env,
                       Argument_for_non_parameter (arg_module, arg_filename)));
@@ -4372,21 +3544,18 @@ let check_argument_type_if_given env sourcefile actual_sig arg_module_opt =
              ai_coercion_from_primary = coercion;
            }
 
-let type_implementation ~sourcefile outputprefix modulename initial_env ast =
+let type_implementation target modulename initial_env ast =
+  let sourcefile = Unit_info.source_file target in
   let error e =
     raise (Error (Location.in_file sourcefile, initial_env, e))
   in
-||||||| 121bedcfd2
-let type_implementation sourcefile outputprefix modulename initial_env ast =
-=======
-let type_implementation target initial_env ast =
-  let sourcefile = Unit_info.source_file target in
-  let save_cmt target annots initial_env cmi shape =
-    Cmt_format.save_cmt (Unit_info.cmt target)
+  let save_cmt_and_cms target annots initial_env cmi shape =
+    Cmt_format.save_cmt (Unit_info.cmt target) modulename
       annots initial_env cmi shape;
+    Cms_format.save_cms (Unit_info.cms target) modulename
+      annots shape;
     gen_annot target annots;
   in
->>>>>>> 5.2.0
   Cmt_format.clear ();
   Misc.try_finally (fun () ->
       Typecore.reset_delayed_checks ();
@@ -4399,26 +3568,12 @@ let type_implementation target initial_env ast =
         error Cannot_compile_implementation_as_parameter;
       register_params !Clflags.parameters;
       let (str, sg, names, shape, finalenv) =
-<<<<<<< HEAD
         Profile.record_call "infer" (fun () ->
           type_structure initial_env ast) in
       let uid = Uid.of_compilation_unit_id modulename in
       let shape = Shape.set_uid_if_none shape uid in
       if !Clflags.binary_annotations_cms then
         cms_register_toplevel_struct_attributes ~sourcefile ~uid ast;
-||||||| 121bedcfd2
-        type_structure initial_env ast in
-      let shape =
-        Shape.set_uid_if_none shape
-          (Uid.of_compilation_unit_id (Ident.create_persistent modulename))
-      in
-=======
-        type_structure initial_env ast in
-      let shape =
-        let id = Ident.create_persistent @@ Unit_info.modname target in
-        Shape.set_uid_if_none shape (Uid.of_compilation_unit_id id)
-      in
->>>>>>> 5.2.0
       let simple_sg = Signature_names.simplify finalenv names sg in
       if !Clflags.print_types then begin
         remove_mode_and_jkind_variables finalenv sg;
@@ -4429,14 +3584,8 @@ let type_implementation target initial_env ast =
             ~zap_modality:Mode.Modality.Value.zap_to_id simple_sg
         in
         Typecore.force_delayed_checks ();
-<<<<<<< HEAD
         Typecore.optimise_allocations ();
         let shape = Shape_reduce.local_reduce Env.empty shape in
-||||||| 121bedcfd2
-        let shape = Shape.local_reduce shape in
-=======
-        let shape = Shape_reduce.local_reduce Env.empty shape in
->>>>>>> 5.2.0
         Printtyp.wrap_printing_env ~error:false initial_env
           (fun () -> fprintf std_formatter "%a@."
               (Printtyp.printed_signature @@ Unit_info.source_file target)
@@ -4450,81 +3599,43 @@ let type_implementation target initial_env ast =
           argument_interface = None;
         } (* result is ignored by Compile.implementation *)
       end else begin
-<<<<<<< HEAD
-<<<<<<< HEAD
-        if !Clflags.as_parameter then
-          error Cannot_compile_implementation_as_parameter;
-||||||| 2572783060
-        if !Clflags.as_parameter then
-          error Cannot_compile_implementation_as_parameter;
-=======
->>>>>>> ocaml-jst/flambda-patches
         let arg_type =
           !Clflags.as_argument_for
           |> Option.map Compilation_unit.Name.of_string
         in
-        let sourceintf =
-          Filename.remove_extension sourcefile ^ !Config.interface_suffix in
-        if !Clflags.cmi_file <> None || Sys.file_exists sourceintf then begin
-          let import = Compilation_unit.name modulename in
-          let intf_file =
-||||||| 121bedcfd2
-        let sourceintf =
-          Filename.remove_extension sourcefile ^ !Config.interface_suffix in
-        if !Clflags.cmi_file <> None || Sys.file_exists sourceintf then begin
-          let intf_file =
-=======
+        let import = Compilation_unit.name modulename in
         let source_intf = Unit_info.mli_from_source target in
         if !Clflags.cmi_file <> None
         || Sys.file_exists source_intf then begin
           let compiled_intf_file =
->>>>>>> 5.2.0
             match !Clflags.cmi_file with
             | Some cmi_file -> Unit_info.Artifact.from_filename cmi_file
             | None ->
-<<<<<<< HEAD
               let basename = import |> Compilation_unit.Name.to_string in
-              (try
-                Load_path.find_uncap (basename ^ ".cmi")
-              with Not_found ->
-                raise(Error(Location.in_file sourcefile, Env.empty,
-                      Interface_not_compiled sourceintf)))
-            | Some cmi_file -> cmi_file
-||||||| 121bedcfd2
-              (try
-                Load_path.find_uncap (modulename ^ ".cmi")
-              with Not_found ->
-                raise(Error(Location.in_file sourcefile, Env.empty,
-                      Interface_not_compiled sourceintf)))
-            | Some cmi_file -> cmi_file
-=======
-                try Unit_info.find_normalized_cmi target with Not_found ->
+              let cmi_file =
+                try
+                  Load_path.find_uncap (basename ^ ".cmi")
+                with Not_found ->
                   raise(Error(Location.in_file sourcefile, Env.empty,
-                              Interface_not_compiled source_intf))
->>>>>>> 5.2.0
+                        Interface_not_compiled source_intf))
+              in
+              Unit_info.Artifact.from_filename cmi_file
           in
-<<<<<<< HEAD
           let dclsig =
-            Env.read_signature import intf_file ~add_binding:false
+            Env.read_signature import compiled_intf_file ~add_binding:false
           in
           if Env.is_parameter_unit import then
-            error (Cannot_implement_parameter (import, intf_file));
+            error (Cannot_implement_parameter (import, source_intf));
           let arg_type_from_cmi = Env.implemented_parameter import in
           if not (Option.equal Compilation_unit.Name.equal
                     arg_type arg_type_from_cmi) then
             error (Inconsistent_argument_types
-                     { new_arg_type = arg_type; old_source_file = intf_file;
+                     { new_arg_type = arg_type; old_source_file = source_intf;
                        old_arg_type = arg_type_from_cmi });
-||||||| 121bedcfd2
-          let dclsig = Env.read_signature modulename intf_file in
-=======
-          let dclsig = Env.read_signature compiled_intf_file in
->>>>>>> 5.2.0
           let coercion, shape =
-<<<<<<< HEAD
             Profile.record_call "check_sig" (fun () ->
               Includemod.compunit initial_env ~mark:Mark_positive
-                sourcefile sg intf_file dclsig shape)
+                sourcefile sg source_intf dclsig shape)
           in
           (* Check the _mli_ against the argument type, since the mli determines
              the visible type of the module and that's what needs to conform to
@@ -4536,41 +3647,17 @@ let type_implementation target initial_env ast =
              coercion in the .cmi if we can sort out the dependency issues
              ([Tcoerce_primitive] is a pain in particular). *)
           let argument_interface =
-            check_argument_type_if_given initial_env intf_file dclsig arg_type
-||||||| 121bedcfd2
-            Includemod.compunit initial_env ~mark:Mark_positive
-              sourcefile sg intf_file dclsig shape
-=======
-            Includemod.compunit initial_env ~mark:Mark_positive
-              sourcefile sg source_intf
-              dclsig shape
->>>>>>> 5.2.0
+            check_argument_type_if_given initial_env source_intf dclsig arg_type
           in
           Typecore.force_delayed_checks ();
           Typecore.optimise_allocations ();
           (* It is important to run these checks after the inclusion test above,
              so that value declarations which are not used internally but
              exported are not reported as being unused. *)
-<<<<<<< HEAD
           Profile.record_call "save_cmt" (fun () ->
             let shape = Shape_reduce.local_reduce Env.empty shape in
             let annots = Cmt_format.Implementation str in
-            Cmt_format.save_cmt (outputprefix ^ ".cmt") modulename
-              annots (Some sourcefile) initial_env None (Some shape);
-            Cms_format.save_cms (outputprefix ^ ".cms") modulename
-              annots (Some sourcefile) (Some shape);
-            gen_annot outputprefix sourcefile annots);
-||||||| 121bedcfd2
-          let shape = Shape.local_reduce shape in
-          let annots = Cmt_format.Implementation str in
-          Cmt_format.save_cmt (outputprefix ^ ".cmt") modulename
-            annots (Some sourcefile) initial_env None (Some shape);
-          gen_annot outputprefix sourcefile annots;
-=======
-          let shape = Shape_reduce.local_reduce Env.empty shape in
-          let annots = Cmt_format.Implementation str in
-          save_cmt target annots initial_env None (Some shape);
->>>>>>> 5.2.0
+            save_cmt_and_cms target annots initial_env None (Some shape));
           { structure = str;
             coercion;
             shape;
@@ -4578,22 +3665,8 @@ let type_implementation target initial_env ast =
             argument_interface;
           }
         end else begin
-<<<<<<< HEAD
-<<<<<<< HEAD
-          if !Clflags.as_parameter then
-            error Cannot_compile_implementation_as_parameter;
-||||||| 2572783060
-          if !Clflags.as_parameter then
-            error Cannot_compile_implementation_as_parameter;
-=======
->>>>>>> ocaml-jst/flambda-patches
-          Location.prerr_warning (Location.in_file sourcefile)
-||||||| 121bedcfd2
-          Location.prerr_warning (Location.in_file sourcefile)
-=======
           Location.prerr_warning
             (Location.in_file (Unit_info.source_file target))
->>>>>>> 5.2.0
             Warnings.Missing_mli;
           let coercion, shape =
             Profile.record_call "check_sig" (fun () ->
@@ -4620,41 +3693,18 @@ let type_implementation target initial_env ast =
           let shape = Shape_reduce.local_reduce Env.empty shape in
           if not !Clflags.dont_write_files then begin
             let alerts = Builtin_attributes.alerts_of_str ast in
-<<<<<<< HEAD
             let name = Compilation_unit.name modulename in
             let kind =
               Cmi_format.Normal { cmi_impl = modulename; cmi_arg_for = arg_type }
-||||||| 121bedcfd2
-            let cmi =
-              Env.save_signature ~alerts
-                simple_sg modulename (outputprefix ^ ".cmi")
-=======
-            let cmi =
-              Env.save_signature ~alerts simple_sg (Unit_info.cmi target)
->>>>>>> 5.2.0
             in
-<<<<<<< HEAD
             let cmi =
               Profile.record_call "save_cmi" (fun () ->
-                Env.save_signature ~alerts
-                  simple_sg name kind (outputprefix ^ ".cmi"))
+                Env.save_signature ~alerts simple_sg name kind
+                  (Unit_info.cmi target))
             in
             Profile.record_call "save_cmt" (fun () ->
               let annots = Cmt_format.Implementation str in
-              Cmt_format.save_cmt  (outputprefix ^ ".cmt") modulename
-                annots (Some sourcefile) initial_env (Some cmi) (Some shape);
-              Cms_format.save_cms  (outputprefix ^ ".cms") modulename
-                annots (Some sourcefile) (Some shape);
-              gen_annot outputprefix sourcefile annots)
-||||||| 121bedcfd2
-            let annots = Cmt_format.Implementation str in
-            Cmt_format.save_cmt  (outputprefix ^ ".cmt") modulename
-              annots (Some sourcefile) initial_env (Some cmi) (Some shape);
-            gen_annot outputprefix sourcefile annots
-=======
-            let annots = Cmt_format.Implementation str in
-            save_cmt target annots initial_env (Some cmi) (Some shape)
->>>>>>> 5.2.0
+              save_cmt_and_cms target annots initial_env (Some cmi) (Some shape));
           end;
           { structure = str;
             coercion;
@@ -4666,51 +3716,20 @@ let type_implementation target initial_env ast =
       end
     )
     ~exceptionally:(fun () ->
-<<<<<<< HEAD
         Profile.record_call "save_cmt" (fun () ->
           let annots =
             Cmt_format.Partial_implementation
               (Array.of_list (Cmt_format.get_saved_types ()))
           in
-          Cmt_format.save_cmt  (outputprefix ^ ".cmt") modulename
-            annots (Some sourcefile) initial_env None None;
-          Cms_format.save_cms  (outputprefix ^ ".cms") modulename
-            annots (Some sourcefile) None;
-          gen_annot outputprefix sourcefile annots)
-||||||| 121bedcfd2
-        let annots =
-          Cmt_format.Partial_implementation
-            (Array.of_list (Cmt_format.get_saved_types ()))
-        in
-        Cmt_format.save_cmt  (outputprefix ^ ".cmt") modulename
-          annots (Some sourcefile) initial_env None None;
-        gen_annot outputprefix sourcefile annots
-=======
-        let annots =
-          Cmt_format.Partial_implementation
-            (Array.of_list (Cmt_format.get_saved_types ()))
-        in
-        save_cmt target annots initial_env None None
->>>>>>> 5.2.0
+          save_cmt_and_cms target annots initial_env None None)
       )
 
-<<<<<<< HEAD
-let save_signature modname tsg outputprefix source_file initial_env cmi =
-  Cmt_format.save_cmt  (outputprefix ^ ".cmti") modname
-    (Cmt_format.Interface tsg) (Some source_file) initial_env (Some cmi) None;
-  Cms_format.save_cms  (outputprefix ^ ".cmsi") modname
-    (Cmt_format.Interface tsg) (Some source_file) None
-||||||| 121bedcfd2
-let save_signature modname tsg outputprefix source_file initial_env cmi =
-  Cmt_format.save_cmt  (outputprefix ^ ".cmti") modname
-    (Cmt_format.Interface tsg) (Some source_file) initial_env (Some cmi) None
-=======
-let save_signature target tsg initial_env cmi =
-  Cmt_format.save_cmt (Unit_info.cmti target)
-    (Cmt_format.Interface tsg) initial_env (Some cmi) None
->>>>>>> 5.2.0
+let save_signature target modname tsg initial_env cmi =
+  Cmt_format.save_cmt (Unit_info.cmti target) modname
+    (Cmt_format.Interface tsg) initial_env (Some cmi) None;
+  Cms_format.save_cms  (Unit_info.cmsi target) modname
+    (Cmt_format.Interface tsg) None
 
-<<<<<<< HEAD
 let cms_register_toplevel_signature_attributes ~sourcefile ~uid ast =
   cms_register_toplevel_attributes ~sourcefile ~uid ast
     ~f:(function
@@ -4732,7 +3751,7 @@ let type_interface ~sourcefile modulename env ast =
     let uid = Shape.Uid.of_compilation_unit_id modulename in
     cms_register_toplevel_signature_attributes ~uid ~sourcefile ast
   end;
-  let sg = transl_signature env ast in
+  let sg = transl_signature ~toplevel:true env ast in
   let arg_type =
     !Clflags.as_argument_for
     |> Option.map Compilation_unit.Name.of_string
@@ -4740,16 +3759,9 @@ let type_interface ~sourcefile modulename env ast =
   ignore (check_argument_type_if_given env sourcefile sg.sig_type arg_type
           : Typedtree.argument_interface option);
   sg
-||||||| 121bedcfd2
-let type_interface env ast =
-  transl_signature env ast
-=======
-let type_interface env ast =
-  transl_signature ~toplevel:true env ast
 
 let transl_signature env ast =
   transl_signature ~toplevel:false env ast
->>>>>>> 5.2.0
 
 (* "Packaging" of several compilation units into one unit
    having them as sub-modules.  *)
@@ -4785,12 +3797,11 @@ let package_signatures units =
       Sig_module(newid, Mp_present, md, Trec_not, Exported))
     units_with_ids
 
-let package_units initial_env objfiles target_cmi =
+let package_units initial_env objfiles target_cmi modulename =
   (* Read the signatures of the units *)
   let units =
     List.map
       (fun f ->
-<<<<<<< HEAD
          let pref = chop_extensions f in
          let unit =
            pref
@@ -4799,47 +3810,22 @@ let package_units initial_env objfiles target_cmi =
            |> Compilation_unit.Name.of_string
          in
          let modname = Compilation_unit.create_child modulename unit in
-         let sg =
-           Env.read_signature unit (pref ^ ".cmi") ~add_binding:false in
-         if Filename.check_suffix f ".cmi" &&
-            not(Mtype.no_code_needed_sig (Lazy.force Env.initial) sg)
-||||||| 121bedcfd2
-         let pref = chop_extensions f in
-         let modname = String.capitalize_ascii(Filename.basename pref) in
-         let sg = Env.read_signature modname (pref ^ ".cmi") in
-         if Filename.check_suffix f ".cmi" &&
-            not(Mtype.no_code_needed_sig Env.initial sg)
-=======
          let artifact = Unit_info.Artifact.from_filename f in
-         let sg = Env.read_signature (Unit_info.companion_cmi artifact) in
+         let sg =
+           Env.read_signature unit (Unit_info.companion_cmi artifact)
+             ~add_binding:false
+         in
          if Unit_info.is_cmi artifact &&
-            not(Mtype.no_code_needed_sig Env.initial sg)
->>>>>>> 5.2.0
+            not(Mtype.no_code_needed_sig (Lazy.force Env.initial) sg)
          then raise(Error(Location.none, Env.empty,
                           Implementation_is_required f));
-<<<<<<< HEAD
-         Compilation_unit.name modname,
-         Env.read_signature unit (pref ^ ".cmi") ~add_binding:false)
-||||||| 121bedcfd2
-         (modname, Env.read_signature modname (pref ^ ".cmi")))
-=======
-         Unit_info.Artifact.modname artifact, sg)
->>>>>>> 5.2.0
+         Compilation_unit.name modname, sg)
       objfiles in
   (* Compute signature of packaged unit *)
   Ident.reinit();
   let sg = package_signatures units in
   (* Compute the shape of the package *)
-<<<<<<< HEAD
-  let prefix = Filename.remove_extension cmifile in
   let pack_uid = Uid.of_compilation_unit_id modulename in
-||||||| 121bedcfd2
-  let prefix = Filename.remove_extension cmifile in
-  let pack_uid = Uid.of_compilation_unit_id (Ident.create_persistent prefix) in
-=======
-  let prefix = Unit_info.Artifact.prefix target_cmi in
-  let pack_uid = Uid.of_compilation_unit_id (Ident.create_persistent prefix) in
->>>>>>> 5.2.0
   let shape =
     List.fold_left (fun map (name, _sg) ->
       let name = Compilation_unit.Name.to_string name in
@@ -4856,30 +3842,16 @@ let package_units initial_env objfiles target_cmi =
       raise(Error(Location.in_file mli, Env.empty,
                   Interface_not_compiled mli))
     end;
-<<<<<<< HEAD
     let name = Compilation_unit.name modulename in
-    let dclsig = Env.read_signature name cmifile ~add_binding:false in
-||||||| 121bedcfd2
-    let dclsig = Env.read_signature modulename cmifile in
-=======
-    let dclsig = Env.read_signature target_cmi in
->>>>>>> 5.2.0
+    let dclsig = Env.read_signature name target_cmi ~add_binding:false in
     let cc, _shape =
       Includemod.compunit initial_env ~mark:Mark_both
         "(obtained by packing)" sg mli dclsig shape
     in
-<<<<<<< HEAD
-    Cmt_format.save_cmt  (prefix ^ ".cmt") modulename
-      (Cmt_format.Packed (sg, objfiles)) None initial_env  None (Some shape);
-    Cms_format.save_cms  (prefix ^ ".cms") modulename
-      (Cmt_format.Packed (sg, objfiles)) None (Some shape);
-||||||| 121bedcfd2
-    Cmt_format.save_cmt  (prefix ^ ".cmt") modulename
-      (Cmt_format.Packed (sg, objfiles)) None initial_env  None (Some shape);
-=======
-    Cmt_format.save_cmt (Unit_info.companion_cmt target_cmi)
+    Cmt_format.save_cmt  (Unit_info.companion_cmt target_cmi) modulename
       (Cmt_format.Packed (sg, objfiles)) initial_env  None (Some shape);
->>>>>>> 5.2.0
+    Cms_format.save_cms  (Unit_info.companion_cms target_cmi) modulename
+      (Cmt_format.Packed (sg, objfiles)) (Some shape);
     cc
   end else begin
     (* Determine imports *)
@@ -4899,29 +3871,13 @@ let package_units initial_env objfiles target_cmi =
       let kind = Cmi_format.Normal { cmi_impl = modulename; cmi_arg_for } in
       let cmi =
         Env.save_signature_with_imports ~alerts:Misc.Stdlib.String.Map.empty
-<<<<<<< HEAD
-          sg name kind (prefix ^ ".cmi") (Array.of_list imports)
-||||||| 121bedcfd2
-          sg modulename
-          (prefix ^ ".cmi") imports
-=======
-          sg target_cmi imports
->>>>>>> 5.2.0
+          sg name kind target_cmi (Array.of_list imports)
       in
-<<<<<<< HEAD
       let sign = Subst.Lazy.force_signature cmi.Cmi_format.cmi_sign in
-      Cmt_format.save_cmt (prefix ^ ".cmt")  modulename
-        (Cmt_format.Packed (sign, objfiles)) None initial_env
-||||||| 121bedcfd2
-      Cmt_format.save_cmt (prefix ^ ".cmt")  modulename
-        (Cmt_format.Packed (cmi.Cmi_format.cmi_sign, objfiles)) None initial_env
-=======
-      Cmt_format.save_cmt (Unit_info.companion_cmt target_cmi)
-        (Cmt_format.Packed (cmi.Cmi_format.cmi_sign, objfiles)) initial_env
->>>>>>> 5.2.0
-        (Some cmi) (Some shape);
-      Cms_format.save_cms (prefix ^ ".cms")  modulename
-        (Cmt_format.Packed (sign, objfiles)) None (Some shape);
+      Cmt_format.save_cmt (Unit_info.companion_cmt target_cmi)  modulename
+        (Cmt_format.Packed (sign, objfiles)) initial_env (Some cmi) (Some shape);
+      Cms_format.save_cms (Unit_info.companion_cms target_cmi)  modulename
+        (Cmt_format.Packed (sign, objfiles)) (Some shape);
     end;
     Tcoerce_none
   end
@@ -4954,40 +3910,30 @@ let report_error ~loc _env = function
       Location.errorf ~loc
         "@[This functor has type@ %a@ \
            The parameter cannot be eliminated in the result type.@ \
-<<<<<<< HEAD
-           %s.@]" modtype mty hint
-||||||| 121bedcfd2
-           Please bind the argument to a module identifier.@]" modtype mty
-=======
-         Please bind the argument to a module identifier.@]"
+           %s.@]"
         (Style.as_inline_code modtype) mty
->>>>>>> 5.2.0
+        hint
   | Signature_expected ->
       Location.errorf ~loc "This module type is not a signature"
   | Structure_expected mty ->
       Location.errorf ~loc
-<<<<<<< HEAD
-        "@[This module is not a structure; it has type@ %a" modtype mty
+        "@[This module is not a structure; it has type@ %a"
+        (Style.as_inline_code modtype) mty
   | Functor_expected mty ->
       Location.errorf ~loc
-        "@[This module is not a functor; it has type@ %a" modtype mty
+        "@[This module is not a functor; it has type@ %a"
+        (Style.as_inline_code modtype) mty
   | Signature_parameter_expected mty ->
       Location.errorf ~loc
         "@[The type of this functor is:@ %a. @ Its parameter is not a signature."
-        modtype mty
+        (Style.as_inline_code modtype) mty
   | Signature_result_expected mty ->
       Location.errorf ~loc
         "@[The type of this functor's result is not includable; it is@ %a"
-        modtype mty
+        (Style.as_inline_code modtype) mty
   | Recursive_include_functor ->
       Location.errorf ~loc
         "@[Including a functor is not supported in recursive module signatures @]"
-||||||| 121bedcfd2
-        "@[This module is not a structure; it has type@ %a" modtype mty
-=======
-        "@[This module is not a structure; it has type@ %a"
-        (Style.as_inline_code modtype) mty
->>>>>>> 5.2.0
   | With_no_component lid ->
       Location.errorf ~loc
         "@[The signature constrained by %a has no component named %a@]"
@@ -5037,19 +3983,6 @@ let report_error ~loc _env = function
           (Path.name p) Printtyp.modtype mty
       in
       Location.errorf ~loc
-<<<<<<< HEAD
-        "This `with' constraint@ %s := %a@ makes a packed module ill-formed."
-        (Path.name p) Printtyp.modtype mty
-  | With_package_manifest (lid, ty) ->
-      Location.errorf ~loc
-        "In the constrained signature, type %a is defined to be %a.@ \
-         Package `with' constraints may only be used on abstract types."
-        longident lid
-        Printtyp.type_expr ty
-||||||| 121bedcfd2
-        "This `with' constraint@ %s := %a@ makes a packed module ill-formed."
-        (Path.name p) Printtyp.modtype mty
-=======
         "This %a constraint@ %a@ makes a packed module ill-formed.@ %a"
         Style.inline_code "with"
         (Style.as_inline_code pp_constraint) ()
@@ -5061,7 +3994,6 @@ let report_error ~loc _env = function
         (Style.as_inline_code longident) lid
         (Style.as_inline_code Printtyp.type_expr) ty
         Style.inline_code "with"
->>>>>>> 5.2.0
   | Repeated_name(kind, name) ->
       Location.errorf ~loc
         "@[Multiple definition of the %s name %a.@ \
@@ -5195,14 +4127,18 @@ let report_error ~loc _env = function
         [ 12; 7; 3 ]
       in
       Location.errorf ~loc
-<<<<<<< HEAD
-        "The module type@ %s@ is not a valid type for a packed module:@ \
-         it is defined as a local substitution for a non-path module type."
-        (Path.name p)
+        "The module type@ %a@ is not a valid type for a packed module:@ \
+         it is defined as a local substitution (temporary name)@ \
+         for an anonymous module type.@ %a"
+        Style.inline_code (Path.name p)
+        Misc.print_see_manual manual_ref
   | Toplevel_nonvalue (id, sort) ->
       Location.errorf ~loc
-        "@[Types of top-level module bindings must have layout value, but@ \
-         the type of %s has layout@ %a.@]" id Jkind.Sort.format sort
+        "@[Types of top-level module bindings must have layout %a, but@ \
+         the type of %a has layout@ %a.@]"
+        Style.inline_code "value"
+        Style.inline_code id
+        (Style.as_inline_code Jkind.Sort.format) sort
  | Strengthening_mismatch(lid, explanation) ->
       let main = Includemod_errorprinter.err_msgs explanation in
       Location.errorf ~loc
@@ -5210,7 +4146,8 @@ let report_error ~loc _env = function
            @[In this strengthened module type, the type of %a@ \
              does not match the underlying type@]@ \
            %t@]"
-        longident lid main
+        (Style.as_inline_code longident) lid
+        main
   | Cannot_pack_parameter ->
       Location.errorf ~loc
         "Cannot compile a parameter with -for-pack."
@@ -5225,13 +4162,13 @@ let report_error ~loc _env = function
       Location.errorf ~loc
         "@[The interface for %a@ was compiled with -as-parameter.@ \
          It cannot be implemented directly.@]"
-        Compilation_unit.Name.print modname
+        (Style.as_inline_code Compilation_unit.Name.print) modname
   | Argument_for_non_parameter(param, path) ->
       Location.errorf ~loc
-        "Interface %s@ found for module@ %a@ is not flagged as a parameter.@ \
+        "Interface %a@ found for module@ %a@ is not flagged as a parameter.@ \
          It cannot be the parameter type for this argument module."
-        path
-        Compilation_unit.Name.print param
+        Style.inline_code path
+        (Style.as_inline_code Compilation_unit.Name.print) param
   | Inconsistent_argument_types
         { new_arg_type; old_source_file; old_arg_type } ->
       let pp_arg_type ppf arg_type =
@@ -5250,23 +4187,12 @@ let report_error ~loc _env = function
   | Cannot_find_argument_type arg_type ->
       Location.errorf ~loc
         "Parameter module %a@ specified by -as-argument-for cannot be found."
-        Compilation_unit.Name.print arg_type
+        (Style.as_inline_code Compilation_unit.Name.print) arg_type
   | Submode_failed (Error (ax, {left; right})) ->
       Location.errorf ~loc
         "This value is %a, but expected to be %a because it is inside a module."
-        (Mode.Value.Const.print_axis ax) left
-        (Mode.Value.Const.print_axis ax) right
-||||||| 121bedcfd2
-        "The module type@ %s@ is not a valid type for a packed module:@ \
-         it is defined as a local substitution for a non-path module type."
-        (Path.name p)
-=======
-        "The module type@ %a@ is not a valid type for a packed module:@ \
-         it is defined as a local substitution (temporary name)@ \
-         for an anonymous module type.@ %a"
-        Style.inline_code (Path.name p)
-        Misc.print_see_manual manual_ref
->>>>>>> 5.2.0
+        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) left
+        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
 
 let report_error env ~loc err =
   Printtyp.wrap_printing_env_error env

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -39,7 +39,7 @@ val type_toplevel_phrase:
   Typedtree.structure * Types.signature * Signature_names.t * Shape.t *
   Env.t
 val type_implementation:
-  Unit_info.t -> Compilation_unit.t -> Compilation_unit.t -> Env.t ->
+  Unit_info.t -> Compilation_unit.t -> Env.t ->
   Parsetree.structure -> Typedtree.implementation
 val type_interface:
   sourcefile:string -> Compilation_unit.t -> Env.t ->


### PR DESCRIPTION
There are several sources of diff:
  * Upstream added `Unit_info.t`; we added `Compilation_unit.Name.t`. For now, we're taking both arguments (see [here](https://github.com/ocaml-flambda/flambda-backend/wiki/Strategy-for-5.2.0-Unit_info-and-compunit)), and we'll add `Compilation_unit.Name.t` to `Unit_info` in the future.
  * Some PRs were realized slightly differently internally vs. externally.
    * Fixing the package hack. ([internal](https://github.com/ocaml-flambda/flambda-backend/pull/2253), [upstream](https://github.com/ocaml/ocaml/pull/12930)). This leads to a slightly nasty diff in `merge_constraint`, which is factored differently internally, but I think it's fine to just take our version.
    * Warning 53 for misplaced attributes ([upstream](https://github.com/ocaml/ocaml/pull/12451)). There appears to be some check about "toplevel" attributes introduced in that PR and later backed out in https://github.com/ocaml/ocaml/pull/13170. @ccasin Should I attempt to backport 13170 as part of this conflict fixing? For now, I've just taken [#12451](https://github.com/ocaml/ocaml/pull/12451), with the thought that we'll pick up [#13170](https://github.com/ocaml/ocaml/pull/13170) in some future merge.
  * Adding more inline-code-formatting to error messages, to match upstream's recent effort to do this.

`Unit_info.t` is the main source of hard-to-understand diff. Let's chat if something looks confusing.