### PR TITLE
Abstracting over datatypes with higher kinds

### DIFF
--- a/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
@@ -1,0 +1,75 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+module M : sig
+  type t : value => value
+end = struct
+  type 'a t = { foo : 'a }
+end
+[%%expect {|
+module M : sig type t : value => value end
+|}]
+
+module M : sig
+  type t : value => value
+end = struct
+  type 'a t = ('a * 'a) list
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t = ('a * 'a) list
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = ('a * 'a) list end
+       is not included in
+         sig type t : value => value end
+       Type declarations do not match:
+         type 'a t = ('a * 'a) list
+       is not included in
+         type t : value => value
+       They have different arities.
+|}]
+
+module M : sig
+  type t : (value, value) => value
+end = struct
+  type ('a, 'b) t = { a : 'a; b : 'b }
+end
+[%%expect {|
+module M : sig type t : (value, value) => value end
+|}]
+
+module M : sig
+  type t : (value, value) => value
+end = struct
+  type ('a, 'b) t
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a, 'b) t end
+       is not included in
+         sig type t : (value, value) => value end
+       Type declarations do not match:
+         type ('a, 'b) t
+       is not included in
+         type t : (value, value) => value
+       They have different arities.
+|}]
+
+module M : sig
+  type t : value => value
+end = struct
+  type t : value => value
+end
+[%%expect {|
+module M : sig type t : value => value end
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
@@ -66,9 +66,49 @@ Error: Signature mismatch:
 |}]
 
 module M : sig
+  type t : (value, value) => value
+end = struct
+  type ('a, 'b) t [@@datatype]
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a, 'b) t end
+       is not included in
+         sig type t : (value, value) => value end
+       Type declarations do not match:
+         type ('a, 'b) t
+       is not included in
+         type t : (value, value) => value
+       They have different arities.
+|}]
+
+module M : sig
   type t : value => value
 end = struct
   type t : value => value
+end
+[%%expect {|
+module M : sig type t : value => value end
+|}]
+
+module M : sig
+  type t : value => value
+end = struct
+  type 'a t [@@datatype]
+end
+[%%expect {|
+module M : sig type t : value => value end
+|}]
+
+module M : sig
+  type 'a t
+end = struct
+  type 'a t [@@datatype]
 end
 [%%expect {|
 module M : sig type t : value => value end

--- a/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
@@ -126,20 +126,13 @@ end = struct
   type t : any => value = array
 end
 [%%expect {|
-Lines 3-5, characters 6-3:
-3 | ......struct
+Line 4, characters 2-31:
 4 |   type t : any => value = array
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type t = array end
-       is not included in
-         sig type ('a : any) t end
-       Type declarations do not match:
-         type t = array
-       is not included in
-         type ('a : any) t
-       The first is abstract, but the second is an abstract datatype.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type array is ((any_non_null) => value)
+         because it is the primitive value type array.
+       But the kind of type array must be a subkind of ((any) => value)
+         because of the definition of t at line 4, characters 2-31.
 |}]
 
 module M : sig
@@ -148,7 +141,13 @@ end = struct
   type t : any => value = array
 end
 [%%expect {|
-module M : sig type t : any => value end
+Line 4, characters 2-31:
+4 |   type t : any => value = array
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type array is ((any_non_null) => value)
+         because it is the primitive value type array.
+       But the kind of type array must be a subkind of ((any) => value)
+         because of the definition of t at line 4, characters 2-31.
 |}]
 
 module M : sig
@@ -276,8 +275,9 @@ Error: Signature mismatch:
          type ('m : value => value) inj = { inj : 'a. 'a -> 'a 'm; }
        is not included in
          type inj : (value => any) => value
-       The layout of the first is ((((value) => value)) => value), because
-         of the definition of inj at lines 4-6, characters 2-3.
-       But the layout of the first must be a sublayout of ((((value) => any)) => value), because
-         of the definition of inj at line 2, characters 2-36.
+       The kind of the first is ((((value) => value)) => value)
+         because of the definition of inj at lines 4-6, characters 2-3.
+       But the kind of the first must be a subkind of
+         ((((value) => any)) => value)
+         because of the definition of inj at line 2, characters 2-36.
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
@@ -113,3 +113,30 @@ end
 [%%expect {|
 module M : sig type t : value => value end
 |}]
+
+module M : sig
+  type 'a t [@@datatype]
+end = struct
+  type 'a t = 'a array
+end
+[%%expect {|
+module M : sig type t : value => value end
+|}]
+
+module M : sig
+  type t : value => value
+end = struct
+  type 'a t = 'a array
+end
+[%%expect {|
+module M : sig type t : value => value end
+|}]
+
+module M : sig
+  type t : value => value
+end = struct
+  type t = array
+end
+[%%expect {|
+module M : sig type t : value => value end
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
@@ -218,3 +218,66 @@ Line 2, characters 0-29:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This is not a datatype, but one was expected.
 |}]
+
+
+module M : sig
+  type ('m : value => value) inj [@@datatype]
+end = struct
+  type ('m : value => value) inj = {
+    inj : 'a. 'a -> 'a 'm;
+  }
+end
+[%%expect{|
+module M : sig type ('m : value => value) inj end
+|}]
+
+module M : sig
+  type inj : (value => value) => value
+end = struct
+  type ('m : value => value) inj = {
+    inj : 'a. 'a -> 'a 'm;
+  }
+end
+[%%expect{|
+module M : sig type inj : (value => value) => value end
+|}]
+
+module M : sig
+  type inj : (value => value) => any
+end = struct
+  type ('m : value => value) inj = {
+    inj : 'a. 'a -> 'a 'm;
+  }
+end
+[%%expect{|
+module M : sig type inj : (value => value) => any end
+|}]
+
+module M : sig
+  type inj : (value => any) => value
+end = struct
+  type ('m : value => value) inj = {
+    inj : 'a. 'a -> 'a 'm;
+  }
+end
+[%%expect{|
+Lines 3-7, characters 6-3:
+3 | ......struct
+4 |   type ('m : value => value) inj = {
+5 |     inj : 'a. 'a -> 'a 'm;
+6 |   }
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('m : value => value) inj = { inj : 'a. 'a -> 'a 'm; } end
+       is not included in
+         sig type inj : (value => any) => value end
+       Type declarations do not match:
+         type ('m : value => value) inj = { inj : 'a. 'a -> 'a 'm; }
+       is not included in
+         type inj : (value => any) => value
+       The layout of the first is ((((value) => value)) => value), because
+         of the definition of inj at lines 4-6, characters 2-3.
+       But the layout of the first must be a sublayout of ((((value) => any)) => value), because
+         of the definition of inj at line 2, characters 2-36.
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
@@ -71,20 +71,7 @@ end = struct
   type ('a, 'b) t [@@datatype]
 end
 [%%expect {|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type ('a, 'b) t
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type ('a, 'b) t end
-       is not included in
-         sig type t : (value, value) => value end
-       Type declarations do not match:
-         type ('a, 'b) t
-       is not included in
-         type t : (value, value) => value
-       They have different arities.
+module M : sig type t : (value, value) => value end
 |}]
 
 module M : sig
@@ -111,32 +98,65 @@ end = struct
   type 'a t [@@datatype]
 end
 [%%expect {|
-module M : sig type t : value => value end
+module M : sig type 'a t end
 |}]
 
 module M : sig
   type 'a t [@@datatype]
 end = struct
-  type 'a t = 'a array
+  type 'a t
 end
 [%%expect {|
-module M : sig type t : value => value end
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t end
+       is not included in
+         sig type 'a t end
+       Type declarations do not match: type 'a t is not included in type 'a t
+       The first is abstract, but the second is an abstract datatype.
 |}]
 
 module M : sig
-  type t : value => value
+  type ('a : any) t [@@datatype]
 end = struct
-  type 'a t = 'a array
+  type t : any => value = array
 end
 [%%expect {|
-module M : sig type t : value => value end
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t : any => value = array
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = array end
+       is not included in
+         sig type ('a : any) t end
+       Type declarations do not match:
+         type t = array
+       is not included in
+         type ('a : any) t
+       The first is abstract, but the second is an abstract datatype.
 |}]
 
 module M : sig
-  type t : value => value
+  type t : any => value
 end = struct
-  type t = array
+  type t : any => value = array
 end
 [%%expect {|
-module M : sig type t : value => value end
+module M : sig type t : any => value end
+|}]
+
+type 'a t = 'a * 'a
+type 'a s = 'a t [@@datatype]
+[%%expect {|
+type 'a t = 'a * 'a
+Line 2, characters 0-29:
+2 | type 'a s = 'a t [@@datatype]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This is not a datatype, but one was expected.
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/abstracted.ml
@@ -151,6 +151,64 @@ end
 module M : sig type t : any => value end
 |}]
 
+module M : sig
+  type t : any => value
+end = struct
+  type s : any => value
+  type t : any => value = s
+end
+[%%expect {|
+module M : sig type t : any => value end
+|}]
+
+module M : sig
+  type t : any => value
+end = struct
+  type ('a : any) s [@@datatype]
+  type t : any => value = s
+end
+[%%expect {|
+module M : sig type t : any => value end
+|}]
+
+module M : sig
+  type t : any => value
+end = struct
+  type ('a : any) s
+  type t : any => value = s
+end
+[%%expect {|
+Line 5, characters 26-27:
+5 |   type t : any => value = s
+                              ^
+Error: The type constructor s expects 1 argument(s),
+       but is here applied to 0 argument(s)
+|}]
+
+module M : sig
+  type t : any => value
+end = struct
+  type ('a : any) s
+  type ('a : any) t = 'a s
+end
+[%%expect {|
+Lines 3-6, characters 6-3:
+3 | ......struct
+4 |   type ('a : any) s
+5 |   type ('a : any) t = 'a s
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a : any) s type ('a : any) t = 'a s end
+       is not included in
+         sig type t : any => value end
+       Type declarations do not match:
+         type ('a : any) t = 'a s
+       is not included in
+         type t : any => value
+       They have different arities.
+|}]
+
 type 'a t = 'a * 'a
 type 'a s = 'a t [@@datatype]
 [%%expect {|

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -1358,7 +1358,7 @@ let new_local_type ?(loc = Location.none) ?manifest_and_scope jkind ~jkind_annot
   {
     type_params = [];
     type_arity = 0;
-    type_kind = Type_abstract Abstract_def;
+    type_kind = Type_abstract { reason = Abstract_def; datatype = false };
     type_jkind = jkind;
     type_jkind_annotation = jkind_annot;
     type_private = Public;
@@ -2125,7 +2125,7 @@ let tvariant_not_immediate row =
 let is_datatype_decl (k : type_decl_kind) =
   match k with
   | Type_record _ | Type_variant _ | Type_open -> true
-  | Type_abstract _ -> false
+  | Type_abstract { reason = _; datatype } -> datatype
 
 let rec jkind_of_decl_unapplied env (decl : type_declaration) =
   (* FIXME jbachurski: Shouldn't we look at type_variance and type_separability here? *)
@@ -6638,7 +6638,8 @@ let nondep_type_decl env mid is_covariant decl =
     let params = List.map (nondep_type_rec env mid) decl.type_params in
     let tk =
       try map_kind (nondep_type_rec env mid) decl.type_kind
-      with Nondep_cannot_erase _ when is_covariant -> Type_abstract Abstract_def
+      with Nondep_cannot_erase _ when is_covariant ->
+        Type_abstract { reason = Abstract_def; datatype = false }
     and tm, priv =
       match decl.type_manifest with
       | None -> None, decl.type_private

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2122,7 +2122,7 @@ let tvariant_not_immediate row =
 
 (* Jkinds *)
 
-let is_datatype_decl (k : type_decl_kind) =
+let is_datatype_decl_kind (k : type_decl_kind) =
   match k with
   | Type_record _ | Type_variant _ | Type_open -> true
   | Type_abstract { reason = _; datatype } -> datatype
@@ -2131,7 +2131,7 @@ let rec jkind_of_decl_unapplied env (decl : type_declaration) =
   (* FIXME jbachurski: Shouldn't we look at type_variance and type_separability here? *)
   match decl.type_arity with
   | 0 -> Some decl.type_jkind
-  | _ when is_datatype_decl decl.type_kind ->
+  | _ when is_datatype_decl_kind decl.type_kind ->
     Some (Jkind.of_arrow
       ~history:(Projection {
         reason = Unapplied;

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -547,6 +547,8 @@ val get_unboxed_type_approximation : Env.t -> type_expr -> type_expr
    void. *)
 val tvariant_not_immediate : row_desc -> bool
 
+val is_datatype_decl_kind : type_decl_kind -> bool
+
 (* Extract the jkind of the declared datatype constructor in an unapplied context.
    None if not a datatype constructor (i.e. abstract type) nor alias for one. *)
 val jkind_of_decl_unapplied : Env.t -> type_declaration -> jkind option

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -1264,7 +1264,7 @@ let rec find_type_data path env =
   | decl ->
     {
       tda_declaration = decl;
-      tda_descriptions = Type_abstract Abstract_def;
+      tda_descriptions = Type_abstract { reason = Abstract_def; datatype = false };
       tda_shape = Shape.leaf decl.type_uid;
     }
   | exception Not_found -> begin
@@ -2164,7 +2164,7 @@ and store_type_infos ~tda_shape id info env =
   let tda =
     {
       tda_declaration = info;
-      tda_descriptions = Type_abstract Abstract_def;
+      tda_descriptions = Type_abstract { reason = Abstract_def; datatype = false };
       tda_shape
     }
   in

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -508,7 +508,7 @@ let report_kind_mismatch first second ppf (kind1, kind2) =
   let pr fmt = Format.fprintf ppf fmt in
   let kind_to_string = function
   | Kind_abstract -> "abstract"
-  | Kind_abstract_datatype -> "abstract datatype"
+  | Kind_abstract_datatype -> "an abstract datatype"
   | Kind_record -> "a record"
   | Kind_variant -> "a variant"
   | Kind_open -> "an extensible variant" in
@@ -1100,8 +1100,12 @@ let type_declarations' ?(equality = false) ~loc env ~mark name
           | () -> None
   in
   if err <> None then err else
+  if not (Ctype.is_datatype_decl_kind decl1.type_kind)
+     && (Ctype.is_datatype_decl_kind decl2.type_kind)
+  then Some (Kind (of_kind decl1.type_kind, of_kind decl2.type_kind))
+  else
   let err = match (decl1.type_kind, decl2.type_kind) with
-      (_, Type_abstract _) ->
+    | (_, Type_abstract _) ->
        (* Note that [decl2.type_jkind] is an upper bound.
           If it isn't tight, [decl2] must
           have a manifest, which we're already checking for equality

--- a/ocaml/typing/includecore.mli
+++ b/ocaml/typing/includecore.mli
@@ -51,6 +51,7 @@ type privacy_mismatch =
 
 type type_kind =
   | Kind_abstract
+  | Kind_abstract_datatype
   | Kind_record
   | Kind_variant
   | Kind_open

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -340,10 +340,12 @@ let build_initial_env add_type add_extension empty_env =
   empty_env
   (* Predefined types *)
   |> add_type1 ident_array
+       ~kind:(fun _ -> Type_abstract { reason = Abstract_def; datatype = true })
        ~variance:Variance.full
        ~separability:Separability.Ind
        ~param_jkind:(Jkind.Type.Primitive.any_non_null ~why:Array_type_argument)
   |> add_type1 ident_iarray
+       ~kind:(fun _ -> Type_abstract { reason = Abstract_def; datatype = true })
        ~variance:Variance.covariant
        ~separability:Separability.Ind
   |> add_type ident_bool

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -220,7 +220,7 @@ let or_null_argument_type_jkind = Jkind.Type.Primitive.value ~why:(
 
 let mk_add_type add_type
       ?manifest type_ident
-      ?(kind=Type_abstract Abstract_def)
+      ?(kind=Type_abstract { reason = Abstract_def; datatype = false })
       ?(jkind=Jkind.Type.Primitive.value ~why:(Primitive type_ident))
       (* [jkind_annotation] is just used for printing. It's best to
          provide it if the jkind is not implied by the kind of the
@@ -250,7 +250,7 @@ let mk_add_type add_type
   add_type type_ident decl env
 
 let mk_add_type1 add_type type_ident
-      ?(kind=fun _ -> Type_abstract Abstract_def)
+      ?(kind=fun _ -> Type_abstract { reason = Abstract_def; datatype = false })
       ?(jkind=Jkind.Type.Primitive.value ~why:(Primitive type_ident))
       (* See the comment on the [jkind_annotation] argument to [mk_add_type]
       *)

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -2368,7 +2368,7 @@ let dummy =
   {
     type_params = [];
     type_arity = 0;
-    type_kind = Type_abstract Abstract_def;
+    type_kind = Type_abstract { reason = Abstract_def; datatype = false };
     type_jkind = Jkind.Primitive.top ~why:Dummy_jkind;
     type_jkind_annotation = None;
     type_private = Public;
@@ -3060,7 +3060,8 @@ let warn_on_missing_def env ppf t =
   match get_desc t with
   | Tconstr (p,_,_) ->
     begin match Env.find_type p env with
-    | { type_kind = Type_abstract Abstract_rec_check_regularity; _ } ->
+    | { type_kind =
+          Type_abstract { reason = Abstract_rec_check_regularity; datatype = _ }; _ } ->
         fprintf ppf
           "@,@[<hov>Type %a was considered abstract@ when checking\
            @ constraints@ in this@ recursive type definition.@]"
@@ -3070,7 +3071,8 @@ let warn_on_missing_def env ppf t =
           "@,@[<hov>Type %a is abstract because@ no corresponding\
            @ cmi file@ was found@ in path.@]" path p
     | {type_kind =
-       Type_abstract Abstract_def | Type_record _ | Type_variant _ | Type_open }
+          Type_abstract { reason = Abstract_def; _}
+        | Type_record _ | Type_variant _ | Type_open }
       -> ()
     end
   | _ -> ()

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1606,7 +1606,7 @@ let temp_abbrev loc id arity uid =
   let ty_td =
       {type_params = !params;
        type_arity = arity;
-       type_kind = Type_abstract Abstract_def;
+       type_kind = Type_abstract { reason = Abstract_def; datatype = false };
        type_jkind = Jkind.Type.Primitive.value ~why:Object |> Jkind.of_type_jkind;
        type_jkind_annotation = None;
        type_private = Public;
@@ -1838,7 +1838,7 @@ let class_infos define_class kind
     {
      type_params = obj_params;
      type_arity = arity;
-     type_kind = Type_abstract Abstract_def;
+     type_kind = Type_abstract { reason = Abstract_def; datatype = false };
      type_jkind = Jkind.Type.Primitive.value ~why:Object |> Jkind.of_type_jkind;
      type_jkind_annotation = None;
      type_private = Public;

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -268,7 +268,7 @@ let enter_type ?abstract_abbrevs rec_flag env sdecl (id, uid) =
   let decl =
     { type_params;
       type_arity = arity;
-      type_kind = Type_abstract abstract_reason;
+      type_kind = Type_abstract { reason = abstract_reason; datatype = false };
       type_jkind;
       type_jkind_annotation;
       type_private = sdecl.ptype_private;
@@ -789,7 +789,9 @@ let transl_declaration env sdecl (id, uid) =
   let (tkind, kind, jkind_default) =
     match sdecl.ptype_kind with
       | Ptype_abstract ->
-        Ttype_abstract, Type_abstract Abstract_def, Jkind.Type.Primitive.value ~why:Default_type_jkind |> Jkind.of_type_jkind
+        Ttype_abstract,
+        Type_abstract { reason = Abstract_def; datatype = false },
+        Jkind.Type.Primitive.value ~why:Default_type_jkind |> Jkind.of_type_jkind
       | Ptype_variant scstrs ->
         if List.exists (fun cstr -> cstr.pcd_res <> None) scstrs then begin
           match cstrs with
@@ -2042,7 +2044,7 @@ let check_duplicates sdecl_list =
 (* Force recursion to go through id for private types*)
 let name_recursion sdecl id decl =
   match decl with
-  | { type_kind = Type_abstract Abstract_def;
+  | { type_kind = Type_abstract { reason = Abstract_def; datatype = false };
       type_manifest = Some ty;
       type_private = Private; } when is_fixed_type sdecl ->
     let ty' = newty2 ~level:(get_level ty) (get_desc ty) in
@@ -3113,7 +3115,8 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
       sig_decl.type_jkind,
       sig_decl.type_jkind_annotation
     else
-      Type_abstract Abstract_def, false, sig_decl.type_jkind, None
+      Type_abstract { reason = Abstract_def; datatype = false },
+      false, sig_decl.type_jkind, None
   in
   let new_sig_decl =
     { type_params = params;
@@ -3196,7 +3199,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
 let transl_package_constraint ~loc ty =
   { type_params = [];
     type_arity = 0;
-    type_kind = Type_abstract Abstract_def;
+    type_kind = Type_abstract { reason = Abstract_def; datatype = false };
     type_jkind = Jkind.Primitive.top ~why:Dummy_jkind;
     (* There is no reason to calculate an accurate jkind here.  This typedecl
        will be thrown away once it is used for the package constraint inclusion
@@ -3223,7 +3226,7 @@ let abstract_type_decl ~injective ~jkind ~jkind_annotation ~params =
     let params = List.map Ctype.newvar params in
     { type_params = params;
       type_arity = arity;
-      type_kind = Type_abstract Abstract_def;
+      type_kind = Type_abstract { reason = Abstract_def; datatype = false };
       type_jkind = jkind;
       type_jkind_annotation = jkind_annotation;
       type_private = Public;

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -124,6 +124,7 @@ type error =
       ; err : Jkind.Violation.t
       }
   | Jkind_empty_record
+  | Non_datatype
   | Non_value_in_sig of Jkind.Violation.t * string * type_expr
   | Invalid_jkind_in_block of type_expr * Jkind.Type.Sort.const * jkind_sort_loc
   | Illegal_mixed_product of mixed_product_violation
@@ -789,8 +790,16 @@ let transl_declaration env sdecl (id, uid) =
   let (tkind, kind, jkind_default) =
     match sdecl.ptype_kind with
       | Ptype_abstract ->
+        let has_datatype_attr =
+          List.exists
+            (fun { attr_name = { txt; _ }; _} -> txt = "datatype")
+            sdecl_attributes
+        in
+        if has_datatype_attr && Option.is_some man then
+          raise (Error (sdecl.ptype_loc, Non_datatype))
+        else
         Ttype_abstract,
-        Type_abstract { reason = Abstract_def; datatype = false },
+        Type_abstract { reason = Abstract_def; datatype = has_datatype_attr },
         Jkind.Type.Primitive.value ~why:Default_type_jkind |> Jkind.of_type_jkind
       | Ptype_variant scstrs ->
         if List.exists (fun cstr -> cstr.pcd_res <> None) scstrs then begin
@@ -3660,6 +3669,8 @@ let report_error ppf = function
          ~offender:(fun ppf -> Printtyp.type_expr ppf typ)) err
   | Jkind_empty_record ->
     fprintf ppf "@[Records must contain at least one runtime value.@]"
+  | Non_datatype ->
+    fprintf ppf "@[This is not a datatype, but one was expected.@]"
   | Non_value_in_sig (err, val_name, ty) ->
     let offender ppf = fprintf ppf "type %a" Printtyp.type_expr ty in
     fprintf ppf "@[This type signature for %s is not a value type.@ %a@]"

--- a/ocaml/typing/typedecl.mli
+++ b/ocaml/typing/typedecl.mli
@@ -163,6 +163,7 @@ type error =
       ; err : Jkind.Violation.t
       }
   | Jkind_empty_record
+  | Non_datatype
   | Non_value_in_sig of Jkind.Violation.t * string * type_expr
   | Invalid_jkind_in_block of type_expr * Jkind.Type.Sort.const * jkind_sort_loc
   | Illegal_mixed_product of mixed_product_violation

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -657,7 +657,7 @@ let merge_constraint initial_env loc sg lid constr =
                 (fun _ -> Btype.newgenvar (Jkind.Primitive.top ~why:Dummy_jkind))
                 sdecl.ptype_params;
             type_arity = arity;
-            type_kind = Type_abstract Abstract_def;
+            type_kind = Type_abstract { reason = Abstract_def; datatype = false };
             type_jkind = Jkind.Type.Primitive.value ~why:(Unknown "merge_constraint") |> Jkind.of_type_jkind;
             type_jkind_annotation = None;
             type_private = Private;

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -277,7 +277,7 @@ type type_declaration =
 and type_decl_kind = (label_declaration, constructor_declaration) type_kind
 
 and ('lbl, 'cstr) type_kind =
-    Type_abstract of abstract_reason
+    Type_abstract of { reason : abstract_reason; datatype : bool }
   | Type_record of 'lbl list * record_representation
   | Type_variant of 'cstr list * variant_representation
   | Type_open

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -551,7 +551,7 @@ type type_declaration =
 and type_decl_kind = (label_declaration, constructor_declaration) type_kind
 
 and ('lbl, 'cstr) type_kind =
-    Type_abstract of abstract_reason
+    Type_abstract of { reason : abstract_reason; datatype : bool }
   | Type_record of 'lbl list  * record_representation
   | Type_variant of 'cstr list * variant_representation
   | Type_open


### PR DESCRIPTION
Implements abstracting over datatypes, i.e. this passes the inclusion check:

```ocaml
module M : sig
  type t : value => value
end = struct
  type 'a t = { foo : 'a }
end
[%%expect {|
module M : sig type t : value => value end
|}]
```

Introduces a `[@@datatype]` attribute for now to denote that a type definition is for a datatype. This is only accepted for abstract types without manifests, as otherwise it is difficult to prove. E.g. we reject this:
```ocaml
type 'a t = 'a * 'a
type 'a s = 'a t [@@datatype]
[%%expect {|
type 'a t = 'a * 'a
Line 2, characters 0-29:
2 | type 'a s = 'a t [@@datatype]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This is not a datatype, but one was expected.
|}]
```
But we still want this to pass:
```ocaml
module M : sig
  type ('a : any) t [@@datatype]  (* datatype_ ('a : any) t *)
end = struct
  type t : any => value = array
end
```
Note that neither `type t = array` (due to some bad jkind defaulting) nor `type 'a t = 'a array` (as it would require implementing a trivial 'proof' of `t` being a datatype) actually work here. 