### PR TITLE
Bidirectional-style higher kind inference with arity-based defaulting

### DIFF
--- a/ocaml/testsuite/tests/typing-higher-jkinds/applied.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/applied.ml
@@ -215,3 +215,29 @@ Line 1, characters 13-25:
 Error: This expression has type int T.t
        but an expression was expected of type 'a 'b
 |}]
+
+type ('t : value => value) inj = { 
+  return : 'a. 'a -> 'a 't 
+}
+module type I = sig
+  type t : value => value
+  val return : 'a -> 'a t
+end
+let inj (type t : value => value) (module M : I with type t = t) = 
+  { return = (fun a -> M.return a) }
+[%%expect{|
+type ('t : value => value) inj = { return : 'a. 'a -> 'a 't; }
+module type I = sig type t : value => value val return : 'a -> 'a t end
+val inj : ('t : value => value). (module I with type t = 't) -> 't inj =
+  <fun>
+|}]
+
+let list = inj (module struct 
+  type t = list
+  let return x = [x]
+end)
+let x = list.return 42
+[%%expect{|
+val list : list inj = {return = <fun>}
+val x : int list = [42]
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/applied.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/applied.ml
@@ -162,32 +162,6 @@ type ('a : value => value) t = int 'a
 module M : sig type a = int list end
 |}]
 
-type ('a : value => value) t = int 'a
-
-module M : sig
-  type a = int list
-end = struct
-  type a = list t
-end
-
-[%%expect{|
-type ('a : value => value) t = int 'a
-module M : sig type a = int list end
-|}]
-
-type ('a : value => value) t = int 'a
-
-module M : sig
-  type a = int list
-end = struct
-  type a = list t
-end
-
-[%%expect{|
-type ('a : value => value) t = int 'a
-module M : sig type a = int list end
-|}]
-
 type 'a t = 'a * 'a
 let id : 'a ('b : value => value). 'a 'b -> 'a 'b = fun x -> x
 [%%expect{|

--- a/ocaml/testsuite/tests/typing-higher-jkinds/applied.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/applied.ml
@@ -162,6 +162,32 @@ type ('a : value => value) t = int 'a
 module M : sig type a = int list end
 |}]
 
+type ('a : value => value) t = int 'a
+
+module M : sig
+  type a = int list
+end = struct
+  type a = list t
+end
+
+[%%expect{|
+type ('a : value => value) t = int 'a
+module M : sig type a = int list end
+|}]
+
+type ('a : value => value) t = int 'a
+
+module M : sig
+  type a = int list
+end = struct
+  type a = list t
+end
+
+[%%expect{|
+type ('a : value => value) t = int 'a
+module M : sig type a = int list end
+|}]
+
 type 'a t = 'a * 'a
 let id : 'a ('b : value => value). 'a 'b -> 'a 'b = fun x -> x
 [%%expect{|

--- a/ocaml/testsuite/tests/typing-higher-jkinds/folds.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/folds.ml
@@ -1,0 +1,110 @@
+(* TEST
+  flags = "-extension layouts_alpha";
+  expect;
+*)
+
+(* Perfect binary trees *)
+type 'a perfect = Zero of 'a | Succ of ('a * 'a) perfect
+[%%expect{|
+type 'a perfect = Zero of 'a | Succ of ('a * 'a) perfect
+|}]
+
+(* Fold combiners for perfect trees *)
+type ('f : value => value) folder = {
+  zero : 'a. 'a -> 'a 'f;
+  succ : 'a. ('a * 'a) 'f -> 'a 'f
+}
+[%%expect{|
+type ('f : value => value) folder = {
+  zero : 'a. 'a -> 'a 'f;
+  succ : 'a. ('a * 'a) 'f -> 'a 'f;
+}
+|}]
+
+(* Fold over perfect tree *)
+let rec fold : 'a. 'f folder -> 'a perfect -> 'a 'f = fun folder -> function
+| Zero l -> folder.zero l
+| Succ p -> folder.succ (fold folder p)
+[%%expect{|
+val fold : ('f : value => value) 'a. 'f folder -> 'a perfect -> 'a 'f = <fun>
+|}]
+
+(* Applicatives *)
+type ('t : value => value) applicative = {
+  return : 'a. 'a -> 'a 't;
+  lift : 'a 'b. ('a -> 'b) -> ('a 't -> 'b 't);
+  both : 'a 'b. 'a 't -> 'b 't -> ('a * 'b) 't
+}
+let lift2 app f x y =
+  (app.lift (fun (a, b) -> f a b)) (app.both x y)
+[%%expect{|
+type ('t : value => value) applicative = {
+  return : 'a. 'a -> 'a 't;
+  lift : 'a 'b. ('a -> 'b) -> 'a 't -> 'b 't;
+  both : 'a 'b. 'a 't -> 'b 't -> ('a * 'b) 't;
+}
+val lift2 :
+  ('a : value => value) 'b 'c 'd.
+    'a applicative -> ('b -> 'c -> 'd) -> 'b 'a -> 'c 'a -> 'd 'a =
+  <fun>
+|}]
+
+(* Identity applicative *)
+type 'a id = { v : 'a }
+let id = {
+  return = (fun v -> { v });
+  lift = (fun f { v } -> { v = f v });
+  both = (fun { v } { v = v' } -> { v = v, v' })
+}
+[%%expect{|
+type 'a id = { v : 'a; }
+val id : id applicative = {return = <fun>; lift = <fun>; both = <fun>}
+|}]
+
+
+(* ** *)
+
+let example = Succ (Succ (Zero (([0; 1; 2], [4; -1]), ([6; 3], []))))
+[%%expect{|
+val example : int list perfect =
+  Succ (Succ (Zero (([0; 1; 2], [4; -1]), ([6; 3], []))))
+|}]
+
+let perfect_id perfect =
+  fold {
+    zero = (fun x -> Zero x);
+    succ = (fun x -> Succ x)
+  } perfect
+let result = perfect_id example
+[%%expect{|
+val perfect_id : 'a perfect -> 'a perfect = <fun>
+val result : int list perfect =
+  Succ (Succ (Zero (([0; 1; 2], [4; -1]), ([6; 3], []))))
+|}]
+
+let leftmost perfect =
+  fold {
+    zero = (fun x -> id.return x);
+    succ = (fun x -> id.lift fst x)
+  } perfect
+let result = leftmost example
+
+[%%expect{|
+val leftmost : 'a perfect -> 'a id = <fun>
+val result : int list id = {v = [0; 1; 2]}
+|}]
+
+let listing perfect =
+  fold {
+    zero = (fun x -> [x]);
+    succ = List.concat_map (fun (x, y) -> [x; y])
+  } perfect
+let result = leftmost example
+
+[%%expect{|
+Line 4, characters 11-49:
+4 |     succ = List.concat_map (fun (x, y) -> [x; y])
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This field value has type ('b * 'b) list -> 'b list
+       which is less general than 'a. ('a * 'a) 'c -> 'a 'c
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/folds.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/folds.ml
@@ -62,7 +62,7 @@ val id : id applicative = {return = <fun>; lift = <fun>; both = <fun>}
 |}]
 
 
-(* ** *)
+(* Correctness tests *)
 
 let example = Succ (Succ (Zero (([0; 1; 2], [4; -1]), ([6; 3], []))))
 [%%expect{|
@@ -94,17 +94,16 @@ val leftmost : 'a perfect -> 'a id = <fun>
 val result : int list id = {v = [0; 1; 2]}
 |}]
 
-let listing perfect =
-  fold {
-    zero = (fun x -> [x]);
-    succ = List.concat_map (fun (x, y) -> [x; y])
-  } perfect
-let result = leftmost example
+let leaves (perfect : 'a perfect) =
+  fold ({
+    zero = (fun l -> [l]);
+    succ = (fun l -> List.concat_map (fun (x, y) -> [x; y]) l)
+  } : list folder) perfect
+let result = leaves example
+let flat = List.concat result
 
 [%%expect{|
-Line 4, characters 11-49:
-4 |     succ = List.concat_map (fun (x, y) -> [x; y])
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This field value has type ('b * 'b) list -> 'b list
-       which is less general than 'a. ('a * 'a) 'c -> 'a 'c
+val leaves : 'a perfect -> 'a list = <fun>
+val result : int list list = [[0; 1; 2]; [4; -1]; [6; 3]; []]
+val flat : int list = [0; 1; 2; 4; -1; 6; 3]
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
@@ -13,7 +13,8 @@ type 'a t = unit 'a
 Line 1, characters 12-19:
 1 | type 'a t = unit 'a
                 ^^^^^^^
-Error: Types of jkind (immediate) cannot be applied to '_representable_layout_1.
+Error: The type expression ('a : '_representable_layout_1)
+         is applied as a type constructor, but it is not of a higher jkind.
 |}]
 
 type ('a, 'm) t = 'a 'm
@@ -21,7 +22,8 @@ type ('a, 'm) t = 'a 'm
 Line 1, characters 18-23:
 1 | type ('a, 'm) t = 'a 'm
                       ^^^^^
-Error: Types of jkind ('_representable_layout_2) cannot be applied to '_representable_layout_3.
+Error: The type expression ('m : '_representable_layout_2)
+         is applied as a type constructor, but it is not of a higher jkind.
 |}]
 
 type ('a, 'm : value => value) t = 'a 'm
@@ -50,8 +52,73 @@ module type M = sig
   val f : unit -> unit 'a
 end
 [%%expect {|
-Line 2, characters 18-25:
-2 |   val f : unit -> unit 'a
-                      ^^^^^^^
-Error: Types of jkind (immediate) cannot be applied to '_representable_layout_4.
+module type M = sig val f : ('a : value => value). unit -> unit 'a end
+|}]
+
+module type M = sig
+  val f : 'a 'b -> int 'a -> list 'b
+end
+[%%expect {|
+Line 2, characters 19-25:
+2 |   val f : 'a 'b -> int 'a -> list 'b
+                       ^^^^^^
+Error: The type expression ('a : '_representable_layout_3)
+         is applied as a type constructor, but it is not of a higher jkind.
+|}]
+
+module type M = sig
+  val f : int 'a -> list 'b -> 'a 'b
+end
+[%%expect {|
+Line 2, characters 20-27:
+2 |   val f : int 'a -> list 'b -> 'a 'b
+                        ^^^^^^^
+Error: The type expression ('b : (('_representable_layout_4) => '_representable_layout_5))
+         cannot be applied to the arguments (list : ((value) => value)).
+|}]
+
+module type M = sig
+  type (_ : any => value) s
+  type (_ : value => value) t
+  val f : 'a s -> 'a t
+end
+[%%expect {|
+module type M =
+  sig
+    type (_ : any => value) s
+    type (_ : value => value) t
+    val f : ('a : any => value). 'a s -> 'a t
+  end
+|}]
+
+module type M = sig
+  type (_ : float64 => value) f64monad
+  val f : 'm f64monad -> 'a -> 'a 'm
+end
+[%%expect {|
+module type M =
+  sig
+    type (_ : float64 => value) f64monad
+    val f :
+      ('m : float64 => value) ('a : float64). 'm f64monad -> 'a -> 'a 'm
+  end
+|}]
+
+module type M = sig
+  val f : 'a -> 'a 'b
+end
+[%%expect {|
+module type M = sig val f : 'a ('b : value => value). 'a -> 'a 'b end
+|}]
+
+module type M = sig
+  type t : (((top => top) => top) => top) => any
+  val f : 'a t -> unit
+end
+[%%expect {|
+module type M =
+  sig
+    type t : (((top => top) => top) => top) => any
+    val f : ('a : ((top => value) => top) => value). 'a t -> unit
+  end
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
@@ -150,3 +150,15 @@ module type M = sig
   type t : immediate => value
   val f : 'a 'm -> 'b 'm -> 'c 'm -> 'd 'm -> 'e 'm -> 'm
 end
+
+[%%expect{|
+Line 3, characters 55-57:
+3 |   val f : 'a 'm -> 'b 'm -> 'c 'm -> 'd 'm -> 'e 'm -> 'm
+                                                           ^^
+Error: Function return types must have a representable layout.
+       The layout of 'm is (('_representable_layout_6) => '_representable_layout_7), because
+         it was defaulted in inference.
+       But the layout of 'm must overlap with any, because
+         it's assigned a dummy layout that should have been overwritten.
+         Please notify the Jane Street compilers group if you see this output.
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
@@ -122,3 +122,26 @@ module type M =
     val f : ('a : ((top => value) => top) => value). 'a t -> unit
   end
 |}]
+
+module type M = sig
+  val f : 'a 'b 'c 'd -> unit 'd
+end
+[%%expect {|
+module type M =
+  sig
+    val f :
+      ('d : value => value) ('c : value => value) ('b : value => value) 'a.
+        'a 'b 'c 'd -> unit 'd
+  end
+|}]
+
+module type M = sig
+  val f : 'a ('b ('c 'd)) -> unit
+end
+[%%expect {|
+module type M =
+  sig
+    val f :
+      ('d : value => value => value => value) 'c 'b 'a. 'a 'b 'c 'd -> unit
+  end
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
@@ -142,7 +142,8 @@ end
 module type M =
   sig
     val f :
-      ('d : value => value => value => value) 'c 'b 'a. 'a 'b 'c 'd -> unit
+      ('d : value => value => value => value) 'c 'b 'a.
+        'a ('b ('c 'd)) -> unit
   end
 |}]
 

--- a/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
@@ -180,6 +180,13 @@ module type S =
   end
 |}]
 
+(* This one is slightly non-obvious: 
+   constraining ['f] with [(value => value) => value] and [_ => value] 
+   yields ['f : top => value]. 
+   Note that both constrainings happen, with 'a inferred as _ (sort var), 
+   and yielding neither (value => value) nor an error.
+   This is below the representable sub-lattice, as only contravariant 
+   positions are non-representable. *)
 type ('f : (value => value) => value) third_order
 module type S = sig 
   val foo1 : 'f third_order -> 'a 'f -> unit

--- a/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
@@ -161,6 +161,5 @@ Error: Function return types must have a representable layout.
          (('_representable_layout_6) => '_representable_layout_7)
          because it was defaulted in inference.
        But the kind of 'm must overlap with any
-         because it's assigned a dummy kind that should have been overwritten.
-                 Please notify the Jane Street compilers group if you see this output.
+         because argument or result of a function type.
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
@@ -145,3 +145,8 @@ module type M =
       ('d : value => value => value => value) 'c 'b 'a. 'a 'b 'c 'd -> unit
   end
 |}]
+
+module type M = sig
+  type t : immediate => value
+  val f : 'a 'm -> 'b 'm -> 'c 'm -> 'd 'm -> 'e 'm -> 'm
+end

--- a/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/jkind_inference.ml
@@ -157,9 +157,10 @@ Line 3, characters 55-57:
 3 |   val f : 'a 'm -> 'b 'm -> 'c 'm -> 'd 'm -> 'e 'm -> 'm
                                                            ^^
 Error: Function return types must have a representable layout.
-       The layout of 'm is (('_representable_layout_6) => '_representable_layout_7), because
-         it was defaulted in inference.
-       But the layout of 'm must overlap with any, because
-         it's assigned a dummy layout that should have been overwritten.
-         Please notify the Jane Street compilers group if you see this output.
+       The kind of 'm is
+         (('_representable_layout_6) => '_representable_layout_7)
+         because it was defaulted in inference.
+       But the kind of 'm must overlap with any
+         because it's assigned a dummy kind that should have been overwritten.
+                 Please notify the Jane Street compilers group if you see this output.
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/leibniz.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/leibniz.ml
@@ -1,0 +1,38 @@
+(* TEST
+  reason = "Leibniz equality is better with partial type application";
+  skip;
+  flags = "-extension layouts_alpha";
+  expect;
+*)
+
+module Eq : sig
+  type ('a : top, 'b : top) eq
+
+  val refl : unit -> ('a, 'a) eq
+  val subst : ('a : top) ('b : top) ('f : top => value). ('a, 'b) eq -> ('a 'f -> 'b 'f)
+end = struct
+  type ('a : top, 'b : top) eq = { subst : ('f : top => value). 'a 'f -> 'b 'f }
+  let refl () = { subst = (fun x -> x) }
+  let subst eq x = eq.subst x
+end
+
+[%%expect{|
+module Eq :
+  sig
+    type ('a : top, 'b : top) eq
+    val refl : unit -> ('a, 'a) eq
+    val subst :
+      ('a : top) ('b : top) ('f : top => value).
+        ('a, 'b) eq -> 'a 'f -> 'b 'f
+  end
+|}]
+
+open Eq
+(* FIXME: this needs both inference and abstract datatypes *)
+let trans : ('a, 'b) eq -> ('b, 'c) eq -> ('a, 'c) eq = fun ab bc -> subst bc ab
+
+(* how does this error?? some intermediate type gets placed in a Tapp, I guess? *)
+[%%expect{|
+Uncaught exception: Failure("no jkind for tconstr???")
+
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/lets.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/lets.ml
@@ -1,0 +1,50 @@
+(* TEST
+  flags = "-extension layouts_alpha";
+  expect;
+*)
+
+type ('m : value => value) monad = {
+  return : 'a. 'a -> 'a 'm;
+  bind : 'a 'b. 'a 'm -> ('a -> 'b 'm) -> 'b 'm
+}
+[%%expect{|
+type ('m : value => value) monad = {
+  return : 'a. 'a -> 'a 'm;
+  bind : 'a 'b. 'a 'm -> ('a -> 'b 'm) -> 'b 'm;
+}
+|}]
+
+let monad_let (m : 'm monad) =
+  let return = m.return in
+  let (let*) = m.bind in
+  let (let+) x f =
+    let* a = x in
+    return (f a)
+  in
+  let (and*) x y =
+    let* a = x in
+    let* b = y in
+    return (a, b)
+  in
+  let (and+) = (and*) in
+  (return, (let*), (let+), (and*), (and+))
+[%%expect{|
+val monad_let :
+  ('m : value => value) 'a 'b 'c 'd 'e 'f 'g 'h 'i.
+    'm monad ->
+    ('a -> 'a 'm) * ('b 'm -> ('b -> 'c 'm) -> 'c 'm) *
+    ('d 'm -> ('d -> 'e) -> 'e 'm) * ('f 'm -> 'g 'm -> ('f * 'g) 'm) *
+    ('h 'm -> 'i 'm -> ('h * 'i) 'm) =
+  <fun>
+|}]
+
+let both m x y =
+  let return, (let*), _, (and*), _ = monad_let m in
+  let* a = x
+  and* b = y in
+  return (a, b)
+[%%expect{|
+val both :
+  ('a : value => value) 'b 'c. 'a monad -> 'b 'a -> 'c 'a -> ('b * 'c) 'a =
+  <fun>
+|}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/specialised.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/specialised.ml
@@ -49,49 +49,89 @@ let foo : type (a : value => value). a t -> int a = function
 val foo : ('a : value => value). 'a t -> int 'a = <fun>
 |}]
 
-type ('m : value => value) functor_instance = {
+type l : value => value = list
+let x: int l = [1]
+[%%expect{|
+type l = list
+val x : int l = <abstr>
+|}]
+
+(* Basic GADTs *)
+
+type ('a : value => value) t =
+  | List : list t
+  | Option : option t
+[%%expect{|
+type ('a : value => value) t = List : list t | Option : option t
+|}]
+
+let foo : type (a : value => value). a t -> int a = function
+  | List -> ([1] : int a)
+  | Option -> Some 2
+[%%expect{|
+val foo : ('a : value => value). 'a t -> int 'a = <fun>
+|}]
+
+type l : value => value = list
+let x: int l = [1]
+[%%expect{|
+type l = list
+val x : int l = <abstr>
+|}]
+
+(* Basic GADTs *)
+
+type ('a : value => value) t =
+  | List : list t
+  | Option : option t
+[%%expect{|
+type ('a : value => value) t = List : list t | Option : option t
+|}]
+
+let foo : type (a : value => value). a t -> int a = function
+  | List -> [1]
+  | Option -> Some 2
+[%%expect{|
+val foo : ('a : value => value). 'a t -> int 'a = <fun>
+|}]
+
+(* Annotations on both [functor_instance] and [funct] are required *)
+
+type ('m : value => value) functor_impl = {
   return : 'a. 'a -> 'a 'm;
   map : 'a 'b. ('a -> 'b) -> ('a 'm -> 'b 'm)
 }
-
 [%%expect{|
-type ('m : value => value) functor_instance = {
+type ('m : value => value) functor_impl = {
   return : 'a. 'a -> 'a 'm;
   map : 'a 'b. ('a -> 'b) -> 'a 'm -> 'b 'm;
 }
 |}]
 
 type 'a id = { id : 'a }
-
-type ('m : value => value) funct =
+type (_ : value => value) funct =
   | Id : id funct
   | List : list funct
-  | Instance : 'm functor_instance -> 'm funct
-
+  | Instance : 'm functor_impl -> 'm funct
 [%%expect{|
 type 'a id = { id : 'a; }
-Line 6, characters 15-17:
-6 |   | Instance : 'm functor_instance -> 'm funct
-                   ^^
-Error: This type ('m : '_representable_layout_1)
-       should be an instance of type ('a : value => value)
-       The kind of 'm is '_representable_layout_1
-         because it's a fresh unification variable.
-       But the kind of 'm must overlap with ((value) => value)
-         because of the definition of functor_instance at lines 1-4, characters 0-1.
+type (_ : value => value) funct =
+    Id : id funct
+  | List : list funct
+  | Instance : ('m : value => value). 'm functor_impl -> 'm funct
 |}]
 
 let return : type a (m : value => value). m funct -> a -> a m = fun f x -> match f with
-  | Id -> { id = x }
+  | Id -> ({ id = x })
   | List -> [x]
   | Instance inst -> inst.return x
 
 [%%expect{|
-Line 1, characters 44-49:
-1 | let return : type a (m : value => value). m funct -> a -> a m = fun f x -> match f with
-                                                ^^^^^
-Error: Unbound type constructor funct
-Hint: Did you mean unit?
+Line 2, characters 10-22:
+2 |   | Id -> ({ id = x })
+              ^^^^^^^^^^^^
+Error: This expression has type a id but an expression was expected of type
+         a m
 |}]
 
 let map : type a b (m : value => value). m funct -> (a -> b) -> a m -> b m = fun f t x -> match f with

--- a/ocaml/testsuite/tests/typing-higher-jkinds/specialised.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/specialised.ml
@@ -33,70 +33,7 @@ type l = list
 val x : int l = <abstr>
 |}]
 
-(* Basic GADTs *)
-
-type ('a : value => value) t =
-  | List : list t
-  | Option : option t
-[%%expect{|
-type ('a : value => value) t = List : list t | Option : option t
-|}]
-
-let foo : type (a : value => value). a t -> int a = function
-  | List -> [1]
-  | Option -> Some 2
-[%%expect{|
-val foo : ('a : value => value). 'a t -> int 'a = <fun>
-|}]
-
-type l : value => value = list
-let x: int l = [1]
-[%%expect{|
-type l = list
-val x : int l = <abstr>
-|}]
-
-(* Basic GADTs *)
-
-type ('a : value => value) t =
-  | List : list t
-  | Option : option t
-[%%expect{|
-type ('a : value => value) t = List : list t | Option : option t
-|}]
-
-let foo : type (a : value => value). a t -> int a = function
-  | List -> ([1] : int a)
-  | Option -> Some 2
-[%%expect{|
-val foo : ('a : value => value). 'a t -> int 'a = <fun>
-|}]
-
-type l : value => value = list
-let x: int l = [1]
-[%%expect{|
-type l = list
-val x : int l = <abstr>
-|}]
-
-(* Basic GADTs *)
-
-type ('a : value => value) t =
-  | List : list t
-  | Option : option t
-[%%expect{|
-type ('a : value => value) t = List : list t | Option : option t
-|}]
-
-let foo : type (a : value => value). a t -> int a = function
-  | List -> [1]
-  | Option -> Some 2
-[%%expect{|
-val foo : ('a : value => value). 'a t -> int 'a = <fun>
-|}]
-
 (* Annotations on both [functor_instance] and [funct] are required *)
-
 type ('m : value => value) functor_impl = {
   return : 'a. 'a -> 'a 'm;
   map : 'a 'b. ('a -> 'b) -> ('a 'm -> 'b 'm)
@@ -127,11 +64,7 @@ let return : type a (m : value => value). m funct -> a -> a m = fun f x -> match
   | Instance inst -> inst.return x
 
 [%%expect{|
-Line 2, characters 10-22:
-2 |   | Id -> ({ id = x })
-              ^^^^^^^^^^^^
-Error: This expression has type a id but an expression was expected of type
-         a m
+val return : ('m : value => value) 'a. 'm funct -> 'a -> 'a 'm = <fun>
 |}]
 
 let map : type a b (m : value => value). m funct -> (a -> b) -> a m -> b m = fun f t x -> match f with
@@ -140,9 +73,7 @@ let map : type a b (m : value => value). m funct -> (a -> b) -> a m -> b m = fun
   | Instance inst -> inst.map t x
 
 [%%expect{|
-Line 1, characters 43-48:
-1 | let map : type a b (m : value => value). m funct -> (a -> b) -> a m -> b m = fun f t x -> match f with
-                                               ^^^^^
-Error: Unbound type constructor funct
-Hint: Did you mean unit?
+val map :
+  ('m : value => value) 'a 'b. 'm funct -> ('a -> 'b) -> 'a 'm -> 'b 'm =
+  <fun>
 |}]

--- a/ocaml/testsuite/tests/typing-higher-jkinds/unapplied.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/unapplied.ml
@@ -110,10 +110,10 @@ module type M = sig
   val f : ('a : value => value). 'a -> 'a
 end
 [%%expect {|
-Line 2, characters 33-35:
+Line 2, characters 39-41:
 2 |   val f : ('a : value => value). 'a -> 'a
-                                     ^^
-Error: Function argument types must have a representable layout.
+                                           ^^
+Error: Function return types must have a representable layout.
        The kind of 'a is ((value) => value)
          because of the annotation on the universal variable 'a.
        But the kind of 'a must overlap with any
@@ -151,7 +151,6 @@ module type M =
   end
 |}]
 
-(* FIXME jbachurski: [int s] is ill-kinded in application to [r] *)
 module type M = sig
   type r : (value => value) => value
   type s : value => value
@@ -168,7 +167,6 @@ Error: This type int s should be an instance of type ('a : value => value)
          because of the definition of r at line 2, characters 2-36.
 |}]
 
-(* FIXME jbachurski: [list] is ill-kinded in application to [s] *)
 module type M = sig
   type r : (value => value) => value
   type s : value => value

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -91,12 +91,13 @@ end
 Line 3, characters 61-63:
 3 |   val f : (('a : value)[@error_message "Custom message"]) -> 'a t
                                                                  ^^
-Error: This type ('a : value) should be an instance of type ('b : float64)
-       The layout of 'a is value
-         because of the annotation on the type variable 'a.
-         Custom message
-       But the layout of 'a must overlap with float64
-         because of the definition of t at line 2, characters 2-28.
+Error: No consistent jkind could be inferred for 'a.
+         Hint: try annotating the type variable at its binding site.
+         The layout of 'a is value
+           because of the annotation on the type variable 'a.
+           Custom message
+         But the layout of 'a must overlap with float64
+           because of the definition of t at line 2, characters 2-28.
 |}]
 
 

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -2530,6 +2530,10 @@ let intersection_with_new_sort ~reason jkind : t =
 
 let rec lower_to_representable ~reason (jkind : t) =
   match get jkind with
+  (* We lower all covariant (result) positions to representable
+     in the expected jkind. The resulting jkind is upper bounded
+     by some jkind in the representables sub-lattice.
+     CR lwhite by jbachurski: Are we sure this is right? *)
   | Arrow { args; result } ->
     of_arrow ~history:jkind.history
       ~args:(List.map (co_lower_to_representable ~reason) args)

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1516,6 +1516,7 @@ module Type = struct
       | Imported_type_argument { parent_path; position; arity } ->
         fprintf ppf "Imported_type_argument (pos %d, arity %d) of %a" position
           arity !printtyp_path parent_path
+      | Defaulted -> fprintf ppf "Defaulted"
       | Generalized (id, loc) ->
         fprintf ppf "Generalized (%s, %a)"
           (match id with Some id -> Ident.unique_name id | None -> "")
@@ -2137,6 +2138,7 @@ module Format_history = struct
       fprintf ppf "the %stype argument of %a has this %s"
         (format_position ~arity position)
         !printtyp_path parent_path layout_or_kind
+    | Defaulted -> fprintf ppf "it was defaulted in inference"
     | Generalized (id, loc) ->
       let format_id ppf = function
         | Some id -> fprintf ppf " of %s" (Ident.name id)

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -169,8 +169,7 @@ module Type = struct
          [if Sort.equate s1 s2 then t1 else Any] is not sound
          and a change to the representation of sorts would be
          required to compute this accurately. Fail for now. *)
-      | Sort s1, Sort s2 when s1 = s2 -> t1
-      | Sort _, Sort _ -> assert false
+      | Sort s1, Sort s2 -> if Sort.equate s1 s2 then t1 else Any
       | _, Any -> Any
       | Any, _ -> Any
 

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -393,6 +393,11 @@ val of_new_sort_var : why:History.concrete_creation_reason -> t * Type.sort
 (** Create a fresh sort variable, packed into a jkind. *)
 val of_new_sort : why:History.concrete_creation_reason -> t
 
+val of_new_legacy_sort_var :
+  why:History.concrete_legacy_creation_reason -> t * Type.sort
+
+val of_new_legacy_sort : why:History.concrete_legacy_creation_reason -> t
+
 val of_const : why:History.creation_reason -> Const.t -> t
 
 val const_of_user_written_annotation :
@@ -570,6 +575,10 @@ val sub_or_error : t -> t -> (unit, Violation.t) result
 
 (** Like [sub], but returns the subjkind with an updated history. *)
 val sub_with_history : t -> t -> (t, Violation.t) result
+
+(** Find a jkind which is a subjkind of both its argument and some jkind 
+    in the representable space *)
+val lower_to_representable : reason:History.interact_reason -> t -> t
 
 (** Checks to see whether a jkind is top. Never does any mutation. *)
 val is_max : t -> bool

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -295,6 +295,7 @@ module History = struct
     | Concrete_creation of concrete_creation_reason
     | Concrete_legacy_creation of concrete_legacy_creation_reason
     | Top_creation of top_creation_reason
+    | Defaulted
     | Imported
     | Imported_type_argument of
         { parent_path : Path.t;

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -295,7 +295,7 @@ module History = struct
     | Concrete_creation of concrete_creation_reason
     | Concrete_legacy_creation of concrete_legacy_creation_reason
     | Top_creation of top_creation_reason
-    | Defaulted
+    | Inferred_in_application
     | Imported
     | Imported_type_argument of
         { parent_path : Path.t;

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -730,7 +730,7 @@ and transl_type_aux env ~row_context ~aliased ~policy ?(jkind_check = Unknown) m
   | Ptyp_arrow _ ->
       let args, ret, ret_mode = extract_params styp in
       let rec loop acc_mode args =
-        let jkind = Jkind.Type.Primitive.any ~why:Dummy_jkind |> Jkind.of_type_jkind in
+        let jkind = Jkind.Type.Primitive.any ~why:Inside_of_Tarrow |> Jkind.of_type_jkind in
         match args with
         | (l, arg_mode, arg) :: rest ->
           check_arg_type arg;

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -446,15 +446,15 @@ end = struct
     let rec lower_to_representable (jkind : Jkind.t) =
       match Jkind.get jkind with
       | Arrow { args; result } ->
-        Jkind.of_arrow 
+        Jkind.of_arrow
           ~history:jkind.history
           ~args:(List.map co_lower_to_representable args)
           ~result:(lower_to_representable result)
-      | Type _ | Top -> {jkind with jkind = (intersection_with_new_sort jkind).jkind }
+      | Type _ | Top -> { jkind with desc = (intersection_with_new_sort jkind).desc }
     and co_lower_to_representable (jkind : Jkind.t) =
       match Jkind.get jkind with
       | Arrow { args; result } ->
-        Jkind.of_arrow 
+        Jkind.of_arrow
           ~history:jkind.history
           ~args:(List.map lower_to_representable args)
           ~result

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -446,15 +446,18 @@ end = struct
     let rec lower_to_representable (jkind : Jkind.t) =
       match Jkind.get jkind with
       | Arrow { args; result } ->
-        Jkind.of_arrow ~history:jkind.history
-          { args = List.map co_lower_to_representable args;
-            result = lower_to_representable result }
+        Jkind.of_arrow 
+          ~history:jkind.history
+          ~args:(List.map co_lower_to_representable args)
+          ~result:(lower_to_representable result)
       | Type _ | Top -> {jkind with jkind = (intersection_with_new_sort jkind).jkind }
     and co_lower_to_representable (jkind : Jkind.t) =
       match Jkind.get jkind with
       | Arrow { args; result } ->
-        Jkind.of_arrow ~history:jkind.history
-          { args = List.map lower_to_representable args; result }
+        Jkind.of_arrow 
+          ~history:jkind.history
+          ~args:(List.map lower_to_representable args)
+          ~result
       | Type _ | Top -> jkind
     in
     match jkind_check, policy.jkind_initialization with
@@ -465,8 +468,8 @@ end = struct
          We'd need to switch variances in the arguments if we recursed there. *)
       Jkind.of_arrow
         ~history:(Creation Defaulted)
-        { args = List.init n (fun _ -> gen_sort ());
-          result = new_jkind ~is_named policy result_jkind_check }
+        ~args:(List.init n (fun _ -> gen_sort ()))
+        ~result:(new_jkind ~is_named policy result_jkind_check)
     | Exact jkind, Any -> jkind
     (* If the initialization policy expects representable layouts,
        we lower all covariant (result) positions to representable

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -737,10 +737,11 @@ and transl_type_aux env ~row_context ~aliased ~policy ?(jkind_check = Unknown) m
         | (l, arg_mode, arg) :: rest ->
           check_arg_type arg;
           let l = transl_label l (Some arg) in
+          let jkind = Jkind.of_new_sort ~why:Wildcard in
           let arg_cty =
             if Btype.is_position l then
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
-            else transl_type env ~policy ~row_context arg_mode arg
+            else transl_type env ~policy ~jkind_check:(Known jkind) ~row_context arg_mode arg
           in
           let acc_mode = curry_mode acc_mode arg_mode in
           let ret_mode =
@@ -763,7 +764,6 @@ and transl_type_aux env ~row_context ~aliased ~policy ?(jkind_check = Unknown) m
             end
           in
           constrain_type_expr_jkind_to_any ~loc:arg_cty.ctyp_loc ~vloc:Fun_arg env arg_cty.ctyp_type;
-          constrain_type_expr_jkind_to_any ~loc:ret_cty.ctyp_loc ~vloc:Fun_ret env ret_cty.ctyp_type;
           let arg_mode = Alloc.of_const arg_mode in
           let ret_mode = Alloc.of_const ret_mode in
           let arrow_desc = (l, arg_mode, ret_mode) in

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -457,10 +457,7 @@ end = struct
         ~args:(List.init n (fun _ -> new_jkind_sort ~is_named))
         ~result:(new_jkind ~is_named policy result_jkind_check)
     | Exact jkind, Any -> jkind
-    (* If the initialization policy expects representable layouts,
-       we lower all covariant (result) positions to representable
-       in the expected jkind. The resulting jkind is upper bounded
-       by some jkind in the representables sub-lattice. *)
+    (* If the initialization policy expects representable layouts, we lower below it *)
     | Exact jkind, Sort -> 
       Jkind.lower_to_representable ~reason:Tyvar_refinement_intersection jkind
 

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -37,6 +37,8 @@ exception Already_bound
    will occur in this case. *)
 type jkind_initialization_choice = Sort | Any
 
+type jkind_check = Unknown | Known of Jkind.t | Arity of int * Jkind.t option
+
 type value_loc =
     Tuple | Poly_variant | Object_field
 
@@ -90,8 +92,8 @@ type error =
   | Non_sort of
       {vloc : sort_loc; typ : type_expr; err : Jkind.Violation.t}
   | Bad_jkind_annot of type_expr * Jkind.Violation.t
-  | Jkind_mismatch_in_application of Jkind.t list * Jkind.t * Jkind.Violation.t option
-  | Unknown_jkind_at_application of type_expr
+  | Jkind_mismatch_in_application of (type_expr * Jkind.t) * (type_expr * Jkind.t) list * Jkind.Violation.t option
+  | Bad_jkind_for_application of type_expr * Jkind.t
   | Did_you_mean_unboxed of Longident.t
   | Invalid_label_for_call_pos of Parsetree.arg_label
 
@@ -144,7 +146,7 @@ module TyVarEnv : sig
   val new_var : ?name:string -> Jkind.t -> policy -> type_expr
     (* create a new variable according to the given policy *)
 
-  val new_jkind : is_named:bool -> policy -> Jkind.t
+  val new_jkind : is_named:bool -> policy -> jkind_check -> Jkind.t
     (* create a new jkind depending on the current policy *)
 
   val add_pre_univar : type_expr -> policy -> unit
@@ -434,16 +436,41 @@ end = struct
     add_pre_univar tv policy;
     tv
 
-  let new_jkind ~is_named { jkind_initialization } =
-    (* FIXME jbachurski: Should these be created with [any], or [top]?
-        (seems to be used for the jkind of [_], so [top]?) *)
-    match jkind_initialization with
-    (* CR layouts v3.0: while [Any] case allows nullable jkinds, [Sort] does not.
-       From testing, we need all callsites that use [Sort] to be non-null to
-       preserve backwards compatibility. But we also need [Any] callsites
-       to accept nullable jkinds to allow cases like [type ('a : value_or_null) t = 'a]. *)
-    | Any -> Jkind.Primitive.top ~why:(if is_named then Unification_var else Wildcard)
-    | Sort -> Jkind.Type.of_new_legacy_sort ~why:(if is_named then Unification_var else Wildcard) |> Jkind.of_type_jkind
+  let new_jkind ~is_named { jkind_initialization } jkind_check =
+    let gen_top  () = Jkind.Primitive.top ~why:(if is_named then Unification_var else Wildcard) in
+    let gen_sort () = Jkind.Type.of_new_legacy_sort ~why:(if is_named then Unification_var else Wildcard) |> Jkind.of_type_jkind in
+    let intersection_with_new_sort jkind : Jkind.t =
+      Jkind.intersection_or_error ~reason:Tyvar_refinement_intersection jkind (gen_sort ())
+      |> Result.get_ok (* sorts are the minimum elements of the jkind lattice *)
+    in
+    let rec lower_to_representable (jkind : Jkind.t) =
+      match Jkind.get jkind with
+      | Arrow { args; result } ->
+        Jkind.of_arrow ~history:jkind.history
+          { args = List.map co_lower_to_representable args;
+            result = lower_to_representable result }
+      | Type _ | Top -> {jkind with jkind = (intersection_with_new_sort jkind).jkind }
+    and co_lower_to_representable (jkind : Jkind.t) =
+      match Jkind.get jkind with
+      | Arrow { args; result } ->
+        Jkind.of_arrow ~history:jkind.history
+          { args = List.map lower_to_representable args; result }
+      | Type _ | Top -> jkind
+    in
+    match jkind_check, jkind_initialization with
+    | Unknown, Any -> gen_top ()
+    | Unknown, Sort -> gen_sort ()
+    | Arity (n, result), _ ->
+      Jkind.of_arrow
+        ~history:(Creation Defaulted)
+        { args = List.init n (fun _ -> gen_sort ());
+          result = match result with Some r -> r | None -> gen_sort () }
+    | Known jkind, Any -> jkind
+    (* If the initialization policy expects representable layouts,
+       we lower all covariant (result) positions to representable
+       in the expected jkind. The resulting jkind is upper bounded
+       by some jkind in the representables sub-lattice. *)
+    | Known jkind, Sort -> lower_to_representable jkind
 
   let new_any_var loc env jkind = function
     | { extensibility = Fixed } -> raise(Error(loc, env, No_type_wildcards))
@@ -677,11 +704,11 @@ let constrain_type_expr_jkind_to_any ~loc ~vloc env typ =
     raise (Error(loc, env,
                 Non_sort {vloc; err; typ}))
 
-let rec transl_type env ~policy ?(aliased=false) ~row_context mode styp =
+let rec transl_type env ~policy ?(jkind_check=Unknown) ?(aliased=false) ~row_context mode styp =
   Builtin_attributes.warning_scope styp.ptyp_attributes
-    (fun () -> transl_type_aux env ~policy ~aliased ~row_context mode styp)
+    (fun () -> transl_type_aux env ~policy ~jkind_check ~aliased ~row_context mode styp)
 
-and transl_type_aux env ~row_context ~aliased ~policy mode styp =
+and transl_type_aux env ~row_context ~aliased ~policy ?(jkind_check = Unknown) mode styp =
   let loc = styp.ptyp_loc in
   let ctyp ctyp_desc ctyp_type =
     { ctyp_desc; ctyp_type; ctyp_env = env;
@@ -694,12 +721,12 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
   match styp.ptyp_desc with
     Ptyp_any ->
      let ty =
-       TyVarEnv.new_any_var loc env (TyVarEnv.new_jkind ~is_named:false policy) policy
+       TyVarEnv.new_any_var loc env (TyVarEnv.new_jkind ~is_named:false policy jkind_check) policy
      in
      ctyp (Ttyp_var (None, None)) ty
   | Ptyp_var name ->
       let desc, typ =
-        transl_type_var env ~policy ~row_context
+        transl_type_var env ~policy ~jkind_check ~row_context
           styp.ptyp_attributes styp.ptyp_loc name None
       in
       ctyp desc typ
@@ -753,7 +780,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
         (List.map (fun t -> (None, t)) stl)
     in
     ctyp desc typ
-  | Ptyp_constr(lid, stl) ->
+    | Ptyp_constr(lid, stl) ->
       let (path, decl) = Env.lookup_type ~loc:lid.loc lid.txt env in
       let stl =
         match stl with
@@ -762,9 +789,6 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
         | _ -> stl
       in
       check_arity_matches_decl ~loc:styp.ptyp_loc ~txt:lid.txt env decl (List.length stl);
-      let args =
-        List.map (transl_type env ~policy ~row_context Alloc.Const.legacy) stl
-      in
       let params = if stl <> [] then instance_list (applied_params_of_decl decl) else [] in
       let unify_param =
         match decl.type_manifest with
@@ -773,9 +797,9 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
             if get_level ty = Btype.generic_level then unify_var else unify
       in
       let arity = List.length params in
-      List.iteri
-        (fun idx ((sty, cty), ty') ->
-           begin match Types.get_desc ty' with
+      let args = List.mapi
+        (fun idx (sty, ty') ->
+           let jkind = match Types.get_desc ty' with
            | Tvar {jkind; _} when Jkind.History.has_imported_history jkind ->
              (* In case of a Tvar with imported jkind history, we can improve
                 the jkind reason using the in scope [path] to the parent type.
@@ -786,41 +810,57 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
                 no statistically significant increase in build time. *)
              let reason = Jkind.History.Imported_type_argument
                             {parent_path = path; position = idx + 1; arity} in
-             Types.set_var_jkind ty' (Jkind.History.update_reason jkind reason)
-           | _ -> ()
-           end;
-           try unify_param env ty' cty.ctyp_type with Unify err ->
+             let jkind = Jkind.History.update_reason jkind reason in
+             Types.set_var_jkind ty' jkind;
+             jkind
+           | _ -> type_jkind_purely env ty'
+           in
+           let cty =
+            transl_type env ~policy ~jkind_check:(Known jkind)
+              ~row_context Alloc.Const.legacy sty
+           in
+           (try unify_param env ty' cty.ctyp_type with Unify err ->
              let err = Errortrace.swap_unification_error err in
-             raise (Error(sty.ptyp_loc, env, Type_mismatch err))
+             raise (Error(sty.ptyp_loc, env, Type_mismatch err)));
+           cty
         )
-        (List.combine (List.combine stl args) params);
+        (List.combine stl params)
+      in
       let constr =
         newconstr path (List.map (fun ctyp -> ctyp.ctyp_type) args) in
       ctyp (Ttyp_constr (path, lid, args)) constr
   | Ptyp_app (st, stl) ->
-    let ty = transl_type env ~policy ~row_context Alloc.Const.legacy st in
-    let arg_tys =
-      List.map (transl_type env ~policy ~row_context Alloc.Const.legacy) stl
-    in
-    let app_jkind = estimate_type_jkind env ty.ctyp_type in
-    let app_err violation =
-      let arg_jkinds =
-        List.map (fun arg -> estimate_type_jkind env arg.ctyp_type) arg_tys
-      in
-      Error (
+    let ty =
+      transl_type env ~policy
+        ~jkind_check:(Arity (
+          List.length stl, match jkind_check with Known k -> Some k | _ -> None))
+        ~row_context Alloc.Const.legacy st in
+    let ty_jkind = estimate_type_jkind env ty.ctyp_type in
+    let arg_ty_jkinds =
+      match Jkind.get ty_jkind with
+      | Arrow { args; result = _ } -> args
+      | Type _ -> raise (Error (
         styp.ptyp_loc, env,
-        Jkind_mismatch_in_application (arg_jkinds, app_jkind, violation))
+        Bad_jkind_for_application (ty.ctyp_type, ty_jkind)))
+      | Top -> raise (Error (st.ptyp_loc, env, Bad_jkind_for_application (ty.ctyp_type, ty_jkind)))
     in
-    begin match Jkind.get app_jkind with
-    | Arrow { args; result = _ } ->
-      List.iter2 (fun arg jkind ->
+    let arg_tys =
+      List.map2 (fun sty jkind ->
+          transl_type env ~policy ~jkind_check:(Known jkind)
+            ~row_context Alloc.Const.legacy sty)
+        stl arg_ty_jkinds
+    in
+    List.iter2 (fun arg jkind ->
       begin match constrain_type_jkind env arg.ctyp_type jkind with
       | Ok () -> ()
-      | Error err -> raise (app_err (Some err))
-      end) arg_tys args
-    | Type _  -> raise (app_err None)
-    | Top -> raise (Error (st.ptyp_loc, env, Unknown_jkind_at_application ty.ctyp_type))
-    end;
+      | Error err ->
+        let arg_infos =
+          List.map (fun a -> (a.ctyp_type, estimate_type_jkind env a.ctyp_type)) arg_tys
+        in
+        raise (Error (
+          styp.ptyp_loc, env,
+          Jkind_mismatch_in_application ((ty.ctyp_type, ty_jkind), arg_infos, Some err)))
+      end) arg_tys arg_ty_jkinds;
     let constr =
       newapp ty.ctyp_type (List.map (fun ctyp -> ctyp.ctyp_type) arg_tys) in
     ctyp (Ttyp_app (ty, arg_tys)) constr
@@ -1065,7 +1105,7 @@ and transl_type_aux_jst_layout env ~policy ~row_context mode attrs loc :
     Ttyp_var (None, Some tjkind_annot),
     TyVarEnv.new_any_var loc env tjkind policy
   | Ltyp_var { name = Some name; jkind } ->
-    transl_type_var env ~policy ~row_context attrs loc name (Some jkind)
+    transl_type_var env ~policy ~jkind_check:Unknown ~row_context attrs loc name (Some jkind)
   | Ltyp_poly { bound_vars; inner_type } ->
     transl_type_poly env ~policy ~row_context mode loc (Either.Right bound_vars)
       inner_type
@@ -1073,7 +1113,7 @@ and transl_type_aux_jst_layout env ~policy ~row_context mode attrs loc :
     transl_type_alias env ~policy ~row_context mode attrs loc aliased_type name
       (Some jkind)
 
-and transl_type_var env ~policy ~row_context attrs loc name jkind_annot_opt =
+and transl_type_var env ~policy ~jkind_check ~row_context attrs loc name jkind_annot_opt =
   let print_name = "'" ^ name in
   if not (valid_tyvar_name name) then
     raise (Error (loc, env, Invalid_variable_name print_name));
@@ -1083,7 +1123,7 @@ and transl_type_var env ~policy ~row_context attrs loc name jkind_annot_opt =
     with Not_found ->
       let jkind =
         try TyVarEnv.lookup_global name |> estimate_type_jkind env
-        with Not_found -> TyVarEnv.new_jkind ~is_named:true policy
+        with Not_found -> TyVarEnv.new_jkind ~is_named:true policy jkind_check
       in
       let ty = TyVarEnv.new_var ~name jkind policy in
       TyVarEnv.remember_used name ty loc;
@@ -1578,16 +1618,18 @@ let report_error env ppf = function
     fprintf ppf "@[<b 2>Bad layout annotation:@ %a@]"
       (Jkind.Violation.report_with_offender
          ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) violation
-  | Jkind_mismatch_in_application (arg_jkinds, app_jkind, _) ->
-    let jkind_format_list =
-      Format.pp_print_list ~pp_sep:(fun ppf () -> Format.fprintf ppf ", ") Jkind.format
-    in
-    fprintf ppf "@[<b 2>Types of jkind (%a) cannot be applied to %a.@]"
-      jkind_format_list arg_jkinds Jkind.format app_jkind
-  | Unknown_jkind_at_application ty ->
-    fprintf ppf "@[<b 2>The type %a is applied,@ \
-                 but its jkind is unknown (presumed top) in this position.@]"
-      Printtyp.type_expr ty
+  | Jkind_mismatch_in_application ((ty, jkind), args, _) ->
+    fprintf ppf "@[<b 2>The type expression (%a : %a)@ cannot be applied to the arguments (%a).@]"
+      Printtyp.type_expr ty Jkind.format jkind
+      (Format.pp_print_list ~pp_sep:(fun ppf () -> Format.fprintf ppf ", ")
+        (fun ppf (arg_ty, arg_jkind) ->
+          fprintf ppf "%a : %a" Printtyp.type_expr arg_ty Jkind.format arg_jkind))
+      args
+  | Bad_jkind_for_application (ty, jkind) ->
+    fprintf ppf "@[<b 2>The type expression (%a : %a)@ \
+                 is applied as a type constructor,@ \
+                 but it is not of a higher jkind.@]"
+      Printtyp.type_expr ty Jkind.format jkind
   | Did_you_mean_unboxed lid ->
     fprintf ppf "@[%a isn't a class type.@ \
                  Did you mean the unboxed type %a#?@]" longident lid longident lid

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -771,7 +771,14 @@ and transl_type_aux env ~row_context ~aliased ~policy ?(jkind_check = Unknown) m
           in
           ctyp (Ttyp_arrow (l, arg_cty, ret_cty)) ty
         | [] ->
-          transl_type env ~policy ~jkind_check:(Exact jkind) ~row_context ret_mode ret
+          let ret_cty =
+            transl_type env ~policy ~jkind_check:(Exact jkind) ~row_context ret_mode ret
+          in
+          (match constrain_type_jkind env ret_cty.ctyp_type jkind with
+          | Ok _ -> ()
+          | Error err ->
+            raise (Error(ret_cty.ctyp_loc, env, Non_sort {vloc = Fun_ret; typ = ret_cty.ctyp_type; err})));
+          ret_cty
       in
       loop mode args
   | Ptyp_tuple stl ->

--- a/ocaml/typing/typetexp.mli
+++ b/ocaml/typing/typetexp.mli
@@ -168,8 +168,8 @@ type error =
   | Non_sort of
       {vloc : sort_loc; typ : type_expr; err : Jkind.Violation.t}
   | Bad_jkind_annot of type_expr * Jkind.Violation.t
-  | Jkind_mismatch_in_application of Jkind.t list * Jkind.t * Jkind.Violation.t option
-  | Unknown_jkind_at_application of type_expr
+  | Jkind_mismatch_in_application of (type_expr * Jkind.t) * (type_expr * Jkind.t) list * Jkind.Violation.t option
+  | Bad_jkind_for_application of type_expr * Jkind.t
   | Did_you_mean_unboxed of Longident.t
   | Invalid_label_for_call_pos of Parsetree.arg_label
 

--- a/ocaml/typing/typetexp.mli
+++ b/ocaml/typing/typetexp.mli
@@ -168,6 +168,7 @@ type error =
   | Non_sort of
       {vloc : sort_loc; typ : type_expr; err : Jkind.Violation.t}
   | Bad_jkind_annot of type_expr * Jkind.Violation.t
+  | Bad_jkind_inference of type_expr * Jkind.Violation.t
   | Jkind_mismatch_in_application of (type_expr * Jkind.t) * (type_expr * Jkind.t) list * Jkind.Violation.t option
   | Bad_jkind_for_application of type_expr * Jkind.t
   | Did_you_mean_unboxed of Longident.t


### PR DESCRIPTION
Extends kind inference in value declarations, where unannotated type variables can have a higher kind inferred based on:
- Application to some arity of arguments, in which case all arguments are assumed to be zeroth-order and representable. For instance, `('a, 'b) 't` infers `'t : (_, _) => ...`, where `_` are sort vars.
- Application as an argument. If `'a 'b` and `'b` has a checked kind `k => k'`, then `'a : k`.
- Application with an expected result. In the above situation `'b` is defaulted to `... => k'`.

The tricky behaviour here is defaulting to the 'representable space' when a known kind is not a subkind of some kind in the representable space, when the jkind initialisation policy (for unannotated type variables) is to default to sort vars. This seemed to be most consistent. 
The rule is: if the policy is `Sort`, then all non-arrow covariant positions in the kind are intersected with a fresh sort var. In particular, as before, an expected `Any` kind is constrained down to a sort var.

Implements and edits some extra tests as less annotations have to be written now.