### PR TITLE
Contravariance in kinds

### DIFF
--- a/ocaml/testsuite/tests/typing-extensions/extensions.ml
+++ b/ocaml/testsuite/tests/typing-extensions/extensions.ml
@@ -358,6 +358,7 @@ module M : sig
 end = struct
   type ('b, 'a) bar = A of 'a
 end;;
+(* CR reisenberg: Similar to an unfortunate change in variants_errors_test.ml. *)
 [%%expect {|
 Lines 3-5, characters 6-3:
 3 | ......struct
@@ -373,10 +374,10 @@ Error: Signature mismatch:
        is not included in
          type ('a, 'b) bar = A of 'a
        Constructors do not match:
-         "A of 'a"
+         "A of 'b"
        is not the same as:
          "A of 'a"
-       The type "'a" is not equal to the type "'b"
+       The type "'b" is not equal to the type "'a"
 |}];;
 
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -246,6 +246,9 @@ Error: Signature mismatch:
          type 'a t = 'a
        is not included in
          type ('a : void) t = 'a
-       The type "('a : value)" is not equal to the type "('a0 : void)"
-       because their layouts are different.
+       The problem is in the kinds of a parameter:
+       The layout of 'a is void, because
+         of the definition of t at line 2, characters 2-25.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 8, characters 2-16.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -247,8 +247,8 @@ Error: Signature mismatch:
        is not included in
          type ('a : void) t = 'a
        The problem is in the kinds of a parameter:
-       The layout of 'a is void, because
-         of the definition of t at line 2, characters 2-25.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 8, characters 2-16.
+       The layout of 'a is void
+         because of the definition of t at line 2, characters 2-25.
+       But the layout of 'a must overlap with value
+         because of the definition of t at line 8, characters 2-16.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -87,9 +87,11 @@ Error: Signature mismatch:
          type 'a t = 'a X.t
        is not included in
          type ('a : value_or_null) t
-       Their parameters differ:
-       The type "('a : value)" is not equal to the type "('a0 : value_or_null)"
-       because their layouts are different.
+       The problem is in the kinds of a parameter:
+       The kind of 'a is value_or_null
+         because of the definition of t at line 1, characters 39-66.
+       But the kind of 'a must be a subkind of value
+         because of the definition of t at line 1, characters 18-27.
 |}]
 
 (* Ttype parameters default to [value] for abstract types with equalities. *)
@@ -111,9 +113,6 @@ Error: This type "t_value_or_null" should be an instance of type "('a : value)"
          because of the definition of t at line 2, characters 2-16.
 |}]
 
-(* CR layouts v3.0: the sublayout check should accept this for backwards
-   compatibility. *)
-
 module M : sig
   type 'a t
 end = struct
@@ -121,22 +120,7 @@ end = struct
 end
 
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type ('a : value_or_null) t = 'a
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type ('a : value_or_null) t = 'a end
-       is not included in
-         sig type 'a t end
-       Type declarations do not match:
-         type ('a : value_or_null) t = 'a
-       is not included in
-         type 'a t
-       Their parameters differ:
-       The type "('a : value_or_null)" is not equal to the type "('a0 : value)"
-       because their layouts are different.
+module M : sig type 'a t end
 |}]
 
 (* Type parameters default to [value] for non-abstract types. *)

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -2073,8 +2073,11 @@ Error: Signature mismatch:
          type 'a t = 'a
        is not included in
          type ('a : any) t = 'a
-       The type "('a : value)" is not equal to the type "('a0 : any)"
-       because their layouts are different.
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-24.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-26.
 |}]
 
 module M3 : sig
@@ -2097,8 +2100,11 @@ Error: Signature mismatch:
          type 'a t = 'a -> 'a
        is not included in
          type ('a : any) t = 'a -> 'a
-       The type "('a : value)" is not equal to the type "('a0 : any)"
-       because their layouts are different.
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-30.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-22.
 |}]
 
 module M4 : sig
@@ -2231,9 +2237,11 @@ Error: Signature mismatch:
          type 'a t = K of ('a -> 'a)
        is not included in
          type ('a : any) t = K of ('a -> 'a)
-       Their parameters differ:
-       The type "('a : value)" is not equal to the type "('a0 : any)"
-       because their layouts are different.
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-37.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-29.
 |}]
 
 module M9 : sig
@@ -2243,24 +2251,8 @@ end = struct
 end
 
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type ('a : any) t = K of ('a -> 'a)
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type ('a : any) t = K of ('a -> 'a) end
-       is not included in
-         sig type 'a t = K of ('a -> 'a) end
-       Type declarations do not match:
-         type ('a : any) t = K of ('a -> 'a)
-       is not included in
-         type 'a t = K of ('a -> 'a)
-       Their parameters differ:
-       The type "('a : any)" is not equal to the type "('a0 : value)"
-       because their layouts are different.
+module M9 : sig type 'a t = K of ('a -> 'a) end
 |}]
-(* CR layouts: This one should be fine to accept *)
 
 (*****************************************************)
 (* Test 38: Ensure Univar unification checks layouts *)

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -2074,10 +2074,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t = 'a
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-24.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-26.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-24.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-26.
 |}]
 
 module M3 : sig
@@ -2101,10 +2101,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t = 'a -> 'a
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-30.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-22.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-30.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-22.
 |}]
 
 module M4 : sig
@@ -2238,10 +2238,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t = K of ('a -> 'a)
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-37.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-29.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-37.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-29.
 |}]
 
 module M9 : sig

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -103,51 +103,18 @@ module type S1_2' = sig type ('a : immediate) t = 'a list end
 module M1_2' : S1_2'
 |}]
 
-(* CR layouts - annoyingly, the immediate annotation on 'a is required.  We
-   can probably relax this so you don't have to label the parameter explcitly
-   and the jkind is determined from the signature.  But we anticipate it'll
-   require non-trivial refactoring of eqtype, so we've put it off for now. *)
 module M1_2'': S1_2' = struct
   type 'a t = 'a list
 end;;
 [%%expect{|
-Lines 1-3, characters 23-3:
-1 | .......................struct
-2 |   type 'a t = 'a list
-3 | end..
-Error: Signature mismatch:
-       Modules do not match:
-         sig type 'a t = 'a list end
-       is not included in
-         S1_2'
-       Type declarations do not match:
-         type 'a t = 'a list
-       is not included in
-         type ('a : immediate) t = 'a list
-       The type "('a : value)" is not equal to the type "('a0 : immediate)"
-       because their layouts are different.
+module M1_2'' : S1_2'
 |}]
 
 module M1_2''' : S1_2 = struct
   type 'a t = 'a list
 end;;
 [%%expect{|
-Lines 1-3, characters 24-3:
-1 | ........................struct
-2 |   type 'a t = 'a list
-3 | end..
-Error: Signature mismatch:
-       Modules do not match:
-         sig type 'a t = 'a list end
-       is not included in
-         S1_2
-       Type declarations do not match:
-         type 'a t = 'a list
-       is not included in
-         type ('a : immediate) t
-       Their parameters differ:
-       The type "('a : value)" is not equal to the type "('a0 : immediate)"
-       because their layouts are different.
+module M1_2''' : S1_2
 |}]
 
 (************************************************************************)
@@ -792,4 +759,679 @@ let m : (module S) =
 
 [%%expect{|
 val m : (module S) = <module>
+|}]
+
+(*********************************************)
+(* Test 13: contravariance of type arguments *)
+
+module M : sig
+  type 'a t
+end = struct
+  type ('a : any) t
+end
+
+[%%expect{|
+module M : sig type 'a t end
+|}]
+
+module M : sig
+  type ('a : any) t
+end = struct
+  type 'a t
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t end
+       is not included in
+         sig type ('a : any) t end
+       Type declarations do not match:
+         type 'a t
+       is not included in
+         type ('a : any) t
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-19.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-11.
+|}]
+
+
+module M : sig
+  type 'a t
+end = struct
+  type ('a : any) t = 'a
+end
+
+[%%expect{|
+module M : sig type 'a t end
+|}]
+
+module M : sig
+  type ('a : any) t
+end = struct
+  type 'a t = 'a
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t = 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a end
+       is not included in
+         sig type ('a : any) t end
+       Type declarations do not match:
+         type 'a t = 'a
+       is not included in
+         type ('a : any) t
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-19.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-16.
+|}]
+
+
+(* this should still fail, in order to remain upstream-compatible *)
+module M : sig
+  type 'a t constraint 'a = int
+end = struct
+  type 'a t
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t end
+       is not included in
+         sig type 'a t constraint 'a = int end
+       Type declarations do not match:
+         type 'a t
+       is not included in
+         type 'a t constraint 'a = int
+       Their parameters differ:
+       The type 'a is not equal to the type int
+|}]
+
+module M : sig
+  type ('a : value) t = 'a
+end = struct
+  type ('a : any) t = 'a
+end
+
+[%%expect {|
+module M : sig type 'a t = 'a end
+|}]
+
+module M : sig
+  type ('a : any) t = 'a
+end = struct
+  type ('a : value) t = 'a
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a : value) t = 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a end
+       is not included in
+         sig type ('a : any) t = 'a end
+       Type declarations do not match:
+         type 'a t = 'a
+       is not included in
+         type ('a : any) t = 'a
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-24.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-26.
+|}]
+
+module M : sig
+  type ('a : value) t2
+  type ('a : value) t = 'a t2
+end = struct
+  type ('a : any) t
+  type ('a : any) t2 = 'a t
+end
+
+[%%expect {|
+module M : sig type 'a t2 type 'a t = 'a t2 end
+|}]
+
+module M : sig
+  type ('a : any) t2
+  type ('a : any) t = 'a t2
+end = struct
+  type ('a : value) t
+  type ('a : value) t2 = 'a t
+end
+
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type ('a : value) t
+6 |   type ('a : value) t2 = 'a t
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t type 'a t2 = 'a t end
+       is not included in
+         sig type ('a : any) t2 type ('a : any) t = 'a t2 end
+       Type declarations do not match:
+         type 'a t2 = 'a t
+       is not included in
+         type ('a : any) t2
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t2 at line 2, characters 2-20.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t2 at line 6, characters 2-29.
+|}]
+
+module M : sig
+  type ('a : value) t = Mk of ('a -> 'a)
+end = struct
+  type ('a : any) t = Mk of ('a -> 'a)
+end
+
+[%%expect {|
+module M : sig type 'a t = Mk of ('a -> 'a) end
+|}]
+
+module M : sig
+  type ('a : any) t = Mk of ('a -> 'a)
+end = struct
+  type ('a : value) t = Mk of ('a -> 'a)
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a : value) t = Mk of ('a -> 'a)
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = Mk of ('a -> 'a) end
+       is not included in
+         sig type ('a : any) t = Mk of ('a -> 'a) end
+       Type declarations do not match:
+         type 'a t = Mk of ('a -> 'a)
+       is not included in
+         type ('a : any) t = Mk of ('a -> 'a)
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-38.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-40.
+|}]
+
+module M : sig
+  type ('a : value) t = { x : 'a -> 'a }
+end = struct
+  type ('a : any) t = { x : 'a -> 'a }
+end
+
+[%%expect {|
+module M : sig type 'a t = { x : 'a -> 'a; } end
+|}]
+
+module M : sig
+  type ('a : any) t = { x : 'a -> 'a }
+end = struct
+  type ('a : value) t = { x : 'a -> 'a }
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a : value) t = { x : 'a -> 'a }
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = { x : 'a -> 'a; } end
+       is not included in
+         sig type ('a : any) t = { x : 'a -> 'a; } end
+       Type declarations do not match:
+         type 'a t = { x : 'a -> 'a; }
+       is not included in
+         type ('a : any) t = { x : 'a -> 'a; }
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-38.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-40.
+|}]
+
+module M : sig
+  type ('a : value) t = Mk of { x : 'a -> 'a }
+end = struct
+  type ('a : any) t = Mk of { x : 'a -> 'a }
+end
+
+[%%expect {|
+module M : sig type 'a t = Mk of { x : 'a -> 'a; } end
+|}]
+
+module M : sig
+  type ('a : any) t = Mk of { x : 'a -> 'a }
+end = struct
+  type ('a : value) t = Mk of { x : 'a -> 'a }
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a : value) t = Mk of { x : 'a -> 'a }
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = Mk of { x : 'a -> 'a; } end
+       is not included in
+         sig type ('a : any) t = Mk of { x : 'a -> 'a; } end
+       Type declarations do not match:
+         type 'a t = Mk of { x : 'a -> 'a; }
+       is not included in
+         type ('a : any) t = Mk of { x : 'a -> 'a; }
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-44.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-46.
+|}]
+
+module M : sig
+  type _ t = Mk : 'a. 'a -> 'a t
+end = struct
+  type (_ : any) t = Mk : 'a. 'a -> 'a t
+end
+
+[%%expect {|
+module M : sig type _ t = Mk : 'a -> 'a t end
+|}]
+
+module M : sig
+  type (_ : any) t = Mk : 'a. 'a -> 'a t
+end = struct
+  type _ t = Mk : 'a. 'a -> 'a t
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type _ t = Mk : 'a. 'a -> 'a t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type _ t = Mk : 'a -> 'a t end
+       is not included in
+         sig type (_ : any) t = Mk : 'a -> 'a t end
+       Type declarations do not match:
+         type _ t = Mk : 'a -> 'a t
+       is not included in
+         type (_ : any) t = Mk : 'a -> 'a t
+       The problem is in the kinds of a parameter:
+       The layout of '_ is any, because
+         of the definition of t at line 2, characters 2-40.
+       But the layout of '_ must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-32.
+|}]
+
+module M : sig
+  type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t
+end = struct
+  type (_ : any) t = Mk : ('a : value). 'a -> 'a t
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type (_ : any) t = Mk : ('a : value). 'a -> 'a t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type (_ : any) t = Mk : 'a -> 'a t end
+       is not included in
+         sig type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t end
+       Type declarations do not match:
+         type (_ : any) t = Mk : 'a -> 'a t
+       is not included in
+         type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t
+       Constructors do not match:
+         Mk : 'a -> 'a t
+       is not the same as:
+         Mk : ('a : immediate). 'a -> 'a t
+       The type 'a t is not equal to the type 'a0 t
+       because the layouts of their variables are different.
+       The layout of 'a is value, because
+         of the definition of t at line 4, characters 2-50.
+       The layout of 'a0 is immediate, because
+         of the definition of t at line 2, characters 2-54.
+|}]
+
+module M : sig
+  type (_ : any) t = Mk : ('a : value). 'a -> 'a t
+end = struct
+  type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t end
+       is not included in
+         sig type (_ : any) t = Mk : 'a -> 'a t end
+       Type declarations do not match:
+         type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t
+       is not included in
+         type (_ : any) t = Mk : 'a -> 'a t
+       Constructors do not match:
+         Mk : ('a : immediate). 'a -> 'a t
+       is not the same as:
+         Mk : 'a -> 'a t
+       The type 'a t is not equal to the type 'a0 t
+       because the layouts of their variables are different.
+       The layout of 'a is immediate, because
+         of the definition of t at line 4, characters 2-54.
+       The layout of 'a0 is value, because
+         of the definition of t at line 2, characters 2-50.
+|}]
+
+module M : sig
+  type (_ : any) t = Mk : ('a : value). 'a -> 'a t
+end = struct
+  type (_ : any) t = Mk : ('a : value). 'a -> 'a t
+end
+
+[%%expect {|
+module M : sig type (_ : any) t = Mk : 'a -> 'a t end
+|}]
+
+module M : sig
+  type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t
+end = struct
+  type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t
+end
+
+[%%expect {|
+module M : sig type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t end
+|}]
+
+module M : sig
+  type t = Mk : ('a : any). ('a -> 'a) -> t
+end = struct
+  type t = Mk : ('a : any). ('a -> 'a) -> t
+end
+
+[%%expect {|
+module M : sig type t = Mk : ('a : any). ('a -> 'a) -> t end
+|}]
+
+module M : sig
+  type t = Mk : ('a : value). ('a -> 'a) -> t
+end = struct
+  type t = Mk : ('a : any). ('a -> 'a) -> t
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = Mk : ('a : any). ('a -> 'a) -> t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Mk : ('a : any). ('a -> 'a) -> t end
+       is not included in
+         sig type t = Mk : ('a -> 'a) -> t end
+       Type declarations do not match:
+         type t = Mk : ('a : any). ('a -> 'a) -> t
+       is not included in
+         type t = Mk : ('a -> 'a) -> t
+       Constructors do not match:
+         Mk : ('a : any). ('a -> 'a) -> t
+       is not the same as:
+         Mk : ('a -> 'a) -> t
+       The type 'a -> 'a is not equal to the type 'a0 -> 'a0
+       because the layouts of their variables are different.
+       The layout of 'a is any, because
+         of the definition of t at line 4, characters 2-43.
+       The layout of 'a0 is value, because
+         of the definition of t at line 2, characters 2-45.
+|}]
+
+module M : sig
+  type t = Mk : ('a : any). ('a -> 'a) -> t
+end = struct
+  type t = Mk : ('a : value). ('a -> 'a) -> t
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = Mk : ('a : value). ('a -> 'a) -> t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Mk : ('a -> 'a) -> t end
+       is not included in
+         sig type t = Mk : ('a : any). ('a -> 'a) -> t end
+       Type declarations do not match:
+         type t = Mk : ('a -> 'a) -> t
+       is not included in
+         type t = Mk : ('a : any). ('a -> 'a) -> t
+       Constructors do not match:
+         Mk : ('a -> 'a) -> t
+       is not the same as:
+         Mk : ('a : any). ('a -> 'a) -> t
+       The type 'a -> 'a is not equal to the type 'a0 -> 'a0
+       because the layouts of their variables are different.
+       The layout of 'a is value, because
+         of the definition of t at line 4, characters 2-45.
+       The layout of 'a0 is any, because
+         of the definition of t at line 2, characters 2-43.
+|}]
+
+module M : sig
+  type t = Mk : ('a : value). ('a -> 'a) -> t
+end = struct
+  type t = Mk : ('a : value). ('a -> 'a) -> t
+end
+
+[%%expect {|
+module M : sig type t = Mk : ('a -> 'a) -> t end
+|}]
+
+(* This would be safe to accept. *)
+module M : sig
+  type 'a t constraint 'a = ('b : immediate) -> ('c : immediate)
+end = struct
+  type 'a t constraint 'a = ('b : value) -> ('c : value)
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t constraint 'a = ('b : value) -> ('c : value)
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t constraint 'a = 'b -> 'c end
+       is not included in
+         sig type 'a t constraint 'a = 'b -> 'c end
+       Type declarations do not match:
+         type 'a t constraint 'a = 'b -> 'c
+       is not included in
+         type 'a t constraint 'a = 'b -> 'c
+       Their parameters differ:
+       The type 'b -> 'c is not equal to the type 'b0 -> 'c0
+       because the layouts of their variables are different.
+       The layout of 'b is value, because
+         of the definition of t at line 4, characters 2-56.
+       The layout of 'b0 is immediate, because
+         of the definition of t at line 2, characters 2-64.
+|}]
+
+module M : sig
+  type 'a t constraint 'a = ('b : value) -> ('c : value)
+end = struct
+  type 'a t constraint 'a = ('b : immediate) -> ('c : immediate)
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t constraint 'a = ('b : immediate) -> ('c : immediate)
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t constraint 'a = 'b -> 'c end
+       is not included in
+         sig type 'a t constraint 'a = 'b -> 'c end
+       Type declarations do not match:
+         type 'a t constraint 'a = 'b -> 'c
+       is not included in
+         type 'a t constraint 'a = 'b -> 'c
+       Their parameters differ:
+       The type 'b -> 'c is not equal to the type 'b0 -> 'c0
+       because the layouts of their variables are different.
+       The layout of 'b is immediate, because
+         of the definition of t at line 4, characters 2-64.
+       The layout of 'b0 is value, because
+         of the definition of t at line 2, characters 2-56.
+|}]
+
+module M : sig
+  type ('a : value) t = private 'a
+end = struct
+  type ('a : any) t = 'a
+end
+
+[%%expect {|
+module M : sig type 'a t = private 'a end
+|}]
+
+module M : sig
+  type ('a : any) t = private 'a
+end = struct
+  type ('a : value) t = 'a
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a : value) t = 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a end
+       is not included in
+         sig type ('a : any) t = private 'a end
+       Type declarations do not match:
+         type 'a t = 'a
+       is not included in
+         type ('a : any) t = private 'a
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-32.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-26.
+|}]
+
+module M : sig
+  type ('a : value) t = private 'a
+end = struct
+  type ('a : any) t = private 'a
+end
+
+[%%expect {|
+module M : sig type 'a t = private 'a end
+|}]
+
+module M : sig
+  type ('a : any) t = private 'a
+end = struct
+  type ('a : value) t = private 'a
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a : value) t = private 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = private 'a end
+       is not included in
+         sig type ('a : any) t = private 'a end
+       Type declarations do not match:
+         type 'a t = private 'a
+       is not included in
+         type ('a : any) t = private 'a
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-32.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-34.
+|}]
+
+type ('a : any) iddy = private 'a
+
+[%%expect {|
+type ('a : any) iddy = private 'a
+|}]
+
+module M : sig
+  type ('a : value) t = private 'a
+end = struct
+  type ('a : any) t = 'a iddy
+end
+
+[%%expect {|
+module M : sig type 'a t = private 'a end
+|}]
+
+module M : sig
+  type ('a : any) t = private 'a iddy
+end = struct
+  type ('a : value) t = 'a
+end
+
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a : value) t = 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a end
+       is not included in
+         sig type ('a : any) t = private 'a iddy end
+       Type declarations do not match:
+         type 'a t = 'a
+       is not included in
+         type ('a : any) t = private 'a iddy
+       The problem is in the kinds of a parameter:
+       The layout of 'a is any, because
+         of the definition of t at line 2, characters 2-37.
+       But the layout of 'a must be a sublayout of value, because
+         of the definition of t at line 4, characters 2-26.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -1410,28 +1410,28 @@ module M : sig type 'a t = private 'a end
 |}]
 
 module M : sig
-  type ('a : any) t = private 'a iddy
+  type ('a : any) t = private 'a
 end = struct
-  type ('a : value) t = 'a
+  type ('a : value) t = 'a iddy
 end
 
 [%%expect {|
 Lines 3-5, characters 6-3:
 3 | ......struct
-4 |   type ('a : value) t = 'a
+4 |   type ('a : value) t = 'a iddy
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type 'a t = 'a end
+         sig type 'a t = 'a iddy end
        is not included in
-         sig type ('a : any) t = private 'a iddy end
+         sig type ('a : any) t = private 'a end
        Type declarations do not match:
-         type 'a t = 'a
+         type 'a t = 'a iddy
        is not included in
-         type ('a : any) t = private 'a iddy
+         type ('a : any) t = private 'a
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-37.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-26.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-32.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-31.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -69,7 +69,7 @@ Line 1, characters 34-36:
 1 | module type S1f'' = S1f with type 'a t = 'a list;;
                                       ^^
 Error: The type constraints are not consistent.
-       Type "('a : value)" is not compatible with type "('b : float64)"
+       Type "('a : value)" is not compatible with type "('a0 : float64)"
        The layout of 'a is float64
          because of the definition of t at line 2, characters 2-23.
        But the layout of 'a must overlap with value

--- a/ocaml/testsuite/tests/typing-layouts/modules.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules.ml
@@ -795,10 +795,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-19.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-11.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-19.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-11.
 |}]
 
 
@@ -833,10 +833,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-19.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-16.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-19.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-16.
 |}]
 
 
@@ -862,7 +862,7 @@ Error: Signature mismatch:
        is not included in
          type 'a t constraint 'a = int
        Their parameters differ:
-       The type 'a is not equal to the type int
+       The type "'a" is not equal to the type "int"
 |}]
 
 module M : sig
@@ -896,10 +896,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t = 'a
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-24.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-26.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-24.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-26.
 |}]
 
 module M : sig
@@ -938,10 +938,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t2
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t2 at line 2, characters 2-20.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t2 at line 6, characters 2-29.
+       The layout of 'a is any
+         because of the definition of t2 at line 2, characters 2-20.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t2 at line 6, characters 2-29.
 |}]
 
 module M : sig
@@ -975,10 +975,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t = Mk of ('a -> 'a)
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-38.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-40.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-38.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-40.
 |}]
 
 module M : sig
@@ -1012,10 +1012,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t = { x : 'a -> 'a; }
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-38.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-40.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-38.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-40.
 |}]
 
 module M : sig
@@ -1049,10 +1049,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t = Mk of { x : 'a -> 'a; }
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-44.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-46.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-44.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-46.
 |}]
 
 module M : sig
@@ -1086,10 +1086,10 @@ Error: Signature mismatch:
        is not included in
          type (_ : any) t = Mk : 'a -> 'a t
        The problem is in the kinds of a parameter:
-       The layout of '_ is any, because
-         of the definition of t at line 2, characters 2-40.
-       But the layout of '_ must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-32.
+       The layout of _ is any
+         because of the definition of t at line 2, characters 2-40.
+       But the layout of _ must be a sublayout of value
+         because of the definition of t at line 4, characters 2-32.
 |}]
 
 module M : sig
@@ -1113,15 +1113,15 @@ Error: Signature mismatch:
        is not included in
          type (_ : any) t = Mk : ('a : immediate). 'a -> 'a t
        Constructors do not match:
-         Mk : 'a -> 'a t
+         "Mk : 'a -> 'a t"
        is not the same as:
-         Mk : ('a : immediate). 'a -> 'a t
-       The type 'a t is not equal to the type 'a0 t
+         "Mk : ('a : immediate). 'a -> 'a t"
+       The type "'a t" is not equal to the type "'a0 t"
        because the layouts of their variables are different.
-       The layout of 'a is value, because
-         of the definition of t at line 4, characters 2-50.
-       The layout of 'a0 is immediate, because
-         of the definition of t at line 2, characters 2-54.
+       The layout of 'a is value
+         because of the definition of t at line 4, characters 2-50.
+       The layout of 'a0 is immediate
+         because of the definition of t at line 2, characters 2-54.
 |}]
 
 module M : sig
@@ -1145,15 +1145,15 @@ Error: Signature mismatch:
        is not included in
          type (_ : any) t = Mk : 'a -> 'a t
        Constructors do not match:
-         Mk : ('a : immediate). 'a -> 'a t
+         "Mk : ('a : immediate). 'a -> 'a t"
        is not the same as:
-         Mk : 'a -> 'a t
-       The type 'a t is not equal to the type 'a0 t
+         "Mk : 'a -> 'a t"
+       The type "'a t" is not equal to the type "'a0 t"
        because the layouts of their variables are different.
-       The layout of 'a is immediate, because
-         of the definition of t at line 4, characters 2-54.
-       The layout of 'a0 is value, because
-         of the definition of t at line 2, characters 2-50.
+       The layout of 'a is immediate
+         because of the definition of t at line 4, characters 2-54.
+       The layout of 'a0 is value
+         because of the definition of t at line 2, characters 2-50.
 |}]
 
 module M : sig
@@ -1207,15 +1207,15 @@ Error: Signature mismatch:
        is not included in
          type t = Mk : ('a -> 'a) -> t
        Constructors do not match:
-         Mk : ('a : any). ('a -> 'a) -> t
+         "Mk : ('a : any). ('a -> 'a) -> t"
        is not the same as:
-         Mk : ('a -> 'a) -> t
-       The type 'a -> 'a is not equal to the type 'a0 -> 'a0
+         "Mk : ('a -> 'a) -> t"
+       The type "'a -> 'a" is not equal to the type "'a0 -> 'a0"
        because the layouts of their variables are different.
-       The layout of 'a is any, because
-         of the definition of t at line 4, characters 2-43.
-       The layout of 'a0 is value, because
-         of the definition of t at line 2, characters 2-45.
+       The layout of 'a is any
+         because of the definition of t at line 4, characters 2-43.
+       The layout of 'a0 is value
+         because of the definition of t at line 2, characters 2-45.
 |}]
 
 module M : sig
@@ -1239,15 +1239,15 @@ Error: Signature mismatch:
        is not included in
          type t = Mk : ('a : any). ('a -> 'a) -> t
        Constructors do not match:
-         Mk : ('a -> 'a) -> t
+         "Mk : ('a -> 'a) -> t"
        is not the same as:
-         Mk : ('a : any). ('a -> 'a) -> t
-       The type 'a -> 'a is not equal to the type 'a0 -> 'a0
+         "Mk : ('a : any). ('a -> 'a) -> t"
+       The type "'a -> 'a" is not equal to the type "'a0 -> 'a0"
        because the layouts of their variables are different.
-       The layout of 'a is value, because
-         of the definition of t at line 4, characters 2-45.
-       The layout of 'a0 is any, because
-         of the definition of t at line 2, characters 2-43.
+       The layout of 'a is value
+         because of the definition of t at line 4, characters 2-45.
+       The layout of 'a0 is any
+         because of the definition of t at line 2, characters 2-43.
 |}]
 
 module M : sig
@@ -1282,12 +1282,12 @@ Error: Signature mismatch:
        is not included in
          type 'a t constraint 'a = 'b -> 'c
        Their parameters differ:
-       The type 'b -> 'c is not equal to the type 'b0 -> 'c0
+       The type "'b -> 'c" is not equal to the type "'b0 -> 'c0"
        because the layouts of their variables are different.
-       The layout of 'b is value, because
-         of the definition of t at line 4, characters 2-56.
-       The layout of 'b0 is immediate, because
-         of the definition of t at line 2, characters 2-64.
+       The layout of 'b is value
+         because of the definition of t at line 4, characters 2-56.
+       The layout of 'b0 is immediate
+         because of the definition of t at line 2, characters 2-64.
 |}]
 
 module M : sig
@@ -1311,12 +1311,12 @@ Error: Signature mismatch:
        is not included in
          type 'a t constraint 'a = 'b -> 'c
        Their parameters differ:
-       The type 'b -> 'c is not equal to the type 'b0 -> 'c0
+       The type "'b -> 'c" is not equal to the type "'b0 -> 'c0"
        because the layouts of their variables are different.
-       The layout of 'b is immediate, because
-         of the definition of t at line 4, characters 2-64.
-       The layout of 'b0 is value, because
-         of the definition of t at line 2, characters 2-56.
+       The layout of 'b is immediate
+         because of the definition of t at line 4, characters 2-64.
+       The layout of 'b0 is value
+         because of the definition of t at line 2, characters 2-56.
 |}]
 
 module M : sig
@@ -1350,10 +1350,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t = private 'a
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-32.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-26.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-32.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-26.
 |}]
 
 module M : sig
@@ -1387,10 +1387,10 @@ Error: Signature mismatch:
        is not included in
          type ('a : any) t = private 'a
        The problem is in the kinds of a parameter:
-       The layout of 'a is any, because
-         of the definition of t at line 2, characters 2-32.
-       But the layout of 'a must be a sublayout of value, because
-         of the definition of t at line 4, characters 2-34.
+       The layout of 'a is any
+         because of the definition of t at line 2, characters 2-32.
+       But the layout of 'a must be a sublayout of value
+         because of the definition of t at line 4, characters 2-34.
 |}]
 
 type ('a : any) iddy = private 'a

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -70,29 +70,11 @@ module type S1_2' = sig type ('a : immediate) t = 'a list end
 module M1_2' : S1_2'
 |}]
 
-(* CR layouts - annoyingly, the immediate annotation on 'a is required.  We
-   can probably relax this so you don't have to label the parameter explcitly
-   and the jkind is determined from the signature.  But we anticipate it'll
-   require non-trivial refactoring of eqtype, so we've put it off for now. *)
 module M1_2'': S1_2' = struct
   type 'a t = 'a list
 end;;
 [%%expect{|
-Lines 1-3, characters 23-3:
-1 | .......................struct
-2 |   type 'a t = 'a list
-3 | end..
-Error: Signature mismatch:
-       Modules do not match:
-         sig type 'a t = 'a list end
-       is not included in
-         S1_2'
-       Type declarations do not match:
-         type 'a t = 'a list
-       is not included in
-         type ('a : immediate) t = 'a list
-       The type "('a : value)" is not equal to the type "('a0 : immediate)"
-       because their layouts are different.
+module M1_2'' : S1_2'
 |}]
 
 (************************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -36,7 +36,7 @@ Line 1, characters 32-34:
 1 | module type S1'' = S1 with type 'a t = 'a list;;
                                     ^^
 Error: The type constraints are not consistent.
-       Type "('a : value)" is not compatible with type "('b : void)"
+       Type "('a : value)" is not compatible with type "('a0 : void)"
        The layout of 'a is void
          because of the definition of t at line 10, characters 2-20.
        But the layout of 'a must overlap with value

--- a/ocaml/testsuite/tests/typing-misc/enrich_typedecl.ml
+++ b/ocaml/testsuite/tests/typing-misc/enrich_typedecl.ml
@@ -160,6 +160,7 @@ Error: Signature mismatch:
          type 'a t = 'a E.t = A of 'a | B
        is not included in
          type 'a t = 'a constraint 'a = [> `Foo ]
+       Their parameters differ:
        The type "'a" is not equal to the type "[> `Foo ]"
 |}];;
 
@@ -224,6 +225,7 @@ Error: Signature mismatch:
          type 'a t = 'a E3.t = A of 'a | B
        is not included in
          type 'a t = 'a constraint 'a = [< `Foo ]
+       Their parameters differ:
        The type "'a" is not equal to the type "[< `Foo ]"
 |}];;
 

--- a/ocaml/testsuite/tests/typing-misc/polyvars.ml
+++ b/ocaml/testsuite/tests/typing-misc/polyvars.ml
@@ -130,11 +130,14 @@ Error: The type "'a" does not expand to a polymorphic variant type
 Hint: Did you mean "`a"?
 |}]
 
+(* CR reisenberg: This test is disabled. It only barely works in `main`
+   anyway, as evidenced by https://github.com/ocaml/ocaml/issues/13369
 (* PR#5927 *)
 type 'a foo = 'a constraint 'a = [< `Tag of & int];;
 [%%expect{|
 type 'a foo = 'a constraint 'a = [< `Tag of & int ]
 |}]
+*)
 
 (* PR#7704 *)
 type t = private [> `A of string ];;

--- a/ocaml/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/ocaml/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -56,6 +56,8 @@ module M: sig
 end = struct
   type ('b,'c,'a) t = ('b * 'c * 'a * 'c * 'a) x
 end
+(* CR reisenberg: The change here is like a change in variants_errors_test.
+   Comment over there. *)
 [%%expect{|
 type 'a x
 Lines 4-6, characters 6-3:
@@ -71,9 +73,9 @@ Error: Signature mismatch:
          type ('b, 'c, 'a) t = ('b * 'c * 'a * 'c * 'a) x
        is not included in
          type ('a, 'b, 'c) t = ('a * 'b * 'c * 'b * 'a) x
-       The type "('b * 'c * 'a * 'c * 'a) x" is not equal to the type
-         "('b * 'c * 'a * 'c * 'b) x"
-       Type "'a" is not equal to type "'b"
+       The type "('a * 'b * 'c * 'b * 'c) x" is not equal to the type
+         "('a * 'b * 'c * 'b * 'a) x"
+       Type "'c" is not equal to type "'a"
 |}]
 
 module M : sig
@@ -427,6 +429,7 @@ Error: Signature mismatch:
          type 'a t = 'a constraint 'a = [> `A of int ]
        is not included in
          type 'a t = 'a constraint 'a = [> `A of int | `B of int ]
+       Their parameters differ:
        The type "[> `A of int ]" is not equal to the type
          "[> `A of int | `B of int ]"
        The first variant type does not allow tag(s) "`B"
@@ -451,6 +454,7 @@ Error: Signature mismatch:
          type 'a t = 'a constraint 'a = [> `A of int | `C of float ]
        is not included in
          type 'a t = 'a constraint 'a = [> `A of int ]
+       Their parameters differ:
        The type "[> `A of int | `C of float ]" is not equal to the type
          "[> `A of int ]"
        The second variant type does not allow tag(s) "`C"

--- a/ocaml/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/ocaml/testsuite/tests/typing-modules/merge_constraint.ml
@@ -95,7 +95,7 @@ module UnboxedEnv :
         module type ReboundSig =
           sig
             type 'a ind = 'a ind
-            type t = t/2 = T : 'a ind -> t/1 [@@unboxed]
+            type t = t/2 = T : 'e ind -> t/1 [@@unboxed]
           end
       end
   end

--- a/ocaml/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/ocaml/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -182,6 +182,8 @@ module M : sig
 end = struct
   type ('b, 'a) t = A of 'a
 end;;
+(* CR reisenberg: This error message change is unfortunate. But so
+   is the original error message! Not quite sure what to do here. *)
 [%%expect {|
 Lines 3-5, characters 6-3:
 3 | ......struct
@@ -197,10 +199,10 @@ Error: Signature mismatch:
        is not included in
          type ('a, 'b) t = A of 'a
        Constructors do not match:
-         "A of 'a"
+         "A of 'b"
        is not the same as:
          "A of 'a"
-       The type "'a" is not equal to the type "'b"
+       The type "'b" is not equal to the type "'a"
 |}];;
 
 

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -1490,9 +1490,10 @@ let map_kind f = function
 
 let instance_declaration decl =
   For_copy.with_scope (fun copy_scope ->
-    {decl with type_params = List.map (copy copy_scope) decl.type_params;
-     type_manifest = Option.map (copy copy_scope) decl.type_manifest;
-     type_kind = map_kind (copy copy_scope) decl.type_kind;
+    let copy = copy ~keep_names:true copy_scope in
+    {decl with type_params = List.map copy decl.type_params;
+     type_manifest = Option.map copy decl.type_manifest;
+     type_kind = map_kind copy decl.type_kind;
     }
   )
 

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -5126,7 +5126,7 @@ let rec rigidify_rec vars ty =
     end
 
 type var = { name : string option
-           ; original_jkind : Jkind.t
+           ; original_jkind : jkind_lr
            ; ty : type_expr }
 
 type t = var list

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -395,17 +395,16 @@ type class_match_failure =
 val match_class_types:
     ?trace:bool -> Env.t -> class_type -> class_type -> class_match_failure list
         (* Check if the first class type is more general than the second. *)
-val equal: Env.t -> bool -> type_expr list -> type_expr list -> unit
+val equal: ?do_jkind_check:bool ->
+  Env.t -> bool -> type_expr list -> type_expr list -> unit
         (* [equal env [x1...xn] tau [y1...yn] sigma]
            checks whether the parameterized types
            [/\x1.../\xn.tau] and [/\y1.../\yn.sigma] are equivalent. *)
 val is_equal : Env.t -> bool -> type_expr list -> type_expr list -> bool
-val equal_private :
-        Env.t -> type_expr list -> type_expr ->
-        type_expr list -> type_expr -> unit
-(* [equal_private env t1 params1 t2 params2] checks that [t1::params1]
-   equals [t2::params2] but it is allowed to expand [t1] if it is a
-   private abbreviations. *)
+val equal_private : Env.t -> type_expr -> type_expr -> unit
+(* [equal_private env t1 t2] checks that [t1] equals [t2] but it is allowed to
+   expand [t1] if it is a private abbreviation. No renaming is allowed, but
+   jkinds are checked. *)
 
 val match_class_declarations:
         Env.t -> type_expr list -> class_type -> type_expr list ->
@@ -419,6 +418,35 @@ val subtype: Env.t -> type_expr -> type_expr -> unit -> unit
            It accumulates the constraints the type variables must
            enforce and returns a function that enforces this
            constraints. *)
+
+(* This module allows a type to become "rigid": after unifying such a type,
+   we can check to see whether any of its variables were unified, issuing
+   an error in such a case. *)
+module Rigidify : sig
+  type t
+
+  type matches_result =
+    (* A variable with name [name] has been unified with a type [ty]. *)
+    | Unification_failure of
+        { name : string option
+        ; ty : type_expr }
+
+    (* A variable [ty] started with an [original_jkind] but now has a
+       [inferred_jkind]. *)
+    | Jkind_mismatch of
+        { original_jkind : jkind; inferred_jkind : jkind; ty : type_expr }
+
+    (* No problems *)
+    | All_good
+
+  (* Mark all the variables in the types given as rigid; these will be tracked
+     for unification. Every call to this function should be paired with a call
+     to [all_distinct_vars_with_original_jkinds]. *)
+  val rigidify_list : type_expr list -> t
+
+  (* Check that no variables in a [t] have actually been unified. *)
+  val all_distinct_vars_with_original_jkinds : Env.t -> t -> matches_result
+end
 
 (* Operations on class signatures *)
 

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -434,7 +434,7 @@ module Rigidify : sig
     (* A variable [ty] started with an [original_jkind] but now has a
        [inferred_jkind]. *)
     | Jkind_mismatch of
-        { original_jkind : jkind; inferred_jkind : jkind; ty : type_expr }
+        { original_jkind : jkind_lr; inferred_jkind : jkind_lr; ty : type_expr }
 
     (* No problems *)
     | All_good

--- a/ocaml/typing/errortrace.ml
+++ b/ocaml/typing/errortrace.ml
@@ -112,7 +112,6 @@ type ('a, 'variety) elt =
   | Bad_jkind_sort : type_expr * Jkind.Violation.t -> ('a, _) elt
   | Unequal_var_jkinds :
       type_expr * jkind_lr * type_expr * jkind_lr -> ('a, _) elt
-  | Unequal_var_jkinds_with_no_history
 
 type ('a, 'variety) t = ('a, 'variety) elt list
 
@@ -129,7 +128,6 @@ let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
   | Bad_jkind _ as x -> x
   | Bad_jkind_sort _ as x -> x
   | Unequal_var_jkinds _ as x -> x
-  | Unequal_var_jkinds_with_no_history as x -> x
 
 let map f t = List.map (map_elt f) t
 

--- a/ocaml/typing/errortrace.mli
+++ b/ocaml/typing/errortrace.mli
@@ -97,7 +97,6 @@ type ('a, 'variety) elt =
   | Bad_jkind_sort : type_expr * Jkind.Violation.t -> ('a, _) elt
   | Unequal_var_jkinds :
       type_expr * jkind_lr * type_expr * jkind_lr -> ('a, _) elt
-  | Unequal_var_jkinds_with_no_history
 
 type ('a, 'variety) t = ('a, 'variety) elt list
 

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -1318,7 +1318,8 @@ let type_declarations ?(equality = false) ~loc env ~mark name
   | Jkind_mismatch { original_jkind; inferred_jkind; ty } ->
      Some (Parameter_jkind
              (ty, Jkind.Violation.of_
-                    (Not_a_subjkind (original_jkind, inferred_jkind))))
+                    (Not_a_subjkind (Jkind.disallow_right original_jkind,
+                                     Jkind.disallow_left inferred_jkind))))
   | All_good ->
   let abstr = Btype.type_kind_is_abstract decl2 && decl2.type_manifest = None in
   let need_variance =

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -256,6 +256,7 @@ type type_mismatch =
   | Kind of kind_mismatch
   | Constraint of Errortrace.equality_error
   | Manifest of Errortrace.equality_error
+  | Parameter_jkind of type_expr * Jkind.Violation.t
   | Private_variant of type_expr * type_expr * private_variant_mismatch
   | Private_object of type_expr * type_expr * private_object_mismatch
   | Variance
@@ -555,6 +556,10 @@ let report_type_mismatch first second decl env ppf err =
       report_type_inequality env ppf err
   | Manifest err ->
       report_type_inequality env ppf err
+  | Parameter_jkind (ty, v) ->
+      pr "The problem is in the kinds of a parameter:@,";
+      Jkind.Violation.report_with_offender
+        ~offender:(fun pp -> Printtyp.type_expr pp ty) ppf v
   | Private_variant (_ty1, _ty2, mismatch) ->
       report_private_variant_mismatch first second decl env ppf mismatch
   | Private_object (_ty1, _ty2, mismatch) ->
@@ -607,6 +612,8 @@ module Record_diffing = struct
             let tl1 = params1 @ [ld1.ld_type] in
             let tl2 = params2 @ [ld2.ld_type] in
             begin
+            (* Allow renaming: this gets called for inline records in GADT
+               constructors that may have existentials. *)
             match Ctype.equal env true tl1 tl2 with
             | exception Ctype.Equality err ->
                 Some (Type err : label_mismatch)
@@ -796,6 +803,9 @@ module Variant_diffing = struct
           and arg2_tys, arg2_gfs = List.split (List.map type_and_mode arg2)
           in
           (* Ctype.equal must be called on all arguments at once, cf. PR#7378 *)
+          (* Allow renaming: in the GADT case, these arguments are distinct from
+             type parameters (which have been unified). See also
+             Note [Contravariance of type parameter jkinds]. *)
           match Ctype.equal env true (params1 @ arg1_tys) (params2 @ arg2_tys) with
           | exception Ctype.Equality err -> Some (Type err)
           | () -> List.combine arg1_gfs arg2_gfs
@@ -813,8 +823,13 @@ module Variant_diffing = struct
   let compare_constructors ~loc env params1 params2 res1 res2 args1 args2 =
     match res1, res2 with
     | Some r1, Some r2 ->
+        (* Allow renaming here: variables in GADT-syntax constructors are
+           distinct from the variables in type parameters *)
         begin match Ctype.equal env true [r1] [r2] with
         | exception Ctype.Equality err -> Some (Type err)
+              (* Pass the result types in this call to
+                 [compare_constructor_arguments], so that the call to [Ctype.equal]
+                 can see the entire scope of the variables *)
         | () -> compare_constructor_arguments ~loc env [r1] [r2] args1 args2
         end
     | Some _, None -> Some (Explicit_return_type First)
@@ -958,7 +973,7 @@ let privacy_mismatch env decl1 decl2 =
   | _, _ ->
       None
 
-let private_variant env row1 params1 row2 params2 =
+let private_variant env row1 row2 =
     let r1, r2, pairs =
       Ctype.merge_row_fields (row_fields row1) (row_fields row2)
     in
@@ -991,7 +1006,7 @@ let private_variant env row1 params1 row2 params2 =
     let rec loop tl1 tl2 pairs =
       match pairs with
       | [] -> begin
-          match Ctype.equal env true tl1 tl2 with
+          match Ctype.equal env false tl1 tl2 with
           | exception Ctype.Equality err ->
               Some (Types err : private_variant_mismatch)
           | () -> None
@@ -1030,9 +1045,9 @@ let private_variant env row1 params1 row2 params2 =
               Some (Missing (First, s) : private_variant_mismatch)
         end
     in
-    loop params1 params2 pairs
+    loop [] [] pairs
 
-let private_object env fields1 params1 fields2 params2 =
+let private_object env fields1 fields2 =
   let pairs, _miss1, miss2 = Ctype.associate_fields fields1 fields2 in
   let err =
     match miss2 with
@@ -1044,18 +1059,18 @@ let private_object env fields1 params1 fields2 params2 =
     List.split (List.map (fun (_,_,t1,_,t2) -> t1, t2) pairs)
   in
   begin
-    match Ctype.equal env true (params1 @ tl1) (params2 @ tl2) with
+    match Ctype.equal env false tl1 tl2 with
     | exception Ctype.Equality err -> Some (Types err)
     | () -> None
   end
 
-let type_manifest env ty1 params1 ty2 params2 priv2 kind2 =
+let type_manifest env ty1 ty2 priv2 kind2 =
   let ty1' = Ctype.expand_head env ty1 and ty2' = Ctype.expand_head env ty2 in
   match get_desc ty1', get_desc ty2' with
   | Tvariant row1, Tvariant row2
     when is_absrow env (row_more row2) -> begin
-      assert (Ctype.is_equal env true (ty1::params1) (row_more row2::params2));
-      match private_variant env row1 params1 row2 params2 with
+      assert (Ctype.is_equal env false [ty1] [row_more row2]);
+      match private_variant env row1 row2 with
       | None -> None
       | Some err -> Some (Private_variant(ty1, ty2, err))
     end
@@ -1063,8 +1078,8 @@ let type_manifest env ty1 params1 ty2 params2 priv2 kind2 =
     when is_absrow env (snd (Ctype.flatten_fields fi2)) -> begin
       let (fields2,rest2) = Ctype.flatten_fields fi2 in
       let (fields1,_) = Ctype.flatten_fields fi1 in
-      assert (Ctype.is_equal env true (ty1::params1) (rest2::params2));
-      match private_object env fields1 params1 fields2 params2 with
+      assert (Ctype.is_equal env false [ty1] [rest2]);
+      match private_object env fields1 fields2 with
       | None -> None
       | Some err -> Some (Private_object(ty1, ty2, err))
     end
@@ -1084,14 +1099,100 @@ let type_manifest env ty1 params1 ty2 params2 priv2 kind2 =
       in
       match
         if is_private_abbrev_2 then
-          Ctype.equal_private env params1 ty1 params2 ty2
+          Ctype.equal_private env ty1 ty2
         else
-          Ctype.equal env true (params1 @ [ty1]) (params2 @ [ty2])
+          Ctype.equal env false [ty1] [ty2]
       with
       | exception Ctype.Equality err -> Some (Manifest err)
       | () -> None
     end
 
+(* Note [Contravariance of type parameter jkinds]
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   The goal of this function is to check whether every possible instantiation of
+   decl2 is also a valid instantiation of decl1. Ideally, we would just make
+   that check directly, by taking the type parameters of decl2, instantiating
+   them with fresh constants (throughout the manifest/kind of decl2), and then
+   unifying decl2 with an instance'd decl1. The problem with this approach is
+   that it is not upstream-compatible: upstream requires that the constraints of
+   decl1 and decl2 match exactly, even though this is more than is necessary for
+   soundness.
+
+   On the other hand, we really want to support contravariance of jkinds in type
+   parameters, to allow something like this:
+
+   {[
+     module F (X : sig type ('a : value) t ... end) = ...
+     module Array = struct type ('a : any) t ... end
+     module M = F(Array)
+   ]}
+
+   This is perfectly safe -- [F] will use [X.t] only with [value]s, which is
+   fine because [X.t] works with [any] type -- but requires contravariance.
+
+   So this is our approach:
+
+   1. Check the type parameters for equality (allowing renaming), but skipping
+   any jkind checks. We must allow renaming because the decls will bind separate
+   variables, and we skip the jkind checks precisely because we don't wish to
+   require the jkinds be equal.
+
+   2. Copy the two declarations. This allows us to unify parts of the copies
+   without affecting the originals. We use [generic_instance_declaration]
+   instead of [instance_declaration] because generic variables are not treated
+   as weakly polymorphic by the pretty printer. That's the only reason to be
+   generic here: levels simply don't matter in this bit.
+
+   3. Rigidify the type parameters of decl2. We want to make sure any possible
+   instantiation of decl2 is a legal instantiation of decl1, so if unification
+   affects the type parameters of decl2, that's an error. (Alternative: we could
+   reify instead of rigidify. But rigidify seems simpler, given that it does not
+   need to extend the env.)
+
+   (Perhaps surprisingly, rigidify does not actually make things rigid. Instead,
+   it remembers the variables free in a type and then can check after a
+   unification to see whether any of them changed. This check is Step 6 in this
+   Note.)
+
+   4. Unify the type parameters of decl1 and decl2. This unification can fail
+   only by a jkind problem: anything else would have been caught by the equality
+   check in Step 1. An outright jkind problem will raise [Unify], and this gets
+   reported to the user. To format the error message well, we can safely search
+   only for a [Bad_jkind] event; it has to be there somewhere. There also might
+   be a jkind mismatch which causes the jkind of a variable in decl2 to be
+   lowered; this gets caught by the call to [all_distinct_vars_with_original_jkinds]
+   in Step 6.
+
+   5. Check the type definitions. This includes doing all the checks on both the
+   manifest and the kind. These checks use Ctype.equal. Importantly, this happens
+   *after* unifying the type parameters, allowing an example like
+
+   {[
+     module M : sig
+       type ('a : value) t = 'a
+     end = struct
+       type ('a : any) t = 'a
+     end
+   ]}
+
+   A naive check that the jkind of the structure's [t] is less than that of the
+   sig's [t] would fail: the structure's [t] has jkind [any] while the sig has
+   jkind [value]. But it's actually all OK: because we have unified the parameters,
+   the jkind of the struct will be [value], and then we'll check that [value]
+   is a subjkind of [value], and the definition will be accepted.
+
+   One worry might be about existential variables. Might they get unified? No.
+   These, by definition, do not appear in the type parameters. And because all
+   checks on the type definition bodies are done with [Ctype.equal], we know the
+   existentials will remain untouched.
+
+   6. Call [all_distinct_vars_with_original_jkinds]. This is the counterpart to
+   Step 3 that checks that none of the type variables in decl2 needed to have
+   their jkinds changed during unification.
+   *)
+
+(* See Note [Contravariance of type parameter jkinds]. *)
 let type_declarations ?(equality = false) ~loc env ~mark name
       decl1 path decl2 =
   Builtin_attributes.check_alerts_inclusion
@@ -1101,6 +1202,42 @@ let type_declarations ?(equality = false) ~loc env ~mark name
     decl1.type_attributes decl2.type_attributes
     name;
   if decl1.type_arity <> decl2.type_arity then Some Arity else
+  (* Step 1 from the Note *)
+  let err =
+    match Ctype.equal ~do_jkind_check:false env true
+            decl1.type_params decl2.type_params with
+    | exception Ctype.Equality err -> Some (Constraint err)
+    | () -> None
+  in
+  if err <> None then err else
+  (* Step 2 from the Note *)
+  let decl1 = Ctype.generic_instance_declaration decl1 in
+  let decl2 = Ctype.generic_instance_declaration decl2 in
+  (* Step 3 from the Note *)
+  let rigidity_info = Ctype.Rigidify.rigidify_list decl2.type_params in
+  (* Step 4 from the Note *)
+  let err =
+    match
+      List.iter2 (Ctype.unify env) decl1.type_params decl2.type_params
+    with
+      | exception Ctype.Unify err ->
+        let get_jkind_violation = function
+          | Errortrace.Bad_jkind (ty, v) -> Some (Parameter_jkind (ty, v))
+          | _ -> None
+        in
+        begin match List.find_map get_jkind_violation err.trace with
+        | Some _ as err -> err
+        | None -> Misc.fatal_errorf
+                    "Unification in type_declarations failed, \
+                     but not with Bad_jkind:@;<1 2>%t"
+              (fun ppf -> Printtyp.report_unification_error ppf env err
+               (fun ppf -> Format.fprintf ppf "The type")
+               (fun ppf -> Format.fprintf ppf "does not unify with the type"))
+        end
+      | () -> None
+  in
+  if err <> None then err else
+  (* Step 5 from the Note *)
   let err =
     match privacy_mismatch env decl1 decl2 with
     | Some err -> Some (Privacy err)
@@ -1108,25 +1245,16 @@ let type_declarations ?(equality = false) ~loc env ~mark name
   in
   if err <> None then err else
   let err = match (decl1.type_manifest, decl2.type_manifest) with
-      (_, None) ->
-        begin
-          match Ctype.equal env true decl1.type_params decl2.type_params with
-          | exception Ctype.Equality err -> Some (Constraint err)
-          | () -> None
-        end
+      (_, None) -> None
     | (Some ty1, Some ty2) ->
-         type_manifest env ty1 decl1.type_params ty2 decl2.type_params
-           decl2.type_private decl2.type_kind
+         type_manifest env ty1 ty2 decl2.type_private decl2.type_kind
     | (None, Some ty2) ->
         let ty1 =
           Btype.newgenty (Tconstr(path, decl2.type_params, ref Mnil))
         in
-        match Ctype.equal env true decl1.type_params decl2.type_params with
-        | exception Ctype.Equality err -> Some (Constraint err)
-        | () ->
-          match Ctype.equal env false [ty1] [ty2] with
-          | exception Ctype.Equality err -> Some (Manifest err)
-          | () -> None
+        match Ctype.equal env false [ty1] [ty2] with
+        | exception Ctype.Equality err -> Some (Manifest err)
+        | () -> None
   in
   if err <> None then err else
   let err = match (decl1.type_kind, decl2.type_kind) with
@@ -1178,6 +1306,20 @@ let type_declarations ?(equality = false) ~loc env ~mark name
     | (_, _) -> Some (Kind (of_kind decl1.type_kind, of_kind decl2.type_kind))
   in
   if err <> None then err else
+  (* Step 6 from the Note *)
+  match Ctype.Rigidify.all_distinct_vars_with_original_jkinds env rigidity_info with
+  | Unification_failure { name; ty }
+    (* This should be caught by the call to Ctype.equal above *)
+    -> Misc.fatal_errorf
+         "Unification failure in type inclusion rigidity check:@;\
+          %s unified with %a."
+         (match name with None -> "_" | Some n -> "'" ^ n)
+         Printtyp.type_expr ty
+  | Jkind_mismatch { original_jkind; inferred_jkind; ty } ->
+     Some (Parameter_jkind
+             (ty, Jkind.Violation.of_
+                    (Not_a_subjkind (original_jkind, inferred_jkind))))
+  | All_good ->
   let abstr = Btype.type_kind_is_abstract decl2 && decl2.type_manifest = None in
   let need_variance =
     abstr || decl1.type_private = Private || decl1.type_kind = Type_open in

--- a/ocaml/typing/includecore.mli
+++ b/ocaml/typing/includecore.mli
@@ -108,6 +108,7 @@ type type_mismatch =
   | Kind of kind_mismatch
   | Constraint of Errortrace.equality_error
   | Manifest of Errortrace.equality_error
+  | Parameter_jkind of type_expr * Jkind.Violation.t
   | Private_variant of type_expr * type_expr * private_variant_mismatch
   | Private_object of type_expr * type_expr * private_object_mismatch
   | Variance

--- a/ocaml/typing/includemod_errorprinter.ml
+++ b/ocaml/typing/includemod_errorprinter.ml
@@ -616,23 +616,6 @@ let core env id x =
         show_locs (diff.got.val_loc, diff.expected.val_loc)
         Printtyp.Conflicts.print_explanations
   | Err.Type_declarations diff ->
-      (* Jkind history doesn't offer helpful information in the case
-         of a signature mismatch. This part is here to strip it away. *)
-      let strip_jkind_history (err: Errortrace.equality_error) =
-        Errortrace.equality_error
-          ~trace:(List.map
-            (function
-              | Errortrace.Unequal_var_jkinds _ ->
-                Errortrace.Unequal_var_jkinds_with_no_history
-              | x -> x) err.trace)
-          ~subst:err.subst
-      in
-      let symptom : Includecore.type_mismatch =
-        match diff.symptom with
-        | Manifest err -> Manifest (strip_jkind_history err)
-        | Constraint err -> Constraint (strip_jkind_history err)
-        | symptom -> symptom
-      in
       Format.dprintf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]%a%a%t@]"
         "Type declarations do not match"
         !Oprint.out_sig_item
@@ -641,7 +624,7 @@ let core env id x =
         !Oprint.out_sig_item
         (Printtyp.tree_of_type_declaration id diff.expected Trec_first)
         (Includecore.report_type_mismatch
-           "the first" "the second" "declaration" env) symptom
+           "the first" "the second" "declaration" env) diff.symptom
         show_locs (diff.got.type_loc, diff.expected.type_loc)
         Printtyp.Conflicts.print_explanations
   | Err.Extension_constructors diff ->

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1128,9 +1128,9 @@ end = struct
           printer_iter_type_expr add_named_vars ty
     end
 
-  let rec substitute ty =
+  let substitute ty =
     match List.assq ty !name_subst with
-    | ty' -> substitute ty'
+    | ty' -> ty'
     | exception Not_found -> ty
 
   let add_subst subst =

--- a/ocaml/typing/printtyp.mli
+++ b/ocaml/typing/printtyp.mli
@@ -222,9 +222,9 @@ val report_ambiguous_type_error:
     (formatter -> unit) -> (formatter -> unit) -> (formatter -> unit) -> unit
 
 val report_unification_error :
+  ?type_expected_explanation:(formatter -> unit) ->
   formatter ->
   Env.t -> Errortrace.unification_error ->
-  ?type_expected_explanation:(formatter -> unit) ->
   (formatter -> unit) -> (formatter -> unit) ->
   unit
 

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -3509,7 +3509,6 @@ let report_error ppf = function
       let get_jkind_error : _ Errortrace.elt -> _ = function
       | Bad_jkind (ty, violation) | Bad_jkind_sort (ty, violation) ->
         Some (ty, violation)
-      | Unequal_var_jkinds_with_no_history
       | Unequal_var_jkinds _ | Diff _ | Variant _ | Obj _
       | Escape _ | Incompatible_fields _ | Rec_occur _ -> None
       in


### PR DESCRIPTION
This allows e.g.

```
module M : sig
  type ('a : value) t = 'a
end = struct
  type ('a : any) t = 'a
end
```

It is careful not to allow

```
module M : sig
  type 'a t constraint 'a = int
end = struct
  type 'a t
end
```

even though doing so would be sound (but not upstream-compatible).

Best to review commit-by-commit:
* The first is a straightforward port of a commit reviewed upstream.
* Next (keep names) is preparatory, to keep error messages good later.
* Then we have the main payload.
* But that payload doesn't quite work, because of https://github.com/ocaml/ocaml/issues/13369. So this last commit just disables the problematic test.

Review suggestion: @ccasin.