### PR TITLE
Add float32 unboxer to global list

### DIFF
--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -52,6 +52,7 @@ let decide tenv param_type deciders : U.decision option =
 let deciders =
   [ Unboxers.Immediate.decider;
     Unboxers.Float.decider;
+    Unboxers.Float32.decider;
     Unboxers.Int32.decider;
     Unboxers.Int64.decider;
     Unboxers.Nativeint.decider;

--- a/middle_end/flambda2/simplify/unboxing/unboxers.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.mli
@@ -30,6 +30,28 @@ type unboxer =
       TE.t -> min_name_mode:Name_mode.t -> T.t -> Simple.t T.meet_shortcut
   }
 
+module Field : sig
+  val unboxing_prim :
+    P.Block_access_kind.t -> block:Simple.t -> index:Targetint_31_63.t -> P.t
+
+  val unboxer :
+    poison_const:Const.t ->
+    P.Block_access_kind.t ->
+    index:Targetint_31_63.t ->
+    unboxer
+end
+
+module Closure_field : sig
+  val unboxing_prim : Function_slot.t -> closure:Simple.t -> Value_slot.t -> P.t
+
+  val unboxer : Function_slot.t -> Value_slot.t -> unboxer
+end
+
+(* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   Each of these modules must be included in the global deciders list in
+   optimistic_unboxing_decision.ml
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! *)
+
 module type Number_S = sig
   val decider : number_decider
 
@@ -51,20 +73,3 @@ module Int64 : Number_S
 module Nativeint : Number_S
 
 module Vec128 : Number_S
-
-module Field : sig
-  val unboxing_prim :
-    P.Block_access_kind.t -> block:Simple.t -> index:Targetint_31_63.t -> P.t
-
-  val unboxer :
-    poison_const:Const.t ->
-    P.Block_access_kind.t ->
-    index:Targetint_31_63.t ->
-    unboxer
-end
-
-module Closure_field : sig
-  val unboxing_prim : Function_slot.t -> closure:Simple.t -> Value_slot.t -> P.t
-
-  val unboxer : Function_slot.t -> Value_slot.t -> unboxer
-end

--- a/tests/small_numbers/float32_u_lib.ml
+++ b/tests/small_numbers/float32_u_lib.ml
@@ -841,3 +841,30 @@ module Bigarray = struct
   end
 end
 
+module Noalloc = struct
+
+  let don't_allocate f : 'a =
+    (* NB: right-to-left evaluation order gets this right *)
+    let baseline_allocation = Gc.allocated_bytes() -. Gc.allocated_bytes() in
+    let before = Gc.allocated_bytes () in
+    let result = (f[@inlined never]) () in
+    let after = Gc.allocated_bytes () in
+    (match Sys.backend_type with
+    | Native ->  assert ((after -. before) = baseline_allocation)
+    | _ -> ());
+    result
+
+  let[@inline] of_int32_preserve_order x =
+    let open Stdlib_beta.Float32 in
+    if Stdlib.( >= ) x 0l then of_bits x else neg (of_bits (Stdlib.Int32.neg x))
+  ;;
+
+  let[@inline] of_int32_preserve_order i : float32# =
+    F32.of_float32 ((of_int32_preserve_order [@inlined hint]) i)
+  ;;
+
+  let _ =
+    don't_allocate (fun () -> of_int32_preserve_order (Sys.opaque_identity 0l))
+  ;;
+
+end


### PR DESCRIPTION
The unboxer module for float32 was implemented, but wasn't included in the global list of deciders.
Also adds a test that fails without the change and a relevant comment.