### PR TITLE
Monadic modalities always implied by mutable

### DIFF
--- a/ocaml/testsuite/tests/typing-modes/mutable.ml
+++ b/ocaml/testsuite/tests/typing-modes/mutable.ml
@@ -90,6 +90,19 @@ let foo r (s @ shared) = r.s <- s
 val foo : 'a r -> 'a -> unit = <fun>
 |}]
 
+let foo (s @ shared) = ({s} : _ @@ unique)
+[%%expect{|
+val foo : 'a -> 'a r = <fun>
+|}]
+
+let foo (r @ unique) = (r.s : _ @@ unique)
+[%%expect{|
+Line 1, characters 24-27:
+1 | let foo (r @ unique) = (r.s : _ @@ unique)
+                            ^^^
+Error: This value is shared but expected to be unique.
+|}]
+
 module M : sig
   type t = { mutable s : string [@no_mutable_implied_modalities] }
 end = struct

--- a/ocaml/testsuite/tests/typing-modes/mutable.ml
+++ b/ocaml/testsuite/tests/typing-modes/mutable.ml
@@ -5,7 +5,7 @@
 
 (* This file tests the typing around mutable() logic. *)
 
-(* By default, mutable implies [global many shared] modalities *)
+(* By default, mutable implies all legacy modalities *)
 type r = {mutable s : string}
 let foo (local_ s) = exclave_ {s}
 [%%expect{|
@@ -16,8 +16,8 @@ Line 2, characters 31-32:
 Error: This value escapes its region.
 |}]
 
-(* [@no_mutable_implied_modalities] disables those implied modalities, and
-   allows us to test [mutable] alone *)
+(* [@no_mutable_implied_modalities] disables those implied modalities on the
+   comonadic axes, and allows us to test [mutable] alone *)
 
 (* Note the attribute is not printed back, which might be confusing.
    Considering this is a short-term workaround, let's not worry too much. *)
@@ -81,14 +81,13 @@ Line 1, characters 26-29:
 Error: This value is nonportable but expected to be portable.
 |}]
 
-(* For monadic axes, mutable defaults to mutable(min). So currently we can't
-   write a [contended] value to a mutable field. *)
-let foo (r @ uncontended) (s @ contended) = r.s <- s
+(* This attribute doesn't disable implied modalities on monadic axes. For
+   example, there is a [shared] modality on the [s] field, which allows the
+   following to type check. Otherwise, new values in mutation are required to be
+   [unique]. *)
+let foo r (s @ shared) = r.s <- s
 [%%expect{|
-Line 1, characters 51-52:
-1 | let foo (r @ uncontended) (s @ contended) = r.s <- s
-                                                       ^
-Error: This value is contended but expected to be uncontended.
+val foo : 'a r -> 'a -> unit = <fun>
 |}]
 
 module M : sig
@@ -114,7 +113,7 @@ Error: Signature mismatch:
          mutable s : string;
        is not the same as:
          mutable s : string;
-       The second is empty and the first is shared.
+       The first is global_ and the second is not.
 |}]
 
 module M : sig

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -2400,8 +2400,7 @@ and type_pat_aux
        combine the two array pattern constructors. *)
     let ty_elt, arg_sort = solve_Ppat_array ~refine loc env mutability expected_ty in
     let modalities =
-      if Types.is_mutable mutability then Typemode.mutable_implied_modalities
-      else Modality.Value.Const.id
+      Typemode.transl_modalities ~maturity:Stable mutability [] []
     in
     check_project_mutability ~loc ~env:!env mutability alloc_mode.mode;
     let alloc_mode = Modality.Value.Const.apply modalities alloc_mode.mode in
@@ -8584,11 +8583,12 @@ and type_generic_array
       sargl
   =
   let alloc_mode, argument_mode = register_allocation expected_mode in
-  let type_, modalities =
-    if Types.is_mutable mutability then
-      Predef.type_array, Typemode.mutable_implied_modalities
-    else
-      Predef.type_iarray, Modality.Value.Const.id
+  let type_ =
+    if Types.is_mutable mutability then Predef.type_array
+    else Predef.type_iarray
+  in
+  let modalities =
+    Typemode.transl_modalities ~maturity:Stable mutability [] []
   in
   check_construct_mutability ~loc ~env mutability argument_mode;
   let argument_mode = mode_modality modalities argument_mode in

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -433,19 +433,8 @@ let transl_labels ~new_var_jkind ~allow_unboxed env univars closed lbls kloc =
           | Immutable -> Immutable
           | Mutable -> Mutable Mode.Alloc.Comonadic.Const.legacy
          in
-         let has_mutable_implied_modalities : _ Mode.monadic_comonadic =
-          let comonadic =
-            if Types.is_mutable mut then
-              not (Builtin_attributes.has_no_mutable_implied_modalities attrs)
-            else
-              false
-          in
-          let monadic = Types.is_mutable mut in
-          {monadic; comonadic}
-         in
          let modalities =
-          Typemode.transl_modalities ~maturity:Stable
-            ~has_mutable_implied_modalities modalities
+          Typemode.transl_modalities ~maturity:Stable mut attrs modalities
          in
          let arg = Ast_helper.Typ.force_poly arg in
          let cty = transl_simple_type ~new_var_jkind env ?univars ~closed Mode.Alloc.Const.legacy arg in
@@ -487,8 +476,7 @@ let transl_types_gf ~new_var_jkind ~allow_unboxed
         Mode.Alloc.Const.legacy arg.pca_type
     in
     let gf =
-      Typemode.transl_modalities ~maturity:Stable
-        ~has_mutable_implied_modalities:{monadic=false; comonadic=false}
+      Typemode.transl_modalities ~maturity:Stable Immutable []
         arg.pca_modalities
     in
     {ca_modalities = gf; ca_type = cty; ca_loc = arg.pca_loc}
@@ -2950,8 +2938,8 @@ let transl_value_decl env loc valdecl =
   let cty = Typetexp.transl_type_scheme env valdecl.pval_type in
   let modalities =
     valdecl.pval_modalities
-    |> Typemode.transl_modalities ~maturity:Alpha
-        ~has_mutable_implied_modalities:{monadic=false;comonadic=false}
+    |> Typemode.transl_modalities ~maturity:Alpha Immutable
+        valdecl.pval_attributes
     |> Mode.Modality.Value.of_const
   in
   (* CR layouts v5: relax this to check for representability. *)

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -433,11 +433,15 @@ let transl_labels ~new_var_jkind ~allow_unboxed env univars closed lbls kloc =
           | Immutable -> Immutable
           | Mutable -> Mutable Mode.Alloc.Comonadic.Const.legacy
          in
-         let has_mutable_implied_modalities =
-          if Types.is_mutable mut then
-            not (Builtin_attributes.has_no_mutable_implied_modalities attrs)
-          else
-            false
+         let has_mutable_implied_modalities : _ Mode.monadic_comonadic =
+          let comonadic =
+            if Types.is_mutable mut then
+              not (Builtin_attributes.has_no_mutable_implied_modalities attrs)
+            else
+              false
+          in
+          let monadic = Types.is_mutable mut in
+          {monadic; comonadic}
          in
          let modalities =
           Typemode.transl_modalities ~maturity:Stable
@@ -484,7 +488,8 @@ let transl_types_gf ~new_var_jkind ~allow_unboxed
     in
     let gf =
       Typemode.transl_modalities ~maturity:Stable
-        ~has_mutable_implied_modalities:false arg.pca_modalities
+        ~has_mutable_implied_modalities:{monadic=false; comonadic=false}
+        arg.pca_modalities
     in
     {ca_modalities = gf; ca_type = cty; ca_loc = arg.pca_loc}
   in
@@ -2946,7 +2951,7 @@ let transl_value_decl env loc valdecl =
   let modalities =
     valdecl.pval_modalities
     |> Typemode.transl_modalities ~maturity:Alpha
-        ~has_mutable_implied_modalities:false
+        ~has_mutable_implied_modalities:{monadic=false;comonadic=false}
     |> Mode.Modality.Value.of_const
   in
   (* CR layouts v5: relax this to check for representability. *)

--- a/ocaml/typing/typemode.mli
+++ b/ocaml/typing/typemode.mli
@@ -9,17 +9,23 @@ val untransl_mode_annots :
 val transl_alloc_mode : Parsetree.modes -> Mode.Alloc.Const.t
 
 (** Interpret mode syntax as modalities. Modalities occuring at different places
-    requires different levels of maturity. *)
+    requires different levels of maturity. Also takes the mutability and
+    attributes on the field and insert mutable-implied modalities accordingly.
+    *)
 val transl_modalities :
   maturity:Language_extension.maturity ->
-  has_mutable_implied_modalities:(bool, bool) Mode.monadic_comonadic ->
+  Types.mutability ->
+  Parsetree.attributes ->
   Parsetree.modalities ->
   Mode.Modality.Value.Const.t
 
+val untransl_modality : Mode.Modality.t -> Parsetree.modality Location.loc
+
+(** Un-interpret modalities back to parsetree. Takes the mutability and
+    attributes on the field and remove mutable-implied modalities accordingly.
+    *)
 val untransl_modalities :
-  loc:Location.t -> Mode.Modality.Value.Const.t -> Parsetree.modalities
-
-val is_mutable_implied_modality :
-  (Mode.Modality.t -> bool, Mode.Modality.t -> bool) Mode.monadic_comonadic
-
-val mutable_implied_modalities : Mode.Modality.Value.Const.t
+  Types.mutability ->
+  Parsetree.attributes ->
+  Mode.Modality.Value.Const.t ->
+  Parsetree.modalities

--- a/ocaml/typing/typemode.mli
+++ b/ocaml/typing/typemode.mli
@@ -12,13 +12,14 @@ val transl_alloc_mode : Parsetree.modes -> Mode.Alloc.Const.t
     requires different levels of maturity. *)
 val transl_modalities :
   maturity:Language_extension.maturity ->
-  has_mutable_implied_modalities:bool ->
+  has_mutable_implied_modalities:(bool, bool) Mode.monadic_comonadic ->
   Parsetree.modalities ->
   Mode.Modality.Value.Const.t
 
 val untransl_modalities :
   loc:Location.t -> Mode.Modality.Value.Const.t -> Parsetree.modalities
 
-val is_mutable_implied_modality : Mode.Modality.t -> bool
+val is_mutable_implied_modality :
+  (Mode.Modality.t -> bool, Mode.Modality.t -> bool) Mode.monadic_comonadic
 
 val mutable_implied_modalities : Mode.Modality.Value.Const.t

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -262,7 +262,7 @@ let type_kind sub tk = match tk with
 
 let constructor_argument sub {ca_loc; ca_type; ca_modalities} =
   let loc = sub.location sub ca_loc in
-  let pca_modalities = Typemode.untransl_modalities ~loc ca_modalities in
+  let pca_modalities = Typemode.untransl_modalities Immutable [] ca_modalities in
   { pca_loc = loc; pca_type = sub.typ sub ca_type; pca_modalities }
 
 let constructor_arguments sub = function
@@ -294,9 +294,11 @@ let label_declaration sub ld =
   let loc = sub.location sub ld.ld_loc in
   let attrs = sub.attributes sub ld.ld_attributes in
   let mut = mutable_ ld.ld_mutable in
-  Type.field ~loc ~attrs
-    ~mut
-    ~modalities:(Typemode.untransl_modalities ~loc ld.ld_modalities)
+  let modalities =
+    Typemode.untransl_modalities ld.ld_mutable ld.ld_attributes
+      ld.ld_modalities
+  in
+  Type.field ~loc ~attrs ~mut ~modalities
     (map_loc sub ld.ld_name)
     (sub.typ sub ld.ld_type)
 


### PR DESCRIPTION
#2716 introduced the `@no_mutable_implied_modalities` attribute that disables the legacy modalities implied by `mutable`, including both monadic and comonadic axes.

In the long run, the implication on the comonadic axes will be disabled by default, and this attribute allows us to experiment with that currently. However, the implication on the monadic axes will stay in the future (more details to be found in the internal doc "Modes and mutations") as it gives the best ergonomics. Therefore, the attribute should not affect the monadic axes. This PR fixes that.