### PR TITLE
Permit layouts to be (polarised) unions of sorts

### DIFF
--- a/ocaml/testsuite/tests/typing-higher-jkinds/folds.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/folds.ml
@@ -95,10 +95,10 @@ val result : int list id = {v = [0; 1; 2]}
 |}]
 
 let leaves (perfect : 'a perfect) =
-  fold ({
+  fold {
     zero = (fun l -> [l]);
     succ = (fun l -> List.concat_map (fun (x, y) -> [x; y]) l)
-  } : list folder) perfect
+  } perfect
 let result = leaves example
 let flat = List.concat result
 

--- a/ocaml/testsuite/tests/typing-higher-jkinds/intro.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/intro.ml
@@ -5,5 +5,7 @@
  check-ocamlopt.byte-output;
 *)
 
-type l : value => value = list
-let x: int l = [1]
+type ('m : value => value) monad = {
+  return : 'a. 'a -> 'a 'm;
+  bind : 'a 'b. 'a 'm -> ('a -> 'b 'm) -> 'b 'm
+}

--- a/ocaml/testsuite/tests/typing-higher-jkinds/leibniz.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/leibniz.ml
@@ -9,7 +9,7 @@ module Eq : sig
   type ('a : top, 'b : top) eq
 
   val refl : unit -> ('a, 'a) eq
-  val subst : ('a : top) ('b : top) ('f : top => value). ('a, 'b) eq -> ('a 'f -> 'b 'f)
+  val subst : 'a 'b ('f : top => value). ('a, 'b) eq -> ('a 'f -> 'b 'f)
 end = struct
   type ('a : top, 'b : top) eq = { subst : ('f : top => value). 'a 'f -> 'b 'f }
   let refl () = { subst = (fun x -> x) }

--- a/ocaml/testsuite/tests/typing-higher-jkinds/specialised.ml
+++ b/ocaml/testsuite/tests/typing-higher-jkinds/specialised.ml
@@ -1,6 +1,4 @@
 (* TEST
-  reason = "No GADTs with higher kinds";
-  skip;
   flags = "-extension layouts_alpha";
   expect;
 *)

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -67,10 +67,10 @@ module Type = struct
   module Layout = struct
     open Jkind_types.Type.Layout
 
-    type nonrec 'sort layout = 'sort layout
-
     module Const = struct
-      type t = Sort.const layout
+      type t = Const.t =
+        | Sort of Sort.const
+        | Any
 
       let max = Any
 
@@ -132,13 +132,51 @@ module Type = struct
       end
     end
 
-    type t = Sort.t layout
+    type nonrec t = t =
+      | Sort of Sort.t
+      | Union of Sort.t list
+      | Any
 
-    let of_const const : t =
+    let of_const (const : Const.t) : t =
       match const with Sort s -> Sort (Const s) | Any -> Any
 
+    let union_with_negative_polarity where =
+      Misc.fatal_errorf "%s: Union of sorts used in a negative position" where
+
+    let union_sort_consts cs : Const.t option =
+      match cs with
+      | [] -> None
+      | c0 :: cs ->
+        if List.for_all (fun c -> Sort.Const.equal c c0) cs
+        then Some (Sort c0)
+        else Some Any
+
+    let repr_union ss =
+      let cs, vs =
+        List.partition_map
+          (fun s ->
+            match Sort.get s with Const s -> Left s | Var v -> Right v)
+          ss
+      in
+      let layout = union_sort_consts cs in
+      layout, vs
+
+    (* Post-condition: If [t] is [Union],
+       it contains at most one [Const] and at least one [Var]. *)
+    let repr t =
+      match t with
+      | Any | Sort _ -> t
+      | Union ss -> (
+        match repr_union ss with
+        | Some Any, _ -> Any
+        | Some (Sort s), [] -> Sort (Sort.of_const s)
+        | _ -> t)
+
     let equate_or_equal ~allow_mutation t1 t2 =
-      match t1, t2 with
+      match repr t1, repr t2 with
+      | _ when t1 == t2 -> true
+      | Union _, _ | _, Union _ ->
+        union_with_negative_polarity "Type.Layout.equate_or_equal"
       | Sort s1, Sort s2 -> (
         match Sort.equate_tracking_mutation s1 s2 with
         | (Equal_mutated_first | Equal_mutated_second) when not allow_mutation
@@ -150,28 +188,34 @@ module Type = struct
       | Any, Any -> true
       | (Any | Sort _), _ -> false
 
-    let sub t1 t2 : Misc.Le_result.t =
-      match t1, t2 with
+    let rec sub t1 t2 : Misc.Le_result.t =
+      match repr t1, repr t2 with
+      | _ when t1 == t2 -> Equal
+      | _, Union _ -> union_with_negative_polarity "Type.Layout.sub"
+      | Union ss1, t2 ->
+        Misc.Le_result.combine_list (List.map (fun s1 -> sub (Sort s1) t2) ss1)
       | Any, Any -> Equal
       | _, Any -> Less
       | Any, _ -> Not_le
       | Sort s1, Sort s2 -> if Sort.equate s1 s2 then Equal else Not_le
 
     let intersection t1 t2 =
-      match t1, t2 with
+      match repr t1, repr t2 with
+      | _ when t1 == t2 -> Some t1
+      | Union _, _ | _, Union _ ->
+        union_with_negative_polarity "Type.Layout.intersection"
       | _, Any -> Some t1
       | Any, _ -> Some t2
       | Sort s1, Sort s2 -> if Sort.equate s1 s2 then Some t1 else None
 
     let union t1 t2 =
-      match t1, t2 with
-      (* TODO jbachurski: As discussed with lwhite,
-         [if Sort.equate s1 s2 then t1 else Any] is not sound
-         and a change to the representation of sorts would be
-         required to compute this accurately. Fail for now. *)
-      | Sort s1, Sort s2 -> if Sort.equate s1 s2 then t1 else Any
+      match repr t1, repr t2 with
       | _, Any -> Any
       | Any, _ -> Any
+      | Sort s1, Sort s2 -> Union [s1; s2]
+      | Union ss1, Sort s2 -> Union (s2 :: ss1)
+      | Sort s1, Union ss2 -> Union (s1 :: ss2)
+      | Union ss1, Union ss2 -> Union (ss1 @ ss2)
 
     let of_new_sort_var () =
       let sort = Sort.new_var () in
@@ -179,12 +223,20 @@ module Type = struct
 
     let format ppf =
       let open Format in
-      function
-      | Any -> fprintf ppf "any"
-      | Sort s -> (
+      let print_sort ppf s =
         match Sort.get s with
         | Const s -> fprintf ppf "%a" Sort.Const.format s
-        | Var v -> fprintf ppf "%s" (Sort.Var.name v))
+        | Var v -> fprintf ppf "%s" (Sort.Var.name v)
+      in
+      function
+      | Any -> fprintf ppf "any"
+      | Sort s -> print_sort ppf s
+      | Union ss ->
+        fprintf ppf "%a"
+          (pp_print_list
+             ~pp_sep:(fun ppf () -> fprintf ppf "%s" " | ")
+             print_sort)
+          ss
 
     module Debug_printers = struct
       open Format
@@ -192,6 +244,12 @@ module Type = struct
       let t ppf = function
         | Any -> fprintf ppf "Any"
         | Sort s -> fprintf ppf "Sort %a" Sort.Debug_printers.t s
+        | Union ss ->
+          fprintf ppf "Union [%a]"
+            (pp_print_list
+               ~pp_sep:(fun ppf () -> fprintf ppf "; ")
+               Sort.Debug_printers.t)
+            ss
     end
   end
 
@@ -815,7 +873,8 @@ module Type = struct
   module Desc = struct
     type t =
       | Const of Const.t
-      | Var of Sort.var (* all modes will be [max] *)
+      | Var of
+          Const.Layout.t option * Sort.var list (* all modes will be [max] *)
 
     (* considers sort variables < Any. Two sort variables are in a [sub]
        relationship only when they are equal.
@@ -825,7 +884,9 @@ module Type = struct
       match d1, d2 with
       | Const c1, Const c2 -> Const.sub c1 c2
       | Var _, Const c when Const.equal Const.max c -> Less
-      | Var v1, Var v2 -> if v1 == v2 then Equal else Not_le
+      | Var (None, [v1]), Var (None, [v2]) -> if v1 == v2 then Equal else Not_le
+      | Var (l1, vs1), Var (l2, vs2) ->
+        if l1 == l2 && vs1 == vs2 then Equal else Not_le
       | Const _, Var _ | Var _, Const _ -> Not_le
   end
 
@@ -860,6 +921,14 @@ module Type = struct
         }
       | Sort s ->
         { layout = Sort (Sort.default_to_value_and_get s);
+          modes_upper_bounds;
+          externality_upper_bound;
+          nullability_upper_bound
+        }
+      | Union ss ->
+        { layout =
+            Layout.union_sort_consts (List.map Sort.default_to_value_and_get ss)
+            |> Option.value ~default:Layout.Const.value;
           modes_upper_bounds;
           externality_upper_bound;
           nullability_upper_bound
@@ -1039,7 +1108,7 @@ module Type = struct
           externality_upper_bound;
           nullability_upper_bound
         } : Desc.t =
-      match layout with
+      match Layout.repr layout with
       | Any ->
         Const
           { layout = Any;
@@ -1056,12 +1125,24 @@ module Type = struct
               externality_upper_bound;
               nullability_upper_bound
             }
-        | Var v -> Var v)
+        | Var v -> Var (None, [v]))
+      | Union ss ->
+        (* [repr] already simplified as much as possible *)
+        let oc, vs = Layout.repr_union ss in
+        Var (oc, vs)
 
     let format ppf t =
+      let print_vars ppf =
+        Format.pp_print_list
+          ~pp_sep:(fun ppf () -> Format.fprintf ppf " | ")
+          (fun ppf v -> Format.fprintf ppf "%s" (Sort.Var.name v))
+          ppf
+      in
       match get t with
       | Const c -> Format.fprintf ppf "%a" Const.format c
-      | Var v -> Format.fprintf ppf "%s" (Sort.Var.name v)
+      | Var (None, vs) -> Format.fprintf ppf "%a" print_vars vs
+      | Var (Some c, vs) ->
+        Format.fprintf ppf "%a | %s" print_vars vs (Const.Layout.to_string c)
 
     module Debug_printers = struct
       open Format
@@ -1246,14 +1327,13 @@ module Type = struct
   let sort_of_jkind l =
     match get l with
     | Const { layout = Sort s; _ } -> Sort.of_const s
-    | Const { layout = Any; _ } -> Misc.fatal_error "Jkind.Type.sort_of_jkind"
-    | Var v -> Sort.of_var v
+    | Const { layout = Any; _ } ->
+      Misc.fatal_error "Jkind.Type.sort_of_jkind: Any"
+    | Var (None, [v]) -> Sort.of_var v
+    | Var _ -> Misc.fatal_error "Jkind.Type.sort_of_jkind: union of Var"
 
   let get_layout jk : Layout.Const.t option =
-    match jk.desc.layout with
-    | Any -> Some Any
-    | Sort s -> (
-      match Sort.get s with Const s -> Some (Sort s) | Var _ -> None)
+    match get jk with Const jkind -> Some jkind.layout | Var _ -> None
 
   let get_modal_upper_bounds jk = jk.desc.modes_upper_bounds
 

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -170,6 +170,7 @@ module Type = struct
         match repr_union ss with
         | Some Any, _ -> Any
         | Some (Sort s), [] -> Sort (Sort.of_const s)
+        | None, [v] -> Sort (Sort.of_var v)
         | _ -> t)
 
     let equate_or_equal ~allow_mutation t1 t2 =
@@ -210,6 +211,7 @@ module Type = struct
 
     let union t1 t2 =
       match repr t1, repr t2 with
+      | _ when t1 == t2 -> t1
       | _, Any -> Any
       | Any, _ -> Any
       | Sort s1, Sort s2 -> Union [s1; s2]

--- a/ocaml/typing/jkind.mli
+++ b/ocaml/typing/jkind.mli
@@ -291,7 +291,7 @@ module Type : sig
     (** The description of a jkind, used as a return type from [get]. *)
     type t =
       | Const of Const.t
-      | Var of Sort.var
+      | Var of Const.Layout.t option * Sort.var list
   end
 
   (** Extract the [const] from a [Jkind.t], looking through unified

--- a/ocaml/typing/jkind_types.ml
+++ b/ocaml/typing/jkind_types.ml
@@ -320,12 +320,10 @@ module Type = struct
   end
 
   module Layout = struct
-    type 'sort layout =
-      | Sort of 'sort
-      | Any
-
     module Const = struct
-      type t = Sort.const layout
+      type t =
+        | Sort of Sort.const
+        | Any
 
       module Legacy = struct
         type t =
@@ -344,7 +342,10 @@ module Type = struct
       end
     end
 
-    type t = Sort.t layout
+    type t =
+      | Sort of Sort.t
+      | Union of Sort.t list
+      | Any
   end
 
   module Externality = struct

--- a/ocaml/typing/jkind_types.mli
+++ b/ocaml/typing/jkind_types.mli
@@ -83,12 +83,10 @@ module Type : sig
   end
 
   module Layout : sig
-    type 'sort layout =
-      | Sort of 'sort
-      | Any
-
     module Const : sig
-      type t = Sort.const layout
+      type t =
+        | Sort of Sort.const
+        | Any
 
       module Legacy : sig
         type t =
@@ -108,7 +106,10 @@ module Type : sig
       end
     end
 
-    type t = Sort.t layout
+    type t =
+      | Sort of Sort.t
+      | Union of Sort.t list
+      | Any
   end
 
   module Externality : sig

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -356,6 +356,16 @@ let rec print_out_jkind ppf = function
     print_arrow
       ~is_atom:(function Ojkind_const (Ojkind_const_arrow _) | Ojkind_arrow _ -> false | _ -> true)
       ppf print_out_jkind args result
+  | Ojkind_union (Some c, vs) ->
+    fprintf ppf "%a | %s"
+      (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf " | ")
+        (fun ppf -> fprintf ppf "%s"))
+      vs c
+  | Ojkind_union (None, vs) ->
+    fprintf ppf "%a"
+      (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf " | ")
+        (fun ppf -> fprintf ppf "%s"))
+      vs
 
 let print_out_jkind_annot ppf = function
   | None -> ()

--- a/ocaml/typing/outcometree.mli
+++ b/ocaml/typing/outcometree.mli
@@ -113,6 +113,7 @@ type out_jkind_const =
 and out_jkind =
   | Ojkind_const of out_jkind_const
   | Ojkind_var of string
+  | Ojkind_union of string option * string list
   | Ojkind_arrow of out_jkind list * out_jkind
 
 and out_type_param =

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1283,11 +1283,21 @@ let out_jkind_of_user_jkind (jkind : Jane_syntax.Jkind.annotation) =
 let out_jkind_of_const_jkind jkind =
   Ojkind_const (Jkind.Type.Const.to_out_jkind_const jkind)
 
+let verbose_out_jkind_of_var ~sort_var_names oc vs =
+  let of_var v =
+    (if sort_var_names then Jkind.Type.Sort.Var.name v else "_")
+  in
+  match oc, vs with
+  | None, [v] -> Ojkind_var (of_var v)
+  | None, vs -> Ojkind_union (None, List.map of_var vs)
+  | Some c, vs -> Ojkind_union (Some (Jkind.Type.Layout.Const.to_string c), List.map of_var vs)
+
 let rec out_jkind_of_jkind ~sort_var_names jkind =
   match Jkind.get jkind with
-  | Type ty -> begin match Jkind.Type.get ty with
+  | Type ty ->
+    begin match Jkind.Type.get ty with
     | Const clay -> out_jkind_of_const_jkind clay
-    | Var v      -> Ojkind_var (if sort_var_names then Jkind.Type.Sort.Var.name v else "_")
+    | Var (oc, vs) -> verbose_out_jkind_of_var ~sort_var_names oc vs
     end
   | Arrow { args; result } ->
     Ojkind_arrow (
@@ -1313,9 +1323,9 @@ let out_jkind_option_of_jkind t =
       | true -> None
       | false -> Some (out_jkind_of_const_jkind jkind)
       end
-    | Var v -> (* This handles (X1). *)
+    | Var (oc, vs) -> (* This handles (X1). *)
       if !Clflags.verbose_types
-      then Some (Ojkind_var (Jkind.Type.Sort.Var.name v))
+      then Some (verbose_out_jkind_of_var ~sort_var_names:true oc vs)
       else None
     end
   (* We ignore the rules above for arrows, which should always be printed *)
@@ -1926,7 +1936,7 @@ let tree_of_type_decl id decl =
         decl.type_jkind_annotation
     | _ -> None (* other cases have no jkind annotation *)
   in
-  let priv : Parsetree.type_privacy = 
+  let priv : Parsetree.type_privacy =
     match priv with
     | Type_private -> Ppriv_private
     | Type_new -> Ppriv_new


### PR DESCRIPTION
- Introducing higher kinds introduces contravariant positions, which in particular means layouts need to also have joins (lattice and not just a meet semi-lattice).
- Implementing joins for layouts per `| Sort s1, Sort s2 -> if Sort.equate s1 s2 then Sort s1 else Any` is incomplete and order-dependent.
- A way forward is to have a case of layout of `Union of Sort.t list`. In general, this is a union of variables possibly lower-bounded by a constant. This is what some functions that want to introspect the current layout need to handle now, where previously they may have only seen that a jkind is non-constant and contains some one sort variable.
- This union representation has to be occasionally normalised (`repr`), with `get`s extracting the maximum amount of information about the current state. There are no errors introduced, as a union of mismatching sorts is just `Any`.
- Where a union is used in a non-positive position (negative for intersections and superkinding, or zero for equating), a fatal error is raised, as such situations are unexpected and means we are mistreating polarisations.

This should lead to a fully legitimate jkind inference rather than an order-dependent heuristic in the case of meeting jkinds over contravariant positions (i.e. joins). This had to be resolved because many seemingly simple examples end up leading to barely-non-trivial joins, so physical equality was not enough as a heuristic.

**TODO:** it would be nice to write down an actual example where order-dependence is exhibited in the previous system.