### PR TITLE
Fix conflicts in `typing/typecore.ml`

### DIFF
--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -255,8 +255,7 @@ let enter_type ?abstract_abbrevs rec_flag env sdecl (id, uid) =
   in
   let abstract_source, type_manifest =
     match sdecl.ptype_manifest, abstract_abbrevs with
-    | None, _             -> Definition, None
-    | Some _, None        -> Definition, Some (Ctype.newvar type_jkind)
+    | None, _ | Some _, None -> Definition, Some (Ctype.newvar type_jkind)
     | Some _, Some reason -> reason, None
 in
   let type_params =

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3526,7 +3526,7 @@ let check_argument_type_if_given env sourcefile actual_sig arg_module_opt =
       let basename = arg_import |> Compilation_unit.Name.to_string in
       let arg_filename =
         try
-          Load_path.find_uncap (basename ^ ".cmi")
+          Load_path.find_normalized (basename ^ ".cmi")
         with Not_found ->
           raise(Error(Location.none, Env.empty,
                       Cannot_find_argument_type arg_module)) in
@@ -3614,7 +3614,7 @@ let type_implementation target modulename initial_env ast =
               let basename = import |> Compilation_unit.Name.to_string in
               let cmi_file =
                 try
-                  Load_path.find_uncap (basename ^ ".cmi")
+                  Load_path.find_normalized (basename ^ ".cmi")
                 with Not_found ->
                   raise(Error(Location.in_file sourcefile, Env.empty,
                         Interface_not_compiled source_intf))


### PR DESCRIPTION
This PR has three things in it:
  * standard conflict resolution
  * duplicating the light changes to `typecore.ml` in https://github.com/ocaml-flambda/flambda-backend/pull/2780/files#diff-774558a171d94ddd65f5327f6ff7f2e15b33ea1284d3d9426964dbfb07d25fb0 (After you click the link, give your browser a few seconds to bring you to the right file.)
  * a minor issue with #2887 that I didn't see before merging

Notable PRs that we are merging into our branch here:
  * https://github.com/ocaml/ocaml/pull/12331. This explains the cases around `env`/`penv`/`Pattern_env.t`. Essentially, an `Env.t ref` got replaced with a record `Pattern_env.t` one of whose fields is a mutable `env`.
  * N-ary functions are on both sides of the diff. Sorry! This sucks.