### PR TITLE
Refactor stringlike indexing primitives

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -528,12 +528,13 @@ let checked_bigstring_access ~dbg ~size_int ~access_size ~primitive arg1
           ~index_kind arg2 ]
 
 (* String-like loads *)
-let string_like_load ~dbg ~unsafe ~access_size ~size_int kind mode ~boxed string
-    ~index_kind index ~current_region =
+let string_like_load ~dbg ~unsafe
+    ~(access_size : Flambda_primitive.string_accessor_width) ~size_int kind mode
+    ~boxed string ~index_kind index ~current_region =
   let unsafe_load =
     let index = convert_index_to_tagged_int index index_kind in
     let wrap =
-      match (access_size : Flambda_primitive.string_accessor_width), mode with
+      match access_size, mode with
       | (Eight | Sixteen), None ->
         assert (not boxed);
         tag_int

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -427,7 +427,8 @@ let max_with_zero ~size_int x =
   ret
 
 (* actual (strict) upper bound for an index in a string-like read/write *)
-let actual_max_length_for_string_like_access ~size_int ~access_size length =
+let actual_max_length_for_string_like_access ~size_int
+    ~(access_size : Flambda_primitive.string_accessor_width) length =
   (* offset to subtract from the length depending on the size of the
      read/write *)
   let length_offset_of_size size =
@@ -441,7 +442,7 @@ let actual_max_length_for_string_like_access ~size_int ~access_size length =
     in
     Targetint_31_63.of_int offset
   in
-  match (access_size : Flambda_primitive.string_accessor_width) with
+  match access_size with
   | Eight -> length (* micro-optimization *)
   | Sixteen | Thirty_two | Single | Sixty_four | One_twenty_eight _ ->
     let offset = length_offset_of_size access_size in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1277,7 +1277,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         ~current_region ]
   | Pbytesrefu, [[bytes]; [index]] ->
     [ string_like_load ~unsafe:true ~dbg ~size_int ~access_size:Eight Bytes None
-        ~boxed:false bytes ~index_kind:Ptagged_int_index index ~current_region ]
+        ~boxed:false bytes ~index_kind:Ptagged_int_index index ~current_region
+    ]
   | Pstringrefs, [[str]; [index]] ->
     [ string_like_load ~unsafe:false ~dbg ~size_int ~access_size:Eight String
         ~boxed:false None str ~index_kind:Ptagged_int_index index

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -381,11 +381,21 @@ let checked_alignment ~dbg ~primitive ~conditions : H.expr_primitive =
       dbg
     }
 
-let check_bound_tagged tagged_index bound : H.expr_primitive =
-  Binary
-    ( Int_comp (I.Naked_immediate, Yielding_bool (Lt Unsigned)),
-      untag_int tagged_index,
-      bound )
+let check_bound ~(index_kind : Lambda.array_index_kind) ~(bound_kind : I_or_f.t)
+    index bound : H.expr_primitive =
+  let (comp_kind : I.t), index, bound =
+    let convert_bound_to dst =
+      H.Prim (Unary (Num_conv { src = bound_kind; dst }, bound))
+    in
+    match index_kind with
+    | Ptagged_int_index ->
+      I.Naked_immediate, untag_int index, convert_bound_to Naked_immediate
+    | Punboxed_int_index bint ->
+      ( standard_int_of_boxed_integer bint,
+        index,
+        convert_bound_to (standard_int_or_float_of_boxed_integer bint) )
+  in
+  Binary (Int_comp (comp_kind, Yielding_bool (Lt Unsigned)), index, bound)
 
 (* This computes the maximum of a given value [x] with zero, in an optimized
    way. It takes as named argument the size (in bytes) of an integer register on
@@ -460,19 +470,19 @@ let actual_max_length_for_string_like_access ~size_int ~access_size length =
 
 (* String-like validity conditions *)
 
-let string_like_access_validity_condition ~size_int ~access_size ~length index :
-    H.expr_primitive =
-  check_bound_tagged index
+let string_like_access_validity_condition ~size_int ~access_size ~length
+    ~index_kind index : H.expr_primitive =
+  check_bound ~index_kind ~bound_kind:Naked_immediate index
     (actual_max_length_for_string_like_access ~size_int ~access_size length)
 
 let string_or_bytes_access_validity_condition ~size_int str kind access_size
-    index : H.expr_primitive =
-  string_like_access_validity_condition index ~size_int ~access_size
+    ~index_kind index : H.expr_primitive =
+  string_like_access_validity_condition ~index_kind index ~size_int ~access_size
     ~length:(Prim (Unary (String_length kind, str)))
 
-let bigstring_access_validity_condition ~size_int big_str access_size index :
-    H.expr_primitive =
-  string_like_access_validity_condition index ~size_int ~access_size
+let bigstring_access_validity_condition ~size_int big_str access_size
+    ~index_kind index : H.expr_primitive =
+  string_like_access_validity_condition ~index_kind index ~size_int ~access_size
     ~length:(bigarray_dim_bound big_str 1)
 
 let bigstring_alignment_validity_condition bstr alignment tagged_index :
@@ -484,7 +494,7 @@ let bigstring_alignment_validity_condition bstr alignment tagged_index :
       Simple Simple.untagged_const_zero )
 
 let checked_string_or_bytes_access ~dbg ~size_int ~access_size ~primitive kind
-    string index =
+    string ~index_kind index =
   (match (access_size : P.string_accessor_width) with
   | One_twenty_eight { aligned = true } ->
     Misc.fatal_error
@@ -495,99 +505,94 @@ let checked_string_or_bytes_access ~dbg ~size_int ~access_size ~primitive kind
   checked_access ~dbg ~primitive
     ~conditions:
       [ string_or_bytes_access_validity_condition ~size_int string kind
-          access_size index ]
+          access_size ~index_kind index ]
 
-let checked_bigstring_access ~dbg ~size_int ~access_size ~primitive arg1 arg2 =
+let checked_bigstring_access ~dbg ~size_int ~access_size ~primitive arg1
+    ~index_kind arg2 =
   let primitive =
     match (access_size : P.string_accessor_width) with
     | One_twenty_eight { aligned = true } ->
       checked_alignment ~dbg ~primitive
-        ~conditions:[bigstring_alignment_validity_condition arg1 16 arg2]
+        ~conditions:
+          [ bigstring_alignment_validity_condition arg1 16
+              (convert_index_to_tagged_int arg2 index_kind) ]
     | Eight | Sixteen | Thirty_two | Single | Sixty_four
     | One_twenty_eight { aligned = false } ->
       primitive
   in
   checked_access ~dbg ~primitive
     ~conditions:
-      [bigstring_access_validity_condition ~size_int arg1 access_size arg2]
+      [ bigstring_access_validity_condition ~size_int arg1 access_size
+          ~index_kind arg2 ]
 
 (* String-like loads *)
-let string_like_load_unsafe ~access_size kind mode ~boxed string index
-    ~current_region =
-  let wrap =
-    match (access_size : Flambda_primitive.string_accessor_width), mode with
-    | (Eight | Sixteen), None ->
-      assert (not boxed);
-      tag_int
-    | Thirty_two, Some mode ->
-      if boxed then box_bint Pint32 mode ~current_region else Fun.id
-    | Single, Some mode ->
-      if boxed then box_float32 mode ~current_region else Fun.id
-    | Sixty_four, Some mode ->
-      if boxed then box_bint Pint64 mode ~current_region else Fun.id
-    | One_twenty_eight _, Some mode ->
-      if boxed then box_vec128 mode ~current_region else Fun.id
-    | (Eight | Sixteen), Some _
-    | (Thirty_two | Single | Sixty_four | One_twenty_eight _), None ->
-      Misc.fatal_error "Inconsistent alloc_mode for string or bytes load"
+let string_like_load ~dbg ~unsafe ~access_size ~size_int kind mode ~boxed string
+    ~index_kind index ~current_region =
+  let unsafe_load =
+    let index = convert_index_to_tagged_int index index_kind in
+    let wrap =
+      match (access_size : Flambda_primitive.string_accessor_width), mode with
+      | (Eight | Sixteen), None ->
+        assert (not boxed);
+        tag_int
+      | Thirty_two, Some mode ->
+        if boxed then box_bint Pint32 mode ~current_region else Fun.id
+      | Single, Some mode ->
+        if boxed then box_float32 mode ~current_region else Fun.id
+      | Sixty_four, Some mode ->
+        if boxed then box_bint Pint64 mode ~current_region else Fun.id
+      | One_twenty_eight _, Some mode ->
+        if boxed then box_vec128 mode ~current_region else Fun.id
+      | (Eight | Sixteen), Some _
+      | (Thirty_two | Single | Sixty_four | One_twenty_eight _), None ->
+        Misc.fatal_error "Inconsistent alloc_mode for string or bytes load"
+    in
+    wrap (Binary (String_or_bigstring_load (kind, access_size), string, index))
   in
-  wrap (Binary (String_or_bigstring_load (kind, access_size), string, index))
+  if unsafe
+  then unsafe_load
+  else
+    let check_access =
+      match (kind : P.string_like_value) with
+      | String -> checked_string_or_bytes_access String
+      | Bytes -> checked_string_or_bytes_access Bytes
+      | Bigstring -> checked_bigstring_access
+    in
+    check_access ~dbg ~size_int ~access_size ~primitive:unsafe_load string
+      ~index_kind index
 
 let get_header obj mode ~current_region =
   let wrap hd = box_bint Pnativeint mode hd ~current_region in
   wrap (Unary (Get_header, obj))
 
-let string_like_load_safe ~dbg ~size_int ~access_size kind mode ~boxed str index
-    ~current_region =
-  match (kind : P.string_like_value) with
-  | String ->
-    checked_string_or_bytes_access ~dbg ~size_int ~access_size String
-      ~primitive:
-        (string_like_load_unsafe ~access_size String mode ~boxed str index
-           ~current_region)
-      str index
-  | Bytes ->
-    checked_string_or_bytes_access ~dbg ~size_int ~access_size Bytes
-      ~primitive:
-        (string_like_load_unsafe ~access_size Bytes mode ~boxed str index
-           ~current_region)
-      str index
-  | Bigstring ->
-    checked_bigstring_access ~dbg ~size_int ~access_size
-      ~primitive:
-        (string_like_load_unsafe ~access_size Bigstring mode ~boxed str index
-           ~current_region)
-      str index
-
 (* Bytes-like set *)
-let bytes_like_set_unsafe ~access_size kind ~boxed bytes index new_value =
-  let wrap =
-    match (access_size : Flambda_primitive.string_accessor_width) with
-    | Eight | Sixteen ->
-      assert (not boxed);
-      untag_int
-    | Thirty_two -> if boxed then unbox_bint Pint32 else Fun.id
-    | Single -> if boxed then unbox_float32 else Fun.id
-    | Sixty_four -> if boxed then unbox_bint Pint64 else Fun.id
-    | One_twenty_eight _ -> if boxed then unbox_vec128 else Fun.id
+let bytes_like_set ~dbg ~unsafe ~access_size ~size_int kind ~boxed bytes
+    ~index_kind index new_value =
+  let unsafe_set =
+    let index = convert_index_to_tagged_int index index_kind in
+    let wrap =
+      match (access_size : Flambda_primitive.string_accessor_width) with
+      | Eight | Sixteen ->
+        assert (not boxed);
+        untag_int
+      | Thirty_two -> if boxed then unbox_bint Pint32 else Fun.id
+      | Single -> if boxed then unbox_float32 else Fun.id
+      | Sixty_four -> if boxed then unbox_bint Pint64 else Fun.id
+      | One_twenty_eight _ -> if boxed then unbox_vec128 else Fun.id
+    in
+    H.Ternary
+      (Bytes_or_bigstring_set (kind, access_size), bytes, index, wrap new_value)
   in
-  H.Ternary
-    (Bytes_or_bigstring_set (kind, access_size), bytes, index, wrap new_value)
-
-let bytes_like_set_safe ~dbg ~size_int ~access_size kind ~boxed bytes index
-    new_value =
-  match (kind : P.bytes_like_value) with
-  | Bytes ->
-    checked_string_or_bytes_access ~dbg ~size_int ~access_size Bytes
-      ~primitive:
-        (bytes_like_set_unsafe ~access_size Bytes ~boxed bytes index new_value)
-      bytes index
-  | Bigstring ->
-    checked_bigstring_access ~dbg ~size_int ~access_size
-      ~primitive:
-        (bytes_like_set_unsafe ~access_size Bigstring ~boxed bytes index
-           new_value)
-      bytes index
+  if unsafe
+  then unsafe_set
+  else
+    let check_access =
+      match (kind : P.bytes_like_value) with
+      | Bytes -> checked_string_or_bytes_access Bytes
+      | Bigstring -> checked_bigstring_access
+    in
+    check_access ~dbg ~size_int ~access_size ~primitive:unsafe_set bytes
+      ~index_kind index
 
 (* Array vector load/store *)
 
@@ -623,13 +628,8 @@ let array_vector_access_validity_condition array ~size_int
            reduced_length_untagged ))
   in
   let check_nativeint = max_with_zero ~size_int reduced_length_nativeint in
-  let check_untagged =
-    H.Prim
-      (Unary
-         ( Num_conv { src = Naked_nativeint; dst = Naked_immediate },
-           check_nativeint ))
-  in
-  check_bound_tagged index check_untagged
+  check_bound ~index_kind:Ptagged_int_index ~bound_kind:Naked_nativeint index
+    check_nativeint
 
 let check_array_vector_access ~dbg ~size_int ~array array_kind ~index primitive
     : H.expr_primitive =
@@ -719,12 +719,18 @@ let bigarray_indexing layout b args =
     | [] -> assert false
     | [idx] ->
       let bound = bigarray_dim_bound b dim in
-      let check = check_bound_tagged idx bound in
+      let check =
+        check_bound ~index_kind:Ptagged_int_index ~bound_kind:Naked_immediate
+          idx bound
+      in
       [check], idx
     | idx :: r ->
       let checks, rem = aux (dim + delta_dim) delta_dim r in
       let bound = bigarray_dim_bound b dim in
-      let check = check_bound_tagged idx bound in
+      let check =
+        check_bound ~index_kind:Ptagged_int_index ~bound_kind:Naked_immediate
+          idx bound
+      in
       (* CR gbury: because we tag bound, and the tagged multiplication untags
          it, we might be left with a needless zero-extend here. *)
       let tmp =
@@ -774,39 +780,16 @@ let bigarray_set ~dbg ~unsafe kind layout b indexes value =
 
 (* Array accesses *)
 let array_access_validity_condition array array_kind index
-    (index_kind : L.array_index_kind) =
+    ~(index_kind : L.array_index_kind) =
   let arr_len_as_tagged_imm = H.Prim (Unary (Array_length array_kind, array)) in
-  (* The reason why we convert the array length instead of the index value is
-     because of edge cases around large negative numbers.
-
-     Given [-9223372036854775807] as a [Naked_int64] index, its bit
-     representation is
-     [0b1000000000000000000000000000000000000000000000000000000000000001]. If we
-     convert that into a [Tagged_immediate], it becomes [0b11] and the bounds
-     check would pass in cases that we should reject.
-
-     This also has the added benefit of producing better assembly code. Usually
-     saving one instruction compared to tagging the index value. *)
-  let (comp_kind : I.t), arr_len =
-    match index_kind with
-    | Ptagged_int_index -> I.Tagged_immediate, arr_len_as_tagged_imm
-    | Punboxed_int_index bint ->
-      ( standard_int_of_boxed_integer bint,
-        H.Prim
-          (Unary
-             ( Num_conv
-                 { src = Tagged_immediate;
-                   dst = standard_int_or_float_of_boxed_integer bint
-                 },
-               arr_len_as_tagged_imm )) )
-  in
-  [H.Binary (Int_comp (comp_kind, Yielding_bool (Lt Unsigned)), index, arr_len)]
+  [ check_bound ~index_kind ~bound_kind:Tagged_immediate index
+      arr_len_as_tagged_imm ]
 
 let check_array_access ~dbg ~array array_kind ~index ~index_kind primitive :
     H.expr_primitive =
   checked_access ~primitive
     ~conditions:
-      (array_access_validity_condition array array_kind index index_kind)
+      (array_access_validity_condition array array_kind index ~index_kind)
     ~dbg
 
 let array_load_unsafe ~array ~index (array_ref_kind : Array_ref_kind.t)
@@ -1289,113 +1272,78 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Pstringlength, [[arg]] -> [tag_int (Unary (String_length String, arg))]
   | Pbyteslength, [[arg]] -> [tag_int (Unary (String_length Bytes, arg))]
   | Pstringrefu, [[str]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Eight String None ~boxed:false str
-        index ~current_region ]
+    [ string_like_load ~unsafe:true ~dbg ~size_int ~access_size:Eight String
+        None ~boxed:false str ~index_kind:Ptagged_int_index index
+        ~current_region ]
   | Pbytesrefu, [[bytes]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Eight Bytes None ~boxed:false bytes
-        index ~current_region ]
+    [ string_like_load ~unsafe:true ~dbg ~size_int ~access_size:Eight Bytes None
+        ~boxed:false bytes ~index_kind:Ptagged_int_index index ~current_region ]
   | Pstringrefs, [[str]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Eight String
-        ~boxed:false None str index ~current_region ]
+    [ string_like_load ~unsafe:false ~dbg ~size_int ~access_size:Eight String
+        ~boxed:false None str ~index_kind:Ptagged_int_index index
+        ~current_region ]
   | Pbytesrefs, [[bytes]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Eight Bytes ~boxed:false
-        None bytes index ~current_region ]
-  | Pstring_load_16 true (* unsafe *), [[str]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Sixteen String ~boxed:false None str
-        index ~current_region ]
-  | Pbytes_load_16 true (* unsafe *), [[bytes]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Sixteen Bytes ~boxed:false None bytes
-        index ~current_region ]
-  | Pstring_load_32 (true (* unsafe *), mode), [[str]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Thirty_two String ~boxed:true
-        (Some mode) str index ~current_region ]
-  | Pstring_load_f32 (true (* unsafe *), mode), [[str]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Single String ~boxed:true (Some mode)
-        str index ~current_region ]
-  | Pbytes_load_32 (true (* unsafe *), mode), [[bytes]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Thirty_two Bytes ~boxed:true
-        (Some mode) bytes index ~current_region ]
-  | Pbytes_load_f32 (true (* unsafe *), mode), [[bytes]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Single Bytes ~boxed:true (Some mode)
-        bytes index ~current_region ]
-  | Pstring_load_64 (true (* unsafe *), mode), [[str]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Sixty_four String ~boxed:true
-        (Some mode) str index ~current_region ]
-  | Pbytes_load_64 (true (* unsafe *), mode), [[bytes]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Sixty_four Bytes ~boxed:true
-        (Some mode) bytes index ~current_region ]
-  | Pstring_load_128 { unsafe = true; mode }, [[str]; [index]] ->
-    [ string_like_load_unsafe
+    [ string_like_load ~unsafe:false ~dbg ~size_int ~access_size:Eight Bytes
+        ~boxed:false None bytes ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pstring_load_16 unsafe, [[str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixteen String
+        ~boxed:false None str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbytes_load_16 unsafe, [[bytes]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixteen Bytes
+        ~boxed:false None bytes ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pstring_load_32 (unsafe, mode), [[str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two String
+        ~boxed:true (Some mode) str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pstring_load_f32 (unsafe, mode), [[str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single String
+        ~boxed:true (Some mode) str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbytes_load_32 (unsafe, mode), [[bytes]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bytes
+        ~boxed:true (Some mode) bytes ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbytes_load_f32 (unsafe, mode), [[bytes]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single Bytes
+        ~boxed:true (Some mode) bytes ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pstring_load_64 (unsafe, mode), [[str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixty_four String
+        ~boxed:true (Some mode) str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbytes_load_64 (unsafe, mode), [[bytes]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bytes
+        ~boxed:true (Some mode) bytes ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pstring_load_128 { unsafe; mode }, [[str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned = false })
-        String ~boxed:true (Some mode) str index ~current_region ]
-  | Pbytes_load_128 { unsafe = true; mode }, [[str]; [index]] ->
-    [ string_like_load_unsafe
+        String ~boxed:true (Some mode) str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbytes_load_128 { unsafe; mode }, [[str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned = false })
-        Bytes ~boxed:true (Some mode) str index ~current_region ]
-  | Pstring_load_16 false (* safe *), [[str]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Sixteen String
-        ~boxed:false None str index ~current_region ]
-  | Pstring_load_32 (false (* safe *), mode), [[str]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Thirty_two String
-        (Some mode) ~boxed:true str index ~current_region ]
-  | Pstring_load_f32 (false (* safe *), mode), [[str]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Single String
-        (Some mode) ~boxed:true str index ~current_region ]
-  | Pstring_load_64 (false (* safe *), mode), [[str]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Sixty_four String
-        (Some mode) ~boxed:true str index ~current_region ]
-  | Pstring_load_128 { unsafe = false; mode }, [[str]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int
+        Bytes ~boxed:true (Some mode) str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbytes_set_16 unsafe, [[bytes]; [index]; [new_value]] ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixteen Bytes
+        ~boxed:false bytes ~index_kind:Ptagged_int_index index new_value ]
+  | Pbytes_set_32 unsafe, [[bytes]; [index]; [new_value]] ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bytes
+        ~boxed:true bytes ~index_kind:Ptagged_int_index index new_value ]
+  | Pbytes_set_f32 unsafe, [[bytes]; [index]; [new_value]] ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Single Bytes
+        ~boxed:true bytes ~index_kind:Ptagged_int_index index new_value ]
+  | Pbytes_set_64 unsafe, [[bytes]; [index]; [new_value]] ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bytes
+        ~boxed:true bytes ~index_kind:Ptagged_int_index index new_value ]
+  | Pbytes_set_128 { unsafe }, [[bytes]; [index]; [new_value]] ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned = false })
-        String (Some mode) ~boxed:true str index ~current_region ]
-  | Pbytes_load_16 false (* safe *), [[bytes]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Sixteen Bytes
-        ~boxed:false None bytes index ~current_region ]
-  | Pbytes_load_32 (false (* safe *), mode), [[bytes]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Thirty_two Bytes
-        ~boxed:true (Some mode) bytes index ~current_region ]
-  | Pbytes_load_f32 (false (* safe *), mode), [[bytes]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Single Bytes ~boxed:true
-        (Some mode) bytes index ~current_region ]
-  | Pbytes_load_64 (false (* safe *), mode), [[bytes]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Sixty_four Bytes
-        ~boxed:true (Some mode) bytes index ~current_region ]
-  | Pbytes_load_128 { unsafe = false; mode }, [[bytes]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int
-        ~access_size:(One_twenty_eight { aligned = false })
-        Bytes ~boxed:true (Some mode) bytes index ~current_region ]
-  | Pbytes_set_16 true (* unsafe *), [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_unsafe ~access_size:Sixteen Bytes ~boxed:false bytes index
-        new_value ]
-  | Pbytes_set_32 true (* unsafe *), [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_unsafe ~access_size:Thirty_two Bytes ~boxed:true bytes
-        index new_value ]
-  | Pbytes_set_f32 true (* unsafe *), [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_unsafe ~access_size:Single Bytes ~boxed:true bytes index
-        new_value ]
-  | Pbytes_set_64 true (* unsafe *), [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_unsafe ~access_size:Sixty_four Bytes ~boxed:true bytes
-        index new_value ]
-  | Pbytes_set_128 { unsafe = true }, [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_unsafe
-        ~access_size:(One_twenty_eight { aligned = false })
-        Bytes ~boxed:true bytes index new_value ]
-  | Pbytes_set_16 false (* safe *), [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_safe ~dbg ~size_int ~access_size:Sixteen Bytes ~boxed:false
-        bytes index new_value ]
-  | Pbytes_set_32 false (* safe *), [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_safe ~dbg ~size_int ~access_size:Thirty_two Bytes
-        ~boxed:true bytes index new_value ]
-  | Pbytes_set_f32 false (* safe *), [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_safe ~dbg ~size_int ~access_size:Single Bytes ~boxed:true
-        bytes index new_value ]
-  | Pbytes_set_64 false (* safe *), [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_safe ~dbg ~size_int ~access_size:Sixty_four Bytes
-        ~boxed:true bytes index new_value ]
-  | Pbytes_set_128 { unsafe = false }, [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_safe ~dbg ~size_int
-        ~access_size:(One_twenty_eight { aligned = false })
-        Bytes ~boxed:true bytes index new_value ]
+        Bytes ~boxed:true bytes ~index_kind:Ptagged_int_index index new_value ]
   | Pisint { variant_only }, [[arg]] ->
     [tag_int (Unary (Is_int { variant_only }, arg))]
   | Pisout, [[arg1]; [arg2]] ->
@@ -1626,11 +1574,11 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
               ~index:(convert_index_to_tagged_int index array_index_kind)
               ~new_value)) ]
   | Pbytessetu (* unsafe *), [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_unsafe ~access_size:Eight Bytes ~boxed:false bytes index
-        new_value ]
+    [ bytes_like_set ~unsafe:true ~dbg ~size_int ~access_size:Eight Bytes
+        ~boxed:false bytes ~index_kind:Ptagged_int_index index new_value ]
   | Pbytessets, [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set_safe ~dbg ~size_int ~access_size:Eight Bytes ~boxed:false
-        bytes index new_value ]
+    [ bytes_like_set ~unsafe:false ~dbg ~size_int ~access_size:Eight Bytes
+        ~boxed:false bytes ~index_kind:Ptagged_int_index index new_value ]
   | Poffsetref n, [[block]] ->
     let block_access : P.Block_access_kind.t =
       Values
@@ -1764,80 +1712,46 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
          with an unknown layout should have been removed by Lambda_to_flambda.")
   | Pbigarraydim dimension, [[arg]] ->
     [tag_int (Unary (Bigarray_length { dimension }, arg))]
-  | Pbigstring_load_16 { unsafe = true }, [[big_str]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Sixteen Bigstring ~boxed:false None
-        big_str index ~current_region ]
-  | Pbigstring_load_32 { unsafe = true; mode; boxed }, [[big_str]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Thirty_two Bigstring (Some mode)
-        ~boxed big_str index ~current_region ]
-  | Pbigstring_load_f32 { unsafe = true; mode; boxed }, [[big_str]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Single Bigstring (Some mode) ~boxed
-        big_str index ~current_region ]
-  | Pbigstring_load_64 { unsafe = true; mode; boxed }, [[big_str]; [index]] ->
-    [ string_like_load_unsafe ~access_size:Sixty_four Bigstring (Some mode)
-        ~boxed big_str index ~current_region ]
-  | ( Pbigstring_load_128 { unsafe = true; aligned; mode; boxed },
-      [[big_str]; [index]] ) ->
-    [ string_like_load_unsafe
+  | Pbigstring_load_16 { unsafe }, [[big_str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixteen Bigstring
+        ~boxed:false None big_str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbigstring_load_32 { unsafe; mode; boxed }, [[big_str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bigstring
+        (Some mode) ~boxed big_str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbigstring_load_f32 { unsafe; mode; boxed }, [[big_str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single Bigstring
+        (Some mode) ~boxed big_str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbigstring_load_64 { unsafe; mode; boxed }, [[big_str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bigstring
+        (Some mode) ~boxed big_str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbigstring_load_128 { unsafe; aligned; mode; boxed }, [[big_str]; [index]]
+    ->
+    [ string_like_load ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned })
-        Bigstring (Some mode) ~boxed big_str index ~current_region ]
-  | Pbigstring_load_16 { unsafe = false }, [[big_str]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Sixteen Bigstring
-        ~boxed:false None big_str index ~current_region ]
-  | Pbigstring_load_32 { unsafe = false; mode; boxed }, [[big_str]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Thirty_two Bigstring
-        (Some mode) ~boxed big_str index ~current_region ]
-  | Pbigstring_load_f32 { unsafe = false; mode; boxed }, [[big_str]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Single Bigstring
-        (Some mode) ~boxed big_str index ~current_region ]
-  | Pbigstring_load_64 { unsafe = false; mode; boxed }, [[big_str]; [index]] ->
-    [ string_like_load_safe ~dbg ~size_int ~access_size:Sixty_four Bigstring
-        (Some mode) ~boxed big_str index ~current_region ]
-  | ( Pbigstring_load_128 { unsafe = false; aligned; mode; boxed },
-      [[big_str]; [index]] ) ->
-    [ string_like_load_safe ~dbg ~size_int
+        Bigstring (Some mode) ~boxed big_str ~index_kind:Ptagged_int_index index
+        ~current_region ]
+  | Pbigstring_set_16 { unsafe }, [[bigstring]; [index]; [new_value]] ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixteen Bigstring
+        ~boxed:false bigstring ~index_kind:Ptagged_int_index index new_value ]
+  | Pbigstring_set_32 { unsafe; boxed }, [[bigstring]; [index]; [new_value]] ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bigstring
+        ~boxed bigstring ~index_kind:Ptagged_int_index index new_value ]
+  | Pbigstring_set_f32 { unsafe; boxed }, [[bigstring]; [index]; [new_value]] ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Single Bigstring ~boxed
+        bigstring ~index_kind:Ptagged_int_index index new_value ]
+  | Pbigstring_set_64 { unsafe; boxed }, [[bigstring]; [index]; [new_value]] ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bigstring
+        ~boxed bigstring ~index_kind:Ptagged_int_index index new_value ]
+  | ( Pbigstring_set_128 { unsafe; aligned; boxed },
+      [[bigstring]; [index]; [new_value]] ) ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned })
-        Bigstring (Some mode) ~boxed big_str index ~current_region ]
-  | Pbigstring_set_16 { unsafe = true }, [[bigstring]; [index]; [new_value]] ->
-    [ bytes_like_set_unsafe ~access_size:Sixteen Bigstring ~boxed:false
-        bigstring index new_value ]
-  | ( Pbigstring_set_32 { unsafe = true; boxed },
-      [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set_unsafe ~access_size:Thirty_two Bigstring ~boxed bigstring
-        index new_value ]
-  | ( Pbigstring_set_f32 { unsafe = true; boxed },
-      [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set_unsafe ~access_size:Single Bigstring ~boxed bigstring index
-        new_value ]
-  | ( Pbigstring_set_64 { unsafe = true; boxed },
-      [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set_unsafe ~access_size:Sixty_four Bigstring ~boxed bigstring
-        index new_value ]
-  | ( Pbigstring_set_128 { unsafe = true; aligned; boxed },
-      [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set_unsafe
-        ~access_size:(One_twenty_eight { aligned })
-        Bigstring ~boxed bigstring index new_value ]
-  | Pbigstring_set_16 { unsafe = false }, [[bigstring]; [index]; [new_value]] ->
-    [ bytes_like_set_safe ~dbg ~size_int ~access_size:Sixteen Bigstring
-        ~boxed:false bigstring index new_value ]
-  | ( Pbigstring_set_32 { unsafe = false; boxed },
-      [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set_safe ~dbg ~size_int ~access_size:Thirty_two Bigstring
-        ~boxed bigstring index new_value ]
-  | ( Pbigstring_set_f32 { unsafe = false; boxed },
-      [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set_safe ~dbg ~size_int ~access_size:Single Bigstring ~boxed
-        bigstring index new_value ]
-  | ( Pbigstring_set_64 { unsafe = false; boxed },
-      [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set_safe ~dbg ~size_int ~access_size:Sixty_four Bigstring
-        ~boxed bigstring index new_value ]
-  | ( Pbigstring_set_128 { unsafe = false; aligned; boxed },
-      [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set_safe ~dbg ~size_int
-        ~access_size:(One_twenty_eight { aligned })
-        Bigstring ~boxed bigstring index new_value ]
+        Bigstring ~boxed bigstring ~index_kind:Ptagged_int_index index new_value
+    ]
   | Pfloat_array_load_128 { unsafe; mode }, [[array]; [index]] ->
     check_float_array_optimisation_enabled "Pfloat_array_load_128";
     [ array_like_load_128 ~dbg ~size_int ~current_region ~unsafe ~mode

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -398,6 +398,14 @@ module Standard_int_or_float = struct
     | Naked_int64
     | Naked_nativeint
 
+  let of_standard_int (t : Standard_int.t) : t =
+    match t with
+    | Tagged_immediate -> Tagged_immediate
+    | Naked_immediate -> Naked_immediate
+    | Naked_int32 -> Naked_int32
+    | Naked_int64 -> Naked_int64
+    | Naked_nativeint -> Naked_nativeint
+
   let to_kind t : kind =
     match t with
     | Tagged_immediate -> Value

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -160,6 +160,8 @@ module Standard_int_or_float : sig
     | Naked_int64
     | Naked_nativeint
 
+  val of_standard_int : Standard_int.t -> t
+
   val to_kind : t -> kind
 
   val print_lowercase : Format.formatter -> t -> unit

--- a/ocaml/testsuite/tests/prim-bigstring/non_existent_primitives.ml
+++ b/ocaml/testsuite/tests/prim-bigstring/non_existent_primitives.ml
@@ -1,0 +1,54 @@
+(* TEST
+ expect;
+*)
+
+open struct
+  open Bigarray
+
+  type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t
+end
+
+external bigstring_get_128_aligned : bigstring -> int -> int8x16
+  = "%caml_bigstring_geta128"
+
+[%%expect
+{|
+type bigstring =
+    (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+external bigstring_get_128_aligned : bigstring -> int -> int8x16
+  = "%caml_bigstring_geta128"
+|}]
+
+external bigstring_get_64_unboxed : bigstring -> int -> int64#
+  = "%caml_bigstring_get64#"
+
+[%%expect
+{|
+external bigstring_get_64_unboxed : bigstring -> int -> int64#
+  = "%caml_bigstring_get64#"
+|}]
+
+[%%expect {|
+|}]
+
+external string_get_128_aligned : string -> int -> int8x16
+  = "%caml_string_geta128"
+
+[%%expect
+{|
+Lines 1-2, characters 0-26:
+1 | external string_get_128_aligned : string -> int -> int8x16
+2 |   = "%caml_string_geta128"
+Error: Unknown builtin primitive "%caml_string_geta128"
+|}]
+
+external string_get_64_unboxed : string -> int -> int64#
+  = "%caml_string_get64#"
+
+[%%expect
+{|
+Lines 1-2, characters 0-25:
+1 | external string_get_64_unboxed : string -> int -> int64#
+2 |   = "%caml_string_get64#"
+Error: Unknown builtin primitive "%caml_string_get64#"
+|}]

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -18,6 +18,8 @@
 open Misc
 open Parsetree
 
+module String = Misc.Stdlib.String
+
 type boxed_integer = Pnativeint | Pint32 | Pint64
 
 type vec128_type = Int8x16 | Int16x8 | Int32x4 | Int64x2 | Float32x4 | Float64x2
@@ -477,7 +479,6 @@ end
 let prim_has_valid_reprs ~loc prim =
   let open Repr_check in
   let check =
-    let module String_map = Map.Make (String) in
     let stringlike_indexing_primitives =
       let widths : (_ * _ * Jkind_types.Sort.const) list =
         [
@@ -522,7 +523,7 @@ let prim_has_valid_reprs ~loc prim =
        let reprs = combine_repr width_kind in
        [ (string, reprs) ])
       |> List.to_seq
-      |> fun seq -> String_map.add_seq seq String_map.empty
+      |> fun seq -> String.Map.add_seq seq String.Map.empty
     in
     match prim.prim_name with
     | "%identity"
@@ -679,7 +680,7 @@ let prim_has_valid_reprs ~loc prim =
     | "%caml_bigstring_seta128#" ->
     | "%caml_bigstring_seta128u#" -> *)
     | name -> (
-        match String_map.find_opt name stringlike_indexing_primitives with
+        match String.Map.find_opt name stringlike_indexing_primitives with
         | Some reprs -> exactly reprs
         | None ->
             if is_builtin_prim_name name then no_non_value_repr

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -477,6 +477,62 @@ end
 let prim_has_valid_reprs ~loc prim =
   let open Repr_check in
   let check =
+    let module String_map = Map.Make (String) in
+    let stringlike_indexing_primitives =
+      let widths : (_ * _ * Jkind_types.Sort.const) list =
+        [
+          ("16", "", Value);
+          ("32", "", Value);
+          ("f32", "", Value);
+          ("64", "", Value);
+          ("a128", "", Value);
+          ("u128", "", Value);
+          ("32", "#", Bits32);
+          ("f32", "#", Float32);
+          ("64", "#", Bits64);
+        ]
+      in
+      let containers = [ "bigstring"; "bytes"; "string" ] in
+      let safes = [ ""; "u" ] in
+      let combiners =
+        [
+          ( Printf.sprintf "%%caml_%s_get%s%s%s",
+            fun width_kind ->
+              [
+                Same_as_ocaml_repr Value;
+                Same_as_ocaml_repr Value;
+                Same_as_ocaml_repr width_kind;
+              ] );
+          ( Printf.sprintf "%%caml_%s_set%s%s%s",
+            fun width_kind ->
+              [
+                Same_as_ocaml_repr Value;
+                Same_as_ocaml_repr Value;
+                Same_as_ocaml_repr width_kind;
+                Same_as_ocaml_repr Value;
+              ] );
+        ]
+      in
+      Misc.Hlist.cartesian_product [ containers; widths; safes; combiners ]
+      |> List.map
+           (fun
+             ([
+                container;
+                (width_sigil, unboxed_sigil, width_kind);
+                safe_sigil;
+                (combine_string, combine_repr);
+              ] :
+               _ Hlist.t)
+           ->
+             let string =
+               combine_string container width_sigil safe_sigil unboxed_sigil
+             in
+
+             let reprs = combine_repr width_kind in
+             (string, reprs))
+      |> List.to_seq
+      |> fun seq -> String_map.add_seq seq String_map.empty
+    in
     match prim.prim_name with
     | "%identity"
     | "%opaque"
@@ -620,100 +676,32 @@ let prim_has_valid_reprs ~loc prim =
     | "%reinterpret_unboxed_int64_as_tagged_int63" ->
       exactly [Same_as_ocaml_repr Bits64; Same_as_ocaml_repr Value]
 
-    (* Bigstring primitives *)
-    | "%caml_bigstring_get32#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Bits32]
-    | "%caml_bigstring_getf32#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Float32]
-    | "%caml_bigstring_get32u#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Bits32]
-    | "%caml_bigstring_getf32u#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Float32]
-    | "%caml_bigstring_get64#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Bits64]
-    | "%caml_bigstring_get64u#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Bits64]
-
     (* CR layouts: add these when we have unboxed simd layouts *)
     (* | "%caml_bigstring_getu128#" ->
     | "%caml_bigstring_getu128u#" ->
     | "%caml_bigstring_geta128#" ->
     | "%caml_bigstring_geta128u#" -> *)
 
-    | "%caml_bigstring_set32#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Bits32;
-        Same_as_ocaml_repr Value]
-    | "%caml_bigstring_setf32#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Float32;
-        Same_as_ocaml_repr Value]
-    | "%caml_bigstring_set32u#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Bits32;
-        Same_as_ocaml_repr Value]
-    | "%caml_bigstring_setf32u#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Float32;
-        Same_as_ocaml_repr Value]
-    | "%caml_bigstring_set64#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Bits64;
-        Same_as_ocaml_repr Value]
-    | "%caml_bigstring_set64u#" ->
-      exactly [
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Value;
-        Same_as_ocaml_repr Bits64;
-        Same_as_ocaml_repr Value]
-
     (* CR layouts: add these when we have unboxed simd layouts *)
     (* | "%caml_bigstring_setu128#" ->
     | "%caml_bigstring_setu128u#" ->
     | "%caml_bigstring_seta128#" ->
     | "%caml_bigstring_seta128u#" -> *)
-
-    | name when is_builtin_prim_name name ->
-      no_non_value_repr
-
-    (* These can probably support non-value reprs if the need arises:
-      {|
-        | "%send"
-        | "%sendself"
-        | "%sendcache"
-      |}
-    *)
-    | _ ->
-      (* make no assumptions about external c primitives *)
-      fun _ -> Success
+    | name -> (
+        match String_map.find_opt name stringlike_indexing_primitives with
+        | Some reprs -> exactly reprs
+        | None ->
+            if is_builtin_prim_name name then no_non_value_repr
+              (* These can probably support non-value reprs if the need arises:
+                 {|
+                   | "%send"
+                   | "%sendself"
+                   | "%sendcache"
+                 |}
+              *)
+            else
+              (* make no assumptions about external c primitives *)
+              fun _ -> Success)
   in
   match check prim with
   | Success -> ()

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -107,6 +107,17 @@ let rec last = function
   | [x] -> Some x
   | _ :: tl -> last tl
 
+module Hlist = struct
+  type _ t = [] : unit t | ( :: ) : 'a * 'b t -> ('a -> 'b) t
+  type _ lt = [] : unit lt | ( :: ) : 'a list * 'b lt -> ('a -> 'b) lt
+
+  let rec cartesian_product : type l. l lt -> l t list = function
+    | [] -> [ [] ]
+    | hd :: tl ->
+        let tl = cartesian_product tl in
+        List.concat_map (fun x1 -> List.map (fun x2 : _ t -> x1 :: x2) tl) hd
+end
+
 module Stdlib = struct
   module List = struct
     include List

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -398,6 +398,16 @@ module Stdlib = struct
         else if unsafe_get s (diff + i) <> unsafe_get suffix i then false
         else aux (i + 1)
       in diff >= 0 && aux 0
+
+    let is_substring string ~substring =
+      let len = String.length substring in
+      String.to_seq string
+      |> Seq.mapi (fun i _ -> i)
+      |> Seq.filter_map (fun i ->
+             if i + len < String.length string then
+               Some (String.sub string i len)
+             else None)
+      |> Seq.exists (fun sub -> String.equal substring sub)
   end
 
   module Int = struct

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -107,17 +107,6 @@ let rec last = function
   | [x] -> Some x
   | _ :: tl -> last tl
 
-module Hlist = struct
-  type _ t = [] : unit t | ( :: ) : 'a * 'b t -> ('a -> 'b) t
-  type _ lt = [] : unit lt | ( :: ) : 'a list * 'b lt -> ('a -> 'b) lt
-
-  let rec cartesian_product : type l. l lt -> l t list = function
-    | [] -> [ [] ]
-    | hd :: tl ->
-        let tl = cartesian_product tl in
-        List.concat_map (fun x1 -> List.map (fun x2 : _ t -> x1 :: x2) tl) hd
-end
-
 module Stdlib = struct
   module List = struct
     include List

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -251,6 +251,8 @@ module Stdlib : sig
 
     val starts_with : prefix:string -> string -> bool
     val ends_with : suffix:string -> string -> bool
+
+    val is_substring : string -> substring:string -> bool
   end
 
   module Int : sig

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -102,6 +102,13 @@ val split_last: 'a list -> 'a list * 'a
 val last : 'a list -> 'a option
         (** Return the last element of a list if it's nonempty *)
 
+module Hlist : sig
+  type _ t = [] : unit t | ( :: ) : 'a * 'b t -> ('a -> 'b) t
+  type _ lt = [] : unit lt | ( :: ) : 'a list * 'b lt -> ('a -> 'b) lt
+
+  val cartesian_product : 'l lt -> 'l t list
+end
+
 (** {1 Hash table operations} *)
 
 val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -102,13 +102,6 @@ val split_last: 'a list -> 'a list * 'a
 val last : 'a list -> 'a option
         (** Return the last element of a list if it's nonempty *)
 
-module Hlist : sig
-  type _ t = [] : unit t | ( :: ) : 'a * 'b t -> ('a -> 'b) t
-  type _ lt = [] : unit lt | ( :: ) : 'a list * 'b lt -> ('a -> 'b) lt
-
-  val cartesian_product : 'l lt -> 'l t list
-end
-
 (** {1 Hash table operations} *)
 
 val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t


### PR DESCRIPTION
Refactor the logic for translating the `get`/`set` primitives for `bigstring`, `string`, and `bytes` in preparation for new versions of these primitives with unboxed indices and unboxed return types (#2906). As part of the refactor, string-like loads and stores now share bounds-checking logic with arrays.

This PR does not add any new primitives. For existing primitives, I rely on existing tests.

I add a small test `ocaml/testsuite/tests/prim-bigstring/non_existent_primitives.ml` to show that the as-yet unoccupied spaces in the (container type x index kind x data width) cartesian product continue to fail with sensible compiler errors.