### PR TITLE
Unboxed load/store primitives for string-likes

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -635,30 +635,30 @@ let primitive_can_raise (prim : Lambda.primitive) =
   match prim with
   | Pccall _ | Praise _ | Parrayrefs _ | Parraysets _ | Pmodint _ | Pdivint _
   | Pstringrefs | Pbytesrefs | Pbytessets
-  | Pstring_load_16 false
-  | Pstring_load_32 (false, _)
-  | Pstring_load_f32 (false, _)
-  | Pstring_load_64 (false, _)
+  | Pstring_load_16 { unsafe = false; _ }
+  | Pstring_load_32 { unsafe = false; _ }
+  | Pstring_load_f32 { unsafe = false; _ }
+  | Pstring_load_64 { unsafe = false; _ }
   | Pstring_load_128 { unsafe = false; _ }
-  | Pbytes_load_16 false
-  | Pbytes_load_32 (false, _)
-  | Pbytes_load_f32 (false, _)
-  | Pbytes_load_64 (false, _)
+  | Pbytes_load_16 { unsafe = false; _ }
+  | Pbytes_load_32 { unsafe = false; _ }
+  | Pbytes_load_f32 { unsafe = false; _ }
+  | Pbytes_load_64 { unsafe = false; _ }
   | Pbytes_load_128 { unsafe = false; _ }
-  | Pbytes_set_16 false
-  | Pbytes_set_32 false
-  | Pbytes_set_f32 false
-  | Pbytes_set_64 false
+  | Pbytes_set_16 { unsafe = false; index_kind = _ }
+  | Pbytes_set_32 { unsafe = false; index_kind = _; boxed = _ }
+  | Pbytes_set_f32 { unsafe = false; index_kind = _; boxed = _ }
+  | Pbytes_set_64 { unsafe = false; index_kind = _; boxed = _ }
   | Pbytes_set_128 { unsafe = false; _ }
-  | Pbigstring_load_16 { unsafe = false }
-  | Pbigstring_load_32 { unsafe = false; mode = _; boxed = _ }
-  | Pbigstring_load_f32 { unsafe = false; mode = _; boxed = _ }
-  | Pbigstring_load_64 { unsafe = false; mode = _; boxed = _ }
+  | Pbigstring_load_16 { unsafe = false; index_kind = _ }
+  | Pbigstring_load_32 { unsafe = false; index_kind = _; mode = _; boxed = _ }
+  | Pbigstring_load_f32 { unsafe = false; index_kind = _; mode = _; boxed = _ }
+  | Pbigstring_load_64 { unsafe = false; index_kind = _; mode = _; boxed = _ }
   | Pbigstring_load_128 { unsafe = false; _ }
-  | Pbigstring_set_16 { unsafe = false }
-  | Pbigstring_set_32 { unsafe = false; boxed = _ }
-  | Pbigstring_set_f32 { unsafe = false; boxed = _ }
-  | Pbigstring_set_64 { unsafe = false; boxed = _ }
+  | Pbigstring_set_16 { unsafe = false; index_kind = _ }
+  | Pbigstring_set_32 { unsafe = false; index_kind = _; boxed = _ }
+  | Pbigstring_set_f32 { unsafe = false; index_kind = _; boxed = _ }
+  | Pbigstring_set_64 { unsafe = false; index_kind = _; boxed = _ }
   | Pbigstring_set_128 { unsafe = false; _ }
   | Pfloatarray_load_128 { unsafe = false; _ }
   | Pfloat_array_load_128 { unsafe = false; _ }
@@ -732,30 +732,30 @@ let primitive_can_raise (prim : Lambda.primitive) =
         | Pbigarray_caml_int | Pbigarray_native_int | Pbigarray_complex32
         | Pbigarray_complex64 ),
         (Pbigarray_c_layout | Pbigarray_fortran_layout) )
-  | Pstring_load_16 true
-  | Pstring_load_32 (true, _)
-  | Pstring_load_f32 (true, _)
-  | Pstring_load_64 (true, _)
+  | Pstring_load_16 { unsafe = true; _ }
+  | Pstring_load_32 { unsafe = true; _ }
+  | Pstring_load_f32 { unsafe = true; _ }
+  | Pstring_load_64 { unsafe = true; _ }
   | Pstring_load_128 { unsafe = true; _ }
-  | Pbytes_load_16 true
-  | Pbytes_load_32 (true, _)
-  | Pbytes_load_f32 (true, _)
-  | Pbytes_load_64 (true, _)
+  | Pbytes_load_16 { unsafe = true; _ }
+  | Pbytes_load_32 { unsafe = true; _ }
+  | Pbytes_load_f32 { unsafe = true; _ }
+  | Pbytes_load_64 { unsafe = true; _ }
   | Pbytes_load_128 { unsafe = true; _ }
-  | Pbytes_set_16 true
-  | Pbytes_set_32 true
-  | Pbytes_set_f32 true
-  | Pbytes_set_64 true
+  | Pbytes_set_16 { unsafe = true; index_kind = _ }
+  | Pbytes_set_32 { unsafe = true; index_kind = _; boxed = _ }
+  | Pbytes_set_f32 { unsafe = true; index_kind = _; boxed = _ }
+  | Pbytes_set_64 { unsafe = true; index_kind = _; boxed = _ }
   | Pbytes_set_128 { unsafe = true; _ }
-  | Pbigstring_load_16 { unsafe = true }
-  | Pbigstring_load_32 { unsafe = true; mode = _; boxed = _ }
-  | Pbigstring_load_f32 { unsafe = true; mode = _; boxed = _ }
-  | Pbigstring_load_64 { unsafe = true; mode = _; boxed = _ }
+  | Pbigstring_load_16 { unsafe = true; index_kind = _ }
+  | Pbigstring_load_32 { unsafe = true; index_kind = _; mode = _; boxed = _ }
+  | Pbigstring_load_f32 { unsafe = true; index_kind = _; mode = _; boxed = _ }
+  | Pbigstring_load_64 { unsafe = true; index_kind = _; mode = _; boxed = _ }
   | Pbigstring_load_128 { unsafe = true; _ }
-  | Pbigstring_set_16 { unsafe = true }
-  | Pbigstring_set_32 { unsafe = true; boxed = _ }
-  | Pbigstring_set_f32 { unsafe = true; boxed = _ }
-  | Pbigstring_set_64 { unsafe = true; boxed = _ }
+  | Pbigstring_set_16 { unsafe = true; _ }
+  | Pbigstring_set_32 { unsafe = true; index_kind = _; boxed = _ }
+  | Pbigstring_set_f32 { unsafe = true; index_kind = _; boxed = _ }
+  | Pbigstring_set_64 { unsafe = true; index_kind = _; boxed = _ }
   | Pbigstring_set_128 { unsafe = true; _ }
   | Pfloatarray_load_128 { unsafe = true; _ }
   | Pfloat_array_load_128 { unsafe = true; _ }

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1344,8 +1344,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     ->
     [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bytes ~boxed
         bytes ~index_kind index new_value ]
-  | ( Pbytes_set_f32 { unsafe; index_kind; boxed },
-      [[bytes]; [index]; [new_value]] )
+  | Pbytes_set_f32 { unsafe; index_kind; boxed }, [[bytes]; [index]; [new_value]]
     ->
     [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Single Bytes ~boxed
         bytes ~index_kind index new_value ]
@@ -1353,8 +1352,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     ->
     [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bytes ~boxed
         bytes ~index_kind index new_value ]
-  | ( Pbytes_set_128 { unsafe; index_kind; boxed },
-      [[bytes]; [index]; [new_value]] )
+  | Pbytes_set_128 { unsafe; index_kind; boxed }, [[bytes]; [index]; [new_value]]
     ->
     [ bytes_like_set ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned = false })
@@ -1739,8 +1737,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     ->
     [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bigstring
         (Some mode) ~boxed big_str ~index_kind index ~current_region ]
-  | ( Pbigstring_load_f32 { unsafe; index_kind; mode; boxed },
-      [[big_str]; [index]] )
+  | Pbigstring_load_f32 { unsafe; index_kind; mode; boxed }, [[big_str]; [index]]
     ->
     [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single Bigstring
         (Some mode) ~boxed big_str ~index_kind index ~current_region ]
@@ -1754,8 +1751,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         ~access_size:(One_twenty_eight { aligned })
         Bigstring (Some mode) ~boxed big_str ~index_kind index ~current_region
     ]
-  | ( Pbigstring_set_16 { unsafe; index_kind },
-      [[bigstring]; [index]; [new_value]] )
+  | Pbigstring_set_16 { unsafe; index_kind }, [[bigstring]; [index]; [new_value]]
     ->
     [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixteen Bigstring
         ~boxed:false bigstring ~index_kind index new_value ]

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1305,64 +1305,60 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     [ string_like_load ~unsafe:false ~dbg ~size_int ~access_size:Eight Bytes
         ~boxed:false None bytes ~index_kind:Ptagged_int_index index
         ~current_region ]
-  | Pstring_load_16 unsafe, [[str]; [index]] ->
+  | Pstring_load_16 { unsafe; index_kind }, [[str]; [index]] ->
     [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixteen String
-        ~boxed:false None str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbytes_load_16 unsafe, [[bytes]; [index]] ->
+        ~boxed:false None str ~index_kind index ~current_region ]
+  | Pbytes_load_16 { unsafe; index_kind }, [[bytes]; [index]] ->
     [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixteen Bytes
-        ~boxed:false None bytes ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pstring_load_32 (unsafe, mode), [[str]; [index]] ->
+        ~boxed:false None bytes ~index_kind index ~current_region ]
+  | Pstring_load_32 { unsafe; index_kind; mode; boxed }, [[str]; [index]] ->
     [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two String
-        ~boxed:true (Some mode) str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pstring_load_f32 (unsafe, mode), [[str]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single String
-        ~boxed:true (Some mode) str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbytes_load_32 (unsafe, mode), [[bytes]; [index]] ->
+        ~boxed (Some mode) str ~index_kind index ~current_region ]
+  | Pstring_load_f32 { unsafe; index_kind; mode; boxed }, [[str]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single String ~boxed
+        (Some mode) str ~index_kind index ~current_region ]
+  | Pbytes_load_32 { unsafe; index_kind; mode; boxed }, [[bytes]; [index]] ->
     [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bytes
-        ~boxed:true (Some mode) bytes ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbytes_load_f32 (unsafe, mode), [[bytes]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single Bytes
-        ~boxed:true (Some mode) bytes ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pstring_load_64 (unsafe, mode), [[str]; [index]] ->
+        ~boxed (Some mode) bytes ~index_kind index ~current_region ]
+  | Pbytes_load_f32 { unsafe; index_kind; mode; boxed }, [[bytes]; [index]] ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single Bytes ~boxed
+        (Some mode) bytes ~index_kind index ~current_region ]
+  | Pstring_load_64 { unsafe; index_kind; mode; boxed }, [[str]; [index]] ->
     [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixty_four String
-        ~boxed:true (Some mode) str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbytes_load_64 (unsafe, mode), [[bytes]; [index]] ->
+        ~boxed (Some mode) str ~index_kind index ~current_region ]
+  | Pbytes_load_64 { unsafe; index_kind; mode; boxed }, [[bytes]; [index]] ->
     [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bytes
-        ~boxed:true (Some mode) bytes ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pstring_load_128 { unsafe; mode }, [[str]; [index]] ->
+        ~boxed (Some mode) bytes ~index_kind index ~current_region ]
+  | Pstring_load_128 { unsafe; index_kind; mode }, [[str]; [index]] ->
     [ string_like_load ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned = false })
-        String ~boxed:true (Some mode) str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbytes_load_128 { unsafe; mode }, [[str]; [index]] ->
+        String ~boxed:true (Some mode) str ~index_kind index ~current_region ]
+  | Pbytes_load_128 { unsafe; index_kind; mode }, [[str]; [index]] ->
     [ string_like_load ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned = false })
-        Bytes ~boxed:true (Some mode) str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbytes_set_16 unsafe, [[bytes]; [index]; [new_value]] ->
+        Bytes ~boxed:true (Some mode) str ~index_kind index ~current_region ]
+  | Pbytes_set_16 { unsafe; index_kind }, [[bytes]; [index]; [new_value]] ->
     [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixteen Bytes
-        ~boxed:false bytes ~index_kind:Ptagged_int_index index new_value ]
-  | Pbytes_set_32 unsafe, [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bytes
-        ~boxed:true bytes ~index_kind:Ptagged_int_index index new_value ]
-  | Pbytes_set_f32 unsafe, [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Single Bytes
-        ~boxed:true bytes ~index_kind:Ptagged_int_index index new_value ]
-  | Pbytes_set_64 unsafe, [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bytes
-        ~boxed:true bytes ~index_kind:Ptagged_int_index index new_value ]
-  | Pbytes_set_128 { unsafe }, [[bytes]; [index]; [new_value]] ->
+        ~boxed:false bytes ~index_kind index new_value ]
+  | Pbytes_set_32 { unsafe; index_kind; boxed }, [[bytes]; [index]; [new_value]]
+    ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bytes ~boxed
+        bytes ~index_kind index new_value ]
+  | ( Pbytes_set_f32 { unsafe; index_kind; boxed },
+      [[bytes]; [index]; [new_value]] )
+    ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Single Bytes ~boxed
+        bytes ~index_kind index new_value ]
+  | Pbytes_set_64 { unsafe; index_kind; boxed }, [[bytes]; [index]; [new_value]]
+    ->
+    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bytes ~boxed
+        bytes ~index_kind index new_value ]
+  | ( Pbytes_set_128 { unsafe; index_kind; boxed },
+      [[bytes]; [index]; [new_value]] )
+    ->
     [ bytes_like_set ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned = false })
-        Bytes ~boxed:true bytes ~index_kind:Ptagged_int_index index new_value ]
+        Bytes ~boxed bytes ~index_kind index new_value ]
   | Pisint { variant_only }, [[arg]] ->
     [tag_int (Unary (Is_int { variant_only }, arg))]
   | Pisout, [[arg1]; [arg2]] ->
@@ -1736,46 +1732,50 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
          with an unknown layout should have been removed by Lambda_to_flambda.")
   | Pbigarraydim dimension, [[arg]] ->
     [tag_int (Unary (Bigarray_length { dimension }, arg))]
-  | Pbigstring_load_16 { unsafe }, [[big_str]; [index]] ->
+  | Pbigstring_load_16 { unsafe; index_kind }, [[big_str]; [index]] ->
     [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixteen Bigstring
-        ~boxed:false None big_str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbigstring_load_32 { unsafe; mode; boxed }, [[big_str]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bigstring
-        (Some mode) ~boxed big_str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbigstring_load_f32 { unsafe; mode; boxed }, [[big_str]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single Bigstring
-        (Some mode) ~boxed big_str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbigstring_load_64 { unsafe; mode; boxed }, [[big_str]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bigstring
-        (Some mode) ~boxed big_str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbigstring_load_128 { unsafe; aligned; mode; boxed }, [[big_str]; [index]]
+        ~boxed:false None big_str ~index_kind index ~current_region ]
+  | Pbigstring_load_32 { unsafe; index_kind; mode; boxed }, [[big_str]; [index]]
     ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bigstring
+        (Some mode) ~boxed big_str ~index_kind index ~current_region ]
+  | ( Pbigstring_load_f32 { unsafe; index_kind; mode; boxed },
+      [[big_str]; [index]] )
+    ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single Bigstring
+        (Some mode) ~boxed big_str ~index_kind index ~current_region ]
+  | Pbigstring_load_64 { unsafe; index_kind; mode; boxed }, [[big_str]; [index]]
+    ->
+    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bigstring
+        (Some mode) ~boxed big_str ~index_kind index ~current_region ]
+  | ( Pbigstring_load_128 { unsafe; aligned; index_kind; mode; boxed },
+      [[big_str]; [index]] ) ->
     [ string_like_load ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned })
-        Bigstring (Some mode) ~boxed big_str ~index_kind:Ptagged_int_index index
-        ~current_region ]
-  | Pbigstring_set_16 { unsafe }, [[bigstring]; [index]; [new_value]] ->
+        Bigstring (Some mode) ~boxed big_str ~index_kind index ~current_region
+    ]
+  | ( Pbigstring_set_16 { unsafe; index_kind },
+      [[bigstring]; [index]; [new_value]] )
+    ->
     [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixteen Bigstring
-        ~boxed:false bigstring ~index_kind:Ptagged_int_index index new_value ]
-  | Pbigstring_set_32 { unsafe; boxed }, [[bigstring]; [index]; [new_value]] ->
+        ~boxed:false bigstring ~index_kind index new_value ]
+  | ( Pbigstring_set_32 { unsafe; index_kind; boxed },
+      [[bigstring]; [index]; [new_value]] ) ->
     [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bigstring
-        ~boxed bigstring ~index_kind:Ptagged_int_index index new_value ]
-  | Pbigstring_set_f32 { unsafe; boxed }, [[bigstring]; [index]; [new_value]] ->
+        ~boxed bigstring ~index_kind index new_value ]
+  | ( Pbigstring_set_f32 { unsafe; index_kind; boxed },
+      [[bigstring]; [index]; [new_value]] ) ->
     [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Single Bigstring ~boxed
-        bigstring ~index_kind:Ptagged_int_index index new_value ]
-  | Pbigstring_set_64 { unsafe; boxed }, [[bigstring]; [index]; [new_value]] ->
+        bigstring ~index_kind index new_value ]
+  | ( Pbigstring_set_64 { unsafe; index_kind; boxed },
+      [[bigstring]; [index]; [new_value]] ) ->
     [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bigstring
-        ~boxed bigstring ~index_kind:Ptagged_int_index index new_value ]
-  | ( Pbigstring_set_128 { unsafe; aligned; boxed },
+        ~boxed bigstring ~index_kind index new_value ]
+  | ( Pbigstring_set_128 { unsafe; aligned; index_kind; boxed },
       [[bigstring]; [index]; [new_value]] ) ->
     [ bytes_like_set ~unsafe ~dbg ~size_int
         ~access_size:(One_twenty_eight { aligned })
-        Bigstring ~boxed bigstring ~index_kind:Ptagged_int_index index new_value
-    ]
+        Bigstring ~boxed bigstring ~index_kind index new_value ]
   | Pfloat_array_load_128 { unsafe; mode }, [[array]; [index]] ->
     check_float_array_optimisation_enabled "Pfloat_array_load_128";
     [ array_like_load_128 ~dbg ~size_int ~current_region ~unsafe ~mode

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -357,7 +357,7 @@ let comp_bint_primitive bi suff args =
                 | Pint64 -> "caml_int64_" in
   Kccall(pref ^ suff, List.length args)
 
-let array_primitive (index_kind : Lambda.array_index_kind) prefix =
+let indexing_primitive (index_kind : Lambda.array_index_kind) prefix =
   let suffix =
     match index_kind with
     | Ptagged_int_index -> ""
@@ -446,18 +446,30 @@ let comp_primitive stack_info p sz args =
   | Pstringrefu -> Kgetstringchar
   | Pbytesrefu -> Kgetbyteschar
   | Pbytessetu -> Ksetbyteschar
-  | Pstring_load_16(_) -> Kccall("caml_string_get16", 2)
-  | Pstring_load_32(_) -> Kccall("caml_string_get32", 2)
-  | Pstring_load_f32(_) -> Kccall("caml_string_getf32", 2)
-  | Pstring_load_64(_) -> Kccall("caml_string_get64", 2)
-  | Pbytes_set_16(_) -> Kccall("caml_bytes_set16", 3)
-  | Pbytes_set_32(_) -> Kccall("caml_bytes_set32", 3)
-  | Pbytes_set_f32(_) -> Kccall("caml_bytes_setf32", 3)
-  | Pbytes_set_64(_) -> Kccall("caml_bytes_set64", 3)
-  | Pbytes_load_16(_) -> Kccall("caml_bytes_get16", 2)
-  | Pbytes_load_32(_) -> Kccall("caml_bytes_get32", 2)
-  | Pbytes_load_f32(_) -> Kccall("caml_bytes_getf32", 2)
-  | Pbytes_load_64(_) -> Kccall("caml_bytes_get64", 2)
+  | Pstring_load_16 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_string_get16", 2)
+  | Pstring_load_32 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_string_get32", 2)
+  | Pstring_load_f32 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_string_getf32", 2)
+  | Pstring_load_64 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_string_get64", 2)
+  | Pbytes_set_16 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_bytes_set16", 3)
+  | Pbytes_set_32 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_bytes_set32", 3)
+  | Pbytes_set_f32 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_bytes_setf32", 3)
+  | Pbytes_set_64 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_bytes_set64", 3)
+  | Pbytes_load_16 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_bytes_get16", 2)
+  | Pbytes_load_32 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_bytes_get32", 2)
+  | Pbytes_load_f32 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_bytes_getf32", 2)
+  | Pbytes_load_64 { index_kind; _ } ->
+      Kccall(indexing_primitive index_kind "caml_bytes_get64", 2)
   | Parraylength _ -> Kvectlength
   (* In bytecode, nothing is ever actually stack-allocated, so we ignore the
      array modes (allocation for [Parrayref{s,u}], modification for
@@ -466,7 +478,7 @@ let comp_primitive stack_info p sz args =
   | Parrayrefs ((Paddrarray_ref | Pintarray_ref | Pfloatarray_ref _
                 | Punboxedfloatarray_ref (Pfloat64 | Pfloat32) | Punboxedintarray_ref _),
                 (Punboxed_int_index _ as index_kind)) ->
-      Kccall(array_primitive index_kind "caml_array_get", 2)
+      Kccall(indexing_primitive index_kind "caml_array_get", 2)
   | Parrayrefs ((Punboxedfloatarray_ref Pfloat64 | Pfloatarray_ref _), Ptagged_int_index) ->
       Kccall("caml_floatarray_get", 2)
   | Parrayrefs ((Punboxedfloatarray_ref Pfloat32 | Punboxedintarray_ref _
@@ -476,7 +488,7 @@ let comp_primitive stack_info p sz args =
   | Parraysets ((Paddrarray_set _ | Pintarray_set | Pfloatarray_set
                 | Punboxedfloatarray_set (Pfloat64 | Pfloat32) | Punboxedintarray_set _),
                 (Punboxed_int_index _ as index_kind)) ->
-      Kccall(array_primitive index_kind "caml_array_set", 3)
+      Kccall(indexing_primitive index_kind "caml_array_set", 3)
   | Parraysets ((Punboxedfloatarray_set Pfloat64 | Pfloatarray_set),
                 Ptagged_int_index) ->
       Kccall("caml_floatarray_set", 3)
@@ -487,7 +499,7 @@ let comp_primitive stack_info p sz args =
   | Parrayrefu ((Paddrarray_ref | Pintarray_ref | Pfloatarray_ref _
                 | Punboxedfloatarray_ref (Pfloat64 | Pfloat32) | Punboxedintarray_ref _),
                 (Punboxed_int_index _ as index_kind)) ->
-      Kccall(array_primitive index_kind "caml_array_unsafe_get", 2)
+      Kccall(indexing_primitive index_kind "caml_array_unsafe_get", 2)
   | Parrayrefu ((Punboxedfloatarray_ref Pfloat64 | Pfloatarray_ref _), Ptagged_int_index) ->
     Kccall("caml_floatarray_unsafe_get", 2)
   | Parrayrefu ((Punboxedfloatarray_ref Pfloat32 | Punboxedintarray_ref _
@@ -496,7 +508,7 @@ let comp_primitive stack_info p sz args =
   | Parraysetu ((Paddrarray_set _ | Pintarray_set | Pfloatarray_set
                 | Punboxedfloatarray_set (Pfloat64 | Pfloat32) | Punboxedintarray_set _),
                 (Punboxed_int_index _ as index_kind)) ->
-      Kccall(array_primitive index_kind "caml_array_unsafe_set", 3)
+      Kccall(indexing_primitive index_kind "caml_array_unsafe_set", 3)
   | Parraysetu ((Punboxedfloatarray_set Pfloat64 | Pfloatarray_set), Ptagged_int_index) ->
       Kccall("caml_floatarray_unsafe_set", 3)
   | Parraysetu ((Punboxedfloatarray_set Pfloat32 | Punboxedintarray_set _
@@ -551,14 +563,22 @@ let comp_primitive stack_info p sz args =
   | Pbigarrayref(_, n, _, _) -> Kccall("caml_ba_get_" ^ Int.to_string n, n + 1)
   | Pbigarrayset(_, n, _, _) -> Kccall("caml_ba_set_" ^ Int.to_string n, n + 2)
   | Pbigarraydim(n) -> Kccall("caml_ba_dim_" ^ Int.to_string n, 1)
-  | Pbigstring_load_16(_) -> Kccall("caml_ba_uint8_get16", 2)
-  | Pbigstring_load_32(_) -> Kccall("caml_ba_uint8_get32", 2)
-  | Pbigstring_load_f32(_) -> Kccall("caml_ba_uint8_getf32", 2)
-  | Pbigstring_load_64(_) -> Kccall("caml_ba_uint8_get64", 2)
-  | Pbigstring_set_16(_) -> Kccall("caml_ba_uint8_set16", 3)
-  | Pbigstring_set_32(_) -> Kccall("caml_ba_uint8_set32", 3)
-  | Pbigstring_set_f32(_) -> Kccall("caml_ba_uint8_setf32", 3)
-  | Pbigstring_set_64(_) -> Kccall("caml_ba_uint8_set64", 3)
+  | Pbigstring_load_16{unsafe=_;index_kind} ->
+      Kccall(indexing_primitive index_kind "caml_ba_uint8_get16", 2)
+  | Pbigstring_load_32{unsafe=_;mode=_;index_kind} ->
+      Kccall(indexing_primitive index_kind "caml_ba_uint8_get32", 2)
+  | Pbigstring_load_f32{unsafe=_;mode=_;index_kind} ->
+      Kccall(indexing_primitive index_kind "caml_ba_uint8_getf32", 2)
+  | Pbigstring_load_64{unsafe=_;mode=_;index_kind} ->
+      Kccall(indexing_primitive index_kind "caml_ba_uint8_get64", 2)
+  | Pbigstring_set_16{unsafe=_;index_kind} ->
+      Kccall(indexing_primitive index_kind "caml_ba_uint8_set16", 3)
+  | Pbigstring_set_32{unsafe=_;index_kind} ->
+      Kccall(indexing_primitive index_kind "caml_ba_uint8_set32", 3)
+  | Pbigstring_set_f32{unsafe=_;index_kind} ->
+      Kccall(indexing_primitive index_kind "caml_ba_uint8_setf32", 3)
+  | Pbigstring_set_64{unsafe=_;index_kind} ->
+      Kccall(indexing_primitive index_kind "caml_ba_uint8_set64", 3)
   | Pbswap16 -> Kccall("caml_bswap16", 1)
   | Pbbswap(bi,_) -> comp_bint_primitive bi "bswap" args
   | Pint_as_pointer _ -> Kccall("caml_int_as_pointer", 1)

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -237,34 +237,53 @@ type primitive =
   (* size of the nth dimension of a Bigarray *)
   | Pbigarraydim of int
   (* load/set 16,32,64,128 bits from a string: (unsafe)*)
-  | Pstring_load_16 of bool
-  | Pstring_load_32 of bool * alloc_mode
-  | Pstring_load_f32 of bool * alloc_mode
-  | Pstring_load_64 of bool * alloc_mode
-  | Pstring_load_128 of { unsafe : bool; mode: alloc_mode }
-  | Pbytes_load_16 of bool
-  | Pbytes_load_32 of bool * alloc_mode
-  | Pbytes_load_f32 of bool * alloc_mode
-  | Pbytes_load_64 of bool * alloc_mode
-  | Pbytes_load_128 of { unsafe : bool; mode: alloc_mode }
-  | Pbytes_set_16 of bool
-  | Pbytes_set_32 of bool
-  | Pbytes_set_f32 of bool
-  | Pbytes_set_64 of bool
-  | Pbytes_set_128 of { unsafe : bool }
+  | Pstring_load_16 of { unsafe : bool; index_kind : array_index_kind }
+  | Pstring_load_32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pstring_load_f32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pstring_load_128 of { unsafe : bool; index_kind : array_index_kind;
+      mode: alloc_mode }
+  | Pbytes_load_16 of { unsafe : bool; index_kind : array_index_kind }
+  | Pbytes_load_32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbytes_load_f32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbytes_load_64 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbytes_load_128 of { unsafe : bool; index_kind : array_index_kind;
+      mode: alloc_mode }
+  | Pbytes_set_16 of { unsafe : bool; index_kind : array_index_kind }
+  | Pbytes_set_32 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
+  | Pbytes_set_f32 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
+  | Pbytes_set_64 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
+  | Pbytes_set_128 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
   (* load/set 16,32,64,128 bits from a
      (char, int8_unsigned_elt, c_layout) Bigarray.Array1.t : (unsafe) *)
-  | Pbigstring_load_16 of { unsafe : bool }
-  | Pbigstring_load_32 of { unsafe : bool; mode: alloc_mode; boxed : bool }
-  | Pbigstring_load_f32 of { unsafe : bool; mode: alloc_mode; boxed : bool }
-  | Pbigstring_load_64 of { unsafe : bool; mode: alloc_mode; boxed : bool }
-  | Pbigstring_load_128 of { aligned : bool; unsafe : bool; mode: alloc_mode;
+  | Pbigstring_load_16 of { unsafe : bool; index_kind : array_index_kind }
+  | Pbigstring_load_32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbigstring_load_f32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbigstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbigstring_load_128 of { aligned : bool; unsafe : bool; index_kind :
+      array_index_kind; mode: alloc_mode; boxed : bool }
+  | Pbigstring_set_16 of { unsafe : bool; index_kind : array_index_kind }
+  | Pbigstring_set_32 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
-  | Pbigstring_set_16 of { unsafe : bool }
-  | Pbigstring_set_32 of { unsafe : bool; boxed : bool }
-  | Pbigstring_set_f32 of { unsafe : bool; boxed : bool }
-  | Pbigstring_set_64 of { unsafe : bool; boxed : bool }
-  | Pbigstring_set_128 of { aligned : bool; unsafe : bool; boxed : bool }
+  | Pbigstring_set_f32 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
+  | Pbigstring_set_64 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
+  | Pbigstring_set_128 of { aligned : bool; unsafe : bool; index_kind :
+      array_index_kind; boxed : bool }
   (* load/set SIMD vectors in GC-managed arrays *)
   | Pfloatarray_load_128 of { unsafe : bool; mode : alloc_mode }
   | Pfloat_array_load_128 of { unsafe : bool; mode : alloc_mode }
@@ -1761,9 +1780,12 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
      (* Boxes arising from Bigarray access are always Alloc_heap *)
      Some alloc_heap
   | Pstring_load_16 _ | Pbytes_load_16 _ -> None
-  | Pstring_load_32 (_, m) | Pbytes_load_32 (_, m)
-  | Pstring_load_f32 (_, m) | Pbytes_load_f32 (_, m)
-  | Pstring_load_64 (_, m) | Pbytes_load_64 (_, m)
+  | Pstring_load_32 { mode = m; boxed = true; _ }
+  | Pbytes_load_32 { mode = m; boxed = true; _ }
+  | Pstring_load_f32 { mode = m; boxed = true; _ }
+  | Pbytes_load_f32 { mode = m; boxed = true; _ }
+  | Pstring_load_64 { mode = m; boxed = true; _ }
+  | Pbytes_load_64 { mode = m; boxed = true; _ }
   | Pstring_load_128 { mode = m; _ } | Pbytes_load_128 { mode = m; _ }
   | Pfloatarray_load_128 { mode = m; _ }
   | Pfloat_array_load_128 { mode = m; _ }
@@ -1774,6 +1796,12 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Punboxed_int64_array_load_128 { mode = m; _ }
   | Punboxed_nativeint_array_load_128 { mode = m; _ }
   | Pget_header m -> Some m
+  | Pstring_load_32 { boxed = false; _ }
+  | Pstring_load_f32 { boxed = false; _ }
+  | Pstring_load_64 { boxed = false; _ }
+  | Pbytes_load_32 { boxed = false; _ }
+  | Pbytes_load_f32 { boxed = false; _ }
+  | Pbytes_load_64 { boxed = false; _ } -> None
   | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_f32 _
   | Pbytes_set_64 _ | Pbytes_set_128 _ -> None
   | Pbigstring_load_16 _ -> None
@@ -1938,21 +1966,27 @@ let primitive_result_layout (p : primitive) =
   | Pbbswap (bi, _) | Pbox_int (bi, _) ->
       layout_boxedint bi
   | Punbox_int bi -> Punboxed_int bi
-  | Pstring_load_32 _ | Pbytes_load_32 _
+  | Pstring_load_32 { boxed = true; _ } | Pbytes_load_32 { boxed = true; _ }
   | Pbigstring_load_32 { boxed = true; _ } ->
       layout_boxedint Pint32
-  | Pstring_load_f32 _ | Pbytes_load_f32 _
+  | Pstring_load_f32 { boxed = true; _ } | Pbytes_load_f32 { boxed = true; _ }
   | Pbigstring_load_f32 { boxed = true; _ } ->
       layout_boxed_float Pfloat32
-  | Pstring_load_64 _ | Pbytes_load_64 _
+  | Pstring_load_64 { boxed = true; _ } | Pbytes_load_64 { boxed = true; _ }
   | Pbigstring_load_64 { boxed = true; _ } ->
       layout_boxedint Pint64
   | Pstring_load_128 _ | Pbytes_load_128 _
   | Pbigstring_load_128 { boxed = true; _ } ->
       layout_boxed_vector (Pvec128 Int8x16)
-  | Pbigstring_load_32 { boxed = false; _ } -> layout_unboxed_int Pint32
-  | Pbigstring_load_f32 { boxed = false; _ } -> layout_unboxed_float Pfloat32
-  | Pbigstring_load_64 { boxed = false; _ } -> layout_unboxed_int Pint64
+  | Pbigstring_load_32 { boxed = false; _ } 
+  | Pstring_load_32 { boxed = false; _ }
+  | Pbytes_load_32 { boxed = false; _ } -> layout_unboxed_int Pint32
+  | Pbigstring_load_f32 { boxed = false; _ }
+  | Pstring_load_f32 { boxed = false; _ }
+  | Pbytes_load_f32 { boxed = false; _ } -> layout_unboxed_float Pfloat32
+  | Pbigstring_load_64 { boxed = false; _ }
+  | Pstring_load_64 { boxed = false; _ }
+  | Pbytes_load_64 { boxed = false; _ } -> layout_unboxed_int Pint64
   | Pbigstring_load_128 { boxed = false; _ } ->
       layout_unboxed_vector (Pvec128 Int8x16)
   | Pfloatarray_load_128 _ | Pfloat_array_load_128 _

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -244,8 +244,8 @@ type primitive =
       mode : alloc_mode; boxed : bool }
   | Pstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
       mode : alloc_mode; boxed : bool }
-  | Pstring_load_128 of { unsafe : bool; index_kind : array_index_kind;
-      mode: alloc_mode }
+  | Pstring_load_128 of
+      { unsafe : bool; index_kind : array_index_kind; mode : alloc_mode }
   | Pbytes_load_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbytes_load_32 of { unsafe : bool; index_kind : array_index_kind;
       mode : alloc_mode; boxed : bool }
@@ -253,8 +253,8 @@ type primitive =
       mode : alloc_mode; boxed : bool }
   | Pbytes_load_64 of { unsafe : bool; index_kind : array_index_kind;
       mode : alloc_mode; boxed : bool }
-  | Pbytes_load_128 of { unsafe : bool; index_kind : array_index_kind;
-      mode: alloc_mode }
+  | Pbytes_load_128 of
+      { unsafe : bool; index_kind : array_index_kind; mode : alloc_mode }
   | Pbytes_set_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbytes_set_32 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
@@ -273,8 +273,8 @@ type primitive =
       mode : alloc_mode; boxed : bool }
   | Pbigstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
       mode : alloc_mode; boxed : bool }
-  | Pbigstring_load_128 of { aligned : bool; unsafe : bool; index_kind :
-      array_index_kind; mode: alloc_mode; boxed : bool }
+  | Pbigstring_load_128 of { aligned : bool; unsafe : bool;
+      index_kind : array_index_kind; mode : alloc_mode; boxed : bool }
   | Pbigstring_set_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbigstring_set_32 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
@@ -282,8 +282,8 @@ type primitive =
       boxed : bool }
   | Pbigstring_set_64 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
-  | Pbigstring_set_128 of { aligned : bool; unsafe : bool; index_kind :
-      array_index_kind; boxed : bool }
+  | Pbigstring_set_128 of { aligned : bool; unsafe : bool;
+      index_kind : array_index_kind; boxed : bool }
   (* load/set SIMD vectors in GC-managed arrays *)
   | Pfloatarray_load_128 of { unsafe : bool; mode : alloc_mode }
   | Pfloat_array_load_128 of { unsafe : bool; mode : alloc_mode }

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -222,34 +222,53 @@ type primitive =
   (* size of the nth dimension of a Bigarray *)
   | Pbigarraydim of int
   (* load/set 16,32,64,128 bits from a string: (unsafe)*)
-  | Pstring_load_16 of bool
-  | Pstring_load_32 of bool * alloc_mode
-  | Pstring_load_f32 of bool * alloc_mode
-  | Pstring_load_64 of bool * alloc_mode
-  | Pstring_load_128 of { unsafe : bool; mode: alloc_mode }
-  | Pbytes_load_16 of bool
-  | Pbytes_load_32 of bool * alloc_mode
-  | Pbytes_load_f32 of bool * alloc_mode
-  | Pbytes_load_64 of bool * alloc_mode
-  | Pbytes_load_128 of { unsafe : bool; mode: alloc_mode }
-  | Pbytes_set_16 of bool
-  | Pbytes_set_32 of bool
-  | Pbytes_set_f32 of bool
-  | Pbytes_set_64 of bool
-  | Pbytes_set_128 of { unsafe : bool }
+  | Pstring_load_16 of { unsafe : bool; index_kind : array_index_kind }
+  | Pstring_load_32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pstring_load_f32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pstring_load_128 of { unsafe : bool; index_kind : array_index_kind;
+      mode: alloc_mode }
+  | Pbytes_load_16 of { unsafe : bool; index_kind : array_index_kind }
+  | Pbytes_load_32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbytes_load_f32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbytes_load_64 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbytes_load_128 of { unsafe : bool; index_kind : array_index_kind;
+      mode: alloc_mode }
+  | Pbytes_set_16 of { unsafe : bool; index_kind : array_index_kind }
+  | Pbytes_set_32 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
+  | Pbytes_set_f32 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
+  | Pbytes_set_64 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
+  | Pbytes_set_128 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
   (* load/set 16,32,64,128 bits from a
      (char, int8_unsigned_elt, c_layout) Bigarray.Array1.t : (unsafe) *)
-  | Pbigstring_load_16 of { unsafe : bool }
-  | Pbigstring_load_32 of { unsafe : bool; mode: alloc_mode; boxed : bool }
-  | Pbigstring_load_f32 of { unsafe : bool; mode: alloc_mode; boxed : bool }
-  | Pbigstring_load_64 of { unsafe : bool; mode: alloc_mode; boxed : bool }
-  | Pbigstring_load_128 of { aligned : bool; unsafe : bool; mode: alloc_mode;
+  | Pbigstring_load_16 of { unsafe : bool; index_kind : array_index_kind }
+  | Pbigstring_load_32 of { unsafe : bool; index_kind : array_index_kind; mode :
+      alloc_mode; boxed : bool }
+  | Pbigstring_load_f32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbigstring_load_64 of { unsafe : bool; index_kind : array_index_kind; mode :
+      alloc_mode; boxed : bool }
+  | Pbigstring_load_128 of { aligned : bool; unsafe : bool; index_kind :
+      array_index_kind; mode: alloc_mode; boxed : bool }
+  | Pbigstring_set_16 of { unsafe : bool; index_kind : array_index_kind }
+  | Pbigstring_set_32 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
-  | Pbigstring_set_16 of { unsafe : bool }
-  | Pbigstring_set_32 of { unsafe : bool; boxed : bool }
-  | Pbigstring_set_f32 of { unsafe : bool; boxed : bool }
-  | Pbigstring_set_64 of { unsafe : bool; boxed : bool }
-  | Pbigstring_set_128 of { aligned : bool; unsafe : bool; boxed : bool }
+  | Pbigstring_set_f32 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
+  | Pbigstring_set_64 of { unsafe : bool; index_kind : array_index_kind;
+      boxed : bool }
+  | Pbigstring_set_128 of { aligned : bool; unsafe : bool; index_kind :
+      array_index_kind; boxed : bool }
   (* load/set SIMD vectors in GC-managed arrays *)
   | Pfloatarray_load_128 of { unsafe : bool; mode : alloc_mode }
   | Pfloat_array_load_128 of { unsafe : bool; mode : alloc_mode }

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -229,8 +229,8 @@ type primitive =
       mode : alloc_mode; boxed : bool }
   | Pstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
       mode : alloc_mode; boxed : bool }
-  | Pstring_load_128 of { unsafe : bool; index_kind : array_index_kind;
-      mode: alloc_mode }
+  | Pstring_load_128 of
+      { unsafe : bool; index_kind : array_index_kind; mode : alloc_mode }
   | Pbytes_load_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbytes_load_32 of { unsafe : bool; index_kind : array_index_kind;
       mode : alloc_mode; boxed : bool }
@@ -238,8 +238,8 @@ type primitive =
       mode : alloc_mode; boxed : bool }
   | Pbytes_load_64 of { unsafe : bool; index_kind : array_index_kind;
       mode : alloc_mode; boxed : bool }
-  | Pbytes_load_128 of { unsafe : bool; index_kind : array_index_kind;
-      mode: alloc_mode }
+  | Pbytes_load_128 of
+      { unsafe : bool; index_kind : array_index_kind; mode : alloc_mode }
   | Pbytes_set_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbytes_set_32 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
@@ -252,14 +252,14 @@ type primitive =
   (* load/set 16,32,64,128 bits from a
      (char, int8_unsigned_elt, c_layout) Bigarray.Array1.t : (unsafe) *)
   | Pbigstring_load_16 of { unsafe : bool; index_kind : array_index_kind }
-  | Pbigstring_load_32 of { unsafe : bool; index_kind : array_index_kind; mode :
-      alloc_mode; boxed : bool }
+  | Pbigstring_load_32 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
   | Pbigstring_load_f32 of { unsafe : bool; index_kind : array_index_kind;
       mode : alloc_mode; boxed : bool }
-  | Pbigstring_load_64 of { unsafe : bool; index_kind : array_index_kind; mode :
-      alloc_mode; boxed : bool }
-  | Pbigstring_load_128 of { aligned : bool; unsafe : bool; index_kind :
-      array_index_kind; mode: alloc_mode; boxed : bool }
+  | Pbigstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
+      mode : alloc_mode; boxed : bool }
+  | Pbigstring_load_128 of { aligned : bool; unsafe : bool;
+      index_kind : array_index_kind; mode : alloc_mode; boxed : bool }
   | Pbigstring_set_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbigstring_set_32 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
@@ -267,8 +267,8 @@ type primitive =
       boxed : bool }
   | Pbigstring_set_64 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
-  | Pbigstring_set_128 of { aligned : bool; unsafe : bool; index_kind :
-      array_index_kind; boxed : bool }
+  | Pbigstring_set_128 of { aligned : bool; unsafe : bool;
+      index_kind : array_index_kind; boxed : bool }
   (* load/set SIMD vectors in GC-managed arrays *)
   | Pfloatarray_load_128 of { unsafe : bool; mode : alloc_mode }
   | Pfloat_array_load_128 of { unsafe : bool; mode : alloc_mode }

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -646,94 +646,103 @@ let primitive ppf = function
   | Pbigarrayset(unsafe, _n, kind, layout) ->
       print_bigarray "set" unsafe kind ppf layout
   | Pbigarraydim(n) -> fprintf ppf "Bigarray.dim_%i" n
-  | Pstring_load_16(unsafe) ->
-     if unsafe then fprintf ppf "string.unsafe_get16"
-     else fprintf ppf "string.get16"
-  | Pstring_load_32(unsafe, m) ->
-     if unsafe then fprintf ppf "string.unsafe_get32%s" (alloc_kind m)
-     else fprintf ppf "string.get32%s" (alloc_kind m)
-  | Pstring_load_f32(unsafe, m) ->
-     if unsafe then fprintf ppf "string.unsafe_getf32%s" (alloc_kind m)
-     else fprintf ppf "string.getf32%s" (alloc_kind m)
-  | Pstring_load_64(unsafe, m) ->
-     if unsafe then fprintf ppf "string.unsafe_get64%s" (alloc_kind m)
-     else fprintf ppf "string.get64%s" (alloc_kind m)
-  | Pstring_load_128 {unsafe = true; mode} ->
-     fprintf ppf "string.unsafe_unaligned_get128%s" (alloc_kind mode)
-  | Pstring_load_128 {unsafe = false; mode} ->
-     fprintf ppf "string.unaligned_get128%s" (alloc_kind mode)
-  | Pbytes_load_16(unsafe) ->
-     if unsafe then fprintf ppf "bytes.unsafe_get16"
-     else fprintf ppf "bytes.get16"
-  | Pbytes_load_32(unsafe,m) ->
-     if unsafe then fprintf ppf "bytes.unsafe_get32%s" (alloc_kind m)
-     else fprintf ppf "bytes.get32%s" (alloc_kind m)
-  | Pbytes_load_f32(unsafe,m) ->
-     if unsafe then fprintf ppf "bytes.unsafe_getf32%s" (alloc_kind m)
-     else fprintf ppf "bytes.getf32%s" (alloc_kind m)
-  | Pbytes_load_64(unsafe,m) ->
-     if unsafe then fprintf ppf "bytes.unsafe_get64%s" (alloc_kind m)
-     else fprintf ppf "bytes.get64%s" (alloc_kind m)
-  | Pbytes_load_128 {unsafe = true; mode} ->
-     fprintf ppf "bytes.unsafe_unaligned_get128%s" (alloc_kind mode)
-  | Pbytes_load_128 {unsafe = false; mode} ->
-     fprintf ppf "bytes.unaligned_get128%s" (alloc_kind mode)
-  | Pbytes_set_16(unsafe) ->
-     if unsafe then fprintf ppf "bytes.unsafe_set16"
-     else fprintf ppf "bytes.set16"
-  | Pbytes_set_32(unsafe) ->
-     if unsafe then fprintf ppf "bytes.unsafe_set32"
-     else fprintf ppf "bytes.set32"
-  | Pbytes_set_f32(unsafe) ->
-     if unsafe then fprintf ppf "bytes.unsafe_setf32"
-     else fprintf ppf "bytes.setf32"
-  | Pbytes_set_64(unsafe) ->
-     if unsafe then fprintf ppf "bytes.unsafe_set64"
-     else fprintf ppf "bytes.set64"
-  | Pbytes_set_128 {unsafe = true} ->
-     fprintf ppf "bytes.unsafe_unaligned_set128"
-  | Pbytes_set_128 {unsafe = false} ->
-     fprintf ppf "bytes.unaligned_set128"
-  | Pbigstring_load_16 { unsafe } ->
-     if unsafe then fprintf ppf "bigarray.array1.unsafe_get16"
-     else fprintf ppf "bigarray.array1.get16"
-  | Pbigstring_load_32 { unsafe; mode = m } ->
-     if unsafe then fprintf ppf "bigarray.array1.unsafe_get32%s" (alloc_kind m)
-     else fprintf ppf "bigarray.array1.get32%s" (alloc_kind m)
-  | Pbigstring_load_f32 { unsafe; mode = m } ->
-     if unsafe then fprintf ppf "bigarray.array1.unsafe_getf32%s" (alloc_kind m)
-     else fprintf ppf "bigarray.array1.getf32%s" (alloc_kind m)
-  | Pbigstring_load_64 { unsafe; mode = m } ->
-     if unsafe then fprintf ppf "bigarray.array1.unsafe_get64%s" (alloc_kind m)
-     else fprintf ppf "bigarray.array1.get64%s" (alloc_kind m)
-  | Pbigstring_load_128 {unsafe = true; aligned = false; mode} ->
-     fprintf ppf "bigarray.array1.unsafe_unaligned_get128%s" (alloc_kind mode)
-  | Pbigstring_load_128 {unsafe = false; aligned = false; mode} ->
-     fprintf ppf "bigarray.array1.unaligned_get128%s" (alloc_kind mode)
-  | Pbigstring_load_128 {unsafe = true; aligned = true; mode} ->
-     fprintf ppf "bigarray.array1.unsafe_aligned_get128%s" (alloc_kind mode)
-  | Pbigstring_load_128 {unsafe = false; aligned = true; mode} ->
-     fprintf ppf "bigarray.array1.aligned_get128%s" (alloc_kind mode)
-  | Pbigstring_set_16 { unsafe } ->
-     if unsafe then fprintf ppf "bigarray.array1.unsafe_set16"
-     else fprintf ppf "bigarray.array1.set16"
-  | Pbigstring_set_32 { unsafe } ->
-     if unsafe then fprintf ppf "bigarray.array1.unsafe_set32"
-     else fprintf ppf "bigarray.array1.set32"
-  | Pbigstring_set_f32 { unsafe } ->
-     if unsafe then fprintf ppf "bigarray.array1.unsafe_setf32"
-     else fprintf ppf "bigarray.array1.setf32"
-  | Pbigstring_set_64 { unsafe } ->
-     if unsafe then fprintf ppf "bigarray.array1.unsafe_set64"
-     else fprintf ppf "bigarray.array1.set64"
-  | Pbigstring_set_128 {unsafe = true; aligned = false} ->
-     fprintf ppf "bigarray.array1.unsafe_unaligned_set128"
-  | Pbigstring_set_128 {unsafe = true; aligned = true} ->
-     fprintf ppf "bigarray.array1.unsafe_aligned_set128"
-  | Pbigstring_set_128 {unsafe = false; aligned = false} ->
-     fprintf ppf "bigarray.array1.unaligned_set128"
-  | Pbigstring_set_128 {unsafe = false; aligned = true} ->
-     fprintf ppf "bigarray.array1.aligned_set128"
+  | Pstring_load_16 {unsafe; index_kind} ->
+     fprintf ppf "string.%sget16[indexed by %a]" (if unsafe then "unsafe_" else "")
+       array_index_kind index_kind
+  | Pstring_load_32 {unsafe; index_kind; mode; boxed} ->
+     fprintf ppf "string.%sget32%s%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
+       (alloc_kind mode) array_index_kind index_kind
+  | Pstring_load_f32{unsafe; index_kind; mode; boxed} ->
+     fprintf ppf "string.%sgetf32%s%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "")
+       (alloc_kind mode) array_index_kind index_kind
+  | Pstring_load_64{unsafe; index_kind; mode; boxed} ->
+     fprintf ppf "string.%sget64%s%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "")
+       (alloc_kind mode) array_index_kind index_kind
+  | Pstring_load_128 {unsafe; index_kind; mode} ->
+     fprintf ppf "string.%sunaligned_get128%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (alloc_kind mode) array_index_kind
+       index_kind
+  | Pbytes_load_16 {unsafe; index_kind} ->
+     fprintf ppf "bytes.%sget16[indexed by %a]" (if unsafe then "unsafe_" else "")
+       array_index_kind index_kind
+  | Pbytes_load_32 {unsafe; index_kind; mode; boxed} ->
+     fprintf ppf "bytes.%sget32%s%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
+       (alloc_kind mode) array_index_kind index_kind
+  | Pbytes_load_f32{unsafe; index_kind; mode; boxed} ->
+     fprintf ppf "bytes.%sgetf32%s%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "")
+       (alloc_kind mode) array_index_kind index_kind
+  | Pbytes_load_64{unsafe; index_kind; mode; boxed} ->
+     fprintf ppf "bytes.%sget64%s%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "")
+       (alloc_kind mode) array_index_kind index_kind
+  | Pbytes_load_128 {unsafe; index_kind; mode} ->
+     fprintf ppf "bytes.%sunaligned_get128%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (alloc_kind mode) array_index_kind
+       index_kind
+  | Pbytes_set_16 {unsafe; index_kind} ->
+     fprintf ppf "bytes.%sset16[indexed by %a]" (if unsafe then "unsafe_" else "")
+       array_index_kind index_kind
+  | Pbytes_set_32 {unsafe; index_kind; boxed} ->
+     fprintf ppf "bytes.%sset32%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
+       array_index_kind index_kind
+  | Pbytes_set_f32{unsafe; index_kind; boxed} ->
+     fprintf ppf "bytes.%ssetf32%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "")
+       array_index_kind index_kind
+  | Pbytes_set_64{unsafe; index_kind; boxed} ->
+     fprintf ppf "bytes.%sset64%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "")
+       array_index_kind index_kind
+  | Pbytes_set_128 { unsafe; boxed; index_kind } ->
+     fprintf ppf "bytes.%sunaligned_get128%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "")
+       (if boxed then "" else "#") array_index_kind index_kind
+  | Pbigstring_load_16 { unsafe; index_kind } ->
+     fprintf ppf "bigarray.array1.%sget16[indexed by %a]"
+       (if unsafe then "unsafe_" else "") array_index_kind index_kind
+  | Pbigstring_load_32 { unsafe; mode; boxed; index_kind } ->
+     fprintf ppf "bigarray.array1.%sget32%s%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
+       (alloc_kind mode) array_index_kind index_kind
+  | Pbigstring_load_f32 { unsafe; mode; boxed; index_kind } ->
+     fprintf ppf "bigarray.array1.%sgetf32%s%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
+       (alloc_kind mode) array_index_kind index_kind
+  | Pbigstring_load_64 { unsafe; mode; boxed; index_kind } ->
+     fprintf ppf "bigarray.array1.%sget64%s%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
+       (alloc_kind mode) array_index_kind index_kind
+  | Pbigstring_load_128 { unsafe; aligned; mode; boxed; index_kind } ->
+     fprintf ppf "bigarray.array1.%s%sget128%s%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "")
+       (if aligned then "aligned_" else "unaligned_")
+       (if boxed then "" else "#") (alloc_kind mode) array_index_kind index_kind
+  | Pbigstring_set_16 { unsafe; index_kind } ->
+     fprintf ppf "bigarray.array1.%sset16[indexed by %a]"
+       (if unsafe then "unsafe_" else "") array_index_kind index_kind
+  | Pbigstring_set_32 { unsafe; boxed; index_kind } ->
+     fprintf ppf "bigarray.array1.%sset32%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
+       array_index_kind index_kind
+  | Pbigstring_set_f32 { unsafe; boxed; index_kind } ->
+     fprintf ppf "bigarray.array1.%ssetf32%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
+       array_index_kind index_kind
+  | Pbigstring_set_64 { unsafe; boxed; index_kind } ->
+     fprintf ppf "bigarray.array1.%sset64%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
+       array_index_kind index_kind
+  | Pbigstring_set_128 { unsafe; aligned; boxed; index_kind } ->
+     fprintf ppf "bigarray.array1.%s%sget128%s[indexed by %a]"
+       (if unsafe then "unsafe_" else "")
+       (if aligned then "aligned_" else "unaligned_")
+       (if boxed then "" else "#") array_index_kind index_kind
   | Pfloatarray_load_128 {unsafe; mode} ->
      if unsafe then fprintf ppf "floatarray.unsafe_get128%s" (alloc_kind mode)
      else fprintf ppf "floatarray.get128%s" (alloc_kind mode)

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -185,88 +185,129 @@ let to_lambda_prim prim ~poly_sort =
 let indexing_primitives =
   let types_and_widths =
     [
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bigstring_get16%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbigstring_load_16 { unsafe } );
-      ( Printf.sprintf "%%caml_bigstring_get32%s%s",
-        fun ~unsafe ~boxed ~mode -> Pbigstring_load_32 { unsafe; mode; boxed }
-      );
-      ( Printf.sprintf "%%caml_bigstring_getf32%s%s",
-        fun ~unsafe ~boxed ~mode -> Pbigstring_load_f32 { unsafe; mode; boxed }
-      );
-      ( Printf.sprintf "%%caml_bigstring_get64%s%s",
-        fun ~unsafe ~boxed ~mode -> Pbigstring_load_64 { unsafe; mode; boxed }
-      );
-      ( Printf.sprintf "%%caml_bigstring_getu128%s%s",
-        fun ~unsafe ~boxed ~mode ->
-          Pbigstring_load_128 { aligned = false; unsafe; mode; boxed } );
-      ( Printf.sprintf "%%caml_bigstring_geta128%s%s",
-        fun ~unsafe ~boxed ~mode ->
-          Pbigstring_load_128 { aligned = true; unsafe; mode; boxed } );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bigstring_set16%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbigstring_set_16 { unsafe } );
-      ( Printf.sprintf "%%caml_bigstring_set32%s%s",
-        fun ~unsafe ~boxed ~mode:_ -> Pbigstring_set_32 { unsafe; boxed } );
-      ( Printf.sprintf "%%caml_bigstring_setf32%s%s",
-        fun ~unsafe ~boxed ~mode:_ -> Pbigstring_set_f32 { unsafe; boxed } );
-      ( Printf.sprintf "%%caml_bigstring_set64%s%s",
-        fun ~unsafe ~boxed ~mode:_ -> Pbigstring_set_64 { unsafe; boxed } );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bigstring_setu128%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ ->
-          Pbigstring_set_128 { aligned = false; unsafe; boxed = true } );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bigstring_seta128%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ ->
-          Pbigstring_set_128 { aligned = true; unsafe; boxed = true } );
-      (* Accessing unboxed data from [string]s and [bytes]s is not currently
-         available, so we ignore the [boxed] argument and only bind the boxed
-         versions of the primitives. *)
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bytes_get16%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_load_16 unsafe );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bytes_get32%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode -> Pbytes_load_32 (unsafe, mode) );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bytes_getf32%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode -> Pbytes_load_f32 (unsafe, mode) );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bytes_get64%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode -> Pbytes_load_64 (unsafe, mode) );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bytes_getu128%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode -> Pbytes_load_128 { unsafe; mode } );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bytes_set16%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_set_16 unsafe );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bytes_set32%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_set_32 unsafe );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bytes_setf32%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_set_f32 unsafe );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bytes_set64%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_set_64 unsafe );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_bytes_setu128%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_set_128 { unsafe } );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_string_get16%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pstring_load_16 unsafe );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_string_get32%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode -> Pstring_load_32 (unsafe, mode) );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_string_getf32%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode -> Pstring_load_f32 (unsafe, mode) );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_string_get64%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode -> Pstring_load_64 (unsafe, mode) );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_string_getu128%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode -> Pstring_load_128 { unsafe; mode } );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_string_set16%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_set_16 unsafe );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_string_set32%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_set_32 unsafe );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_string_setf32%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_set_f32 unsafe );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_string_set64%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_set_64 unsafe );
-      ( (fun unsafe _boxed -> Printf.sprintf "%%caml_string_setu128%s" unsafe),
-        fun ~unsafe ~boxed:_ ~mode:_ -> Pbytes_set_128 { unsafe } );
+      ( (fun unsafe _boxed index_kind ->
+          Printf.sprintf "%%caml_bigstring_get16%s%s" unsafe index_kind),
+        fun ~unsafe ~boxed:_ ~index_kind ~mode:_ ->
+          Pbigstring_load_16 { unsafe; index_kind } );
+      ( Printf.sprintf "%%caml_bigstring_get32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pbigstring_load_32 { unsafe; index_kind; mode; boxed } );
+      ( Printf.sprintf "%%caml_bigstring_getf32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pbigstring_load_f32 { unsafe; index_kind; mode; boxed } );
+      ( Printf.sprintf "%%caml_bigstring_get64%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pbigstring_load_64 { unsafe; index_kind; mode; boxed } );
+      ( Printf.sprintf "%%caml_bigstring_getu128%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pbigstring_load_128
+            { aligned = false; unsafe; index_kind; mode; boxed } );
+      ( Printf.sprintf "%%caml_bigstring_geta128%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pbigstring_load_128
+            { aligned = true; unsafe; index_kind; mode; boxed } );
+      ( (fun unsafe _boxed index_kind ->
+          Printf.sprintf "%%caml_bigstring_set16%s%s" unsafe index_kind),
+        fun ~unsafe ~boxed:_ ~index_kind ~mode:_ ->
+          Pbigstring_set_16 { unsafe; index_kind } );
+      ( Printf.sprintf "%%caml_bigstring_set32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbigstring_set_32 { unsafe; index_kind; boxed } );
+      ( Printf.sprintf "%%caml_bigstring_setf32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbigstring_set_f32 { unsafe; index_kind; boxed } );
+      ( Printf.sprintf "%%caml_bigstring_set64%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbigstring_set_64 { unsafe; index_kind; boxed } );
+      ( Printf.sprintf "%%caml_bigstring_setu128%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbigstring_set_128 { aligned = false; unsafe; index_kind; boxed } );
+      ( Printf.sprintf "%%caml_bigstring_seta128%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbigstring_set_128 { aligned = true; unsafe; index_kind; boxed } );
+      ( (fun unsafe _boxed index_kind ->
+          Printf.sprintf "%%caml_bytes_get16%s%s" unsafe index_kind),
+        fun ~unsafe ~boxed:_ ~index_kind ~mode:_ ->
+          Pbytes_load_16 { unsafe; index_kind } );
+      ( Printf.sprintf "%%caml_bytes_get32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pbytes_load_32 { unsafe; index_kind; mode; boxed } );
+      ( Printf.sprintf "%%caml_bytes_getf32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pbytes_load_f32 { unsafe; index_kind; mode; boxed } );
+      ( Printf.sprintf "%%caml_bytes_get64%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pbytes_load_64 { unsafe; index_kind; mode; boxed } );
+      ( (fun unsafe _boxed index_kind ->
+          Printf.sprintf "%%caml_bytes_getu128%s%s" unsafe index_kind),
+        fun ~unsafe ~boxed:_ ~index_kind ~mode ->
+          Pbytes_load_128 { unsafe; index_kind; mode } );
+      ( (fun unsafe _boxed index_kind ->
+          Printf.sprintf "%%caml_bytes_set16%s%s" unsafe index_kind),
+        fun ~unsafe ~boxed:_ ~index_kind ~mode:_ ->
+          Pbytes_set_16 { unsafe; index_kind } );
+      ( Printf.sprintf "%%caml_bytes_set32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbytes_set_32 { unsafe; index_kind; boxed } );
+      ( Printf.sprintf "%%caml_bytes_setf32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbytes_set_f32 { unsafe; index_kind; boxed } );
+      ( Printf.sprintf "%%caml_bytes_set64%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbytes_set_64 { unsafe; index_kind; boxed } );
+      ( Printf.sprintf "%%caml_bytes_setu128%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbytes_set_128 { unsafe; index_kind; boxed } );
+      ( (fun unsafe _boxed index_kind ->
+          Printf.sprintf "%%caml_string_get16%s%s" unsafe index_kind),
+        fun ~unsafe ~boxed:_ ~index_kind ~mode:_ ->
+          Pstring_load_16 { unsafe; index_kind } );
+      ( Printf.sprintf "%%caml_string_get32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pstring_load_32 { unsafe; index_kind; mode; boxed } );
+      ( Printf.sprintf "%%caml_string_getf32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pstring_load_f32 { unsafe; index_kind; mode; boxed } );
+      ( Printf.sprintf "%%caml_string_get64%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode ->
+          Pstring_load_64 { unsafe; index_kind; mode; boxed } );
+      ( (fun unsafe _boxed index_kind ->
+          Printf.sprintf "%%caml_string_getu128%s%s" unsafe index_kind),
+        fun ~unsafe ~boxed:_ ~index_kind ~mode ->
+          Pstring_load_128 { unsafe; index_kind; mode } );
+      ( (fun unsafe _boxed index_kind ->
+          Printf.sprintf "%%caml_string_set16%s%s" unsafe index_kind),
+        fun ~unsafe ~boxed:_ ~index_kind ~mode:_ ->
+          Pbytes_set_16 { unsafe; index_kind } );
+      ( Printf.sprintf "%%caml_string_set32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbytes_set_32 { unsafe; index_kind; boxed } );
+      ( Printf.sprintf "%%caml_string_setf32%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbytes_set_f32 { unsafe; index_kind; boxed } );
+      ( Printf.sprintf "%%caml_string_set64%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbytes_set_64 { unsafe; index_kind; boxed } );
+      ( Printf.sprintf "%%caml_string_setu128%s%s%s",
+        fun ~unsafe ~boxed ~index_kind ~mode:_ ->
+          Pbytes_set_128 { unsafe; index_kind; boxed } );
+    ]
+  in
+  let index_kinds =
+    [
+      (Ptagged_int_index, "");
+      (Punboxed_int_index Pnativeint, "_indexed_by_nativeint#");
+      (Punboxed_int_index Pint32, "_indexed_by_int32#");
+      (Punboxed_int_index Pint64, "_indexed_by_int64#");
     ]
   in
   (let ( let* ) x f = List.concat_map f x in
    let* string_gen, primitive_gen = types_and_widths in
+   let* index_kind, index_kind_sigil = index_kinds in
    let* unsafe, unsafe_sigil = [ (true, "u"); (false, "") ] in
    let* boxed, boxed_sigil = [ (true, ""); (false, "#") ] in
-   let string = string_gen unsafe_sigil boxed_sigil in
-   let primitive = primitive_gen ~unsafe ~boxed in
+   let string = string_gen unsafe_sigil boxed_sigil index_kind_sigil in
+   let primitive = primitive_gen ~unsafe ~boxed ~index_kind in
    let arity = if String.is_substring string ~substring:"get" then 2 else 3 in
    [ (string, fun ~mode -> Primitive (primitive ~mode, arity)) ])
   |> List.to_seq

--- a/ocaml/runtime/array.c
+++ b/ocaml/runtime/array.c
@@ -968,7 +968,7 @@ CAMLprim value caml_array_unsafe_get_indexed_by_nativeint(value, value);
 CAMLprim value caml_array_set_indexed_by_nativeint(value, value, value);
 CAMLprim value caml_array_unsafe_set_indexed_by_nativeint(value, value, value);
 
-#define CAMLprim_indexed_by(name, index_type, val_func)                     \
+#define Array_access_index_by(name, index_type, val_func)                   \
   CAMLprim value caml_array_get_indexed_by_##name(value array, value index) \
   {                                                                         \
     index_type idx = val_func(index);                                       \
@@ -995,6 +995,6 @@ CAMLprim value caml_array_unsafe_set_indexed_by_nativeint(value, value, value);
     return caml_array_unsafe_set(array, Val_long(val_func(index)), newval); \
   }
 
-CAMLprim_indexed_by(int64, int64_t, Int64_val)
-CAMLprim_indexed_by(int32, int32_t, Int32_val)
-CAMLprim_indexed_by(nativeint, intnat, Nativeint_val)
+Array_access_index_by(int64, int64_t, Int64_val)
+Array_access_index_by(int32, int32_t, Int32_val)
+Array_access_index_by(nativeint, intnat, Nativeint_val)

--- a/ocaml/runtime/bigarray.c
+++ b/ocaml/runtime/bigarray.c
@@ -887,31 +887,32 @@ CAMLprim value caml_ba_uint8_set64_indexed_by_int64(value, value, value);
 CAMLprim value caml_ba_uint8_set64_indexed_by_int32(value, value, value);
 CAMLprim value caml_ba_uint8_set64_indexed_by_nativeint(value, value, value);
 
-#define CAMLprim_indexed_by(width, name, index_type, val_func)                 \
-  CAMLprim value caml_ba_uint8_get##width##_indexed_by_##name(value vb,        \
-      value vind)                                                              \
-  {                                                                            \
-    index_type idx = val_func(vind);                                           \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
-    return caml_ba_uint8_get##width(vb, Val_long(idx));                        \
-  }                                                                            \
-  CAMLprim value caml_ba_uint8_set##width##_indexed_by_##name(value vb,        \
-      value vind, value newval)                                                \
-  {                                                                            \
-    index_type idx = val_func(vind);                                           \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
-    return caml_ba_uint8_set##width(vb, Val_long(idx), newval);                \
+#define Bigstring_access_index_by(width, name, index_type, val_func)        \
+  CAMLprim value caml_ba_uint8_get##width##_indexed_by_##name(value vb,     \
+                                                              value vind)   \
+  {                                                                         \
+    index_type idx = val_func(vind);                                        \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();           \
+    return caml_ba_uint8_get##width(vb, Val_long(idx));                     \
+  }                                                                         \
+  CAMLprim value caml_ba_uint8_set##width##_indexed_by_##name(value vb,     \
+                                                              value vind,   \
+                                                              value newval) \
+  {                                                                         \
+    index_type idx = val_func(vind);                                        \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();           \
+    return caml_ba_uint8_set##width(vb, Val_long(idx), newval);             \
   }
 
-CAMLprim_indexed_by(16, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(16, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(16, nativeint, intnat, Nativeint_val)
-CAMLprim_indexed_by(32, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(32, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(32, nativeint, intnat, Nativeint_val)
-CAMLprim_indexed_by(64, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(64, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(64, nativeint, intnat, Nativeint_val)
+Bigstring_access_index_by(16, int64, int64_t, Int64_val)
+Bigstring_access_index_by(16, int32, int32_t, Int32_val)
+Bigstring_access_index_by(16, nativeint, intnat, Nativeint_val)
+Bigstring_access_index_by(32, int64, int64_t, Int64_val)
+Bigstring_access_index_by(32, int32, int32_t, Int32_val)
+Bigstring_access_index_by(32, nativeint, intnat, Nativeint_val)
+Bigstring_access_index_by(64, int64, int64_t, Int64_val)
+Bigstring_access_index_by(64, int32, int32_t, Int32_val)
+Bigstring_access_index_by(64, nativeint, intnat, Nativeint_val)
 
 /* Return the number of dimensions of a big array */
 

--- a/ocaml/runtime/bigarray.c
+++ b/ocaml/runtime/bigarray.c
@@ -868,6 +868,51 @@ CAMLprim value caml_ba_uint8_set64(value vb, value vind, value newval)
   return Val_unit;
 }
 
+CAMLprim value caml_ba_uint8_get16_indexed_by_int64(value, value);
+CAMLprim value caml_ba_uint8_get16_indexed_by_int32(value, value);
+CAMLprim value caml_ba_uint8_get16_indexed_by_nativeint(value, value);
+CAMLprim value caml_ba_uint8_get32_indexed_by_int64(value, value);
+CAMLprim value caml_ba_uint8_get32_indexed_by_int32(value, value);
+CAMLprim value caml_ba_uint8_get32_indexed_by_nativeint(value, value);
+CAMLprim value caml_ba_uint8_get64_indexed_by_int64(value, value);
+CAMLprim value caml_ba_uint8_get64_indexed_by_int32(value, value);
+CAMLprim value caml_ba_uint8_get64_indexed_by_nativeint(value, value);
+CAMLprim value caml_ba_uint8_set16_indexed_by_int64(value, value, value);
+CAMLprim value caml_ba_uint8_set16_indexed_by_int32(value, value, value);
+CAMLprim value caml_ba_uint8_set16_indexed_by_nativeint(value, value, value);
+CAMLprim value caml_ba_uint8_set32_indexed_by_int64(value, value, value);
+CAMLprim value caml_ba_uint8_set32_indexed_by_int32(value, value, value);
+CAMLprim value caml_ba_uint8_set32_indexed_by_nativeint(value, value, value);
+CAMLprim value caml_ba_uint8_set64_indexed_by_int64(value, value, value);
+CAMLprim value caml_ba_uint8_set64_indexed_by_int32(value, value, value);
+CAMLprim value caml_ba_uint8_set64_indexed_by_nativeint(value, value, value);
+
+#define CAMLprim_indexed_by(width, name, index_type, val_func)                 \
+  CAMLprim value caml_ba_uint8_get##width##_indexed_by_##name(value vb,        \
+      value vind)                                                              \
+  {                                                                            \
+    index_type idx = val_func(vind);                                           \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
+    return caml_ba_uint8_get##width(vb, Val_long(idx));                        \
+  }                                                                            \
+  CAMLprim value caml_ba_uint8_set##width##_indexed_by_##name(value vb,        \
+      value vind, value newval)                                                \
+  {                                                                            \
+    index_type idx = val_func(vind);                                           \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
+    return caml_ba_uint8_set##width(vb, Val_long(idx), newval);                \
+  }
+
+CAMLprim_indexed_by(16, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(16, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(16, nativeint, intnat, Nativeint_val)
+CAMLprim_indexed_by(32, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(32, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(32, nativeint, intnat, Nativeint_val)
+CAMLprim_indexed_by(64, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(64, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(64, nativeint, intnat, Nativeint_val)
+
 /* Return the number of dimensions of a big array */
 
 CAMLprim value caml_ba_num_dims(value vb)

--- a/ocaml/runtime/float32.c
+++ b/ocaml/runtime/float32.c
@@ -483,6 +483,60 @@ CAMLprim value caml_ba_uint8_setf32(value vb, value vind, value newval)
 #endif
 }
 
+CAMLprim value caml_ba_uint8_getf32_indexed_by_int64(value array, value index);
+CAMLprim value caml_ba_uint8_getf32_indexed_by_int32(value array, value index);
+CAMLprim value caml_ba_uint8_getf32_indexed_by_nativeint(value array, value index);
+
+CAMLprim value caml_ba_uint8_setf32_indexed_by_int64(value array, value index,
+                                                     value newval);
+CAMLprim value caml_ba_uint8_setf32_indexed_by_int32(value array, value index,
+                                                     value newval);
+CAMLprim value caml_ba_uint8_setf32_indexed_by_nativeint(value array, value index,
+                                                         value newval);
+
+CAMLprim value caml_string_getf32_indexed_by_int64(value array, value index);
+CAMLprim value caml_string_getf32_indexed_by_int32(value array, value index);
+CAMLprim value caml_string_getf32_indexed_by_nativeint(value array, value index);
+
+CAMLprim value caml_bytes_getf32_indexed_by_int64(value array, value index);
+CAMLprim value caml_bytes_getf32_indexed_by_int32(value array, value index);
+CAMLprim value caml_bytes_getf32_indexed_by_nativeint(value array, value index);
+
+CAMLprim value caml_bytes_setf32_indexed_by_int64(value array, value index,
+                                                  value newval);
+CAMLprim value caml_bytes_setf32_indexed_by_int32(value array, value index,
+                                                  value newval);
+CAMLprim value caml_bytes_setf32_indexed_by_nativeint(value array, value index,
+                                                      value newval);
+
+#define CAMLprim_indexed_by_get(name, container, index_type, val_func)             \
+  CAMLprim value caml_##container##_getf32_indexed_by_##name(value vb, value vind) \
+  {                                                                                \
+    index_type idx = val_func(vind);                                               \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();                  \
+    return caml_##container##_getf32(vb, Val_long(idx));                           \
+  }
+
+#define CAMLprim_indexed_by_set(name, container, index_type, val_func)             \
+  CAMLprim value caml_##container##_setf32_indexed_by_##name(value vb, value vind, \
+                                                             value newval)         \
+  {                                                                                \
+    index_type idx = val_func(vind);                                               \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();                  \
+    return caml_##container##_setf32(vb, Val_long(idx), newval);                   \
+  }
+
+#define CAMLprim_indexed_by(name, index_type, val_func)                            \
+  CAMLprim_indexed_by_get(name, ba_uint8, index_type, val_func)                    \
+  CAMLprim_indexed_by_get(name, string, index_type, val_func)                      \
+  CAMLprim_indexed_by_get(name, bytes, index_type, val_func)                       \
+  CAMLprim_indexed_by_set(name, ba_uint8, index_type, val_func)                    \
+  CAMLprim_indexed_by_set(name, bytes, index_type, val_func)                       \
+
+CAMLprim_indexed_by(int64, int64_t, Int64_val)
+CAMLprim_indexed_by(int32, int32_t, Int32_val)
+CAMLprim_indexed_by(nativeint, intnat, Nativeint_val)
+
 /* Defined in bigarray.c */
 CAMLextern intnat caml_ba_offset(struct caml_ba_array * b, intnat * index);
 

--- a/ocaml/runtime/float32.c
+++ b/ocaml/runtime/float32.c
@@ -509,33 +509,35 @@ CAMLprim value caml_bytes_setf32_indexed_by_int32(value array, value index,
 CAMLprim value caml_bytes_setf32_indexed_by_nativeint(value array, value index,
                                                       value newval);
 
-#define CAMLprim_indexed_by_get(name, container, index_type, val_func)             \
-  CAMLprim value caml_##container##_getf32_indexed_by_##name(value vb, value vind) \
-  {                                                                                \
-    index_type idx = val_func(vind);                                               \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();                  \
-    return caml_##container##_getf32(vb, Val_long(idx));                           \
+#define Float32_get_index_by(name, container, index_type, val_func)      \
+  CAMLprim value caml_##container##_getf32_indexed_by_##name(value vb,   \
+                                                             value vind) \
+  {                                                                      \
+    index_type idx = val_func(vind);                                     \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();        \
+    return caml_##container##_getf32(vb, Val_long(idx));                 \
   }
 
-#define CAMLprim_indexed_by_set(name, container, index_type, val_func)             \
-  CAMLprim value caml_##container##_setf32_indexed_by_##name(value vb, value vind, \
-                                                             value newval)         \
-  {                                                                                \
-    index_type idx = val_func(vind);                                               \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();                  \
-    return caml_##container##_setf32(vb, Val_long(idx), newval);                   \
+#define Float32_set_index_by(name, container, index_type, val_func)        \
+  CAMLprim value caml_##container##_setf32_indexed_by_##name(value vb,     \
+                                                             value vind,   \
+                                                             value newval) \
+  {                                                                        \
+    index_type idx = val_func(vind);                                       \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();          \
+    return caml_##container##_setf32(vb, Val_long(idx), newval);           \
   }
 
-#define CAMLprim_indexed_by(name, index_type, val_func)                            \
-  CAMLprim_indexed_by_get(name, ba_uint8, index_type, val_func)                    \
-  CAMLprim_indexed_by_get(name, string, index_type, val_func)                      \
-  CAMLprim_indexed_by_get(name, bytes, index_type, val_func)                       \
-  CAMLprim_indexed_by_set(name, ba_uint8, index_type, val_func)                    \
-  CAMLprim_indexed_by_set(name, bytes, index_type, val_func)                       \
+#define Float32_access_index_by(name, index_type, val_func)  \
+  Float32_get_index_by(name, ba_uint8, index_type, val_func) \
+  Float32_get_index_by(name, string, index_type, val_func)   \
+  Float32_get_index_by(name, bytes, index_type, val_func)    \
+  Float32_set_index_by(name, ba_uint8, index_type, val_func) \
+  Float32_set_index_by(name, bytes, index_type, val_func)
 
-CAMLprim_indexed_by(int64, int64_t, Int64_val)
-CAMLprim_indexed_by(int32, int32_t, Int32_val)
-CAMLprim_indexed_by(nativeint, intnat, Nativeint_val)
+Float32_access_index_by(int64, int64_t, Int64_val)
+Float32_access_index_by(int32, int32_t, Int32_val)
+Float32_access_index_by(nativeint, intnat, Nativeint_val)
 
 /* Defined in bigarray.c */
 CAMLextern intnat caml_ba_offset(struct caml_ba_array * b, intnat * index);

--- a/ocaml/runtime/str.c
+++ b/ocaml/runtime/str.c
@@ -276,6 +276,69 @@ CAMLprim value caml_bytes_set64(value str, value index, value newval)
   return Val_unit;
 }
 
+CAMLprim value caml_string_get16_indexed_by_int64(value, value);
+CAMLprim value caml_string_get16_indexed_by_int32(value, value);
+CAMLprim value caml_string_get16_indexed_by_nativeint(value, value);
+CAMLprim value caml_string_get32_indexed_by_int64(value, value);
+CAMLprim value caml_string_get32_indexed_by_int32(value, value);
+CAMLprim value caml_string_get32_indexed_by_nativeint(value, value);
+CAMLprim value caml_string_get64_indexed_by_int64(value, value);
+CAMLprim value caml_string_get64_indexed_by_int32(value, value);
+CAMLprim value caml_string_get64_indexed_by_nativeint(value, value);
+
+CAMLprim value caml_bytes_get16_indexed_by_int64(value, value);
+CAMLprim value caml_bytes_get16_indexed_by_int32(value, value);
+CAMLprim value caml_bytes_get16_indexed_by_nativeint(value, value);
+CAMLprim value caml_bytes_get32_indexed_by_int64(value, value);
+CAMLprim value caml_bytes_get32_indexed_by_int32(value, value);
+CAMLprim value caml_bytes_get32_indexed_by_nativeint(value, value);
+CAMLprim value caml_bytes_get64_indexed_by_int64(value, value);
+CAMLprim value caml_bytes_get64_indexed_by_int32(value, value);
+CAMLprim value caml_bytes_get64_indexed_by_nativeint(value, value);
+
+CAMLprim value caml_bytes_set16_indexed_by_int64(value, value, value);
+CAMLprim value caml_bytes_set16_indexed_by_int32(value, value, value);
+CAMLprim value caml_bytes_set16_indexed_by_nativeint(value, value, value);
+CAMLprim value caml_bytes_set32_indexed_by_int64(value, value, value);
+CAMLprim value caml_bytes_set32_indexed_by_int32(value, value, value);
+CAMLprim value caml_bytes_set32_indexed_by_nativeint(value, value, value);
+CAMLprim value caml_bytes_set64_indexed_by_int64(value, value, value);
+CAMLprim value caml_bytes_set64_indexed_by_int32(value, value, value);
+CAMLprim value caml_bytes_set64_indexed_by_nativeint(value, value, value);
+
+#define CAMLprim_indexed_by(width, name, index_type, val_func)                 \
+  CAMLprim value caml_string_get##width##_indexed_by_##name(value vb,          \
+      value vind)                                                              \
+  {                                                                            \
+    index_type idx = val_func(vind);                                           \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
+    return caml_string_get##width(vb, Val_long(idx));                          \
+  }                                                                            \
+  CAMLprim value caml_bytes_get##width##_indexed_by_##name(value vb,           \
+      value vind)                                                              \
+  {                                                                            \
+    index_type idx = val_func(vind);                                           \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
+    return caml_bytes_get##width(vb, Val_long(idx));                           \
+  }                                                                            \
+  CAMLprim value caml_bytes_set##width##_indexed_by_##name(value vb,           \
+      value vind, value newval)                                                \
+  {                                                                            \
+    index_type idx = val_func(vind);                                           \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
+    return caml_bytes_set##width(vb, Val_long(idx), newval);                   \
+  }
+
+CAMLprim_indexed_by(16, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(16, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(16, nativeint, intnat, Nativeint_val)
+CAMLprim_indexed_by(32, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(32, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(32, nativeint, intnat, Nativeint_val)
+CAMLprim_indexed_by(64, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(64, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(64, nativeint, intnat, Nativeint_val)
+
 CAMLprim value caml_string_equal(value s1, value s2)
 {
   mlsize_t sz1, sz2;

--- a/ocaml/runtime/str.c
+++ b/ocaml/runtime/str.c
@@ -306,38 +306,38 @@ CAMLprim value caml_bytes_set64_indexed_by_int64(value, value, value);
 CAMLprim value caml_bytes_set64_indexed_by_int32(value, value, value);
 CAMLprim value caml_bytes_set64_indexed_by_nativeint(value, value, value);
 
-#define CAMLprim_indexed_by(width, name, index_type, val_func)                 \
-  CAMLprim value caml_string_get##width##_indexed_by_##name(value vb,          \
-      value vind)                                                              \
-  {                                                                            \
-    index_type idx = val_func(vind);                                           \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
-    return caml_string_get##width(vb, Val_long(idx));                          \
-  }                                                                            \
-  CAMLprim value caml_bytes_get##width##_indexed_by_##name(value vb,           \
-      value vind)                                                              \
-  {                                                                            \
-    index_type idx = val_func(vind);                                           \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
-    return caml_bytes_get##width(vb, Val_long(idx));                           \
-  }                                                                            \
-  CAMLprim value caml_bytes_set##width##_indexed_by_##name(value vb,           \
-      value vind, value newval)                                                \
-  {                                                                            \
-    index_type idx = val_func(vind);                                           \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
-    return caml_bytes_set##width(vb, Val_long(idx), newval);                   \
+#define String_and_bytes_access_index_by(width, name, index_type, val_func) \
+  CAMLprim value caml_string_get##width##_indexed_by_##name(value vb,       \
+      value vind)                                                           \
+  {                                                                         \
+    index_type idx = val_func(vind);                                        \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();           \
+    return caml_string_get##width(vb, Val_long(idx));                       \
+  }                                                                         \
+  CAMLprim value caml_bytes_get##width##_indexed_by_##name(value vb,        \
+      value vind)                                                           \
+  {                                                                         \
+    index_type idx = val_func(vind);                                        \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();           \
+    return caml_bytes_get##width(vb, Val_long(idx));                        \
+  }                                                                         \
+  CAMLprim value caml_bytes_set##width##_indexed_by_##name(value vb,        \
+      value vind, value newval)                                             \
+  {                                                                         \
+    index_type idx = val_func(vind);                                        \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();           \
+    return caml_bytes_set##width(vb, Val_long(idx), newval);                \
   }
 
-CAMLprim_indexed_by(16, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(16, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(16, nativeint, intnat, Nativeint_val)
-CAMLprim_indexed_by(32, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(32, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(32, nativeint, intnat, Nativeint_val)
-CAMLprim_indexed_by(64, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(64, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(64, nativeint, intnat, Nativeint_val)
+String_and_bytes_access_index_by(16, int64, int64_t, Int64_val)
+String_and_bytes_access_index_by(16, int32, int32_t, Int32_val)
+String_and_bytes_access_index_by(16, nativeint, intnat, Nativeint_val)
+String_and_bytes_access_index_by(32, int64, int64_t, Int64_val)
+String_and_bytes_access_index_by(32, int32, int32_t, Int32_val)
+String_and_bytes_access_index_by(32, nativeint, intnat, Nativeint_val)
+String_and_bytes_access_index_by(64, int64, int64_t, Int64_val)
+String_and_bytes_access_index_by(64, int32, int32_t, Int32_val)
+String_and_bytes_access_index_by(64, nativeint, intnat, Nativeint_val)
 
 CAMLprim value caml_string_equal(value s1, value s2)
 {

--- a/ocaml/runtime4/array.c
+++ b/ocaml/runtime4/array.c
@@ -926,7 +926,7 @@ CAMLprim value caml_array_unsafe_get_indexed_by_nativeint(value, value);
 CAMLprim value caml_array_set_indexed_by_nativeint(value, value, value);
 CAMLprim value caml_array_unsafe_set_indexed_by_nativeint(value, value, value);
 
-#define CAMLprim_indexed_by(name, index_type, val_func)                     \
+#define Array_access_index_by(name, index_type, val_func)                   \
   CAMLprim value caml_array_get_indexed_by_##name(value array, value index) \
   {                                                                         \
     index_type idx = val_func(index);                                       \
@@ -953,6 +953,6 @@ CAMLprim value caml_array_unsafe_set_indexed_by_nativeint(value, value, value);
     return caml_array_unsafe_set(array, Val_long(val_func(index)), newval); \
   }
 
-CAMLprim_indexed_by(int64, int64_t, Int64_val)
-CAMLprim_indexed_by(int32, int32_t, Int32_val)
-CAMLprim_indexed_by(nativeint, intnat, Nativeint_val)
+Array_access_index_by(int64, int64_t, Int64_val)
+Array_access_index_by(int32, int32_t, Int32_val)
+Array_access_index_by(nativeint, intnat, Nativeint_val)

--- a/ocaml/runtime4/bigarray.c
+++ b/ocaml/runtime4/bigarray.c
@@ -885,31 +885,32 @@ CAMLprim value caml_ba_uint8_set64_indexed_by_int64(value, value, value);
 CAMLprim value caml_ba_uint8_set64_indexed_by_int32(value, value, value);
 CAMLprim value caml_ba_uint8_set64_indexed_by_nativeint(value, value, value);
 
-#define CAMLprim_indexed_by(width, name, index_type, val_func)                 \
-  CAMLprim value caml_ba_uint8_get##width##_indexed_by_##name(value vb,        \
-      value vind)                                                              \
-  {                                                                            \
-    index_type idx = val_func(vind);                                           \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
-    return caml_ba_uint8_get##width(vb, Val_long(idx));                        \
-  }                                                                            \
-  CAMLprim value caml_ba_uint8_set##width##_indexed_by_##name(value vb,        \
-      value vind, value newval)                                                \
-  {                                                                            \
-    index_type idx = val_func(vind);                                           \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
-    return caml_ba_uint8_set##width(vb, Val_long(idx), newval);                \
+#define Bigstring_access_index_by(width, name, index_type, val_func)        \
+  CAMLprim value caml_ba_uint8_get##width##_indexed_by_##name(value vb,     \
+                                                              value vind)   \
+  {                                                                         \
+    index_type idx = val_func(vind);                                        \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();           \
+    return caml_ba_uint8_get##width(vb, Val_long(idx));                     \
+  }                                                                         \
+  CAMLprim value caml_ba_uint8_set##width##_indexed_by_##name(value vb,     \
+                                                              value vind,   \
+                                                              value newval) \
+  {                                                                         \
+    index_type idx = val_func(vind);                                        \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();           \
+    return caml_ba_uint8_set##width(vb, Val_long(idx), newval);             \
   }
 
-CAMLprim_indexed_by(16, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(16, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(16, nativeint, intnat, Nativeint_val)
-CAMLprim_indexed_by(32, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(32, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(32, nativeint, intnat, Nativeint_val)
-CAMLprim_indexed_by(64, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(64, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(64, nativeint, intnat, Nativeint_val)
+Bigstring_access_index_by(16, int64, int64_t, Int64_val)
+Bigstring_access_index_by(16, int32, int32_t, Int32_val)
+Bigstring_access_index_by(16, nativeint, intnat, Nativeint_val)
+Bigstring_access_index_by(32, int64, int64_t, Int64_val)
+Bigstring_access_index_by(32, int32, int32_t, Int32_val)
+Bigstring_access_index_by(32, nativeint, intnat, Nativeint_val)
+Bigstring_access_index_by(64, int64, int64_t, Int64_val)
+Bigstring_access_index_by(64, int32, int32_t, Int32_val)
+Bigstring_access_index_by(64, nativeint, intnat, Nativeint_val)
 
 /* Return the number of dimensions of a big array */
 

--- a/ocaml/runtime4/bigarray.c
+++ b/ocaml/runtime4/bigarray.c
@@ -866,6 +866,51 @@ CAMLprim value caml_ba_uint8_set64(value vb, value vind, value newval)
   return Val_unit;
 }
 
+CAMLprim value caml_ba_uint8_get16_indexed_by_int64(value, value);
+CAMLprim value caml_ba_uint8_get16_indexed_by_int32(value, value);
+CAMLprim value caml_ba_uint8_get16_indexed_by_nativeint(value, value);
+CAMLprim value caml_ba_uint8_get32_indexed_by_int64(value, value);
+CAMLprim value caml_ba_uint8_get32_indexed_by_int32(value, value);
+CAMLprim value caml_ba_uint8_get32_indexed_by_nativeint(value, value);
+CAMLprim value caml_ba_uint8_get64_indexed_by_int64(value, value);
+CAMLprim value caml_ba_uint8_get64_indexed_by_int32(value, value);
+CAMLprim value caml_ba_uint8_get64_indexed_by_nativeint(value, value);
+CAMLprim value caml_ba_uint8_set16_indexed_by_int64(value, value, value);
+CAMLprim value caml_ba_uint8_set16_indexed_by_int32(value, value, value);
+CAMLprim value caml_ba_uint8_set16_indexed_by_nativeint(value, value, value);
+CAMLprim value caml_ba_uint8_set32_indexed_by_int64(value, value, value);
+CAMLprim value caml_ba_uint8_set32_indexed_by_int32(value, value, value);
+CAMLprim value caml_ba_uint8_set32_indexed_by_nativeint(value, value, value);
+CAMLprim value caml_ba_uint8_set64_indexed_by_int64(value, value, value);
+CAMLprim value caml_ba_uint8_set64_indexed_by_int32(value, value, value);
+CAMLprim value caml_ba_uint8_set64_indexed_by_nativeint(value, value, value);
+
+#define CAMLprim_indexed_by(width, name, index_type, val_func)                 \
+  CAMLprim value caml_ba_uint8_get##width##_indexed_by_##name(value vb,        \
+      value vind)                                                              \
+  {                                                                            \
+    index_type idx = val_func(vind);                                           \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
+    return caml_ba_uint8_get##width(vb, Val_long(idx));                        \
+  }                                                                            \
+  CAMLprim value caml_ba_uint8_set##width##_indexed_by_##name(value vb,        \
+      value vind, value newval)                                                \
+  {                                                                            \
+    index_type idx = val_func(vind);                                           \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
+    return caml_ba_uint8_set##width(vb, Val_long(idx), newval);                \
+  }
+
+CAMLprim_indexed_by(16, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(16, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(16, nativeint, intnat, Nativeint_val)
+CAMLprim_indexed_by(32, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(32, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(32, nativeint, intnat, Nativeint_val)
+CAMLprim_indexed_by(64, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(64, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(64, nativeint, intnat, Nativeint_val)
+
 /* Return the number of dimensions of a big array */
 
 CAMLprim value caml_ba_num_dims(value vb)

--- a/ocaml/runtime4/float32.c
+++ b/ocaml/runtime4/float32.c
@@ -483,6 +483,60 @@ CAMLprim value caml_ba_uint8_setf32(value vb, value vind, value newval)
 #endif
 }
 
+CAMLprim value caml_ba_uint8_getf32_indexed_by_int64(value array, value index);
+CAMLprim value caml_ba_uint8_getf32_indexed_by_int32(value array, value index);
+CAMLprim value caml_ba_uint8_getf32_indexed_by_nativeint(value array, value index);
+
+CAMLprim value caml_ba_uint8_setf32_indexed_by_int64(value array, value index,
+                                                     value newval);
+CAMLprim value caml_ba_uint8_setf32_indexed_by_int32(value array, value index,
+                                                     value newval);
+CAMLprim value caml_ba_uint8_setf32_indexed_by_nativeint(value array, value index,
+                                                         value newval);
+
+CAMLprim value caml_string_getf32_indexed_by_int64(value array, value index);
+CAMLprim value caml_string_getf32_indexed_by_int32(value array, value index);
+CAMLprim value caml_string_getf32_indexed_by_nativeint(value array, value index);
+
+CAMLprim value caml_bytes_getf32_indexed_by_int64(value array, value index);
+CAMLprim value caml_bytes_getf32_indexed_by_int32(value array, value index);
+CAMLprim value caml_bytes_getf32_indexed_by_nativeint(value array, value index);
+
+CAMLprim value caml_bytes_setf32_indexed_by_int64(value array, value index,
+                                                  value newval);
+CAMLprim value caml_bytes_setf32_indexed_by_int32(value array, value index,
+                                                  value newval);
+CAMLprim value caml_bytes_setf32_indexed_by_nativeint(value array, value index,
+                                                      value newval);
+
+#define CAMLprim_indexed_by_get(name, container, index_type, val_func)             \
+  CAMLprim value caml_##container##_getf32_indexed_by_##name(value vb, value vind) \
+  {                                                                                \
+    index_type idx = val_func(vind);                                               \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();                  \
+    return caml_##container##_getf32(vb, Val_long(idx));                           \
+  }
+
+#define CAMLprim_indexed_by_set(name, container, index_type, val_func)             \
+  CAMLprim value caml_##container##_setf32_indexed_by_##name(value vb, value vind, \
+                                                             value newval)         \
+  {                                                                                \
+    index_type idx = val_func(vind);                                               \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();                  \
+    return caml_##container##_setf32(vb, Val_long(idx), newval);                   \
+  }
+
+#define CAMLprim_indexed_by(name, index_type, val_func)                            \
+  CAMLprim_indexed_by_get(name, ba_uint8, index_type, val_func)                    \
+  CAMLprim_indexed_by_get(name, string, index_type, val_func)                      \
+  CAMLprim_indexed_by_get(name, bytes, index_type, val_func)                       \
+  CAMLprim_indexed_by_set(name, ba_uint8, index_type, val_func)                    \
+  CAMLprim_indexed_by_set(name, bytes, index_type, val_func)                       \
+
+CAMLprim_indexed_by(int64, int64_t, Int64_val)
+CAMLprim_indexed_by(int32, int32_t, Int32_val)
+CAMLprim_indexed_by(nativeint, intnat, Nativeint_val)
+
 /* Defined in bigarray.c */
 CAMLextern intnat caml_ba_offset(struct caml_ba_array * b, intnat * index);
 

--- a/ocaml/runtime4/float32.c
+++ b/ocaml/runtime4/float32.c
@@ -509,33 +509,35 @@ CAMLprim value caml_bytes_setf32_indexed_by_int32(value array, value index,
 CAMLprim value caml_bytes_setf32_indexed_by_nativeint(value array, value index,
                                                       value newval);
 
-#define CAMLprim_indexed_by_get(name, container, index_type, val_func)             \
-  CAMLprim value caml_##container##_getf32_indexed_by_##name(value vb, value vind) \
-  {                                                                                \
-    index_type idx = val_func(vind);                                               \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();                  \
-    return caml_##container##_getf32(vb, Val_long(idx));                           \
+#define Float32_get_index_by(name, container, index_type, val_func)      \
+  CAMLprim value caml_##container##_getf32_indexed_by_##name(value vb,   \
+                                                             value vind) \
+  {                                                                      \
+    index_type idx = val_func(vind);                                     \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();        \
+    return caml_##container##_getf32(vb, Val_long(idx));                 \
   }
 
-#define CAMLprim_indexed_by_set(name, container, index_type, val_func)             \
-  CAMLprim value caml_##container##_setf32_indexed_by_##name(value vb, value vind, \
-                                                             value newval)         \
-  {                                                                                \
-    index_type idx = val_func(vind);                                               \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();                  \
-    return caml_##container##_setf32(vb, Val_long(idx), newval);                   \
+#define Float32_set_index_by(name, container, index_type, val_func)        \
+  CAMLprim value caml_##container##_setf32_indexed_by_##name(value vb,     \
+                                                             value vind,   \
+                                                             value newval) \
+  {                                                                        \
+    index_type idx = val_func(vind);                                       \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();          \
+    return caml_##container##_setf32(vb, Val_long(idx), newval);           \
   }
 
-#define CAMLprim_indexed_by(name, index_type, val_func)                            \
-  CAMLprim_indexed_by_get(name, ba_uint8, index_type, val_func)                    \
-  CAMLprim_indexed_by_get(name, string, index_type, val_func)                      \
-  CAMLprim_indexed_by_get(name, bytes, index_type, val_func)                       \
-  CAMLprim_indexed_by_set(name, ba_uint8, index_type, val_func)                    \
-  CAMLprim_indexed_by_set(name, bytes, index_type, val_func)                       \
+#define Float32_access_index_by(name, index_type, val_func)  \
+  Float32_get_index_by(name, ba_uint8, index_type, val_func) \
+  Float32_get_index_by(name, string, index_type, val_func)   \
+  Float32_get_index_by(name, bytes, index_type, val_func)    \
+  Float32_set_index_by(name, ba_uint8, index_type, val_func) \
+  Float32_set_index_by(name, bytes, index_type, val_func)
 
-CAMLprim_indexed_by(int64, int64_t, Int64_val)
-CAMLprim_indexed_by(int32, int32_t, Int32_val)
-CAMLprim_indexed_by(nativeint, intnat, Nativeint_val)
+Float32_access_index_by(int64, int64_t, Int64_val)
+Float32_access_index_by(int32, int32_t, Int32_val)
+Float32_access_index_by(nativeint, intnat, Nativeint_val)
 
 /* Defined in bigarray.c */
 CAMLextern intnat caml_ba_offset(struct caml_ba_array * b, intnat * index);

--- a/ocaml/runtime4/str.c
+++ b/ocaml/runtime4/str.c
@@ -276,6 +276,69 @@ CAMLprim value caml_bytes_set64(value str, value index, value newval)
   return Val_unit;
 }
 
+CAMLprim value caml_string_get16_indexed_by_int64(value, value);
+CAMLprim value caml_string_get16_indexed_by_int32(value, value);
+CAMLprim value caml_string_get16_indexed_by_nativeint(value, value);
+CAMLprim value caml_string_get32_indexed_by_int64(value, value);
+CAMLprim value caml_string_get32_indexed_by_int32(value, value);
+CAMLprim value caml_string_get32_indexed_by_nativeint(value, value);
+CAMLprim value caml_string_get64_indexed_by_int64(value, value);
+CAMLprim value caml_string_get64_indexed_by_int32(value, value);
+CAMLprim value caml_string_get64_indexed_by_nativeint(value, value);
+
+CAMLprim value caml_bytes_get16_indexed_by_int64(value, value);
+CAMLprim value caml_bytes_get16_indexed_by_int32(value, value);
+CAMLprim value caml_bytes_get16_indexed_by_nativeint(value, value);
+CAMLprim value caml_bytes_get32_indexed_by_int64(value, value);
+CAMLprim value caml_bytes_get32_indexed_by_int32(value, value);
+CAMLprim value caml_bytes_get32_indexed_by_nativeint(value, value);
+CAMLprim value caml_bytes_get64_indexed_by_int64(value, value);
+CAMLprim value caml_bytes_get64_indexed_by_int32(value, value);
+CAMLprim value caml_bytes_get64_indexed_by_nativeint(value, value);
+
+CAMLprim value caml_bytes_set16_indexed_by_int64(value, value, value);
+CAMLprim value caml_bytes_set16_indexed_by_int32(value, value, value);
+CAMLprim value caml_bytes_set16_indexed_by_nativeint(value, value, value);
+CAMLprim value caml_bytes_set32_indexed_by_int64(value, value, value);
+CAMLprim value caml_bytes_set32_indexed_by_int32(value, value, value);
+CAMLprim value caml_bytes_set32_indexed_by_nativeint(value, value, value);
+CAMLprim value caml_bytes_set64_indexed_by_int64(value, value, value);
+CAMLprim value caml_bytes_set64_indexed_by_int32(value, value, value);
+CAMLprim value caml_bytes_set64_indexed_by_nativeint(value, value, value);
+
+#define CAMLprim_indexed_by(width, name, index_type, val_func)                 \
+  CAMLprim value caml_string_get##width##_indexed_by_##name(value vb,          \
+      value vind)                                                              \
+  {                                                                            \
+    index_type idx = val_func(vind);                                           \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
+    return caml_string_get##width(vb, Val_long(idx));                          \
+  }                                                                            \
+  CAMLprim value caml_bytes_get##width##_indexed_by_##name(value vb,           \
+      value vind)                                                              \
+  {                                                                            \
+    index_type idx = val_func(vind);                                           \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
+    return caml_bytes_get##width(vb, Val_long(idx));                           \
+  }                                                                            \
+  CAMLprim value caml_bytes_set##width##_indexed_by_##name(value vb,           \
+      value vind, value newval)                                                \
+  {                                                                            \
+    index_type idx = val_func(vind);                                           \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
+    return caml_bytes_set##width(vb, Val_long(idx), newval);                   \
+  }
+
+CAMLprim_indexed_by(16, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(16, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(16, nativeint, intnat, Nativeint_val)
+CAMLprim_indexed_by(32, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(32, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(32, nativeint, intnat, Nativeint_val)
+CAMLprim_indexed_by(64, int64, int64_t, Int64_val)
+CAMLprim_indexed_by(64, int32, int32_t, Int32_val)
+CAMLprim_indexed_by(64, nativeint, intnat, Nativeint_val)
+
 CAMLprim value caml_string_equal(value s1, value s2)
 {
   mlsize_t sz1, sz2;

--- a/ocaml/runtime4/str.c
+++ b/ocaml/runtime4/str.c
@@ -306,38 +306,38 @@ CAMLprim value caml_bytes_set64_indexed_by_int64(value, value, value);
 CAMLprim value caml_bytes_set64_indexed_by_int32(value, value, value);
 CAMLprim value caml_bytes_set64_indexed_by_nativeint(value, value, value);
 
-#define CAMLprim_indexed_by(width, name, index_type, val_func)                 \
-  CAMLprim value caml_string_get##width##_indexed_by_##name(value vb,          \
-      value vind)                                                              \
-  {                                                                            \
-    index_type idx = val_func(vind);                                           \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
-    return caml_string_get##width(vb, Val_long(idx));                          \
-  }                                                                            \
-  CAMLprim value caml_bytes_get##width##_indexed_by_##name(value vb,           \
-      value vind)                                                              \
-  {                                                                            \
-    index_type idx = val_func(vind);                                           \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
-    return caml_bytes_get##width(vb, Val_long(idx));                           \
-  }                                                                            \
-  CAMLprim value caml_bytes_set##width##_indexed_by_##name(value vb,           \
-      value vind, value newval)                                                \
-  {                                                                            \
-    index_type idx = val_func(vind);                                           \
-    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();              \
-    return caml_bytes_set##width(vb, Val_long(idx), newval);                   \
+#define String_and_bytes_access_index_by(width, name, index_type, val_func) \
+  CAMLprim value caml_string_get##width##_indexed_by_##name(value vb,       \
+      value vind)                                                           \
+  {                                                                         \
+    index_type idx = val_func(vind);                                        \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();           \
+    return caml_string_get##width(vb, Val_long(idx));                       \
+  }                                                                         \
+  CAMLprim value caml_bytes_get##width##_indexed_by_##name(value vb,        \
+      value vind)                                                           \
+  {                                                                         \
+    index_type idx = val_func(vind);                                        \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();           \
+    return caml_bytes_get##width(vb, Val_long(idx));                        \
+  }                                                                         \
+  CAMLprim value caml_bytes_set##width##_indexed_by_##name(value vb,        \
+      value vind, value newval)                                             \
+  {                                                                         \
+    index_type idx = val_func(vind);                                        \
+    if (idx != Long_val(Val_long(idx))) caml_array_bound_error();           \
+    return caml_bytes_set##width(vb, Val_long(idx), newval);                \
   }
 
-CAMLprim_indexed_by(16, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(16, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(16, nativeint, intnat, Nativeint_val)
-CAMLprim_indexed_by(32, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(32, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(32, nativeint, intnat, Nativeint_val)
-CAMLprim_indexed_by(64, int64, int64_t, Int64_val)
-CAMLprim_indexed_by(64, int32, int32_t, Int32_val)
-CAMLprim_indexed_by(64, nativeint, intnat, Nativeint_val)
+String_and_bytes_access_index_by(16, int64, int64_t, Int64_val)
+String_and_bytes_access_index_by(16, int32, int32_t, Int32_val)
+String_and_bytes_access_index_by(16, nativeint, intnat, Nativeint_val)
+String_and_bytes_access_index_by(32, int64, int64_t, Int64_val)
+String_and_bytes_access_index_by(32, int32, int32_t, Int32_val)
+String_and_bytes_access_index_by(32, nativeint, intnat, Nativeint_val)
+String_and_bytes_access_index_by(64, int64, int64_t, Int64_val)
+String_and_bytes_access_index_by(64, int32, int32_t, Int32_val)
+String_and_bytes_access_index_by(64, nativeint, intnat, Nativeint_val)
 
 CAMLprim value caml_string_equal(value s1, value s2)
 {

--- a/ocaml/testsuite/tests/prim-bigstring/non_existent_primitives.ml
+++ b/ocaml/testsuite/tests/prim-bigstring/non_existent_primitives.ml
@@ -41,14 +41,3 @@ Lines 1-2, characters 0-26:
 2 |   = "%caml_string_geta128"
 Error: Unknown builtin primitive "%caml_string_geta128"
 |}]
-
-external string_get_64_unboxed : string -> int -> int64#
-  = "%caml_string_get64#"
-
-[%%expect
-{|
-Lines 1-2, characters 0-25:
-1 | external string_get_64_unboxed : string -> int -> int64#
-2 |   = "%caml_string_get64#"
-Error: Unknown builtin primitive "%caml_string_get64#"
-|}]

--- a/ocaml/testsuite/tests/typing-layouts/generate.ml
+++ b/ocaml/testsuite/tests/typing-layouts/generate.ml
@@ -1,0 +1,12 @@
+(* TEST
+   readonly_files = "generate_stringlike_indexing.ml";
+   setup-ocamlopt.opt-build-env;
+   program = "${test_source_directory}/generate.out";
+   all_modules = "generate_stringlike_indexing.ml";
+   ocamlopt.opt;
+   output = "${test_source_directory}/unboxed_int_stringlike_indexing.ml.corrected";
+   run;
+   output = "${test_source_directory}/unboxed_int_stringlike_indexing.ml.corrected";
+   reference = "${test_source_directory}/unboxed_int_stringlike_indexing.ml";
+   check-program-output;
+*)

--- a/ocaml/testsuite/tests/typing-layouts/generate_stringlike_indexing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/generate_stringlike_indexing.ml
@@ -1,3 +1,10 @@
+let indent spaces string =
+  let indent_string = String.make spaces ' ' in
+  String.split_on_char '\n' string
+  |> List.concat_map (fun line ->
+    if String.equal line "" then [ "\n" ] else [ indent_string; line; "\n" ])
+  |> String.concat ""
+
 let template ~tests = {|(* TEST
  flambda2;
  include stdlib_upstream_compatible;
@@ -145,6 +152,7 @@ module Tester (Primitives : sig
   ;;
 
   let test length =
+    Random.init 1234;
     let check_get_bounds, check_get, check_set_bounds, check_set =
       make_tester_functions length
     in
@@ -166,12 +174,22 @@ end
 
 let test_group_template ~setup ~tests = {|
 open struct
-|}^setup^{|
-|}^String.concat "" tests^{|
+|}^indent 2 setup^{|
+|}^indent 2 (String.concat "" tests)^{|
 end
 |}
 
-let type_utilities_template ~boxed_index ~boxed_data ~generate_data ~to_index ~unbox_index ~unbox_data ~box_data ~data_equal ~extra_bounds = {|
+let type_utilities_template
+  ~boxed_index
+  ~boxed_data
+  ~generate_data
+  ~to_index
+  ~unbox_index
+  ~unbox_data
+  ~box_data
+  ~data_equal
+  ~extra_bounds
+  = {|
 type boxed_index = |}^boxed_index^{|
 type boxed_data = |}^boxed_data^{|
 
@@ -184,7 +202,16 @@ let box_data = |}^box_data^{|
 let extra_bounds_checks = |}^extra_bounds^{|
 |}
 
-let one_test_template ~index ~boxed_data ~tested_data ~index_sigil ~data_sigil ~unboxed_sigil ~container ~create = {|
+let one_test_template
+  ~index
+  ~boxed_data
+  ~tested_data
+  ~index_sigil
+  ~data_sigil
+  ~unboxed_sigil
+  ~container
+  ~create
+  = {|
 module _ = Tester (struct
     type nonrec boxed_index = boxed_index
     type nonrec boxed_data = boxed_data
@@ -245,27 +272,43 @@ module _ = Tester (struct
   end)
 |}
 
-(* We can't just look up min/max int in the module because of the [int16] accessors, which
-   use [Int]. *)
-let int_examples_template ~module_ ~width = {|
-let rec x = function
-  | i when i <= 0 -> |}^module_^{|.zero
-  | 1 ->
-      (* min int *)
-      |}^module_^{|.(shift_left one) (|}^width^{| - 1)
-  | 2 ->
-      (* max int *)
-      let shift = |}^width^{| - 1 in
-      |}^module_^{|.(lognot (shift_left (shift_right (lognot zero) shift) shift))
-  | i ->
-      (* flip 3 "random" bits *)
-      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
-      let x = x (i - 1) in
-      let x = |}^module_^{|.(logxor x (shift_left one (i1 mod |}^width^{|))) in
-      let x = |}^module_^{|.(logxor x (shift_left one (i2 mod |}^width^{|))) in
-      let x = |}^module_^{|.(logxor x (shift_left one (i3 mod |}^width^{|))) in
-      x
-in x
+(* We can't always just look up min/max int in the module because of the [int16]
+   accessors, which use [Int]. *)
+let int_examples_template ~module_ ~min ~max ~min_for_rand ~max_for_rand ~type_ = {|
+fun i ->
+  match i mod 4 with
+  | 0 -> |}^module_^{|.zero
+  | 1 -> |}^min^{|
+  | 2 -> |}^max^{|
+  | _ -> Random.|}^type_^{|_in_range ~min:|}^min_for_rand^{| ~max:|}^max_for_rand^{|
+|}
+
+let int_examples_custom_bounds ~module_ ~width ~type_ =
+  let min_int = {|(|}^module_^{|.(shift_left one) (|}^width^{| - 1))|} in
+  let max_int = {|
+    (let shift = |}^width^{| - 1 in
+    |}^module_^{|.(lognot (shift_left (shift_right (lognot zero) shift) shift)))|}
+  in
+  int_examples_template
+    ~module_
+    ~min:min_int
+    ~max:max_int
+    ~min_for_rand:(module_^{|.zero|})
+    ~max_for_rand:min_int
+    ~type_
+
+let int_examples_default_bounds ~module_ ~width ~type_ =
+  let min = module_^{|.min_int|} in
+  let max = module_^{|.max_int|} in
+  int_examples_template ~module_ ~min ~max ~min_for_rand:min ~max_for_rand:max ~type_
+
+let float_examples = {|
+fun _ ->
+  let f =
+    let f = Random.float Float.max_float in
+    if Random.bool () then Float.neg f else f
+  in
+  Stdlib_beta.Float32.of_float f
 |}
 
 type index =
@@ -292,7 +335,7 @@ type container =
   ; create : string
   }
 
-let int_result ~width ~unboxed ~module_ =
+let int_result ~width ~unboxed ~module_ ~examples =
   let type_ = String.lowercase_ascii module_ in
   let unboxed_sigil = if unboxed then "#" else "" in
   { boxed_type = type_
@@ -308,7 +351,7 @@ let int_result ~width ~unboxed ~module_ =
        then "Stdlib_upstream_compatible." ^ module_ ^ "_u.of_" ^ type_
        else "fun x -> x")
   ; eq = module_ ^ ".equal"
-  ; example = int_examples_template ~module_ ~width
+  ; example = examples ~module_ ~width ~type_ |> indent 2
   }
 ;;
 
@@ -338,31 +381,36 @@ let indices =
 
 let datas =
   [ int_result ~width:"16" ~unboxed:false ~module_:"Int"
+      ~examples:int_examples_custom_bounds
   ; int_result ~width:"32" ~unboxed:false ~module_:"Int32"
+      ~examples:int_examples_default_bounds
   ; int_result ~width:"64" ~unboxed:false ~module_:"Int64"
+      ~examples:int_examples_default_bounds
   ; int_result ~width:"32" ~unboxed:true ~module_:"Int32"
+      ~examples:int_examples_default_bounds
   ; int_result ~width:"64" ~unboxed:true ~module_:"Int64"
-    (* CR layouts: generate more interesting examples for f32 *)
-  ; { width = "f32"
-    ; unboxed_sigil = ""
-    ; boxed_type = "float32"
-    ; tested_type = "float32"
-    ; box = "fun x -> x"
-    ; unbox = "fun x -> x"
-    ; eq = "Stdlib_beta.Float32.equal"
-    ; example = "fun _ -> Stdlib_beta.Float32.of_float 5.0\n"
+      ~examples:int_examples_default_bounds
+  ; {
+      width = "f32";
+      unboxed_sigil = "";
+      boxed_type = "float32";
+      tested_type = "float32";
+      box = "fun x -> x";
+      unbox = "fun x -> x";
+      eq = "Stdlib_beta.Float32.equal";
+      example = float_examples;
     }
-  ; { width = "f32"
-    ; unboxed_sigil = "#"
-    ; boxed_type = "float32"
-    ; tested_type = "float32#"
-    ; box = "Stdlib_beta.Float32_u.to_float32"
-    ; unbox = "Stdlib_beta.Float32_u.of_float32"
-    ; eq = "Stdlib_beta.Float32.equal"
-    ; example = "fun _ -> Stdlib_beta.Float32.of_float 5.0\n"
-    }
+  ; {
+      width = "f32";
+      unboxed_sigil = "#";
+      boxed_type = "float32";
+      tested_type = "float32#";
+      box = "Stdlib_beta.Float32_u.to_float32";
+      unbox = "Stdlib_beta.Float32_u.of_float32";
+      eq = "Stdlib_beta.Float32.equal";
+      example = float_examples;
+    };
   ]
-;;
 
 let containers =
   [ { container = "string"; create = "create_s" }

--- a/ocaml/testsuite/tests/typing-layouts/generate_stringlike_indexing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/generate_stringlike_indexing.ml
@@ -8,7 +8,7 @@ let indent spaces string =
 let template ~tests = {|(* TEST
  flambda2;
  include stdlib_upstream_compatible;
- include stdlib_beta;
+ include stdlib_stable;
  {
    native;
  }{
@@ -307,7 +307,7 @@ fun _ ->
     let f = Random.float Float.max_float in
     if Random.bool () then Float.neg f else f
   in
-  Stdlib_beta.Float32.of_float f
+  Stdlib_stable.Float32.of_float f
 |}
 
 let int_extra_bounds_template ~module_ =
@@ -398,7 +398,7 @@ let datas =
       tested_type = "float32";
       box = "fun x -> x";
       unbox = "fun x -> x";
-      eq = "Stdlib_beta.Float32.equal";
+      eq = "Stdlib_stable.Float32.equal";
       example = float_examples;
     }
   ; {
@@ -406,9 +406,9 @@ let datas =
       unboxed_sigil = "#";
       boxed_type = "float32";
       tested_type = "float32#";
-      box = "Stdlib_beta.Float32_u.to_float32";
-      unbox = "Stdlib_beta.Float32_u.of_float32";
-      eq = "Stdlib_beta.Float32.equal";
+      box = "Stdlib_stable.Float32_u.to_float32";
+      unbox = "Stdlib_stable.Float32_u.of_float32";
+      eq = "Stdlib_stable.Float32.equal";
       example = float_examples;
     };
   ]

--- a/ocaml/testsuite/tests/typing-layouts/generate_stringlike_indexing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/generate_stringlike_indexing.ml
@@ -1,0 +1,351 @@
+let template ~tests = {|(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ include stdlib_beta;
+ {
+   native;
+ }{
+   flags = "-O3";
+   native;
+ }{
+   bytecode;
+ }{
+   flags = "-extension layouts_alpha";
+   native;
+ }{
+   flags = "-extension layouts_alpha -O3";
+   native;
+ }{
+   flags = "-extension layouts_alpha";
+   bytecode;
+ }{
+   flags = "-extension layouts_beta";
+   native;
+ }{
+   flags = "-extension layouts_beta -O3";
+   native;
+ }{
+   flags = "-extension layouts_beta";
+   bytecode;
+ }
+*)
+
+|}^tests
+
+(* CR layouts: functorize these tests like in [tests/simd/arrays.ml]. *)
+
+let tests_template ~length ~tests = {|
+let length = |}^length^{|
+let reference_str = String.init length (fun i -> i * 7 mod 256 |> char_of_int)
+let create_b () = reference_str |> Bytes.of_string
+let create_s () = reference_str
+
+open struct
+  open Bigarray
+
+  type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t
+
+  let bigstring_of_string s =
+    let a = Array1.create char c_layout (String.length s) in
+    for i = 0 to String.length s - 1 do
+      a.{i} <- s.[i]
+    done;
+    a
+
+  let create_bs () = reference_str |> bigstring_of_string
+end
+
+|}^tests
+
+let external_bindings_template ~container ~sigil ~width ~test_suffix ~index ~ref_result
+      ~test_result = {|
+external |}^sigil^{|_get_reference : |}^container^{| -> int -> |}^ref_result^{|
+  = "%caml_|}^container^{|_get|}^width^{|"
+
+external |}^sigil^{|_get_tested_s : |}^container^{| -> |}^index^{| -> |}^test_result^{|
+  = "%caml_|}^container^{|_get|}^width^test_suffix^{|_indexed_by_|}^index^{|"
+
+external |}^sigil^{|_get_tested_u : |}^container^{| -> |}^index^{| -> |}^test_result^{|
+  = "%caml_|}^container^{|_get|}^width^{|u|}^test_suffix^{|_indexed_by_|}^index^{|"
+
+external |}^sigil^{|_set_reference
+  : |}^container^{| -> int -> |}^ref_result^{| -> unit
+  = "%caml_|}^container^{|_set|}^width^{|"
+
+external |}^sigil^{|_set_tested_s
+  : |}^container^{| -> |}^index^{| -> |}^test_result^{| -> unit
+  = "%caml_|}^container^{|_set|}^width^test_suffix^{|_indexed_by_|}^index^{|"
+
+external |}^sigil^{|_set_tested_u
+  : |}^container^{| -> |}^index^{| -> |}^test_result^{| -> unit
+  = "%caml_|}^container^{|_set|}^width^{|u|}^test_suffix^{|_indexed_by_|}^index^{|"
+|}
+
+let one_test_template ~width ~test_suffix ~index ~ref_result ~test_result
+      ~conv_index ~box_result ~unbox_result ~eq ~extra_bounds ~example = {|
+let of_boxed_index : int -> |}^index^{| = |}^conv_index^{|
+let to_boxed_result : |}^test_result^{| -> |}^ref_result^{| = |}^box_result^{|
+let of_boxed_result : |}^ref_result^{| -> |}^test_result^{| = |}^unbox_result^{|
+let eq : |}^ref_result^{| -> |}^ref_result^{| -> bool = |}^eq^{|
+|}
+^example
+^external_bindings_template
+   ~container:"bigstring" ~sigil:"bs" ~width ~test_suffix ~index ~ref_result ~test_result
+^external_bindings_template
+   ~container:"string" ~sigil:"s" ~width ~test_suffix ~index ~ref_result ~test_result
+^external_bindings_template
+   ~container:"bytes" ~sigil:"b" ~width ~test_suffix ~index ~ref_result ~test_result
+^{|
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+|}^extra_bounds^{|
+|}
+;;
+
+let extra_bounds_template ~index = {|
+check_get_bounds (|}^index^{|);;
+check_set_bounds (|}^index^{|) (x 1);;|}
+
+(* We can't just look up min/max int in the module because of the [int16] accessors, which
+   use [Int]. *)
+let int_examples_template ~module_ ~width = {|
+let rec x = function
+  | i when i <= 0 -> |}^module_^{|.zero
+  | 1 ->
+      (* min int *)
+      |}^module_^{|.(shift_left one) (|}^width^{| - 1)
+  | 2 ->
+      (* max int *)
+      let shift = |}^width^{| - 1 in
+      |}^module_^{|.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = |}^module_^{|.(logxor x (shift_left one (i1 mod |}^width^{|))) in
+      let x = |}^module_^{|.(logxor x (shift_left one (i2 mod |}^width^{|))) in
+      let x = |}^module_^{|.(logxor x (shift_left one (i3 mod |}^width^{|))) in
+      x
+|}
+
+(* Copied from [utils/misc.ml] *)
+module Hlist = struct
+  type _ t =
+    | [] : unit t
+    | ( :: ) : 'a * 'b t -> ('a -> 'b) t
+
+  type _ lt =
+    | [] : unit lt
+    | ( :: ) : 'a list * 'b lt -> ('a -> 'b) lt
+
+  let rec cartesian_product : type l. l lt -> l t list = function
+    | [] -> [ [] ]
+    | hd :: tl ->
+      let tl = cartesian_product tl in
+      List.concat_map (fun x1 -> List.map (fun x2 : _ t -> x1 :: x2) tl) hd
+  ;;
+end
+
+type index =
+  { type_ : string
+  ; conv : string
+  ; extra_bounds : string list
+  }
+
+type result =
+  { width : string
+  ; test_suffix : string
+  ; ref : string
+  ; test : string
+  ; box : string
+  ; unbox : string
+  ; eq : string
+  ; example : string
+  }
+
+let int_result ~width ~unboxed ~module_ =
+  let type_ = String.lowercase_ascii module_ in
+  let suffix = if unboxed then "#" else "" in
+  { width
+  ; test_suffix = suffix
+  ; ref = type_
+  ; test = type_ ^ suffix
+  ; box =
+      (if unboxed
+       then "Stdlib_upstream_compatible." ^ module_ ^ "_u.to_" ^ type_
+       else "fun x -> x")
+  ; unbox =
+      (if unboxed
+       then "Stdlib_upstream_compatible." ^ module_ ^ "_u.of_" ^ type_
+       else "fun x -> x")
+  ; eq = module_ ^ ".equal"
+  ; example = int_examples_template ~module_ ~width
+  }
+;;
+
+let bigstring_tests =
+  Hlist.cartesian_product
+    ([ [ { type_ = "nativeint#"
+         ; conv = "Stdlib_upstream_compatible.Nativeint_u.of_int"
+         ; extra_bounds = [ "-#1n" ]
+         }
+       ; { type_ = "int32#"
+         ; conv = "Stdlib_upstream_compatible.Int32_u.of_int"
+         ; extra_bounds =
+             [ "-#2147483648l"; "-#2147483647l"; "#2147483647l"; "-#1l" ]
+         }
+       ; { type_ = "int64#"
+         ; conv = "Stdlib_upstream_compatible.Int64_u.of_int"
+         ; extra_bounds =
+             [ "-#9223372036854775808L"
+             ; "-#9223372036854775807L"
+             ; "#9223372036854775807L"
+             ; "-#1L"
+             ]
+         }
+       ]
+     ; [ int_result ~width:"16" ~unboxed:false ~module_:"Int"
+       ; int_result ~width:"32" ~unboxed:false ~module_:"Int32"
+       ; int_result ~width:"64" ~unboxed:false ~module_:"Int64"
+       ; int_result ~width:"32" ~unboxed:true ~module_:"Int32"
+       ; int_result ~width:"64" ~unboxed:true ~module_:"Int64"
+       (* CR layouts: generate more interesting examples for f32 *)
+       ; { width = "f32"
+         ; test_suffix = ""
+         ; ref = "float32"
+         ; test = "float32"
+         ; box = "fun x -> x"
+         ; unbox = "fun x -> x"
+         ; eq = "Stdlib_beta.Float32.equal"
+         ; example =
+             "let x _ = Stdlib_beta.Float32.of_float 5.0\n"
+         }
+       ; { width = "f32"
+         ; test_suffix = "#"
+         ; ref = "float32"
+         ; test = "float32#"
+         ; box = "Stdlib_beta.Float32_u.to_float32"
+         ; unbox = "Stdlib_beta.Float32_u.of_float32"
+         ; eq = "Stdlib_beta.Float32.equal"
+         ; example =
+             "let x _ = Stdlib_beta.Float32.of_float 5.0\n"
+         }
+       ]
+     ]
+     : _ Hlist.lt)
+  |> List.map
+       (fun
+           ([ { type_; conv = conv_index; extra_bounds }
+            ; { width; test_suffix; ref; test; box; unbox; eq; example }
+            ] :
+             _ Hlist.t)
+         ->
+          let extra_bounds =
+            String.concat
+              ""
+              (List.map
+                 (fun index -> extra_bounds_template ~index)
+                 extra_bounds)
+          in
+          one_test_template
+            ~width
+            ~test_suffix
+            ~index:type_
+            ~ref_result:ref
+            ~test_result:test
+            ~conv_index
+            ~box_result:box
+            ~unbox_result:unbox
+            ~eq
+            ~extra_bounds
+            ~example)
+  |> String.concat ""
+;;
+
+template ~tests:(tests_template ~length:"300" ~tests:bigstring_tests)
+|> print_string

--- a/ocaml/testsuite/tests/typing-layouts/generate_stringlike_indexing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/generate_stringlike_indexing.ml
@@ -199,8 +199,7 @@ let data_equal = |}^data_equal^{|
 let unbox_index = |}^unbox_index^{|
 let unbox_data = |}^unbox_data^{|
 let box_data = |}^box_data^{|
-let extra_bounds_checks = |}^extra_bounds^{|
-|}
+let extra_bounds_checks = |}^extra_bounds
 
 let one_test_template
   ~index
@@ -311,6 +310,10 @@ fun _ ->
   Stdlib_beta.Float32.of_float f
 |}
 
+let int_extra_bounds_template ~module_ =
+  module_ ^ {|.[ min_int; max_int; add min_int one; sub zero one ]|}
+;;
+
 type index =
   { boxed_type : string
   ; tested_type : string
@@ -360,21 +363,19 @@ let indices =
     ; tested_type = "nativeint#"
     ; of_int = "Nativeint.of_int"
     ; unbox = "Stdlib_upstream_compatible.Nativeint_u.of_nativeint"
-    ; extra_bounds = "[ -1n ]"
+    ; extra_bounds = int_extra_bounds_template ~module_:"Nativeint"
     }
   ; { boxed_type = "int32"
     ; tested_type = "int32#"
     ; of_int = "Int32.of_int"
     ; unbox = "Stdlib_upstream_compatible.Int32_u.of_int32"
-    ; extra_bounds = "[ -2147483648l; -2147483647l; 2147483647l; -1l ]"
+    ; extra_bounds = int_extra_bounds_template ~module_:"Int32"
     }
   ; { boxed_type = "int64"
     ; tested_type = "int64#"
     ; of_int = "Int64.of_int"
     ; unbox = "Stdlib_upstream_compatible.Int64_u.of_int64"
-    ; extra_bounds =
-        "[ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; \
-         -1L ]"
+    ; extra_bounds = int_extra_bounds_template ~module_:"Int64"
     }
   ]
 ;;

--- a/ocaml/testsuite/tests/typing-layouts/unboxed_int_stringlike_indexing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/unboxed_int_stringlike_indexing.ml
@@ -185,8 +185,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -1n ]
-
+  let extra_bounds_checks = Nativeint.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -388,8 +387,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -1n ]
-
+  let extra_bounds_checks = Nativeint.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -591,8 +589,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -1n ]
-
+  let extra_bounds_checks = Nativeint.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -794,8 +791,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
   let unbox_data = Stdlib_upstream_compatible.Int32_u.of_int32
   let box_data = Stdlib_upstream_compatible.Int32_u.to_int32
-  let extra_bounds_checks = [ -1n ]
-
+  let extra_bounds_checks = Nativeint.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -997,8 +993,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
   let unbox_data = Stdlib_upstream_compatible.Int64_u.of_int64
   let box_data = Stdlib_upstream_compatible.Int64_u.to_int64
-  let extra_bounds_checks = [ -1n ]
-
+  let extra_bounds_checks = Nativeint.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -1199,8 +1194,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -1n ]
-
+  let extra_bounds_checks = Nativeint.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -1401,8 +1395,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
   let unbox_data = Stdlib_beta.Float32_u.of_float32
   let box_data = Stdlib_beta.Float32_u.to_float32
-  let extra_bounds_checks = [ -1n ]
-
+  let extra_bounds_checks = Nativeint.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -1606,8 +1599,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
-
+  let extra_bounds_checks = Int32.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -1809,8 +1801,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
-
+  let extra_bounds_checks = Int32.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -2012,8 +2003,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
-
+  let extra_bounds_checks = Int32.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -2215,8 +2205,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
   let unbox_data = Stdlib_upstream_compatible.Int32_u.of_int32
   let box_data = Stdlib_upstream_compatible.Int32_u.to_int32
-  let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
-
+  let extra_bounds_checks = Int32.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -2418,8 +2407,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
   let unbox_data = Stdlib_upstream_compatible.Int64_u.of_int64
   let box_data = Stdlib_upstream_compatible.Int64_u.to_int64
-  let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
-
+  let extra_bounds_checks = Int32.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -2620,8 +2608,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
-
+  let extra_bounds_checks = Int32.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -2822,8 +2809,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
   let unbox_data = Stdlib_beta.Float32_u.of_float32
   let box_data = Stdlib_beta.Float32_u.to_float32
-  let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
-
+  let extra_bounds_checks = Int32.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -3027,8 +3013,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
-
+  let extra_bounds_checks = Int64.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -3230,8 +3215,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
-
+  let extra_bounds_checks = Int64.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -3433,8 +3417,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
-
+  let extra_bounds_checks = Int64.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -3636,8 +3619,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
   let unbox_data = Stdlib_upstream_compatible.Int32_u.of_int32
   let box_data = Stdlib_upstream_compatible.Int32_u.to_int32
-  let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
-
+  let extra_bounds_checks = Int64.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -3839,8 +3821,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
   let unbox_data = Stdlib_upstream_compatible.Int64_u.of_int64
   let box_data = Stdlib_upstream_compatible.Int64_u.to_int64
-  let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
-
+  let extra_bounds_checks = Int64.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -4041,8 +4022,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
   let unbox_data = fun x -> x
   let box_data = fun x -> x
-  let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
-
+  let extra_bounds_checks = Int64.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct
@@ -4243,8 +4223,7 @@ open struct
   let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
   let unbox_data = Stdlib_beta.Float32_u.of_float32
   let box_data = Stdlib_beta.Float32_u.to_float32
-  let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
-
+  let extra_bounds_checks = Int64.[ min_int; max_int; add min_int one; sub zero one ]
 
 
   module _ = Tester (struct

--- a/ocaml/testsuite/tests/typing-layouts/unboxed_int_stringlike_indexing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/unboxed_int_stringlike_indexing.ml
@@ -30,11 +30,15 @@
  }
 *)
 
+let lengths = List.init 17 (fun x -> x) @ List.init 17 (fun x -> 300 + x)
 
-let length = 300
-let reference_str = String.init length (fun i -> i * 7 mod 256 |> char_of_int)
-let create_b () = reference_str |> Bytes.of_string
-let create_s () = reference_str
+type exn += Test_failed
+
+let create_s length =
+  String.init length (fun i -> i * 7 mod 256 |> char_of_int)
+;;
+
+let create_b length = create_s length |> Bytes.of_string
 
 open struct
   open Bigarray
@@ -48,15 +52,123 @@ open struct
     done;
     a
 
-  let create_bs () = reference_str |> bigstring_of_string
+  let create_bs length = create_s length |> bigstring_of_string
+end
+
+module Tester (Primitives : sig
+    type boxed_index
+    type boxed_data
+    type container
+
+    val create : int -> container
+    val generate_data : int -> boxed_data
+    val to_index : int -> boxed_index
+    val data_equal : boxed_data -> boxed_data -> bool
+
+    type 'a getter := container -> 'a -> boxed_data
+    type 'a setter := container -> 'a -> boxed_data -> unit
+
+    val get_reference : int getter
+    val get_safe : boxed_index getter
+    val get_unsafe : boxed_index getter
+    val set_reference : int setter
+    val set_safe : boxed_index setter
+    val set_unsafe : boxed_index setter
+    val extra_bounds_checks : boxed_index list
+  end) : sig end = struct
+  open Primitives
+
+  let make_tester_functions length =
+    let for_reference = create length
+    and for_safe = create length
+    and for_unsafe = create length in
+    let check_get_bounds i =
+      try
+        let _ = get_safe for_safe i in
+        assert false
+      with
+      | Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      try
+        let _ = set_safe for_safe i x in
+        assert false
+      with
+      | Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = to_index i in
+      try
+        let res = get_reference for_reference i in
+        try
+          assert (data_equal res (get_safe for_safe test_i));
+          assert (data_equal res (get_unsafe for_unsafe test_i))
+        with
+        | _ -> raise Test_failed
+      with
+      | Test_failed -> assert false
+      | Invalid_argument _ -> check_get_bounds test_i
+      | _ ->
+        (try
+           let _ = get_safe for_safe test_i in
+           assert false
+         with
+         | Invalid_argument _ -> assert false
+         | _ -> ())
+    in
+    let check_set i x =
+      let test_i = to_index i in
+      try
+        set_reference for_reference i x;
+        try
+          set_safe for_safe test_i x;
+          assert (data_equal x (get_reference for_safe i));
+          set_unsafe for_unsafe test_i x;
+          assert (data_equal x (get_reference for_unsafe i));
+          (* Check that we didn't ruin adjacent indices *)
+          check_get (i - 1);
+          check_get (i + 1)
+        with
+        | _ -> raise Test_failed
+      with
+      | Test_failed -> assert false
+      | Invalid_argument _ -> check_set_bounds test_i x
+      | _ ->
+        (try
+           set_safe for_safe test_i x;
+           assert false
+         with
+         | Invalid_argument _ -> assert false
+         | _ -> ())
+    in
+    check_get_bounds, check_get, check_set_bounds, check_set
+  ;;
+
+  let test length =
+    let check_get_bounds, check_get, check_set_bounds, check_set =
+      make_tester_functions length
+    in
+    for i = -1 to length + 1 do
+      check_get i;
+      check_set i (generate_data i)
+    done;
+    List.iter
+      (fun bound ->
+        check_get_bounds bound;
+        check_set_bounds bound (generate_data 1))
+      extra_bounds_checks
+  ;;
+
+  let () = List.iter test lengths
 end
 
 
-let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
-let to_boxed_result : int -> int = fun x -> x
-let of_boxed_result : int -> int = fun x -> x
-let eq : int -> int -> bool = Int.equal
+open struct
 
+type boxed_index = nativeint
+type boxed_data = int
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int.zero
   | 1 ->
@@ -74,166 +186,201 @@ let rec x = function
       let x = Int.(logxor x (shift_left one (i2 mod 16))) in
       let x = Int.(logxor x (shift_left one (i3 mod 16))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int
-  = "%caml_bigstring_get16"
+let to_index = Nativeint.of_int
+let data_equal = Int.equal
+let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -1n ]
 
-external bs_get_tested_s : bigstring -> nativeint# -> int
-  = "%caml_bigstring_get16_indexed_by_nativeint#"
 
-external bs_get_tested_u : bigstring -> nativeint# -> int
-  = "%caml_bigstring_get16u_indexed_by_nativeint#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int -> unit
-  = "%caml_bigstring_set16"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> nativeint# -> int -> unit
-  = "%caml_bigstring_set16_indexed_by_nativeint#"
+    external get_reference
+      : string
+      -> int
+      -> int
+      = "%caml_string_get16"
 
-external bs_set_tested_u
-  : bigstring -> nativeint# -> int -> unit
-  = "%caml_bigstring_set16u_indexed_by_nativeint#"
+    external get_safe
+      :  string
+      -> nativeint#
+      -> int
+      = "%caml_string_get16_indexed_by_nativeint#"
 
-external s_get_reference : string -> int -> int
-  = "%caml_string_get16"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> nativeint# -> int
-  = "%caml_string_get16_indexed_by_nativeint#"
+    external get_unsafe
+      :  string
+      -> nativeint#
+      -> int
+      = "%caml_string_get16u_indexed_by_nativeint#"
 
-external s_get_tested_u : string -> nativeint# -> int
-  = "%caml_string_get16u_indexed_by_nativeint#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int -> unit
-  = "%caml_string_set16"
+    external set_reference
+      : string
+      -> int
+      -> int
+      -> unit
+      = "%caml_string_set16"
 
-external s_set_tested_s
-  : string -> nativeint# -> int -> unit
-  = "%caml_string_set16_indexed_by_nativeint#"
+    external set_safe
+      :  string
+      -> nativeint#
+      -> int
+      -> unit
+      = "%caml_string_set16_indexed_by_nativeint#"
 
-external s_set_tested_u
-  : string -> nativeint# -> int -> unit
-  = "%caml_string_set16u_indexed_by_nativeint#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int
-  = "%caml_bytes_get16"
+    external set_unsafe
+      :  string
+      -> nativeint#
+      -> int
+      -> unit
+      = "%caml_string_set16u_indexed_by_nativeint#"
 
-external b_get_tested_s : bytes -> nativeint# -> int
-  = "%caml_bytes_get16_indexed_by_nativeint#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> nativeint# -> int
-  = "%caml_bytes_get16u_indexed_by_nativeint#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int -> unit
-  = "%caml_bytes_set16"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> nativeint# -> int -> unit
-  = "%caml_bytes_set16_indexed_by_nativeint#"
+    external get_reference
+      : bytes
+      -> int
+      -> int
+      = "%caml_bytes_get16"
 
-external b_set_tested_u
-  : bytes -> nativeint# -> int -> unit
-  = "%caml_bytes_set16u_indexed_by_nativeint#"
+    external get_safe
+      :  bytes
+      -> nativeint#
+      -> int
+      = "%caml_bytes_get16_indexed_by_nativeint#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> nativeint#
+      -> int
+      = "%caml_bytes_get16u_indexed_by_nativeint#"
 
-check_get_bounds (-#1n);;
-check_set_bounds (-#1n) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
-let to_boxed_result : int32 -> int32 = fun x -> x
-let of_boxed_result : int32 -> int32 = fun x -> x
-let eq : int32 -> int32 -> bool = Int32.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int
+      -> unit
+      = "%caml_bytes_set16"
 
+    external set_safe
+      :  bytes
+      -> nativeint#
+      -> int
+      -> unit
+      = "%caml_bytes_set16_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> nativeint#
+      -> int
+      -> unit
+      = "%caml_bytes_set16u_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int
+      = "%caml_bigstring_get16"
+
+    external get_safe
+      :  bigstring
+      -> nativeint#
+      -> int
+      = "%caml_bigstring_get16_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> nativeint#
+      -> int
+      = "%caml_bigstring_get16u_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int
+      -> unit
+      = "%caml_bigstring_set16"
+
+    external set_safe
+      :  bigstring
+      -> nativeint#
+      -> int
+      -> unit
+      = "%caml_bigstring_set16_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> nativeint#
+      -> int
+      -> unit
+      = "%caml_bigstring_set16u_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = nativeint
+type boxed_data = int32
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int32.zero
   | 1 ->
@@ -251,166 +398,201 @@ let rec x = function
       let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
       let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int32
-  = "%caml_bigstring_get32"
+let to_index = Nativeint.of_int
+let data_equal = Int32.equal
+let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -1n ]
 
-external bs_get_tested_s : bigstring -> nativeint# -> int32
-  = "%caml_bigstring_get32_indexed_by_nativeint#"
 
-external bs_get_tested_u : bigstring -> nativeint# -> int32
-  = "%caml_bigstring_get32u_indexed_by_nativeint#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int32 -> unit
-  = "%caml_bigstring_set32"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> nativeint# -> int32 -> unit
-  = "%caml_bigstring_set32_indexed_by_nativeint#"
+    external get_reference
+      : string
+      -> int
+      -> int32
+      = "%caml_string_get32"
 
-external bs_set_tested_u
-  : bigstring -> nativeint# -> int32 -> unit
-  = "%caml_bigstring_set32u_indexed_by_nativeint#"
+    external get_safe
+      :  string
+      -> nativeint#
+      -> int32
+      = "%caml_string_get32_indexed_by_nativeint#"
 
-external s_get_reference : string -> int -> int32
-  = "%caml_string_get32"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> nativeint# -> int32
-  = "%caml_string_get32_indexed_by_nativeint#"
+    external get_unsafe
+      :  string
+      -> nativeint#
+      -> int32
+      = "%caml_string_get32u_indexed_by_nativeint#"
 
-external s_get_tested_u : string -> nativeint# -> int32
-  = "%caml_string_get32u_indexed_by_nativeint#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int32 -> unit
-  = "%caml_string_set32"
+    external set_reference
+      : string
+      -> int
+      -> int32
+      -> unit
+      = "%caml_string_set32"
 
-external s_set_tested_s
-  : string -> nativeint# -> int32 -> unit
-  = "%caml_string_set32_indexed_by_nativeint#"
+    external set_safe
+      :  string
+      -> nativeint#
+      -> int32
+      -> unit
+      = "%caml_string_set32_indexed_by_nativeint#"
 
-external s_set_tested_u
-  : string -> nativeint# -> int32 -> unit
-  = "%caml_string_set32u_indexed_by_nativeint#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int32
-  = "%caml_bytes_get32"
+    external set_unsafe
+      :  string
+      -> nativeint#
+      -> int32
+      -> unit
+      = "%caml_string_set32u_indexed_by_nativeint#"
 
-external b_get_tested_s : bytes -> nativeint# -> int32
-  = "%caml_bytes_get32_indexed_by_nativeint#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> nativeint# -> int32
-  = "%caml_bytes_get32u_indexed_by_nativeint#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int32 -> unit
-  = "%caml_bytes_set32"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> nativeint# -> int32 -> unit
-  = "%caml_bytes_set32_indexed_by_nativeint#"
+    external get_reference
+      : bytes
+      -> int
+      -> int32
+      = "%caml_bytes_get32"
 
-external b_set_tested_u
-  : bytes -> nativeint# -> int32 -> unit
-  = "%caml_bytes_set32u_indexed_by_nativeint#"
+    external get_safe
+      :  bytes
+      -> nativeint#
+      -> int32
+      = "%caml_bytes_get32_indexed_by_nativeint#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> nativeint#
+      -> int32
+      = "%caml_bytes_get32u_indexed_by_nativeint#"
 
-check_get_bounds (-#1n);;
-check_set_bounds (-#1n) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
-let to_boxed_result : int64 -> int64 = fun x -> x
-let of_boxed_result : int64 -> int64 = fun x -> x
-let eq : int64 -> int64 -> bool = Int64.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bytes_set32"
 
+    external set_safe
+      :  bytes
+      -> nativeint#
+      -> int32
+      -> unit
+      = "%caml_bytes_set32_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> nativeint#
+      -> int32
+      -> unit
+      = "%caml_bytes_set32u_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int32
+      = "%caml_bigstring_get32"
+
+    external get_safe
+      :  bigstring
+      -> nativeint#
+      -> int32
+      = "%caml_bigstring_get32_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> nativeint#
+      -> int32
+      = "%caml_bigstring_get32u_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32"
+
+    external set_safe
+      :  bigstring
+      -> nativeint#
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> nativeint#
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32u_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = nativeint
+type boxed_data = int64
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int64.zero
   | 1 ->
@@ -428,166 +610,201 @@ let rec x = function
       let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
       let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int64
-  = "%caml_bigstring_get64"
+let to_index = Nativeint.of_int
+let data_equal = Int64.equal
+let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -1n ]
 
-external bs_get_tested_s : bigstring -> nativeint# -> int64
-  = "%caml_bigstring_get64_indexed_by_nativeint#"
 
-external bs_get_tested_u : bigstring -> nativeint# -> int64
-  = "%caml_bigstring_get64u_indexed_by_nativeint#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int64 -> unit
-  = "%caml_bigstring_set64"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> nativeint# -> int64 -> unit
-  = "%caml_bigstring_set64_indexed_by_nativeint#"
+    external get_reference
+      : string
+      -> int
+      -> int64
+      = "%caml_string_get64"
 
-external bs_set_tested_u
-  : bigstring -> nativeint# -> int64 -> unit
-  = "%caml_bigstring_set64u_indexed_by_nativeint#"
+    external get_safe
+      :  string
+      -> nativeint#
+      -> int64
+      = "%caml_string_get64_indexed_by_nativeint#"
 
-external s_get_reference : string -> int -> int64
-  = "%caml_string_get64"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> nativeint# -> int64
-  = "%caml_string_get64_indexed_by_nativeint#"
+    external get_unsafe
+      :  string
+      -> nativeint#
+      -> int64
+      = "%caml_string_get64u_indexed_by_nativeint#"
 
-external s_get_tested_u : string -> nativeint# -> int64
-  = "%caml_string_get64u_indexed_by_nativeint#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int64 -> unit
-  = "%caml_string_set64"
+    external set_reference
+      : string
+      -> int
+      -> int64
+      -> unit
+      = "%caml_string_set64"
 
-external s_set_tested_s
-  : string -> nativeint# -> int64 -> unit
-  = "%caml_string_set64_indexed_by_nativeint#"
+    external set_safe
+      :  string
+      -> nativeint#
+      -> int64
+      -> unit
+      = "%caml_string_set64_indexed_by_nativeint#"
 
-external s_set_tested_u
-  : string -> nativeint# -> int64 -> unit
-  = "%caml_string_set64u_indexed_by_nativeint#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int64
-  = "%caml_bytes_get64"
+    external set_unsafe
+      :  string
+      -> nativeint#
+      -> int64
+      -> unit
+      = "%caml_string_set64u_indexed_by_nativeint#"
 
-external b_get_tested_s : bytes -> nativeint# -> int64
-  = "%caml_bytes_get64_indexed_by_nativeint#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> nativeint# -> int64
-  = "%caml_bytes_get64u_indexed_by_nativeint#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int64 -> unit
-  = "%caml_bytes_set64"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> nativeint# -> int64 -> unit
-  = "%caml_bytes_set64_indexed_by_nativeint#"
+    external get_reference
+      : bytes
+      -> int
+      -> int64
+      = "%caml_bytes_get64"
 
-external b_set_tested_u
-  : bytes -> nativeint# -> int64 -> unit
-  = "%caml_bytes_set64u_indexed_by_nativeint#"
+    external get_safe
+      :  bytes
+      -> nativeint#
+      -> int64
+      = "%caml_bytes_get64_indexed_by_nativeint#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> nativeint#
+      -> int64
+      = "%caml_bytes_get64u_indexed_by_nativeint#"
 
-check_get_bounds (-#1n);;
-check_set_bounds (-#1n) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
-let to_boxed_result : int32# -> int32 = Stdlib_upstream_compatible.Int32_u.to_int32
-let of_boxed_result : int32 -> int32# = Stdlib_upstream_compatible.Int32_u.of_int32
-let eq : int32 -> int32 -> bool = Int32.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bytes_set64"
 
+    external set_safe
+      :  bytes
+      -> nativeint#
+      -> int64
+      -> unit
+      = "%caml_bytes_set64_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> nativeint#
+      -> int64
+      -> unit
+      = "%caml_bytes_set64u_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int64
+      = "%caml_bigstring_get64"
+
+    external get_safe
+      :  bigstring
+      -> nativeint#
+      -> int64
+      = "%caml_bigstring_get64_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> nativeint#
+      -> int64
+      = "%caml_bigstring_get64u_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64"
+
+    external set_safe
+      :  bigstring
+      -> nativeint#
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> nativeint#
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64u_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = nativeint
+type boxed_data = int32
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int32.zero
   | 1 ->
@@ -605,166 +822,201 @@ let rec x = function
       let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
       let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int32
-  = "%caml_bigstring_get32"
+let to_index = Nativeint.of_int
+let data_equal = Int32.equal
+let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
+let unbox_data = Stdlib_upstream_compatible.Int32_u.of_int32
+let box_data = Stdlib_upstream_compatible.Int32_u.to_int32
+let extra_bounds_checks = [ -1n ]
 
-external bs_get_tested_s : bigstring -> nativeint# -> int32#
-  = "%caml_bigstring_get32#_indexed_by_nativeint#"
 
-external bs_get_tested_u : bigstring -> nativeint# -> int32#
-  = "%caml_bigstring_get32u#_indexed_by_nativeint#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int32 -> unit
-  = "%caml_bigstring_set32"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> nativeint# -> int32# -> unit
-  = "%caml_bigstring_set32#_indexed_by_nativeint#"
+    external get_reference
+      : string
+      -> int
+      -> int32
+      = "%caml_string_get32"
 
-external bs_set_tested_u
-  : bigstring -> nativeint# -> int32# -> unit
-  = "%caml_bigstring_set32u#_indexed_by_nativeint#"
+    external get_safe
+      :  string
+      -> nativeint#
+      -> int32#
+      = "%caml_string_get32#_indexed_by_nativeint#"
 
-external s_get_reference : string -> int -> int32
-  = "%caml_string_get32"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> nativeint# -> int32#
-  = "%caml_string_get32#_indexed_by_nativeint#"
+    external get_unsafe
+      :  string
+      -> nativeint#
+      -> int32#
+      = "%caml_string_get32u#_indexed_by_nativeint#"
 
-external s_get_tested_u : string -> nativeint# -> int32#
-  = "%caml_string_get32u#_indexed_by_nativeint#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int32 -> unit
-  = "%caml_string_set32"
+    external set_reference
+      : string
+      -> int
+      -> int32
+      -> unit
+      = "%caml_string_set32"
 
-external s_set_tested_s
-  : string -> nativeint# -> int32# -> unit
-  = "%caml_string_set32#_indexed_by_nativeint#"
+    external set_safe
+      :  string
+      -> nativeint#
+      -> int32#
+      -> unit
+      = "%caml_string_set32#_indexed_by_nativeint#"
 
-external s_set_tested_u
-  : string -> nativeint# -> int32# -> unit
-  = "%caml_string_set32u#_indexed_by_nativeint#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int32
-  = "%caml_bytes_get32"
+    external set_unsafe
+      :  string
+      -> nativeint#
+      -> int32#
+      -> unit
+      = "%caml_string_set32u#_indexed_by_nativeint#"
 
-external b_get_tested_s : bytes -> nativeint# -> int32#
-  = "%caml_bytes_get32#_indexed_by_nativeint#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> nativeint# -> int32#
-  = "%caml_bytes_get32u#_indexed_by_nativeint#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int32 -> unit
-  = "%caml_bytes_set32"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> nativeint# -> int32# -> unit
-  = "%caml_bytes_set32#_indexed_by_nativeint#"
+    external get_reference
+      : bytes
+      -> int
+      -> int32
+      = "%caml_bytes_get32"
 
-external b_set_tested_u
-  : bytes -> nativeint# -> int32# -> unit
-  = "%caml_bytes_set32u#_indexed_by_nativeint#"
+    external get_safe
+      :  bytes
+      -> nativeint#
+      -> int32#
+      = "%caml_bytes_get32#_indexed_by_nativeint#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> nativeint#
+      -> int32#
+      = "%caml_bytes_get32u#_indexed_by_nativeint#"
 
-check_get_bounds (-#1n);;
-check_set_bounds (-#1n) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
-let to_boxed_result : int64# -> int64 = Stdlib_upstream_compatible.Int64_u.to_int64
-let of_boxed_result : int64 -> int64# = Stdlib_upstream_compatible.Int64_u.of_int64
-let eq : int64 -> int64 -> bool = Int64.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bytes_set32"
 
+    external set_safe
+      :  bytes
+      -> nativeint#
+      -> int32#
+      -> unit
+      = "%caml_bytes_set32#_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> nativeint#
+      -> int32#
+      -> unit
+      = "%caml_bytes_set32u#_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int32
+      = "%caml_bigstring_get32"
+
+    external get_safe
+      :  bigstring
+      -> nativeint#
+      -> int32#
+      = "%caml_bigstring_get32#_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> nativeint#
+      -> int32#
+      = "%caml_bigstring_get32u#_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32"
+
+    external set_safe
+      :  bigstring
+      -> nativeint#
+      -> int32#
+      -> unit
+      = "%caml_bigstring_set32#_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> nativeint#
+      -> int32#
+      -> unit
+      = "%caml_bigstring_set32u#_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = nativeint
+type boxed_data = int64
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int64.zero
   | 1 ->
@@ -782,486 +1034,589 @@ let rec x = function
       let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
       let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
       x
-
-external bs_get_reference : bigstring -> int -> int64
-  = "%caml_bigstring_get64"
-
-external bs_get_tested_s : bigstring -> nativeint# -> int64#
-  = "%caml_bigstring_get64#_indexed_by_nativeint#"
-
-external bs_get_tested_u : bigstring -> nativeint# -> int64#
-  = "%caml_bigstring_get64u#_indexed_by_nativeint#"
-
-external bs_set_reference
-  : bigstring -> int -> int64 -> unit
-  = "%caml_bigstring_set64"
-
-external bs_set_tested_s
-  : bigstring -> nativeint# -> int64# -> unit
-  = "%caml_bigstring_set64#_indexed_by_nativeint#"
-
-external bs_set_tested_u
-  : bigstring -> nativeint# -> int64# -> unit
-  = "%caml_bigstring_set64u#_indexed_by_nativeint#"
-
-external s_get_reference : string -> int -> int64
-  = "%caml_string_get64"
-
-external s_get_tested_s : string -> nativeint# -> int64#
-  = "%caml_string_get64#_indexed_by_nativeint#"
-
-external s_get_tested_u : string -> nativeint# -> int64#
-  = "%caml_string_get64u#_indexed_by_nativeint#"
-
-external s_set_reference
-  : string -> int -> int64 -> unit
-  = "%caml_string_set64"
-
-external s_set_tested_s
-  : string -> nativeint# -> int64# -> unit
-  = "%caml_string_set64#_indexed_by_nativeint#"
-
-external s_set_tested_u
-  : string -> nativeint# -> int64# -> unit
-  = "%caml_string_set64u#_indexed_by_nativeint#"
-
-external b_get_reference : bytes -> int -> int64
-  = "%caml_bytes_get64"
-
-external b_get_tested_s : bytes -> nativeint# -> int64#
-  = "%caml_bytes_get64#_indexed_by_nativeint#"
-
-external b_get_tested_u : bytes -> nativeint# -> int64#
-  = "%caml_bytes_get64u#_indexed_by_nativeint#"
-
-external b_set_reference
-  : bytes -> int -> int64 -> unit
-  = "%caml_bytes_set64"
-
-external b_set_tested_s
-  : bytes -> nativeint# -> int64# -> unit
-  = "%caml_bytes_set64#_indexed_by_nativeint#"
-
-external b_set_tested_u
-  : bytes -> nativeint# -> int64# -> unit
-  = "%caml_bytes_set64u#_indexed_by_nativeint#"
-
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
-
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
-
-check_get_bounds (-#1n);;
-check_set_bounds (-#1n) (x 1);;
-
-let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
-let to_boxed_result : float32 -> float32 = fun x -> x
-let of_boxed_result : float32 -> float32 = fun x -> x
-let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
-let x _ = Stdlib_beta.Float32.of_float 5.0
-
-external bs_get_reference : bigstring -> int -> float32
-  = "%caml_bigstring_getf32"
-
-external bs_get_tested_s : bigstring -> nativeint# -> float32
-  = "%caml_bigstring_getf32_indexed_by_nativeint#"
-
-external bs_get_tested_u : bigstring -> nativeint# -> float32
-  = "%caml_bigstring_getf32u_indexed_by_nativeint#"
-
-external bs_set_reference
-  : bigstring -> int -> float32 -> unit
-  = "%caml_bigstring_setf32"
-
-external bs_set_tested_s
-  : bigstring -> nativeint# -> float32 -> unit
-  = "%caml_bigstring_setf32_indexed_by_nativeint#"
-
-external bs_set_tested_u
-  : bigstring -> nativeint# -> float32 -> unit
-  = "%caml_bigstring_setf32u_indexed_by_nativeint#"
-
-external s_get_reference : string -> int -> float32
-  = "%caml_string_getf32"
-
-external s_get_tested_s : string -> nativeint# -> float32
-  = "%caml_string_getf32_indexed_by_nativeint#"
-
-external s_get_tested_u : string -> nativeint# -> float32
-  = "%caml_string_getf32u_indexed_by_nativeint#"
-
-external s_set_reference
-  : string -> int -> float32 -> unit
-  = "%caml_string_setf32"
-
-external s_set_tested_s
-  : string -> nativeint# -> float32 -> unit
-  = "%caml_string_setf32_indexed_by_nativeint#"
-
-external s_set_tested_u
-  : string -> nativeint# -> float32 -> unit
-  = "%caml_string_setf32u_indexed_by_nativeint#"
-
-external b_get_reference : bytes -> int -> float32
-  = "%caml_bytes_getf32"
-
-external b_get_tested_s : bytes -> nativeint# -> float32
-  = "%caml_bytes_getf32_indexed_by_nativeint#"
-
-external b_get_tested_u : bytes -> nativeint# -> float32
-  = "%caml_bytes_getf32u_indexed_by_nativeint#"
-
-external b_set_reference
-  : bytes -> int -> float32 -> unit
-  = "%caml_bytes_setf32"
-
-external b_set_tested_s
-  : bytes -> nativeint# -> float32 -> unit
-  = "%caml_bytes_setf32_indexed_by_nativeint#"
-
-external b_set_tested_u
-  : bytes -> nativeint# -> float32 -> unit
-  = "%caml_bytes_setf32u_indexed_by_nativeint#"
-
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
-
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
-
-check_get_bounds (-#1n);;
-check_set_bounds (-#1n) (x 1);;
-
-let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
-let to_boxed_result : float32# -> float32 = Stdlib_beta.Float32_u.to_float32
-let of_boxed_result : float32 -> float32# = Stdlib_beta.Float32_u.of_float32
-let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
-let x _ = Stdlib_beta.Float32.of_float 5.0
-
-external bs_get_reference : bigstring -> int -> float32
-  = "%caml_bigstring_getf32"
-
-external bs_get_tested_s : bigstring -> nativeint# -> float32#
-  = "%caml_bigstring_getf32#_indexed_by_nativeint#"
-
-external bs_get_tested_u : bigstring -> nativeint# -> float32#
-  = "%caml_bigstring_getf32u#_indexed_by_nativeint#"
-
-external bs_set_reference
-  : bigstring -> int -> float32 -> unit
-  = "%caml_bigstring_setf32"
-
-external bs_set_tested_s
-  : bigstring -> nativeint# -> float32# -> unit
-  = "%caml_bigstring_setf32#_indexed_by_nativeint#"
-
-external bs_set_tested_u
-  : bigstring -> nativeint# -> float32# -> unit
-  = "%caml_bigstring_setf32u#_indexed_by_nativeint#"
-
-external s_get_reference : string -> int -> float32
-  = "%caml_string_getf32"
-
-external s_get_tested_s : string -> nativeint# -> float32#
-  = "%caml_string_getf32#_indexed_by_nativeint#"
-
-external s_get_tested_u : string -> nativeint# -> float32#
-  = "%caml_string_getf32u#_indexed_by_nativeint#"
-
-external s_set_reference
-  : string -> int -> float32 -> unit
-  = "%caml_string_setf32"
-
-external s_set_tested_s
-  : string -> nativeint# -> float32# -> unit
-  = "%caml_string_setf32#_indexed_by_nativeint#"
-
-external s_set_tested_u
-  : string -> nativeint# -> float32# -> unit
-  = "%caml_string_setf32u#_indexed_by_nativeint#"
-
-external b_get_reference : bytes -> int -> float32
-  = "%caml_bytes_getf32"
-
-external b_get_tested_s : bytes -> nativeint# -> float32#
-  = "%caml_bytes_getf32#_indexed_by_nativeint#"
-
-external b_get_tested_u : bytes -> nativeint# -> float32#
-  = "%caml_bytes_getf32u#_indexed_by_nativeint#"
-
-external b_set_reference
-  : bytes -> int -> float32 -> unit
-  = "%caml_bytes_setf32"
-
-external b_set_tested_s
-  : bytes -> nativeint# -> float32# -> unit
-  = "%caml_bytes_setf32#_indexed_by_nativeint#"
-
-external b_set_tested_u
-  : bytes -> nativeint# -> float32# -> unit
-  = "%caml_bytes_setf32u#_indexed_by_nativeint#"
-
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
-
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
-
-check_get_bounds (-#1n);;
-check_set_bounds (-#1n) (x 1);;
-
-let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
-let to_boxed_result : int -> int = fun x -> x
-let of_boxed_result : int -> int = fun x -> x
-let eq : int -> int -> bool = Int.equal
-
+in x
+
+let to_index = Nativeint.of_int
+let data_equal = Int64.equal
+let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
+let unbox_data = Stdlib_upstream_compatible.Int64_u.of_int64
+let box_data = Stdlib_upstream_compatible.Int64_u.to_int64
+let extra_bounds_checks = [ -1n ]
+
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
+
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : string
+      -> int
+      -> int64
+      = "%caml_string_get64"
+
+    external get_safe
+      :  string
+      -> nativeint#
+      -> int64#
+      = "%caml_string_get64#_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  string
+      -> nativeint#
+      -> int64#
+      = "%caml_string_get64u#_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : string
+      -> int
+      -> int64
+      -> unit
+      = "%caml_string_set64"
+
+    external set_safe
+      :  string
+      -> nativeint#
+      -> int64#
+      -> unit
+      = "%caml_string_set64#_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  string
+      -> nativeint#
+      -> int64#
+      -> unit
+      = "%caml_string_set64u#_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
+
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bytes
+      -> int
+      -> int64
+      = "%caml_bytes_get64"
+
+    external get_safe
+      :  bytes
+      -> nativeint#
+      -> int64#
+      = "%caml_bytes_get64#_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bytes
+      -> nativeint#
+      -> int64#
+      = "%caml_bytes_get64u#_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bytes
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bytes_set64"
+
+    external set_safe
+      :  bytes
+      -> nativeint#
+      -> int64#
+      -> unit
+      = "%caml_bytes_set64#_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> nativeint#
+      -> int64#
+      -> unit
+      = "%caml_bytes_set64u#_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int64
+      = "%caml_bigstring_get64"
+
+    external get_safe
+      :  bigstring
+      -> nativeint#
+      -> int64#
+      = "%caml_bigstring_get64#_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> nativeint#
+      -> int64#
+      = "%caml_bigstring_get64u#_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64"
+
+    external set_safe
+      :  bigstring
+      -> nativeint#
+      -> int64#
+      -> unit
+      = "%caml_bigstring_set64#_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> nativeint#
+      -> int64#
+      -> unit
+      = "%caml_bigstring_set64u#_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = nativeint
+type boxed_data = float32
+
+let generate_data = fun _ -> Stdlib_beta.Float32.of_float 5.0
+
+let to_index = Nativeint.of_int
+let data_equal = Stdlib_beta.Float32.equal
+let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -1n ]
+
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
+
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : string
+      -> int
+      -> float32
+      = "%caml_string_getf32"
+
+    external get_safe
+      :  string
+      -> nativeint#
+      -> float32
+      = "%caml_string_getf32_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  string
+      -> nativeint#
+      -> float32
+      = "%caml_string_getf32u_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : string
+      -> int
+      -> float32
+      -> unit
+      = "%caml_string_setf32"
+
+    external set_safe
+      :  string
+      -> nativeint#
+      -> float32
+      -> unit
+      = "%caml_string_setf32_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  string
+      -> nativeint#
+      -> float32
+      -> unit
+      = "%caml_string_setf32u_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
+
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bytes
+      -> int
+      -> float32
+      = "%caml_bytes_getf32"
+
+    external get_safe
+      :  bytes
+      -> nativeint#
+      -> float32
+      = "%caml_bytes_getf32_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bytes
+      -> nativeint#
+      -> float32
+      = "%caml_bytes_getf32u_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bytes
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32"
+
+    external set_safe
+      :  bytes
+      -> nativeint#
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> nativeint#
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32u_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> float32
+      = "%caml_bigstring_getf32"
+
+    external get_safe
+      :  bigstring
+      -> nativeint#
+      -> float32
+      = "%caml_bigstring_getf32_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> nativeint#
+      -> float32
+      = "%caml_bigstring_getf32u_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32"
+
+    external set_safe
+      :  bigstring
+      -> nativeint#
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> nativeint#
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32u_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = nativeint
+type boxed_data = float32
+
+let generate_data = fun _ -> Stdlib_beta.Float32.of_float 5.0
+
+let to_index = Nativeint.of_int
+let data_equal = Stdlib_beta.Float32.equal
+let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
+let unbox_data = Stdlib_beta.Float32_u.of_float32
+let box_data = Stdlib_beta.Float32_u.to_float32
+let extra_bounds_checks = [ -1n ]
+
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
+
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : string
+      -> int
+      -> float32
+      = "%caml_string_getf32"
+
+    external get_safe
+      :  string
+      -> nativeint#
+      -> float32#
+      = "%caml_string_getf32#_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  string
+      -> nativeint#
+      -> float32#
+      = "%caml_string_getf32u#_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : string
+      -> int
+      -> float32
+      -> unit
+      = "%caml_string_setf32"
+
+    external set_safe
+      :  string
+      -> nativeint#
+      -> float32#
+      -> unit
+      = "%caml_string_setf32#_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  string
+      -> nativeint#
+      -> float32#
+      -> unit
+      = "%caml_string_setf32u#_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
+
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bytes
+      -> int
+      -> float32
+      = "%caml_bytes_getf32"
+
+    external get_safe
+      :  bytes
+      -> nativeint#
+      -> float32#
+      = "%caml_bytes_getf32#_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bytes
+      -> nativeint#
+      -> float32#
+      = "%caml_bytes_getf32u#_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bytes
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32"
+
+    external set_safe
+      :  bytes
+      -> nativeint#
+      -> float32#
+      -> unit
+      = "%caml_bytes_setf32#_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> nativeint#
+      -> float32#
+      -> unit
+      = "%caml_bytes_setf32u#_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> float32
+      = "%caml_bigstring_getf32"
+
+    external get_safe
+      :  bigstring
+      -> nativeint#
+      -> float32#
+      = "%caml_bigstring_getf32#_indexed_by_nativeint#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> nativeint#
+      -> float32#
+      = "%caml_bigstring_getf32u#_indexed_by_nativeint#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32"
+
+    external set_safe
+      :  bigstring
+      -> nativeint#
+      -> float32#
+      -> unit
+      = "%caml_bigstring_setf32#_indexed_by_nativeint#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> nativeint#
+      -> float32#
+      -> unit
+      = "%caml_bigstring_setf32u#_indexed_by_nativeint#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int32
+type boxed_data = int
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int.zero
   | 1 ->
@@ -1279,172 +1634,201 @@ let rec x = function
       let x = Int.(logxor x (shift_left one (i2 mod 16))) in
       let x = Int.(logxor x (shift_left one (i3 mod 16))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int
-  = "%caml_bigstring_get16"
+let to_index = Int32.of_int
+let data_equal = Int.equal
+let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
 
-external bs_get_tested_s : bigstring -> int32# -> int
-  = "%caml_bigstring_get16_indexed_by_int32#"
 
-external bs_get_tested_u : bigstring -> int32# -> int
-  = "%caml_bigstring_get16u_indexed_by_int32#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int -> unit
-  = "%caml_bigstring_set16"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> int32# -> int -> unit
-  = "%caml_bigstring_set16_indexed_by_int32#"
+    external get_reference
+      : string
+      -> int
+      -> int
+      = "%caml_string_get16"
 
-external bs_set_tested_u
-  : bigstring -> int32# -> int -> unit
-  = "%caml_bigstring_set16u_indexed_by_int32#"
+    external get_safe
+      :  string
+      -> int32#
+      -> int
+      = "%caml_string_get16_indexed_by_int32#"
 
-external s_get_reference : string -> int -> int
-  = "%caml_string_get16"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> int32# -> int
-  = "%caml_string_get16_indexed_by_int32#"
+    external get_unsafe
+      :  string
+      -> int32#
+      -> int
+      = "%caml_string_get16u_indexed_by_int32#"
 
-external s_get_tested_u : string -> int32# -> int
-  = "%caml_string_get16u_indexed_by_int32#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int -> unit
-  = "%caml_string_set16"
+    external set_reference
+      : string
+      -> int
+      -> int
+      -> unit
+      = "%caml_string_set16"
 
-external s_set_tested_s
-  : string -> int32# -> int -> unit
-  = "%caml_string_set16_indexed_by_int32#"
+    external set_safe
+      :  string
+      -> int32#
+      -> int
+      -> unit
+      = "%caml_string_set16_indexed_by_int32#"
 
-external s_set_tested_u
-  : string -> int32# -> int -> unit
-  = "%caml_string_set16u_indexed_by_int32#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int
-  = "%caml_bytes_get16"
+    external set_unsafe
+      :  string
+      -> int32#
+      -> int
+      -> unit
+      = "%caml_string_set16u_indexed_by_int32#"
 
-external b_get_tested_s : bytes -> int32# -> int
-  = "%caml_bytes_get16_indexed_by_int32#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> int32# -> int
-  = "%caml_bytes_get16u_indexed_by_int32#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int -> unit
-  = "%caml_bytes_set16"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> int32# -> int -> unit
-  = "%caml_bytes_set16_indexed_by_int32#"
+    external get_reference
+      : bytes
+      -> int
+      -> int
+      = "%caml_bytes_get16"
 
-external b_set_tested_u
-  : bytes -> int32# -> int -> unit
-  = "%caml_bytes_set16u_indexed_by_int32#"
+    external get_safe
+      :  bytes
+      -> int32#
+      -> int
+      = "%caml_bytes_get16_indexed_by_int32#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> int32#
+      -> int
+      = "%caml_bytes_get16u_indexed_by_int32#"
 
-check_get_bounds (-#2147483648l);;
-check_set_bounds (-#2147483648l) (x 1);;
-check_get_bounds (-#2147483647l);;
-check_set_bounds (-#2147483647l) (x 1);;
-check_get_bounds (#2147483647l);;
-check_set_bounds (#2147483647l) (x 1);;
-check_get_bounds (-#1l);;
-check_set_bounds (-#1l) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
-let to_boxed_result : int32 -> int32 = fun x -> x
-let of_boxed_result : int32 -> int32 = fun x -> x
-let eq : int32 -> int32 -> bool = Int32.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int
+      -> unit
+      = "%caml_bytes_set16"
 
+    external set_safe
+      :  bytes
+      -> int32#
+      -> int
+      -> unit
+      = "%caml_bytes_set16_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int32#
+      -> int
+      -> unit
+      = "%caml_bytes_set16u_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int
+      = "%caml_bigstring_get16"
+
+    external get_safe
+      :  bigstring
+      -> int32#
+      -> int
+      = "%caml_bigstring_get16_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int32#
+      -> int
+      = "%caml_bigstring_get16u_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int
+      -> unit
+      = "%caml_bigstring_set16"
+
+    external set_safe
+      :  bigstring
+      -> int32#
+      -> int
+      -> unit
+      = "%caml_bigstring_set16_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int32#
+      -> int
+      -> unit
+      = "%caml_bigstring_set16u_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int32
+type boxed_data = int32
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int32.zero
   | 1 ->
@@ -1462,172 +1846,201 @@ let rec x = function
       let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
       let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int32
-  = "%caml_bigstring_get32"
+let to_index = Int32.of_int
+let data_equal = Int32.equal
+let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
 
-external bs_get_tested_s : bigstring -> int32# -> int32
-  = "%caml_bigstring_get32_indexed_by_int32#"
 
-external bs_get_tested_u : bigstring -> int32# -> int32
-  = "%caml_bigstring_get32u_indexed_by_int32#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int32 -> unit
-  = "%caml_bigstring_set32"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> int32# -> int32 -> unit
-  = "%caml_bigstring_set32_indexed_by_int32#"
+    external get_reference
+      : string
+      -> int
+      -> int32
+      = "%caml_string_get32"
 
-external bs_set_tested_u
-  : bigstring -> int32# -> int32 -> unit
-  = "%caml_bigstring_set32u_indexed_by_int32#"
+    external get_safe
+      :  string
+      -> int32#
+      -> int32
+      = "%caml_string_get32_indexed_by_int32#"
 
-external s_get_reference : string -> int -> int32
-  = "%caml_string_get32"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> int32# -> int32
-  = "%caml_string_get32_indexed_by_int32#"
+    external get_unsafe
+      :  string
+      -> int32#
+      -> int32
+      = "%caml_string_get32u_indexed_by_int32#"
 
-external s_get_tested_u : string -> int32# -> int32
-  = "%caml_string_get32u_indexed_by_int32#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int32 -> unit
-  = "%caml_string_set32"
+    external set_reference
+      : string
+      -> int
+      -> int32
+      -> unit
+      = "%caml_string_set32"
 
-external s_set_tested_s
-  : string -> int32# -> int32 -> unit
-  = "%caml_string_set32_indexed_by_int32#"
+    external set_safe
+      :  string
+      -> int32#
+      -> int32
+      -> unit
+      = "%caml_string_set32_indexed_by_int32#"
 
-external s_set_tested_u
-  : string -> int32# -> int32 -> unit
-  = "%caml_string_set32u_indexed_by_int32#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int32
-  = "%caml_bytes_get32"
+    external set_unsafe
+      :  string
+      -> int32#
+      -> int32
+      -> unit
+      = "%caml_string_set32u_indexed_by_int32#"
 
-external b_get_tested_s : bytes -> int32# -> int32
-  = "%caml_bytes_get32_indexed_by_int32#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> int32# -> int32
-  = "%caml_bytes_get32u_indexed_by_int32#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int32 -> unit
-  = "%caml_bytes_set32"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> int32# -> int32 -> unit
-  = "%caml_bytes_set32_indexed_by_int32#"
+    external get_reference
+      : bytes
+      -> int
+      -> int32
+      = "%caml_bytes_get32"
 
-external b_set_tested_u
-  : bytes -> int32# -> int32 -> unit
-  = "%caml_bytes_set32u_indexed_by_int32#"
+    external get_safe
+      :  bytes
+      -> int32#
+      -> int32
+      = "%caml_bytes_get32_indexed_by_int32#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> int32#
+      -> int32
+      = "%caml_bytes_get32u_indexed_by_int32#"
 
-check_get_bounds (-#2147483648l);;
-check_set_bounds (-#2147483648l) (x 1);;
-check_get_bounds (-#2147483647l);;
-check_set_bounds (-#2147483647l) (x 1);;
-check_get_bounds (#2147483647l);;
-check_set_bounds (#2147483647l) (x 1);;
-check_get_bounds (-#1l);;
-check_set_bounds (-#1l) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
-let to_boxed_result : int64 -> int64 = fun x -> x
-let of_boxed_result : int64 -> int64 = fun x -> x
-let eq : int64 -> int64 -> bool = Int64.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bytes_set32"
 
+    external set_safe
+      :  bytes
+      -> int32#
+      -> int32
+      -> unit
+      = "%caml_bytes_set32_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int32#
+      -> int32
+      -> unit
+      = "%caml_bytes_set32u_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int32
+      = "%caml_bigstring_get32"
+
+    external get_safe
+      :  bigstring
+      -> int32#
+      -> int32
+      = "%caml_bigstring_get32_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int32#
+      -> int32
+      = "%caml_bigstring_get32u_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32"
+
+    external set_safe
+      :  bigstring
+      -> int32#
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int32#
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32u_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int32
+type boxed_data = int64
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int64.zero
   | 1 ->
@@ -1645,172 +2058,201 @@ let rec x = function
       let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
       let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int64
-  = "%caml_bigstring_get64"
+let to_index = Int32.of_int
+let data_equal = Int64.equal
+let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
 
-external bs_get_tested_s : bigstring -> int32# -> int64
-  = "%caml_bigstring_get64_indexed_by_int32#"
 
-external bs_get_tested_u : bigstring -> int32# -> int64
-  = "%caml_bigstring_get64u_indexed_by_int32#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int64 -> unit
-  = "%caml_bigstring_set64"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> int32# -> int64 -> unit
-  = "%caml_bigstring_set64_indexed_by_int32#"
+    external get_reference
+      : string
+      -> int
+      -> int64
+      = "%caml_string_get64"
 
-external bs_set_tested_u
-  : bigstring -> int32# -> int64 -> unit
-  = "%caml_bigstring_set64u_indexed_by_int32#"
+    external get_safe
+      :  string
+      -> int32#
+      -> int64
+      = "%caml_string_get64_indexed_by_int32#"
 
-external s_get_reference : string -> int -> int64
-  = "%caml_string_get64"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> int32# -> int64
-  = "%caml_string_get64_indexed_by_int32#"
+    external get_unsafe
+      :  string
+      -> int32#
+      -> int64
+      = "%caml_string_get64u_indexed_by_int32#"
 
-external s_get_tested_u : string -> int32# -> int64
-  = "%caml_string_get64u_indexed_by_int32#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int64 -> unit
-  = "%caml_string_set64"
+    external set_reference
+      : string
+      -> int
+      -> int64
+      -> unit
+      = "%caml_string_set64"
 
-external s_set_tested_s
-  : string -> int32# -> int64 -> unit
-  = "%caml_string_set64_indexed_by_int32#"
+    external set_safe
+      :  string
+      -> int32#
+      -> int64
+      -> unit
+      = "%caml_string_set64_indexed_by_int32#"
 
-external s_set_tested_u
-  : string -> int32# -> int64 -> unit
-  = "%caml_string_set64u_indexed_by_int32#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int64
-  = "%caml_bytes_get64"
+    external set_unsafe
+      :  string
+      -> int32#
+      -> int64
+      -> unit
+      = "%caml_string_set64u_indexed_by_int32#"
 
-external b_get_tested_s : bytes -> int32# -> int64
-  = "%caml_bytes_get64_indexed_by_int32#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> int32# -> int64
-  = "%caml_bytes_get64u_indexed_by_int32#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int64 -> unit
-  = "%caml_bytes_set64"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> int32# -> int64 -> unit
-  = "%caml_bytes_set64_indexed_by_int32#"
+    external get_reference
+      : bytes
+      -> int
+      -> int64
+      = "%caml_bytes_get64"
 
-external b_set_tested_u
-  : bytes -> int32# -> int64 -> unit
-  = "%caml_bytes_set64u_indexed_by_int32#"
+    external get_safe
+      :  bytes
+      -> int32#
+      -> int64
+      = "%caml_bytes_get64_indexed_by_int32#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> int32#
+      -> int64
+      = "%caml_bytes_get64u_indexed_by_int32#"
 
-check_get_bounds (-#2147483648l);;
-check_set_bounds (-#2147483648l) (x 1);;
-check_get_bounds (-#2147483647l);;
-check_set_bounds (-#2147483647l) (x 1);;
-check_get_bounds (#2147483647l);;
-check_set_bounds (#2147483647l) (x 1);;
-check_get_bounds (-#1l);;
-check_set_bounds (-#1l) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
-let to_boxed_result : int32# -> int32 = Stdlib_upstream_compatible.Int32_u.to_int32
-let of_boxed_result : int32 -> int32# = Stdlib_upstream_compatible.Int32_u.of_int32
-let eq : int32 -> int32 -> bool = Int32.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bytes_set64"
 
+    external set_safe
+      :  bytes
+      -> int32#
+      -> int64
+      -> unit
+      = "%caml_bytes_set64_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int32#
+      -> int64
+      -> unit
+      = "%caml_bytes_set64u_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int64
+      = "%caml_bigstring_get64"
+
+    external get_safe
+      :  bigstring
+      -> int32#
+      -> int64
+      = "%caml_bigstring_get64_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int32#
+      -> int64
+      = "%caml_bigstring_get64u_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64"
+
+    external set_safe
+      :  bigstring
+      -> int32#
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int32#
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64u_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int32
+type boxed_data = int32
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int32.zero
   | 1 ->
@@ -1828,172 +2270,201 @@ let rec x = function
       let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
       let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int32
-  = "%caml_bigstring_get32"
+let to_index = Int32.of_int
+let data_equal = Int32.equal
+let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
+let unbox_data = Stdlib_upstream_compatible.Int32_u.of_int32
+let box_data = Stdlib_upstream_compatible.Int32_u.to_int32
+let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
 
-external bs_get_tested_s : bigstring -> int32# -> int32#
-  = "%caml_bigstring_get32#_indexed_by_int32#"
 
-external bs_get_tested_u : bigstring -> int32# -> int32#
-  = "%caml_bigstring_get32u#_indexed_by_int32#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int32 -> unit
-  = "%caml_bigstring_set32"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> int32# -> int32# -> unit
-  = "%caml_bigstring_set32#_indexed_by_int32#"
+    external get_reference
+      : string
+      -> int
+      -> int32
+      = "%caml_string_get32"
 
-external bs_set_tested_u
-  : bigstring -> int32# -> int32# -> unit
-  = "%caml_bigstring_set32u#_indexed_by_int32#"
+    external get_safe
+      :  string
+      -> int32#
+      -> int32#
+      = "%caml_string_get32#_indexed_by_int32#"
 
-external s_get_reference : string -> int -> int32
-  = "%caml_string_get32"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> int32# -> int32#
-  = "%caml_string_get32#_indexed_by_int32#"
+    external get_unsafe
+      :  string
+      -> int32#
+      -> int32#
+      = "%caml_string_get32u#_indexed_by_int32#"
 
-external s_get_tested_u : string -> int32# -> int32#
-  = "%caml_string_get32u#_indexed_by_int32#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int32 -> unit
-  = "%caml_string_set32"
+    external set_reference
+      : string
+      -> int
+      -> int32
+      -> unit
+      = "%caml_string_set32"
 
-external s_set_tested_s
-  : string -> int32# -> int32# -> unit
-  = "%caml_string_set32#_indexed_by_int32#"
+    external set_safe
+      :  string
+      -> int32#
+      -> int32#
+      -> unit
+      = "%caml_string_set32#_indexed_by_int32#"
 
-external s_set_tested_u
-  : string -> int32# -> int32# -> unit
-  = "%caml_string_set32u#_indexed_by_int32#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int32
-  = "%caml_bytes_get32"
+    external set_unsafe
+      :  string
+      -> int32#
+      -> int32#
+      -> unit
+      = "%caml_string_set32u#_indexed_by_int32#"
 
-external b_get_tested_s : bytes -> int32# -> int32#
-  = "%caml_bytes_get32#_indexed_by_int32#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> int32# -> int32#
-  = "%caml_bytes_get32u#_indexed_by_int32#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int32 -> unit
-  = "%caml_bytes_set32"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> int32# -> int32# -> unit
-  = "%caml_bytes_set32#_indexed_by_int32#"
+    external get_reference
+      : bytes
+      -> int
+      -> int32
+      = "%caml_bytes_get32"
 
-external b_set_tested_u
-  : bytes -> int32# -> int32# -> unit
-  = "%caml_bytes_set32u#_indexed_by_int32#"
+    external get_safe
+      :  bytes
+      -> int32#
+      -> int32#
+      = "%caml_bytes_get32#_indexed_by_int32#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> int32#
+      -> int32#
+      = "%caml_bytes_get32u#_indexed_by_int32#"
 
-check_get_bounds (-#2147483648l);;
-check_set_bounds (-#2147483648l) (x 1);;
-check_get_bounds (-#2147483647l);;
-check_set_bounds (-#2147483647l) (x 1);;
-check_get_bounds (#2147483647l);;
-check_set_bounds (#2147483647l) (x 1);;
-check_get_bounds (-#1l);;
-check_set_bounds (-#1l) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
-let to_boxed_result : int64# -> int64 = Stdlib_upstream_compatible.Int64_u.to_int64
-let of_boxed_result : int64 -> int64# = Stdlib_upstream_compatible.Int64_u.of_int64
-let eq : int64 -> int64 -> bool = Int64.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bytes_set32"
 
+    external set_safe
+      :  bytes
+      -> int32#
+      -> int32#
+      -> unit
+      = "%caml_bytes_set32#_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int32#
+      -> int32#
+      -> unit
+      = "%caml_bytes_set32u#_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int32
+      = "%caml_bigstring_get32"
+
+    external get_safe
+      :  bigstring
+      -> int32#
+      -> int32#
+      = "%caml_bigstring_get32#_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int32#
+      -> int32#
+      = "%caml_bigstring_get32u#_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32"
+
+    external set_safe
+      :  bigstring
+      -> int32#
+      -> int32#
+      -> unit
+      = "%caml_bigstring_set32#_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int32#
+      -> int32#
+      -> unit
+      = "%caml_bigstring_set32u#_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int32
+type boxed_data = int64
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int64.zero
   | 1 ->
@@ -2011,504 +2482,589 @@ let rec x = function
       let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
       let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
       x
-
-external bs_get_reference : bigstring -> int -> int64
-  = "%caml_bigstring_get64"
-
-external bs_get_tested_s : bigstring -> int32# -> int64#
-  = "%caml_bigstring_get64#_indexed_by_int32#"
-
-external bs_get_tested_u : bigstring -> int32# -> int64#
-  = "%caml_bigstring_get64u#_indexed_by_int32#"
-
-external bs_set_reference
-  : bigstring -> int -> int64 -> unit
-  = "%caml_bigstring_set64"
-
-external bs_set_tested_s
-  : bigstring -> int32# -> int64# -> unit
-  = "%caml_bigstring_set64#_indexed_by_int32#"
-
-external bs_set_tested_u
-  : bigstring -> int32# -> int64# -> unit
-  = "%caml_bigstring_set64u#_indexed_by_int32#"
-
-external s_get_reference : string -> int -> int64
-  = "%caml_string_get64"
-
-external s_get_tested_s : string -> int32# -> int64#
-  = "%caml_string_get64#_indexed_by_int32#"
-
-external s_get_tested_u : string -> int32# -> int64#
-  = "%caml_string_get64u#_indexed_by_int32#"
-
-external s_set_reference
-  : string -> int -> int64 -> unit
-  = "%caml_string_set64"
-
-external s_set_tested_s
-  : string -> int32# -> int64# -> unit
-  = "%caml_string_set64#_indexed_by_int32#"
-
-external s_set_tested_u
-  : string -> int32# -> int64# -> unit
-  = "%caml_string_set64u#_indexed_by_int32#"
-
-external b_get_reference : bytes -> int -> int64
-  = "%caml_bytes_get64"
-
-external b_get_tested_s : bytes -> int32# -> int64#
-  = "%caml_bytes_get64#_indexed_by_int32#"
-
-external b_get_tested_u : bytes -> int32# -> int64#
-  = "%caml_bytes_get64u#_indexed_by_int32#"
-
-external b_set_reference
-  : bytes -> int -> int64 -> unit
-  = "%caml_bytes_set64"
-
-external b_set_tested_s
-  : bytes -> int32# -> int64# -> unit
-  = "%caml_bytes_set64#_indexed_by_int32#"
-
-external b_set_tested_u
-  : bytes -> int32# -> int64# -> unit
-  = "%caml_bytes_set64u#_indexed_by_int32#"
-
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
-
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
-
-check_get_bounds (-#2147483648l);;
-check_set_bounds (-#2147483648l) (x 1);;
-check_get_bounds (-#2147483647l);;
-check_set_bounds (-#2147483647l) (x 1);;
-check_get_bounds (#2147483647l);;
-check_set_bounds (#2147483647l) (x 1);;
-check_get_bounds (-#1l);;
-check_set_bounds (-#1l) (x 1);;
-
-let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
-let to_boxed_result : float32 -> float32 = fun x -> x
-let of_boxed_result : float32 -> float32 = fun x -> x
-let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
-let x _ = Stdlib_beta.Float32.of_float 5.0
-
-external bs_get_reference : bigstring -> int -> float32
-  = "%caml_bigstring_getf32"
-
-external bs_get_tested_s : bigstring -> int32# -> float32
-  = "%caml_bigstring_getf32_indexed_by_int32#"
-
-external bs_get_tested_u : bigstring -> int32# -> float32
-  = "%caml_bigstring_getf32u_indexed_by_int32#"
-
-external bs_set_reference
-  : bigstring -> int -> float32 -> unit
-  = "%caml_bigstring_setf32"
-
-external bs_set_tested_s
-  : bigstring -> int32# -> float32 -> unit
-  = "%caml_bigstring_setf32_indexed_by_int32#"
-
-external bs_set_tested_u
-  : bigstring -> int32# -> float32 -> unit
-  = "%caml_bigstring_setf32u_indexed_by_int32#"
-
-external s_get_reference : string -> int -> float32
-  = "%caml_string_getf32"
-
-external s_get_tested_s : string -> int32# -> float32
-  = "%caml_string_getf32_indexed_by_int32#"
-
-external s_get_tested_u : string -> int32# -> float32
-  = "%caml_string_getf32u_indexed_by_int32#"
-
-external s_set_reference
-  : string -> int -> float32 -> unit
-  = "%caml_string_setf32"
-
-external s_set_tested_s
-  : string -> int32# -> float32 -> unit
-  = "%caml_string_setf32_indexed_by_int32#"
-
-external s_set_tested_u
-  : string -> int32# -> float32 -> unit
-  = "%caml_string_setf32u_indexed_by_int32#"
-
-external b_get_reference : bytes -> int -> float32
-  = "%caml_bytes_getf32"
-
-external b_get_tested_s : bytes -> int32# -> float32
-  = "%caml_bytes_getf32_indexed_by_int32#"
-
-external b_get_tested_u : bytes -> int32# -> float32
-  = "%caml_bytes_getf32u_indexed_by_int32#"
-
-external b_set_reference
-  : bytes -> int -> float32 -> unit
-  = "%caml_bytes_setf32"
-
-external b_set_tested_s
-  : bytes -> int32# -> float32 -> unit
-  = "%caml_bytes_setf32_indexed_by_int32#"
-
-external b_set_tested_u
-  : bytes -> int32# -> float32 -> unit
-  = "%caml_bytes_setf32u_indexed_by_int32#"
-
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
-
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
-
-check_get_bounds (-#2147483648l);;
-check_set_bounds (-#2147483648l) (x 1);;
-check_get_bounds (-#2147483647l);;
-check_set_bounds (-#2147483647l) (x 1);;
-check_get_bounds (#2147483647l);;
-check_set_bounds (#2147483647l) (x 1);;
-check_get_bounds (-#1l);;
-check_set_bounds (-#1l) (x 1);;
-
-let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
-let to_boxed_result : float32# -> float32 = Stdlib_beta.Float32_u.to_float32
-let of_boxed_result : float32 -> float32# = Stdlib_beta.Float32_u.of_float32
-let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
-let x _ = Stdlib_beta.Float32.of_float 5.0
-
-external bs_get_reference : bigstring -> int -> float32
-  = "%caml_bigstring_getf32"
-
-external bs_get_tested_s : bigstring -> int32# -> float32#
-  = "%caml_bigstring_getf32#_indexed_by_int32#"
-
-external bs_get_tested_u : bigstring -> int32# -> float32#
-  = "%caml_bigstring_getf32u#_indexed_by_int32#"
-
-external bs_set_reference
-  : bigstring -> int -> float32 -> unit
-  = "%caml_bigstring_setf32"
-
-external bs_set_tested_s
-  : bigstring -> int32# -> float32# -> unit
-  = "%caml_bigstring_setf32#_indexed_by_int32#"
-
-external bs_set_tested_u
-  : bigstring -> int32# -> float32# -> unit
-  = "%caml_bigstring_setf32u#_indexed_by_int32#"
-
-external s_get_reference : string -> int -> float32
-  = "%caml_string_getf32"
-
-external s_get_tested_s : string -> int32# -> float32#
-  = "%caml_string_getf32#_indexed_by_int32#"
-
-external s_get_tested_u : string -> int32# -> float32#
-  = "%caml_string_getf32u#_indexed_by_int32#"
-
-external s_set_reference
-  : string -> int -> float32 -> unit
-  = "%caml_string_setf32"
-
-external s_set_tested_s
-  : string -> int32# -> float32# -> unit
-  = "%caml_string_setf32#_indexed_by_int32#"
-
-external s_set_tested_u
-  : string -> int32# -> float32# -> unit
-  = "%caml_string_setf32u#_indexed_by_int32#"
-
-external b_get_reference : bytes -> int -> float32
-  = "%caml_bytes_getf32"
-
-external b_get_tested_s : bytes -> int32# -> float32#
-  = "%caml_bytes_getf32#_indexed_by_int32#"
-
-external b_get_tested_u : bytes -> int32# -> float32#
-  = "%caml_bytes_getf32u#_indexed_by_int32#"
-
-external b_set_reference
-  : bytes -> int -> float32 -> unit
-  = "%caml_bytes_setf32"
-
-external b_set_tested_s
-  : bytes -> int32# -> float32# -> unit
-  = "%caml_bytes_setf32#_indexed_by_int32#"
-
-external b_set_tested_u
-  : bytes -> int32# -> float32# -> unit
-  = "%caml_bytes_setf32u#_indexed_by_int32#"
-
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
-
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
-
-check_get_bounds (-#2147483648l);;
-check_set_bounds (-#2147483648l) (x 1);;
-check_get_bounds (-#2147483647l);;
-check_set_bounds (-#2147483647l) (x 1);;
-check_get_bounds (#2147483647l);;
-check_set_bounds (#2147483647l) (x 1);;
-check_get_bounds (-#1l);;
-check_set_bounds (-#1l) (x 1);;
-
-let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
-let to_boxed_result : int -> int = fun x -> x
-let of_boxed_result : int -> int = fun x -> x
-let eq : int -> int -> bool = Int.equal
-
+in x
+
+let to_index = Int32.of_int
+let data_equal = Int64.equal
+let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
+let unbox_data = Stdlib_upstream_compatible.Int64_u.of_int64
+let box_data = Stdlib_upstream_compatible.Int64_u.to_int64
+let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
+
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
+
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : string
+      -> int
+      -> int64
+      = "%caml_string_get64"
+
+    external get_safe
+      :  string
+      -> int32#
+      -> int64#
+      = "%caml_string_get64#_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  string
+      -> int32#
+      -> int64#
+      = "%caml_string_get64u#_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : string
+      -> int
+      -> int64
+      -> unit
+      = "%caml_string_set64"
+
+    external set_safe
+      :  string
+      -> int32#
+      -> int64#
+      -> unit
+      = "%caml_string_set64#_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  string
+      -> int32#
+      -> int64#
+      -> unit
+      = "%caml_string_set64u#_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
+
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bytes
+      -> int
+      -> int64
+      = "%caml_bytes_get64"
+
+    external get_safe
+      :  bytes
+      -> int32#
+      -> int64#
+      = "%caml_bytes_get64#_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bytes
+      -> int32#
+      -> int64#
+      = "%caml_bytes_get64u#_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bytes
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bytes_set64"
+
+    external set_safe
+      :  bytes
+      -> int32#
+      -> int64#
+      -> unit
+      = "%caml_bytes_set64#_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int32#
+      -> int64#
+      -> unit
+      = "%caml_bytes_set64u#_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int64
+      = "%caml_bigstring_get64"
+
+    external get_safe
+      :  bigstring
+      -> int32#
+      -> int64#
+      = "%caml_bigstring_get64#_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int32#
+      -> int64#
+      = "%caml_bigstring_get64u#_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64"
+
+    external set_safe
+      :  bigstring
+      -> int32#
+      -> int64#
+      -> unit
+      = "%caml_bigstring_set64#_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int32#
+      -> int64#
+      -> unit
+      = "%caml_bigstring_set64u#_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int32
+type boxed_data = float32
+
+let generate_data = fun _ -> Stdlib_beta.Float32.of_float 5.0
+
+let to_index = Int32.of_int
+let data_equal = Stdlib_beta.Float32.equal
+let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
+
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
+
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : string
+      -> int
+      -> float32
+      = "%caml_string_getf32"
+
+    external get_safe
+      :  string
+      -> int32#
+      -> float32
+      = "%caml_string_getf32_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  string
+      -> int32#
+      -> float32
+      = "%caml_string_getf32u_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : string
+      -> int
+      -> float32
+      -> unit
+      = "%caml_string_setf32"
+
+    external set_safe
+      :  string
+      -> int32#
+      -> float32
+      -> unit
+      = "%caml_string_setf32_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  string
+      -> int32#
+      -> float32
+      -> unit
+      = "%caml_string_setf32u_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
+
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bytes
+      -> int
+      -> float32
+      = "%caml_bytes_getf32"
+
+    external get_safe
+      :  bytes
+      -> int32#
+      -> float32
+      = "%caml_bytes_getf32_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bytes
+      -> int32#
+      -> float32
+      = "%caml_bytes_getf32u_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bytes
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32"
+
+    external set_safe
+      :  bytes
+      -> int32#
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int32#
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32u_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> float32
+      = "%caml_bigstring_getf32"
+
+    external get_safe
+      :  bigstring
+      -> int32#
+      -> float32
+      = "%caml_bigstring_getf32_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int32#
+      -> float32
+      = "%caml_bigstring_getf32u_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32"
+
+    external set_safe
+      :  bigstring
+      -> int32#
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int32#
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32u_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int32
+type boxed_data = float32
+
+let generate_data = fun _ -> Stdlib_beta.Float32.of_float 5.0
+
+let to_index = Int32.of_int
+let data_equal = Stdlib_beta.Float32.equal
+let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
+let unbox_data = Stdlib_beta.Float32_u.of_float32
+let box_data = Stdlib_beta.Float32_u.to_float32
+let extra_bounds_checks = [ -2147483648l; -2147483647l; 2147483647l; -1l ]
+
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
+
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : string
+      -> int
+      -> float32
+      = "%caml_string_getf32"
+
+    external get_safe
+      :  string
+      -> int32#
+      -> float32#
+      = "%caml_string_getf32#_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  string
+      -> int32#
+      -> float32#
+      = "%caml_string_getf32u#_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : string
+      -> int
+      -> float32
+      -> unit
+      = "%caml_string_setf32"
+
+    external set_safe
+      :  string
+      -> int32#
+      -> float32#
+      -> unit
+      = "%caml_string_setf32#_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  string
+      -> int32#
+      -> float32#
+      -> unit
+      = "%caml_string_setf32u#_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
+
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bytes
+      -> int
+      -> float32
+      = "%caml_bytes_getf32"
+
+    external get_safe
+      :  bytes
+      -> int32#
+      -> float32#
+      = "%caml_bytes_getf32#_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bytes
+      -> int32#
+      -> float32#
+      = "%caml_bytes_getf32u#_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bytes
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32"
+
+    external set_safe
+      :  bytes
+      -> int32#
+      -> float32#
+      -> unit
+      = "%caml_bytes_setf32#_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int32#
+      -> float32#
+      -> unit
+      = "%caml_bytes_setf32u#_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> float32
+      = "%caml_bigstring_getf32"
+
+    external get_safe
+      :  bigstring
+      -> int32#
+      -> float32#
+      = "%caml_bigstring_getf32#_indexed_by_int32#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int32#
+      -> float32#
+      = "%caml_bigstring_getf32u#_indexed_by_int32#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32"
+
+    external set_safe
+      :  bigstring
+      -> int32#
+      -> float32#
+      -> unit
+      = "%caml_bigstring_setf32#_indexed_by_int32#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int32#
+      -> float32#
+      -> unit
+      = "%caml_bigstring_setf32u#_indexed_by_int32#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int64
+type boxed_data = int
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int.zero
   | 1 ->
@@ -2526,172 +3082,201 @@ let rec x = function
       let x = Int.(logxor x (shift_left one (i2 mod 16))) in
       let x = Int.(logxor x (shift_left one (i3 mod 16))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int
-  = "%caml_bigstring_get16"
+let to_index = Int64.of_int
+let data_equal = Int.equal
+let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
 
-external bs_get_tested_s : bigstring -> int64# -> int
-  = "%caml_bigstring_get16_indexed_by_int64#"
 
-external bs_get_tested_u : bigstring -> int64# -> int
-  = "%caml_bigstring_get16u_indexed_by_int64#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int -> unit
-  = "%caml_bigstring_set16"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> int64# -> int -> unit
-  = "%caml_bigstring_set16_indexed_by_int64#"
+    external get_reference
+      : string
+      -> int
+      -> int
+      = "%caml_string_get16"
 
-external bs_set_tested_u
-  : bigstring -> int64# -> int -> unit
-  = "%caml_bigstring_set16u_indexed_by_int64#"
+    external get_safe
+      :  string
+      -> int64#
+      -> int
+      = "%caml_string_get16_indexed_by_int64#"
 
-external s_get_reference : string -> int -> int
-  = "%caml_string_get16"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> int64# -> int
-  = "%caml_string_get16_indexed_by_int64#"
+    external get_unsafe
+      :  string
+      -> int64#
+      -> int
+      = "%caml_string_get16u_indexed_by_int64#"
 
-external s_get_tested_u : string -> int64# -> int
-  = "%caml_string_get16u_indexed_by_int64#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int -> unit
-  = "%caml_string_set16"
+    external set_reference
+      : string
+      -> int
+      -> int
+      -> unit
+      = "%caml_string_set16"
 
-external s_set_tested_s
-  : string -> int64# -> int -> unit
-  = "%caml_string_set16_indexed_by_int64#"
+    external set_safe
+      :  string
+      -> int64#
+      -> int
+      -> unit
+      = "%caml_string_set16_indexed_by_int64#"
 
-external s_set_tested_u
-  : string -> int64# -> int -> unit
-  = "%caml_string_set16u_indexed_by_int64#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int
-  = "%caml_bytes_get16"
+    external set_unsafe
+      :  string
+      -> int64#
+      -> int
+      -> unit
+      = "%caml_string_set16u_indexed_by_int64#"
 
-external b_get_tested_s : bytes -> int64# -> int
-  = "%caml_bytes_get16_indexed_by_int64#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> int64# -> int
-  = "%caml_bytes_get16u_indexed_by_int64#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int -> unit
-  = "%caml_bytes_set16"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> int64# -> int -> unit
-  = "%caml_bytes_set16_indexed_by_int64#"
+    external get_reference
+      : bytes
+      -> int
+      -> int
+      = "%caml_bytes_get16"
 
-external b_set_tested_u
-  : bytes -> int64# -> int -> unit
-  = "%caml_bytes_set16u_indexed_by_int64#"
+    external get_safe
+      :  bytes
+      -> int64#
+      -> int
+      = "%caml_bytes_get16_indexed_by_int64#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> int64#
+      -> int
+      = "%caml_bytes_get16u_indexed_by_int64#"
 
-check_get_bounds (-#9223372036854775808L);;
-check_set_bounds (-#9223372036854775808L) (x 1);;
-check_get_bounds (-#9223372036854775807L);;
-check_set_bounds (-#9223372036854775807L) (x 1);;
-check_get_bounds (#9223372036854775807L);;
-check_set_bounds (#9223372036854775807L) (x 1);;
-check_get_bounds (-#1L);;
-check_set_bounds (-#1L) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
-let to_boxed_result : int32 -> int32 = fun x -> x
-let of_boxed_result : int32 -> int32 = fun x -> x
-let eq : int32 -> int32 -> bool = Int32.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int
+      -> unit
+      = "%caml_bytes_set16"
 
+    external set_safe
+      :  bytes
+      -> int64#
+      -> int
+      -> unit
+      = "%caml_bytes_set16_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int64#
+      -> int
+      -> unit
+      = "%caml_bytes_set16u_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int
+      = "%caml_bigstring_get16"
+
+    external get_safe
+      :  bigstring
+      -> int64#
+      -> int
+      = "%caml_bigstring_get16_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int64#
+      -> int
+      = "%caml_bigstring_get16u_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int
+      -> unit
+      = "%caml_bigstring_set16"
+
+    external set_safe
+      :  bigstring
+      -> int64#
+      -> int
+      -> unit
+      = "%caml_bigstring_set16_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int64#
+      -> int
+      -> unit
+      = "%caml_bigstring_set16u_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int64
+type boxed_data = int32
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int32.zero
   | 1 ->
@@ -2709,172 +3294,201 @@ let rec x = function
       let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
       let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int32
-  = "%caml_bigstring_get32"
+let to_index = Int64.of_int
+let data_equal = Int32.equal
+let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
 
-external bs_get_tested_s : bigstring -> int64# -> int32
-  = "%caml_bigstring_get32_indexed_by_int64#"
 
-external bs_get_tested_u : bigstring -> int64# -> int32
-  = "%caml_bigstring_get32u_indexed_by_int64#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int32 -> unit
-  = "%caml_bigstring_set32"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> int64# -> int32 -> unit
-  = "%caml_bigstring_set32_indexed_by_int64#"
+    external get_reference
+      : string
+      -> int
+      -> int32
+      = "%caml_string_get32"
 
-external bs_set_tested_u
-  : bigstring -> int64# -> int32 -> unit
-  = "%caml_bigstring_set32u_indexed_by_int64#"
+    external get_safe
+      :  string
+      -> int64#
+      -> int32
+      = "%caml_string_get32_indexed_by_int64#"
 
-external s_get_reference : string -> int -> int32
-  = "%caml_string_get32"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> int64# -> int32
-  = "%caml_string_get32_indexed_by_int64#"
+    external get_unsafe
+      :  string
+      -> int64#
+      -> int32
+      = "%caml_string_get32u_indexed_by_int64#"
 
-external s_get_tested_u : string -> int64# -> int32
-  = "%caml_string_get32u_indexed_by_int64#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int32 -> unit
-  = "%caml_string_set32"
+    external set_reference
+      : string
+      -> int
+      -> int32
+      -> unit
+      = "%caml_string_set32"
 
-external s_set_tested_s
-  : string -> int64# -> int32 -> unit
-  = "%caml_string_set32_indexed_by_int64#"
+    external set_safe
+      :  string
+      -> int64#
+      -> int32
+      -> unit
+      = "%caml_string_set32_indexed_by_int64#"
 
-external s_set_tested_u
-  : string -> int64# -> int32 -> unit
-  = "%caml_string_set32u_indexed_by_int64#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int32
-  = "%caml_bytes_get32"
+    external set_unsafe
+      :  string
+      -> int64#
+      -> int32
+      -> unit
+      = "%caml_string_set32u_indexed_by_int64#"
 
-external b_get_tested_s : bytes -> int64# -> int32
-  = "%caml_bytes_get32_indexed_by_int64#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> int64# -> int32
-  = "%caml_bytes_get32u_indexed_by_int64#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int32 -> unit
-  = "%caml_bytes_set32"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> int64# -> int32 -> unit
-  = "%caml_bytes_set32_indexed_by_int64#"
+    external get_reference
+      : bytes
+      -> int
+      -> int32
+      = "%caml_bytes_get32"
 
-external b_set_tested_u
-  : bytes -> int64# -> int32 -> unit
-  = "%caml_bytes_set32u_indexed_by_int64#"
+    external get_safe
+      :  bytes
+      -> int64#
+      -> int32
+      = "%caml_bytes_get32_indexed_by_int64#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> int64#
+      -> int32
+      = "%caml_bytes_get32u_indexed_by_int64#"
 
-check_get_bounds (-#9223372036854775808L);;
-check_set_bounds (-#9223372036854775808L) (x 1);;
-check_get_bounds (-#9223372036854775807L);;
-check_set_bounds (-#9223372036854775807L) (x 1);;
-check_get_bounds (#9223372036854775807L);;
-check_set_bounds (#9223372036854775807L) (x 1);;
-check_get_bounds (-#1L);;
-check_set_bounds (-#1L) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
-let to_boxed_result : int64 -> int64 = fun x -> x
-let of_boxed_result : int64 -> int64 = fun x -> x
-let eq : int64 -> int64 -> bool = Int64.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bytes_set32"
 
+    external set_safe
+      :  bytes
+      -> int64#
+      -> int32
+      -> unit
+      = "%caml_bytes_set32_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int64#
+      -> int32
+      -> unit
+      = "%caml_bytes_set32u_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int32
+      = "%caml_bigstring_get32"
+
+    external get_safe
+      :  bigstring
+      -> int64#
+      -> int32
+      = "%caml_bigstring_get32_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int64#
+      -> int32
+      = "%caml_bigstring_get32u_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32"
+
+    external set_safe
+      :  bigstring
+      -> int64#
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int64#
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32u_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int64
+type boxed_data = int64
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int64.zero
   | 1 ->
@@ -2892,172 +3506,201 @@ let rec x = function
       let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
       let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int64
-  = "%caml_bigstring_get64"
+let to_index = Int64.of_int
+let data_equal = Int64.equal
+let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
 
-external bs_get_tested_s : bigstring -> int64# -> int64
-  = "%caml_bigstring_get64_indexed_by_int64#"
 
-external bs_get_tested_u : bigstring -> int64# -> int64
-  = "%caml_bigstring_get64u_indexed_by_int64#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int64 -> unit
-  = "%caml_bigstring_set64"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> int64# -> int64 -> unit
-  = "%caml_bigstring_set64_indexed_by_int64#"
+    external get_reference
+      : string
+      -> int
+      -> int64
+      = "%caml_string_get64"
 
-external bs_set_tested_u
-  : bigstring -> int64# -> int64 -> unit
-  = "%caml_bigstring_set64u_indexed_by_int64#"
+    external get_safe
+      :  string
+      -> int64#
+      -> int64
+      = "%caml_string_get64_indexed_by_int64#"
 
-external s_get_reference : string -> int -> int64
-  = "%caml_string_get64"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> int64# -> int64
-  = "%caml_string_get64_indexed_by_int64#"
+    external get_unsafe
+      :  string
+      -> int64#
+      -> int64
+      = "%caml_string_get64u_indexed_by_int64#"
 
-external s_get_tested_u : string -> int64# -> int64
-  = "%caml_string_get64u_indexed_by_int64#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int64 -> unit
-  = "%caml_string_set64"
+    external set_reference
+      : string
+      -> int
+      -> int64
+      -> unit
+      = "%caml_string_set64"
 
-external s_set_tested_s
-  : string -> int64# -> int64 -> unit
-  = "%caml_string_set64_indexed_by_int64#"
+    external set_safe
+      :  string
+      -> int64#
+      -> int64
+      -> unit
+      = "%caml_string_set64_indexed_by_int64#"
 
-external s_set_tested_u
-  : string -> int64# -> int64 -> unit
-  = "%caml_string_set64u_indexed_by_int64#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int64
-  = "%caml_bytes_get64"
+    external set_unsafe
+      :  string
+      -> int64#
+      -> int64
+      -> unit
+      = "%caml_string_set64u_indexed_by_int64#"
 
-external b_get_tested_s : bytes -> int64# -> int64
-  = "%caml_bytes_get64_indexed_by_int64#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> int64# -> int64
-  = "%caml_bytes_get64u_indexed_by_int64#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int64 -> unit
-  = "%caml_bytes_set64"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> int64# -> int64 -> unit
-  = "%caml_bytes_set64_indexed_by_int64#"
+    external get_reference
+      : bytes
+      -> int
+      -> int64
+      = "%caml_bytes_get64"
 
-external b_set_tested_u
-  : bytes -> int64# -> int64 -> unit
-  = "%caml_bytes_set64u_indexed_by_int64#"
+    external get_safe
+      :  bytes
+      -> int64#
+      -> int64
+      = "%caml_bytes_get64_indexed_by_int64#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> int64#
+      -> int64
+      = "%caml_bytes_get64u_indexed_by_int64#"
 
-check_get_bounds (-#9223372036854775808L);;
-check_set_bounds (-#9223372036854775808L) (x 1);;
-check_get_bounds (-#9223372036854775807L);;
-check_set_bounds (-#9223372036854775807L) (x 1);;
-check_get_bounds (#9223372036854775807L);;
-check_set_bounds (#9223372036854775807L) (x 1);;
-check_get_bounds (-#1L);;
-check_set_bounds (-#1L) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
-let to_boxed_result : int32# -> int32 = Stdlib_upstream_compatible.Int32_u.to_int32
-let of_boxed_result : int32 -> int32# = Stdlib_upstream_compatible.Int32_u.of_int32
-let eq : int32 -> int32 -> bool = Int32.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bytes_set64"
 
+    external set_safe
+      :  bytes
+      -> int64#
+      -> int64
+      -> unit
+      = "%caml_bytes_set64_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int64#
+      -> int64
+      -> unit
+      = "%caml_bytes_set64u_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int64
+      = "%caml_bigstring_get64"
+
+    external get_safe
+      :  bigstring
+      -> int64#
+      -> int64
+      = "%caml_bigstring_get64_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int64#
+      -> int64
+      = "%caml_bigstring_get64u_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64"
+
+    external set_safe
+      :  bigstring
+      -> int64#
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int64#
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64u_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int64
+type boxed_data = int32
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int32.zero
   | 1 ->
@@ -3075,172 +3718,201 @@ let rec x = function
       let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
       let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
       x
+in x
 
-external bs_get_reference : bigstring -> int -> int32
-  = "%caml_bigstring_get32"
+let to_index = Int64.of_int
+let data_equal = Int32.equal
+let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
+let unbox_data = Stdlib_upstream_compatible.Int32_u.of_int32
+let box_data = Stdlib_upstream_compatible.Int32_u.to_int32
+let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
 
-external bs_get_tested_s : bigstring -> int64# -> int32#
-  = "%caml_bigstring_get32#_indexed_by_int64#"
 
-external bs_get_tested_u : bigstring -> int64# -> int32#
-  = "%caml_bigstring_get32u#_indexed_by_int64#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
 
-external bs_set_reference
-  : bigstring -> int -> int32 -> unit
-  = "%caml_bigstring_set32"
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external bs_set_tested_s
-  : bigstring -> int64# -> int32# -> unit
-  = "%caml_bigstring_set32#_indexed_by_int64#"
+    external get_reference
+      : string
+      -> int
+      -> int32
+      = "%caml_string_get32"
 
-external bs_set_tested_u
-  : bigstring -> int64# -> int32# -> unit
-  = "%caml_bigstring_set32u#_indexed_by_int64#"
+    external get_safe
+      :  string
+      -> int64#
+      -> int32#
+      = "%caml_string_get32#_indexed_by_int64#"
 
-external s_get_reference : string -> int -> int32
-  = "%caml_string_get32"
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-external s_get_tested_s : string -> int64# -> int32#
-  = "%caml_string_get32#_indexed_by_int64#"
+    external get_unsafe
+      :  string
+      -> int64#
+      -> int32#
+      = "%caml_string_get32u#_indexed_by_int64#"
 
-external s_get_tested_u : string -> int64# -> int32#
-  = "%caml_string_get32u#_indexed_by_int64#"
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-external s_set_reference
-  : string -> int -> int32 -> unit
-  = "%caml_string_set32"
+    external set_reference
+      : string
+      -> int
+      -> int32
+      -> unit
+      = "%caml_string_set32"
 
-external s_set_tested_s
-  : string -> int64# -> int32# -> unit
-  = "%caml_string_set32#_indexed_by_int64#"
+    external set_safe
+      :  string
+      -> int64#
+      -> int32#
+      -> unit
+      = "%caml_string_set32#_indexed_by_int64#"
 
-external s_set_tested_u
-  : string -> int64# -> int32# -> unit
-  = "%caml_string_set32u#_indexed_by_int64#"
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
 
-external b_get_reference : bytes -> int -> int32
-  = "%caml_bytes_get32"
+    external set_unsafe
+      :  string
+      -> int64#
+      -> int32#
+      -> unit
+      = "%caml_string_set32u#_indexed_by_int64#"
 
-external b_get_tested_s : bytes -> int64# -> int32#
-  = "%caml_bytes_get32#_indexed_by_int64#"
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
 
-external b_get_tested_u : bytes -> int64# -> int32#
-  = "%caml_bytes_get32u#_indexed_by_int64#"
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
 
-external b_set_reference
-  : bytes -> int -> int32 -> unit
-  = "%caml_bytes_set32"
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
 
-external b_set_tested_s
-  : bytes -> int64# -> int32# -> unit
-  = "%caml_bytes_set32#_indexed_by_int64#"
+    external get_reference
+      : bytes
+      -> int
+      -> int32
+      = "%caml_bytes_get32"
 
-external b_set_tested_u
-  : bytes -> int64# -> int32# -> unit
-  = "%caml_bytes_set32u#_indexed_by_int64#"
+    external get_safe
+      :  bytes
+      -> int64#
+      -> int32#
+      = "%caml_bytes_get32#_indexed_by_int64#"
 
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
+    let get_safe b i = box_data (get_safe b (unbox_index i))
 
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
+    external get_unsafe
+      :  bytes
+      -> int64#
+      -> int32#
+      = "%caml_bytes_get32u#_indexed_by_int64#"
 
-check_get_bounds (-#9223372036854775808L);;
-check_set_bounds (-#9223372036854775808L) (x 1);;
-check_get_bounds (-#9223372036854775807L);;
-check_set_bounds (-#9223372036854775807L) (x 1);;
-check_get_bounds (#9223372036854775807L);;
-check_set_bounds (#9223372036854775807L) (x 1);;
-check_get_bounds (-#1L);;
-check_set_bounds (-#1L) (x 1);;
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
 
-let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
-let to_boxed_result : int64# -> int64 = Stdlib_upstream_compatible.Int64_u.to_int64
-let of_boxed_result : int64 -> int64# = Stdlib_upstream_compatible.Int64_u.of_int64
-let eq : int64 -> int64 -> bool = Int64.equal
+    external set_reference
+      : bytes
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bytes_set32"
 
+    external set_safe
+      :  bytes
+      -> int64#
+      -> int32#
+      -> unit
+      = "%caml_bytes_set32#_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int64#
+      -> int32#
+      -> unit
+      = "%caml_bytes_set32u#_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int32
+      = "%caml_bigstring_get32"
+
+    external get_safe
+      :  bigstring
+      -> int64#
+      -> int32#
+      = "%caml_bigstring_get32#_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int64#
+      -> int32#
+      = "%caml_bigstring_get32u#_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int32
+      -> unit
+      = "%caml_bigstring_set32"
+
+    external set_safe
+      :  bigstring
+      -> int64#
+      -> int32#
+      -> unit
+      = "%caml_bigstring_set32#_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int64#
+      -> int32#
+      -> unit
+      = "%caml_bigstring_set32u#_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int64
+type boxed_data = int64
+
+let generate_data = 
 let rec x = function
   | i when i <= 0 -> Int64.zero
   | 1 ->
@@ -3258,495 +3930,579 @@ let rec x = function
       let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
       let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
       x
-
-external bs_get_reference : bigstring -> int -> int64
-  = "%caml_bigstring_get64"
-
-external bs_get_tested_s : bigstring -> int64# -> int64#
-  = "%caml_bigstring_get64#_indexed_by_int64#"
-
-external bs_get_tested_u : bigstring -> int64# -> int64#
-  = "%caml_bigstring_get64u#_indexed_by_int64#"
-
-external bs_set_reference
-  : bigstring -> int -> int64 -> unit
-  = "%caml_bigstring_set64"
-
-external bs_set_tested_s
-  : bigstring -> int64# -> int64# -> unit
-  = "%caml_bigstring_set64#_indexed_by_int64#"
-
-external bs_set_tested_u
-  : bigstring -> int64# -> int64# -> unit
-  = "%caml_bigstring_set64u#_indexed_by_int64#"
-
-external s_get_reference : string -> int -> int64
-  = "%caml_string_get64"
-
-external s_get_tested_s : string -> int64# -> int64#
-  = "%caml_string_get64#_indexed_by_int64#"
-
-external s_get_tested_u : string -> int64# -> int64#
-  = "%caml_string_get64u#_indexed_by_int64#"
-
-external s_set_reference
-  : string -> int -> int64 -> unit
-  = "%caml_string_set64"
-
-external s_set_tested_s
-  : string -> int64# -> int64# -> unit
-  = "%caml_string_set64#_indexed_by_int64#"
-
-external s_set_tested_u
-  : string -> int64# -> int64# -> unit
-  = "%caml_string_set64u#_indexed_by_int64#"
-
-external b_get_reference : bytes -> int -> int64
-  = "%caml_bytes_get64"
-
-external b_get_tested_s : bytes -> int64# -> int64#
-  = "%caml_bytes_get64#_indexed_by_int64#"
-
-external b_get_tested_u : bytes -> int64# -> int64#
-  = "%caml_bytes_get64u#_indexed_by_int64#"
-
-external b_set_reference
-  : bytes -> int -> int64 -> unit
-  = "%caml_bytes_set64"
-
-external b_set_tested_s
-  : bytes -> int64# -> int64# -> unit
-  = "%caml_bytes_set64#_indexed_by_int64#"
-
-external b_set_tested_u
-  : bytes -> int64# -> int64# -> unit
-  = "%caml_bytes_set64u#_indexed_by_int64#"
-
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
-
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
-
-check_get_bounds (-#9223372036854775808L);;
-check_set_bounds (-#9223372036854775808L) (x 1);;
-check_get_bounds (-#9223372036854775807L);;
-check_set_bounds (-#9223372036854775807L) (x 1);;
-check_get_bounds (#9223372036854775807L);;
-check_set_bounds (#9223372036854775807L) (x 1);;
-check_get_bounds (-#1L);;
-check_set_bounds (-#1L) (x 1);;
-
-let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
-let to_boxed_result : float32 -> float32 = fun x -> x
-let of_boxed_result : float32 -> float32 = fun x -> x
-let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
-let x _ = Stdlib_beta.Float32.of_float 5.0
-
-external bs_get_reference : bigstring -> int -> float32
-  = "%caml_bigstring_getf32"
-
-external bs_get_tested_s : bigstring -> int64# -> float32
-  = "%caml_bigstring_getf32_indexed_by_int64#"
-
-external bs_get_tested_u : bigstring -> int64# -> float32
-  = "%caml_bigstring_getf32u_indexed_by_int64#"
-
-external bs_set_reference
-  : bigstring -> int -> float32 -> unit
-  = "%caml_bigstring_setf32"
-
-external bs_set_tested_s
-  : bigstring -> int64# -> float32 -> unit
-  = "%caml_bigstring_setf32_indexed_by_int64#"
-
-external bs_set_tested_u
-  : bigstring -> int64# -> float32 -> unit
-  = "%caml_bigstring_setf32u_indexed_by_int64#"
-
-external s_get_reference : string -> int -> float32
-  = "%caml_string_getf32"
-
-external s_get_tested_s : string -> int64# -> float32
-  = "%caml_string_getf32_indexed_by_int64#"
-
-external s_get_tested_u : string -> int64# -> float32
-  = "%caml_string_getf32u_indexed_by_int64#"
-
-external s_set_reference
-  : string -> int -> float32 -> unit
-  = "%caml_string_setf32"
-
-external s_set_tested_s
-  : string -> int64# -> float32 -> unit
-  = "%caml_string_setf32_indexed_by_int64#"
-
-external s_set_tested_u
-  : string -> int64# -> float32 -> unit
-  = "%caml_string_setf32u_indexed_by_int64#"
-
-external b_get_reference : bytes -> int -> float32
-  = "%caml_bytes_getf32"
-
-external b_get_tested_s : bytes -> int64# -> float32
-  = "%caml_bytes_getf32_indexed_by_int64#"
-
-external b_get_tested_u : bytes -> int64# -> float32
-  = "%caml_bytes_getf32u_indexed_by_int64#"
-
-external b_set_reference
-  : bytes -> int -> float32 -> unit
-  = "%caml_bytes_setf32"
-
-external b_set_tested_s
-  : bytes -> int64# -> float32 -> unit
-  = "%caml_bytes_setf32_indexed_by_int64#"
-
-external b_set_tested_u
-  : bytes -> int64# -> float32 -> unit
-  = "%caml_bytes_setf32u_indexed_by_int64#"
-
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
-
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
-
-check_get_bounds (-#9223372036854775808L);;
-check_set_bounds (-#9223372036854775808L) (x 1);;
-check_get_bounds (-#9223372036854775807L);;
-check_set_bounds (-#9223372036854775807L) (x 1);;
-check_get_bounds (#9223372036854775807L);;
-check_set_bounds (#9223372036854775807L) (x 1);;
-check_get_bounds (-#1L);;
-check_set_bounds (-#1L) (x 1);;
-
-let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
-let to_boxed_result : float32# -> float32 = Stdlib_beta.Float32_u.to_float32
-let of_boxed_result : float32 -> float32# = Stdlib_beta.Float32_u.of_float32
-let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
-let x _ = Stdlib_beta.Float32.of_float 5.0
-
-external bs_get_reference : bigstring -> int -> float32
-  = "%caml_bigstring_getf32"
-
-external bs_get_tested_s : bigstring -> int64# -> float32#
-  = "%caml_bigstring_getf32#_indexed_by_int64#"
-
-external bs_get_tested_u : bigstring -> int64# -> float32#
-  = "%caml_bigstring_getf32u#_indexed_by_int64#"
-
-external bs_set_reference
-  : bigstring -> int -> float32 -> unit
-  = "%caml_bigstring_setf32"
-
-external bs_set_tested_s
-  : bigstring -> int64# -> float32# -> unit
-  = "%caml_bigstring_setf32#_indexed_by_int64#"
-
-external bs_set_tested_u
-  : bigstring -> int64# -> float32# -> unit
-  = "%caml_bigstring_setf32u#_indexed_by_int64#"
-
-external s_get_reference : string -> int -> float32
-  = "%caml_string_getf32"
-
-external s_get_tested_s : string -> int64# -> float32#
-  = "%caml_string_getf32#_indexed_by_int64#"
-
-external s_get_tested_u : string -> int64# -> float32#
-  = "%caml_string_getf32u#_indexed_by_int64#"
-
-external s_set_reference
-  : string -> int -> float32 -> unit
-  = "%caml_string_setf32"
-
-external s_set_tested_s
-  : string -> int64# -> float32# -> unit
-  = "%caml_string_setf32#_indexed_by_int64#"
-
-external s_set_tested_u
-  : string -> int64# -> float32# -> unit
-  = "%caml_string_setf32u#_indexed_by_int64#"
-
-external b_get_reference : bytes -> int -> float32
-  = "%caml_bytes_getf32"
-
-external b_get_tested_s : bytes -> int64# -> float32#
-  = "%caml_bytes_getf32#_indexed_by_int64#"
-
-external b_get_tested_u : bytes -> int64# -> float32#
-  = "%caml_bytes_getf32u#_indexed_by_int64#"
-
-external b_set_reference
-  : bytes -> int -> float32 -> unit
-  = "%caml_bytes_setf32"
-
-external b_set_tested_s
-  : bytes -> int64# -> float32# -> unit
-  = "%caml_bytes_setf32#_indexed_by_int64#"
-
-external b_set_tested_u
-  : bytes -> int64# -> float32# -> unit
-  = "%caml_bytes_setf32u#_indexed_by_int64#"
-
-let check_get_bounds, check_get, check_set_bounds, check_set =
-  let create_checkers create reference_get reference_set get_s get_u set_s
-      set_u =
-    let for_ref = create () and for_s = create () and for_u = create () in
-    let check_get_bounds i =
-      try
-        let _ = get_s for_s i in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_set_bounds i x =
-      let test_x = of_boxed_result x in
-      try
-        let _ = set_s for_s i test_x in
-        assert false
-      with Invalid_argument _ -> ()
-    in
-    let check_get i =
-      let test_i = of_boxed_index i in
-      try
-        let res = reference_get for_ref i in
-        try
-          assert (eq res (to_boxed_result (get_s for_s test_i)));
-          assert (eq res (to_boxed_result (get_u for_u test_i)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
-      | _ -> (
-          try
-            let _ = get_s for_s test_i in
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    let check_set i x =
-      let test_i = of_boxed_index i in
-      let test_x = of_boxed_result x in
-      try
-        reference_set for_ref i x;
-        try
-          set_s for_s test_i test_x;
-          assert (eq x (reference_get for_s i));
-          set_u for_u test_i test_x;
-          assert (eq x (reference_get for_u i));
-          (* Check that we didn't ruin adjacent indices *)
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
-          assert (
-            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
-          assert (
-            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
-        with _ -> assert false
-      with
-      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
-      | _ -> (
-          try
-            set_s for_s test_i test_x;
-            assert false
-          with
-          | Invalid_argument _ -> assert false
-          | _ -> ())
-    in
-    (check_get_bounds, check_get, check_set_bounds, check_set)
-  in
-  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
-    create_checkers create_bs bs_get_reference bs_set_reference
-      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
-  let gb_for_s, g_for_s, sb_for_s, s_for_s =
-    create_checkers create_s s_get_reference s_set_reference
-      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
-  let gb_for_b, g_for_b, sb_for_b, s_for_b =
-    create_checkers create_b b_get_reference b_set_reference
-      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
-  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
-  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
-  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
-  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
-;;
-
-for i = -1 to length + 1 do
-  check_get i;
-  check_set i (x i)
-done
-;;
-
-check_get_bounds (-#9223372036854775808L);;
-check_set_bounds (-#9223372036854775808L) (x 1);;
-check_get_bounds (-#9223372036854775807L);;
-check_set_bounds (-#9223372036854775807L) (x 1);;
-check_get_bounds (#9223372036854775807L);;
-check_set_bounds (#9223372036854775807L) (x 1);;
-check_get_bounds (-#1L);;
-check_set_bounds (-#1L) (x 1);;
+in x
+
+let to_index = Int64.of_int
+let data_equal = Int64.equal
+let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
+let unbox_data = Stdlib_upstream_compatible.Int64_u.of_int64
+let box_data = Stdlib_upstream_compatible.Int64_u.to_int64
+let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
+
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
+
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : string
+      -> int
+      -> int64
+      = "%caml_string_get64"
+
+    external get_safe
+      :  string
+      -> int64#
+      -> int64#
+      = "%caml_string_get64#_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  string
+      -> int64#
+      -> int64#
+      = "%caml_string_get64u#_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : string
+      -> int
+      -> int64
+      -> unit
+      = "%caml_string_set64"
+
+    external set_safe
+      :  string
+      -> int64#
+      -> int64#
+      -> unit
+      = "%caml_string_set64#_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  string
+      -> int64#
+      -> int64#
+      -> unit
+      = "%caml_string_set64u#_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
+
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bytes
+      -> int
+      -> int64
+      = "%caml_bytes_get64"
+
+    external get_safe
+      :  bytes
+      -> int64#
+      -> int64#
+      = "%caml_bytes_get64#_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bytes
+      -> int64#
+      -> int64#
+      = "%caml_bytes_get64u#_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bytes
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bytes_set64"
+
+    external set_safe
+      :  bytes
+      -> int64#
+      -> int64#
+      -> unit
+      = "%caml_bytes_set64#_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int64#
+      -> int64#
+      -> unit
+      = "%caml_bytes_set64u#_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> int64
+      = "%caml_bigstring_get64"
+
+    external get_safe
+      :  bigstring
+      -> int64#
+      -> int64#
+      = "%caml_bigstring_get64#_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int64#
+      -> int64#
+      = "%caml_bigstring_get64u#_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> int64
+      -> unit
+      = "%caml_bigstring_set64"
+
+    external set_safe
+      :  bigstring
+      -> int64#
+      -> int64#
+      -> unit
+      = "%caml_bigstring_set64#_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int64#
+      -> int64#
+      -> unit
+      = "%caml_bigstring_set64u#_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int64
+type boxed_data = float32
+
+let generate_data = fun _ -> Stdlib_beta.Float32.of_float 5.0
+
+let to_index = Int64.of_int
+let data_equal = Stdlib_beta.Float32.equal
+let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
+let unbox_data = fun x -> x
+let box_data = fun x -> x
+let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
+
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
+
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : string
+      -> int
+      -> float32
+      = "%caml_string_getf32"
+
+    external get_safe
+      :  string
+      -> int64#
+      -> float32
+      = "%caml_string_getf32_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  string
+      -> int64#
+      -> float32
+      = "%caml_string_getf32u_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : string
+      -> int
+      -> float32
+      -> unit
+      = "%caml_string_setf32"
+
+    external set_safe
+      :  string
+      -> int64#
+      -> float32
+      -> unit
+      = "%caml_string_setf32_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  string
+      -> int64#
+      -> float32
+      -> unit
+      = "%caml_string_setf32u_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
+
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bytes
+      -> int
+      -> float32
+      = "%caml_bytes_getf32"
+
+    external get_safe
+      :  bytes
+      -> int64#
+      -> float32
+      = "%caml_bytes_getf32_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bytes
+      -> int64#
+      -> float32
+      = "%caml_bytes_getf32u_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bytes
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32"
+
+    external set_safe
+      :  bytes
+      -> int64#
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int64#
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32u_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> float32
+      = "%caml_bigstring_getf32"
+
+    external get_safe
+      :  bigstring
+      -> int64#
+      -> float32
+      = "%caml_bigstring_getf32_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int64#
+      -> float32
+      = "%caml_bigstring_getf32u_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32"
+
+    external set_safe
+      :  bigstring
+      -> int64#
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int64#
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32u_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end
+
+open struct
+
+type boxed_index = int64
+type boxed_data = float32
+
+let generate_data = fun _ -> Stdlib_beta.Float32.of_float 5.0
+
+let to_index = Int64.of_int
+let data_equal = Stdlib_beta.Float32.equal
+let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
+let unbox_data = Stdlib_beta.Float32_u.of_float32
+let box_data = Stdlib_beta.Float32_u.to_float32
+let extra_bounds_checks = [ -9223372036854775808L; -9223372036854775807L; 9223372036854775807L; -1L ]
+
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = string
+
+    let create = create_s
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : string
+      -> int
+      -> float32
+      = "%caml_string_getf32"
+
+    external get_safe
+      :  string
+      -> int64#
+      -> float32#
+      = "%caml_string_getf32#_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  string
+      -> int64#
+      -> float32#
+      = "%caml_string_getf32u#_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : string
+      -> int
+      -> float32
+      -> unit
+      = "%caml_string_setf32"
+
+    external set_safe
+      :  string
+      -> int64#
+      -> float32#
+      -> unit
+      = "%caml_string_setf32#_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  string
+      -> int64#
+      -> float32#
+      -> unit
+      = "%caml_string_setf32u#_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bytes
+
+    let create = create_b
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bytes
+      -> int
+      -> float32
+      = "%caml_bytes_getf32"
+
+    external get_safe
+      :  bytes
+      -> int64#
+      -> float32#
+      = "%caml_bytes_getf32#_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bytes
+      -> int64#
+      -> float32#
+      = "%caml_bytes_getf32u#_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bytes
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bytes_setf32"
+
+    external set_safe
+      :  bytes
+      -> int64#
+      -> float32#
+      -> unit
+      = "%caml_bytes_setf32#_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bytes
+      -> int64#
+      -> float32#
+      -> unit
+      = "%caml_bytes_setf32u#_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+module _ = Tester (struct
+    type nonrec boxed_index = boxed_index
+    type nonrec boxed_data = boxed_data
+    type container = bigstring
+
+    let create = create_bs
+    let generate_data = generate_data
+    let to_index = to_index
+    let data_equal = data_equal
+    let extra_bounds_checks = extra_bounds_checks
+
+    external get_reference
+      : bigstring
+      -> int
+      -> float32
+      = "%caml_bigstring_getf32"
+
+    external get_safe
+      :  bigstring
+      -> int64#
+      -> float32#
+      = "%caml_bigstring_getf32#_indexed_by_int64#"
+
+    let get_safe b i = box_data (get_safe b (unbox_index i))
+
+    external get_unsafe
+      :  bigstring
+      -> int64#
+      -> float32#
+      = "%caml_bigstring_getf32u#_indexed_by_int64#"
+
+    let get_unsafe b i = box_data (get_unsafe b (unbox_index i))
+
+    external set_reference
+      : bigstring
+      -> int
+      -> float32
+      -> unit
+      = "%caml_bigstring_setf32"
+
+    external set_safe
+      :  bigstring
+      -> int64#
+      -> float32#
+      -> unit
+      = "%caml_bigstring_setf32#_indexed_by_int64#"
+
+    let set_safe b i d = set_safe b (unbox_index i) (unbox_data d)
+
+    external set_unsafe
+      :  bigstring
+      -> int64#
+      -> float32#
+      -> unit
+      = "%caml_bigstring_setf32u#_indexed_by_int64#"
+
+    let set_unsafe b i d = set_unsafe b (unbox_index i) (unbox_data d)
+  end)
+
+end

--- a/ocaml/testsuite/tests/typing-layouts/unboxed_int_stringlike_indexing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/unboxed_int_stringlike_indexing.ml
@@ -1,7 +1,7 @@
 (* TEST
  flambda2;
  include stdlib_upstream_compatible;
- include stdlib_beta;
+ include stdlib_stable;
  {
    native;
  }{
@@ -1187,10 +1187,10 @@ open struct
       let f = Random.float Float.max_float in
       if Random.bool () then Float.neg f else f
     in
-    Stdlib_beta.Float32.of_float f
+    Stdlib_stable.Float32.of_float f
 
   let to_index = Nativeint.of_int
-  let data_equal = Stdlib_beta.Float32.equal
+  let data_equal = Stdlib_stable.Float32.equal
   let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
   let unbox_data = fun x -> x
   let box_data = fun x -> x
@@ -1388,13 +1388,13 @@ open struct
       let f = Random.float Float.max_float in
       if Random.bool () then Float.neg f else f
     in
-    Stdlib_beta.Float32.of_float f
+    Stdlib_stable.Float32.of_float f
 
   let to_index = Nativeint.of_int
-  let data_equal = Stdlib_beta.Float32.equal
+  let data_equal = Stdlib_stable.Float32.equal
   let unbox_index = Stdlib_upstream_compatible.Nativeint_u.of_nativeint
-  let unbox_data = Stdlib_beta.Float32_u.of_float32
-  let box_data = Stdlib_beta.Float32_u.to_float32
+  let unbox_data = Stdlib_stable.Float32_u.of_float32
+  let box_data = Stdlib_stable.Float32_u.to_float32
   let extra_bounds_checks = Nativeint.[ min_int; max_int; add min_int one; sub zero one ]
 
 
@@ -2601,10 +2601,10 @@ open struct
       let f = Random.float Float.max_float in
       if Random.bool () then Float.neg f else f
     in
-    Stdlib_beta.Float32.of_float f
+    Stdlib_stable.Float32.of_float f
 
   let to_index = Int32.of_int
-  let data_equal = Stdlib_beta.Float32.equal
+  let data_equal = Stdlib_stable.Float32.equal
   let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
   let unbox_data = fun x -> x
   let box_data = fun x -> x
@@ -2802,13 +2802,13 @@ open struct
       let f = Random.float Float.max_float in
       if Random.bool () then Float.neg f else f
     in
-    Stdlib_beta.Float32.of_float f
+    Stdlib_stable.Float32.of_float f
 
   let to_index = Int32.of_int
-  let data_equal = Stdlib_beta.Float32.equal
+  let data_equal = Stdlib_stable.Float32.equal
   let unbox_index = Stdlib_upstream_compatible.Int32_u.of_int32
-  let unbox_data = Stdlib_beta.Float32_u.of_float32
-  let box_data = Stdlib_beta.Float32_u.to_float32
+  let unbox_data = Stdlib_stable.Float32_u.of_float32
+  let box_data = Stdlib_stable.Float32_u.to_float32
   let extra_bounds_checks = Int32.[ min_int; max_int; add min_int one; sub zero one ]
 
 
@@ -4015,10 +4015,10 @@ open struct
       let f = Random.float Float.max_float in
       if Random.bool () then Float.neg f else f
     in
-    Stdlib_beta.Float32.of_float f
+    Stdlib_stable.Float32.of_float f
 
   let to_index = Int64.of_int
-  let data_equal = Stdlib_beta.Float32.equal
+  let data_equal = Stdlib_stable.Float32.equal
   let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
   let unbox_data = fun x -> x
   let box_data = fun x -> x
@@ -4216,13 +4216,13 @@ open struct
       let f = Random.float Float.max_float in
       if Random.bool () then Float.neg f else f
     in
-    Stdlib_beta.Float32.of_float f
+    Stdlib_stable.Float32.of_float f
 
   let to_index = Int64.of_int
-  let data_equal = Stdlib_beta.Float32.equal
+  let data_equal = Stdlib_stable.Float32.equal
   let unbox_index = Stdlib_upstream_compatible.Int64_u.of_int64
-  let unbox_data = Stdlib_beta.Float32_u.of_float32
-  let box_data = Stdlib_beta.Float32_u.to_float32
+  let unbox_data = Stdlib_stable.Float32_u.of_float32
+  let box_data = Stdlib_stable.Float32_u.to_float32
   let extra_bounds_checks = Int64.[ min_int; max_int; add min_int one; sub zero one ]
 
 

--- a/ocaml/testsuite/tests/typing-layouts/unboxed_int_stringlike_indexing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/unboxed_int_stringlike_indexing.ml
@@ -1,0 +1,3752 @@
+(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ include stdlib_beta;
+ {
+   native;
+ }{
+   flags = "-O3";
+   native;
+ }{
+   bytecode;
+ }{
+   flags = "-extension layouts_alpha";
+   native;
+ }{
+   flags = "-extension layouts_alpha -O3";
+   native;
+ }{
+   flags = "-extension layouts_alpha";
+   bytecode;
+ }{
+   flags = "-extension layouts_beta";
+   native;
+ }{
+   flags = "-extension layouts_beta -O3";
+   native;
+ }{
+   flags = "-extension layouts_beta";
+   bytecode;
+ }
+*)
+
+
+let length = 300
+let reference_str = String.init length (fun i -> i * 7 mod 256 |> char_of_int)
+let create_b () = reference_str |> Bytes.of_string
+let create_s () = reference_str
+
+open struct
+  open Bigarray
+
+  type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t
+
+  let bigstring_of_string s =
+    let a = Array1.create char c_layout (String.length s) in
+    for i = 0 to String.length s - 1 do
+      a.{i} <- s.[i]
+    done;
+    a
+
+  let create_bs () = reference_str |> bigstring_of_string
+end
+
+
+let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
+let to_boxed_result : int -> int = fun x -> x
+let of_boxed_result : int -> int = fun x -> x
+let eq : int -> int -> bool = Int.equal
+
+let rec x = function
+  | i when i <= 0 -> Int.zero
+  | 1 ->
+      (* min int *)
+      Int.(shift_left one) (16 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 16 - 1 in
+      Int.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int.(logxor x (shift_left one (i1 mod 16))) in
+      let x = Int.(logxor x (shift_left one (i2 mod 16))) in
+      let x = Int.(logxor x (shift_left one (i3 mod 16))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int
+  = "%caml_bigstring_get16"
+
+external bs_get_tested_s : bigstring -> nativeint# -> int
+  = "%caml_bigstring_get16_indexed_by_nativeint#"
+
+external bs_get_tested_u : bigstring -> nativeint# -> int
+  = "%caml_bigstring_get16u_indexed_by_nativeint#"
+
+external bs_set_reference
+  : bigstring -> int -> int -> unit
+  = "%caml_bigstring_set16"
+
+external bs_set_tested_s
+  : bigstring -> nativeint# -> int -> unit
+  = "%caml_bigstring_set16_indexed_by_nativeint#"
+
+external bs_set_tested_u
+  : bigstring -> nativeint# -> int -> unit
+  = "%caml_bigstring_set16u_indexed_by_nativeint#"
+
+external s_get_reference : string -> int -> int
+  = "%caml_string_get16"
+
+external s_get_tested_s : string -> nativeint# -> int
+  = "%caml_string_get16_indexed_by_nativeint#"
+
+external s_get_tested_u : string -> nativeint# -> int
+  = "%caml_string_get16u_indexed_by_nativeint#"
+
+external s_set_reference
+  : string -> int -> int -> unit
+  = "%caml_string_set16"
+
+external s_set_tested_s
+  : string -> nativeint# -> int -> unit
+  = "%caml_string_set16_indexed_by_nativeint#"
+
+external s_set_tested_u
+  : string -> nativeint# -> int -> unit
+  = "%caml_string_set16u_indexed_by_nativeint#"
+
+external b_get_reference : bytes -> int -> int
+  = "%caml_bytes_get16"
+
+external b_get_tested_s : bytes -> nativeint# -> int
+  = "%caml_bytes_get16_indexed_by_nativeint#"
+
+external b_get_tested_u : bytes -> nativeint# -> int
+  = "%caml_bytes_get16u_indexed_by_nativeint#"
+
+external b_set_reference
+  : bytes -> int -> int -> unit
+  = "%caml_bytes_set16"
+
+external b_set_tested_s
+  : bytes -> nativeint# -> int -> unit
+  = "%caml_bytes_set16_indexed_by_nativeint#"
+
+external b_set_tested_u
+  : bytes -> nativeint# -> int -> unit
+  = "%caml_bytes_set16u_indexed_by_nativeint#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#1n);;
+check_set_bounds (-#1n) (x 1);;
+
+let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
+let to_boxed_result : int32 -> int32 = fun x -> x
+let of_boxed_result : int32 -> int32 = fun x -> x
+let eq : int32 -> int32 -> bool = Int32.equal
+
+let rec x = function
+  | i when i <= 0 -> Int32.zero
+  | 1 ->
+      (* min int *)
+      Int32.(shift_left one) (32 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 32 - 1 in
+      Int32.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int32.(logxor x (shift_left one (i1 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int32
+  = "%caml_bigstring_get32"
+
+external bs_get_tested_s : bigstring -> nativeint# -> int32
+  = "%caml_bigstring_get32_indexed_by_nativeint#"
+
+external bs_get_tested_u : bigstring -> nativeint# -> int32
+  = "%caml_bigstring_get32u_indexed_by_nativeint#"
+
+external bs_set_reference
+  : bigstring -> int -> int32 -> unit
+  = "%caml_bigstring_set32"
+
+external bs_set_tested_s
+  : bigstring -> nativeint# -> int32 -> unit
+  = "%caml_bigstring_set32_indexed_by_nativeint#"
+
+external bs_set_tested_u
+  : bigstring -> nativeint# -> int32 -> unit
+  = "%caml_bigstring_set32u_indexed_by_nativeint#"
+
+external s_get_reference : string -> int -> int32
+  = "%caml_string_get32"
+
+external s_get_tested_s : string -> nativeint# -> int32
+  = "%caml_string_get32_indexed_by_nativeint#"
+
+external s_get_tested_u : string -> nativeint# -> int32
+  = "%caml_string_get32u_indexed_by_nativeint#"
+
+external s_set_reference
+  : string -> int -> int32 -> unit
+  = "%caml_string_set32"
+
+external s_set_tested_s
+  : string -> nativeint# -> int32 -> unit
+  = "%caml_string_set32_indexed_by_nativeint#"
+
+external s_set_tested_u
+  : string -> nativeint# -> int32 -> unit
+  = "%caml_string_set32u_indexed_by_nativeint#"
+
+external b_get_reference : bytes -> int -> int32
+  = "%caml_bytes_get32"
+
+external b_get_tested_s : bytes -> nativeint# -> int32
+  = "%caml_bytes_get32_indexed_by_nativeint#"
+
+external b_get_tested_u : bytes -> nativeint# -> int32
+  = "%caml_bytes_get32u_indexed_by_nativeint#"
+
+external b_set_reference
+  : bytes -> int -> int32 -> unit
+  = "%caml_bytes_set32"
+
+external b_set_tested_s
+  : bytes -> nativeint# -> int32 -> unit
+  = "%caml_bytes_set32_indexed_by_nativeint#"
+
+external b_set_tested_u
+  : bytes -> nativeint# -> int32 -> unit
+  = "%caml_bytes_set32u_indexed_by_nativeint#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#1n);;
+check_set_bounds (-#1n) (x 1);;
+
+let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
+let to_boxed_result : int64 -> int64 = fun x -> x
+let of_boxed_result : int64 -> int64 = fun x -> x
+let eq : int64 -> int64 -> bool = Int64.equal
+
+let rec x = function
+  | i when i <= 0 -> Int64.zero
+  | 1 ->
+      (* min int *)
+      Int64.(shift_left one) (64 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 64 - 1 in
+      Int64.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int64.(logxor x (shift_left one (i1 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int64
+  = "%caml_bigstring_get64"
+
+external bs_get_tested_s : bigstring -> nativeint# -> int64
+  = "%caml_bigstring_get64_indexed_by_nativeint#"
+
+external bs_get_tested_u : bigstring -> nativeint# -> int64
+  = "%caml_bigstring_get64u_indexed_by_nativeint#"
+
+external bs_set_reference
+  : bigstring -> int -> int64 -> unit
+  = "%caml_bigstring_set64"
+
+external bs_set_tested_s
+  : bigstring -> nativeint# -> int64 -> unit
+  = "%caml_bigstring_set64_indexed_by_nativeint#"
+
+external bs_set_tested_u
+  : bigstring -> nativeint# -> int64 -> unit
+  = "%caml_bigstring_set64u_indexed_by_nativeint#"
+
+external s_get_reference : string -> int -> int64
+  = "%caml_string_get64"
+
+external s_get_tested_s : string -> nativeint# -> int64
+  = "%caml_string_get64_indexed_by_nativeint#"
+
+external s_get_tested_u : string -> nativeint# -> int64
+  = "%caml_string_get64u_indexed_by_nativeint#"
+
+external s_set_reference
+  : string -> int -> int64 -> unit
+  = "%caml_string_set64"
+
+external s_set_tested_s
+  : string -> nativeint# -> int64 -> unit
+  = "%caml_string_set64_indexed_by_nativeint#"
+
+external s_set_tested_u
+  : string -> nativeint# -> int64 -> unit
+  = "%caml_string_set64u_indexed_by_nativeint#"
+
+external b_get_reference : bytes -> int -> int64
+  = "%caml_bytes_get64"
+
+external b_get_tested_s : bytes -> nativeint# -> int64
+  = "%caml_bytes_get64_indexed_by_nativeint#"
+
+external b_get_tested_u : bytes -> nativeint# -> int64
+  = "%caml_bytes_get64u_indexed_by_nativeint#"
+
+external b_set_reference
+  : bytes -> int -> int64 -> unit
+  = "%caml_bytes_set64"
+
+external b_set_tested_s
+  : bytes -> nativeint# -> int64 -> unit
+  = "%caml_bytes_set64_indexed_by_nativeint#"
+
+external b_set_tested_u
+  : bytes -> nativeint# -> int64 -> unit
+  = "%caml_bytes_set64u_indexed_by_nativeint#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#1n);;
+check_set_bounds (-#1n) (x 1);;
+
+let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
+let to_boxed_result : int32# -> int32 = Stdlib_upstream_compatible.Int32_u.to_int32
+let of_boxed_result : int32 -> int32# = Stdlib_upstream_compatible.Int32_u.of_int32
+let eq : int32 -> int32 -> bool = Int32.equal
+
+let rec x = function
+  | i when i <= 0 -> Int32.zero
+  | 1 ->
+      (* min int *)
+      Int32.(shift_left one) (32 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 32 - 1 in
+      Int32.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int32.(logxor x (shift_left one (i1 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int32
+  = "%caml_bigstring_get32"
+
+external bs_get_tested_s : bigstring -> nativeint# -> int32#
+  = "%caml_bigstring_get32#_indexed_by_nativeint#"
+
+external bs_get_tested_u : bigstring -> nativeint# -> int32#
+  = "%caml_bigstring_get32u#_indexed_by_nativeint#"
+
+external bs_set_reference
+  : bigstring -> int -> int32 -> unit
+  = "%caml_bigstring_set32"
+
+external bs_set_tested_s
+  : bigstring -> nativeint# -> int32# -> unit
+  = "%caml_bigstring_set32#_indexed_by_nativeint#"
+
+external bs_set_tested_u
+  : bigstring -> nativeint# -> int32# -> unit
+  = "%caml_bigstring_set32u#_indexed_by_nativeint#"
+
+external s_get_reference : string -> int -> int32
+  = "%caml_string_get32"
+
+external s_get_tested_s : string -> nativeint# -> int32#
+  = "%caml_string_get32#_indexed_by_nativeint#"
+
+external s_get_tested_u : string -> nativeint# -> int32#
+  = "%caml_string_get32u#_indexed_by_nativeint#"
+
+external s_set_reference
+  : string -> int -> int32 -> unit
+  = "%caml_string_set32"
+
+external s_set_tested_s
+  : string -> nativeint# -> int32# -> unit
+  = "%caml_string_set32#_indexed_by_nativeint#"
+
+external s_set_tested_u
+  : string -> nativeint# -> int32# -> unit
+  = "%caml_string_set32u#_indexed_by_nativeint#"
+
+external b_get_reference : bytes -> int -> int32
+  = "%caml_bytes_get32"
+
+external b_get_tested_s : bytes -> nativeint# -> int32#
+  = "%caml_bytes_get32#_indexed_by_nativeint#"
+
+external b_get_tested_u : bytes -> nativeint# -> int32#
+  = "%caml_bytes_get32u#_indexed_by_nativeint#"
+
+external b_set_reference
+  : bytes -> int -> int32 -> unit
+  = "%caml_bytes_set32"
+
+external b_set_tested_s
+  : bytes -> nativeint# -> int32# -> unit
+  = "%caml_bytes_set32#_indexed_by_nativeint#"
+
+external b_set_tested_u
+  : bytes -> nativeint# -> int32# -> unit
+  = "%caml_bytes_set32u#_indexed_by_nativeint#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#1n);;
+check_set_bounds (-#1n) (x 1);;
+
+let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
+let to_boxed_result : int64# -> int64 = Stdlib_upstream_compatible.Int64_u.to_int64
+let of_boxed_result : int64 -> int64# = Stdlib_upstream_compatible.Int64_u.of_int64
+let eq : int64 -> int64 -> bool = Int64.equal
+
+let rec x = function
+  | i when i <= 0 -> Int64.zero
+  | 1 ->
+      (* min int *)
+      Int64.(shift_left one) (64 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 64 - 1 in
+      Int64.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int64.(logxor x (shift_left one (i1 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int64
+  = "%caml_bigstring_get64"
+
+external bs_get_tested_s : bigstring -> nativeint# -> int64#
+  = "%caml_bigstring_get64#_indexed_by_nativeint#"
+
+external bs_get_tested_u : bigstring -> nativeint# -> int64#
+  = "%caml_bigstring_get64u#_indexed_by_nativeint#"
+
+external bs_set_reference
+  : bigstring -> int -> int64 -> unit
+  = "%caml_bigstring_set64"
+
+external bs_set_tested_s
+  : bigstring -> nativeint# -> int64# -> unit
+  = "%caml_bigstring_set64#_indexed_by_nativeint#"
+
+external bs_set_tested_u
+  : bigstring -> nativeint# -> int64# -> unit
+  = "%caml_bigstring_set64u#_indexed_by_nativeint#"
+
+external s_get_reference : string -> int -> int64
+  = "%caml_string_get64"
+
+external s_get_tested_s : string -> nativeint# -> int64#
+  = "%caml_string_get64#_indexed_by_nativeint#"
+
+external s_get_tested_u : string -> nativeint# -> int64#
+  = "%caml_string_get64u#_indexed_by_nativeint#"
+
+external s_set_reference
+  : string -> int -> int64 -> unit
+  = "%caml_string_set64"
+
+external s_set_tested_s
+  : string -> nativeint# -> int64# -> unit
+  = "%caml_string_set64#_indexed_by_nativeint#"
+
+external s_set_tested_u
+  : string -> nativeint# -> int64# -> unit
+  = "%caml_string_set64u#_indexed_by_nativeint#"
+
+external b_get_reference : bytes -> int -> int64
+  = "%caml_bytes_get64"
+
+external b_get_tested_s : bytes -> nativeint# -> int64#
+  = "%caml_bytes_get64#_indexed_by_nativeint#"
+
+external b_get_tested_u : bytes -> nativeint# -> int64#
+  = "%caml_bytes_get64u#_indexed_by_nativeint#"
+
+external b_set_reference
+  : bytes -> int -> int64 -> unit
+  = "%caml_bytes_set64"
+
+external b_set_tested_s
+  : bytes -> nativeint# -> int64# -> unit
+  = "%caml_bytes_set64#_indexed_by_nativeint#"
+
+external b_set_tested_u
+  : bytes -> nativeint# -> int64# -> unit
+  = "%caml_bytes_set64u#_indexed_by_nativeint#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#1n);;
+check_set_bounds (-#1n) (x 1);;
+
+let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
+let to_boxed_result : float32 -> float32 = fun x -> x
+let of_boxed_result : float32 -> float32 = fun x -> x
+let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
+let x _ = Stdlib_beta.Float32.of_float 5.0
+
+external bs_get_reference : bigstring -> int -> float32
+  = "%caml_bigstring_getf32"
+
+external bs_get_tested_s : bigstring -> nativeint# -> float32
+  = "%caml_bigstring_getf32_indexed_by_nativeint#"
+
+external bs_get_tested_u : bigstring -> nativeint# -> float32
+  = "%caml_bigstring_getf32u_indexed_by_nativeint#"
+
+external bs_set_reference
+  : bigstring -> int -> float32 -> unit
+  = "%caml_bigstring_setf32"
+
+external bs_set_tested_s
+  : bigstring -> nativeint# -> float32 -> unit
+  = "%caml_bigstring_setf32_indexed_by_nativeint#"
+
+external bs_set_tested_u
+  : bigstring -> nativeint# -> float32 -> unit
+  = "%caml_bigstring_setf32u_indexed_by_nativeint#"
+
+external s_get_reference : string -> int -> float32
+  = "%caml_string_getf32"
+
+external s_get_tested_s : string -> nativeint# -> float32
+  = "%caml_string_getf32_indexed_by_nativeint#"
+
+external s_get_tested_u : string -> nativeint# -> float32
+  = "%caml_string_getf32u_indexed_by_nativeint#"
+
+external s_set_reference
+  : string -> int -> float32 -> unit
+  = "%caml_string_setf32"
+
+external s_set_tested_s
+  : string -> nativeint# -> float32 -> unit
+  = "%caml_string_setf32_indexed_by_nativeint#"
+
+external s_set_tested_u
+  : string -> nativeint# -> float32 -> unit
+  = "%caml_string_setf32u_indexed_by_nativeint#"
+
+external b_get_reference : bytes -> int -> float32
+  = "%caml_bytes_getf32"
+
+external b_get_tested_s : bytes -> nativeint# -> float32
+  = "%caml_bytes_getf32_indexed_by_nativeint#"
+
+external b_get_tested_u : bytes -> nativeint# -> float32
+  = "%caml_bytes_getf32u_indexed_by_nativeint#"
+
+external b_set_reference
+  : bytes -> int -> float32 -> unit
+  = "%caml_bytes_setf32"
+
+external b_set_tested_s
+  : bytes -> nativeint# -> float32 -> unit
+  = "%caml_bytes_setf32_indexed_by_nativeint#"
+
+external b_set_tested_u
+  : bytes -> nativeint# -> float32 -> unit
+  = "%caml_bytes_setf32u_indexed_by_nativeint#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#1n);;
+check_set_bounds (-#1n) (x 1);;
+
+let of_boxed_index : int -> nativeint# = Stdlib_upstream_compatible.Nativeint_u.of_int
+let to_boxed_result : float32# -> float32 = Stdlib_beta.Float32_u.to_float32
+let of_boxed_result : float32 -> float32# = Stdlib_beta.Float32_u.of_float32
+let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
+let x _ = Stdlib_beta.Float32.of_float 5.0
+
+external bs_get_reference : bigstring -> int -> float32
+  = "%caml_bigstring_getf32"
+
+external bs_get_tested_s : bigstring -> nativeint# -> float32#
+  = "%caml_bigstring_getf32#_indexed_by_nativeint#"
+
+external bs_get_tested_u : bigstring -> nativeint# -> float32#
+  = "%caml_bigstring_getf32u#_indexed_by_nativeint#"
+
+external bs_set_reference
+  : bigstring -> int -> float32 -> unit
+  = "%caml_bigstring_setf32"
+
+external bs_set_tested_s
+  : bigstring -> nativeint# -> float32# -> unit
+  = "%caml_bigstring_setf32#_indexed_by_nativeint#"
+
+external bs_set_tested_u
+  : bigstring -> nativeint# -> float32# -> unit
+  = "%caml_bigstring_setf32u#_indexed_by_nativeint#"
+
+external s_get_reference : string -> int -> float32
+  = "%caml_string_getf32"
+
+external s_get_tested_s : string -> nativeint# -> float32#
+  = "%caml_string_getf32#_indexed_by_nativeint#"
+
+external s_get_tested_u : string -> nativeint# -> float32#
+  = "%caml_string_getf32u#_indexed_by_nativeint#"
+
+external s_set_reference
+  : string -> int -> float32 -> unit
+  = "%caml_string_setf32"
+
+external s_set_tested_s
+  : string -> nativeint# -> float32# -> unit
+  = "%caml_string_setf32#_indexed_by_nativeint#"
+
+external s_set_tested_u
+  : string -> nativeint# -> float32# -> unit
+  = "%caml_string_setf32u#_indexed_by_nativeint#"
+
+external b_get_reference : bytes -> int -> float32
+  = "%caml_bytes_getf32"
+
+external b_get_tested_s : bytes -> nativeint# -> float32#
+  = "%caml_bytes_getf32#_indexed_by_nativeint#"
+
+external b_get_tested_u : bytes -> nativeint# -> float32#
+  = "%caml_bytes_getf32u#_indexed_by_nativeint#"
+
+external b_set_reference
+  : bytes -> int -> float32 -> unit
+  = "%caml_bytes_setf32"
+
+external b_set_tested_s
+  : bytes -> nativeint# -> float32# -> unit
+  = "%caml_bytes_setf32#_indexed_by_nativeint#"
+
+external b_set_tested_u
+  : bytes -> nativeint# -> float32# -> unit
+  = "%caml_bytes_setf32u#_indexed_by_nativeint#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#1n);;
+check_set_bounds (-#1n) (x 1);;
+
+let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
+let to_boxed_result : int -> int = fun x -> x
+let of_boxed_result : int -> int = fun x -> x
+let eq : int -> int -> bool = Int.equal
+
+let rec x = function
+  | i when i <= 0 -> Int.zero
+  | 1 ->
+      (* min int *)
+      Int.(shift_left one) (16 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 16 - 1 in
+      Int.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int.(logxor x (shift_left one (i1 mod 16))) in
+      let x = Int.(logxor x (shift_left one (i2 mod 16))) in
+      let x = Int.(logxor x (shift_left one (i3 mod 16))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int
+  = "%caml_bigstring_get16"
+
+external bs_get_tested_s : bigstring -> int32# -> int
+  = "%caml_bigstring_get16_indexed_by_int32#"
+
+external bs_get_tested_u : bigstring -> int32# -> int
+  = "%caml_bigstring_get16u_indexed_by_int32#"
+
+external bs_set_reference
+  : bigstring -> int -> int -> unit
+  = "%caml_bigstring_set16"
+
+external bs_set_tested_s
+  : bigstring -> int32# -> int -> unit
+  = "%caml_bigstring_set16_indexed_by_int32#"
+
+external bs_set_tested_u
+  : bigstring -> int32# -> int -> unit
+  = "%caml_bigstring_set16u_indexed_by_int32#"
+
+external s_get_reference : string -> int -> int
+  = "%caml_string_get16"
+
+external s_get_tested_s : string -> int32# -> int
+  = "%caml_string_get16_indexed_by_int32#"
+
+external s_get_tested_u : string -> int32# -> int
+  = "%caml_string_get16u_indexed_by_int32#"
+
+external s_set_reference
+  : string -> int -> int -> unit
+  = "%caml_string_set16"
+
+external s_set_tested_s
+  : string -> int32# -> int -> unit
+  = "%caml_string_set16_indexed_by_int32#"
+
+external s_set_tested_u
+  : string -> int32# -> int -> unit
+  = "%caml_string_set16u_indexed_by_int32#"
+
+external b_get_reference : bytes -> int -> int
+  = "%caml_bytes_get16"
+
+external b_get_tested_s : bytes -> int32# -> int
+  = "%caml_bytes_get16_indexed_by_int32#"
+
+external b_get_tested_u : bytes -> int32# -> int
+  = "%caml_bytes_get16u_indexed_by_int32#"
+
+external b_set_reference
+  : bytes -> int -> int -> unit
+  = "%caml_bytes_set16"
+
+external b_set_tested_s
+  : bytes -> int32# -> int -> unit
+  = "%caml_bytes_set16_indexed_by_int32#"
+
+external b_set_tested_u
+  : bytes -> int32# -> int -> unit
+  = "%caml_bytes_set16u_indexed_by_int32#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#2147483648l);;
+check_set_bounds (-#2147483648l) (x 1);;
+check_get_bounds (-#2147483647l);;
+check_set_bounds (-#2147483647l) (x 1);;
+check_get_bounds (#2147483647l);;
+check_set_bounds (#2147483647l) (x 1);;
+check_get_bounds (-#1l);;
+check_set_bounds (-#1l) (x 1);;
+
+let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
+let to_boxed_result : int32 -> int32 = fun x -> x
+let of_boxed_result : int32 -> int32 = fun x -> x
+let eq : int32 -> int32 -> bool = Int32.equal
+
+let rec x = function
+  | i when i <= 0 -> Int32.zero
+  | 1 ->
+      (* min int *)
+      Int32.(shift_left one) (32 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 32 - 1 in
+      Int32.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int32.(logxor x (shift_left one (i1 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int32
+  = "%caml_bigstring_get32"
+
+external bs_get_tested_s : bigstring -> int32# -> int32
+  = "%caml_bigstring_get32_indexed_by_int32#"
+
+external bs_get_tested_u : bigstring -> int32# -> int32
+  = "%caml_bigstring_get32u_indexed_by_int32#"
+
+external bs_set_reference
+  : bigstring -> int -> int32 -> unit
+  = "%caml_bigstring_set32"
+
+external bs_set_tested_s
+  : bigstring -> int32# -> int32 -> unit
+  = "%caml_bigstring_set32_indexed_by_int32#"
+
+external bs_set_tested_u
+  : bigstring -> int32# -> int32 -> unit
+  = "%caml_bigstring_set32u_indexed_by_int32#"
+
+external s_get_reference : string -> int -> int32
+  = "%caml_string_get32"
+
+external s_get_tested_s : string -> int32# -> int32
+  = "%caml_string_get32_indexed_by_int32#"
+
+external s_get_tested_u : string -> int32# -> int32
+  = "%caml_string_get32u_indexed_by_int32#"
+
+external s_set_reference
+  : string -> int -> int32 -> unit
+  = "%caml_string_set32"
+
+external s_set_tested_s
+  : string -> int32# -> int32 -> unit
+  = "%caml_string_set32_indexed_by_int32#"
+
+external s_set_tested_u
+  : string -> int32# -> int32 -> unit
+  = "%caml_string_set32u_indexed_by_int32#"
+
+external b_get_reference : bytes -> int -> int32
+  = "%caml_bytes_get32"
+
+external b_get_tested_s : bytes -> int32# -> int32
+  = "%caml_bytes_get32_indexed_by_int32#"
+
+external b_get_tested_u : bytes -> int32# -> int32
+  = "%caml_bytes_get32u_indexed_by_int32#"
+
+external b_set_reference
+  : bytes -> int -> int32 -> unit
+  = "%caml_bytes_set32"
+
+external b_set_tested_s
+  : bytes -> int32# -> int32 -> unit
+  = "%caml_bytes_set32_indexed_by_int32#"
+
+external b_set_tested_u
+  : bytes -> int32# -> int32 -> unit
+  = "%caml_bytes_set32u_indexed_by_int32#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#2147483648l);;
+check_set_bounds (-#2147483648l) (x 1);;
+check_get_bounds (-#2147483647l);;
+check_set_bounds (-#2147483647l) (x 1);;
+check_get_bounds (#2147483647l);;
+check_set_bounds (#2147483647l) (x 1);;
+check_get_bounds (-#1l);;
+check_set_bounds (-#1l) (x 1);;
+
+let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
+let to_boxed_result : int64 -> int64 = fun x -> x
+let of_boxed_result : int64 -> int64 = fun x -> x
+let eq : int64 -> int64 -> bool = Int64.equal
+
+let rec x = function
+  | i when i <= 0 -> Int64.zero
+  | 1 ->
+      (* min int *)
+      Int64.(shift_left one) (64 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 64 - 1 in
+      Int64.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int64.(logxor x (shift_left one (i1 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int64
+  = "%caml_bigstring_get64"
+
+external bs_get_tested_s : bigstring -> int32# -> int64
+  = "%caml_bigstring_get64_indexed_by_int32#"
+
+external bs_get_tested_u : bigstring -> int32# -> int64
+  = "%caml_bigstring_get64u_indexed_by_int32#"
+
+external bs_set_reference
+  : bigstring -> int -> int64 -> unit
+  = "%caml_bigstring_set64"
+
+external bs_set_tested_s
+  : bigstring -> int32# -> int64 -> unit
+  = "%caml_bigstring_set64_indexed_by_int32#"
+
+external bs_set_tested_u
+  : bigstring -> int32# -> int64 -> unit
+  = "%caml_bigstring_set64u_indexed_by_int32#"
+
+external s_get_reference : string -> int -> int64
+  = "%caml_string_get64"
+
+external s_get_tested_s : string -> int32# -> int64
+  = "%caml_string_get64_indexed_by_int32#"
+
+external s_get_tested_u : string -> int32# -> int64
+  = "%caml_string_get64u_indexed_by_int32#"
+
+external s_set_reference
+  : string -> int -> int64 -> unit
+  = "%caml_string_set64"
+
+external s_set_tested_s
+  : string -> int32# -> int64 -> unit
+  = "%caml_string_set64_indexed_by_int32#"
+
+external s_set_tested_u
+  : string -> int32# -> int64 -> unit
+  = "%caml_string_set64u_indexed_by_int32#"
+
+external b_get_reference : bytes -> int -> int64
+  = "%caml_bytes_get64"
+
+external b_get_tested_s : bytes -> int32# -> int64
+  = "%caml_bytes_get64_indexed_by_int32#"
+
+external b_get_tested_u : bytes -> int32# -> int64
+  = "%caml_bytes_get64u_indexed_by_int32#"
+
+external b_set_reference
+  : bytes -> int -> int64 -> unit
+  = "%caml_bytes_set64"
+
+external b_set_tested_s
+  : bytes -> int32# -> int64 -> unit
+  = "%caml_bytes_set64_indexed_by_int32#"
+
+external b_set_tested_u
+  : bytes -> int32# -> int64 -> unit
+  = "%caml_bytes_set64u_indexed_by_int32#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#2147483648l);;
+check_set_bounds (-#2147483648l) (x 1);;
+check_get_bounds (-#2147483647l);;
+check_set_bounds (-#2147483647l) (x 1);;
+check_get_bounds (#2147483647l);;
+check_set_bounds (#2147483647l) (x 1);;
+check_get_bounds (-#1l);;
+check_set_bounds (-#1l) (x 1);;
+
+let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
+let to_boxed_result : int32# -> int32 = Stdlib_upstream_compatible.Int32_u.to_int32
+let of_boxed_result : int32 -> int32# = Stdlib_upstream_compatible.Int32_u.of_int32
+let eq : int32 -> int32 -> bool = Int32.equal
+
+let rec x = function
+  | i when i <= 0 -> Int32.zero
+  | 1 ->
+      (* min int *)
+      Int32.(shift_left one) (32 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 32 - 1 in
+      Int32.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int32.(logxor x (shift_left one (i1 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int32
+  = "%caml_bigstring_get32"
+
+external bs_get_tested_s : bigstring -> int32# -> int32#
+  = "%caml_bigstring_get32#_indexed_by_int32#"
+
+external bs_get_tested_u : bigstring -> int32# -> int32#
+  = "%caml_bigstring_get32u#_indexed_by_int32#"
+
+external bs_set_reference
+  : bigstring -> int -> int32 -> unit
+  = "%caml_bigstring_set32"
+
+external bs_set_tested_s
+  : bigstring -> int32# -> int32# -> unit
+  = "%caml_bigstring_set32#_indexed_by_int32#"
+
+external bs_set_tested_u
+  : bigstring -> int32# -> int32# -> unit
+  = "%caml_bigstring_set32u#_indexed_by_int32#"
+
+external s_get_reference : string -> int -> int32
+  = "%caml_string_get32"
+
+external s_get_tested_s : string -> int32# -> int32#
+  = "%caml_string_get32#_indexed_by_int32#"
+
+external s_get_tested_u : string -> int32# -> int32#
+  = "%caml_string_get32u#_indexed_by_int32#"
+
+external s_set_reference
+  : string -> int -> int32 -> unit
+  = "%caml_string_set32"
+
+external s_set_tested_s
+  : string -> int32# -> int32# -> unit
+  = "%caml_string_set32#_indexed_by_int32#"
+
+external s_set_tested_u
+  : string -> int32# -> int32# -> unit
+  = "%caml_string_set32u#_indexed_by_int32#"
+
+external b_get_reference : bytes -> int -> int32
+  = "%caml_bytes_get32"
+
+external b_get_tested_s : bytes -> int32# -> int32#
+  = "%caml_bytes_get32#_indexed_by_int32#"
+
+external b_get_tested_u : bytes -> int32# -> int32#
+  = "%caml_bytes_get32u#_indexed_by_int32#"
+
+external b_set_reference
+  : bytes -> int -> int32 -> unit
+  = "%caml_bytes_set32"
+
+external b_set_tested_s
+  : bytes -> int32# -> int32# -> unit
+  = "%caml_bytes_set32#_indexed_by_int32#"
+
+external b_set_tested_u
+  : bytes -> int32# -> int32# -> unit
+  = "%caml_bytes_set32u#_indexed_by_int32#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#2147483648l);;
+check_set_bounds (-#2147483648l) (x 1);;
+check_get_bounds (-#2147483647l);;
+check_set_bounds (-#2147483647l) (x 1);;
+check_get_bounds (#2147483647l);;
+check_set_bounds (#2147483647l) (x 1);;
+check_get_bounds (-#1l);;
+check_set_bounds (-#1l) (x 1);;
+
+let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
+let to_boxed_result : int64# -> int64 = Stdlib_upstream_compatible.Int64_u.to_int64
+let of_boxed_result : int64 -> int64# = Stdlib_upstream_compatible.Int64_u.of_int64
+let eq : int64 -> int64 -> bool = Int64.equal
+
+let rec x = function
+  | i when i <= 0 -> Int64.zero
+  | 1 ->
+      (* min int *)
+      Int64.(shift_left one) (64 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 64 - 1 in
+      Int64.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int64.(logxor x (shift_left one (i1 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int64
+  = "%caml_bigstring_get64"
+
+external bs_get_tested_s : bigstring -> int32# -> int64#
+  = "%caml_bigstring_get64#_indexed_by_int32#"
+
+external bs_get_tested_u : bigstring -> int32# -> int64#
+  = "%caml_bigstring_get64u#_indexed_by_int32#"
+
+external bs_set_reference
+  : bigstring -> int -> int64 -> unit
+  = "%caml_bigstring_set64"
+
+external bs_set_tested_s
+  : bigstring -> int32# -> int64# -> unit
+  = "%caml_bigstring_set64#_indexed_by_int32#"
+
+external bs_set_tested_u
+  : bigstring -> int32# -> int64# -> unit
+  = "%caml_bigstring_set64u#_indexed_by_int32#"
+
+external s_get_reference : string -> int -> int64
+  = "%caml_string_get64"
+
+external s_get_tested_s : string -> int32# -> int64#
+  = "%caml_string_get64#_indexed_by_int32#"
+
+external s_get_tested_u : string -> int32# -> int64#
+  = "%caml_string_get64u#_indexed_by_int32#"
+
+external s_set_reference
+  : string -> int -> int64 -> unit
+  = "%caml_string_set64"
+
+external s_set_tested_s
+  : string -> int32# -> int64# -> unit
+  = "%caml_string_set64#_indexed_by_int32#"
+
+external s_set_tested_u
+  : string -> int32# -> int64# -> unit
+  = "%caml_string_set64u#_indexed_by_int32#"
+
+external b_get_reference : bytes -> int -> int64
+  = "%caml_bytes_get64"
+
+external b_get_tested_s : bytes -> int32# -> int64#
+  = "%caml_bytes_get64#_indexed_by_int32#"
+
+external b_get_tested_u : bytes -> int32# -> int64#
+  = "%caml_bytes_get64u#_indexed_by_int32#"
+
+external b_set_reference
+  : bytes -> int -> int64 -> unit
+  = "%caml_bytes_set64"
+
+external b_set_tested_s
+  : bytes -> int32# -> int64# -> unit
+  = "%caml_bytes_set64#_indexed_by_int32#"
+
+external b_set_tested_u
+  : bytes -> int32# -> int64# -> unit
+  = "%caml_bytes_set64u#_indexed_by_int32#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#2147483648l);;
+check_set_bounds (-#2147483648l) (x 1);;
+check_get_bounds (-#2147483647l);;
+check_set_bounds (-#2147483647l) (x 1);;
+check_get_bounds (#2147483647l);;
+check_set_bounds (#2147483647l) (x 1);;
+check_get_bounds (-#1l);;
+check_set_bounds (-#1l) (x 1);;
+
+let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
+let to_boxed_result : float32 -> float32 = fun x -> x
+let of_boxed_result : float32 -> float32 = fun x -> x
+let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
+let x _ = Stdlib_beta.Float32.of_float 5.0
+
+external bs_get_reference : bigstring -> int -> float32
+  = "%caml_bigstring_getf32"
+
+external bs_get_tested_s : bigstring -> int32# -> float32
+  = "%caml_bigstring_getf32_indexed_by_int32#"
+
+external bs_get_tested_u : bigstring -> int32# -> float32
+  = "%caml_bigstring_getf32u_indexed_by_int32#"
+
+external bs_set_reference
+  : bigstring -> int -> float32 -> unit
+  = "%caml_bigstring_setf32"
+
+external bs_set_tested_s
+  : bigstring -> int32# -> float32 -> unit
+  = "%caml_bigstring_setf32_indexed_by_int32#"
+
+external bs_set_tested_u
+  : bigstring -> int32# -> float32 -> unit
+  = "%caml_bigstring_setf32u_indexed_by_int32#"
+
+external s_get_reference : string -> int -> float32
+  = "%caml_string_getf32"
+
+external s_get_tested_s : string -> int32# -> float32
+  = "%caml_string_getf32_indexed_by_int32#"
+
+external s_get_tested_u : string -> int32# -> float32
+  = "%caml_string_getf32u_indexed_by_int32#"
+
+external s_set_reference
+  : string -> int -> float32 -> unit
+  = "%caml_string_setf32"
+
+external s_set_tested_s
+  : string -> int32# -> float32 -> unit
+  = "%caml_string_setf32_indexed_by_int32#"
+
+external s_set_tested_u
+  : string -> int32# -> float32 -> unit
+  = "%caml_string_setf32u_indexed_by_int32#"
+
+external b_get_reference : bytes -> int -> float32
+  = "%caml_bytes_getf32"
+
+external b_get_tested_s : bytes -> int32# -> float32
+  = "%caml_bytes_getf32_indexed_by_int32#"
+
+external b_get_tested_u : bytes -> int32# -> float32
+  = "%caml_bytes_getf32u_indexed_by_int32#"
+
+external b_set_reference
+  : bytes -> int -> float32 -> unit
+  = "%caml_bytes_setf32"
+
+external b_set_tested_s
+  : bytes -> int32# -> float32 -> unit
+  = "%caml_bytes_setf32_indexed_by_int32#"
+
+external b_set_tested_u
+  : bytes -> int32# -> float32 -> unit
+  = "%caml_bytes_setf32u_indexed_by_int32#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#2147483648l);;
+check_set_bounds (-#2147483648l) (x 1);;
+check_get_bounds (-#2147483647l);;
+check_set_bounds (-#2147483647l) (x 1);;
+check_get_bounds (#2147483647l);;
+check_set_bounds (#2147483647l) (x 1);;
+check_get_bounds (-#1l);;
+check_set_bounds (-#1l) (x 1);;
+
+let of_boxed_index : int -> int32# = Stdlib_upstream_compatible.Int32_u.of_int
+let to_boxed_result : float32# -> float32 = Stdlib_beta.Float32_u.to_float32
+let of_boxed_result : float32 -> float32# = Stdlib_beta.Float32_u.of_float32
+let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
+let x _ = Stdlib_beta.Float32.of_float 5.0
+
+external bs_get_reference : bigstring -> int -> float32
+  = "%caml_bigstring_getf32"
+
+external bs_get_tested_s : bigstring -> int32# -> float32#
+  = "%caml_bigstring_getf32#_indexed_by_int32#"
+
+external bs_get_tested_u : bigstring -> int32# -> float32#
+  = "%caml_bigstring_getf32u#_indexed_by_int32#"
+
+external bs_set_reference
+  : bigstring -> int -> float32 -> unit
+  = "%caml_bigstring_setf32"
+
+external bs_set_tested_s
+  : bigstring -> int32# -> float32# -> unit
+  = "%caml_bigstring_setf32#_indexed_by_int32#"
+
+external bs_set_tested_u
+  : bigstring -> int32# -> float32# -> unit
+  = "%caml_bigstring_setf32u#_indexed_by_int32#"
+
+external s_get_reference : string -> int -> float32
+  = "%caml_string_getf32"
+
+external s_get_tested_s : string -> int32# -> float32#
+  = "%caml_string_getf32#_indexed_by_int32#"
+
+external s_get_tested_u : string -> int32# -> float32#
+  = "%caml_string_getf32u#_indexed_by_int32#"
+
+external s_set_reference
+  : string -> int -> float32 -> unit
+  = "%caml_string_setf32"
+
+external s_set_tested_s
+  : string -> int32# -> float32# -> unit
+  = "%caml_string_setf32#_indexed_by_int32#"
+
+external s_set_tested_u
+  : string -> int32# -> float32# -> unit
+  = "%caml_string_setf32u#_indexed_by_int32#"
+
+external b_get_reference : bytes -> int -> float32
+  = "%caml_bytes_getf32"
+
+external b_get_tested_s : bytes -> int32# -> float32#
+  = "%caml_bytes_getf32#_indexed_by_int32#"
+
+external b_get_tested_u : bytes -> int32# -> float32#
+  = "%caml_bytes_getf32u#_indexed_by_int32#"
+
+external b_set_reference
+  : bytes -> int -> float32 -> unit
+  = "%caml_bytes_setf32"
+
+external b_set_tested_s
+  : bytes -> int32# -> float32# -> unit
+  = "%caml_bytes_setf32#_indexed_by_int32#"
+
+external b_set_tested_u
+  : bytes -> int32# -> float32# -> unit
+  = "%caml_bytes_setf32u#_indexed_by_int32#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#2147483648l);;
+check_set_bounds (-#2147483648l) (x 1);;
+check_get_bounds (-#2147483647l);;
+check_set_bounds (-#2147483647l) (x 1);;
+check_get_bounds (#2147483647l);;
+check_set_bounds (#2147483647l) (x 1);;
+check_get_bounds (-#1l);;
+check_set_bounds (-#1l) (x 1);;
+
+let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
+let to_boxed_result : int -> int = fun x -> x
+let of_boxed_result : int -> int = fun x -> x
+let eq : int -> int -> bool = Int.equal
+
+let rec x = function
+  | i when i <= 0 -> Int.zero
+  | 1 ->
+      (* min int *)
+      Int.(shift_left one) (16 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 16 - 1 in
+      Int.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int.(logxor x (shift_left one (i1 mod 16))) in
+      let x = Int.(logxor x (shift_left one (i2 mod 16))) in
+      let x = Int.(logxor x (shift_left one (i3 mod 16))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int
+  = "%caml_bigstring_get16"
+
+external bs_get_tested_s : bigstring -> int64# -> int
+  = "%caml_bigstring_get16_indexed_by_int64#"
+
+external bs_get_tested_u : bigstring -> int64# -> int
+  = "%caml_bigstring_get16u_indexed_by_int64#"
+
+external bs_set_reference
+  : bigstring -> int -> int -> unit
+  = "%caml_bigstring_set16"
+
+external bs_set_tested_s
+  : bigstring -> int64# -> int -> unit
+  = "%caml_bigstring_set16_indexed_by_int64#"
+
+external bs_set_tested_u
+  : bigstring -> int64# -> int -> unit
+  = "%caml_bigstring_set16u_indexed_by_int64#"
+
+external s_get_reference : string -> int -> int
+  = "%caml_string_get16"
+
+external s_get_tested_s : string -> int64# -> int
+  = "%caml_string_get16_indexed_by_int64#"
+
+external s_get_tested_u : string -> int64# -> int
+  = "%caml_string_get16u_indexed_by_int64#"
+
+external s_set_reference
+  : string -> int -> int -> unit
+  = "%caml_string_set16"
+
+external s_set_tested_s
+  : string -> int64# -> int -> unit
+  = "%caml_string_set16_indexed_by_int64#"
+
+external s_set_tested_u
+  : string -> int64# -> int -> unit
+  = "%caml_string_set16u_indexed_by_int64#"
+
+external b_get_reference : bytes -> int -> int
+  = "%caml_bytes_get16"
+
+external b_get_tested_s : bytes -> int64# -> int
+  = "%caml_bytes_get16_indexed_by_int64#"
+
+external b_get_tested_u : bytes -> int64# -> int
+  = "%caml_bytes_get16u_indexed_by_int64#"
+
+external b_set_reference
+  : bytes -> int -> int -> unit
+  = "%caml_bytes_set16"
+
+external b_set_tested_s
+  : bytes -> int64# -> int -> unit
+  = "%caml_bytes_set16_indexed_by_int64#"
+
+external b_set_tested_u
+  : bytes -> int64# -> int -> unit
+  = "%caml_bytes_set16u_indexed_by_int64#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#9223372036854775808L);;
+check_set_bounds (-#9223372036854775808L) (x 1);;
+check_get_bounds (-#9223372036854775807L);;
+check_set_bounds (-#9223372036854775807L) (x 1);;
+check_get_bounds (#9223372036854775807L);;
+check_set_bounds (#9223372036854775807L) (x 1);;
+check_get_bounds (-#1L);;
+check_set_bounds (-#1L) (x 1);;
+
+let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
+let to_boxed_result : int32 -> int32 = fun x -> x
+let of_boxed_result : int32 -> int32 = fun x -> x
+let eq : int32 -> int32 -> bool = Int32.equal
+
+let rec x = function
+  | i when i <= 0 -> Int32.zero
+  | 1 ->
+      (* min int *)
+      Int32.(shift_left one) (32 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 32 - 1 in
+      Int32.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int32.(logxor x (shift_left one (i1 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int32
+  = "%caml_bigstring_get32"
+
+external bs_get_tested_s : bigstring -> int64# -> int32
+  = "%caml_bigstring_get32_indexed_by_int64#"
+
+external bs_get_tested_u : bigstring -> int64# -> int32
+  = "%caml_bigstring_get32u_indexed_by_int64#"
+
+external bs_set_reference
+  : bigstring -> int -> int32 -> unit
+  = "%caml_bigstring_set32"
+
+external bs_set_tested_s
+  : bigstring -> int64# -> int32 -> unit
+  = "%caml_bigstring_set32_indexed_by_int64#"
+
+external bs_set_tested_u
+  : bigstring -> int64# -> int32 -> unit
+  = "%caml_bigstring_set32u_indexed_by_int64#"
+
+external s_get_reference : string -> int -> int32
+  = "%caml_string_get32"
+
+external s_get_tested_s : string -> int64# -> int32
+  = "%caml_string_get32_indexed_by_int64#"
+
+external s_get_tested_u : string -> int64# -> int32
+  = "%caml_string_get32u_indexed_by_int64#"
+
+external s_set_reference
+  : string -> int -> int32 -> unit
+  = "%caml_string_set32"
+
+external s_set_tested_s
+  : string -> int64# -> int32 -> unit
+  = "%caml_string_set32_indexed_by_int64#"
+
+external s_set_tested_u
+  : string -> int64# -> int32 -> unit
+  = "%caml_string_set32u_indexed_by_int64#"
+
+external b_get_reference : bytes -> int -> int32
+  = "%caml_bytes_get32"
+
+external b_get_tested_s : bytes -> int64# -> int32
+  = "%caml_bytes_get32_indexed_by_int64#"
+
+external b_get_tested_u : bytes -> int64# -> int32
+  = "%caml_bytes_get32u_indexed_by_int64#"
+
+external b_set_reference
+  : bytes -> int -> int32 -> unit
+  = "%caml_bytes_set32"
+
+external b_set_tested_s
+  : bytes -> int64# -> int32 -> unit
+  = "%caml_bytes_set32_indexed_by_int64#"
+
+external b_set_tested_u
+  : bytes -> int64# -> int32 -> unit
+  = "%caml_bytes_set32u_indexed_by_int64#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#9223372036854775808L);;
+check_set_bounds (-#9223372036854775808L) (x 1);;
+check_get_bounds (-#9223372036854775807L);;
+check_set_bounds (-#9223372036854775807L) (x 1);;
+check_get_bounds (#9223372036854775807L);;
+check_set_bounds (#9223372036854775807L) (x 1);;
+check_get_bounds (-#1L);;
+check_set_bounds (-#1L) (x 1);;
+
+let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
+let to_boxed_result : int64 -> int64 = fun x -> x
+let of_boxed_result : int64 -> int64 = fun x -> x
+let eq : int64 -> int64 -> bool = Int64.equal
+
+let rec x = function
+  | i when i <= 0 -> Int64.zero
+  | 1 ->
+      (* min int *)
+      Int64.(shift_left one) (64 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 64 - 1 in
+      Int64.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int64.(logxor x (shift_left one (i1 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int64
+  = "%caml_bigstring_get64"
+
+external bs_get_tested_s : bigstring -> int64# -> int64
+  = "%caml_bigstring_get64_indexed_by_int64#"
+
+external bs_get_tested_u : bigstring -> int64# -> int64
+  = "%caml_bigstring_get64u_indexed_by_int64#"
+
+external bs_set_reference
+  : bigstring -> int -> int64 -> unit
+  = "%caml_bigstring_set64"
+
+external bs_set_tested_s
+  : bigstring -> int64# -> int64 -> unit
+  = "%caml_bigstring_set64_indexed_by_int64#"
+
+external bs_set_tested_u
+  : bigstring -> int64# -> int64 -> unit
+  = "%caml_bigstring_set64u_indexed_by_int64#"
+
+external s_get_reference : string -> int -> int64
+  = "%caml_string_get64"
+
+external s_get_tested_s : string -> int64# -> int64
+  = "%caml_string_get64_indexed_by_int64#"
+
+external s_get_tested_u : string -> int64# -> int64
+  = "%caml_string_get64u_indexed_by_int64#"
+
+external s_set_reference
+  : string -> int -> int64 -> unit
+  = "%caml_string_set64"
+
+external s_set_tested_s
+  : string -> int64# -> int64 -> unit
+  = "%caml_string_set64_indexed_by_int64#"
+
+external s_set_tested_u
+  : string -> int64# -> int64 -> unit
+  = "%caml_string_set64u_indexed_by_int64#"
+
+external b_get_reference : bytes -> int -> int64
+  = "%caml_bytes_get64"
+
+external b_get_tested_s : bytes -> int64# -> int64
+  = "%caml_bytes_get64_indexed_by_int64#"
+
+external b_get_tested_u : bytes -> int64# -> int64
+  = "%caml_bytes_get64u_indexed_by_int64#"
+
+external b_set_reference
+  : bytes -> int -> int64 -> unit
+  = "%caml_bytes_set64"
+
+external b_set_tested_s
+  : bytes -> int64# -> int64 -> unit
+  = "%caml_bytes_set64_indexed_by_int64#"
+
+external b_set_tested_u
+  : bytes -> int64# -> int64 -> unit
+  = "%caml_bytes_set64u_indexed_by_int64#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#9223372036854775808L);;
+check_set_bounds (-#9223372036854775808L) (x 1);;
+check_get_bounds (-#9223372036854775807L);;
+check_set_bounds (-#9223372036854775807L) (x 1);;
+check_get_bounds (#9223372036854775807L);;
+check_set_bounds (#9223372036854775807L) (x 1);;
+check_get_bounds (-#1L);;
+check_set_bounds (-#1L) (x 1);;
+
+let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
+let to_boxed_result : int32# -> int32 = Stdlib_upstream_compatible.Int32_u.to_int32
+let of_boxed_result : int32 -> int32# = Stdlib_upstream_compatible.Int32_u.of_int32
+let eq : int32 -> int32 -> bool = Int32.equal
+
+let rec x = function
+  | i when i <= 0 -> Int32.zero
+  | 1 ->
+      (* min int *)
+      Int32.(shift_left one) (32 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 32 - 1 in
+      Int32.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int32.(logxor x (shift_left one (i1 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i2 mod 32))) in
+      let x = Int32.(logxor x (shift_left one (i3 mod 32))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int32
+  = "%caml_bigstring_get32"
+
+external bs_get_tested_s : bigstring -> int64# -> int32#
+  = "%caml_bigstring_get32#_indexed_by_int64#"
+
+external bs_get_tested_u : bigstring -> int64# -> int32#
+  = "%caml_bigstring_get32u#_indexed_by_int64#"
+
+external bs_set_reference
+  : bigstring -> int -> int32 -> unit
+  = "%caml_bigstring_set32"
+
+external bs_set_tested_s
+  : bigstring -> int64# -> int32# -> unit
+  = "%caml_bigstring_set32#_indexed_by_int64#"
+
+external bs_set_tested_u
+  : bigstring -> int64# -> int32# -> unit
+  = "%caml_bigstring_set32u#_indexed_by_int64#"
+
+external s_get_reference : string -> int -> int32
+  = "%caml_string_get32"
+
+external s_get_tested_s : string -> int64# -> int32#
+  = "%caml_string_get32#_indexed_by_int64#"
+
+external s_get_tested_u : string -> int64# -> int32#
+  = "%caml_string_get32u#_indexed_by_int64#"
+
+external s_set_reference
+  : string -> int -> int32 -> unit
+  = "%caml_string_set32"
+
+external s_set_tested_s
+  : string -> int64# -> int32# -> unit
+  = "%caml_string_set32#_indexed_by_int64#"
+
+external s_set_tested_u
+  : string -> int64# -> int32# -> unit
+  = "%caml_string_set32u#_indexed_by_int64#"
+
+external b_get_reference : bytes -> int -> int32
+  = "%caml_bytes_get32"
+
+external b_get_tested_s : bytes -> int64# -> int32#
+  = "%caml_bytes_get32#_indexed_by_int64#"
+
+external b_get_tested_u : bytes -> int64# -> int32#
+  = "%caml_bytes_get32u#_indexed_by_int64#"
+
+external b_set_reference
+  : bytes -> int -> int32 -> unit
+  = "%caml_bytes_set32"
+
+external b_set_tested_s
+  : bytes -> int64# -> int32# -> unit
+  = "%caml_bytes_set32#_indexed_by_int64#"
+
+external b_set_tested_u
+  : bytes -> int64# -> int32# -> unit
+  = "%caml_bytes_set32u#_indexed_by_int64#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#9223372036854775808L);;
+check_set_bounds (-#9223372036854775808L) (x 1);;
+check_get_bounds (-#9223372036854775807L);;
+check_set_bounds (-#9223372036854775807L) (x 1);;
+check_get_bounds (#9223372036854775807L);;
+check_set_bounds (#9223372036854775807L) (x 1);;
+check_get_bounds (-#1L);;
+check_set_bounds (-#1L) (x 1);;
+
+let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
+let to_boxed_result : int64# -> int64 = Stdlib_upstream_compatible.Int64_u.to_int64
+let of_boxed_result : int64 -> int64# = Stdlib_upstream_compatible.Int64_u.of_int64
+let eq : int64 -> int64 -> bool = Int64.equal
+
+let rec x = function
+  | i when i <= 0 -> Int64.zero
+  | 1 ->
+      (* min int *)
+      Int64.(shift_left one) (64 - 1)
+  | 2 ->
+      (* max int *)
+      let shift = 64 - 1 in
+      Int64.(lognot (shift_left (shift_right (lognot zero) shift) shift))
+  | i ->
+      (* flip 3 "random" bits *)
+      let i1 = 3 * i and i2 = 7 * i and i3 = 11 * i in
+      let x = x (i - 1) in
+      let x = Int64.(logxor x (shift_left one (i1 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i2 mod 64))) in
+      let x = Int64.(logxor x (shift_left one (i3 mod 64))) in
+      x
+
+external bs_get_reference : bigstring -> int -> int64
+  = "%caml_bigstring_get64"
+
+external bs_get_tested_s : bigstring -> int64# -> int64#
+  = "%caml_bigstring_get64#_indexed_by_int64#"
+
+external bs_get_tested_u : bigstring -> int64# -> int64#
+  = "%caml_bigstring_get64u#_indexed_by_int64#"
+
+external bs_set_reference
+  : bigstring -> int -> int64 -> unit
+  = "%caml_bigstring_set64"
+
+external bs_set_tested_s
+  : bigstring -> int64# -> int64# -> unit
+  = "%caml_bigstring_set64#_indexed_by_int64#"
+
+external bs_set_tested_u
+  : bigstring -> int64# -> int64# -> unit
+  = "%caml_bigstring_set64u#_indexed_by_int64#"
+
+external s_get_reference : string -> int -> int64
+  = "%caml_string_get64"
+
+external s_get_tested_s : string -> int64# -> int64#
+  = "%caml_string_get64#_indexed_by_int64#"
+
+external s_get_tested_u : string -> int64# -> int64#
+  = "%caml_string_get64u#_indexed_by_int64#"
+
+external s_set_reference
+  : string -> int -> int64 -> unit
+  = "%caml_string_set64"
+
+external s_set_tested_s
+  : string -> int64# -> int64# -> unit
+  = "%caml_string_set64#_indexed_by_int64#"
+
+external s_set_tested_u
+  : string -> int64# -> int64# -> unit
+  = "%caml_string_set64u#_indexed_by_int64#"
+
+external b_get_reference : bytes -> int -> int64
+  = "%caml_bytes_get64"
+
+external b_get_tested_s : bytes -> int64# -> int64#
+  = "%caml_bytes_get64#_indexed_by_int64#"
+
+external b_get_tested_u : bytes -> int64# -> int64#
+  = "%caml_bytes_get64u#_indexed_by_int64#"
+
+external b_set_reference
+  : bytes -> int -> int64 -> unit
+  = "%caml_bytes_set64"
+
+external b_set_tested_s
+  : bytes -> int64# -> int64# -> unit
+  = "%caml_bytes_set64#_indexed_by_int64#"
+
+external b_set_tested_u
+  : bytes -> int64# -> int64# -> unit
+  = "%caml_bytes_set64u#_indexed_by_int64#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#9223372036854775808L);;
+check_set_bounds (-#9223372036854775808L) (x 1);;
+check_get_bounds (-#9223372036854775807L);;
+check_set_bounds (-#9223372036854775807L) (x 1);;
+check_get_bounds (#9223372036854775807L);;
+check_set_bounds (#9223372036854775807L) (x 1);;
+check_get_bounds (-#1L);;
+check_set_bounds (-#1L) (x 1);;
+
+let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
+let to_boxed_result : float32 -> float32 = fun x -> x
+let of_boxed_result : float32 -> float32 = fun x -> x
+let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
+let x _ = Stdlib_beta.Float32.of_float 5.0
+
+external bs_get_reference : bigstring -> int -> float32
+  = "%caml_bigstring_getf32"
+
+external bs_get_tested_s : bigstring -> int64# -> float32
+  = "%caml_bigstring_getf32_indexed_by_int64#"
+
+external bs_get_tested_u : bigstring -> int64# -> float32
+  = "%caml_bigstring_getf32u_indexed_by_int64#"
+
+external bs_set_reference
+  : bigstring -> int -> float32 -> unit
+  = "%caml_bigstring_setf32"
+
+external bs_set_tested_s
+  : bigstring -> int64# -> float32 -> unit
+  = "%caml_bigstring_setf32_indexed_by_int64#"
+
+external bs_set_tested_u
+  : bigstring -> int64# -> float32 -> unit
+  = "%caml_bigstring_setf32u_indexed_by_int64#"
+
+external s_get_reference : string -> int -> float32
+  = "%caml_string_getf32"
+
+external s_get_tested_s : string -> int64# -> float32
+  = "%caml_string_getf32_indexed_by_int64#"
+
+external s_get_tested_u : string -> int64# -> float32
+  = "%caml_string_getf32u_indexed_by_int64#"
+
+external s_set_reference
+  : string -> int -> float32 -> unit
+  = "%caml_string_setf32"
+
+external s_set_tested_s
+  : string -> int64# -> float32 -> unit
+  = "%caml_string_setf32_indexed_by_int64#"
+
+external s_set_tested_u
+  : string -> int64# -> float32 -> unit
+  = "%caml_string_setf32u_indexed_by_int64#"
+
+external b_get_reference : bytes -> int -> float32
+  = "%caml_bytes_getf32"
+
+external b_get_tested_s : bytes -> int64# -> float32
+  = "%caml_bytes_getf32_indexed_by_int64#"
+
+external b_get_tested_u : bytes -> int64# -> float32
+  = "%caml_bytes_getf32u_indexed_by_int64#"
+
+external b_set_reference
+  : bytes -> int -> float32 -> unit
+  = "%caml_bytes_setf32"
+
+external b_set_tested_s
+  : bytes -> int64# -> float32 -> unit
+  = "%caml_bytes_setf32_indexed_by_int64#"
+
+external b_set_tested_u
+  : bytes -> int64# -> float32 -> unit
+  = "%caml_bytes_setf32u_indexed_by_int64#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#9223372036854775808L);;
+check_set_bounds (-#9223372036854775808L) (x 1);;
+check_get_bounds (-#9223372036854775807L);;
+check_set_bounds (-#9223372036854775807L) (x 1);;
+check_get_bounds (#9223372036854775807L);;
+check_set_bounds (#9223372036854775807L) (x 1);;
+check_get_bounds (-#1L);;
+check_set_bounds (-#1L) (x 1);;
+
+let of_boxed_index : int -> int64# = Stdlib_upstream_compatible.Int64_u.of_int
+let to_boxed_result : float32# -> float32 = Stdlib_beta.Float32_u.to_float32
+let of_boxed_result : float32 -> float32# = Stdlib_beta.Float32_u.of_float32
+let eq : float32 -> float32 -> bool = Stdlib_beta.Float32.equal
+let x _ = Stdlib_beta.Float32.of_float 5.0
+
+external bs_get_reference : bigstring -> int -> float32
+  = "%caml_bigstring_getf32"
+
+external bs_get_tested_s : bigstring -> int64# -> float32#
+  = "%caml_bigstring_getf32#_indexed_by_int64#"
+
+external bs_get_tested_u : bigstring -> int64# -> float32#
+  = "%caml_bigstring_getf32u#_indexed_by_int64#"
+
+external bs_set_reference
+  : bigstring -> int -> float32 -> unit
+  = "%caml_bigstring_setf32"
+
+external bs_set_tested_s
+  : bigstring -> int64# -> float32# -> unit
+  = "%caml_bigstring_setf32#_indexed_by_int64#"
+
+external bs_set_tested_u
+  : bigstring -> int64# -> float32# -> unit
+  = "%caml_bigstring_setf32u#_indexed_by_int64#"
+
+external s_get_reference : string -> int -> float32
+  = "%caml_string_getf32"
+
+external s_get_tested_s : string -> int64# -> float32#
+  = "%caml_string_getf32#_indexed_by_int64#"
+
+external s_get_tested_u : string -> int64# -> float32#
+  = "%caml_string_getf32u#_indexed_by_int64#"
+
+external s_set_reference
+  : string -> int -> float32 -> unit
+  = "%caml_string_setf32"
+
+external s_set_tested_s
+  : string -> int64# -> float32# -> unit
+  = "%caml_string_setf32#_indexed_by_int64#"
+
+external s_set_tested_u
+  : string -> int64# -> float32# -> unit
+  = "%caml_string_setf32u#_indexed_by_int64#"
+
+external b_get_reference : bytes -> int -> float32
+  = "%caml_bytes_getf32"
+
+external b_get_tested_s : bytes -> int64# -> float32#
+  = "%caml_bytes_getf32#_indexed_by_int64#"
+
+external b_get_tested_u : bytes -> int64# -> float32#
+  = "%caml_bytes_getf32u#_indexed_by_int64#"
+
+external b_set_reference
+  : bytes -> int -> float32 -> unit
+  = "%caml_bytes_setf32"
+
+external b_set_tested_s
+  : bytes -> int64# -> float32# -> unit
+  = "%caml_bytes_setf32#_indexed_by_int64#"
+
+external b_set_tested_u
+  : bytes -> int64# -> float32# -> unit
+  = "%caml_bytes_setf32u#_indexed_by_int64#"
+
+let check_get_bounds, check_get, check_set_bounds, check_set =
+  let create_checkers create reference_get reference_set get_s get_u set_s
+      set_u =
+    let for_ref = create () and for_s = create () and for_u = create () in
+    let check_get_bounds i =
+      try
+        let _ = get_s for_s i in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_set_bounds i x =
+      let test_x = of_boxed_result x in
+      try
+        let _ = set_s for_s i test_x in
+        assert false
+      with Invalid_argument _ -> ()
+    in
+    let check_get i =
+      let test_i = of_boxed_index i in
+      try
+        let res = reference_get for_ref i in
+        try
+          assert (eq res (to_boxed_result (get_s for_s test_i)));
+          assert (eq res (to_boxed_result (get_u for_u test_i)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_get_bounds (of_boxed_index i)
+      | _ -> (
+          try
+            let _ = get_s for_s test_i in
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    let check_set i x =
+      let test_i = of_boxed_index i in
+      let test_x = of_boxed_result x in
+      try
+        reference_set for_ref i x;
+        try
+          set_s for_s test_i test_x;
+          assert (eq x (reference_get for_s i));
+          set_u for_u test_i test_x;
+          assert (eq x (reference_get for_u i));
+          (* Check that we didn't ruin adjacent indices *)
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_s (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_s (i + 1)));
+          assert (
+            eq (reference_get for_ref (i - 1)) (reference_get for_u (i - 1)));
+          assert (
+            eq (reference_get for_ref (i + 1)) (reference_get for_u (i + 1)))
+        with _ -> assert false
+      with
+      | Invalid_argument _ -> check_set_bounds (of_boxed_index i) x
+      | _ -> (
+          try
+            set_s for_s test_i test_x;
+            assert false
+          with
+          | Invalid_argument _ -> assert false
+          | _ -> ())
+    in
+    (check_get_bounds, check_get, check_set_bounds, check_set)
+  in
+  let gb_for_bs, g_for_bs, sb_for_bs, s_for_bs =
+    create_checkers create_bs bs_get_reference bs_set_reference
+      bs_get_tested_s bs_get_tested_u bs_set_tested_s bs_set_tested_u in
+  let gb_for_s, g_for_s, sb_for_s, s_for_s =
+    create_checkers create_s s_get_reference s_set_reference
+      s_get_tested_s s_get_tested_u s_set_tested_s s_set_tested_u in
+  let gb_for_b, g_for_b, sb_for_b, s_for_b =
+    create_checkers create_b b_get_reference b_set_reference
+      b_get_tested_s b_get_tested_u b_set_tested_s b_set_tested_u in
+  ( (fun i -> gb_for_bs i; gb_for_s i; gb_for_b i)
+  , (fun i -> g_for_bs i; g_for_s i; g_for_b i)
+  , (fun i x -> sb_for_bs i x; sb_for_s i x; sb_for_b i x)
+  , (fun i x -> s_for_bs i x; s_for_s i x; s_for_b i x) )
+;;
+
+for i = -1 to length + 1 do
+  check_get i;
+  check_set i (x i)
+done
+;;
+
+check_get_bounds (-#9223372036854775808L);;
+check_set_bounds (-#9223372036854775808L) (x 1);;
+check_get_bounds (-#9223372036854775807L);;
+check_set_bounds (-#9223372036854775807L) (x 1);;
+check_get_bounds (#9223372036854775807L);;
+check_set_bounds (#9223372036854775807L) (x 1);;
+check_get_bounds (-#1L);;
+check_set_bounds (-#1L) (x 1);;

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -493,20 +493,28 @@ let prim_has_valid_reprs ~loc prim =
           ("64", "#", Bits64);
         ]
       in
+      let indices : (_ * Jkind_types.Sort.const) list =
+        [
+          ("", Value);
+          ("_indexed_by_nativeint#", Word);
+          ("_indexed_by_int32#", Bits32);
+          ("_indexed_by_int64#", Bits64);
+        ]
+      in
       let combiners =
         [
-          ( Printf.sprintf "%%caml_%s_get%s%s%s",
-            fun width_kind ->
+          ( Printf.sprintf "%%caml_%s_get%s%s%s%s",
+            fun index_kind width_kind ->
               [
                 Same_as_ocaml_repr Value;
-                Same_as_ocaml_repr Value;
+                Same_as_ocaml_repr index_kind;
                 Same_as_ocaml_repr width_kind;
               ] );
-          ( Printf.sprintf "%%caml_%s_set%s%s%s",
-            fun width_kind ->
+          ( Printf.sprintf "%%caml_%s_set%s%s%s%s",
+            fun index_kind width_kind ->
               [
                 Same_as_ocaml_repr Value;
-                Same_as_ocaml_repr Value;
+                Same_as_ocaml_repr index_kind;
                 Same_as_ocaml_repr width_kind;
                 Same_as_ocaml_repr Value;
               ] );
@@ -515,12 +523,14 @@ let prim_has_valid_reprs ~loc prim =
       (let ( let* ) x f = List.concat_map f x in
        let* container = [ "bigstring"; "bytes"; "string" ] in
        let* safe_sigil = [ ""; "u" ] in
+       let* index_sigil, index_kind = indices in
        let* width_sigil, unboxed_sigil, width_kind = widths in
        let* combine_string, combine_repr = combiners in
        let string =
          combine_string container width_sigil safe_sigil unboxed_sigil
+           index_sigil
        in
-       let reprs = combine_repr width_kind in
+       let reprs = combine_repr index_kind width_kind in
        [ (string, reprs) ])
       |> List.to_seq
       |> fun seq -> String.Map.add_seq seq String.Map.empty

--- a/tests/simd/arrays.ml
+++ b/tests/simd/arrays.ml
@@ -26,13 +26,14 @@ let eq lv hv l h =
   if h <> hv then Printf.printf "%016Lx <> %016Lx\n" hv h
 ;;
 
-module Bytes = struct
-
-  external get_int8x16_unaligned : bytes -> int -> int8x16 = "%caml_bytes_getu128"
-  external get_int8x16_unaligned_unsafe : bytes -> int -> int8x16 = "%caml_bytes_getu128u"
-
-  external set_int8x16_unaligned : bytes -> int -> int8x16 -> unit = "%caml_bytes_setu128"
-  external set_int8x16_unaligned_unsafe : bytes -> int -> int8x16 -> unit = "%caml_bytes_setu128u"
+module Bytes (Primitives : sig
+  val get_int8x16_unaligned : bytes -> int -> int8x16
+  val get_int8x16_unaligned_unsafe : bytes -> int -> int8x16
+  val set_int8x16_unaligned : bytes -> int -> int8x16 -> unit
+  val set_int8x16_unaligned_unsafe : bytes -> int -> int8x16 -> unit
+end) =
+struct
+  open Primitives
 
   let data = Bytes.of_string "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x00\x01\x02\x03\x04\x05\x06\x07"
 
@@ -100,10 +101,56 @@ module Bytes = struct
   ;;
 end
 
-module String_ = struct
+module _ = Bytes(struct
+  external get_int8x16_unaligned : bytes -> int -> int8x16 = "%caml_bytes_getu128"
+  external get_int8x16_unaligned_unsafe : bytes -> int -> int8x16 = "%caml_bytes_getu128u"
 
-  external get_int8x16_unaligned : string -> int -> int8x16 = "%caml_string_getu128"
-  external get_int8x16_unaligned_unsafe : string -> int -> int8x16 = "%caml_string_getu128u"
+  external set_int8x16_unaligned : bytes -> int -> int8x16 -> unit = "%caml_bytes_setu128"
+  external set_int8x16_unaligned_unsafe : bytes -> int -> int8x16 -> unit = "%caml_bytes_setu128u"
+end)
+
+module _ = Bytes(struct
+  external get_int8x16_unaligned : bytes -> int32# -> int8x16 = "%caml_bytes_getu128_indexed_by_int32#"
+  let get_int8x16_unaligned b i = get_int8x16_unaligned b (Stdlib_upstream_compatible.Int32_u.of_int i)
+  external get_int8x16_unaligned_unsafe : bytes -> int32# -> int8x16 = "%caml_bytes_getu128u_indexed_by_int32#"
+  let get_int8x16_unaligned_unsafe b i = get_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Int32_u.of_int i)
+
+  external set_int8x16_unaligned : bytes -> int32# -> int8x16 -> unit = "%caml_bytes_setu128_indexed_by_int32#"
+  let set_int8x16_unaligned b i v = set_int8x16_unaligned b (Stdlib_upstream_compatible.Int32_u.of_int i) v
+  external set_int8x16_unaligned_unsafe : bytes -> int32# -> int8x16 -> unit = "%caml_bytes_setu128u_indexed_by_int32#"
+  let set_int8x16_unaligned_unsafe b i v = set_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Int32_u.of_int i) v
+end)
+
+module _ = Bytes(struct
+  external get_int8x16_unaligned : bytes -> int64# -> int8x16 = "%caml_bytes_getu128_indexed_by_int64#"
+  let get_int8x16_unaligned b i = get_int8x16_unaligned b (Stdlib_upstream_compatible.Int64_u.of_int i)
+  external get_int8x16_unaligned_unsafe : bytes -> int64# -> int8x16 = "%caml_bytes_getu128u_indexed_by_int64#"
+  let get_int8x16_unaligned_unsafe b i = get_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Int64_u.of_int i)
+
+  external set_int8x16_unaligned : bytes -> int64# -> int8x16 -> unit = "%caml_bytes_setu128_indexed_by_int64#"
+  let set_int8x16_unaligned b i v = set_int8x16_unaligned b (Stdlib_upstream_compatible.Int64_u.of_int i) v
+  external set_int8x16_unaligned_unsafe : bytes -> int64# -> int8x16 -> unit = "%caml_bytes_setu128u_indexed_by_int64#"
+  let set_int8x16_unaligned_unsafe b i v = set_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Int64_u.of_int i) v
+end)
+
+module _ = Bytes(struct
+  external get_int8x16_unaligned : bytes -> nativeint# -> int8x16 = "%caml_bytes_getu128_indexed_by_nativeint#"
+  let get_int8x16_unaligned b i = get_int8x16_unaligned b (Stdlib_upstream_compatible.Nativeint_u.of_int i)
+  external get_int8x16_unaligned_unsafe : bytes -> nativeint# -> int8x16 = "%caml_bytes_getu128u_indexed_by_nativeint#"
+  let get_int8x16_unaligned_unsafe b i = get_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Nativeint_u.of_int i)
+
+  external set_int8x16_unaligned : bytes -> nativeint# -> int8x16 -> unit = "%caml_bytes_setu128_indexed_by_nativeint#"
+  let set_int8x16_unaligned b i v = set_int8x16_unaligned b (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
+  external set_int8x16_unaligned_unsafe : bytes -> nativeint# -> int8x16 -> unit = "%caml_bytes_setu128u_indexed_by_nativeint#"
+  let set_int8x16_unaligned_unsafe b i v = set_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
+end)
+
+module String_ (Primitives : sig
+  val get_int8x16_unaligned : string -> int -> int8x16
+  val get_int8x16_unaligned_unsafe : string -> int -> int8x16
+end) =
+struct
+  open Primitives
 
   let data = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x00\x01\x02\x03\x04\x05\x06\x07"
 
@@ -133,137 +180,243 @@ module String_ = struct
   ;;
 end
 
-module Bigstring = struct
+module _ = String_(struct
+  external get_int8x16_unaligned : string -> int -> int8x16 = "%caml_string_getu128"
+  external get_int8x16_unaligned_unsafe : string -> int -> int8x16 = "%caml_string_getu128u"
+end)
 
+module _ = String_(struct
+  external get_int8x16_unaligned : string -> int32# -> int8x16 = "%caml_string_getu128_indexed_by_int32#"
+  let get_int8x16_unaligned b i = get_int8x16_unaligned b (Stdlib_upstream_compatible.Int32_u.of_int i)
+  external get_int8x16_unaligned_unsafe : string -> int32# -> int8x16 = "%caml_string_getu128u_indexed_by_int32#"
+  let get_int8x16_unaligned_unsafe b i = get_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Int32_u.of_int i)
+end)
+
+module _ = String_(struct
+  external get_int8x16_unaligned : string -> int64# -> int8x16 = "%caml_string_getu128_indexed_by_int64#"
+  let get_int8x16_unaligned b i = get_int8x16_unaligned b (Stdlib_upstream_compatible.Int64_u.of_int i)
+  external get_int8x16_unaligned_unsafe : string -> int64# -> int8x16 = "%caml_string_getu128u_indexed_by_int64#"
+  let get_int8x16_unaligned_unsafe b i = get_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Int64_u.of_int i)
+end)
+
+module _ = String_(struct
+  external get_int8x16_unaligned : string -> nativeint# -> int8x16 = "%caml_string_getu128_indexed_by_nativeint#"
+  let get_int8x16_unaligned b i = get_int8x16_unaligned b (Stdlib_upstream_compatible.Nativeint_u.of_int i)
+  external get_int8x16_unaligned_unsafe : string -> nativeint# -> int8x16 = "%caml_string_getu128u_indexed_by_nativeint#"
+  let get_int8x16_unaligned_unsafe b i = get_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Nativeint_u.of_int i)
+end)
+
+open struct
   open Bigarray
   type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t
 
-  let bigstring_of_string s =
-    let a = Array1.create char c_layout (String.length s) in
-    for i = 0 to String.length s - 1 do
-      a.{i} <- s.[i]
-    done;
-    a
+  module Bigstring (Primitives : sig
+    val get_int8x16_unaligned : bigstring -> int -> int8x16
+    val get_int8x16_unaligned_unsafe : bigstring -> int -> int8x16
+    val get_int8x16_aligned : bigstring -> int -> int8x16
+    val get_int8x16_aligned_unsafe : bigstring -> int -> int8x16
 
-  external get_int8x16_unaligned : bigstring -> int -> int8x16 = "%caml_bigstring_getu128"
-  external get_int8x16_unaligned_unsafe : bigstring -> int -> int8x16 = "%caml_bigstring_getu128u"
-  external get_int8x16_aligned : bigstring -> int -> int8x16 = "%caml_bigstring_geta128"
-  external get_int8x16_aligned_unsafe : bigstring -> int -> int8x16 = "%caml_bigstring_geta128u"
+    val set_int8x16_unaligned : bigstring -> int -> int8x16 -> unit
+    val set_int8x16_unaligned_unsafe : bigstring -> int -> int8x16 -> unit
+    val set_int8x16_aligned : bigstring -> int -> int8x16 -> unit
+    val set_int8x16_aligned_unsafe : bigstring -> int -> int8x16 -> unit
+  end) =
+  struct
+    open Primitives
 
-  external set_int8x16_unaligned : bigstring -> int -> int8x16 -> unit = "%caml_bigstring_setu128"
-  external set_int8x16_unaligned_unsafe : bigstring -> int -> int8x16 -> unit = "%caml_bigstring_setu128u"
-  external set_int8x16_aligned : bigstring -> int -> int8x16 -> unit = "%caml_bigstring_seta128"
-  external set_int8x16_aligned_unsafe : bigstring -> int -> int8x16 -> unit = "%caml_bigstring_seta128u"
+    let bigstring_of_string s =
+      let a = Array1.create char c_layout (String.length s) in
+      for i = 0 to String.length s - 1 do
+        a.{i} <- s.[i]
+      done;
+      a
 
-  (* Data is allocated off-heap, and will always be 16-byte aligned. *)
-  let data = bigstring_of_string "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x00\x01\x02\x03\x04\x05\x06\x07"
+    (* Data is allocated off-heap, and will always be 16-byte aligned. *)
+    let data = bigstring_of_string "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x00\x01\x02\x03\x04\x05\x06\x07"
 
-  let low = 0x0706050403020100L
-  let high = 0x0f0e0d0c0b0a0908L
+    let low = 0x0706050403020100L
+    let high = 0x0f0e0d0c0b0a0908L
 
-  (* Getters *)
+    (* Getters *)
 
-  let () =
-    let v = get_int8x16_unaligned data 0 in
-    eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
-    let v = get_int8x16_unaligned_unsafe data 0 in
-    eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
-    let v = get_int8x16_unaligned data 8 in
-    eq high low (int8x16_low_int64 v) (int8x16_high_int64 v);
-    let v = get_int8x16_unaligned_unsafe data 8 in
-    eq high low (int8x16_low_int64 v) (int8x16_high_int64 v);
-  ;;
+    let () =
+      let v = get_int8x16_unaligned data 0 in
+      eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
+      let v = get_int8x16_unaligned_unsafe data 0 in
+      eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
+      let v = get_int8x16_unaligned data 8 in
+      eq high low (int8x16_low_int64 v) (int8x16_high_int64 v);
+      let v = get_int8x16_unaligned_unsafe data 8 in
+      eq high low (int8x16_low_int64 v) (int8x16_high_int64 v);
+    ;;
 
-  let () =
-    for bad = 9 to 24 do
-      try
-        let _ = get_int8x16_unaligned data bad in
-        assert false
-      with | Invalid_argument s when s = "index out of bounds" -> ()
-    done;
-  ;;
+    let () =
+      for bad = 9 to 24 do
+        try
+          let _ = get_int8x16_unaligned data bad in
+          assert false
+        with | Invalid_argument s when s = "index out of bounds" -> ()
+      done;
+    ;;
 
-  let () =
-    let v = get_int8x16_aligned data 0 in
-    eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
-    let v = get_int8x16_aligned_unsafe data 0 in
-    eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
-    for bad = 1 to 8 do
-      try
-        let _ = get_int8x16_aligned data bad in
-        assert false
-      with | Invalid_argument s when s = "address was misaligned" -> ()
-    done;
-    for bad = 9 to 24 do
-      try
-        let _ = get_int8x16_aligned data bad in
-        assert false
-      with | Invalid_argument s when s = "index out of bounds" -> ()
-    done;
-  ;;
+    let () =
+      let v = get_int8x16_aligned data 0 in
+      eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
+      let v = get_int8x16_aligned_unsafe data 0 in
+      eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
+      for bad = 1 to 8 do
+        try
+          let _ = get_int8x16_aligned data bad in
+          assert false
+        with | Invalid_argument s when s = "address was misaligned" -> ()
+      done;
+      for bad = 9 to 24 do
+        try
+          let _ = get_int8x16_aligned data bad in
+          assert false
+        with | Invalid_argument s when s = "index out of bounds" -> ()
+      done;
+    ;;
 
-  (* Setters *)
+    (* Setters *)
 
-  let set_unaligned low high offset =
-    let set = int8x16_of_int64s low high in
-    set_int8x16_unaligned data offset set;
-    let v = get_int8x16_unaligned data offset in
-    eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
-  ;;
+    let set_unaligned low high offset =
+      let set = int8x16_of_int64s low high in
+      set_int8x16_unaligned data offset set;
+      let v = get_int8x16_unaligned data offset in
+      eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
+    ;;
 
-  let set_unaligned_unsafe low high offset =
-    let set = int8x16_of_int64s low high in
-    set_int8x16_unaligned_unsafe data offset set;
-    let v = get_int8x16_unaligned data offset in
-    eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
-  ;;
+    let set_unaligned_unsafe low high offset =
+      let set = int8x16_of_int64s low high in
+      set_int8x16_unaligned_unsafe data offset set;
+      let v = get_int8x16_unaligned data offset in
+      eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
+    ;;
 
-  let set_aligned low high offset =
-    let set = int8x16_of_int64s low high in
-    set_int8x16_aligned data offset set;
-    let v = get_int8x16_aligned data offset in
-    eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
-  ;;
+    let set_aligned low high offset =
+      let set = int8x16_of_int64s low high in
+      set_int8x16_aligned data offset set;
+      let v = get_int8x16_aligned data offset in
+      eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
+    ;;
 
-  let set_aligned_unsafe low high offset =
-    let set = int8x16_of_int64s low high in
-    set_int8x16_aligned_unsafe data offset set;
-    let v = get_int8x16_aligned_unsafe data offset in
-    eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
-  ;;
+    let set_aligned_unsafe low high offset =
+      let set = int8x16_of_int64s low high in
+      set_int8x16_aligned_unsafe data offset set;
+      let v = get_int8x16_aligned_unsafe data offset in
+      eq low high (int8x16_low_int64 v) (int8x16_high_int64 v);
+    ;;
 
-  let () =
-    set_unaligned 0x1010101010101010L 0x1010101010101010L 0;
-    set_unaligned 0x2020202020202020L 0x2020202020202020L 8;
-    set_unaligned_unsafe 0x3030303030303030L 0x3030303030303030L 0;
-    set_unaligned_unsafe 0x4040404040404040L 0x4040404040404040L 8;
-    set_aligned 0x5050505050505050L 0x5050505050505050L 0;
-    set_aligned_unsafe 0x6060606060606060L 0x6060606060606060L 0;
-    Random.init 1234;
-    for _ = 1 to 1000 do
-      set_unaligned (Random.int64 Int64.max_int) (Random.int64 Int64.max_int) (Random.int 9);
-      set_unaligned_unsafe (Random.int64 Int64.max_int) (Random.int64 Int64.max_int) (Random.int 9);
-      set_aligned (Random.int64 Int64.max_int) (Random.int64 Int64.max_int) 0;
-      set_aligned_unsafe (Random.int64 Int64.max_int) (Random.int64 Int64.max_int) 0;
-    done;
-  ;;
+    let () =
+      set_unaligned 0x1010101010101010L 0x1010101010101010L 0;
+      set_unaligned 0x2020202020202020L 0x2020202020202020L 8;
+      set_unaligned_unsafe 0x3030303030303030L 0x3030303030303030L 0;
+      set_unaligned_unsafe 0x4040404040404040L 0x4040404040404040L 8;
+      set_aligned 0x5050505050505050L 0x5050505050505050L 0;
+      set_aligned_unsafe 0x6060606060606060L 0x6060606060606060L 0;
+      Random.init 1234;
+      for _ = 1 to 1000 do
+        set_unaligned (Random.int64 Int64.max_int) (Random.int64 Int64.max_int) (Random.int 9);
+        set_unaligned_unsafe (Random.int64 Int64.max_int) (Random.int64 Int64.max_int) (Random.int 9);
+        set_aligned (Random.int64 Int64.max_int) (Random.int64 Int64.max_int) 0;
+        set_aligned_unsafe (Random.int64 Int64.max_int) (Random.int64 Int64.max_int) 0;
+      done;
+    ;;
 
-  let () =
-    let set = int8x16_of_int64s 0xFFFFFFFFFFFFFFFFL 0xFFFFFFFFFFFFFFFFL in
-    for bad = 1 to 8 do
-      try
-        let _ = set_int8x16_aligned data bad set in
-        assert false
-      with | Invalid_argument s when s = "address was misaligned" -> ()
-    done;
-    for bad = 9 to 24 do
-      try
-        let _ = get_int8x16_aligned data bad in
-        assert false
-      with | Invalid_argument s when s = "index out of bounds" -> ()
-    done;
-  ;;
+    let () =
+      let set = int8x16_of_int64s 0xFFFFFFFFFFFFFFFFL 0xFFFFFFFFFFFFFFFFL in
+      for bad = 1 to 8 do
+        try
+          let _ = set_int8x16_aligned data bad set in
+          assert false
+        with | Invalid_argument s when s = "address was misaligned" -> ()
+      done;
+      for bad = 9 to 24 do
+        try
+          let _ = get_int8x16_aligned data bad in
+          assert false
+        with | Invalid_argument s when s = "index out of bounds" -> ()
+      done;
+    ;;
+  end
+
+  module _ = Bigstring(struct
+    external get_int8x16_unaligned : bigstring -> int -> int8x16 = "%caml_bigstring_getu128"
+    external get_int8x16_unaligned_unsafe : bigstring -> int -> int8x16 = "%caml_bigstring_getu128u"
+    external get_int8x16_aligned : bigstring -> int -> int8x16 = "%caml_bigstring_geta128"
+    external get_int8x16_aligned_unsafe : bigstring -> int -> int8x16 = "%caml_bigstring_geta128u"
+
+    external set_int8x16_unaligned : bigstring -> int -> int8x16 -> unit = "%caml_bigstring_setu128"
+    external set_int8x16_unaligned_unsafe : bigstring -> int -> int8x16 -> unit = "%caml_bigstring_setu128u"
+    external set_int8x16_aligned : bigstring -> int -> int8x16 -> unit = "%caml_bigstring_seta128"
+    external set_int8x16_aligned_unsafe : bigstring -> int -> int8x16 -> unit = "%caml_bigstring_seta128u"
+  end)
+
+  module _ = Bigstring(struct
+    external get_int8x16_unaligned : bigstring -> int32# -> int8x16 = "%caml_bigstring_getu128_indexed_by_int32#"
+    let get_int8x16_unaligned b i = get_int8x16_unaligned b (Stdlib_upstream_compatible.Int32_u.of_int i)
+    external get_int8x16_unaligned_unsafe : bigstring -> int32# -> int8x16 = "%caml_bigstring_getu128u_indexed_by_int32#"
+    let get_int8x16_unaligned_unsafe b i = get_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Int32_u.of_int i)
+    external get_int8x16_aligned : bigstring -> int32# -> int8x16 = "%caml_bigstring_geta128_indexed_by_int32#"
+    let get_int8x16_aligned b i = get_int8x16_aligned b (Stdlib_upstream_compatible.Int32_u.of_int i)
+    external get_int8x16_aligned_unsafe : bigstring -> int32# -> int8x16 = "%caml_bigstring_geta128u_indexed_by_int32#"
+    let get_int8x16_aligned_unsafe b i = get_int8x16_aligned_unsafe b (Stdlib_upstream_compatible.Int32_u.of_int i)
+
+    external set_int8x16_unaligned : bigstring -> int32# -> int8x16 -> unit = "%caml_bigstring_setu128_indexed_by_int32#"
+    let set_int8x16_unaligned b i v = set_int8x16_unaligned b (Stdlib_upstream_compatible.Int32_u.of_int i) v
+    external set_int8x16_unaligned_unsafe : bigstring -> int32# -> int8x16 -> unit = "%caml_bigstring_setu128u_indexed_by_int32#"
+    let set_int8x16_unaligned_unsafe b i v = set_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Int32_u.of_int i) v
+    external set_int8x16_aligned : bigstring -> int32# -> int8x16 -> unit = "%caml_bigstring_seta128_indexed_by_int32#"
+    let set_int8x16_aligned b i v = set_int8x16_aligned b (Stdlib_upstream_compatible.Int32_u.of_int i) v
+    external set_int8x16_aligned_unsafe : bigstring -> int32# -> int8x16 -> unit = "%caml_bigstring_seta128u_indexed_by_int32#"
+    let set_int8x16_aligned_unsafe b i v = set_int8x16_aligned_unsafe b (Stdlib_upstream_compatible.Int32_u.of_int i) v
+  end)
+
+  module _ = Bigstring(struct
+    external get_int8x16_unaligned : bigstring -> int64# -> int8x16 = "%caml_bigstring_getu128_indexed_by_int64#"
+    let get_int8x16_unaligned b i = get_int8x16_unaligned b (Stdlib_upstream_compatible.Int64_u.of_int i)
+    external get_int8x16_unaligned_unsafe : bigstring -> int64# -> int8x16 = "%caml_bigstring_getu128u_indexed_by_int64#"
+    let get_int8x16_unaligned_unsafe b i = get_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Int64_u.of_int i)
+    external get_int8x16_aligned : bigstring -> int64# -> int8x16 = "%caml_bigstring_geta128_indexed_by_int64#"
+    let get_int8x16_aligned b i = get_int8x16_aligned b (Stdlib_upstream_compatible.Int64_u.of_int i)
+    external get_int8x16_aligned_unsafe : bigstring -> int64# -> int8x16 = "%caml_bigstring_geta128u_indexed_by_int64#"
+    let get_int8x16_aligned_unsafe b i = get_int8x16_aligned_unsafe b (Stdlib_upstream_compatible.Int64_u.of_int i)
+
+    external set_int8x16_unaligned : bigstring -> int64# -> int8x16 -> unit = "%caml_bigstring_setu128_indexed_by_int64#"
+    let set_int8x16_unaligned b i v = set_int8x16_unaligned b (Stdlib_upstream_compatible.Int64_u.of_int i) v
+    external set_int8x16_unaligned_unsafe : bigstring -> int64# -> int8x16 -> unit = "%caml_bigstring_setu128u_indexed_by_int64#"
+    let set_int8x16_unaligned_unsafe b i v = set_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Int64_u.of_int i) v
+    external set_int8x16_aligned : bigstring -> int64# -> int8x16 -> unit = "%caml_bigstring_seta128_indexed_by_int64#"
+    let set_int8x16_aligned b i v = set_int8x16_aligned b (Stdlib_upstream_compatible.Int64_u.of_int i) v
+    external set_int8x16_aligned_unsafe : bigstring -> int64# -> int8x16 -> unit = "%caml_bigstring_seta128u_indexed_by_int64#"
+    let set_int8x16_aligned_unsafe b i v = set_int8x16_aligned_unsafe b (Stdlib_upstream_compatible.Int64_u.of_int i) v
+  end)
+
+  module _ = Bigstring(struct
+    external get_int8x16_unaligned : bigstring -> nativeint# -> int8x16 = "%caml_bigstring_getu128_indexed_by_nativeint#"
+    let get_int8x16_unaligned b i = get_int8x16_unaligned b (Stdlib_upstream_compatible.Nativeint_u.of_int i)
+    external get_int8x16_unaligned_unsafe : bigstring -> nativeint# -> int8x16 = "%caml_bigstring_getu128u_indexed_by_nativeint#"
+    let get_int8x16_unaligned_unsafe b i = get_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Nativeint_u.of_int i)
+    external get_int8x16_aligned : bigstring -> nativeint# -> int8x16 = "%caml_bigstring_geta128_indexed_by_nativeint#"
+    let get_int8x16_aligned b i = get_int8x16_aligned b (Stdlib_upstream_compatible.Nativeint_u.of_int i)
+    external get_int8x16_aligned_unsafe : bigstring -> nativeint# -> int8x16 = "%caml_bigstring_geta128u_indexed_by_nativeint#"
+    let get_int8x16_aligned_unsafe b i = get_int8x16_aligned_unsafe b (Stdlib_upstream_compatible.Nativeint_u.of_int i)
+
+    external set_int8x16_unaligned : bigstring -> nativeint# -> int8x16 -> unit = "%caml_bigstring_setu128_indexed_by_nativeint#"
+    let set_int8x16_unaligned b i v = set_int8x16_unaligned b (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
+    external set_int8x16_unaligned_unsafe : bigstring -> nativeint# -> int8x16 -> unit = "%caml_bigstring_setu128u_indexed_by_nativeint#"
+    let set_int8x16_unaligned_unsafe b i v = set_int8x16_unaligned_unsafe b (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
+    external set_int8x16_aligned : bigstring -> nativeint# -> int8x16 -> unit = "%caml_bigstring_seta128_indexed_by_nativeint#"
+    let set_int8x16_aligned b i v = set_int8x16_aligned b (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
+    external set_int8x16_aligned_unsafe : bigstring -> nativeint# -> int8x16 -> unit = "%caml_bigstring_seta128u_indexed_by_nativeint#"
+    let set_int8x16_aligned_unsafe b i v = set_int8x16_aligned_unsafe b (Stdlib_upstream_compatible.Nativeint_u.of_int i) v
+  end)
 end
+
+(* CR layouts: Test more edge-cases for unboxed indices *)
+
+(* CR layouts: Consider generating bindings? *)
 
 module Float_arrays = struct
 

--- a/tests/simd/dune
+++ b/tests/simd/dune
@@ -19,7 +19,7 @@
 (executables
  (names basic ops arrays scalar_ops consts)
  (modules basic ops arrays scalar_ops consts)
- (libraries simd_test_helpers stdlib_stable)
+ (libraries simd_test_helpers stdlib_stable stdlib_upstream_compatible)
  (foreign_archives stubs)
  (ocamlopt_flags
   (:standard -extension simd)))
@@ -92,7 +92,7 @@
   consts_nodynlink
   arrays_nodynlink
   scalar_ops_nodynlink)
- (libraries simd_test_helpers stdlib_stable)
+ (libraries simd_test_helpers stdlib_stable stdlib_upstream_compatible)
  (foreign_archives stubs)
  (ocamlopt_flags
   (:standard -extension simd -nodynlink)))
@@ -182,7 +182,7 @@
   consts_internal
   arrays_internal
   scalar_ops_internal)
- (libraries simd_test_helpers stdlib_stable)
+ (libraries simd_test_helpers stdlib_stable stdlib_upstream_compatible)
  (enabled_if
   (<> %{system} macosx))
  (foreign_archives stubs)


### PR DESCRIPTION
Add primitives for:
- Load/store
- From: `bigstring`, `string`, and `bytes`
- Index by: `int`, `int32#`, `int64#`, `nativeint#`
- Data width: `int16`, `int32`, `float32`, `int64`, `int128` (both boxed and unboxed when possible)

I add tests of operation over `int128` to the `simd/arrays.ml` test. `tests/typing-layouts/generate_stringlike_indexing.ml` generates a test (`tests/typing-layouts/unboxed_int_stringlike_indexing.ml`) that stresses the remaining primitives.