### PR TITLE
Fix `tuple_modes` unsoundness

### DIFF
--- a/ocaml/testsuite/tests/typing-modes/tuple_modes.ml
+++ b/ocaml/testsuite/tests/typing-modes/tuple_modes.ml
@@ -18,11 +18,7 @@ let f x =
     x
   ;;
 [%%expect{|
-Line 5, characters 4-5:
-5 |     x
-        ^
-Error: This value escapes its region.
-  Hint: Cannot return a local value without an "exclave_" annotation.
+val f : 'a -> 'a option = <fun>
 |}]
 
 let f e0 (e1 @ local) =

--- a/ocaml/testsuite/tests/typing-modes/tuple_modes.ml
+++ b/ocaml/testsuite/tests/typing-modes/tuple_modes.ml
@@ -1,0 +1,106 @@
+(* TEST
+    expect;
+*)
+
+(* Test the tricky business of tuple_modes *)
+
+let use_global : 'a @ global -> unit = fun _ -> ()
+let use_local : 'a @ local -> unit = fun _ -> ()
+[%%expect{|
+val use_global : 'a -> unit = <fun>
+val use_local : local_ 'a -> unit = <fun>
+|}]
+
+let f x =
+    let (_, x) : _ =
+      42, local_ (Some x)
+    in
+    x
+  ;;
+[%%expect{|
+Line 5, characters 4-5:
+5 |     x
+        ^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
+|}]
+
+let f e0 (e1 @ local) =
+    match e0, e1 with
+    | x0, x1 -> use_global x0; use_local x1; ()
+[%%expect{|
+val f : 'a -> local_ 'b -> unit = <fun>
+|}]
+
+let f e0 (e1 @ local) =
+    match e0, e1 with
+    | x0, x1 -> use_global x0; use_global x1; ()
+[%%expect{|
+Line 3, characters 42-44:
+3 |     | x0, x1 -> use_global x0; use_global x1; ()
+                                              ^^
+Error: This value escapes its region.
+|}]
+
+let f e0 (e1 @ local) =
+    match e0, e1 with
+    | x0, x1 when x0 = x1 -> use_global x0; use_local x1; ()
+    | x -> use_global x; ()
+[%%expect{|
+Line 4, characters 22-23:
+4 |     | x -> use_global x; ()
+                          ^
+Error: This value escapes its region.
+|}]
+
+
+let f e0 (e1 @ local) =
+    match e0, e1 with
+    | x0, x1 when x0 = x1 -> use_global x0; use_local x1; ()
+    | x -> use_local x; ()
+[%%expect{|
+val f : 'a -> local_ 'a -> unit = <fun>
+|}]
+
+(* we can return [e1], because it's regional. We can't return [x]
+   (or its component) because [x] is allocated in the current region. *)
+let f e0 (e1 @ local) =
+    match e0, e1 with
+    | x0, x1 when x0 = x1 -> use_global x0; use_local x1; e1
+    | x -> use_local x; let (x0, x1) = x in x0
+[%%expect{|
+Line 4, characters 44-46:
+4 |     | x -> use_local x; let (x0, x1) = x in x0
+                                                ^^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
+|}]
+
+(* The value being matched upon is [local] in one branch, so the match result is
+   [local]. *)
+let f b e0 (e1 @ local) (e @ local)=
+    match if b then e0, e1 else e with
+    | x0, x1 -> use_global x0; use_local x1; ()
+[%%expect{|
+Line 3, characters 27-29:
+3 |     | x0, x1 -> use_global x0; use_local x1; ()
+                               ^^
+Error: This value escapes its region.
+|}]
+
+let f b e0 (e1 @ local) e2 e3 =
+    match if b then e0, e1 else e2, e3 with
+    | x0, x1 -> use_global x0; use_local x1; ()
+[%%expect{|
+val f : bool -> 'a -> local_ 'b -> 'a -> 'b -> unit = <fun>
+|}]
+
+let f b e0 (e1 @ local) e2 e3 =
+    match if b then e0, e1 else e2, e3 with
+    | x0, x1 -> use_global x0; use_global x1; ()
+[%%expect{|
+Line 3, characters 42-44:
+3 |     | x0, x1 -> use_global x0; use_global x1; ()
+                                              ^^
+Error: This value escapes its region.
+|}]

--- a/ocaml/testsuite/tests/typing-modes/tuple_modes.ml
+++ b/ocaml/testsuite/tests/typing-modes/tuple_modes.ml
@@ -18,7 +18,11 @@ let f x =
     x
   ;;
 [%%expect{|
-val f : 'a -> 'a option = <fun>
+Line 5, characters 4-5:
+5 |     x
+        ^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 let f e0 (e1 @ local) =

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -375,18 +375,15 @@ type expected_mode =
     sensible, but not very useful as it will fail all expressions. *)
 
     tuple_modes : Value.r list option;
-    (** No invariant between this and [mode]. It is UNSOUND to ignore this field.
-        If this is [Some [x0; x1; ..]]:
+    (** No invariant between this and [mode]. It is UNSOUND to ignore this
+        field. If this is [Some [x0; x1; ..]]:
 
-        - If we are type checking [Pexp_tuple [e0; e1; ..]], then we check
-          [e0 <= x0] and [e1 <= x1] and so on. Moreover, we check
-          [regional_to_local(join(e0, e1, ..)) <= mode].
+        - For a general expression [e], we check [e <= x0] and [e <= x1] and so
+          on; we also check [e <= mode].
 
-        - If we are type checking "non-concrete" [Pexp_constraint] etc, this
-          field must be preserved.
-
-        - If we are type checking other expression [e], then we check [e <= x0]
-          and [e <= x1] and so on. Moreover, [e <= mode]. *)
+        - Specifically for [Pexp_tuple [e0; e1; ..]], a finer-grained check is
+          performed instead: we check [e0 <= x0] and [e1 <= x1] and so on; we
+          also check [regional_to_local(join(e0, e1, ..)) <= mode]. *)
   }
 
 type position_and_mode = {

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -8684,12 +8684,6 @@ and type_expect_jane_syntax
         ~loc ~env ~expected_mode ~ty_expected ~explanation ~attributes x
 
 and type_expect_mode ~loc ~env ~(modes : Alloc.Const.Option.t) expected_mode =
-  match modes = Alloc.Const.Option.none with
-  | true ->
-    (* This is not just a short-circuit, it also prevents [mode_coerce] below from
-       removing [tuple_modes] when there's no mode annotation on the tuple *)
-    expected_mode
-  | false ->
     let min = Alloc.Const.Option.value ~default:Alloc.Const.min modes |> Const.alloc_as_value in
     let max = Alloc.Const.Option.value ~default:Alloc.Const.max modes |> Const.alloc_as_value in
     submode ~loc ~env ~reason:Other (Value.of_const min) expected_mode;

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -374,8 +374,19 @@ type expected_mode =
     field and [mode]: this field being [true] while [mode] being [global] is
     sensible, but not very useful as it will fail all expressions. *)
 
-    tuple_modes : Value.r list;
-    (** For t in tuple_modes, t <= regional_to_global mode *)
+    tuple_modes : Value.r list option;
+    (** No invariant between this and [mode]. It is UNSOUND to ignore this field.
+        If this is [Some [x0; x1; ..]]:
+
+        - If we are type checking [Pexp_tuple [e0; e1; ..]], then we check
+          [e0 <= x0] and [e1 <= x1] and so on. Moreover, we check
+          [regional_to_local(join(e0, e1, ..)) <= mode].
+
+        - If we are type checking "non-concrete" [Pexp_constraint] etc, this
+          field must be preserved.
+
+        - If we are type checking other expression [e], then we check [e <= x0]
+          and [e <= x1] and so on. Moreover, [e <= mode]. *)
   }
 
 type position_and_mode = {
@@ -437,23 +448,34 @@ let meet_regional mode =
   let mode = Value.disallow_left mode in
   Value.meet [mode; (Value.max_with (Comonadic Areality) Regionality.regional)]
 
-let value_regional_to_local mode =
-  mode
-  |> value_to_alloc_r2l
-  |> alloc_as_value
-
 let mode_default mode =
   { position = RNontail;
     closure_context = None;
     contention_context = None;
     mode = Value.disallow_left mode;
     strictly_local = false;
-    tuple_modes = [] }
+    tuple_modes = None }
 
 let mode_legacy = mode_default Value.legacy
 
+let as_single_mode {mode; tuple_modes; _} =
+  match tuple_modes with
+  | Some l -> Value.meet (mode :: l)
+  | None -> mode
+
+let get_single_mode_exn {mode; tuple_modes; _} =
+  match tuple_modes with
+  | Some _ -> Misc.fatal_error "tuple_modes should be None"
+  | None -> mode
+
+let mode_morph f expected_mode =
+  let mode = as_single_mode expected_mode in
+  let mode = f mode in
+  let tuple_modes = None in
+  {expected_mode with mode; tuple_modes}
+
 let mode_modality modality expected_mode =
-  expected_mode.mode
+  get_single_mode_exn expected_mode
   |> Modality.Value.Const.apply modality
   |> mode_default
 
@@ -487,7 +509,7 @@ let mode_max_with_position position =
 let mode_exclave expected_mode =
   let mode =
     Value.join_with (Comonadic Areality)
-      Regionality.Const.Local expected_mode.mode
+      Regionality.Const.Local (as_single_mode expected_mode)
   in
   { (mode_default mode)
     with strictly_local = true
@@ -499,8 +521,7 @@ let mode_strictly_local expected_mode =
   }
 
 let mode_coerce mode expected_mode =
-  let mode = Value.meet [expected_mode.mode; mode] in
-  { expected_mode with mode; tuple_modes = [] }
+  mode_morph (fun m -> Value.meet [m; mode]) expected_mode
 
 let mode_tailcall_function mode =
   { (mode_default mode) with
@@ -510,19 +531,19 @@ let mode_tailcall_argument mode =
   { (mode_default mode) with
     closure_context = Some Tailcall_argument }
 
-
 let mode_partial_application expected_mode =
-  let mode = alloc_as_value (value_to_alloc_r2g expected_mode.mode) in
+  let expected_mode =
+    mode_morph (fun mode -> alloc_as_value (value_to_alloc_r2g mode))
+      expected_mode
+  in
   { expected_mode with
-    mode;
     closure_context = Some Partial_application }
-
 
 let mode_trywith expected_mode =
   { expected_mode with position = RNontail }
 
 let mode_tuple mode tuple_modes =
-  let tuple_modes = Value.List.disallow_left tuple_modes in
+  let tuple_modes = Some (Value.List.disallow_left tuple_modes) in
   { (mode_default mode) with
     tuple_modes }
 
@@ -556,11 +577,7 @@ let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
 (* expected_mode.closure_context explains why expected_mode.mode is low;
    shared_context explains why mode.uniqueness is high *)
 let submode ~loc ~env ?(reason = Other) ?shared_context mode expected_mode =
-  let res =
-    match expected_mode.tuple_modes with
-    | [] -> Value.submode mode expected_mode.mode
-    | ts -> Value.submode mode (Value.meet ts)
-  in
+  let res = Value.submode mode (as_single_mode expected_mode) in
   match res with
   | Ok () -> ()
   | Error failure_reason ->
@@ -582,14 +599,19 @@ let escape ~loc ~env ~reason m =
 
 type expected_pat_mode =
   { mode : Value.l;
-    tuple_modes : Value.l list; }
+    (** The mode of the current pattern. *)
+
+    tuple_modes : Value.l list option;
+    (** If the current pattern is [Ppat_tuple], the sub-patterns will have these
+        modes. It is sound to ignore this field and get weaker modes. *)
+    }
 
 let simple_pat_mode mode =
-  { mode = Value.disallow_right mode; tuple_modes = [] }
+  { mode = Value.disallow_right mode; tuple_modes = None }
 
 let tuple_pat_mode mode tuple_modes =
   let mode = Value.disallow_right mode in
-  let tuple_modes = Value.List.disallow_right tuple_modes in
+  let tuple_modes = Some (Value.List.disallow_right tuple_modes) in
   { mode; tuple_modes }
 
 let allocations : Alloc.r list ref = Local_store.s_ref []
@@ -611,7 +633,7 @@ let register_allocation_value_mode mode =
     of potential subcomponents. *)
 let register_allocation (expected_mode : expected_mode) =
   let alloc_mode, mode =
-    register_allocation_value_mode expected_mode.mode
+    register_allocation_value_mode (get_single_mode_exn expected_mode)
   in
   let alloc_mode =
     { mode = alloc_mode;
@@ -845,12 +867,7 @@ let expect_mode_cross env ty (expected_mode : expected_mode) =
   let jkind = type_jkind_purely env ty in
   let upper_bounds = Jkind.get_modal_upper_bounds jkind in
   let upper_bounds = Const.alloc_as_value upper_bounds in
-  let mode = Value.imply upper_bounds expected_mode.mode in
-  (* - [strict_local] doesn't need to be updated, because it's only relavant for
-     functions, which don't cross locality.
-     - [mode_tuples] doesn't need to be updated, because [mode] being higher
-     won't violate the invariant. *)
-  { expected_mode with mode }
+  mode_morph (Value.imply upper_bounds) expected_mode
 
 let mode_annots_from_pat pat =
   let modes =
@@ -1444,10 +1461,10 @@ let reorder_pat loc env patl closed labeled_tl expected_ty =
 let solve_Ppat_tuple ~refine ~alloc_mode loc env args expected_ty =
   let arity = List.length args in
   let arg_modes =
-    if List.compare_length_with alloc_mode.tuple_modes arity = 0 then
-      alloc_mode.tuple_modes
-    else
-      List.init arity (fun _ -> alloc_mode.mode)
+    match alloc_mode.tuple_modes with
+    (* CR zqian: improve the modes of opened labeled tuple pattern. *)
+    | Some l when List.compare_length_with l arity = 0 -> l
+    | _ -> List.init arity (fun _ -> alloc_mode.mode)
   in
   let ann =
     (* CR layouts v5: restriction to value here to be relaxed. *)
@@ -4738,7 +4755,7 @@ let split_function_ty
          to be made global if its inner function is global. As a result, a
          function deserves a separate allocation mode.
       *)
-      let mode, _ = Value.newvar_below expected_mode.mode in
+      let mode, _ = Value.newvar_below (get_single_mode_exn expected_mode) in
       fst (register_allocation_value_mode mode)
   in
   if expected_mode.strictly_local then
@@ -4943,9 +4960,7 @@ let pat_modes ~force_toplevel rec_mode_var (attrs, spat) =
             simple_pat_mode mode, mode_default mode
         | Local_tuple arity ->
             let modes = List.init arity (fun _ -> Value.newvar ()) in
-            let mode =
-              value_regional_to_local (fst (Value.newvar_above (Value.join modes)))
-            in
+            let mode = Value.newvar () in
             tuple_pat_mode mode modes, mode_tuple mode modes
       end
     | Some mode ->
@@ -5060,10 +5075,12 @@ and type_expect_
               Env.find_value_by_name (Longident.Lident ("self-" ^ cl_num)) env
             in
             Texp_ident(path, lid, desc, kind,
-              unique_use ~loc ~env actual_mode.mode expected_mode.mode)
+              unique_use ~loc ~env actual_mode.mode
+                (get_single_mode_exn expected_mode))
         | _ ->
             Texp_ident(path, lid, desc, kind,
-              unique_use ~loc ~env actual_mode.mode expected_mode.mode)
+              unique_use ~loc ~env actual_mode.mode
+                (as_single_mode expected_mode))
       in
       let exp = rue {
         exp_desc; exp_loc = loc; exp_extra = [];
@@ -5337,8 +5354,7 @@ and type_expect_
           simple_pat_mode mode, mode_default mode
         | Local_tuple arity ->
           let modes = List.init arity (fun _ -> Value.newvar ()) in
-          let mode, _ = Value.newvar_above (Value.join modes) in
-          let mode = value_regional_to_local mode in
+          let mode = Value.newvar () in
           tuple_pat_mode mode modes, mode_tuple mode modes
       in
       let arg, sort =
@@ -5580,7 +5596,8 @@ and type_expect_
                   in
                   submode ~loc ~env mode argument_mode;
                   Kept (ty_arg1, lbl.lbl_mut,
-                        unique_use ~loc ~env mode argument_mode.mode)
+                        unique_use ~loc ~env mode
+                          (get_single_mode_exn argument_mode))
                 end
             in
             let label_definitions = Array.map unify_kept lbl.lbl_all in
@@ -5642,12 +5659,14 @@ and type_expect_
           let alloc_mode, argument_mode = register_allocation expected_mode in
           let mode = mode_cross_left env Predef.type_unboxed_float mode in
           submode ~loc ~env mode argument_mode;
-          let uu = unique_use ~loc ~env mode argument_mode.mode in
+          let uu =
+            unique_use ~loc ~env mode (get_single_mode_exn argument_mode)
+          in
           Boxing (alloc_mode, uu)
         | false ->
           let mode = mode_cross_left env ty_arg mode in
           submode ~loc ~env mode expected_mode;
-          let uu = unique_use ~loc ~env mode expected_mode.mode in
+          let uu = unique_use ~loc ~env mode (as_single_mode expected_mode) in
           Non_boxing uu
       in
       rue {
@@ -7297,7 +7316,7 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
     Some (safe_expect, lv) ->
       (* apply omittable arguments when expected type is "" *)
       (* we must be very careful about not breaking the semantics *)
-      let exp_mode, _ = Value.newvar_below mode.mode in
+      let exp_mode, _ = Value.newvar_below (as_single_mode mode) in
       let texp =
         with_local_level_if_principal ~post:generalize_structure_exp
           (fun () -> type_exp env {mode with mode = Value.disallow_left exp_mode} sarg)
@@ -7633,9 +7652,13 @@ and type_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
   with_explanation explanation (fun () ->
     unify_exp_types loc env to_unify (generic_instance ty_expected));
   let argument_modes =
-    if List.compare_length_with expected_mode.tuple_modes arity = 0 then
-      expected_mode.tuple_modes
-    else List.init arity (fun _ -> argument_mode)
+    match expected_mode.tuple_modes with
+    (* CR zqian: improve the modes of opened labeled tuple pattern. *)
+    | Some tuple_modes when List.compare_length_with tuple_modes arity = 0 ->
+        List.map (fun mode -> Value.meet [mode; argument_mode])
+          tuple_modes
+    | _ ->
+        List.init arity (fun _ -> argument_mode)
   in
   let types_and_modes = List.combine labeled_subtypes argument_modes in
   let expl =


### PR DESCRIPTION
The current `mode_coerce` has a soundness bug wrt its treatment of `tuple_modes`. The bug was exposed during development of #2741, but in the end worked around so it won't be exposed in that particular way.

It is still a bug and needs to be fixed. In this PR:
- The first commit adds some tests wrt `tuple_modes`.
- The second commit removes the workaround introduced by #2741 to expose the bug.
- The last commit fixes the bug.

# The design
I tried to understand the current design of `tuple_modes` but found it difficult (partially because I've messed it up over time). So instead I came up with a new design that works as follows. Consider the example:
```
match e0, e1 with
| x0, x1 -> ..
```
The simplest design, which is to not have `tuple_modes` at all, is to have a single `mode` that will the mode of `(e0, e1)` and `(x0, x1)`. That means if any of `e0/e1` is `local`, both `x0/x1` will be `local`. However, a typical ocaml programer thinks tuples as primitive langauge construct, and they would expect `x0` to be `global` if `e0` is `global` regardless of `e1`.

To that end, we consider a canonical example to motivate our design:
```
match if b then e0, e1 else e with
| x0, x1 -> ..
| x -> ..
```
We want the following two groups of mode constraints to hold.
```
regional_to_local(join(e0,e1)) <= x 
e0 <= x0
e1 <= x1 
```

```
e <= x0
e <= x1
e <= x
```
The `regional_to_local` mapping is to represent allocation: if both `e0` and `e1` are `regional`, the tuple will be allocated in the current region `local` instead of the parent region `regional`. In implementation we move it to the RHS of `<=` as `regional_to_global`.

Following the existing design, we first look at the pattern: If the pattern is a tuple pattern, we create a mode variable `mode` for the tuple, and a list of mode variables `tuple_modes` corresponding to tuple fields. If the pattern is not tuple pattern, we let `tuple_modes = None`. Both `mode` and `tuple_modes` are used to construct `expected_pat_mode` and `expected_mode`, passed to patterns and expressions accordingly.

The type checking of patterns will try to make use of `tuple_modes` to get better modes; but it's sound to ignore that field. For the above example, `x` will enjoy `mode`, and `[x0;x1]` will enjoy `tuple_modes`.

The type checking of expression is responsible for enforcing the above constraints. If the expression is `Pexp_tuple [e0; e1]`, we enforce the first group of constraints. Otherwise the expression is some general `e`, we enforce the second group of constraints. In any case, if `tuple_modes = None`, then we don't need to enforce the related constraints.

Note: it's unsound for the type-checking of expressions to ignore `expected_mode.tuple_modes`. Therefore, I replaced all usage of `expected_mode.mode` with `as_single_mode expected_mode` or `get_single_mode_exn expected_mode`. The former allows treating `expected_mode` as a single mode. The latter is used when we are sure `tuple_modes` will be `None`. To do this properly we should make `expected_mode` abstract (future work :wink: ).