### PR TITLE
Rename float32 round_half_to_even to round_current

### DIFF
--- a/ocaml/otherlibs/stdlib_beta/amd64/float32.ml
+++ b/ocaml/otherlibs/stdlib_beta/amd64/float32.ml
@@ -277,7 +277,7 @@ let[@inline] min_max_num (x : t) (y : t) =
   else if y > x || ((not (sign_bit y)) && sign_bit x) then (x, y)
   else (y, x)
 
-external iround_half_to_even : t -> int64
+external iround_current : t -> int64
   = "caml_sse_cast_float32_int64_bytecode" "caml_sse_cast_float32_int64"
   [@@noalloc] [@@unboxed] [@@builtin]
 
@@ -290,7 +290,7 @@ let round_neg_inf = 0x9
 let round_pos_inf = 0xA
 let round_zero = 0xB
 let round_current_mode = 0xC
-let[@inline] round_half_to_even x = round_intrinsic round_current_mode x
+let[@inline] round_current x = round_intrinsic round_current_mode x
 let[@inline] round_down x = round_intrinsic round_neg_inf x
 let[@inline] round_up x = round_intrinsic round_pos_inf x
 let[@inline] round_towards_zero x = round_intrinsic round_zero x

--- a/ocaml/otherlibs/stdlib_beta/amd64/float32.mli
+++ b/ocaml/otherlibs/stdlib_beta/amd64/float32.mli
@@ -494,20 +494,21 @@ val min_max_num : t -> t -> t * t
    efficient.  Note that in particular [min_max_num x nan = (x, x)]
    and [min_max_num nan y = (y, y)]. *)
 
-external iround_half_to_even : t -> int64
+external iround_current : t -> int64
   = "caml_sse_cast_float32_int64_bytecode" "caml_sse_cast_float32_int64"
   [@@noalloc] [@@unboxed] [@@builtin]
 (** Rounds a [float32] to an [int64] using the current rounding mode. The default
-    rounding mode is "round half to even", and we expect that no program will
-    change the rounding mode.
+    rounding mode on amd64 is "round half to even", and we expect that no
+    program will change the mode. The default mode may differ on other platforms.
     If the argument is NaN or infinite or if the rounded value cannot be
     represented, then the result is unspecified.
     The amd64 flambda-backend compiler translates this call to CVTSS2SI. *)
 
-val round_half_to_even : t -> t
-(** Rounds a [float32] to an integer [float32] using the current rounding
-    mode.  The default rounding mode is "round half to even", and we
-    expect that no program will change the rounding mode.
+val round_current : t -> t
+(** Rounds a [float32] to an integer [float32] using the current rounding mode.
+    The default rounding mode on amd64 is "round half to even", and we
+    expect that no program will change the mode. The default mode may differ
+    on other platforms.
     The amd64 flambda-backend compiler translates this call to ROUNDSS. *)
 
 val round_down : t -> t

--- a/ocaml/otherlibs/stdlib_beta/amd64/float32_u.ml
+++ b/ocaml/otherlibs/stdlib_beta/amd64/float32_u.ml
@@ -194,15 +194,15 @@ let[@inline always] min_num x y = of_float32 (Float32.min_num (to_float32 x) (to
 
 let[@inline always] max_num x y = of_float32 (Float32.max_num (to_float32 x) (to_float32 y))
 
-let iround_half_to_even x = unbox_int64 (Float32.iround_half_to_even (to_float32 x))
+let[@inline always] iround_current x = unbox_int64 (Float32.iround_current (to_float32 x))
 
-let round_half_to_even x = of_float32 (Float32.round_half_to_even (to_float32 x))
+let[@inline always] round_current x = of_float32 (Float32.round_current (to_float32 x))
 
-let round_down x = of_float32 (Float32.round_down (to_float32 x))
+let[@inline always] round_down x = of_float32 (Float32.round_down (to_float32 x))
 
-let round_up x = of_float32 (Float32.round_up (to_float32 x))
+let[@inline always] round_up x = of_float32 (Float32.round_up (to_float32 x))
 
-let round_towards_zero x = of_float32 (Float32.round_towards_zero (to_float32 x))
+let[@inline always] round_towards_zero x = of_float32 (Float32.round_towards_zero (to_float32 x))
 
 module Bytes = struct
   let get bytes ~pos = of_float32 (Float32.Bytes.get bytes ~pos)

--- a/ocaml/otherlibs/stdlib_beta/amd64/float32_u.mli
+++ b/ocaml/otherlibs/stdlib_beta/amd64/float32_u.mli
@@ -390,18 +390,19 @@ val max_num : t -> t -> t
     missing values.  If both [x] and [y] are [nan] [nan] is returned.
     Moreover [max_num #-0.s #+0.s = #+0.s] *)
 
-val iround_half_to_even : t -> int64#
+val iround_current : t -> int64#
 (** Rounds a [float32#] to an [int64#] using the current rounding mode. The default
-    rounding mode is "round half to even", and we expect that no program will
-    change the rounding mode.
+    rounding mode on amd64 is "round half to even", and we expect that no
+    program will change the mode. The default mode may differ on other platforms.
     If the argument is NaN or infinite or if the rounded value cannot be
     represented, then the result is unspecified.
     The amd64 flambda-backend compiler translates this call to CVTSS2SI. *)
 
-val round_half_to_even : t -> t
-(** Rounds a [float32#] to an integer [float32#] using the current rounding
-    mode.  The default rounding mode is "round half to even", and we
-    expect that no program will change the rounding mode.
+val round_current : t -> t
+(** Rounds a [float32#] to an integer [float32#] using the current rounding mode.
+    The default rounding mode on amd64 is "round half to even", and we
+    expect that no program will change the mode. The default mode may differ
+    on other platforms.
     The amd64 flambda-backend compiler translates this call to ROUNDSS. *)
 
 val round_down : t -> t

--- a/tests/small_numbers/float32_lib.ml
+++ b/tests/small_numbers/float32_lib.ml
@@ -249,9 +249,9 @@ let () =
   CF32.check_float32s (fun f _ ->
     bit_eq (F32.round_up f) (CF32.ceil f);
     bit_eq (F32.round_down f) (CF32.floor f);
-    bit_eq (F32.round_half_to_even f) (CF32.round_current f);
+    bit_eq (F32.round_current f) (CF32.round_current f);
     (* Returns int64, so can compare directly. *)
-    assert ((F32.iround_half_to_even f) = (CF32.iround_current f));
+    assert ((F32.iround_current f) = (CF32.iround_current f));
   )
 ;;
 

--- a/tests/small_numbers/float32_u_lib.ml
+++ b/tests/small_numbers/float32_u_lib.ml
@@ -242,9 +242,9 @@ let () =
     let u = F32.of_float32 f in
     bit_eq (F32.round_up u) (CF32.ceil f);
     bit_eq (F32.round_down u) (CF32.floor f);
-    bit_eq (F32.round_half_to_even u) (CF32.round_current f);
+    bit_eq (F32.round_current u) (CF32.round_current f);
     (* Returns int64, so can compare directly. *)
-    assert (box_int64 (F32.iround_half_to_even u) = (CF32.iround_current f));
+    assert (box_int64 (F32.iround_current u) = (CF32.iround_current f));
   )
 ;;
 


### PR DESCRIPTION
Float32 will soon be supported in javascript and wasm, where the default rounding mode is not half-to-even.
This PR renames the `round_half_to_even` functions to `round_current`, because they actually round using the current mode.
The comments have been updated as well.