### PR TITLE
Move alert attributes in stdlib mlis to where they aren't ignored

### DIFF
--- a/ocaml/stdlib/arg.mli
+++ b/ocaml/stdlib/arg.mli
@@ -14,8 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Stdlib
-
 (** Parsing of command line arguments.
 
    This module provides a general mechanism for extracting options and
@@ -78,6 +76,8 @@ open! Stdlib
     "The Arg module relies on a mutable global state, parsing functions should \
      only be called from a single domain."
 ]
+
+open! Stdlib
 
 type spec =
   | Unit of (unit -> unit)     (** Call the function with unit argument *)

--- a/ocaml/stdlib/buffer.mli
+++ b/ocaml/stdlib/buffer.mli
@@ -14,8 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Stdlib
-
 (** Extensible buffers.
 
    This module implements buffers that automatically expand
@@ -40,6 +38,8 @@ open! Stdlib
 [@@@alert unsynchronized_access
     "Unsynchronized accesses to buffers are a programming error."
 ]
+
+open! Stdlib
 
  (**
     Unsynchronized accesses to a buffer may lead to an invalid buffer state.

--- a/ocaml/stdlib/ephemeron.mli
+++ b/ocaml/stdlib/ephemeron.mli
@@ -14,7 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Stdlib
 (** Ephemerons and weak hash tables.
 
     Ephemerons and weak hash tables are useful when one wants to cache
@@ -72,6 +71,8 @@ open! Stdlib
 [@@@alert unsynchronized_access
   "Unsynchronized accesses to weak hash tables are a programming error."
 ]
+
+open! Stdlib
 
 (**
     Unsynchronized accesses to a weak hash table may lead to an invalid

--- a/ocaml/stdlib/queue.mli
+++ b/ocaml/stdlib/queue.mli
@@ -14,8 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Stdlib
-
 (** First-in first-out queues.
 
    This module implements queues (FIFOs), with in-place modification.
@@ -27,6 +25,8 @@ open! Stdlib
 [@@@alert unsynchronized_access
     "Unsynchronized accesses to queues are a programming error."
 ]
+
+open! Stdlib
 
 (**
     Unsynchronized accesses to a queue may lead to an invalid queue state.

--- a/ocaml/stdlib/scanf.mli
+++ b/ocaml/stdlib/scanf.mli
@@ -14,8 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Stdlib
-
 (** Formatted input functions. *)
 
 [@@@ocaml.warning "+A-e"]
@@ -91,6 +89,8 @@ open! Stdlib
 [@@@alert unsynchronized_access
     "Unsynchronized accesses to Scanning.in_channel are a programming error."
 ]
+
+open! Stdlib
 
  (**
       Unsynchronized accesses to a {!Scanning.in_channel} may lead to an

--- a/ocaml/stdlib/stack.mli
+++ b/ocaml/stdlib/stack.mli
@@ -14,8 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open! Stdlib
-
 (** Last-in first-out stacks.
 
    This module implements stacks (LIFOs), with in-place modification.
@@ -26,6 +24,8 @@ open! Stdlib
 [@@@alert unsynchronized_access
     "Unsynchronized accesses to stacks are a programming error."
 ]
+
+open! Stdlib
 
  (**
     Unsynchronized accesses to a stack may lead to an invalid queue state.


### PR DESCRIPTION
Our copy of stdlib mlis unintentionally disabled alerts by adding a signature item (`open! Stdlib`) before the top-level alert attribute. This PR fixes things by moving the open after the top-level alert.

This is required to build the stdlib now that we've merged #2912.