### PR TITLE
Enable split preprocessing by default (CFG-based register allocators)

### DIFF
--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -4,7 +4,8 @@ open! Regalloc_utils
 
 let split_debug = false
 
-let split_live_ranges : bool Lazy.t = bool_of_param "SPLIT_LIVE_RANGES"
+let split_live_ranges : bool Lazy.t =
+  bool_of_param ~default:true "SPLIT_LIVE_RANGES"
 
 let split_more_destruction_points : bool Lazy.t =
   bool_of_param "SPLIT_MORE_DESTR_POINTS"

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -23,14 +23,15 @@ let find_param_value param_name =
            then Some (String.concat ":" rest)
            else None)
 
-let bool_of_param ?guard param_name =
+let bool_of_param ?guard ?(default = false) param_name =
   lazy
     (let res =
        match
          find_param_value param_name |> Option.map String.lowercase_ascii
        with
+       | None -> default
        | Some ("1" | "true" | "on") -> true
-       | Some ("0" | "false" | "off") | None -> false
+       | Some ("0" | "false" | "off") -> false
        | Some value ->
          Misc.fatal_errorf
            "the %s variable is %S but should be one of: \"0\", \"1\", \

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -10,7 +10,8 @@ val fatal : ('a, Format.formatter, unit, 'b) format4 -> 'a
 
 val find_param_value : string -> string option
 
-val bool_of_param : ?guard:bool * string -> string -> bool Lazy.t
+val bool_of_param :
+  ?guard:bool * string -> ?default:bool -> string -> bool Lazy.t
 
 val validator_debug : bool Lazy.t
 


### PR DESCRIPTION
As per title - it has been widely tested
(and it covered by the validator).