### PR TITLE
Fix CI on macOS (unknown linker option)

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-caml-modify/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-caml-modify/basics.ml
@@ -1,6 +1,7 @@
 (* TEST
  modules = "replace_caml_modify.c";
  {
+   not-macos;
    flags = "-cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify
             -cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify_local";
    native;


### PR DESCRIPTION
The linker on macOS does not support the `--wrap` command-line option,
so this pull request simply disables a test on macOS.