### PR TITLE
Use untagged indices for string-like access in flambda

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -358,6 +358,15 @@ let convert_index_to_tagged_int index (index_kind : Lambda.array_index_kind) =
              },
            index ))
 
+let convert_index_to_untagged_int index
+    (index_kind : Lambda.array_index_kind) =
+  let src : I_or_f.t =
+    match index_kind with
+    | Ptagged_int_index -> Tagged_immediate
+    | Punboxed_int_index bint -> standard_int_or_float_of_boxed_integer bint
+  in
+  H.Prim (Unary (Num_conv { src; dst = Naked_immediate }, index))
+
 let check_non_negative_imm imm prim_name =
   if not (Targetint_31_63.is_non_negative imm)
   then
@@ -545,7 +554,7 @@ let string_like_load ~dbg ~unsafe
     (kind : P.string_like_value) mode ~boxed string ~index_kind index
     ~current_region =
   let unsafe_load =
-    let index = convert_index_to_tagged_int index index_kind in
+    let index = convert_index_to_untagged_int index index_kind in
     let wrap =
       match access_size, mode with
       | (Eight | Sixteen), None ->
@@ -586,7 +595,7 @@ let bytes_like_set ~dbg ~unsafe
     ~(access_size : Flambda_primitive.string_accessor_width) ~size_int
     (kind : P.bytes_like_value) ~boxed bytes ~index_kind index new_value =
   let unsafe_set =
-    let index = convert_index_to_tagged_int index index_kind in
+    let index = convert_index_to_untagged_int index index_kind in
     let wrap =
       match access_size with
       | Eight | Sixteen ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -346,7 +346,7 @@ let bint_shift bi mode prim arg1 arg2 =
          unbox_bint bi arg1,
          untag_int arg2 ))
 
-let convert_index_to_tagged_int index (index_kind : Lambda.array_index_kind) =
+let convert_index_to_tagged_int ~index ~(index_kind : Lambda.array_index_kind) =
   match index_kind with
   | Ptagged_int_index -> index
   | Punboxed_int_index bint ->
@@ -358,8 +358,8 @@ let convert_index_to_tagged_int index (index_kind : Lambda.array_index_kind) =
              },
            index ))
 
-let convert_index_to_untagged_int index
-    (index_kind : Lambda.array_index_kind) =
+let convert_index_to_untagged_int ~index ~(index_kind : Lambda.array_index_kind)
+    =
   let src : I_or_f.t =
     match index_kind with
     | Ptagged_int_index -> Tagged_immediate
@@ -538,7 +538,7 @@ let checked_bigstring_access ~dbg ~size_int ~access_size ~primitive arg1
       checked_alignment ~dbg ~primitive
         ~conditions:
           [ bigstring_alignment_validity_condition arg1 16
-              (convert_index_to_tagged_int arg2 index_kind) ]
+              (convert_index_to_tagged_int ~index:arg2 ~index_kind) ]
     | Eight | Sixteen | Thirty_two | Single | Sixty_four
     | One_twenty_eight { aligned = false } ->
       primitive
@@ -554,7 +554,7 @@ let string_like_load ~dbg ~unsafe
     (kind : P.string_like_value) mode ~boxed string ~index_kind index
     ~current_region =
   let unsafe_load =
-    let index = convert_index_to_untagged_int index index_kind in
+    let index = convert_index_to_untagged_int ~index ~index_kind in
     let wrap =
       match access_size, mode with
       | (Eight | Sixteen), None ->
@@ -595,7 +595,7 @@ let bytes_like_set ~dbg ~unsafe
     ~(access_size : Flambda_primitive.string_accessor_width) ~size_int
     (kind : P.bytes_like_value) ~boxed bytes ~index_kind index new_value =
   let unsafe_set =
-    let index = convert_index_to_untagged_int index index_kind in
+    let index = convert_index_to_untagged_int ~index ~index_kind in
     let wrap =
       match access_size with
       | Eight | Sixteen ->
@@ -1564,36 +1564,32 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Pmodbint { size = Pnativeint; is_safe = Safe; mode }, [[arg1]; [arg2]] ->
     [ checked_arith_op ~dbg (Some Pnativeint) Mod (Some mode) arg1 arg2
         ~current_region ]
-  | Parrayrefu (array_ref_kind, array_index_kind), [[array]; [index]] ->
+  | Parrayrefu (array_ref_kind, index_kind), [[array]; [index]] ->
     (* For this and the following cases we will end up relying on the backend to
        CSE the two accesses to the array's header word in the [Pgenarray]
        case. *)
     [ match_on_array_ref_kind ~array array_ref_kind
         (array_load_unsafe ~array
-           ~index:(convert_index_to_tagged_int index array_index_kind)
+           ~index:(convert_index_to_tagged_int ~index ~index_kind)
            ~current_region) ]
-  | Parrayrefs (array_ref_kind, array_index_kind), [[array]; [index]] ->
+  | Parrayrefs (array_ref_kind, index_kind), [[array]; [index]] ->
     let array_kind = convert_array_ref_kind_for_length array_ref_kind in
-    [ check_array_access ~dbg ~array array_kind ~index
-        ~index_kind:array_index_kind
+    [ check_array_access ~dbg ~array array_kind ~index ~index_kind
         (match_on_array_ref_kind ~array array_ref_kind
            (array_load_unsafe ~array
-              ~index:(convert_index_to_tagged_int index array_index_kind)
+              ~index:(convert_index_to_tagged_int ~index ~index_kind)
               ~current_region)) ]
-  | ( Parraysetu (array_set_kind, array_index_kind),
-      [[array]; [index]; [new_value]] ) ->
+  | Parraysetu (array_set_kind, index_kind), [[array]; [index]; [new_value]] ->
     [ match_on_array_set_kind ~array array_set_kind
         (array_set_unsafe ~array
-           ~index:(convert_index_to_tagged_int index array_index_kind)
+           ~index:(convert_index_to_tagged_int ~index ~index_kind)
            ~new_value) ]
-  | ( Parraysets (array_set_kind, array_index_kind),
-      [[array]; [index]; [new_value]] ) ->
+  | Parraysets (array_set_kind, index_kind), [[array]; [index]; [new_value]] ->
     let array_kind = convert_array_set_kind_for_length array_set_kind in
-    [ check_array_access ~dbg ~array array_kind ~index
-        ~index_kind:array_index_kind
+    [ check_array_access ~dbg ~array array_kind ~index ~index_kind
         (match_on_array_set_kind ~array array_set_kind
            (array_set_unsafe ~array
-              ~index:(convert_index_to_tagged_int index array_index_kind)
+              ~index:(convert_index_to_tagged_int ~index ~index_kind)
               ~new_value)) ]
   | Pbytessetu (* unsafe *), [[bytes]; [index]; [new_value]] ->
     [ bytes_like_set ~unsafe:true ~dbg ~size_int ~access_size:Eight Bytes

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -563,9 +563,9 @@ let block_index_kind = K.value
 
 let array_index_kind = K.value
 
-let string_or_bigstring_index_kind = K.value
+let string_or_bigstring_index_kind = K.naked_immediate
 
-let bytes_or_bigstring_index_kind = K.value
+let bytes_or_bigstring_index_kind = K.naked_immediate
 
 type 'signed_or_unsigned comparison =
   | Eq

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -281,7 +281,8 @@ let bigarray_store ~dbg kind ~bigarray ~index ~new_value =
   bigarray_load_or_store ~dbg kind ~bigarray ~index
     (C.bigarray_store ~new_value)
 
-(* String and bytes access. For these functions, [index] is an untagged integer. *)
+(* String and bytes access. For these functions, [index] is an untagged
+   integer. *)
 
 let string_like_load_aux ~dbg width ~str ~index =
   match (width : P.string_accessor_width) with

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -281,10 +281,9 @@ let bigarray_store ~dbg kind ~bigarray ~index ~new_value =
   bigarray_load_or_store ~dbg kind ~bigarray ~index
     (C.bigarray_store ~new_value)
 
-(* String and bytes access. For these functions, [index] is a tagged integer. *)
+(* String and bytes access. For these functions, [index] is an untagged integer. *)
 
 let string_like_load_aux ~dbg width ~str ~index =
-  let index = C.untag_int index dbg in
   match (width : P.string_accessor_width) with
   | Eight -> C.load ~dbg Byte_unsigned Mutable ~addr:(C.add_int str index dbg)
   | Sixteen -> C.unaligned_load_16 str index dbg
@@ -304,7 +303,6 @@ let string_like_load ~dbg kind width ~str ~index =
         string_like_load_aux ~dbg width ~str ~index)
 
 let bytes_or_bigstring_set_aux ~dbg width ~bytes ~index ~new_value =
-  let index = C.untag_int index dbg in
   match (width : P.string_accessor_width) with
   | Eight ->
     let addr = C.add_int bytes index dbg in


### PR DESCRIPTION
The primitives added in #2906 for string-like access via unboxed indices generate bad code. For example, `%caml_string_get64u#_indexed_by_int64#` generates:
```
salq $1, %rbx
sarq $1, %rbx
movq (%rax,%rbx), %rax
ret
```
This is because the flambda primitives for string-like load and store operate on tagged indices, and the untagging does not happen until conversion to cmm. So an unboxed index is first tagged when the primitive is translated to flambda, and then untagged by cmm. The simplifications in `cmm_helpers.ml` can't rewrite a left shift followed by a right shift, so the tag-untag sequence is not eliminated.

Flambda's array-access primitives also operate on tagged indices, but these indices are shifted further left when they're used, so the simplifications in `cmm_helpers.ml` are able to eliminate the right shift for untagging and combine the left shifts. As a result, `%array_unsafe_get_indexed_by_int64#` already generates the sensible:
```
movq (%rax,%rbx,8), %rax
ret
```

This PR changes the flambda primitives for string-like access to use untagged indices, so `%caml_string_get64u#_indexed_by_int64#` now generates
```
movq (%rax,%rbx), %rax
ret
```

For testing, I skimmed the output of
```bash
#!/bin/bash

fin=/tmp/a.ml
fout=/tmp/a.s

for index in int32 int64 nativeint
do
  for width in int16 int32 'int32#' float32 'float32#' int64 'int64#'
  do
    for container in string bigstring bytes
    do
      access_sigil=`echo $width | sed -E 's/(f?)(loat|int)([0-9]+)(#?)/\1\3u\4/'`
      access_type=`echo $width | sed 's/16//'`
      printf "open Bigarray\n`
             `type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t\n`
             `external get_unsafe`
             ` : $container`
             ` -> ${index}#`
             ` -> $access_type`
             ` = \"%%caml_${container}_get${access_sigil}_indexed_by_${index}#\"\n`
             `external set_unsafe`
             ` : $container`
             ` -> ${index}#`
             ` -> $access_type`
             ` -> unit`
             ` = \"%%caml_${container}_set${access_sigil}_indexed_by_${index}#\"\n`
             `let[@inline never] get s i = get_unsafe s i\n`
             `let[@inline never] set s i v = set_unsafe s i v" > $fin
      $INSTALL_DIR/bin/ocamlopt.opt -S -c -O3 $fin
      echo "==== access $width in $container by ${index}# ===="
      sed -nE '/^caml.*__get_.*code/,/^\s*ret$/p' $fout
      sed -nE '/^caml.*__set_.*code/,/^\s*ret$/p' $fout
    done
  done
done
```
and the various combinations generally look right.