### PR TITLE
Revert "Remove "scheduling" leftovers"

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -63,7 +63,7 @@ let pass_dump_cfg_if ppf flag message c =
 let start_from_emit = ref true
 
 let should_save_before_emit () =
-  should_save_ir_after Compiler_pass.Linearization && (not !start_from_emit)
+  should_save_ir_after Compiler_pass.Scheduling && (not !start_from_emit)
 
 let should_save_cfg_before_emit () =
   should_save_ir_after Compiler_pass.Simplify_cfg && (not !start_from_emit)
@@ -148,7 +148,7 @@ let write_ir prefix =
       Cfg_format.save filename cfg_unit_info end)
     pass_to_cfg;
   if should_save_before_emit () then begin
-    let filename = Compiler_pass.(to_output_filename Linearization ~prefix) in
+    let filename = Compiler_pass.(to_output_filename Scheduling ~prefix) in
     linear_unit_info.items <- List.rev linear_unit_info.items;
     Linear_format.save filename linear_unit_info
   end;
@@ -159,7 +159,7 @@ let write_ir prefix =
   end
 
 let should_emit () =
-  not (should_stop_after Compiler_pass.Linearization)
+  not (should_stop_after Compiler_pass.Scheduling)
 
 let should_use_linscan fun_codegen_options =
   !use_linscan ||

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -90,7 +90,7 @@ let main unix argv ppf ~flambda2 =
       | None ->
           Compenv.fatal "Please specify at most one of -pack, -a, -shared, -c, \
                          -output-obj";
-      | Some ((P.Parsing | P.Typing | P.Lambda | P.Middle_end | P.Linearization
+      | Some ((P.Parsing | P.Typing | P.Lambda | P.Middle_end | P.Scheduling
               | P.Simplify_cfg | P.Emit | P.Selection) as p) ->
         assert (P.is_compilation_pass p);
         Printf.ksprintf Compenv.fatal

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -860,6 +860,9 @@ let mk_dalloc f =
 let mk_dreload f =
   "-dreload", Arg.Unit f, " (undocumented)"
 
+let mk_dscheduling f =
+  "-dscheduling", Arg.Unit f, " (undocumented)"
+
 let mk_dlinear f =
   "-dlinear", Arg.Unit f, " (undocumented)"
 
@@ -1141,6 +1144,7 @@ module type Optcommon_options = sig
   val _dprefer : unit -> unit
   val _dalloc : unit -> unit
   val _dreload : unit -> unit
+  val _dscheduling :  unit -> unit
   val _dlinear :  unit -> unit
   val _dinterval : unit -> unit
   val _dstartup :  unit -> unit
@@ -1578,6 +1582,7 @@ struct
     mk_dprefer F._dprefer;
     mk_dalloc F._dalloc;
     mk_dreload F._dreload;
+    mk_dscheduling F._dscheduling;
     mk_dlinear F._dlinear;
     mk_dinterval F._dinterval;
     mk_dstartup F._dstartup;
@@ -1705,6 +1710,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_dprefer F._dprefer;
     mk_dalloc F._dalloc;
     mk_dreload F._dreload;
+    mk_dscheduling F._dscheduling;
     mk_dlinear F._dlinear;
     mk_dinterval F._dinterval;
     mk_dstartup F._dstartup;
@@ -1937,6 +1943,7 @@ module Default = struct
     let _drawclambda = set dump_rawclambda
     let _drawflambda = set dump_rawflambda
     let _dreload = set dump_reload
+    let _dscheduling = set dump_scheduling
     let _dsel = set dump_selection
     let _dspill = set dump_spill
     let _dsplit = set dump_split

--- a/ocaml/driver/main_args.mli
+++ b/ocaml/driver/main_args.mli
@@ -241,6 +241,7 @@ module type Optcommon_options = sig
   val _dprefer : unit -> unit
   val _dalloc : unit -> unit
   val _dreload : unit -> unit
+  val _dscheduling :  unit -> unit
   val _dlinear :  unit -> unit
   val _dinterval : unit -> unit
   val _dstartup :  unit -> unit

--- a/ocaml/driver/maindriver.ml
+++ b/ocaml/driver/maindriver.ml
@@ -67,7 +67,7 @@ let main argv ppf =
            are  incompatible with -pack, -a, -output-obj"
           (String.concat "|"
              (P.available_pass_names ~filter:(fun _ -> true) ~native:false))
-      | Some (P.Middle_end | P.Linearization | P.Simplify_cfg | P.Emit | P.Selection) ->
+      | Some (P.Middle_end | P.Scheduling | P.Simplify_cfg | P.Emit | P.Selection) ->
         assert false (* native only *)
     end;
     if !make_archive then begin

--- a/ocaml/testsuite/tests/tool-ocamlopt-save-ir/check_for_pack.ml
+++ b/ocaml/testsuite/tests/tool-ocamlopt-save-ir/check_for_pack.ml
@@ -1,7 +1,7 @@
 (* TEST
  native-compiler;
  setup-ocamlopt.byte-build-env;
- flags = "-save-ir-after linearization";
+ flags = "-save-ir-after scheduling";
  ocamlopt_byte_exit_status = "0";
  ocamlopt.byte;
  script = "touch empty.ml";

--- a/ocaml/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_scheduling.ml
+++ b/ocaml/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_scheduling.ml
@@ -1,10 +1,10 @@
 (* TEST
  native-compiler;
  setup-ocamlopt.byte-build-env;
- flags = "-save-ir-after linearization -S";
+ flags = "-save-ir-after scheduling -S";
  ocamlopt.byte;
  check-ocamlopt.byte-output;
- script = "sh ${test_source_directory}/save_ir_after_linearization.sh";
+ script = "sh ${test_source_directory}/save_ir_after_scheduling.sh";
  script;
 *)
 

--- a/ocaml/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_scheduling.sh
+++ b/ocaml/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_scheduling.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-cmir=save_ir_after_linearization.cmir-linear
+cmir=save_ir_after_scheduling.cmir-linear
 
 # Check that cmir is generated
 if [ -e "$cmir" ] ; then

--- a/ocaml/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.compilers.reference
+++ b/ocaml/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.compilers.reference
@@ -1,1 +1,1 @@
-wrong argument 'typing'; option '-save-ir-after' expects one of: linearization simplify_cfg selection.
+wrong argument 'typing'; option '-save-ir-after' expects one of: scheduling simplify_cfg selection.

--- a/ocaml/testsuite/tests/tool-ocamlopt-save-ir/start_from_emit.ml
+++ b/ocaml/testsuite/tests/tool-ocamlopt-save-ir/start_from_emit.ml
@@ -1,7 +1,7 @@
 (* TEST
  native-compiler;
  setup-ocamlopt.byte-build-env;
- flags = "-save-ir-after linearization -stop-after linearization";
+ flags = "-save-ir-after scheduling -stop-after scheduling";
  ocamlopt_byte_exit_status = "0";
  ocamlopt.byte;
  script = "touch empty.ml";
@@ -13,7 +13,7 @@
  check-ocamlopt.byte-output;
  script = "sh ${test_source_directory}/start_from_emit.sh";
  script;
- flags = "-S start_from_emit.cmir-linear -save-ir-after linearization";
+ flags = "-S start_from_emit.cmir-linear -save-ir-after scheduling";
  module = "empty.ml";
  ocamlopt_byte_exit_status = "0";
  ocamlopt.byte;

--- a/ocaml/testsuite/tests/tool-ocamlopt-stop-after/stop_after_scheduling.ml
+++ b/ocaml/testsuite/tests/tool-ocamlopt-stop-after/stop_after_scheduling.ml
@@ -1,11 +1,11 @@
 (* TEST
  native-compiler;
  setup-ocamlopt.byte-build-env;
- flags = "-stop-after linearization -S";
+ flags = "-stop-after scheduling -S";
  ocamlopt_byte_exit_status = "0";
  ocamlopt.byte;
  check-ocamlopt.byte-output;
- script = "sh ${test_source_directory}/stop_after_linearization.sh";
+ script = "sh ${test_source_directory}/stop_after_scheduling.sh";
  script;
 *)
 

--- a/ocaml/testsuite/tests/tool-ocamlopt-stop-after/stop_after_scheduling.sh
+++ b/ocaml/testsuite/tests/tool-ocamlopt-stop-after/stop_after_scheduling.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-asm=stop_after_linearization.${asmext}
-obj=stop_after_linearization.${objext}
-cmx=stop_after_linearization.cmx
+asm=stop_after_scheduling.${asmext}
+obj=stop_after_scheduling.${objext}
+cmx=stop_after_scheduling.cmx
 
 # Check that cmx is generated but asm and obj are not
 if [ -e "$asm" ] ; then

--- a/ocaml/testsuite/tools/codegen_main.ml
+++ b/ocaml/testsuite/tools/codegen_main.ml
@@ -74,6 +74,7 @@ let main() =
      "-dprefer", Arg.Set dump_prefer, "";
      "-dalloc", Arg.Set dump_regalloc, "";
      "-dreload", Arg.Set dump_reload, "";
+     "-dscheduling", Arg.Set dump_scheduling, "";
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
      "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -151,6 +151,7 @@ let dump_interf = ref false             (* -dinterf *)
 let dump_prefer = ref false             (* -dprefer *)
 let dump_regalloc = ref false           (* -dalloc *)
 let dump_reload = ref false             (* -dreload *)
+let dump_scheduling = ref false         (* -dscheduling *)
 let dump_linear = ref false             (* -dlinear *)
 let dump_interval = ref false           (* -dinterval *)
 let keep_startup_file = ref false       (* -dstartup *)
@@ -535,14 +536,14 @@ module Compiler_pass = struct
      - the manual manual/src/cmds/unified-options.etex
   *)
   type t = Parsing | Typing | Lambda | Middle_end
-         | Linearization | Emit | Simplify_cfg | Selection
+         | Scheduling | Emit | Simplify_cfg | Selection
 
   let to_string = function
     | Parsing -> "parsing"
     | Typing -> "typing"
     | Lambda -> "lambda"
     | Middle_end -> "middle_end"
-    | Linearization -> "linearization"
+    | Scheduling -> "scheduling"
     | Emit -> "emit"
     | Simplify_cfg -> "simplify_cfg"
     | Selection -> "selection"
@@ -552,7 +553,7 @@ module Compiler_pass = struct
     | "typing" -> Some Typing
     | "lambda" -> Some Lambda
     | "middle_end" -> Some Middle_end
-    | "linearization" -> Some Linearization
+    | "scheduling" -> Some Scheduling
     | "emit" -> Some Emit
     | "simplify_cfg" -> Some Simplify_cfg
     | "selection" -> Some Selection
@@ -565,7 +566,7 @@ module Compiler_pass = struct
     | Middle_end -> 3
     | Selection -> 20
     | Simplify_cfg -> 49
-    | Linearization -> 50
+    | Scheduling -> 50
     | Emit -> 60
 
   let passes = [
@@ -573,7 +574,7 @@ module Compiler_pass = struct
     Typing;
     Lambda;
     Middle_end;
-    Linearization;
+    Scheduling;
     Emit;
     Simplify_cfg;
     Selection;
@@ -581,7 +582,7 @@ module Compiler_pass = struct
   let is_compilation_pass _ = true
   let is_native_only = function
     | Middle_end -> true
-    | Linearization -> true
+    | Scheduling -> true
     | Emit -> true
     | Simplify_cfg -> true
     | Selection -> true
@@ -589,7 +590,7 @@ module Compiler_pass = struct
 
   let enabled is_native t = not (is_native_only t) || is_native
   let can_save_ir_after = function
-    | Linearization -> true
+    | Scheduling -> true
     | Simplify_cfg -> true
     | Selection -> true
     | Parsing | Typing | Lambda | Middle_end | Emit -> false
@@ -605,7 +606,7 @@ module Compiler_pass = struct
 
   let to_output_filename t ~prefix =
     match t with
-    | Linearization -> prefix ^ Compiler_ir.(extension Linear)
+    | Scheduling -> prefix ^ Compiler_ir.(extension Linear)
     | Simplify_cfg -> prefix ^ Compiler_ir.(extension Cfg)
     | Selection -> prefix ^ Compiler_ir.(extension Cfg) ^ "-sel"
     | Emit | Parsing | Typing | Lambda | Middle_end -> Misc.fatal_error "Not supported"

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -158,6 +158,7 @@ val dump_interf : bool ref
 val dump_prefer : bool ref
 val dump_regalloc : bool ref
 val dump_reload : bool ref
+val dump_scheduling : bool ref
 val dump_linear : bool ref
 val dump_interval : bool ref
 val debug_ocaml : bool ref
@@ -277,7 +278,7 @@ end
 
 module Compiler_pass : sig
   type t = Parsing | Typing | Lambda | Middle_end
-         | Linearization | Emit | Simplify_cfg | Selection
+         | Scheduling | Emit | Simplify_cfg | Selection
   val of_string : string -> t option
   val to_string : t -> string
   val is_compilation_pass : t -> bool

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -71,6 +71,7 @@ let main() =
      "-dprefer", Arg.Set dump_prefer, "";
      "-dalloc", Arg.Set dump_regalloc, "";
      "-dreload", Arg.Set dump_reload, "";
+     "-dscheduling", Arg.Set dump_scheduling, "";
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
      "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#2857

Per discussion, this is needed for the minus-21 compiler roll due to use of `-stop-after scheduling`.  I will also make a microbranch adding this PR on top of the previous minus-21 tag and retag it.