### PR TITLE
Restructure `type_declaration`s into a more precise representation

### DIFF
--- a/ocaml/debugger/eval.ml
+++ b/ocaml/debugger/eval.ml
@@ -167,7 +167,7 @@ and find_label lbl env ty path tydesc pos = function
   | {ld_id; ld_type} :: rem ->
       if Ident.name ld_id = lbl then begin
         let ty_res =
-          Btype.newgenty(Tconstr(path, tydesc.type_params, ref Mnil))
+          Btype.newgenty(Tconstr(path, get_type_params tydesc, ref Mnil))
         in
         (pos,
          try Ctype.apply env [ty_res] ld_type [ty] with Ctype.Cannot_apply ->

--- a/ocaml/debugger4/eval.ml
+++ b/ocaml/debugger4/eval.ml
@@ -168,7 +168,7 @@ and find_label lbl env ty path tydesc pos = function
   | {ld_id; ld_type} :: rem ->
       if Ident.name ld_id = lbl then begin
         let ty_res =
-          Btype.newgenty(Tconstr(path, tydesc.type_params, ref Mnil))
+          Btype.newgenty(Tconstr(path, get_type_params tydesc, ref Mnil))
         in
         (pos,
          try Ctype.apply env [ty_res] ld_type [ty] with Ctype.Cannot_apply ->

--- a/ocaml/ocamldoc/odoc_ast.ml
+++ b/ocaml/ocamldoc/odoc_ast.ml
@@ -149,7 +149,7 @@ module Typedtree_search =
           (
            try
              let type_decl = search_type_declaration table name in
-             (ce, type_decl.typ_type.Types.type_params)
+             (ce, Types.get_type_params type_decl.typ_type)
            with
              Not_found ->
                (ce, [])
@@ -1186,8 +1186,8 @@ module Analyser =
                       ty_info = com_opt ;
                       ty_parameters =
                       List.map2 (fun p v -> Odoc_env.subst_type env p, v)
-                       tt_type_decl.Types.type_params
-                       tt_type_decl.Types.type_variance ;
+                        (Types.get_type_params tt_type_decl)
+                        (Types.get_type_variance tt_type_decl);
                       ty_kind = kind ;
                       ty_private = tt_type_decl.Types.type_private;
                       ty_manifest =

--- a/ocaml/ocamldoc/odoc_sig.ml
+++ b/ocaml/ocamldoc/odoc_sig.ml
@@ -1118,8 +1118,8 @@ module Analyser =
                       ty_info = assoc_com ;
                       ty_parameters =
                         List.map2 (fun p v -> Odoc_env.subst_type env p,v)
-                        sig_type_decl.Types.type_params
-                        sig_type_decl.Types.type_variance;
+                        (Types.get_type_params sig_type_decl)
+                        (Types.get_type_variance sig_type_decl);
                       ty_kind = type_kind;
                       ty_private = sig_type_decl.Types.type_private;
                       ty_manifest =
@@ -1201,8 +1201,8 @@ module Analyser =
                       ty_info = assoc_com ;
                       ty_parameters =
                         List.map2 (fun p v -> Odoc_env.subst_type env p,v)
-                        sig_type_decl.Types.type_params
-                        sig_type_decl.Types.type_variance;
+                        (Types.get_type_params sig_type_decl)
+                        (Types.get_type_variance sig_type_decl);
                       ty_kind = type_kind;
                       ty_private = sig_type_decl.Types.type_private;
                       ty_manifest =

--- a/ocaml/toplevel/genprintval.ml
+++ b/ocaml/toplevel/genprintval.ml
@@ -401,7 +401,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                     Oval_stuff "<abstr>"
                 | {type_kind = Type_abstract _; type_manifest = Some body} ->
                     tree_of_val depth obj
-                      (instantiate_type env decl.type_params ty_list body)
+                      (instantiate_type env (get_type_params decl) ty_list body)
                 | {type_kind = Type_variant (constr_list,rep)} ->
                   (* Here we work backwards from the actual runtime value to
                      find the appropriate `constructor_declaration` in
@@ -440,7 +440,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                             Tconstr (_,params,_) ->
                               params
                           | _ -> assert false end
-                      | None -> decl.type_params
+                      | None -> (get_type_params decl)
                     in
                     let unbx =
                       match rep with
@@ -512,7 +512,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                                 else Outval_record_boxed
                         in
                         tree_of_record_fields depth
-                          env path decl.type_params ty_list
+                          env path (get_type_params decl) ty_list
                           lbl_list pos obj rep
                     end
                 | {type_kind = Type_open} ->

--- a/ocaml/toplevel/topdirs.ml
+++ b/ocaml/toplevel/topdirs.ml
@@ -501,7 +501,7 @@ let () =
          in
          let ext =
            { ext_type_path = path;
-             ext_type_params = type_decl.type_params;
+             ext_type_params = get_type_params type_decl;
              ext_args = Cstr_tuple desc.cstr_args;
              ext_arg_jkinds = desc.cstr_arg_jkinds;
              ext_shape = desc.cstr_shape;

--- a/ocaml/typing/btype.ml
+++ b/ocaml/typing/btype.ml
@@ -230,7 +230,7 @@ let set_static_row_name decl path =
       match get_desc ty with
         Tvariant row when static_row row ->
           let row =
-            set_row_name row (Some (path, decl.type_params)) in
+            set_row_name row (Some (path, get_type_params decl)) in
           set_type_desc ty (Tvariant row)
       | _ -> ()
 
@@ -355,7 +355,7 @@ let type_iterators =
   and it_value_description it vd =
     it.it_type_expr it vd.val_type
   and it_type_declaration it td =
-    List.iter (it.it_type_expr it) td.type_params;
+    List.iter (it.it_type_expr it) (get_type_params td);
     Option.iter (it.it_type_expr it) td.type_manifest;
     it.it_type_kind it td.type_kind
   and it_extension_constructor it td =

--- a/ocaml/typing/datarepr.ml
+++ b/ocaml/typing/datarepr.ml
@@ -76,15 +76,13 @@ let constructor_args ~current_unit priv cd_args cd_res path rep =
       in
       let tdecl =
         {
-          type_params;
+          type_params_ = create_type_params_of_unknowns ~injective:true type_params;
           type_arity = arity;
           type_kind = Type_record (lbls, rep);
           type_jkind = jkind;
           type_jkind_annotation = None;
           type_private = priv;
           type_manifest = None;
-          type_variance = Variance.unknown_signature ~injective:true ~arity;
-          type_separability = Types.Separability.default_signature ~arity;
           type_is_newtype = false;
           type_expansion_scope = Btype.lowest_level;
           type_loc = Location.none;
@@ -105,7 +103,7 @@ let constructor_args ~current_unit priv cd_args cd_res path rep =
       Some tdecl
 
 let constructor_descrs ~current_unit ty_path decl cstrs rep =
-  let ty_res = newgenconstr ty_path decl.type_params in
+  let ty_res = newgenconstr ty_path (get_type_params decl) in
   let cstr_shapes_and_arg_jkinds =
     match rep with
     | Variant_extensible -> assert false
@@ -269,6 +267,6 @@ let constructors_of_type ~current_unit ty_path decl =
 let labels_of_type ty_path decl =
   match decl.type_kind with
   | Type_record(labels, rep) ->
-      label_descrs (newgenconstr ty_path decl.type_params)
+      label_descrs (newgenconstr ty_path (get_type_params decl))
         labels rep decl.type_private
   | Type_variant _ | Type_abstract _ | Type_open -> []

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -1541,7 +1541,7 @@ let find_type_expansion path env =
   | Some body when decl.type_private = Public
               || not (Btype.type_kind_is_abstract decl)
               || Btype.has_constr_row body ->
-      (decl.type_params, body, decl.type_expansion_scope)
+      (get_type_params decl, body, decl.type_expansion_scope)
   (* The manifest type of Private abstract data types without
      private row are still considered unknown to the type system.
      Hence, this case is caught by the following clause that also handles
@@ -1558,7 +1558,7 @@ let find_type_expansion_opt path env =
   (* The manifest type of Private abstract data types can still get
      an approximation using their manifest type. *)
   | Some body ->
-      (decl.type_params, body, decl.type_expansion_scope)
+      (get_type_params decl, body, decl.type_expansion_scope)
   | _ -> raise Not_found
 
 let find_modtype_expansion_lazy path env =

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -1063,18 +1063,18 @@ let type_declarations ?(equality = false) ~loc env ~mark name
   let err = match (decl1.type_manifest, decl2.type_manifest) with
       (_, None) ->
         begin
-          match Ctype.equal env true decl1.type_params decl2.type_params with
+          match Ctype.equal env true (get_type_params decl1) (get_type_params decl2) with
           | exception Ctype.Equality err -> Some (Constraint err)
           | () -> None
         end
     | (Some ty1, Some ty2) ->
-         type_manifest env ty1 decl1.type_params ty2 decl2.type_params
+         type_manifest env ty1 (get_type_params decl1) ty2 (get_type_params decl2)
            decl2.type_private decl2.type_kind
     | (None, Some ty2) ->
         let ty1 =
-          Btype.newgenty (Tconstr(path, decl2.type_params, ref Mnil))
+          Btype.newgenty (Tconstr(path, (get_type_params decl2), ref Mnil))
         in
-        match Ctype.equal env true decl1.type_params decl2.type_params with
+        match Ctype.equal env true (get_type_params decl1) (get_type_params decl2) with
         | exception Ctype.Equality err -> Some (Constraint err)
         | () ->
           match Ctype.equal env false [ty1] [ty2] with
@@ -1105,8 +1105,8 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           if equality then mark Env.Exported cstrs2
         end;
         Variant_diffing.compare_with_representation ~loc env
-          decl1.type_params
-          decl2.type_params
+          (get_type_params decl1)
+          (get_type_params decl2)
           cstrs1
           cstrs2
           rep1
@@ -1124,7 +1124,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           if equality then mark Env.Exported labels2
         end;
         Record_diffing.compare_with_representation ~loc env
-          decl1.type_params decl2.type_params
+          (get_type_params decl1) (get_type_params decl2)
           labels1 labels2
           rep1 rep2
     | (Type_open, Type_open) -> None
@@ -1148,7 +1148,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
          else true) &&
         let (p1,n1,j1) = get_lower v1 and (p2,n2,j2) = get_lower v2 in
         imp abstr (imp p2 p1 && imp n2 n1 && imp j2 j1))
-      decl2.type_params (List.combine decl1.type_variance decl2.type_variance)
+      (get_type_params decl2) (List.combine (get_type_variance decl1) (get_type_variance decl2))
   then None else Some Variance
 
 (* Inclusion between extension constructors *)

--- a/ocaml/typing/mtype.ml
+++ b/ocaml/typing/mtype.ml
@@ -95,7 +95,7 @@ and strengthen_lazy_sig' ~aliasable sg p =
         | _ ->
             let manif =
               Some(Btype.newgenty(Tconstr(Pdot(p, Ident.name id),
-                                          decl.type_params, ref Mnil))) in
+                                          (get_type_params decl), ref Mnil))) in
             if Btype.type_kind_is_abstract decl then
               { decl with type_private = Public; type_manifest = manif }
             else
@@ -301,7 +301,7 @@ let rec sig_make_manifest sg =
       | Some _, Private, (Type_record _ | Type_variant _) -> decl
       | _ ->
         let manif =
-          Some (Btype.newgenty(Tconstr(Pident id, decl.type_params, ref Mnil)))
+          Some (Btype.newgenty(Tconstr(Pident id, get_type_params decl, ref Mnil)))
         in
         match decl.type_kind with
         | Type_abstract _ ->
@@ -521,11 +521,11 @@ let enrich_typedecl env p id decl =
         else begin
           let orig_ty =
             Ctype.reify_univars env
-              (Btype.newgenty(Tconstr(p, orig_decl.type_params, ref Mnil)))
+              (Btype.newgenty(Tconstr(p, get_type_params orig_decl, ref Mnil)))
           in
           let new_ty =
             Ctype.reify_univars env
-              (Btype.newgenty(Tconstr(Pident id, decl.type_params, ref Mnil)))
+              (Btype.newgenty(Tconstr(Pident id, get_type_params decl, ref Mnil)))
           in
           let env = Env.add_type ~check:false id decl env in
           match Ctype.mcomp env orig_ty new_ty with
@@ -536,7 +536,7 @@ let enrich_typedecl env p id decl =
                  different, which we didn't. *)
           | () ->
               let orig_ty =
-                Btype.newgenty(Tconstr(p, decl.type_params, ref Mnil))
+                Btype.newgenty(Tconstr(p, get_type_params decl, ref Mnil))
               in
               {decl with type_manifest = Some orig_ty}
         end

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -225,7 +225,7 @@ let mk_add_type add_type
       ?jkind_annotation
       env =
   let decl =
-    {type_params = [];
+    {type_params_ = [];
      type_arity = 0;
      type_kind = kind;
      type_jkind = jkind;
@@ -233,8 +233,6 @@ let mk_add_type add_type
      type_loc = Location.none;
      type_private = Asttypes.Public;
      type_manifest = manifest;
-     type_variance = [];
-     type_separability = [];
      type_is_newtype = false;
      type_expansion_scope = lowest_level;
      type_attributes = [];
@@ -260,7 +258,7 @@ let mk_add_type1 add_type type_ident
     ~variance ~separability env =
   let param = newgenvar param_jkind in
   let decl =
-    {type_params = [param];
+    {type_params_ = [{ param_expr = param; variance; separability }];
       type_arity = 1;
       type_kind = kind param;
       type_jkind = jkind;
@@ -268,8 +266,6 @@ let mk_add_type1 add_type type_ident
       type_loc = Location.none;
       type_private = Asttypes.Public;
       type_manifest = None;
-      type_variance = [variance];
-      type_separability = [separability];
       type_is_newtype = false;
       type_expansion_scope = lowest_level;
       type_attributes = [];

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1730,7 +1730,7 @@ let tree_of_constructor_in_decl cd =
   | Some _ -> Names.with_local_names (fun () -> tree_of_single_constructor cd)
 
 let prepare_decl id decl =
-  let params = filter_params decl.type_params in
+  let params = filter_params (get_type_params decl) in
   begin match decl.type_manifest with
   | Some ty ->
       let vars = free_variables ty in
@@ -1816,7 +1816,7 @@ let tree_of_type_decl id decl =
              if not co then Contravariant else NoVariance),
             (if inj then Injective else NoInjectivity)
           else (NoVariance, NoInjectivity))
-        decl.type_params decl.type_variance
+        (get_type_params decl) (get_type_variance decl)
     in
     let mk_param ty (variance, injectivity) =
       { oparam_name = type_param (tree_of_typexp Type ty);
@@ -2317,15 +2317,13 @@ let wrap_env fenv ftree arg =
 
 let dummy =
   {
-    type_params = [];
+    type_params_ = [];
     type_arity = 0;
     type_kind = Type_abstract Abstract_def;
     type_jkind = Jkind.Builtin.any ~why:Dummy_jkind;
     type_jkind_annotation = None;
     type_private = Public;
     type_manifest = None;
-    type_variance = [];
-    type_separability = [];
     type_is_newtype = false;
     type_expansion_scope = Btype.lowest_level;
     type_loc = Location.none;

--- a/ocaml/typing/subst.ml
+++ b/ocaml/typing/subst.ml
@@ -455,7 +455,8 @@ let record_representation ~prepare_jkind loc = function
   | (Record_float | Record_ufloat | Record_mixed _) as rep -> rep
 
 let type_declaration' copy_scope s decl =
-  { type_params = List.map (typexp copy_scope s decl.type_loc) decl.type_params;
+  { type_params_ =
+      (set_type_params decl (List.map (typexp copy_scope s decl.type_loc) (get_type_params decl))).type_params_;
     type_arity = decl.type_arity;
     type_kind =
       begin match decl.type_kind with
@@ -495,8 +496,6 @@ let type_declaration' copy_scope s decl =
     (* CR layouts v10: Apply the substitution here, too *)
     type_jkind_annotation = decl.type_jkind_annotation;
     type_private = decl.type_private;
-    type_variance = decl.type_variance;
-    type_separability = decl.type_separability;
     type_is_newtype = false;
     type_expansion_scope = Btype.lowest_level;
     type_loc = loc s decl.type_loc;

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -983,7 +983,7 @@ let unify_pat ?refine ?sdesc_for_hint env pat expected_ty =
 let unify_head_only ~refine loc env ty constr =
   let path = cstr_type_path constr in
   let decl = Env.find_type path !env in
-  let ty' = Ctype.newconstr path (Ctype.instance_list decl.type_params) in
+  let ty' = Ctype.newconstr path (Ctype.instance_list (get_type_params decl)) in
   unify_pat_types ~refine loc env ty' ty
 
 (* Creating new conjunctive types is not allowed when typing patterns *)
@@ -1693,10 +1693,10 @@ let build_or_pat env loc lid =
   (* CR layouts: the use of value here is wrong:
      there could be other jkinds in a polymorphic variant argument;
      see Test 24 in tests/typing-layouts/basics_alpha.ml *)
-  let arity = List.length decl.type_params in
+  let arity = List.length (get_type_params decl) in
   let tyl = List.mapi (fun i _ ->
     newvar (Jkind.Builtin.value ~why:(Type_argument {parent_path = path; position = i+1; arity}))
-  ) decl.type_params in
+  ) (get_type_params decl) in
   let row0 =
     let ty = expand_head env (newty(Tconstr(path, tyl, ref Mnil))) in
     match get_desc ty with
@@ -5499,7 +5499,7 @@ and type_expect_
             let decl = Env.find_type p' env in
             let ty =
               with_local_level ~post:generalize_structure
-                (fun () -> newconstr p' (instance_list decl.type_params))
+                (fun () -> newconstr p' (instance_list (get_type_params decl)))
             in
             ty, opt_exp_opath
       in

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -498,7 +498,7 @@ end
 (* Type definitions *)
 
 type type_declaration =
-  { type_params: type_expr list;
+  { type_params_: type_param list;
     type_arity: int;
     type_kind: type_decl_kind;
 
@@ -522,9 +522,6 @@ type type_declaration =
 
     type_private: private_flag;
     type_manifest: type_expr option;
-    type_variance: Variance.t list;
-    (* covariant, contravariant, weakly contravariant, injective *)
-    type_separability: Separability.t list;
     type_is_newtype: bool;
     type_expansion_scope: int;
     type_loc: Location.t;
@@ -536,6 +533,13 @@ type type_declaration =
     (* true iff the type definition has illegal crossings of the portability and
        contention axes *)
     (* CR layouts v2.8: remove type_has_illegal_crossings *)
+  }
+
+and type_param =
+  { param_expr: type_expr;
+    variance: Variance.t;
+    (* covariant, contravariant, weakly contravariant, injective *)
+    separability: Separability.t;
   }
 
 and type_decl_kind = (label_declaration, constructor_declaration) type_kind
@@ -682,6 +686,21 @@ and type_transparence =
     Type_public      (* unrestricted expansion *)
   | Type_new         (* "new" type *)
   | Type_private     (* private type *)
+
+(* Legacy properties *)
+(* FIXME jbachurski: All of these should be removed by the time this PR is done. *)
+
+val create_type_params : type_expr list -> Variance.t list -> Separability.t list -> type_param list
+val create_type_params_of_unknowns : injective:bool -> type_expr list -> type_param list
+
+val get_type_params : type_declaration -> type_expr list
+val set_type_params : type_declaration -> type_expr list -> type_declaration
+
+val get_type_variance : type_declaration -> Variance.t list
+val set_type_variance : type_declaration -> Variance.t list -> type_declaration
+
+val get_type_separability : type_declaration -> Separability.t list
+val set_type_separability : type_declaration -> Separability.t list -> type_declaration
 
 (* Type expressions for the class language *)
 

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -719,7 +719,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       let stl =
         match stl with
         | [ {ptyp_desc=Ptyp_any} as t ] when decl.type_arity > 1 ->
-            List.map (fun _ -> t) decl.type_params
+            List.map (fun _ -> t) (get_type_params decl)
         | _ -> stl
       in
       if List.length stl <> decl.type_arity then
@@ -729,7 +729,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       let args =
         List.map (transl_type env ~policy ~row_context Alloc.Const.legacy) stl
       in
-      let params = instance_list decl.type_params in
+      let params = instance_list (get_type_params decl) in
       let unify_param =
         match decl.type_manifest with
           None -> unify_var
@@ -791,7 +791,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
         List.map (transl_type env ~policy ~row_context Alloc.Const.legacy) stl
       in
       let body = Option.get decl.type_manifest in
-      let (params, body) = instance_parameterized_type decl.type_params body in
+      let (params, body) = instance_parameterized_type (get_type_params decl) body in
       List.iter2
         (fun (sty, cty) ty' ->
            try unify_var env ty' cty.ctyp_type with Unify err ->


### PR DESCRIPTION
_Sketch of the changes from discussions:_

```ocaml
type type_declaration =
  { type_manifest : Path.t option;
    type_kind : type_kind;
    type_is_newtype : bool;
    type_expansion_scope: int;
    type_jkind_annotation: type_expr Jkind_types.annotation option;
    type_loc: Location.t;
    type_attributes: Parsetree.attributes;
    type_uid: Uid.t;
    type_has_illegal_crossings: bool;
  }

and type_kind =
  | Datatype of datatype_kind
  | Type of
      { equation : type_equation;
        jkind: jkind; }
  | Type_constructor of
      { params : type_parameter list;
        equation : type_equation;
        jkind: jkind; }

and datatype_kind =
    Datatype_abstract of abstract_reason * type_jkind
  | Datatype_record of private_flag * 'lbl list  * record_representation * type_jkind
  | Datatype_variant of private_flag * 'cstr list * variant_representation  * type_jkind
  | Datatype_open of private_flag
  | Datatype_private of type_expr * type_jkind
  | Datatype_new of type_expr * type_jkind
  | Datatype_fun of type_parameter list * type_representation

and type_equation =
  | Type_abstract of abstract_reason
  | Type_expr of 
      { private_row: private_flag; 
        expansion : type_expr }

and type_parameter =
  { param_expr : type_expr;
    variance : Variance.t;
    separability : Separability.t;
    cached_jkind : jkind; }

and record_representation =
  | Record_unboxed of { unboxed_default : bool }
  | Record_inlined of tag * constructor_representation * variant_representation
  | Record_boxed of jkind array
  | Record_float
  | Record_ufloat
  | Record_mixed of mixed_product_shape

and variant_representation =
  | Variant_unboxed of { unboxed_default : bool }
  | Variant_boxed of (constructor_representation * jkind array) array
  | Variant_extensible
```

This sketch also includes changes relevant to higher kinds (incl. `new` type abbreviations) - `Datatype_new` and `Datatype_fun` won't appear in this approach.

Goals / expectations:

- More precise:
  - Only allows general type manifests for general equations, and not datatypes 
    - They cannot appear in any position except ones where the manifest is a path: `type ('a, 'b) bar = ('b, 'a) foo = Foo of 'a * 'b` is rejected as `('a, 'b) != ('b, 'a)`). Path manifests are the only kind that has to be settable for any type (this is done often by the module system when `module M = struct type foo = Foo end` results in a `type foo = M.foo = Foo`).
    - This should also result in performance gains, as the path case is a shorter code path than a general substitution. 
  - Type parameters, variances and separabilities are held as a list-of-structs vs struct-of-lists, and the arity is computed from them rather than independent (and dubiously consistent).
- More compositional through richer `type_kind` - easier to implement repeated type application
- Better framework for implementing getters for semantic properties, like 'how many parameters in the outermost application?' (usually `type_arity` when `> 0`).
- Separates out the many meanings of `private_flag` - for manifests, record/variant constructors, and private rows in type equations. This should lead to cleaner logic and stamp out bugs.

**This is a working draft.**