### PR TITLE
Runtime cherry picks: upstream trunk -> 5.2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
                 "smmintrin.h": "c",
                 "tmmintrin.h": "c",
                 "pmmintrin.h": "c",
-                "*.tbl": "c"
+                "*.tbl": "c",
+                "platform.h": "c"
         }
 }

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -751,6 +751,7 @@ let operation_supported = function
   | Cprobe _ | Cprobe_is_enabled _ | Copaque | Cbeginregion | Cendregion
   | Ctuple_field _
   | Cdls_get
+  | Cpoll
     -> true
 
 let trap_size_in_bytes = 16

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -1197,8 +1197,7 @@ let emit_instr i =
     | Lpushtrap { lbl_handler; } ->
         `	adr	{emit_reg reg_tmp1}, {emit_label lbl_handler}\n`;
         stack_offset := !stack_offset + 16;
-        `	str	{emit_reg reg_trap_ptr}, [sp, -16]!\n`;
-        `	str	{emit_reg reg_tmp1}, [sp, #8]\n`;
+        `	stp	{emit_reg reg_trap_ptr}, {emit_reg reg_tmp1}, [sp, -16]!\n`;
         cfi_adjust_cfa_offset 16;
         `	mov	{emit_reg reg_trap_ptr}, sp\n`
     | Lpoptrap ->
@@ -1218,8 +1217,7 @@ let emit_instr i =
           `{record_frame Reg.Set.empty (Dbg_raise i.dbg)}\n`
         | Lambda.Raise_notrace ->
           `	mov	sp, {emit_reg reg_trap_ptr}\n`;
-          `	ldr	{emit_reg reg_tmp1}, [sp, #8]\n`;
-          `	ldr	{emit_reg reg_trap_ptr}, [sp], 16\n`;
+          `	ldp	{emit_reg reg_trap_ptr}, {emit_reg reg_tmp1}, [sp], 16\n`;
           `	br	{emit_reg reg_tmp1}\n`
       end
     | Lstackcheck { max_frame_size_bytes; } ->

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -513,6 +513,7 @@ let operation_supported = function
   | Cprobe _ | Cprobe_is_enabled _ | Copaque
   | Cbeginregion | Cendregion | Ctuple_field _
   | Cdls_get
+  | Cpoll
     -> true
 
 let trap_size_in_bytes = 16

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -267,6 +267,7 @@ type operation =
   | Cbeginregion | Cendregion
   | Ctuple_field of int * machtype array
   | Cdls_get
+  | Cpoll
 
 type kind_for_unboxing =
   | Any

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -253,6 +253,7 @@ type operation =
   | Ctuple_field of int * machtype array
       (* the [machtype array] refers to the whole tuple *)
   | Cdls_get
+  | Cpoll
 
 (* This is information used exclusively during construction of cmm terms by
    cmmgen, and thus irrelevant for selectgen and flambda2. *)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4234,3 +4234,5 @@ let reperform ~dbg ~eff ~cont ~last_fiber =
         cont;
         last_fiber ],
       dbg )
+
+let poll ~dbg = return_unit dbg (Cop (Cpoll, [], dbg))

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1136,3 +1136,5 @@ val setfield_unboxed_float32 : ternary_primitive
 val setfield_unboxed_int64_or_nativeint : ternary_primitive
 
 val dls_get : dbg:Debuginfo.t -> expression
+
+val poll : dbg:Debuginfo.t -> expression

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -271,6 +271,7 @@ let operation d = function
   | Ctuple_field (field, _ty) ->
     to_string "tuple_field %i" field
   | Cdls_get -> "dls_get"
+  | Cpoll -> "poll"
 
 let rec expr ppf = function
   | Cconst_int (n, _dbg) -> fprintf ppf "%i" n

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -992,7 +992,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Punbox_int _ | Pbox_int _ | Pmake_unboxed_product _
       | Punboxed_product_field _ | Pget_header _ | Prunstack | Pperform
       | Presume | Preperform | Patomic_exchange | Patomic_cas
-      | Patomic_fetch_add | Pdls_get | Patomic_load _
+      | Patomic_fetch_add | Pdls_get | Ppoll | Patomic_load _
       | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 ->
         (* Inconsistent with outer match *)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -758,7 +758,7 @@ let primitive_can_raise (prim : Lambda.primitive) =
     false
   | Patomic_exchange | Patomic_cas | Patomic_fetch_add | Patomic_load _ -> false
   | Prunstack | Pperform | Presume | Preperform -> true (* XXX! *)
-  | Pdls_get | Preinterpret_tagged_int63_as_unboxed_int64
+  | Pdls_get | Ppoll | Preinterpret_tagged_int63_as_unboxed_int64
   | Preinterpret_unboxed_int64_as_tagged_int63 ->
     false
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1940,6 +1940,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Patomic_fetch_add, [[atomic]; [i]] ->
     [Binary (Atomic_fetch_and_add, atomic, i)]
   | Pdls_get, _ -> [Nullary Dls_get]
+  | Ppoll, _ -> [Nullary Poll]
   | Preinterpret_unboxed_int64_as_tagged_int63, [[i]] ->
     if not (Target_system.is_64_bit ())
     then

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -517,7 +517,7 @@ let nullop _env (op : Flambda_primitive.nullary_primitive) : Fexpr.nullop =
   | Begin_region -> Begin_region
   | Begin_try_region -> Begin_try_region
   | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Enter_inlined_apply _
-  | Dls_get ->
+  | Dls_get | Poll ->
     Misc.fatal_errorf "TODO: Nullary primitive: %a" Flambda_primitive.print
       (Flambda_primitive.Nullary op)
 

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -54,3 +54,8 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     let ty = T.any_value in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc
+  | Poll ->
+    let named = Named.create_prim original_prim dbg in
+    let ty = T.this_tagged_immediate Targetint_31_63.zero in
+    let dacc = DA.add_variable dacc result_var ty in
+    Simplify_primitive_result.create named ~try_reify:false dacc

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -335,6 +335,7 @@ let nullary_prim_size prim =
   | Begin_try_region -> 1
   | Enter_inlined_apply _ -> 0
   | Dls_get -> 1
+  | Poll -> alloc_size
 
 let unary_prim_size prim =
   match (prim : Flambda_primitive.unary_primitive) with

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -300,6 +300,10 @@ type nullary_primitive =
       (** Used in classic mode to denote the start of an inlined function body.
           This is then used in to_cmm to correctly add inlined debuginfo. *)
   | Dls_get  (** Obtain the domain-local state block. *)
+  | Poll
+      (** Poll for runtime actions. May run pending actions such as signal
+          handlers, finalizers, memprof callbacks, etc, as well as GCs and
+          GC slices, so should not be moved or optimised away. *)
 
 (** Untagged binary integer arithmetic operations.
 

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -678,6 +678,7 @@ let nullary_primitive _env res dbg prim =
        [to_cmm_primitive] but should instead be handled in [to_cmm_expr] to \
        correctly adjust the inlined debuginfo in the env."
   | Dls_get -> None, res, C.dls_get ~dbg
+  | Poll -> None, res, C.poll ~dbg
 
 let unary_primitive env res dbg f arg =
   match (f : P.unary_primitive) with

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -195,7 +195,7 @@ let preserve_tailcall_for_prim = function
   | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer _
   | Patomic_exchange | Patomic_cas | Patomic_fetch_add | Patomic_load _
   | Pdls_get | Preinterpret_tagged_int63_as_unboxed_int64
-  | Preinterpret_unboxed_int64_as_tagged_int63 ->
+  | Preinterpret_unboxed_int64_as_tagged_int63 | Ppoll ->
       false
 
 (* Add a Kpop N instruction in front of a continuation *)
@@ -603,6 +603,7 @@ let comp_primitive stack_info p sz args =
   | Patomic_cas -> Kccall("caml_atomic_cas", 3)
   | Patomic_fetch_add -> Kccall("caml_atomic_fetch_add", 2)
   | Pdls_get -> Kccall("caml_domain_dls_get", 1)
+  | Ppoll -> Kccall("caml_process_pending_actions_with_root", 1)
   | Pstring_load_128 _ | Pbytes_load_128 _ | Pbytes_set_128 _
   | Pbigstring_load_128 _ | Pbigstring_set_128 _
   | Pfloatarray_load_128 _ | Pfloat_array_load_128 _ | Pint_array_load_128 _

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -1146,6 +1146,10 @@ AC_CHECK_HEADER([stdatomic.h], [AC_DEFINE([HAS_STDATOMIC_H])])
 
 AC_CHECK_HEADER([sys/mman.h], [AC_DEFINE([HAS_SYS_MMAN_H])])
 
+AS_CASE([$host],
+  [*-*-linux*],
+    [AC_CHECK_HEADER([linux/futex.h], [AC_DEFINE([HAS_LINUX_FUTEX_H])])])
+
 # Checks for types
 
 ## off_t
@@ -2766,11 +2770,12 @@ ocamlc_cppflags="$common_cppflags $CPPFLAGS"
 
 AS_CASE([$host],
   [*-*-mingw32*],
-    [cclibs="$cclibs -lole32 -luuid -lversion"],
+    [cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi -lsynchronization"],
   [*-pc-windows],
-    [# For whatever reason, flexlink includes -ladvapi32 for mingw-w64, but
-    # doesn't include advapi32.lib for MSVC
-    cclibs="$cclibs ole32.lib uuid.lib advapi32.lib version.lib"])
+    [# For whatever reason, flexlink includes -ladvapi32 and -lshell32 for
+    # mingw-w64, but doesn't include advapi32.lib and shell32.lib for MSVC
+    cclibs="$cclibs ole32.lib uuid.lib advapi32.lib shell32.lib version.lib \
+shlwapi.lib synchronization.lib"])
 
 AC_CONFIG_COMMANDS_PRE([cclibs="$cclibs $mathlib $DLLIBS $PTHREAD_LIBS"])
 

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -313,6 +313,8 @@ type primitive =
   | Pget_header of alloc_mode
   (* Fetching domain-local state *)
   | Pdls_get
+  (* Poll for runtime actions *)
+  | Ppoll
 
 and extern_repr =
   | Same_as_ocaml_repr of Jkind.Sort.const
@@ -1808,8 +1810,9 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pobj_magic _ -> None
   | Punbox_float _ | Punbox_int _ -> None
   | Pbox_float (_, m) | Pbox_int (_, m) -> Some m
-  | Prunstack | Presume | Pperform | Preperform ->
+  | Prunstack | Presume | Pperform | Preperform
     (* CR mshinwell: check *)
+  | Ppoll ->
     Some alloc_heap
   | Patomic_load _
   | Patomic_exchange
@@ -2011,6 +2014,7 @@ let primitive_result_layout (p : primitive) =
   | Patomic_cas
   | Patomic_fetch_add
   | Pdls_get -> layout_any_value
+  | Ppoll -> layout_unit
   | Preinterpret_tagged_int63_as_unboxed_int64 -> layout_unboxed_int64
   | Preinterpret_unboxed_int64_as_tagged_int63 -> layout_int
 

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -313,6 +313,10 @@ type primitive =
      if the value is locally allocated *)
   (* Fetching domain-local state *)
   | Pdls_get
+  (* Poll for runtime actions. May run pending actions such as signal
+     handlers, finalizers, memprof callbacks, etc, as well as GCs and
+     GC slices, so should not be moved or optimised away. *)
+  | Ppoll
 
 (** This is the same as [Primitive.native_repr] but with [Repr_poly]
     compiled away. *)

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -795,6 +795,7 @@ let primitive ppf = function
   | Patomic_fetch_add -> fprintf ppf "atomic_fetch_add"
   | Popaque _ -> fprintf ppf "opaque"
   | Pdls_get -> fprintf ppf "dls_get"
+  | Ppoll -> fprintf ppf "poll"
   | Pprobe_is_enabled {name} -> fprintf ppf "probe_is_enabled[%s]" name
   | Pobj_dup -> fprintf ppf "obj_dup"
   | Pobj_magic _ -> fprintf ppf "obj_magic"
@@ -967,6 +968,7 @@ let name_of_primitive = function
   | Pperform -> "Pperform"
   | Preperform -> "Preperform"
   | Pdls_get -> "Pdls_get"
+  | Ppoll -> "Ppoll"
   | Pprobe_is_enabled _ -> "Pprobe_is_enabled"
   | Pobj_dup -> "Pobj_dup"
   | Pobj_magic _ -> "Pobj_magic"

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -967,6 +967,7 @@ let rec choice ctx t =
     | Pbbswap _
     | Pint_as_pointer _
     | Psequand | Psequor
+    | Ppoll
       ->
         let primargs = traverse_list ctx primargs in
         Choice.lambda (Lprim (prim, primargs, loc))

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -818,6 +818,7 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
       if runtime5 then Primitive (Presume, 3) else Unsupported Presume
 >>>>>>> ocaml-jst/flambda-patches
     | "%dls_get" -> Primitive (Pdls_get, 1)
+    | "%poll" -> Primitive (Ppoll, 1)
     | "%unbox_nativeint" -> Primitive(Punbox_int Pnativeint, 1)
     | "%box_nativeint" -> Primitive(Pbox_int (Pnativeint, mode), 1)
     | "%unbox_int32" -> Primitive(Punbox_int Pint32, 1)
@@ -1577,7 +1578,7 @@ let lambda_primitive_needs_event_after = function
   | Punboxed_int32_array_set_128 _ | Punboxed_int64_array_set_128 _
   | Punboxed_nativeint_array_set_128 _
   | Prunstack | Pperform | Preperform | Presume
-  | Pbbswap _ | Pobj_dup | Pget_header _ -> true
+  | Pbbswap _ | Ppoll | Pobj_dup | Pget_header _ -> true
   (* [Preinterpret_tagged_int63_as_unboxed_int64] has to allocate in
      bytecode, because int64# is actually represented as a boxed value. *)
   | Preinterpret_tagged_int63_as_unboxed_int64 -> true

--- a/ocaml/lambda/value_rec_compiler.ml
+++ b/ocaml/lambda/value_rec_compiler.ml
@@ -218,7 +218,8 @@ let compute_static_size lam =
     | Pbigstring_set_16 _
     | Pbigstring_set_32 _
     | Pbigstring_set_f32 _
-    | Pbigstring_set_64 _ ->
+    | Pbigstring_set_64 _
+    | Ppoll ->
         (* Unit-returning primitives. Most of these are only generated from
            external declarations and not special-cased by [Value_rec_check],
            but it doesn't hurt to be consistent. *)

--- a/ocaml/otherlibs/unix/chmod.c
+++ b/ocaml/otherlibs/unix/chmod.c
@@ -23,15 +23,16 @@
 #include <caml/osdeps.h>
 #include "caml/unixsupport.h"
 
-CAMLprim value caml_unix_chmod(value path, value perm)
+CAMLprim value caml_unix_chmod(value path, value vperm)
 {
-  CAMLparam2(path, perm);
+  CAMLparam2(path, vperm);
   char_os * p;
   int ret;
+  int perm = Int_val(vperm);
   caml_unix_check_path(path, "chmod");
   p = caml_stat_strdup_to_os(String_val(path));
   caml_enter_blocking_section();
-  ret = chmod_os(p, Int_val(perm));
+  ret = chmod_os(p, perm);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) caml_uerror("chmod", path);

--- a/ocaml/otherlibs/unix/mkdir.c
+++ b/ocaml/otherlibs/unix/mkdir.c
@@ -26,15 +26,16 @@
 #include <caml/signals.h>
 #include "caml/unixsupport.h"
 
-CAMLprim value caml_unix_mkdir(value path, value perm)
+CAMLprim value caml_unix_mkdir(value path, value vperm)
 {
-  CAMLparam2(path, perm);
+  CAMLparam2(path, vperm);
   char_os * p;
   int ret;
+  int perm = Int_val(vperm);
   caml_unix_check_path(path, "mkdir");
   p = caml_stat_strdup_to_os(String_val(path));
   caml_enter_blocking_section();
-  ret = mkdir_os(p, Int_val(perm));
+  ret = mkdir_os(p, perm);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) caml_uerror("mkdir", path);

--- a/ocaml/otherlibs/unix/mkfifo.c
+++ b/ocaml/otherlibs/unix/mkfifo.c
@@ -23,15 +23,16 @@
 
 #ifdef HAS_MKFIFO
 
-CAMLprim value caml_unix_mkfifo(value path, value mode)
+CAMLprim value caml_unix_mkfifo(value path, value vmode)
 {
-  CAMLparam2(path, mode);
+  CAMLparam2(path, vmode);
   char * p;
   int ret;
+  int mode = Int_val(vmode);
   caml_unix_check_path(path, "mkfifo");
   p = caml_stat_strdup(String_val(path));
   caml_enter_blocking_section();
-  ret = mkfifo(p, Int_val(mode));
+  ret = mkfifo(p, mode);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1)
@@ -46,15 +47,16 @@ CAMLprim value caml_unix_mkfifo(value path, value mode)
 
 #ifdef S_IFIFO
 
-CAMLprim value caml_unix_mkfifo(value path, value mode)
+CAMLprim value caml_unix_mkfifo(value path, value vmode)
 {
-  CAMLparam2(path, mode);
+  CAMLparam2(path, vmode);
   char * p;
   int ret;
+  int mode = Int_val(vmode);
   caml_unix_check_path(path, "mkfifo");
   p = caml_stat_strdup(String_val(path));
   caml_enter_blocking_section();
-  ret = mknod(p, (Int_val(mode) & 07777) | S_IFIFO, 0);
+  ret = mknod(p, (mode & 07777) | S_IFIFO, 0);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1)

--- a/ocaml/otherlibs/unix/open_unix.c
+++ b/ocaml/otherlibs/unix/open_unix.c
@@ -55,11 +55,12 @@ static const int open_cloexec_table[15] = {
   CLOEXEC, KEEPEXEC
 };
 
-CAMLprim value caml_unix_open(value path, value flags, value perm)
+CAMLprim value caml_unix_open(value path, value flags, value vperm)
 {
-  CAMLparam3(path, flags, perm);
+  CAMLparam3(path, flags, vperm);
   int fd, cv_flags, clo_flags, cloexec;
   char * p;
+  int perm = Int_val(vperm);
 
   caml_unix_check_path(path, "open");
   cv_flags = caml_convert_flag_list(flags, open_flag_table);
@@ -76,7 +77,7 @@ CAMLprim value caml_unix_open(value path, value flags, value perm)
   p = caml_stat_strdup(String_val(path));
   /* open on a named FIFO can block (PR#8005) */
   caml_enter_blocking_section();
-  fd = open(p, cv_flags, Int_val(perm));
+  fd = open(p, cv_flags, perm);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (fd == -1) caml_uerror("open", path);

--- a/ocaml/otherlibs/unix/read_unix.c
+++ b/ocaml/otherlibs/unix/read_unix.c
@@ -37,18 +37,19 @@ CAMLprim value caml_unix_read(value fd, value buf, value ofs, value len)
   CAMLreturn(Val_int(ret));
 }
 
-CAMLprim value caml_unix_read_bigarray(value fd, value vbuf,
+CAMLprim value caml_unix_read_bigarray(value vfd, value vbuf,
                                        value vofs, value vlen)
 {
-  CAMLparam4(fd, vbuf, vofs, vlen);
+  CAMLparam4(vfd, vbuf, vofs, vlen);
   intnat ofs, len, ret;
   void *buf;
 
   buf = Caml_ba_data_val(vbuf);
   ofs = Long_val(vofs);
   len = Long_val(vlen);
+  int fd = Int_val(vfd);
   caml_enter_blocking_section();
-  ret = read(Int_val(fd), (char *) buf + ofs, len);
+  ret = read(fd, (char *) buf + ofs, len);
   caml_leave_blocking_section();
   if (ret == -1) caml_uerror("read_bigarray", Nothing);
   CAMLreturn(Val_long(ret));

--- a/ocaml/otherlibs/unix/socketpair_win32.c
+++ b/ocaml/otherlibs/unix/socketpair_win32.c
@@ -170,18 +170,21 @@ fail:
   return SOCKET_ERROR;
 }
 
-CAMLprim value caml_unix_socketpair(value cloexec, value domain, value type,
-                               value protocol)
+CAMLprim value caml_unix_socketpair(value cloexec, value vdomain, value vtype,
+                               value vprotocol)
 {
-  CAMLparam4(cloexec, domain, type, protocol);
+  CAMLparam4(cloexec, vdomain, vtype, vprotocol);
   CAMLlocal1(result);
   SOCKET sv[2];
   int rc;
+  int domain = Int_val(vdomain);
+  int type = Int_val(vtype);
+  int protocol = Int_val(vprotocol);
 
   caml_enter_blocking_section();
-  rc = socketpair(caml_unix_socket_domain_table[Int_val(domain)],
-                  caml_unix_socket_type_table[Int_val(type)],
-                  Int_val(protocol),
+  rc = socketpair(caml_unix_socket_domain_table[domain],
+                  caml_unix_socket_type_table[type],
+                  protocol,
                   sv,
                   ! caml_unix_cloexec_p(cloexec));
   caml_leave_blocking_section();

--- a/ocaml/otherlibs/unix/truncate_unix.c
+++ b/ocaml/otherlibs/unix/truncate_unix.c
@@ -28,15 +28,16 @@
 
 #ifdef HAS_TRUNCATE
 
-CAMLprim value caml_unix_truncate(value path, value len)
+CAMLprim value caml_unix_truncate(value path, value vlen)
 {
-  CAMLparam2(path, len);
+  CAMLparam2(path, vlen);
   char * p;
   int ret;
+  file_offset len = Long_val(vlen);
   caml_unix_check_path(path, "truncate");
   p = caml_stat_strdup(String_val(path));
   caml_enter_blocking_section();
-  ret = truncate(p, Long_val(len));
+  ret = truncate(p, len);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1)

--- a/ocaml/otherlibs/unix/truncate_win32.c
+++ b/ocaml/otherlibs/unix/truncate_win32.c
@@ -69,15 +69,16 @@ static int truncate(WCHAR * path, __int64 len)
   return ret;
 }
 
-CAMLprim value caml_unix_truncate(value path, value len)
+CAMLprim value caml_unix_truncate(value path, value vlen)
 {
-  CAMLparam2(path, len);
+  CAMLparam2(path, vlen);
   WCHAR * p;
   int ret;
+  file_offset len = Long_val(vlen);
   caml_unix_check_path(path, "truncate");
   p = caml_stat_strdup_to_utf16(String_val(path));
   caml_enter_blocking_section();
-  ret = truncate(p, Long_val(len));
+  ret = truncate(p, len);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1)

--- a/ocaml/otherlibs/unix/write_unix.c
+++ b/ocaml/otherlibs/unix/write_unix.c
@@ -55,20 +55,21 @@ CAMLprim value caml_unix_write(value fd, value buf, value vofs, value vlen)
   CAMLreturn(Val_long(written));
 }
 
-CAMLprim value caml_unix_write_bigarray(value fd, value vbuf,
+CAMLprim value caml_unix_write_bigarray(value vfd, value vbuf,
                                         value vofs, value vlen, value vsingle)
 {
-  CAMLparam5(fd, vbuf, vofs, vlen, vsingle);
+  CAMLparam5(vfd, vbuf, vofs, vlen, vsingle);
   intnat ofs, len, written, ret;
   void *buf;
 
   buf = Caml_ba_data_val(vbuf);
   ofs = Long_val(vofs);
   len = Long_val(vlen);
+  int fd = Int_val(vfd);
   written = 0;
   caml_enter_blocking_section();
   while (len > 0) {
-    ret = write(Int_val(fd), (char *) buf + ofs, len);
+    ret = write(fd, (char *) buf + ofs, len);
     if (ret == -1) {
       if ((errno == EAGAIN || errno == EWOULDBLOCK) && written > 0) break;
       caml_leave_blocking_section();

--- a/ocaml/runtime/afl.c
+++ b/ocaml/runtime/afl.c
@@ -16,6 +16,7 @@
 
 #define CAML_INTERNALS
 
+#include <string.h>
 #include "caml/config.h"
 #include "caml/memory.h"
 #include "caml/mlvalues.h"

--- a/ocaml/runtime/arm64.S
+++ b/ocaml/runtime/arm64.S
@@ -600,8 +600,9 @@ FUNCTION(caml_c_call)
         str     TRAP_PTR, Caml_state(exn_handler)
     /* Call the function */
         blr     ADDITIONAL_ARG
-    /* Reload alloc ptr  */
+    /* Reload new allocation pointer & exn handler */
         ldr     ALLOC_PTR, Caml_state(young_ptr)
+        ldr     TRAP_PTR, Caml_state(exn_handler)
     /* Load ocaml stack */
         SWITCH_C_TO_OCAML
 #if defined(WITH_THREAD_SANITIZER)
@@ -657,8 +658,9 @@ FUNCTION(caml_c_call_stack_args)
         blr     ADDITIONAL_ARG
     /* Restore stack */
         mov     sp, x19
-    /* Reload alloc ptr */
+    /* Reload new allocation pointer & exn handler */
         ldr     ALLOC_PTR, Caml_state(young_ptr)
+        ldr     TRAP_PTR, Caml_state(exn_handler)
     /* Switch from C to OCaml */
         SWITCH_C_TO_OCAML
     /* Return */

--- a/ocaml/runtime/arm64.S
+++ b/ocaml/runtime/arm64.S
@@ -834,8 +834,7 @@ L(trap_handler):
     /* Cut stack at current trap handler */
         mov     sp, TRAP_PTR
     /* Pop previous handler and jump to it */
-        ldr     TMP, [sp, 8]
-        ldr     TRAP_PTR, [sp], 16
+        ldp     TRAP_PTR, TMP, [sp], 16
         br      TMP
 .endm
 

--- a/ocaml/runtime/arm64.S
+++ b/ocaml/runtime/arm64.S
@@ -697,10 +697,10 @@ FUNCTION(caml_start_program)
 
 L(jump_to_caml):
     /* Set up stack frame and save callee-save registers */
-        CFI_OFFSET(29, -160)
-        CFI_OFFSET(30, -152)
         stp     x29, x30, [sp, -160]!
         CFI_ADJUST(160)
+        CFI_OFFSET(29, 0)
+        CFI_OFFSET(30, 8)
         add     x29, sp, #0
         stp     x19, x20, [sp, 16]
         stp     x21, x22, [sp, 32]

--- a/ocaml/runtime/arm64.S
+++ b/ocaml/runtime/arm64.S
@@ -693,10 +693,10 @@ FUNCTION(caml_start_program)
 
 L(jump_to_caml):
     /* Set up stack frame and save callee-save registers */
+        CFI_OFFSET(29, -160)
+        CFI_OFFSET(30, -152)
         stp     x29, x30, [sp, -160]!
         CFI_ADJUST(160)
-        CFI_OFFSET(29, 0)
-        CFI_OFFSET(30, 8)
         add     x29, sp, #0
         stp     x19, x20, [sp, 16]
         stp     x21, x22, [sp, 32]

--- a/ocaml/runtime/arm64.S
+++ b/ocaml/runtime/arm64.S
@@ -455,6 +455,7 @@ G(caml_system__code_begin):
 
 FUNCTION(caml_call_realloc_stack)
         CFI_STARTPROC
+        CFI_SIGNAL_FRAME
     /* Save return address and frame pointer */
         CFI_OFFSET(29, -16)
         CFI_OFFSET(30, -8)
@@ -479,11 +480,12 @@ FUNCTION(caml_call_realloc_stack)
         ADDRGLOBAL(x0, caml_exn_Stack_overflow)
         b       G(caml_raise_async)
         CFI_ENDPROC
-        END_FUNCTION(caml_call_realloc_stack)
+END_FUNCTION(caml_call_realloc_stack)
 
 FUNCTION(caml_call_gc)
         CFI_STARTPROC
 L(caml_call_gc):
+        CFI_SIGNAL_FRAME
     /* Save return address and frame pointer */
         CFI_OFFSET(29, -16)
         CFI_OFFSET(30, -8)
@@ -503,7 +505,7 @@ L(caml_call_gc):
         ldp     x29, x30, [sp], 16
         ret
         CFI_ENDPROC
-        END_FUNCTION(caml_call_gc)
+END_FUNCTION(caml_call_gc)
 
 FUNCTION(caml_alloc1)
         CFI_STARTPROC
@@ -513,7 +515,7 @@ FUNCTION(caml_alloc1)
         b.lo    L(caml_call_gc)
         ret
         CFI_ENDPROC
-        END_FUNCTION(caml_alloc1)
+END_FUNCTION(caml_alloc1)
 
 FUNCTION(caml_alloc2)
         CFI_STARTPROC
@@ -523,7 +525,7 @@ FUNCTION(caml_alloc2)
         b.lo    L(caml_call_gc)
         ret
         CFI_ENDPROC
-        END_FUNCTION(caml_alloc2)
+END_FUNCTION(caml_alloc2)
 
 FUNCTION(caml_alloc3)
         CFI_STARTPROC
@@ -533,7 +535,7 @@ FUNCTION(caml_alloc3)
         b.lo    L(caml_call_gc)
         ret
         CFI_ENDPROC
-        END_FUNCTION(caml_alloc3)
+END_FUNCTION(caml_alloc3)
 
 FUNCTION(caml_allocN)
         CFI_STARTPROC
@@ -543,7 +545,7 @@ FUNCTION(caml_allocN)
         b.lo    L(caml_call_gc)
         ret
         CFI_ENDPROC
-        END_FUNCTION(caml_allocN)
+END_FUNCTION(caml_allocN)
 
 /* Reallocate the locals stack.  This is like caml_call_gc, above. */
 FUNCTION(caml_call_local_realloc)
@@ -582,6 +584,7 @@ L(caml_call_local_realloc):
 
 FUNCTION(caml_c_call)
         CFI_STARTPROC
+        CFI_SIGNAL_FRAME
         CFI_OFFSET(29, -16)
         CFI_OFFSET(30, -8)
         stp     x29, x30, [sp, -16]!
@@ -624,6 +627,7 @@ END_FUNCTION(caml_c_call)
 
 FUNCTION(caml_c_call_stack_args)
         CFI_STARTPROC
+        CFI_SIGNAL_FRAME
     /* Arguments:
         C arguments  : x0 to x7, d0 to d7
         C function   : ADDITIONAL_ARG
@@ -809,7 +813,7 @@ L(return_result):
     /* Return to C caller */
         ret
         CFI_ENDPROC
-        END_FUNCTION(caml_start_program)
+END_FUNCTION(caml_start_program)
 
 /* The trap handler */
 
@@ -861,7 +865,7 @@ L(caml_reraise_exn_stash):
         mov     x0, x19
         b       1b
         CFI_ENDPROC
-        END_FUNCTION(caml_raise_exn)
+END_FUNCTION(caml_raise_exn)
 
 FUNCTION(caml_reraise_exn)
         CFI_STARTPROC
@@ -869,7 +873,7 @@ FUNCTION(caml_reraise_exn)
         cbnz    TMP, L(caml_reraise_exn_stash)
         JUMP_TO_TRAP_PTR
         CFI_ENDPROC
-        END_FUNCTION(caml_reraise_exn)
+END_FUNCTION(caml_reraise_exn)
 
 #if defined(WITH_THREAD_SANITIZER)
 /* When TSan support is enabled, this routine should be called just before
@@ -885,7 +889,7 @@ FUNCTION(caml_tsan_exit_on_raise_asm)
         TSAN_C_CALL G(caml_tsan_exit_on_raise)
         ret
         CFI_ENDPROC
-        END_FUNCTION(caml_tsan_exit_on_raise_asm)
+END_FUNCTION(caml_tsan_exit_on_raise_asm)
 #endif
 
 /* Raise an exception from C */
@@ -923,7 +927,7 @@ FUNCTION(caml_raise_exception)
         ldp     x29, x30, [sp], 16
         b       G(caml_raise_exn)
         CFI_ENDPROC
-        END_FUNCTION(caml_raise_exception)
+END_FUNCTION(caml_raise_exception)
 
 /* Callback from C to OCaml */
 
@@ -950,7 +954,7 @@ FUNCTION(caml_callback_asm)
         ldr     TMP2, [x1]       /* code pointer */
         b       L(jump_to_caml)
         CFI_ENDPROC
-        END_FUNCTION(caml_callback_asm)
+END_FUNCTION(caml_callback_asm)
 
 FUNCTION(caml_callback2_asm)
         CFI_STARTPROC
@@ -976,7 +980,7 @@ FUNCTION(caml_callback2_asm)
         ADDRGLOBAL(TMP2, caml_apply2)
         b       L(jump_to_caml)
         CFI_ENDPROC
-        END_FUNCTION(caml_callback2_asm)
+END_FUNCTION(caml_callback2_asm)
 
 FUNCTION(caml_callback3_asm)
         CFI_STARTPROC
@@ -1003,7 +1007,7 @@ FUNCTION(caml_callback3_asm)
         ADDRGLOBAL(TMP2, caml_apply3)
         b       L(jump_to_caml)
         CFI_ENDPROC
-        END_FUNCTION(caml_callback3_asm)
+END_FUNCTION(caml_callback3_asm)
 
 /* Fibers */
 
@@ -1110,7 +1114,7 @@ L(do_perform):
         ADDRGLOBAL(ADDITIONAL_ARG, caml_raise_unhandled_effect)
         b       G(caml_c_call)
         CFI_ENDPROC
-        END_FUNCTION(caml_perform)
+END_FUNCTION(caml_perform)
 
 FUNCTION(caml_reperform)
         CFI_STARTPROC
@@ -1123,10 +1127,10 @@ FUNCTION(caml_reperform)
         add     x3, x2, 1 /* x3 (last_fiber) := Val_ptr(old stack) */
         b       L(do_perform)
         CFI_ENDPROC
-        END_FUNCTION(caml_reperform)
+END_FUNCTION(caml_reperform)
 
 FUNCTION(caml_resume)
-CFI_STARTPROC
+        CFI_STARTPROC
     /*  x0: new fiber
         x1: fun
         x2: arg
@@ -1174,12 +1178,12 @@ CFI_STARTPROC
 1:      ADDRGLOBAL(ADDITIONAL_ARG, caml_raise_continuation_already_resumed)
         b       G(caml_c_call)
         CFI_ENDPROC
-        END_FUNCTION(caml_resume)
+END_FUNCTION(caml_resume)
 
 /* Run a function on a new stack, then either
    return the value or invoke exception handler */
 FUNCTION(caml_runstack)
-CFI_STARTPROC
+        CFI_STARTPROC
 #if defined(WITH_THREAD_SANITIZER)
     /* Save non-callee-saved registers x0, x1 and x2 */
         stp     x0, x1, [sp, -16]!
@@ -1193,6 +1197,7 @@ CFI_STARTPROC
         ldp     x0, x1, [sp], 16
         CFI_ADJUST(-16)
 #endif
+        CFI_SIGNAL_FRAME
     /*  x0: fiber
         x1: fun
         x2: arg */
@@ -1276,7 +1281,7 @@ L(fiber_exn_handler):
         ldr     x19, Handler_exception(x8)
         b       1b
         CFI_ENDPROC
-        END_FUNCTION(caml_runstack)
+END_FUNCTION(caml_runstack)
 
 FUNCTION(caml_ml_array_bound_error)
         CFI_STARTPROC
@@ -1285,7 +1290,7 @@ FUNCTION(caml_ml_array_bound_error)
     /* Call that function */
         b       G(caml_c_call)
         CFI_ENDPROC
-        END_FUNCTION(caml_ml_array_bound_error)
+END_FUNCTION(caml_ml_array_bound_error)
 
          TEXT_SECTION(caml_system__code_end)
         .globl  G(caml_system__code_end)

--- a/ocaml/runtime/callback.c
+++ b/ocaml/runtime/callback.c
@@ -453,7 +453,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
   unsigned int h = hash_value_name(name);
   int found = 0;
 
-  caml_plat_lock(&named_value_lock);
+  caml_plat_lock_blocking(&named_value_lock);
   for (nv = named_value_table[h]; nv != NULL; nv = nv->next) {
     if (strcmp(name, nv->name) == 0) {
       caml_modify_generational_global_root(&nv->val, val);
@@ -477,7 +477,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
 CAMLexport const value* caml_named_value(char const *name)
 {
   struct named_value * nv;
-  caml_plat_lock(&named_value_lock);
+  caml_plat_lock_blocking(&named_value_lock);
   for (nv = named_value_table[hash_value_name(name)];
        nv != NULL;
        nv = nv->next) {
@@ -493,7 +493,7 @@ CAMLexport const value* caml_named_value(char const *name)
 CAMLexport void caml_iterate_named_values(caml_named_action f)
 {
   int i;
-  caml_plat_lock(&named_value_lock);
+  caml_plat_lock_blocking(&named_value_lock);
   for(i = 0; i < Named_value_size; i++){
     struct named_value * nv;
     for (nv = named_value_table[i]; nv != NULL; nv = nv->next) {

--- a/ocaml/runtime/caml/camlatomic.h
+++ b/ocaml/runtime/caml/camlatomic.h
@@ -82,4 +82,19 @@ typedef struct { intnat repr; } atomic_intnat;
 #error "C11 atomics are unavailable on this platform. See camlatomic.h"
 #endif
 
+#ifdef CAML_INTERNALS
+
+/* Loads and stores with acquire, release and relaxed semantics */
+
+#define atomic_load_acquire(p)                    \
+  atomic_load_explicit((p), memory_order_acquire)
+#define atomic_load_relaxed(p)                    \
+  atomic_load_explicit((p), memory_order_relaxed)
+#define atomic_store_release(p, v)                      \
+  atomic_store_explicit((p), (v), memory_order_release)
+#define atomic_store_relaxed(p, v)                      \
+  atomic_store_explicit((p), (v), memory_order_relaxed)
+
+#endif /* CAML_INTERNALS */
+
 #endif /* CAML_ATOMIC_H */

--- a/ocaml/runtime/caml/domain.h
+++ b/ocaml/runtime/caml/domain.h
@@ -27,7 +27,6 @@ extern "C" {
 #include "config.h"
 #include "mlvalues.h"
 #include "domain_state.h"
-#include "platform.h"
 
 /* The runtime currently has a hard limit on the number of domains.
    This hard limit may go away in the future. */

--- a/ocaml/runtime/caml/domain.h
+++ b/ocaml/runtime/caml/domain.h
@@ -101,12 +101,16 @@ Caml_inline intnat caml_domain_alone(void)
 int caml_domain_is_in_stw(void);
 #endif
 
+int caml_domain_terminating(caml_domain_state *);
+int caml_domain_is_terminating(void);
+
 int caml_try_run_on_all_domains_with_spin_work(
   int sync,
   void (*handler)(caml_domain_state*, void*, int, caml_domain_state**),
   void* data,
   void (*leader_setup)(caml_domain_state*),
-  void (*enter_spin_callback)(caml_domain_state*, void*),
+  /* return nonzero if there may still be useful work to do while spinning */
+  int (*enter_spin_callback)(caml_domain_state*, void*),
   void* enter_spin_data);
 int caml_try_run_on_all_domains(
   void (*handler)(caml_domain_state*, void*, int, caml_domain_state**),
@@ -167,16 +171,54 @@ int caml_try_run_on_all_domains(
 */
 
 
-/* barriers */
-typedef uintnat barrier_status;
-void caml_global_barrier(void);
-barrier_status caml_global_barrier_begin(void);
-int caml_global_barrier_is_final(barrier_status);
-void caml_global_barrier_end(barrier_status);
-int caml_global_barrier_num_domains(void);
+/* Barriers */
 
-int caml_domain_terminating(caml_domain_state *);
-int caml_domain_is_terminating(void);
+/* Get the number of parties expected to arrive into the barrier, i.e. the
+   number of domains participating in the STW section. In most cases the barrier
+   is used directly from an STW callback that already has the number of
+   participating domains at hand, which should be used instead. */
+int caml_global_barrier_num_participating(void);
+
+/* Unconditionally arrive at the barrier and wait for all parties,
+   [caml_global_barrier] below should be used instead. */
+void caml_enter_global_barrier(int num_participating);
+/* Arrive at the barrier and wait iff there is more than one party */
+Caml_inline void caml_global_barrier(int num_participating) {
+  if (num_participating != 1) caml_enter_global_barrier(num_participating);
+}
+
+typedef uintnat barrier_status;
+/* Arrive at the barrier; if we are the final party, immediately returns a
+   nonzero value to be passed to [caml_global_barrier_release_as_final]
+   later, otherwise blocks and returns zero. */
+barrier_status caml_global_barrier_and_check_final(int num_participating);
+/* Release the barrier with the given status */
+void caml_global_barrier_release_as_final(barrier_status status);
+/* Arrive at the global barrier and run the body if we are the final party.
+   Other threads will not be released from the barrier until the final party
+   finishes executing the body.
+
+   Example usage:
+
+   Caml_global_barrier_if_final(num_participating) {
+     do_something_in_final_domain();
+   }
+
+   Note: this expands to an [if] and [for] header, do not exit the body using
+   jumps or returns, and do not put an [else] immediately after.
+ */
+#define Caml_global_barrier_if_final(num_participating)                 \
+  /* fast path when alone */                                            \
+  int CAML_GENSYM(alone) = (num_participating) == 1;                    \
+  barrier_status CAML_GENSYM(b) = 0;                                    \
+  if (CAML_GENSYM(alone) ||                                             \
+      (CAML_GENSYM(b)                                                   \
+       = caml_global_barrier_and_check_final(num_participating)))       \
+    for (int CAML_GENSYM(continue) = 1; CAML_GENSYM(continue);          \
+         /* release the barrier after the body has executed once */     \
+         ((CAML_GENSYM(alone) ? (void)0 :                               \
+           caml_global_barrier_release_as_final(CAML_GENSYM(b))),       \
+          CAML_GENSYM(continue) = 0))
 
 #endif /* CAML_INTERNALS */
 

--- a/ocaml/runtime/caml/domain_state.tbl
+++ b/ocaml/runtime/caml/domain_state.tbl
@@ -83,6 +83,12 @@ DOMAIN_STATE(uintnat, sweeping_done)
 /* Is sweeping done for the current major cycle. */
 
 DOMAIN_STATE(uintnat, allocated_words)
+/* Number of words promoted or allocated directly to the major heap since
+   latest slice. */
+
+DOMAIN_STATE(uintnat, allocated_words_direct)
+/* Number of words allocated directly to the major heap since the latest
+   slice. (subset of allocated_words) */
 
 DOMAIN_STATE(uintnat, swept_words)
 

--- a/ocaml/runtime/caml/gc_ctrl.h
+++ b/ocaml/runtime/caml/gc_ctrl.h
@@ -20,7 +20,7 @@
 
 #include "misc.h"
 
-CAMLextern uintnat caml_max_stack_wsize;
+CAMLextern atomic_uintnat caml_max_stack_wsize;
 CAMLextern uintnat caml_fiber_wsz;
 CAMLextern uintnat caml_major_cycles_completed;
 

--- a/ocaml/runtime/caml/major_gc.h
+++ b/ocaml/runtime/caml/major_gc.h
@@ -31,7 +31,7 @@ Caml_inline int caml_marking_started(void) {
   return caml_gc_phase != Phase_sweep_main;
 }
 
-intnat caml_opportunistic_major_work_available (void);
+intnat caml_opportunistic_major_work_available (caml_domain_state*);
 void caml_opportunistic_major_collection_slice (intnat);
 /* auto-triggered slice from within the GC */
 #define AUTO_TRIGGERED_MAJOR_SLICE -1

--- a/ocaml/runtime/caml/memprof.h
+++ b/ocaml/runtime/caml/memprof.h
@@ -64,35 +64,23 @@ extern void caml_memprof_update_suspended(_Bool);
  * point to minor heaps (the `SCANNING_ONLY_YOUNG_VALUES` flag).
  *
  * If `weak` is false then only scan strong roots. If `weak`
- * is true then also scan weak roots.
- *
- * If `global` is false then only scan roots for `state`. If `global`
- * is true then also scan roots shared between all domains. */
+ * is true then also scan weak roots. */
 
 extern void caml_memprof_scan_roots(scanning_action f,
                                     scanning_action_flags fflags,
                                     void* fdata,
                                     caml_domain_state *state,
-                                    _Bool weak,
-                                    _Bool global);
+                                    _Bool weak);
 
 /* Update memprof data structures for the domain `state`, to reflect
- * survival and promotion, after a minor GC is completed.
- *
- * If `global` is false then only update structures for `state`. If
- * `global` is true then also update structures shared between all
- * domains. */
+ * survival and promotion, after a minor GC is completed. */
 
-extern void caml_memprof_after_minor_gc(caml_domain_state *state, _Bool global);
+extern void caml_memprof_after_minor_gc(caml_domain_state *state);
 
 /* Update memprof data structures for the domain `state`, to reflect
- * survival, after a minor GC is completed.
- *
- * If `global` is false then only update structures for `state`. If
- * `global` is true then also update structures shared between all
- * domains. */
+ * survival, after a minor GC is completed. */
 
-extern void caml_memprof_after_major_gc(caml_domain_state *state, _Bool global);
+extern void caml_memprof_after_major_gc(caml_domain_state *state);
 
 /* Freshly computes state->memprof_young_trigger. *Does not* set the
  * young limit. */

--- a/ocaml/runtime/caml/misc.h
+++ b/ocaml/runtime/caml/misc.h
@@ -595,6 +595,11 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #  endif
 #endif
 
+/* Generate a named symbol that is unique within the current macro expansion */
+#define CAML_GENSYM_3(name, l) caml__##name##_##l
+#define CAML_GENSYM_2(name, l) CAML_GENSYM_3(name, l)
+#define CAML_GENSYM(name) CAML_GENSYM_2(name, __LINE__)
+
 #endif /* CAML_INTERNALS */
 
 /* The [backtrace_slot] type represents values stored in

--- a/ocaml/runtime/caml/misc.h
+++ b/ocaml/runtime/caml/misc.h
@@ -250,9 +250,20 @@ typedef char char_os;
 #define __OSFILE__ __FILE__
 #endif
 
+/* Although caml_failed_assert never returns, it is not marked as such.
+   This prevents the C compiler optimising away all of the useful context
+   from the callsite, making debuggers able to see it. */
 #define CAMLassert(x) \
   (CAMLlikely(x) ? (void) 0 : caml_failed_assert ( #x , __OSFILE__, __LINE__))
-CAMLnoret CAMLextern void caml_failed_assert (char *, char_os *, int);
+CAMLextern void caml_failed_assert (char *, char_os *, int)
+#if defined(__has_feature)
+  /* However, we do inform clang-analyzer that this function never returns,
+     since that improves analysis without breaking debugging */
+  #if __has_feature(attribute_analyzer_noreturn)
+    __attribute__((analyzer_noreturn))
+  #endif
+#endif
+;
 #else
 #define CAMLassert(x) ((void) 0)
 #endif

--- a/ocaml/runtime/caml/platform.h
+++ b/ocaml/runtime/caml/platform.h
@@ -53,33 +53,6 @@ Caml_inline void cpu_relax(void) {
 #endif
 }
 
-/* Spin-wait loops */
-
-#define Max_spins 1000
-
-CAMLextern unsigned caml_plat_spin_wait(unsigned spins,
-                                        const char* file, int line,
-                                        const char* function);
-
-#define GENSYM_3(name, l) name##l
-#define GENSYM_2(name, l) GENSYM_3(name, l)
-#define GENSYM(name) GENSYM_2(name, __LINE__)
-
-#define SPIN_WAIT                                                       \
-  unsigned GENSYM(caml__spins) = 0;                                     \
-  for (; 1; cpu_relax(),                                                \
-         GENSYM(caml__spins) =                                          \
-           CAMLlikely(GENSYM(caml__spins) < Max_spins) ?                \
-         GENSYM(caml__spins) + 1 :                                      \
-         caml_plat_spin_wait(GENSYM(caml__spins),                       \
-                             __FILE__, __LINE__, __func__))
-
-Caml_inline uintnat atomic_load_wait_nonzero(atomic_uintnat* p) {
-  SPIN_WAIT {
-    uintnat v = atomic_load_acquire(p);
-    if (v) return v;
-  }
-}
 
 /* Atomic read-modify-write instructions, with full fences */
 
@@ -150,6 +123,309 @@ void caml_plat_wait(caml_plat_cond*, caml_plat_mutex*); /* blocking */
 void caml_plat_broadcast(caml_plat_cond*);
 void caml_plat_signal(caml_plat_cond*);
 void caml_plat_cond_free(caml_plat_cond*);
+
+/* Futexes
+
+   A futex is an integer that can be waited on and woken, used to build other
+   synchronisation primitives. Either uses OS facilities directly, or a
+   condition variable fallback.
+*/
+typedef struct caml_plat_futex /* {
+  // this field is available regardless of implementation
+  caml_plat_futex_word value;
+  <possibly other fields>; ...
+} */ caml_plat_futex;
+
+typedef uint32_t caml_plat_futex_value;
+typedef _Atomic caml_plat_futex_value caml_plat_futex_word;
+
+/* Block while [futex] has the value [undesired], until woken by [wake_all()] */
+void caml_plat_futex_wait(caml_plat_futex* futex,
+                          caml_plat_futex_value undesired);
+/* Wake all threads [wait()]-ing on [futex] */
+void caml_plat_futex_wake_all(caml_plat_futex* futex);
+/* Initialise the futex for the first time, use [CAML_PLAT_FUTEX_INITIALIZER] to
+   do this statically */
+void caml_plat_futex_init(caml_plat_futex* ftx, caml_plat_futex_value value);
+/* Deinitialise the futex; no-op if native futexes are used */
+void caml_plat_futex_free(caml_plat_futex*);
+
+/* [CAML_PLAT_FUTEX_FALLBACK] can be defined to use the condition variable
+   fallback, even if a futex implementation is available. */
+#ifndef CAML_PLAT_FUTEX_FALLBACK
+#  if defined(_WIN32)                                   \
+  || (defined(__linux__) && defined(HAS_LINUX_FUTEX_H)) \
+  || defined(__FreeBSD__) || defined(__OpenBSD__)
+/* TODO We have implementations for these platforms, but they are
+   currently untested, so use the fallback instead.
+  || defined(__NetBSD__) || defined(__DragonFly__) */
+#  else
+/* Use the fallback on platforms that we do not have an OS-specific
+   implementation for, such as macOS. */
+#    define CAML_PLAT_FUTEX_FALLBACK
+#  endif
+#endif
+
+#ifdef CAML_PLAT_FUTEX_FALLBACK
+struct caml_plat_futex {
+  caml_plat_futex_word value;
+  caml_plat_mutex mutex;
+  caml_plat_cond cond;
+};
+#  define CAML_PLAT_FUTEX_INITIALIZER(value) \
+  { (value), CAML_PLAT_MUTEX_INITIALIZER, CAML_PLAT_COND_INITIALIZER }
+#else
+struct caml_plat_futex {
+  caml_plat_futex_word value;
+};
+#  define CAML_PLAT_FUTEX_INITIALIZER(value) { (value) }
+#endif /* CAML_PLAT_FUTEX_FALLBACK */
+
+/* Latches
+
+   A binary latch is a boolean value with a [wait()] operation. It has two
+   states, "released" and "unreleased" (or "set"). [latch_set()] can be used to
+   set the latch to unreleased, [latch_release()] can be used to release it, and
+   [latch_wait()] can be used from the unreleased state to block until
+   [latch_release()] is called.
+
+                    [latch_set()]
+         +------------------------------------+
+         v                                    |
+     UNRELEASED                            RELEASED
+         |                                    ^
+         +-< unblock [latch_wait()] callers >-+
+                   [latch_release()]
+
+   This type of object is also called a manual-reset event in Windows APIs, or
+   it can be considered a special case of Java's [CountDownLatch] or C++'s
+   [std::latch] with the counter capped at one.
+ */
+typedef caml_plat_futex caml_plat_binary_latch;
+
+/* Released state */
+#define Latch_released 0 /* must be zero, see barrier initialisation */
+/* Unreleased state, no [latch_wait()] callers */
+#define Latch_unreleased 1
+/* Unreleased state, at least one [latch_wait()] caller */
+#define Latch_contested 2
+
+/* Initialise the latch to a released state */
+#define CAML_PLAT_LATCH_INITIALIZER CAML_PLAT_FUTEX_INITIALIZER(Latch_released)
+Caml_inline void caml_plat_latch_init(caml_plat_binary_latch* latch) {
+  caml_plat_futex_init(latch, Latch_released);
+}
+/* Release the latch, waking any waiters */
+void caml_plat_latch_release(caml_plat_binary_latch*);
+/* Block until released. This is no-op (but more expensive than checking with
+   [is_released()]) if the latch has already been released. */
+void caml_plat_latch_wait(caml_plat_binary_latch*);
+/* Check if a latch is released */
+Caml_inline int caml_plat_latch_is_released(caml_plat_binary_latch* latch) {
+  return atomic_load_acquire(&latch->value) == Latch_released;
+}
+/* Check if a latch is unreleased */
+Caml_inline int caml_plat_latch_is_set(caml_plat_binary_latch* latch) {
+  return !caml_plat_latch_is_released(latch);
+}
+/* Set the latch to unreleased */
+Caml_inline void caml_plat_latch_set(caml_plat_binary_latch* latch) {
+  atomic_store_release(&latch->value, Latch_unreleased);
+}
+
+/* Barriers
+
+   A barrier is an object used to synchronise a variable number of
+   threads/parties. Each party arrives at the barrier, and only once all parties
+   have arrived can any threads leave the barrier. There are two variants: the
+   "single-sense" barrier must be manually reset before it can be reused,
+   whereas the "sense-reversing" barrier can be reused immediately after it has
+   been released.
+
+   | Operation | [caml_plat_barrier_*] function      |
+   |           |---------------+---------------------|
+   |           | Single-sense  | Sense-reversing     |
+   |-----------|---------------+---------------------|
+   | Reset     | [reset]       | automatic at [flip] |
+   | Arrive    | [arrive]      | [arrive]            |
+   | Check     | [is_released] | [sense_has_flipped] |
+   | Block     | [wait]        | [wait_sense]        |
+   | Release   | [release]     | [flip]              |
+
+   The lifecycle is as follows:
+
+        Reset (1 thread)          (other threads)
+                |                       |
+                +----------+------------+
+                           |
+                        Arrive (all threads)
+                           |
+                           | check arrival number
+                +----------+------------+
+                |                       |
+         Check or Block              Release
+       (non-final threads)        (final thread)
+                |                       |
+
+   Leaving the barrier after [Block] or a nonzero [Check] result synchronises
+   with the [Release] of the barrier from the final thread, which in turn
+   synchronises with the non-final threads at the time they [Arrive]d.
+
+   That is, on non-final threads, anything performed before [Check]/[Block] may
+   race with code in other threads that happens before they [Arrive], and
+   anything performed after [Arrive] is entirely unsynchronised by the barrier,
+   so may race with code in other threads that happens after they [Arrive]. In
+   particular, code between [Arrive] and [Check]/[Block] may race with code
+   before or after the barrier in all other threads. The final thread is the
+   exception, and may execute code after [Arrive] but before [Release] that will
+   still be synchronised by the barrier.
+*/
+typedef struct caml_plat_barrier {
+  caml_plat_futex futex;
+  atomic_uintnat arrived; /* includes sense bit */
+} caml_plat_barrier;
+
+/* This initialises both a single-sense and sense-reversing barrier, for
+   single-sense this is the released state ([Latch_released], which must be 0)
+   and for sense-reversing it is just a valid initialised state. */
+#define CAML_PLAT_BARRIER_INITIALIZER \
+  { CAML_PLAT_FUTEX_INITIALIZER(Latch_released), 0 }
+
+typedef uintnat barrier_status;
+#define BARRIER_SENSE_BIT 0x100000
+/* Arrive at the barrier, returns the number of parties that have arrived at the
+   barrier (including this one); the caller should check whether it is the last
+   expected party to arrive, and release or flip the barrier if so.
+
+   In a sense-reversing barrier, this also encodes the current sense of the
+   barrier in [BARRIER_SENSE_BIT], which should be masked off if checking for
+   the last arrival. */
+Caml_inline barrier_status caml_plat_barrier_arrive(caml_plat_barrier* barrier)
+{
+  return 1 + atomic_fetch_add(&barrier->arrived, 1);
+}
+
+/* -- Single-sense --
+   [futex] is used as a binary latch. */
+
+/* Reset the barrier to 0 arrivals, block new waiters */
+Caml_inline void caml_plat_barrier_reset(caml_plat_barrier* barrier) {
+  caml_plat_latch_set(&barrier->futex);
+  atomic_store_release(&barrier->arrived, 0);
+}
+/* Check if the barrier has been released */
+Caml_inline int caml_plat_barrier_is_released(caml_plat_barrier* barrier) {
+  return caml_plat_latch_is_released(&barrier->futex);
+}
+/* Release the barrier unconditionally, letting all parties through */
+Caml_inline void caml_plat_barrier_release(caml_plat_barrier* barrier) {
+  caml_plat_latch_release(&barrier->futex);
+}
+/* Block until released */
+Caml_inline void caml_plat_barrier_wait(caml_plat_barrier* barrier) {
+  caml_plat_latch_wait(&barrier->futex);
+}
+
+/* -- Sense-reversing -- */
+/* Flip the sense of the barrier, releasing current waiters and
+   blocking new ones.
+
+   [current_sense] should be [(b & BARRIER_SENSE_BIT)] with [b] as
+   returned by [barrier_arrive()]. */
+void caml_plat_barrier_flip(caml_plat_barrier*, barrier_status current_sense);
+Caml_inline int
+caml_plat_barrier_sense_has_flipped(caml_plat_barrier* barrier,
+                                    barrier_status current_sense)
+{
+  return (atomic_load_acquire(&barrier->futex.value) & BARRIER_SENSE_BIT)
+    != current_sense;
+}
+/* Block until flipped */
+void caml_plat_barrier_wait_sense(caml_plat_barrier*,
+                                  barrier_status current_sense);
+
+/* Spin-wait loops
+
+   We provide the macros [SPIN_WAIT], [SPIN_WAIT_NTIMES(N)] and
+   [SPIN_WAIT_BOUNDED] that expand to [for]-loop headers for spin-wait
+   loops. The latter two are expected to be used alongside OS-based
+   synchronisation (e.g. latches, barriers).
+
+   Example usage:
+
+   SPIN_WAIT {
+     if (condition_has_come_true()) {
+       break; // or return;
+     }
+
+     perform_useful_spin_work();
+   }
+
+   [SPIN_WAIT] spins for unbounded time, and should only be used when hashing
+   out contention over a short critical section that only one thread needs to
+   run, where more complex synchronisation would be too expensive and
+   unnecessary.
+
+   [SPIN_WAIT_NTIMES(N)] should be used with one of the [Max_spins_*] constants
+   defined below (though the N expression doesn't need to be a constant), it
+   loops the body up to N times and then ends, even if the condition hasn't come
+   true. Exactly how much spinning is optimal can be tricky and may warrant
+   profiling, with the caveat that it is also probably machine-dependent.
+   Typically, [Max_spins_long] iterations are only useful when there are exactly
+   2 domains, otherwise [Max_spins_short] is best to yield to OS synchronisation
+   as fast as possible.
+
+   [SPIN_WAIT_BOUNDED] expands to [SPIN_WAIT_NTIMES(Max_spins_medium)] and
+   should be used when there is useful work to do in the body of the loop.
+ */
+
+/* The exact values here are estimates based on data from a specific machine,
+   and shouldn't be focused on too much. */
+#define Max_spins_long 1000
+#define Max_spins_medium 300
+#define Max_spins_short 30
+
+#define SPIN_WAIT_NTIMES(N)                             \
+  unsigned CAML_GENSYM(spins) = 0;                      \
+  unsigned CAML_GENSYM(max_spins) = (N);                \
+  for (; CAML_GENSYM(spins) < CAML_GENSYM(max_spins);   \
+       cpu_relax(), ++CAML_GENSYM(spins))
+#define SPIN_WAIT_BOUNDED SPIN_WAIT_NTIMES(Max_spins_medium)
+#define SPIN_WAIT SPIN_WAIT_BACK_OFF(Max_spins_long)
+
+/* [SPIN_WAIT_*] implementation details */
+
+struct caml_plat_srcloc {
+  const char* file;
+  int line;
+  const char* function;
+};
+
+/* Start/continue backing off, returns the next [sleep_ns] */
+CAMLextern unsigned caml_plat_spin_back_off(unsigned sleep_ns,
+                                            const struct caml_plat_srcloc* loc);
+
+Caml_inline unsigned caml_plat_spin_step(unsigned spins,
+                                         unsigned max_spins,
+                                         const struct caml_plat_srcloc *loc) {
+  cpu_relax();
+  if (CAMLlikely(spins < max_spins)) {
+    return spins + 1;
+  } else {
+    /* [spins] becomes [sleep_ns] at this point, which remains greater than
+       [max_spins] */
+    return caml_plat_spin_back_off(spins, loc);
+  }
+}
+
+#define SPIN_WAIT_BACK_OFF(max_spins)                                   \
+  unsigned CAML_GENSYM(spins) = 0;                                      \
+  unsigned CAML_GENSYM(max_spins) = (max_spins);                        \
+  static const struct caml_plat_srcloc CAML_GENSYM(loc) = {             \
+    __FILE__, __LINE__, __func__                                        \
+  };                                                                    \
+  for (; 1; CAML_GENSYM(spins) = caml_plat_spin_step(                   \
+         CAML_GENSYM(spins), CAML_GENSYM(max_spins), &CAML_GENSYM(loc)))
 
 /* Memory management primitives (mmap) */
 

--- a/ocaml/runtime/caml/s.h.in
+++ b/ocaml/runtime/caml/s.h.in
@@ -82,6 +82,8 @@
 
 #undef HAS_SYS_MMAN_H
 
+#undef HAS_LINUX_FUTEX_H
+
 /* 2. For the Unix library. */
 
 #undef HAS_SOCKETS

--- a/ocaml/runtime/caml/sync.h
+++ b/ocaml/runtime/caml/sync.h
@@ -21,28 +21,21 @@
 #ifdef CAML_INTERNALS
 
 #include "mlvalues.h"
+#include "platform.h"
 
-typedef pthread_mutex_t * sync_mutex;
+/* OCaml mutexes and condition variables can also be manipulated from
+   C code with non-raising primitives from caml/platform.h. In this
+   case, pairs of lock/unlock for a critical section must come from
+   the same header (sync.h or platform.h). */
+
+typedef caml_plat_mutex * sync_mutex;
+typedef caml_plat_cond * sync_condvar;
 
 #define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v)))
+#define Condition_val(v) (* (sync_condvar *) Data_custom_val(v))
 
 CAMLextern int caml_mutex_lock(sync_mutex mut);
 CAMLextern int caml_mutex_unlock(sync_mutex mut);
-
-/* If we're using glibc, use a custom condition variable implementation to
-   avoid this bug: https://sourceware.org/bugzilla/show_bug.cgi?id=25847
-
-   For now we only have this on linux because it directly uses the linux futex
-   syscalls. */
-#if defined(__linux__) && defined(__GNU_LIBRARY__) && defined(__GLIBC__) && defined(__GLIBC_MINOR__)
-typedef struct {
-  volatile unsigned counter;
-} custom_condvar;
-#define CUSTOM_COND_INITIALIZER {0}
-#else
-typedef pthread_cond_t custom_condvar;
-#define CUSTOM_COND_INITIALIZER PTHREAD_COND_INITIALIZER
-#endif
 
 value caml_ml_mutex_lock(value wrapper);
 value caml_ml_mutex_unlock(value wrapper);

--- a/ocaml/runtime/codefrag.c
+++ b/ocaml/runtime/codefrag.c
@@ -131,7 +131,7 @@ unsigned char *caml_digest_of_code_fragment(struct code_fragment *cf) {
      all cases. It would be possible to take a lock only in the
      DIGEST_LATER case, which occurs at most once per fragment, by
      using double-checked locking -- see #11791. */
-  caml_plat_lock(&cf->mutex);
+  caml_plat_lock_blocking(&cf->mutex);
   {
     if (cf->digest_status == DIGEST_IGNORE) {
       digest = NULL;

--- a/ocaml/runtime/domain.c
+++ b/ocaml/runtime/domain.c
@@ -716,6 +716,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
   domain_state->gc_regs = NULL;
 
   domain_state->allocated_words = 0;
+  domain_state->allocated_words_direct = 0;
   domain_state->swept_words = 0;
 
   domain_state->local_roots = NULL;

--- a/ocaml/runtime/domain.c
+++ b/ocaml/runtime/domain.c
@@ -167,8 +167,16 @@ struct interruptor {
   /* unlike the domain ID, this ID number is not reused */
   uintnat unique_id;
 
+  /* indicates whether there is an interrupt pending */
   atomic_uintnat interrupt_pending;
 };
+
+Caml_inline int interruptor_has_pending(struct interruptor *s)
+{ return atomic_load_acquire(&s->interrupt_pending) != 0; }
+Caml_inline void interruptor_set_handled(struct interruptor *s)
+{ atomic_store_release(&s->interrupt_pending, 0); }
+Caml_inline void interruptor_set_pending(struct interruptor *s)
+{ atomic_store_release(&s->interrupt_pending, 1); }
 
 struct dom_internal {
   /* readonly fields, initialised and never modified */
@@ -189,38 +197,42 @@ struct dom_internal {
 };
 typedef struct dom_internal dom_internal;
 
-
 static struct {
-  atomic_uintnat domains_still_running;
+  /* enter barrier for STW sections, participating domains arrive into
+     the barrier before executing the STW callback */
+  caml_plat_barrier domains_still_running;
+  /* the number of domains that have yet to return from the callback */
   atomic_uintnat num_domains_still_processing;
   void (*callback)(caml_domain_state*,
                    void*,
                    int participating_count,
                    caml_domain_state** others_participating);
   void* data;
-  void (*enter_spin_callback)(caml_domain_state*, void*);
+  int (*enter_spin_callback)(caml_domain_state*, void*);
   void* enter_spin_data;
 
-  /* barrier state */
+  /* global_barrier state */
   int num_domains;
-  atomic_uintnat barrier;
+  caml_plat_barrier barrier;
 
   caml_domain_state* participating[Max_domains];
 } stw_request = {
-  ATOMIC_UINTNAT_INIT(0),
-  ATOMIC_UINTNAT_INIT(0),
+  CAML_PLAT_BARRIER_INITIALIZER,
+  0,
   NULL,
   NULL,
   NULL,
   NULL,
   0,
-  ATOMIC_UINTNAT_INIT(0),
+  CAML_PLAT_BARRIER_INITIALIZER,
   { 0 },
 };
 
 static caml_plat_mutex all_domains_lock = CAML_PLAT_MUTEX_INITIALIZER;
 static caml_plat_cond all_domains_cond = CAML_PLAT_COND_INITIALIZER;
 static atomic_uintnat /* dom_internal* */ stw_leader = 0;
+static uintnat stw_requests_suspended = 0; /* protected by all_domains_lock */
+static caml_plat_cond requests_suspended_cond = CAML_PLAT_COND_INITIALIZER;
 static dom_internal all_domains[Max_domains];
 
 CAMLexport atomic_uintnat caml_num_domains_running;
@@ -324,17 +336,17 @@ Caml_inline void interrupt_domain_local(caml_domain_state* dom_st)
 
 int caml_incoming_interrupts_queued(void)
 {
-  return atomic_load_acquire(&domain_self->interruptor.interrupt_pending);
+  return interruptor_has_pending(&domain_self->interruptor);
 }
 
 /* must NOT be called with s->lock held */
 static void stw_handler(caml_domain_state* domain);
-static uintnat handle_incoming(struct interruptor* s)
+static int handle_incoming(struct interruptor* s)
 {
-  uintnat handled = atomic_load_acquire(&s->interrupt_pending);
+  int handled = interruptor_has_pending(s);
   CAMLassert (s->running);
   if (handled) {
-    atomic_store_release(&s->interrupt_pending, 0);
+    interruptor_set_handled(s);
 
     stw_handler(domain_self->state);
   }
@@ -355,7 +367,7 @@ void caml_handle_incoming_interrupts(void)
 int caml_send_interrupt(struct interruptor* target)
 {
   /* signal that there is an interrupt pending */
-  atomic_store_release(&target->interrupt_pending, 1);
+  interruptor_set_pending(target);
 
   /* Signal the condition variable, in case the target is
      itself waiting for an interrupt to be processed elsewhere */
@@ -366,26 +378,6 @@ int caml_send_interrupt(struct interruptor* target)
   interrupt_domain(target);
 
   return 1;
-}
-
-static void caml_wait_interrupt_serviced(struct interruptor* target)
-{
-  int i;
-
-  /* Often, interrupt handlers are fast, so spin for a bit before waiting */
-  for (i=0; i<1000; i++) {
-    if (!atomic_load_acquire(&target->interrupt_pending)) {
-      return;
-    }
-    cpu_relax();
-  }
-
-  {
-    SPIN_WAIT {
-      if (!atomic_load_acquire(&target->interrupt_pending))
-        return;
-    }
-  }
 }
 
 asize_t caml_norm_minor_heap_size (intnat wsize)
@@ -573,11 +565,30 @@ static void domain_create(uintnat initial_minor_heap_wsize,
      set atomically */
   caml_plat_lock_blocking(&all_domains_lock);
 
+  /* How many STW sections we are willing to wait for, any more are
+     prevented from happening */
+#define Max_stws_before_suspend 2
+  int stws_waited = 1;
   /* Wait until any in-progress STW sections end. */
   while (atomic_load_acquire(&stw_leader)) {
-    /* [caml_plat_wait] releases [all_domains_lock] until the current
-       STW section ends, and then takes the lock again. */
-    caml_plat_wait(&all_domains_cond, &all_domains_lock);
+    if (stws_waited++ < Max_stws_before_suspend) {
+      /* [caml_plat_wait] releases [all_domains_lock] until the current
+         STW section ends, and then takes the lock again. */
+      caml_plat_wait(&all_domains_cond, &all_domains_lock);
+    } else {
+      /* Prevent new STW requests to avoid our own starvation */
+      stw_requests_suspended++;
+      /* Wait for the current STW to end */
+      do {
+        caml_plat_wait(&all_domains_cond, &all_domains_lock);
+      } while (atomic_load_acquire(&stw_leader));
+      if (--stw_requests_suspended == 0) {
+        /* Notify threads that were trying to run an STW section.
+           We still hold the lock, so they won't wake up yet. */
+        caml_plat_broadcast(&requests_suspended_cond);
+      }
+      break;
+    }
   }
 
   d = next_free_domain();
@@ -587,7 +598,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   s = &d->interruptor;
   CAMLassert(!s->running);
-  CAMLassert(!s->interrupt_pending);
+  CAMLassert(!interruptor_has_pending(s));
 
   /* If the chosen domain slot has not been previously used, allocate a fresh
      domain state. Otherwise, reuse it.
@@ -642,7 +653,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
     goto init_memprof_failure;
   }
 
-  CAMLassert(!s->interrupt_pending);
+  CAMLassert(!interruptor_has_pending(s));
 
   domain_state->extra_heap_resources = 0.0;
   domain_state->extra_heap_resources_minor = 0.0;
@@ -870,46 +881,49 @@ static void unreserve_minor_heaps_from_stw_single(void) {
   caml_mem_unmap((void *) caml_minor_heaps_start, size);
 }
 
-static void stw_resize_minor_heap_reservation(caml_domain_state* domain,
-                                       void* minor_wsz_data,
-                                       int participating_count,
-                                       caml_domain_state** participating) {
-  barrier_status b;
-  uintnat new_minor_wsz = (uintnat) minor_wsz_data;
+static
+void domain_resize_heap_reservation_from_stw_single(uintnat new_minor_wsz)
+{
+  CAML_EV_BEGIN(EV_DOMAIN_RESIZE_HEAP_RESERVATION);
+  caml_gc_log("stw_resize_minor_heap_reservation: "
+              "unreserve_minor_heaps");
 
+  unreserve_minor_heaps_from_stw_single();
+  /* new_minor_wsz is page-aligned because caml_norm_minor_heap_size has
+     been called to normalize it earlier.
+  */
+  caml_minor_heap_max_wsz = new_minor_wsz;
+  caml_gc_log("stw_resize_minor_heap_reservation: reserve_minor_heaps");
+  reserve_minor_heaps_from_stw_single();
+  /* The call to [reserve_minor_heaps_from_stw_single] makes a new
+     reservation, and it also updates the reservation boundaries of each
+     domain by mutating its [minor_heap_area_start{,_end}] variables.
+
+     These variables are synchronized by the fact that we are inside
+     a STW section: no other domains are running in parallel, and
+     the participating domains will synchronize with this write by
+     exiting the barrier, before they read those variables in
+     [allocate_minor_heap] below. */
+  CAML_EV_END(EV_DOMAIN_RESIZE_HEAP_RESERVATION);
+}
+
+static void
+stw_resize_minor_heap_reservation(caml_domain_state* domain,
+                                  void* minor_wsz_data,
+                                  int participating_count,
+                                  caml_domain_state** participating) {
   caml_gc_log("stw_resize_minor_heap_reservation: "
               "caml_empty_minor_heap_no_major_slice_from_stw");
-  caml_empty_minor_heap_no_major_slice_from_stw(domain, NULL,
-                                            participating_count, participating);
+  caml_empty_minor_heap_no_major_slice_from_stw(
+    domain, NULL, participating_count, participating);
 
   caml_gc_log("stw_resize_minor_heap_reservation: free_minor_heap");
   free_minor_heap();
 
-  b = caml_global_barrier_begin ();
-  if (caml_global_barrier_is_final(b)) {
-    CAML_EV_BEGIN(EV_DOMAIN_RESIZE_HEAP_RESERVATION);
-    caml_gc_log("stw_resize_minor_heap_reservation: "
-                "unreserve_minor_heaps");
-
-    unreserve_minor_heaps_from_stw_single();
-    /* new_minor_wsz is page-aligned because caml_norm_minor_heap_size has
-       been called to normalize it earlier.
-    */
-    caml_minor_heap_max_wsz = new_minor_wsz;
-    caml_gc_log("stw_resize_minor_heap_reservation: reserve_minor_heaps");
-    reserve_minor_heaps_from_stw_single();
-    /* The call to [reserve_minor_heaps_from_stw_single] makes a new
-       reservation, and it also updates the reservation boundaries of each
-       domain by mutating its [minor_heap_area_start{,_end}] variables.
-
-       These variables are synchronized by the fact that we are inside
-       a STW section: no other domains are running in parallel, and
-       the participating domains will synchronize with this write by
-       exiting the barrier, before they read those variables in
-       [allocate_minor_heap] below. */
-    CAML_EV_END(EV_DOMAIN_RESIZE_HEAP_RESERVATION);
+  Caml_global_barrier_if_final(participating_count) {
+    uintnat new_minor_wsz = (uintnat) minor_wsz_data;
+    domain_resize_heap_reservation_from_stw_single(new_minor_wsz);
   }
-  caml_global_barrier_end(b);
 
   caml_gc_log("stw_resize_minor_heap_reservation: "
               "allocate_minor_heap");
@@ -1327,42 +1341,75 @@ CAMLprim value caml_ml_domain_id(value unit)
   return Val_long(domain_self->interruptor.unique_id);
 }
 
-/* sense-reversing barrier */
-#define BARRIER_SENSE_BIT 0x100000
-
-barrier_status caml_global_barrier_begin(void)
+CAMLprim value caml_ml_domain_index(value unit)
 {
-  uintnat b = 1 + atomic_fetch_add(&stw_request.barrier, 1);
-  return b;
+  CAMLnoalloc;
+  return Val_long(domain_self->id);
 }
 
-int caml_global_barrier_is_final(barrier_status b)
-{
-  return ((b & ~BARRIER_SENSE_BIT) == stw_request.num_domains);
+/* Global barrier implementation */
+
+Caml_inline int global_barrier_is_nth(barrier_status b, int n) {
+  return (b & ~BARRIER_SENSE_BIT) == n;
 }
 
-void caml_global_barrier_end(barrier_status b)
+static barrier_status global_barrier_begin(void)
 {
-  uintnat sense = b & BARRIER_SENSE_BIT;
-  if (caml_global_barrier_is_final(b)) {
-    /* last domain into the barrier, flip sense */
-    atomic_store_release(&stw_request.barrier, sense ^ BARRIER_SENSE_BIT);
-  } else {
-    /* wait until another domain flips the sense */
-    SPIN_WAIT {
-      uintnat barrier = atomic_load_acquire(&stw_request.barrier);
-      if ((barrier & BARRIER_SENSE_BIT) != sense) break;
+  return caml_plat_barrier_arrive(&stw_request.barrier);
+}
+
+/* last domain into the barrier, flip sense */
+static void global_barrier_flip(barrier_status sense)
+{
+  caml_plat_barrier_flip(&stw_request.barrier, sense);
+}
+
+/* wait until another domain flips the sense */
+static void global_barrier_wait(barrier_status sense, int num_participating)
+{
+  /* it's not worth spinning for too long if there's more than one other domain
+   */
+  unsigned spins = num_participating == 2 ? Max_spins_long : Max_spins_medium;
+  SPIN_WAIT_NTIMES(spins) {
+    if (caml_plat_barrier_sense_has_flipped(&stw_request.barrier, sense)) {
+      return;
     }
+  }
+  /* just block */
+  caml_plat_barrier_wait_sense(&stw_request.barrier, sense);
+}
+
+void caml_enter_global_barrier(int num_participating)
+{
+  CAMLassert(num_participating == stw_request.num_domains);
+  barrier_status b = global_barrier_begin();
+  barrier_status sense = b & BARRIER_SENSE_BIT;
+  if (global_barrier_is_nth(b, num_participating)) {
+    global_barrier_flip(sense);
+  } else {
+    global_barrier_wait(sense, num_participating);
   }
 }
 
-void caml_global_barrier(void)
+barrier_status caml_global_barrier_and_check_final(int num_participating)
 {
-  barrier_status b = caml_global_barrier_begin();
-  caml_global_barrier_end(b);
+  CAMLassert(num_participating == stw_request.num_domains);
+  barrier_status b = global_barrier_begin();
+  if (global_barrier_is_nth(b, num_participating)) {
+    CAMLassert(b); /* always nonzero */
+    return b;
+  } else {
+    global_barrier_wait(b & BARRIER_SENSE_BIT, num_participating);
+    return 0;
+  }
 }
 
-int caml_global_barrier_num_domains(void)
+void caml_global_barrier_release_as_final(barrier_status b)
+{
+  global_barrier_flip(b & BARRIER_SENSE_BIT);
+}
+
+int caml_global_barrier_num_participating(void)
 {
   return stw_request.num_domains;
 }
@@ -1385,20 +1432,58 @@ static void decrement_stw_domains_still_processing(void)
   }
 }
 
+/* Wait for other running domains to stop, called by interrupted
+   domains before entering the STW section */
+static void stw_wait_for_running(caml_domain_state* domain)
+{
+  /* The STW leader issues interrupts to all domains, then they all
+     arrive into this barrier, with the last one releasing it; this
+     tends to (and should) be fast, but we likely need to wait a bit
+     in any case */
+
+  if (stw_request.enter_spin_callback) {
+    /* Spin while there is useful work to do */
+    SPIN_WAIT_BOUNDED {
+      if (caml_plat_barrier_is_released(&stw_request.domains_still_running)) {
+        return;
+      }
+
+      if (!stw_request.enter_spin_callback
+            (domain, stw_request.enter_spin_data)) {
+        break;
+      }
+    }
+  }
+
+  /* Spin a bit for the other domains */
+  SPIN_WAIT_NTIMES(Max_spins_long) {
+    if (caml_plat_barrier_is_released(&stw_request.domains_still_running)) {
+      return;
+    }
+  }
+
+  /* If we're still waiting, block */
+  caml_plat_barrier_wait(&stw_request.domains_still_running);
+}
+
+static void stw_api_barrier(caml_domain_state* domain)
+{
+  CAML_EV_BEGIN(EV_STW_API_BARRIER);
+  if (caml_plat_barrier_arrive(&stw_request.domains_still_running)
+      == stw_request.num_domains) {
+    caml_plat_barrier_release(&stw_request.domains_still_running);
+  } else {
+    stw_wait_for_running(domain);
+  }
+  CAML_EV_END(EV_STW_API_BARRIER);
+}
+
 static void stw_handler(caml_domain_state* domain)
 {
   CAML_EV_BEGIN(EV_STW_HANDLER);
-  CAML_EV_BEGIN(EV_STW_API_BARRIER);
-  {
-    SPIN_WAIT {
-      if (atomic_load_acquire(&stw_request.domains_still_running) == 0)
-        break;
-
-      if (stw_request.enter_spin_callback)
-        stw_request.enter_spin_callback(domain, stw_request.enter_spin_data);
-    }
+  if (!caml_plat_barrier_is_released(&stw_request.domains_still_running)) {
+    stw_api_barrier(domain);
   }
-  CAML_EV_END(EV_STW_API_BARRIER);
 
   #ifdef DEBUG
   Caml_state->inside_stw_handler = 1;
@@ -1445,9 +1530,11 @@ int caml_domain_is_in_stw(void) {
      this function in a loop.)
 
    - Domain initialization code from [domain_create] will not run in
-     parallel with a STW section, as [domain_create] starts by
-     looping until (1) it has the [all_domains_lock] and (2) there is
-     no current STW section (using the [stw_leader] variable).
+     parallel with a STW section, as [domain_create] starts by looping
+     until (1) it has the [all_domains_lock] and (2) there is no
+     current STW section (using the [stw_leader] variable). To avoid
+     starvation, [domain_create] will prevent new STW sections if it
+     can't make progress.
 
    - Domain cleanup code runs after the terminating domain may run in
      parallel to a STW section, but only after that domain has safely
@@ -1495,7 +1582,7 @@ int caml_try_run_on_all_domains_with_spin_work(
   void (*handler)(caml_domain_state*, void*, int, caml_domain_state**),
   void* data,
   void (*leader_setup)(caml_domain_state*),
-  void (*enter_spin_callback)(caml_domain_state*, void*),
+  int (*enter_spin_callback)(caml_domain_state*, void*),
   void* enter_spin_data)
 {
   int i;
@@ -1517,11 +1604,24 @@ int caml_try_run_on_all_domains_with_spin_work(
     return 0;
   }
 
-  /* see if there is a stw_leader already */
-  if (atomic_load_acquire(&stw_leader)) {
-    caml_plat_unlock(&all_domains_lock);
-    caml_handle_incoming_interrupts();
-    return 0;
+  while (1) {
+    /* see if there is a stw_leader already */
+    if (atomic_load_acquire(&stw_leader)) {
+      caml_plat_unlock(&all_domains_lock);
+      caml_handle_incoming_interrupts();
+      return 0;
+    }
+
+    /* STW requests may be suspended by [domain_create], in which case, instead
+       of claiming the stw_leader, we should release the lock and wait for
+       requests to be unsuspended before trying again */
+    if (CAMLunlikely(stw_requests_suspended)) {
+      caml_plat_wait(&requests_suspended_cond, &all_domains_lock);
+      /* we hold the lock, but we must check for [stw_leader] again */
+      continue;
+    }
+
+    break;
   }
 
   /* we have the lock and can claim the stw_leader */
@@ -1530,17 +1630,23 @@ int caml_try_run_on_all_domains_with_spin_work(
   CAML_EV_BEGIN(EV_STW_LEADER);
   caml_gc_log("causing STW");
 
-  /* setup all fields for this stw_request, must have those needed
-     for domains waiting at the enter spin barrier */
+  /* set up all fields for this stw_request; they must be available
+     for domains when they get interrupted */
   stw_request.enter_spin_callback = enter_spin_callback;
   stw_request.enter_spin_data = enter_spin_data;
   stw_request.callback = handler;
   stw_request.data = data;
-  atomic_store_release(&stw_request.barrier, 0);
-  atomic_store_release(&stw_request.domains_still_running, sync);
   stw_request.num_domains = stw_domains.participating_domains;
+  /* stw_request.barrier doesn't need resetting */
   atomic_store_release(&stw_request.num_domains_still_processing,
-                   stw_domains.participating_domains);
+                       stw_domains.participating_domains);
+
+  int is_alone = stw_request.num_domains == 1;
+  int should_sync = sync && !is_alone;
+
+  if (should_sync) {
+    caml_plat_barrier_reset(&stw_request.domains_still_running);
+  }
 
   if( leader_setup ) {
     leader_setup(domain_state);
@@ -1562,7 +1668,7 @@ int caml_try_run_on_all_domains_with_spin_work(
   for(i = 0; i < stw_domains.participating_domains; i++) {
     dom_internal * d = stw_domains.domains[i];
     stw_request.participating[i] = d->state;
-    CAMLassert(!d->interruptor.interrupt_pending);
+    CAMLassert(!interruptor_has_pending(&d->interruptor));
     if (d->state != domain_state) caml_send_interrupt(&d->interruptor);
   }
 
@@ -1583,13 +1689,10 @@ int caml_try_run_on_all_domains_with_spin_work(
   */
   caml_plat_unlock(&all_domains_lock);
 
-  for(i = 0; i < stw_request.num_domains; i++) {
-    int id = stw_request.participating[i]->id;
-    caml_wait_interrupt_serviced(&all_domains[id].interruptor);
+  /* arrive at enter barrier */
+  if (should_sync) {
+    stw_api_barrier(domain_state);
   }
-
-  /* release from the enter barrier */
-  atomic_store_release(&stw_request.domains_still_running, 0);
 
   #ifdef DEBUG
   domain_state->inside_stw_handler = 1;
@@ -1678,7 +1781,7 @@ void caml_reset_young_limit(caml_domain_state * dom_st)
   /* For non-delayable asynchronous actions, we immediately interrupt
      the domain again. */
   dom_internal * d = &all_domains[dom_st->id];
-  if (atomic_load_relaxed(&d->interruptor.interrupt_pending)
+  if (interruptor_has_pending(&d->interruptor)
       || dom_st->requested_minor_gc
       || dom_st->requested_major_slice
       || dom_st->major_slice_epoch < atomic_load (&caml_major_slice_epoch)) {

--- a/ocaml/runtime/domain.c
+++ b/ocaml/runtime/domain.c
@@ -219,8 +219,7 @@ static struct {
 };
 
 static caml_plat_mutex all_domains_lock = CAML_PLAT_MUTEX_INITIALIZER;
-static caml_plat_cond all_domains_cond =
-    CAML_PLAT_COND_INITIALIZER(&all_domains_lock);
+static caml_plat_cond all_domains_cond = CAML_PLAT_COND_INITIALIZER;
 static atomic_uintnat /* dom_internal* */ stw_leader = 0;
 static dom_internal all_domains[Max_domains];
 
@@ -360,7 +359,7 @@ int caml_send_interrupt(struct interruptor* target)
 
   /* Signal the condition variable, in case the target is
      itself waiting for an interrupt to be processed elsewhere */
-  caml_plat_lock(&target->lock);
+  caml_plat_lock_blocking(&target->lock);
   caml_plat_broadcast(&target->cond); // OPT before/after unlock? elide?
   caml_plat_unlock(&target->lock);
 
@@ -572,13 +571,13 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   /* take the all_domains_lock so that we can alter the STW participant
      set atomically */
-  caml_plat_lock(&all_domains_lock);
+  caml_plat_lock_blocking(&all_domains_lock);
 
   /* Wait until any in-progress STW sections end. */
   while (atomic_load_acquire(&stw_leader)) {
     /* [caml_plat_wait] releases [all_domains_lock] until the current
        STW section ends, and then takes the lock again. */
-    caml_plat_wait(&all_domains_cond);
+    caml_plat_wait(&all_domains_cond, &all_domains_lock);
   }
 
   d = next_free_domain();
@@ -615,7 +614,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
    * shared with a domain which is terminating (see
    * domain_terminate). */
 
-  caml_plat_lock(&d->domain_lock);
+  caml_plat_lock_blocking(&d->domain_lock);
 
   /* Set domain_self if we have successfully allocated the
    * caml_domain_state. Otherwise domain_self will be NULL and it's up
@@ -797,7 +796,7 @@ CAMLexport void caml_reset_domain_lock(void)
        prior to calling fork and then init afterwards in both parent
        and child. */
   caml_plat_mutex_init(&self->domain_lock);
-  caml_plat_cond_init(&self->domain_cond, &self->domain_lock);
+  caml_plat_cond_init(&self->domain_cond);
 
   return;
 }
@@ -949,15 +948,14 @@ void caml_init_domains(uintnat minor_heap_wsz) {
 
     dom->interruptor.interrupt_word = NULL;
     caml_plat_mutex_init(&dom->interruptor.lock);
-    caml_plat_cond_init(&dom->interruptor.cond,
-                        &dom->interruptor.lock);
+    caml_plat_cond_init(&dom->interruptor.cond);
     dom->interruptor.running = 0;
     dom->interruptor.terminating = 0;
     dom->interruptor.unique_id = 0;
     dom->interruptor.interrupt_pending = 0;
 
     caml_plat_mutex_init(&dom->domain_lock);
-    caml_plat_cond_init(&dom->domain_cond, &dom->domain_lock);
+    caml_plat_cond_init(&dom->domain_cond);
     dom->backup_thread_running = 0;
     dom->backup_thread_msg = BT_INIT;
   }
@@ -1047,11 +1045,11 @@ static void* backup_thread_func(void* v)
         /* Wait safely if there is nothing to do.
          * Will be woken from caml_leave_blocking_section
          */
-        caml_plat_lock(&s->lock);
+        caml_plat_lock_blocking(&s->lock);
         msg = atomic_load_acquire (&di->backup_thread_msg);
         if (msg == BT_IN_BLOCKING_SECTION &&
             !caml_incoming_interrupts_queued())
-          caml_plat_wait(&s->cond);
+          caml_plat_wait(&s->cond, &s->lock);
         caml_plat_unlock(&s->lock);
         break;
       case BT_ENTERING_OCAML:
@@ -1059,10 +1057,10 @@ static void* backup_thread_func(void* v)
          * Will be woken from caml_bt_exit_ocaml
          * or domain_terminate
          */
-        caml_plat_lock(&di->domain_lock);
+        caml_plat_lock_blocking(&di->domain_lock);
         msg = atomic_load_acquire (&di->backup_thread_msg);
         if (msg == BT_ENTERING_OCAML)
-          caml_plat_wait(&di->domain_cond);
+          caml_plat_wait(&di->domain_cond, &di->domain_lock);
         caml_plat_unlock(&di->domain_lock);
         break;
       default:
@@ -1095,7 +1093,7 @@ static void install_backup_thread (dom_internal* di)
       /* Give a chance for backup thread on this domain to terminate */
       caml_plat_unlock (&di->domain_lock);
       cpu_relax ();
-      caml_plat_lock (&di->domain_lock);
+      caml_plat_lock_blocking(&di->domain_lock);
       msg = atomic_load_acquire(&di->backup_thread_msg);
     }
 
@@ -1209,7 +1207,7 @@ static void* domain_thread_func(void* v)
   p->newdom = domain_self;
 
   /* handshake with the parent domain */
-  caml_plat_lock(&p->parent->interruptor.lock);
+  caml_plat_lock_blocking(&p->parent->interruptor.lock);
   if (domain_self) {
     p->status = Dom_started;
     p->unique_id = domain_self->interruptor.unique_id;
@@ -1292,17 +1290,18 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
 
   /* While waiting for the child thread to start up, we need to service any
      stop-the-world requests as they come in. */
-  caml_plat_lock(&domain_self->interruptor.lock);
+  struct interruptor *interruptor = &domain_self->interruptor;
+  caml_plat_lock_blocking(&interruptor->lock);
   while (p.status == Dom_starting) {
     if (caml_incoming_interrupts_queued()) {
-      caml_plat_unlock(&domain_self->interruptor.lock);
-      handle_incoming(&domain_self->interruptor);
-      caml_plat_lock(&domain_self->interruptor.lock);
+      caml_plat_unlock(&interruptor->lock);
+      handle_incoming(interruptor);
+      caml_plat_lock_blocking(&interruptor->lock);
     } else {
-      caml_plat_wait(&domain_self->interruptor.cond);
+      caml_plat_wait(&interruptor->cond, &interruptor->lock);
     }
   }
-  caml_plat_unlock(&domain_self->interruptor.lock);
+  caml_plat_unlock(&interruptor->lock);
 
   if (p.status == Dom_started) {
     /* successfully created a domain.
@@ -1378,7 +1377,7 @@ static void decrement_stw_domains_still_processing(void)
 
   if( am_last ) {
     /* release the STW lock to allow new STW sections */
-    caml_plat_lock(&all_domains_lock);
+    caml_plat_lock_blocking(&all_domains_lock);
     atomic_store_release(&stw_leader, 0);
     caml_plat_broadcast(&all_domains_cond);
     caml_gc_log("clearing stw leader");
@@ -1828,7 +1827,7 @@ CAMLexport intnat caml_domain_is_multicore (void)
 CAMLexport void caml_acquire_domain_lock(void)
 {
   dom_internal* self = domain_self;
-  caml_plat_lock(&self->domain_lock);
+  caml_plat_lock_blocking(&self->domain_lock);
   caml_state = self->state;
 }
 
@@ -1918,7 +1917,7 @@ static void domain_terminate (void)
 
     /* take the all_domains_lock to try and exit the STW participant set
        without racing with a STW section being triggered */
-    caml_plat_lock(&all_domains_lock);
+    caml_plat_lock_blocking(&all_domains_lock);
 
     /* The interaction of termination and major GC is quite subtle.
 
@@ -1944,7 +1943,7 @@ static void domain_terminate (void)
       /* signal the interruptor condition variable
        * because the backup thread may be waiting on it
        */
-      caml_plat_lock(&s->lock);
+      caml_plat_lock_blocking(&s->lock);
       caml_plat_broadcast(&s->cond);
       caml_plat_unlock(&s->lock);
 

--- a/ocaml/runtime/fiber.c
+++ b/ocaml/runtime/fiber.c
@@ -823,8 +823,9 @@ int caml_try_realloc_stack(asize_t required_space)
   old_stack = Caml_state->current_stack;
   stack_used = Stack_high(old_stack) - (value*)old_stack->sp;
   wsize = Stack_high(old_stack) - Stack_base(old_stack);
+  uintnat max_stack_wsize = caml_max_stack_wsize;
   do {
-    if (wsize >= caml_max_stack_wsize) return 0;
+    if (wsize >= max_stack_wsize) return 0;
     wsize *= 2;
   } while (wsize < stack_used + required_space);
 

--- a/ocaml/runtime/frame_descriptors.c
+++ b/ocaml/runtime/frame_descriptors.c
@@ -195,13 +195,9 @@ static void stw_register_frametables(
     int participating_count,
     caml_domain_state** participating)
 {
-  barrier_status b = caml_global_barrier_begin ();
-
-  if (caml_global_barrier_is_final(b)) {
-    register_frametables_from_stw_single((frametable_array*) frametables);
+  Caml_global_barrier_if_final(participating_count) {
+    register_frametables_from_stw_single(frametables);
   }
-
-  caml_global_barrier_end(b);
 }
 
 void caml_register_frametables(void **table, int ntables) {

--- a/ocaml/runtime/gc_ctrl.c
+++ b/ocaml/runtime/gc_ctrl.c
@@ -38,7 +38,7 @@
 #include "caml/startup.h"
 #include "caml/fail.h"
 
-uintnat caml_max_stack_wsize;
+atomic_uintnat caml_max_stack_wsize;
 uintnat caml_fiber_wsz;
 
 extern uintnat caml_major_heap_increment; /* percent or words; see major_gc.c */
@@ -338,7 +338,7 @@ void caml_init_gc (void)
   caml_percent_free = norm_pfree (caml_params->init_percent_free);
   caml_gc_log ("Initial stack limit: %"
                ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
-               caml_max_stack_wsize / 1024 * sizeof (value));
+               caml_params->init_max_stack_wsz / 1024 * sizeof (value));
 
   caml_custom_major_ratio =
       norm_custom_maj (caml_params->init_custom_major_ratio);

--- a/ocaml/runtime/gc_stats.c
+++ b/ocaml/runtime/gc_stats.c
@@ -17,6 +17,7 @@
 
 #include "caml/gc_stats.h"
 #include "caml/minor_gc.h"
+#include "caml/platform.h"
 #include "caml/shared_heap.h"
 
 Caml_inline intnat intnat_max(intnat a, intnat b) {
@@ -82,7 +83,7 @@ static caml_plat_mutex orphan_lock = CAML_PLAT_MUTEX_INITIALIZER;
 static struct alloc_stats orphaned_alloc_stats = {0,};
 
 void caml_accum_orphan_alloc_stats(struct alloc_stats *acc) {
-  caml_plat_lock(&orphan_lock);
+  caml_plat_lock_blocking(&orphan_lock);
   caml_accum_alloc_stats(acc, &orphaned_alloc_stats);
   caml_plat_unlock(&orphan_lock);
 }
@@ -95,7 +96,7 @@ void caml_orphan_alloc_stats(caml_domain_state *domain) {
   caml_reset_domain_alloc_stats(domain);
 
   /* push them into the orphan stats */
-  caml_plat_lock(&orphan_lock);
+  caml_plat_lock_blocking(&orphan_lock);
   caml_accum_alloc_stats(&orphaned_alloc_stats, &alloc_stats);
   caml_plat_unlock(&orphan_lock);
 }

--- a/ocaml/runtime/globroots.c
+++ b/ocaml/runtime/globroots.c
@@ -19,6 +19,7 @@
 
 #include "caml/mlvalues.h"
 #include "caml/memory.h"
+#include "caml/platform.h"
 #include "caml/roots.h"
 #include "caml/globroots.h"
 #include "caml/skiplist.h"
@@ -52,14 +53,14 @@ struct skiplist caml_global_roots_old = SKIPLIST_STATIC_INITIALIZER;
 
 Caml_inline void caml_insert_global_root(struct skiplist * list, value * r)
 {
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
   caml_skiplist_insert(list, (uintnat) r, 0);
   caml_plat_unlock(&roots_mutex);
 }
 
 Caml_inline void caml_delete_global_root(struct skiplist * list, value * r)
 {
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
   caml_skiplist_remove(list, (uintnat) r);
   caml_plat_unlock(&roots_mutex);
 }
@@ -201,7 +202,7 @@ static void caml_register_dyn_global(void *v) {
 
 void caml_register_dyn_globals(void **globals, int nglobals) {
   int i;
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
   for (i = 0; i < nglobals; i++)
     caml_register_dyn_global(globals[i]);
   caml_plat_unlock(&roots_mutex);
@@ -254,7 +255,7 @@ static void scan_native_globals(scanning_action f, void* fdata)
   int start, stop;
   link* lnk;
 
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
   dyn_globals = caml_dyn_globals;
   caml_plat_unlock(&roots_mutex);
 
@@ -295,7 +296,7 @@ Caml_inline void caml_iterate_global_roots(scanning_action f,
 
 /* Scan all global roots */
 void caml_scan_global_roots(scanning_action f, void* fdata) {
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
   caml_iterate_global_roots(f, &caml_global_roots, fdata);
   caml_iterate_global_roots(f, &caml_global_roots_young, fdata);
   caml_iterate_global_roots(f, &caml_global_roots_old, fdata);
@@ -309,7 +310,7 @@ void caml_scan_global_roots(scanning_action f, void* fdata) {
 /* Scan global roots for a minor collection */
 void caml_scan_global_young_roots(scanning_action f, void* fdata)
 {
-  caml_plat_lock(&roots_mutex);
+  caml_plat_lock_blocking(&roots_mutex);
 
   caml_iterate_global_roots(f, &caml_global_roots, fdata);
   caml_iterate_global_roots(f, &caml_global_roots_young, fdata);

--- a/ocaml/runtime/intern.c
+++ b/ocaml/runtime/intern.c
@@ -434,11 +434,12 @@ static value intern_alloc_obj(struct caml_intern_state* s, caml_domain_state* d,
   } else {
     p = caml_shared_try_alloc(d->shared_heap, wosize, tag,
                               0 /* no reserved bits */);
-    d->allocated_words += Whsize_wosize(wosize);
     if (p == NULL) {
       intern_cleanup (s);
       caml_raise_out_of_memory();
     }
+    d->allocated_words += Whsize_wosize(wosize);
+    d->allocated_words_direct += Whsize_wosize(wosize);
     Hd_hp(p) = Make_header (wosize, tag, caml_allocation_status());
     caml_memprof_sample_block(Val_hp(p), wosize,
                               Whsize_wosize(wosize),

--- a/ocaml/runtime/major_gc.c
+++ b/ocaml/runtime/major_gc.c
@@ -1419,15 +1419,105 @@ static void start_marking (int participant_count, caml_domain_state** barrier_pa
     ephe_todo_list_emptied();
 }
 
+static void cycle_major_heap_from_stw_single(
+  caml_domain_state* domain,
+  uintnat num_domains_in_stw)
+{
+  /* Cycle major heap */
+  /* FIXME: delete caml_cycle_heap_from_stw_single
+     and have per-domain copies of the data? */
+  caml_cycle_heap_from_stw_single();
+  caml_gc_log("GC cycle %lu completed (heap cycled)",
+              (long unsigned int)caml_major_cycles_completed);
+
+  caml_major_cycles_completed++;
+  caml_gc_message(0x40, "Starting major GC cycle\n");
+
+  if (atomic_load_relaxed(&caml_verb_gc) & 0x400) {
+    struct gc_stats s;
+    intnat heap_words, not_garbage_words, swept_words;
+
+    caml_compute_gc_stats(&s);
+    heap_words = s.heap_stats.pool_words + s.heap_stats.large_words;
+    not_garbage_words = s.heap_stats.pool_live_words
+      + s.heap_stats.large_words;
+    swept_words = domain->swept_words;
+    caml_gc_log ("heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d "
+                 "not_garbage_words %"ARCH_INTNAT_PRINTF_FORMAT"d "
+                 "swept_words %"ARCH_INTNAT_PRINTF_FORMAT"d",
+                 heap_words, not_garbage_words, swept_words);
+
+    if (caml_stat_space_overhead.heap_words_last_cycle != 0) {
+      /* At the end of a major cycle, no object has colour MARKED.
+
+         [not_garbage_words] counts all objects which are UNMARKED.
+         Importantly, this includes both live objects and objects which are
+         unreachable in the current cycle (i.e, garbage). But we don't get
+         to know which objects are garbage until the end of the next cycle.
+
+         live_words@N = not_garbage_words@N - swept_words@N+1
+
+         space_overhead@N =
+         100.0 * (heap_words@N - live_words@N) / live_words@N
+      */
+      double live_words_last_cycle =
+        caml_stat_space_overhead.not_garbage_words_last_cycle - swept_words;
+      double space_overhead =
+        100.0 * (double)(caml_stat_space_overhead.heap_words_last_cycle
+                         - live_words_last_cycle) / live_words_last_cycle;
+
+      if (caml_stat_space_overhead.l == NULL ||
+          caml_stat_space_overhead.index == BUFFER_SIZE) {
+        struct buf_list_t *l =
+          (struct buf_list_t*)
+          caml_stat_alloc_noexc(sizeof(struct buf_list_t));
+        l->next = caml_stat_space_overhead.l;
+        caml_stat_space_overhead.l = l;
+        caml_stat_space_overhead.index = 0;
+      }
+      caml_stat_space_overhead.l->buffer[caml_stat_space_overhead.index++] =
+        space_overhead;
+      caml_gc_log("Previous cycle's space_overhead: %lf", space_overhead);
+    }
+    caml_stat_space_overhead.heap_words_last_cycle = heap_words;
+
+    caml_stat_space_overhead.not_garbage_words_last_cycle
+      = not_garbage_words;
+  }
+
+  domain->swept_words = 0;
+
+  atomic_store_release(&num_domains_to_sweep, num_domains_in_stw);
+  atomic_store_release(&num_domains_to_mark, num_domains_in_stw);
+
+      caml_gc_phase = Phase_sweep_main;
+      atomic_store(&ephe_cycle_info.num_domains_todo, num_domains_in_stw);
+      atomic_store(&ephe_cycle_info.ephe_cycle, 1);
+      atomic_store(&ephe_cycle_info.num_domains_done, 0);
+
+  atomic_store_release(&num_domains_to_ephe_sweep, 0);
+  /* Will be set to the correct number when switching to
+     [Phase_sweep_ephe] */
+
+  atomic_store_release(&num_domains_to_final_update_first,
+                       num_domains_in_stw);
+  atomic_store_release(&num_domains_to_final_update_last,
+                       num_domains_in_stw);
+
+  atomic_store(&domain_global_roots_started, WORK_UNSTARTED);
+
+  caml_code_fragment_cleanup_from_stw_single();
+}
+
 struct cycle_callback_params {
   int force_compaction;
 };
 
-static void stw_cycle_all_domains(caml_domain_state* domain, void* args,
-                                       int participating_count,
-                                       caml_domain_state** participating)
+static void stw_cycle_all_domains(
+  caml_domain_state* domain, void* args,
+  int participating_count,
+  caml_domain_state** participating)
 {
-  uintnat num_domains_in_stw;
   /* We copy params because the stw leader may leave early. No barrier needed
      because there's one in the minor gc and after. */
   struct cycle_callback_params params = *((struct cycle_callback_params*)args);
@@ -1455,99 +1545,8 @@ static void stw_cycle_all_domains(caml_domain_state* domain, void* args,
                         (domain, (void*)0, participating_count, participating);
 
   CAML_EV_BEGIN(EV_MAJOR_GC_STW);
-
-  {
-    /* Cycle major heap */
-    /* FIXME: delete caml_cycle_heap_from_stw_single
-       and have per-domain copies of the data? */
-    barrier_status b = caml_global_barrier_begin();
-    if (caml_global_barrier_is_final(b)) {
-      caml_cycle_heap_from_stw_single();
-      caml_gc_log("GC cycle %lu completed (heap cycled)",
-                  (long unsigned int)caml_major_cycles_completed);
-
-      caml_major_cycles_completed++;
-      caml_gc_message(0x40, "Starting major GC cycle\n");
-
-      if (atomic_load_relaxed(&caml_verb_gc) & 0x400) {
-        struct gc_stats s;
-        intnat heap_words, not_garbage_words, swept_words;
-
-        caml_compute_gc_stats(&s);
-        heap_words = s.heap_stats.pool_words + s.heap_stats.large_words;
-        not_garbage_words = s.heap_stats.pool_live_words
-                            + s.heap_stats.large_words;
-        swept_words = domain->swept_words;
-        caml_gc_log ("heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d "
-                      "not_garbage_words %"ARCH_INTNAT_PRINTF_FORMAT"d "
-                      "swept_words %"ARCH_INTNAT_PRINTF_FORMAT"d",
-                      heap_words, not_garbage_words, swept_words);
-
-        if (caml_stat_space_overhead.heap_words_last_cycle != 0) {
-          /* At the end of a major cycle, no object has colour MARKED.
-
-             [not_garbage_words] counts all objects which are UNMARKED.
-             Importantly, this includes both live objects and objects which are
-             unreachable in the current cycle (i.e, garbage). But we don't get
-             to know which objects are garbage until the end of the next cycle.
-
-             live_words@N = not_garbage_words@N - swept_words@N+1
-
-             space_overhead@N =
-                      100.0 * (heap_words@N - live_words@N) / live_words@N
-            */
-          double live_words_last_cycle =
-            caml_stat_space_overhead.not_garbage_words_last_cycle - swept_words;
-          double space_overhead =
-            100.0 * (double)(caml_stat_space_overhead.heap_words_last_cycle
-                            - live_words_last_cycle) / live_words_last_cycle;
-
-          if (caml_stat_space_overhead.l == NULL ||
-              caml_stat_space_overhead.index == BUFFER_SIZE) {
-            struct buf_list_t *l =
-              (struct buf_list_t*)
-                  caml_stat_alloc_noexc(sizeof(struct buf_list_t));
-            l->next = caml_stat_space_overhead.l;
-            caml_stat_space_overhead.l = l;
-            caml_stat_space_overhead.index = 0;
-          }
-          caml_stat_space_overhead.l->buffer[caml_stat_space_overhead.index++] =
-            space_overhead;
-          caml_gc_log("Previous cycle's space_overhead: %lf", space_overhead);
-        }
-        caml_stat_space_overhead.heap_words_last_cycle = heap_words;
-
-        caml_stat_space_overhead.not_garbage_words_last_cycle
-        = not_garbage_words;
-      }
-
-      domain->swept_words = 0;
-
-      num_domains_in_stw = (uintnat)caml_global_barrier_num_domains();
-      atomic_store_release(&num_domains_to_sweep, num_domains_in_stw);
-      atomic_store_release(&num_domains_to_mark, num_domains_in_stw);
-
-      caml_gc_phase = Phase_sweep_main;
-      atomic_store(&ephe_cycle_info.num_domains_todo, num_domains_in_stw);
-      atomic_store(&ephe_cycle_info.ephe_cycle, 1);
-      atomic_store(&ephe_cycle_info.num_domains_done, 0);
-
-      atomic_store_release(&num_domains_to_ephe_sweep, 0);
-      /* Will be set to the correct number when switching to
-         [Phase_sweep_ephe] */
-
-      atomic_store_release(&num_domains_to_final_update_first,
-                           num_domains_in_stw);
-      atomic_store_release(&num_domains_to_final_update_last,
-                           num_domains_in_stw);
-
-      atomic_store(&domain_global_roots_started, WORK_UNSTARTED);
-
-      caml_code_fragment_cleanup_from_stw_single();
-    }
-    // should interrupts be processed here or not?
-    // depends on whether marking above may need interrupts
-    caml_global_barrier_end(b);
+  Caml_global_barrier_if_final(participating_count) {
+    cycle_major_heap_from_stw_single(domain, (uintnat) participating_count);
   }
 
   /* If the heap is to be verified, do it before the domains continue
@@ -1558,7 +1557,7 @@ static void stw_cycle_all_domains(caml_domain_state* domain, void* args,
     /* This global barrier avoids races between the verify_heap code
        and the rest of the STW critical section, for example the parts
        that mark global roots. */
-    caml_global_barrier();
+    caml_global_barrier(participating_count);
   }
 
   caml_cycle_heap(domain->shared_heap);
@@ -1615,10 +1614,10 @@ static void stw_cycle_all_domains(caml_domain_state* domain, void* args,
   /* To ensure a mutator doesn't resume while global roots are being marked.
      Mutators can alter the set of global roots, to preserve its correctness,
      they should not run while global roots are being marked.*/
-  caml_global_barrier();
+  caml_global_barrier(participating_count);
 
   /* Someone should flush the allocation stats we gathered during the cycle */
-  if( participating[0] == Caml_state ) {
+  if( participating[0] == domain ) {
     CAML_EV_ALLOC_FLUSH();
   }
 
@@ -1682,11 +1681,9 @@ static void stw_try_complete_gc_phase(
   int participant_count,
   caml_domain_state** participating)
 {
-  barrier_status b;
   CAML_EV_BEGIN(EV_MAJOR_GC_PHASE_CHANGE);
 
-  b = caml_global_barrier_begin ();
-  if (caml_global_barrier_is_final(b)) {
+  Caml_global_barrier_if_final(participant_count) {
     if (is_complete_phase_sweep_and_mark_main()) {
       caml_gc_phase = Phase_mark_final;
     } else if (is_complete_phase_mark_final()) {
@@ -1696,13 +1693,12 @@ static void stw_try_complete_gc_phase(
         participating[i]->ephe_info->must_sweep_ephe = 1;
     }
   }
-  caml_global_barrier_end(b);
+
   CAML_EV_END(EV_MAJOR_GC_PHASE_CHANGE);
 }
 
-intnat caml_opportunistic_major_work_available (void)
+intnat caml_opportunistic_major_work_available (caml_domain_state* domain_state)
 {
-  caml_domain_state* domain_state = Caml_state;
   return !domain_state->sweeping_done || !domain_state->marking_done;
 }
 
@@ -1748,7 +1744,7 @@ static void major_collection_slice(intnat howmuch,
   /* shortcut out if there is no opportunistic work to be done
    * NB: needed particularly to avoid caml_ev spam when polling */
   if (mode == Slice_opportunistic &&
-      !caml_opportunistic_major_work_available()) {
+      !caml_opportunistic_major_work_available(domain_state)) {
     commit_major_slice_work (0);
     return;
   }

--- a/ocaml/runtime/major_gc.c
+++ b/ocaml/runtime/major_gc.c
@@ -1400,10 +1400,8 @@ static void start_marking (int participant_count, caml_domain_state** barrier_pa
   CAML_EV_END(EV_MAJOR_MARK_ROOTS);
 
   CAML_EV_BEGIN(EV_MAJOR_MEMPROF_ROOTS);
-  int is_main_domain =
-    barrier_participants == NULL || barrier_participants[0] == domain;
   caml_memprof_scan_roots(caml_darken, darken_scanning_flags, domain,
-                          domain, false, is_main_domain);
+                          domain, false);
   CAML_EV_END(EV_MAJOR_MEMPROF_ROOTS);
 
   caml_gc_log("Marking started, %ld entries on mark stack",
@@ -1441,7 +1439,7 @@ static void stw_cycle_all_domains(caml_domain_state* domain, void* args,
    * mysteriously put all domains back into mark/sweep.
    */
   CAML_EV_BEGIN(EV_MAJOR_MEMPROF_CLEAN);
-  caml_memprof_after_major_gc(domain, domain == participating[0]);
+  caml_memprof_after_major_gc(domain);
   CAML_EV_END(EV_MAJOR_MEMPROF_CLEAN);
 
   CAML_EV_BEGIN(EV_MAJOR_GC_CYCLE_DOMAINS);

--- a/ocaml/runtime/major_gc.c
+++ b/ocaml/runtime/major_gc.c
@@ -294,7 +294,7 @@ Caml_inline void prefetch_block(value v)
 
 static void ephe_next_cycle (void)
 {
-  caml_plat_lock(&ephe_lock);
+  caml_plat_lock_blocking(&ephe_lock);
 
   atomic_fetch_add(&ephe_cycle_info.ephe_cycle, +1);
   CAMLassert(atomic_load_acquire(&ephe_cycle_info.num_domains_done) <=
@@ -309,7 +309,7 @@ static void ephe_todo_list_emptied (void)
   /* If we haven't started marking, the todo list can grow (during ephemeron
      allocation), so we should not yet announce that it has emptied */
   CAMLassert (caml_marking_started());
-  caml_plat_lock(&ephe_lock);
+  caml_plat_lock_blocking(&ephe_lock);
 
   /* Force next ephemeron marking cycle in order to avoid reasoning about
    * whether the domain has already incremented
@@ -335,7 +335,7 @@ static void record_ephe_marking_done (uintnat ephe_cycle)
   if (ephe_cycle < atomic_load_acquire(&ephe_cycle_info.ephe_cycle))
     return;
 
-  caml_plat_lock(&ephe_lock);
+  caml_plat_lock_blocking(&ephe_lock);
   if (ephe_cycle == atomic_load(&ephe_cycle_info.ephe_cycle)) {
     Caml_state->ephe_info->cycle = ephe_cycle;
     atomic_fetch_add(&ephe_cycle_info.num_domains_done, +1);
@@ -418,7 +418,7 @@ void caml_orphan_ephemerons (caml_domain_state* domain_state)
     value live_tail = ephe_list_tail(ephe_info->live);
     CAMLassert(Ephe_link(live_tail) == 0);
 
-    caml_plat_lock(&orphaned_lock);
+    caml_plat_lock_blocking(&orphaned_lock);
     Ephe_link(live_tail) = orph_structs.ephe_list_live;
     orph_structs.ephe_list_live = ephe_info->live;
     ephe_info->live = 0;
@@ -452,7 +452,7 @@ void caml_orphan_finalisers (caml_domain_state* domain_state)
     CAMLassert (!f->updated_last);
 
     /* Add the finalisers to [orph_structs] */
-    caml_plat_lock(&orphaned_lock);
+    caml_plat_lock_blocking(&orphaned_lock);
     f->next = orph_structs.final_info;
     orph_structs.final_info = f;
     caml_plat_unlock(&orphaned_lock);
@@ -491,7 +491,7 @@ static void adopt_orphaned_work (void)
   if (no_orphaned_work() || caml_domain_is_terminating())
     return;
 
-  caml_plat_lock(&orphaned_lock);
+  caml_plat_lock_blocking(&orphaned_lock);
 
   orph_ephe_list_live = orph_structs.ephe_list_live;
   orph_structs.ephe_list_live = 0;

--- a/ocaml/runtime/major_gc.c
+++ b/ocaml/runtime/major_gc.c
@@ -630,16 +630,18 @@ static void update_major_slice_work(intnat howmuch,
 {
   double heap_words;
   intnat alloc_work, dependent_work, extra_work, new_work;
-  intnat my_alloc_count, my_dependent_count;
+  intnat my_alloc_count, my_alloc_direct_count, my_dependent_count;
   double my_extra_count;
   caml_domain_state *dom_st = Caml_state;
   uintnat heap_size, heap_sweep_words, total_cycle_work;
 
   my_alloc_count = dom_st->allocated_words;
+  my_alloc_direct_count = dom_st->allocated_words_direct;
   my_dependent_count = dom_st->dependent_allocated;
   my_extra_count = dom_st->extra_heap_resources;
   dom_st->stat_major_words += dom_st->allocated_words;
   dom_st->allocated_words = 0;
+  dom_st->allocated_words_direct = 0;
   dom_st->dependent_allocated = 0;
   dom_st->extra_heap_resources = 0.0;
   /*
@@ -711,6 +713,9 @@ static void update_major_slice_work(intnat howmuch,
   caml_gc_message (0x40, "allocated_words = %"
                          ARCH_INTNAT_PRINTF_FORMAT "u\n",
                    my_alloc_count);
+  caml_gc_message (0x40, "allocated_words_direct = %"
+                         ARCH_INTNAT_PRINTF_FORMAT "u\n",
+                   my_alloc_direct_count);
   caml_gc_message (0x40, "alloc work-to-do = %"
                          ARCH_INTNAT_PRINTF_FORMAT "d\n",
                    alloc_work);
@@ -2067,6 +2072,7 @@ void caml_finish_marking (void)
     caml_shrink_mark_stack();
     Caml_state->stat_major_words += Caml_state->allocated_words;
     Caml_state->allocated_words = 0;
+    Caml_state->allocated_words_direct = 0;
     CAML_EV_END(EV_MAJOR_FINISH_MARKING);
   }
 }

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -575,7 +575,8 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
   }
 
   dom_st->allocated_words += Whsize_wosize(wosize);
-  if (dom_st->allocated_words > dom_st->minor_heap_wsz / 5) {
+  dom_st->allocated_words_direct += Whsize_wosize(wosize);
+  if (dom_st->allocated_words_direct > dom_st->minor_heap_wsz / 5) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
     caml_request_major_slice(1);
   }

--- a/ocaml/runtime/memory.c
+++ b/ocaml/runtime/memory.c
@@ -676,7 +676,7 @@ static struct pool_block* get_pool_block(caml_stat_block b)
 /* Linking a pool block into the ring */
 static void link_pool_block(struct pool_block *pb)
 {
-  caml_plat_lock(&pool_mutex);
+  caml_plat_lock_blocking(&pool_mutex);
   pb->next = pool->next;
   pb->prev = pool;
   pool->next->prev = pb;
@@ -687,7 +687,7 @@ static void link_pool_block(struct pool_block *pb)
 /* Unlinking a pool block from the ring */
 static void unlink_pool_block(struct pool_block *pb)
 {
-    caml_plat_lock(&pool_mutex);
+    caml_plat_lock_blocking(&pool_mutex);
     pb->prev->next = pb->next;
     pb->next->prev = pb->prev;
     caml_plat_unlock(&pool_mutex);
@@ -709,7 +709,7 @@ CAMLexport void caml_stat_create_pool(void)
 
 CAMLexport void caml_stat_destroy_pool(void)
 {
-  caml_plat_lock(&pool_mutex);
+  caml_plat_lock_blocking(&pool_mutex);
   if (pool != NULL) {
     pool->prev->next = NULL;
     while (pool != NULL) {

--- a/ocaml/runtime/memprof.c
+++ b/ocaml/runtime/memprof.c
@@ -626,8 +626,11 @@ struct memprof_orphan_table_s {
 /* List of orphaned entry tables not yet adopted by any domain. */
 static memprof_orphan_table_t orphans = NULL;
 
-/* lock controlling access to `orphans` variable */
+/* lock controlling access to `orphans` and writes to `orphans_present` */
 static caml_plat_mutex orphans_lock = CAML_PLAT_MUTEX_INITIALIZER;
+
+/* Flag indicating non-NULL orphans. Only modified when holding orphans_lock. */
+static atomic_uintnat orphans_present;
 
 /**** Initializing and clearing entries tables ****/
 
@@ -965,6 +968,7 @@ static void orphans_abandon(memprof_domain_t domain)
   caml_plat_lock(&orphans_lock);
   ot->next = orphans;
   orphans = domain->orphans;
+  atomic_store_release(&orphans_present, 1);
   caml_plat_unlock(&orphans_lock);
   domain->orphans = NULL;
 }
@@ -973,15 +977,22 @@ static void orphans_abandon(memprof_domain_t domain)
 
 static void orphans_adopt(memprof_domain_t domain)
 {
+  if (!atomic_load_acquire(&orphans_present))
+    return; /* No orphans to adopt */
+
   /* Find the end of the domain's orphans list */
   memprof_orphan_table_t *p = &domain->orphans;
   while(*p) {
     p = &(*p)->next;
   }
 
+  // XXX mshinwell: was caml_plat_lock_blocking in PR13299
   caml_plat_lock(&orphans_lock);
-  *p = orphans;
-  orphans = NULL;
+  if (orphans) {
+    *p = orphans;
+    orphans = NULL;
+    atomic_store_release(&orphans_present, 0);
+  }
   caml_plat_unlock(&orphans_lock);
 }
 
@@ -1464,15 +1475,13 @@ void caml_memprof_scan_roots(scanning_action f,
                              scanning_action_flags fflags,
                              void* fdata,
                              caml_domain_state *state,
-                             bool weak,
-                             bool global)
+                             bool weak)
 {
   memprof_domain_t domain = state->memprof;
   CAMLassert(domain);
-  if (global) {
-    /* Adopt all global orphans into this domain. */
-    orphans_adopt(domain);
-  }
+
+  /* Adopt all global orphans into this domain. */
+  orphans_adopt(domain);
 
   bool young = (fflags & SCANNING_ONLY_YOUNG_VALUES);
   struct scan_closure closure = {f, fflags, fdata, weak};
@@ -1516,17 +1525,15 @@ static void entries_update_after_minor_gc(entries_t entries,
 }
 
 /* Update all memprof structures for a given domain, at the end of a
- * minor GC. If `global` is set, also ensure shared structures are
- * updated (we do this by adopting orphans into this domain). */
+ * minor GC. */
 
-void caml_memprof_after_minor_gc(caml_domain_state *state, bool global)
+void caml_memprof_after_minor_gc(caml_domain_state *state)
 {
   memprof_domain_t domain = state->memprof;
   CAMLassert(domain);
-  if (global) {
-    /* Adopt all global orphans into this domain. */
-    orphans_adopt(domain);
-  }
+
+  /* Adopt all global orphans into this domain. */
+  orphans_adopt(domain);
 
   domain_apply_actions(domain, true, entry_update_after_minor_gc,
                        NULL, entries_update_after_minor_gc);
@@ -1559,17 +1566,16 @@ static bool entry_update_after_major_gc(entry_t e, void *data)
  * is no "entries_update_after_major_gc" function. */
 
 /* Update all memprof structures for a given domain, at the end of a
- * major GC. If `global` is set, also update shared structures (we do
- * this by adopting orphans into this domain). */
+ * major GC. */
 
-void caml_memprof_after_major_gc(caml_domain_state *state, bool global)
+void caml_memprof_after_major_gc(caml_domain_state *state)
 {
   memprof_domain_t domain = state->memprof;
   CAMLassert(domain);
-  if (global) {
-    /* Adopt all global orphans into this domain. */
-    orphans_adopt(domain);
-  }
+
+  /* Adopt all global orphans into this domain. */
+  orphans_adopt(domain);
+
   domain_apply_actions(domain, false, entry_update_after_major_gc,
                        NULL, NULL);
   orphans_update_pending(domain);

--- a/ocaml/runtime/memprof.c
+++ b/ocaml/runtime/memprof.c
@@ -965,7 +965,7 @@ static void orphans_abandon(memprof_domain_t domain)
     ot = ot->next;
   }
 
-  caml_plat_lock(&orphans_lock);
+  caml_plat_lock_blocking(&orphans_lock);
   ot->next = orphans;
   orphans = domain->orphans;
   atomic_store_release(&orphans_present, 1);
@@ -986,8 +986,7 @@ static void orphans_adopt(memprof_domain_t domain)
     p = &(*p)->next;
   }
 
-  // XXX mshinwell: was caml_plat_lock_blocking in PR13299
-  caml_plat_lock(&orphans_lock);
+  caml_plat_lock_blocking(&orphans_lock);
   if (orphans) {
     *p = orphans;
     orphans = NULL;

--- a/ocaml/runtime/minor_gc.c
+++ b/ocaml/runtime/minor_gc.c
@@ -48,7 +48,7 @@ struct generic_table CAML_TABLE_STRUCT(char);
 CAMLexport atomic_uintnat caml_minor_collections_count;
 CAMLexport atomic_uintnat caml_major_slice_epoch;
 
-static atomic_intnat domains_finished_minor_gc;
+static caml_plat_barrier minor_gc_end_barrier = CAML_PLAT_BARRIER_INITIALIZER;
 
 static atomic_uintnat caml_minor_cycles_started = 0;
 
@@ -523,8 +523,14 @@ void caml_empty_minor_heap_domain_clear(caml_domain_state* domain)
   domain->extra_heap_resources_minor = 0.0;
 }
 
-void caml_do_opportunistic_major_slice
+/* Try to do a major slice, returns nonzero if there was any work available,
+   used as useful spin work while waiting for synchronisation. The return type
+   is [int] and not [bool] since it is passed as a parameter to
+   [caml_try_run_on_all_domains_with_spin_work]. */
+int caml_do_opportunistic_major_slice
   (caml_domain_state* domain_unused, void* unused);
+static void minor_gc_leave_barrier
+  (caml_domain_state* domain, int participating_count);
 
 void caml_empty_minor_heap_promote(caml_domain_state* domain,
                                    int participating_count,
@@ -549,7 +555,9 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   CAML_EV_BEGIN(EV_MINOR);
   call_timing_hook(&caml_minor_gc_begin_hook);
 
-  if( participating[0] == Caml_state ) {
+  CAMLassert(domain == Caml_state);
+
+  if( participating[0] == domain ) {
     CAML_EV_BEGIN(EV_MINOR_GLOBAL_ROOTS);
     caml_scan_global_young_roots(oldify_one, &st);
     CAML_EV_END(EV_MINOR_GLOBAL_ROOTS);
@@ -559,7 +567,6 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
 
   if( participating_count > 1 ) {
     int participating_idx = -1;
-    CAMLassert(domain == Caml_state);
 
     for( int i = 0; i < participating_count ; i++ ) {
       if( participating[i] == domain ) {
@@ -633,7 +640,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   }
 
   #ifdef DEBUG
-    caml_global_barrier();
+    caml_global_barrier(participating_count);
     /* At this point all domains should have gone through all remembered set
        entries. We need to verify that all our remembered set entries are now in
        the major heap or promoted */
@@ -663,7 +670,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
               remembered_roots, st.live_bytes);
 
 #ifdef DEBUG
-  caml_global_barrier();
+  caml_global_barrier(participating_count);
   caml_gc_log("ref_base: %p, ref_ptr: %p",
     self_minor_tables->major_ref.base, self_minor_tables->major_ref.ptr);
   for (r = self_minor_tables->major_ref.base;
@@ -722,8 +729,10 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
 
   /* arrive at the barrier */
   if( participating_count > 1 ) {
-    atomic_fetch_add_explicit
-      (&domains_finished_minor_gc, 1, memory_order_release);
+    if (caml_plat_barrier_arrive(&minor_gc_end_barrier)
+        == participating_count) {
+      caml_plat_barrier_release(&minor_gc_end_barrier);
+    }
   }
   /* other domains may be executing mutator code from this point, but
      not before */
@@ -743,16 +752,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   /* leave the barrier */
   if( participating_count > 1 ) {
     CAML_EV_BEGIN(EV_MINOR_LEAVE_BARRIER);
-    {
-      SPIN_WAIT {
-        if (atomic_load_acquire(&domains_finished_minor_gc) ==
-            participating_count) {
-          break;
-        }
-
-        caml_do_opportunistic_major_slice(domain, 0);
-      }
-    }
+    minor_gc_leave_barrier(domain, participating_count);
     CAML_EV_END(EV_MINOR_LEAVE_BARRIER);
   }
 }
@@ -779,26 +779,61 @@ static void custom_finalize_minor (caml_domain_state * domain)
   }
 }
 
-void caml_do_opportunistic_major_slice
-  (caml_domain_state* domain_unused, void* unused)
+/* Increment the counter non-atomically, when it is already known that this
+   thread is alone in trying to increment it. */
+static void nonatomic_increment_counter(atomic_uintnat* counter) {
+  atomic_store_relaxed(counter, 1 + atomic_load_relaxed(counter));
+}
+
+static void minor_gc_leave_barrier
+  (caml_domain_state* domain, int participating_count)
 {
-  /* NB: need to put guard around the ev logs to prevent
-    spam when we poll */
-  if (caml_opportunistic_major_work_available()) {
+  /* Spin while we have major work available */
+  SPIN_WAIT_BOUNDED {
+    if (caml_plat_barrier_is_released(&minor_gc_end_barrier)) {
+      return;
+    }
+
+    if (!caml_do_opportunistic_major_slice(domain, 0)) {
+      break;
+    }
+  }
+
+  /* Spin a bit longer, which is far less fruitful if we're waiting on
+     more than one thread */
+  unsigned spins =
+    participating_count == 2 ? Max_spins_long : Max_spins_medium;
+  SPIN_WAIT_NTIMES(spins) {
+    if (caml_plat_barrier_is_released(&minor_gc_end_barrier)) {
+      return;
+    }
+  }
+
+  /* If there's nothing to do, block */
+  caml_plat_barrier_wait(&minor_gc_end_barrier);
+}
+
+int caml_do_opportunistic_major_slice
+  (caml_domain_state* domain_state, void* unused)
+{
+  int work_available = caml_opportunistic_major_work_available(domain_state);
+  if (work_available) {
+    /* NB: need to put guard around the ev logs to prevent spam when we poll */
     uintnat log_events = atomic_load_relaxed(&caml_verb_gc) & 0x40;
     if (log_events) CAML_EV_BEGIN(EV_MAJOR_MARK_OPPORTUNISTIC);
     caml_opportunistic_major_collection_slice(Major_slice_work_min);
     if (log_events) CAML_EV_END(EV_MAJOR_MARK_OPPORTUNISTIC);
   }
+  return work_available;
 }
 
 /* Make sure the minor heap is empty by performing a minor collection
    if needed.
 */
 void caml_empty_minor_heap_setup(caml_domain_state* domain_unused) {
-  atomic_store_release(&domains_finished_minor_gc, 0);
   /* Increment the total number of minor collections done in the program */
-  atomic_fetch_add (&caml_minor_collections_count, 1);
+  nonatomic_increment_counter (&caml_minor_collections_count);
+  caml_plat_barrier_reset(&minor_gc_end_barrier);
 }
 
 /* must be called within a STW section */
@@ -816,8 +851,8 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
     caml_fatal_error("Minor GC triggered recursively");
   Caml_state->in_minor_collection = 1;
 
-  if( participating[0] == Caml_state ) {
-    atomic_fetch_add(&caml_minor_cycles_started, 1);
+  if( participating[0] == domain ) {
+    nonatomic_increment_counter(&caml_minor_cycles_started);
   }
 
   caml_gc_log("running stw empty_minor_heap_promote");
@@ -867,11 +902,9 @@ void caml_empty_minor_heap_no_major_slice_from_stw(
   int participating_count,
   caml_domain_state** participating)
 {
-  barrier_status b = caml_global_barrier_begin();
-  if( caml_global_barrier_is_final(b) ) {
+  Caml_global_barrier_if_final(participating_count) {
     caml_empty_minor_heap_setup(domain);
   }
-  caml_global_barrier_end(b);
 
   /* if we are entering from within a major GC STW section then
      we do not schedule another major collection slice */
@@ -899,7 +932,7 @@ int caml_try_empty_minor_heap_on_all_domains (void)
    minor heap */
 void caml_empty_minor_heaps_once (void)
 {
-  uintnat saved_minor_cycle = atomic_load(&caml_minor_cycles_started);
+  uintnat saved_minor_cycle = atomic_load_relaxed(&caml_minor_cycles_started);
 
   #ifdef DEBUG
   CAMLassert(!caml_domain_is_in_stw());
@@ -909,7 +942,8 @@ void caml_empty_minor_heaps_once (void)
      STW section */
   do {
     caml_try_empty_minor_heap_on_all_domains();
-  } while (saved_minor_cycle == atomic_load(&caml_minor_cycles_started));
+  } while (saved_minor_cycle ==
+           atomic_load_relaxed(&caml_minor_cycles_started));
 }
 
 /* Called by minor allocations when [Caml_state->young_ptr] reaches

--- a/ocaml/runtime/minor_gc.c
+++ b/ocaml/runtime/minor_gc.c
@@ -652,7 +652,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
 
   CAML_EV_BEGIN(EV_MINOR_MEMPROF_ROOTS);
   caml_memprof_scan_roots(&oldify_one, oldify_scanning_flags, &st,
-                          domain, false, participating[0] == domain);
+                          domain, false);
   CAML_EV_END(EV_MINOR_MEMPROF_ROOTS);
 
   CAML_EV_BEGIN(EV_MINOR_REMEMBERED_SET_PROMOTE);
@@ -690,7 +690,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   CAML_EV_END(EV_MINOR_LOCAL_ROOTS);
 
   CAML_EV_BEGIN(EV_MINOR_MEMPROF_CLEAN);
-  caml_memprof_after_minor_gc(domain, participating[0] == domain);
+  caml_memprof_after_minor_gc(domain);
   CAML_EV_END(EV_MINOR_MEMPROF_CLEAN);
 
   domain->young_ptr = domain->young_end;

--- a/ocaml/runtime/misc.c
+++ b/ocaml/runtime/misc.c
@@ -54,6 +54,9 @@ void caml_failed_assert (char * expr, char_os * file_os, int line)
           (Caml_state_opt != NULL) ? Caml_state_opt->id : -1, file, line, expr);
   fflush(stderr);
   caml_stat_free(file);
+#if __has_builtin(__builtin_trap) || defined(__GNUC__)
+  __builtin_trap();
+#endif
   abort();
 }
 #endif

--- a/ocaml/runtime/misc.c
+++ b/ocaml/runtime/misc.c
@@ -317,7 +317,8 @@ void caml_flambda2_invalid (value message)
    un-instruments function, this simply silences reports when the call stack
    contains a frame matching one of the lines starting with "race:". */
 const char * __tsan_default_suppressions(void) {
-  return "deadlock:caml_plat_lock\n" /* Avoids deadlock inversion messages */
+  return "deadlock:caml_plat_lock_blocking\n" /* Avoids deadlock inversion
+                                                 messages */
          "deadlock:pthread_mutex_lock\n"; /* idem */
 }
 #endif /* WITH_THREAD_SANITIZER */

--- a/ocaml/runtime/platform.c
+++ b/ocaml/runtime/platform.c
@@ -155,6 +155,228 @@ void caml_plat_cond_free(caml_plat_cond* cond)
   check_err("cond_free", custom_condvar_destroy(cond));
 }
 
+/* Futexes */
+
+#ifdef CAML_PLAT_FUTEX_FALLBACK
+
+/* Condition-variable-based futex implementation, for when a native OS
+   version isn't available. This also illustrates the semantics of the
+   [wait()] and [wake_all()] operations. */
+
+void caml_plat_futex_wait(caml_plat_futex* futex,
+                          caml_plat_futex_value undesired) {
+  caml_plat_lock_blocking(&futex->mutex);
+  while (atomic_load_acquire(&futex->value) == undesired) {
+    caml_plat_wait(&futex->cond, &futex->mutex);
+  }
+  caml_plat_unlock(&futex->mutex);
+}
+
+void caml_plat_futex_wake_all(caml_plat_futex* futex) {
+  caml_plat_lock_blocking(&futex->mutex);
+  caml_plat_broadcast(&futex->cond);
+  caml_plat_unlock(&futex->mutex);
+}
+
+void caml_plat_futex_init(caml_plat_futex* ftx, caml_plat_futex_value value) {
+  ftx->value = value;
+  caml_plat_mutex_init(&ftx->mutex);
+  caml_plat_cond_init(&ftx->cond);
+}
+
+void caml_plat_futex_free(caml_plat_futex* ftx) {
+  caml_plat_mutex_free(&ftx->mutex);
+  check_err("cond_destroy", pthread_cond_destroy(&ftx->cond));
+}
+
+#else /* ! CAML_PLAT_FUTEX_FALLBACK */
+
+/* Platform-specific futex implementation.
+
+   For each platform we define [WAIT(futex_word* ftx, futex_value
+   undesired)] and [WAKE(futex_word* ftx)] in terms of
+   platform-specific syscalls. The exact semantics vary, but these are
+   the weakest expected guarantees:
+
+   - [WAIT()] compares the value at [ftx] to [undesired], and if they
+     are equal, goes to sleep on [ftx].
+
+   - [WAKE()] wakes up all [WAIT()]-ers on [ftx].
+
+   - [WAIT()] must be atomic with respect to [WAKE()], in that if the
+     [WAIT()]-ing thread observes the undesired value and goes to
+     sleep, it will not miss a wakeup from the [WAKE()]-ing thread
+     between the comparison and sleep.
+
+   - [WAIT()]'s initial read of [ftx] is to be treated as being atomic
+     with [memory_order_relaxed]. That is, no memory ordering is
+     guaranteed around it.
+
+   - Spurious wakeups of [WAIT()] may be possible.
+*/
+
+#  if defined(_WIN32)
+#    include <synchapi.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)  \
+  WaitOnAddress((volatile void *)ftx, &undesired, \
+                sizeof(undesired), INFINITE)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)           \
+  WakeByAddressAll((void *)ftx)
+
+#  elif defined(__linux__)
+#    include <linux/futex.h>
+#    include <sys/syscall.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
+  syscall(SYS_futex, ftx, FUTEX_WAIT_PRIVATE,       \
+          /* expected */ undesired,                 \
+          /* timeout */ NULL,                       \
+          /* ignored */ NULL, 0)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)           \
+  syscall(SYS_futex, ftx, FUTEX_WAKE_PRIVATE,   \
+          /* count */ INT_MAX,                  \
+          /* timeout */ NULL,                   \
+          /* ignored */ NULL, 0)
+
+#  elif 0 /* defined(__APPLE__)
+   macOS has [__ulock_(wait|wake)()] which is used in implementations
+   of libc++, (e.g. by LLVM) but the API is private and unstable.
+   Therefore, we currently use the condition variable fallback on
+   macOS. */
+
+#  elif defined(__FreeBSD__)
+#    include <sys/umtx.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired) \
+  _umtx_op(ftx, UMTX_OP_WAIT_UINT_PRIVATE,       \
+           /* expected */ undesired,             \
+           /* timeout */ NULL, NULL)
+#    define CAML_PLAT_FUTEX_WAKE(ftx) \
+  _umtx_op(ftx, UMTX_OP_WAKE_PRIVATE, \
+           /* count */ INT_MAX,       \
+           /* unused */ NULL, NULL)
+
+#  elif defined(__OpenBSD__)
+#    include <sys/futex.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)      \
+  futex((volatile uint32_t*)ftx, FUTEX_WAIT_PRIVATE,  \
+        /* expected */ undesired,                     \
+        /* timeout */ NULL,                           \
+        /* ignored */ NULL)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)                \
+  futex((volatile uint32_t*)ftx, FUTEX_WAKE_PRIVATE, \
+        /* count */ INT_MAX,                         \
+        /* ignored */ NULL, NULL)
+
+#  elif 0 /* defined(__NetBSD__)
+   TODO The following code for NetBSD is untested,
+   we currently use the fallback instead. */
+#    include <sys/futex.h>
+#    include <sys/syscall.h>
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)    \
+  syscall(SYS___futex, ftx,                         \
+          FUTEX_WAIT | FUTEX_PRIVATE_FLAG,          \
+          /* expected */ undesired,                 \
+          /* timeout */ NULL,                       \
+          /* ignored */ NULL, 0, 0)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)            \
+  sycall(SYS___futex, ftx,                       \
+         FUTEX_WAKE | FUTEX_PRIVATE_FLAG,        \
+         /* count */ INT_MAX,                    \
+         /* ignored */ NULL, NULL, 0, 0)
+
+#  elif 0 /* defined(__DragonFly__)
+   TODO The following code for DragonFly is untested,
+   we currently use the fallback instead. */ */
+#    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)        \
+  umtx_sleep((volatile const int*)ftx, undesired, 0)
+#    define CAML_PLAT_FUTEX_WAKE(ftx)               \
+  umtx_wakeup((volatile const int*)ftx, INT_MAX)
+
+#  else
+#    error "No futex implementation available"
+#  endif
+
+void caml_plat_futex_wait(caml_plat_futex* ftx,
+                          caml_plat_futex_value undesired) {
+  while (atomic_load_acquire(&ftx->value) == undesired) {
+    CAML_PLAT_FUTEX_WAIT(&ftx->value, undesired);
+  }
+}
+
+void caml_plat_futex_wake_all(caml_plat_futex* ftx) {
+  CAML_PLAT_FUTEX_WAKE(&ftx->value);
+}
+
+void caml_plat_futex_init(caml_plat_futex* ftx,
+                          caml_plat_futex_value value) {
+  ftx->value = value;
+}
+
+void caml_plat_futex_free(caml_plat_futex* ftx) {
+  (void) ftx; /* noop */
+}
+
+#endif /* CAML_PLAT_FUTEX_FALLBACK */
+
+/* Latches */
+
+void caml_plat_latch_release(caml_plat_binary_latch* latch) {
+  /* if nobody is blocking, release in user-space */
+  if (atomic_exchange(&latch->value, Latch_released)
+      != Latch_unreleased) {
+    /* at least one thread is (going to be) blocked on the futex, notify */
+    caml_plat_futex_wake_all(latch);
+  }
+}
+
+Caml_inline void latchlike_wait(caml_plat_futex *ftx,
+                                caml_plat_futex_value unreleased,
+                                caml_plat_futex_value contested) {
+  /* indicate that we are about to block */
+  caml_plat_futex_value expected = unreleased;
+  (void)atomic_compare_exchange_strong
+    (&ftx->value, &expected, contested);
+  /* ftx is either already released (neither [unreleased] nor
+     [contested]), or we are going to block (== [contested]),
+     [futex_wait()] here will take care of both */
+  caml_plat_futex_wait(ftx, contested);
+}
+
+void caml_plat_latch_wait(caml_plat_binary_latch* latch) {
+  latchlike_wait(latch, Latch_unreleased, Latch_contested);
+}
+
+/* Sense-reversing barrier */
+/* futex states:
+   - X...0 if nobody is blocking (but they may be spinning)
+   - X...1 if anybody is blocking (or about to)
+
+   where X is the sense bit
+ */
+
+void caml_plat_barrier_flip(caml_plat_barrier* barrier,
+                            barrier_status current_sense) {
+  uintnat new_sense = current_sense ^ BARRIER_SENSE_BIT;
+  atomic_store_relaxed(&barrier->arrived, new_sense);
+  /* if a thread observes the flip below, it will also observe the
+     reset counter, since any currently waiting threads will check the
+     futex before leaving, they will see the counter correctly */
+
+  caml_plat_futex_value
+    current_sense_word = (caml_plat_futex_value) current_sense,
+    new_sense_word = (caml_plat_futex_value) new_sense;
+
+  /* if nobody is blocking, flip in user-space */
+  if (atomic_exchange(&barrier->futex.value, new_sense_word)
+      != current_sense_word) {
+    /* a thread is (about to be) blocked, notify */
+    caml_plat_futex_wake_all(&barrier->futex);
+  }
+}
+
+void caml_plat_barrier_wait_sense(caml_plat_barrier* barrier,
+                                  barrier_status sense_bit) {
+  latchlike_wait(&barrier->futex, sense_bit, sense_bit | 1);
+}
 
 /* Memory management */
 
@@ -217,21 +439,20 @@ void caml_mem_unmap(void* mem, uintnat size)
 #define Slow_sleep_ns    1000000 //  1 ms
 #define Max_sleep_ns  1000000000 //  1 s
 
-unsigned caml_plat_spin_wait(unsigned spins,
-                             const char* file, int line,
-                             const char* function)
+unsigned caml_plat_spin_back_off(unsigned sleep_ns,
+                                 const struct caml_plat_srcloc* loc)
 {
-  unsigned next_spins;
-  if (spins < Min_sleep_ns) spins = Min_sleep_ns;
-  if (spins > Max_sleep_ns) spins = Max_sleep_ns;
-  next_spins = spins + spins / 4;
-  if (spins < Slow_sleep_ns && Slow_sleep_ns <= next_spins) {
-    caml_gc_log("Slow spin-wait loop in %s at %s:%d", function, file, line);
+  if (sleep_ns < Min_sleep_ns) sleep_ns = Min_sleep_ns;
+  if (sleep_ns > Max_sleep_ns) sleep_ns = Max_sleep_ns;
+  unsigned next_sleep_ns = sleep_ns + sleep_ns / 4;
+  if (sleep_ns < Slow_sleep_ns && Slow_sleep_ns <= next_sleep_ns) {
+    caml_gc_log("Slow spin-wait loop in %s at %s:%d",
+                loc->function, loc->file, loc->line);
   }
 #ifdef _WIN32
-  Sleep(spins/1000000);
+  Sleep(sleep_ns/1000000);
 #else
-  usleep(spins/1000);
+  usleep(sleep_ns/1000);
 #endif
-  return next_spins;
+  return next_sleep_ns;
 }

--- a/ocaml/runtime/platform.c
+++ b/ocaml/runtime/platform.c
@@ -24,6 +24,7 @@
 #include "caml/osdeps.h"
 #include "caml/platform.h"
 #include "caml/fail.h"
+#include "caml/signals.h"
 #ifdef HAS_SYS_MMAN_H
 #include <sys/mman.h>
 #endif
@@ -98,11 +99,23 @@ void caml_plat_assert_locked(caml_plat_mutex* m)
 #endif
 }
 
+CAMLexport CAMLthread_local int caml_lockdepth = 0;
+
 void caml_plat_assert_all_locks_unlocked(void)
 {
 #ifdef DEBUG
-  if (lockdepth) caml_fatal_error("Locks still locked at termination");
+  if (caml_lockdepth) caml_fatal_error("Locks still locked at termination");
 #endif
+}
+
+CAMLexport void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m)
+{
+  /* Avoid exceptions */
+  caml_enter_blocking_section_no_pending();
+  int rc = pthread_mutex_lock(m);
+  caml_leave_blocking_section();
+  check_err("lock_non_blocking", rc);
+  DEBUG_LOCK(m);
 }
 
 void caml_plat_mutex_free(caml_plat_mutex* m)
@@ -112,38 +125,34 @@ void caml_plat_mutex_free(caml_plat_mutex* m)
 
 static void caml_plat_cond_init_aux(caml_plat_cond *cond)
 {
-  custom_condvar_init(&cond->cond);
+  custom_condvar_init(cond);
 }
 
 /* Condition variables */
-void caml_plat_cond_init(caml_plat_cond* cond, caml_plat_mutex* m)
+void caml_plat_cond_init(caml_plat_cond* cond)
 {
   caml_plat_cond_init_aux(cond);
-  cond->mutex = m;
 }
 
-void caml_plat_wait(caml_plat_cond* cond)
+void caml_plat_wait(caml_plat_cond* cond, caml_plat_mutex* mut)
 {
-  caml_plat_assert_locked(cond->mutex);
-  check_err("wait", custom_condvar_wait(&cond->cond, cond->mutex));
+  caml_plat_assert_locked(mut);
+  check_err("wait", custom_condvar_wait(cond, mut));
 }
 
 void caml_plat_broadcast(caml_plat_cond* cond)
 {
-  caml_plat_assert_locked(cond->mutex);
-  check_err("cond_broadcast", custom_condvar_broadcast(&cond->cond));
+  check_err("cond_broadcast", custom_condvar_broadcast(cond));
 }
 
 void caml_plat_signal(caml_plat_cond* cond)
 {
-  caml_plat_assert_locked(cond->mutex);
-  check_err("cond_signal", custom_condvar_signal(&cond->cond));
+  check_err("cond_signal", custom_condvar_signal(cond));
 }
 
 void caml_plat_cond_free(caml_plat_cond* cond)
 {
-  check_err("cond_free", custom_condvar_destroy(&cond->cond));
-  cond->mutex=0;
+  check_err("cond_free", custom_condvar_destroy(cond));
 }
 
 

--- a/ocaml/runtime/runtime_events.c
+++ b/ocaml/runtime/runtime_events.c
@@ -22,6 +22,7 @@
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 #include "caml/osdeps.h"
+#include "caml/platform.h"
 #include "caml/startup_aux.h"
 
 #include <fcntl.h>
@@ -381,7 +382,7 @@ static void runtime_events_create_from_stw_single(void) {
 
     // at the same instant: snapshot user_events list and set
     // runtime_events_enabled to 1
-    caml_plat_lock(&user_events_lock);
+    caml_plat_lock_blocking(&user_events_lock);
     value current_user_event = user_events;
     atomic_store_release(&runtime_events_enabled, 1);
     caml_plat_unlock(&user_events_lock);
@@ -684,7 +685,7 @@ CAMLprim value caml_runtime_events_user_register(value event_name,
   Field(event, 3) = event_tag;
 
 
-  caml_plat_lock(&user_events_lock);
+  caml_plat_lock_blocking(&user_events_lock);
   // critical section: when we update the user_events list we need to make sure
   // it is not updated while we construct the pointer to the next element
 
@@ -800,7 +801,7 @@ CAMLexport value caml_runtime_events_user_resolve(
   CAMLlocal3(event, cur_event_name, ml_event_name);
 
   // TODO: it might be possible to atomic load instead
-  caml_plat_lock(&user_events_lock);
+  caml_plat_lock_blocking(&user_events_lock);
   value current_user_event = user_events;
   caml_plat_unlock(&user_events_lock);
 

--- a/ocaml/runtime/shared_heap.c
+++ b/ocaml/runtime/shared_heap.c
@@ -1251,7 +1251,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
 
   /* Memprof roots and "weak" pointers to tracked blocks */
   caml_memprof_scan_roots(&compact_update_value, 0, NULL,
-                          Caml_state, true, participants[0] == Caml_state);
+                          Caml_state, true);
 
   /* Next, one domain does the global roots */
   if (participants[0] == Caml_state) {

--- a/ocaml/runtime/shared_heap.c
+++ b/ocaml/runtime/shared_heap.c
@@ -499,7 +499,7 @@ value* caml_shared_try_alloc(struct caml_heap_state* local, mlsize_t wosize,
 
 static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
                          sizeclass sz, int release_to_global_pool) {
-  intnat work = 0;
+  intnat work;
   pool* a = *plist;
   if (!a) return 0;
   *plist = a->next;
@@ -511,7 +511,11 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
     int all_used = 1;
     struct heap_stats* s = &local->stats;
 
-    while (p + wh <= end) {
+    /* conceptually, this is incremented by [wh] for every iteration
+       below, however we can hoist these increments knowing that [p ==
+       end] on exit from the loop (as asserted) */
+    work = end - p;
+    do {
       header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
       if (hd == 0) {
         /* already on freelist */
@@ -547,8 +551,8 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
         release_to_global_pool = 0;
       }
       p += wh;
-      work += wh;
-    }
+    } while (p + wh <= end);
+    CAMLassert(p == end);
 
     if (release_to_global_pool) {
       pool_release(local, a, sz);
@@ -1007,7 +1011,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   filled pools, determine pools to be evacuated and then evacuate from them.
   For the first phase we need not consider full pools, they
   cannot be evacuated to or from. */
-  caml_global_barrier();
+  caml_global_barrier(participating_count);
   CAML_EV_BEGIN(EV_COMPACT_EVACUATE);
 
   struct caml_heap_state* heap = Caml_state->shared_heap;
@@ -1234,7 +1238,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   }
 
   CAML_EV_END(EV_COMPACT_EVACUATE);
-  caml_global_barrier();
+  caml_global_barrier(participating_count);
   CAML_EV_BEGIN(EV_COMPACT_FORWARD);
 
   /* Second phase: at this point all live blocks in evacuated pools
@@ -1278,7 +1282,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   compact_update_ephe_list(&ephe_info->live);
 
   CAML_EV_END(EV_COMPACT_FORWARD);
-  caml_global_barrier();
+  caml_global_barrier(participating_count);
   CAML_EV_BEGIN(EV_COMPACT_RELEASE);
 
   /* Third phase: free all evacuated pools and release the mappings back to
@@ -1308,7 +1312,7 @@ void caml_compact_heap(caml_domain_state* domain_state,
   caml_plat_unlock(&pool_freelist.lock);
 
   CAML_EV_END(EV_COMPACT_RELEASE);
-  caml_global_barrier();
+  caml_global_barrier(participating_count);
 
   /* Fourth phase: one domain also needs to release the free list */
   if( participants[0] == Caml_state ) {

--- a/ocaml/runtime/signals.c
+++ b/ocaml/runtime/signals.c
@@ -30,6 +30,7 @@
 #include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
+#include "caml/platform.h"
 #include "caml/roots.h"
 #include "caml/signals.h"
 #include "caml/sys.h"
@@ -737,7 +738,7 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     if (caml_signal_handlers == 0) {
       tmp_signal_handlers = caml_alloc(NSIG, 0);
     }
-    caml_plat_lock(&signal_install_mutex);
+    caml_plat_lock_blocking(&signal_install_mutex);
     if (caml_signal_handlers == 0) {
       /* caml_alloc cannot raise asynchronous exceptions from signals
          so this is safe */

--- a/ocaml/runtime/signals.c
+++ b/ocaml/runtime/signals.c
@@ -424,7 +424,7 @@ value caml_process_pending_actions_with_root_exn(value root)
   return root;
 }
 
-value caml_process_pending_actions_with_root(value root)
+CAMLprim value caml_process_pending_actions_with_root(value root)
 {
   return caml_raise_async_if_exception(
     caml_process_pending_actions_with_root_exn(root),

--- a/ocaml/runtime/sync_posix.h
+++ b/ocaml/runtime/sync_posix.h
@@ -23,6 +23,8 @@
 #include <pthread.h>
 #include <string.h>
 
+#include "caml/sync.h"
+
 #ifdef __linux__
 #include <features.h>
 #include <unistd.h>
@@ -34,10 +36,6 @@
 typedef int sync_retcode;
 
 /* Mutexes */
-
-/* Already defined in <caml/sync.h> */
-/* typedef pthread_mutex_t * sync_mutex; */
-/* #define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v))) */
 
 Caml_inline int sync_mutex_create(sync_mutex * res)
 {
@@ -165,10 +163,6 @@ static int custom_condvar_broadcast(custom_condvar * cv)
 
 
 /* Condition variables */
-
-typedef custom_condvar * sync_condvar;
-
-#define Condition_val(v) (* (sync_condvar *) Data_custom_val(v))
 
 Caml_inline int sync_condvar_create(sync_condvar * res)
 {

--- a/ocaml/runtime/sys.c
+++ b/ocaml/runtime/sys.c
@@ -364,15 +364,16 @@ CAMLprim value caml_sys_chdir(value dirname)
   CAMLreturn(Val_unit);
 }
 
-CAMLprim value caml_sys_mkdir(value path, value perm)
+CAMLprim value caml_sys_mkdir(value path, value vperm)
 {
-  CAMLparam2(path, perm);
+  CAMLparam2(path, vperm);
   char_os * p;
   int ret;
+  int perm = Int_val(vperm);
   caml_sys_check_path(path);
   p = caml_stat_strdup_to_os(String_val(path));
   caml_enter_blocking_section();
-  ret = mkdir_os(p, Int_val(perm));
+  ret = mkdir_os(p, perm);
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) caml_sys_error(path);

--- a/ocaml/stdlib/sys.ml.in
+++ b/ocaml/stdlib/sys.ml.in
@@ -76,6 +76,7 @@ let max_unboxed_nativeint_array_length =
 
 external runtime_variant : unit -> string = "caml_runtime_variant"
 external runtime_parameters : unit -> string = "caml_runtime_parameters"
+external poll_actions : unit -> unit = "%poll"
 
 external file_exists: string -> bool = "caml_sys_file_exists"
 external is_directory : string -> bool = "caml_sys_is_directory"

--- a/ocaml/stdlib/sys.mli
+++ b/ocaml/stdlib/sys.mli
@@ -231,6 +231,9 @@ external runtime_parameters : unit -> string = "caml_runtime_parameters"
     as the contents of the [OCAMLRUNPARAM] environment variable.
     @since 4.03 *)
 
+external poll_actions : unit -> unit = "%poll"
+(** Run any pending runtime actions, such as minor collections, major
+    GC slices, signal handlers, finalizers, or memprof callbacks. *)
 
 (** {1 Signal handling} *)
 

--- a/ocaml/testsuite/tests/callback/test1.ml
+++ b/ocaml/testsuite/tests/callback/test1.ml
@@ -28,6 +28,9 @@ external mycallback3 : ('a -> 'b -> 'c -> 'd) -> 'a -> 'b -> 'c -> 'd
 external mycallback4 :
     ('a -> 'b -> 'c -> 'd -> 'e) -> 'a -> 'b -> 'c -> 'd -> 'e = "mycallback4"
 
+let rec growstack n =
+  if n <= 0 then 0 else 1 + growstack (n - 1)
+
 let rec tak (x, y, z as _tuple) =
   if x > y then tak(tak (x-1, y, z), tak (y-1, z, x), tak (z-1, x, y))
            else z
@@ -63,3 +66,5 @@ let _ =
   print_int(trapexit ()); print_newline();
   print_string(tripwire mypushroot); print_newline();
   print_string(tripwire mycamlparam); print_newline();
+  begin try ignore (mycallback1 growstack 1_000); raise Exit
+  with Exit -> () end


### PR DESCRIPTION
These correspond to the list here:
https://github.com/ocaml-flambda/flambda-backend/wiki/Post%E2%80%905.2-changesets-from-trunk-to-backport-to-5.2.0minus

I think the only significant change to any of these is the flambda2 support for `Sys.poll_actions`, but it is straightforward.

This PR is based on #2941.
