### PR TITLE
Require let rec pattern variables to have layout value.

### DIFF
--- a/ocaml/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
+++ b/ocaml/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
@@ -24,10 +24,15 @@ val rec_t : rec_t = {rec_t = <cycle>; x1 = <abstr>}
 let rec x2 = let _ = { t = rec_t; x2 } in #4.0;;
 
 [%%expect {|
-Line 1, characters 13-46:
+Line 1, characters 34-36:
 1 | let rec x2 = let _ = { t = rec_t; x2 } in #4.0;;
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                      ^^
+Error: This expression has type ('a : value)
+       but an expression was expected of type float#
+       The layout of float# is float64
+         because it is the primitive type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of the recursive variable x2.
 |}];;
 
 (* OK: an adapted version of the above error to show that the difference
@@ -54,10 +59,15 @@ val rec_cstr : cstr = A (<cycle>, <abstr>)
 (* Error: the recursive use is for a field in the flat suffix *)
 let rec bad_flat = let _ = A (rec_cstr, bad_flat) in #4.0;;
 [%%expect {|
-Line 1, characters 19-57:
+Line 1, characters 40-48:
 1 | let rec bad_flat = let _ = A (rec_cstr, bad_flat) in #4.0;;
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                            ^^^^^^^^
+Error: This expression has type ('a : value)
+       but an expression was expected of type float#
+       The layout of float# is float64
+         because it is the primitive type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of the recursive variable bad_flat.
 |}];;
 
 (* OK: an adapted version of the above error to show that the difference
@@ -84,10 +94,15 @@ val rec_cstr : cstr = A {cstr = <cycle>; flt = <abstr>}
 (* Error: the recursive use is for a field in the flat suffix *)
 let rec bad_flat = let _ = A { cstr = rec_cstr; flt = bad_flat } in #4.0;;
 [%%expect {|
-Line 1, characters 19-72:
+Line 1, characters 54-62:
 1 | let rec bad_flat = let _ = A { cstr = rec_cstr; flt = bad_flat } in #4.0;;
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                                          ^^^^^^^^
+Error: This expression has type ('a : value)
+       but an expression was expected of type float#
+       The layout of float# is float64
+         because it is the primitive type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of the recursive variable bad_flat.
 |}];;
 
 (* OK: an adapted version of the above error to show that the difference

--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
@@ -294,10 +294,15 @@ let _ =
   let[@warning "-10"] rec x = [| x |]; #42.0 in
   ();;
 [%%expect{|
-Line 2, characters 30-44:
+Line 2, characters 39-44:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0 in
-                                  ^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                           ^^^^^
+Error: This expression has type float# but an expression was expected of type
+         ('a : value)
+       The layout of float# is float64
+         because it is the primitive type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of the recursive variable x.
 |}]
 
 let _ =
@@ -305,10 +310,15 @@ let _ =
   ();;
 
 [%%expect{|
-Line 2, characters 30-43:
+Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42l in
-                                  ^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                           ^^^^
+Error: This expression has type int32# but an expression was expected of type
+         ('a : value)
+       The layout of int32# is bits32
+         because it is the primitive type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's the type of the recursive variable x.
 |}]
 
 let _ =
@@ -316,10 +326,15 @@ let _ =
   ();;
 
 [%%expect{|
-Line 2, characters 30-43:
+Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42L in
-                                  ^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                           ^^^^
+Error: This expression has type int64# but an expression was expected of type
+         ('a : value)
+       The layout of int64# is bits64
+         because it is the primitive type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's the type of the recursive variable x.
 |}]
 
 let _ =
@@ -327,10 +342,15 @@ let _ =
   ();;
 
 [%%expect{|
-Line 2, characters 30-43:
+Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42n in
-                                  ^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                           ^^^^
+Error: This expression has type nativeint#
+       but an expression was expected of type ('a : value)
+       The layout of nativeint# is word
+         because it is the primitive type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's the type of the recursive variable x.
 |}]
 
 let _ =
@@ -338,8 +358,13 @@ let _ =
   ();;
 
 [%%expect{|
-Line 2, characters 30-45:
+Line 2, characters 39-45:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0s in
-                                  ^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                           ^^^^^^
+Error: This expression has type float32#
+       but an expression was expected of type ('a : value)
+       The layout of float32# is float32
+         because it is the primitive type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's the type of the recursive variable x.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
@@ -292,10 +292,15 @@ let _ =
   let[@warning "-10"] rec x = [| x |]; #42.0 in
   ();;
 [%%expect{|
-Line 2, characters 30-44:
+Line 2, characters 39-44:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0 in
-                                  ^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                           ^^^^^
+Error: This expression has type float# but an expression was expected of type
+         ('a : value)
+       The layout of float# is float64
+         because it is the primitive type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of the recursive variable x.
 |}]
 
 let _ =
@@ -303,10 +308,15 @@ let _ =
   ();;
 
 [%%expect{|
-Line 2, characters 30-43:
+Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42l in
-                                  ^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                           ^^^^
+Error: This expression has type int32# but an expression was expected of type
+         ('a : value)
+       The layout of int32# is bits32
+         because it is the primitive type int32#.
+       But the layout of int32# must be a sublayout of value
+         because it's the type of the recursive variable x.
 |}]
 
 let _ =
@@ -314,10 +324,15 @@ let _ =
   ();;
 
 [%%expect{|
-Line 2, characters 30-43:
+Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42L in
-                                  ^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                           ^^^^
+Error: This expression has type int64# but an expression was expected of type
+         ('a : value)
+       The layout of int64# is bits64
+         because it is the primitive type int64#.
+       But the layout of int64# must be a sublayout of value
+         because it's the type of the recursive variable x.
 |}]
 
 let _ =
@@ -325,10 +340,15 @@ let _ =
   ();;
 
 [%%expect{|
-Line 2, characters 30-43:
+Line 2, characters 39-43:
 2 |   let[@warning "-10"] rec x = [| x |]; #42n in
-                                  ^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                           ^^^^
+Error: This expression has type nativeint#
+       but an expression was expected of type ('a : value)
+       The layout of nativeint# is word
+         because it is the primitive type nativeint#.
+       But the layout of nativeint# must be a sublayout of value
+         because it's the type of the recursive variable x.
 |}]
 
 let _ =
@@ -336,8 +356,13 @@ let _ =
   ();;
 
 [%%expect{|
-Line 2, characters 30-45:
+Line 2, characters 39-45:
 2 |   let[@warning "-10"] rec x = [| x |]; #42.0s in
-                                  ^^^^^^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
+                                           ^^^^^^
+Error: This expression has type float32#
+       but an expression was expected of type ('a : value)
+       The layout of float32# is float32
+         because it is the primitive type float32#.
+       But the layout of float32# must be a sublayout of value
+         because it's the type of the recursive variable x.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -2803,3 +2803,21 @@ Line 5, characters 13-14:
 Error: This match case could not be refuted.
        Here is an example of a value that would reach it: Refl
 |}]
+
+(********************************************************)
+(* Test 45: let rec pattern variables have layout value *)
+
+let three =
+  let rec x = #3.4 in
+  Stdlib_upstream_compatible.Float_u.to_int x
+[%%expect{|
+Line 2, characters 14-18:
+2 |   let rec x = #3.4 in
+                  ^^^^
+Error: This expression has type float# but an expression was expected of type
+         ('a : value)
+       The layout of float# is float64
+         because it is the primitive type float#.
+       But the layout of float# must be a sublayout of value
+         because it's the type of the recursive variable x.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -891,21 +891,15 @@ let () = assert (x = 42);;
 let () = assert (List.for_all2 (=) !r [2;1]);;
 
 [%%expect{|
-Lines 4-11, characters 2-11:
- 4 | ..let v = match vh with
- 5 |     | V v -> v
- 6 |   in
- 7 |   (* not all void *)
- 8 |   let rec y = (cons_r 1; x)
- 9 |   and v' = (cons_r 2; v)
-10 |   in
-11 |   (y, V v')
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
+Line 9, characters 22-23:
+9 |   and v' = (cons_r 2; v)
+                          ^
+Error: This expression has type t_void but an expression was expected of type
+         ('a : value)
        The layout of t_void is void
          because of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+         because it's the type of the recursive variable v'.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after
@@ -934,22 +928,15 @@ let () = assert (x = 42);;
 let () = assert (List.for_all2 (=) !r [3;2;1]);;
 
 [%%expect{|
-Lines 4-12, characters 2-23:
- 4 | ..let v = match vh with
- 5 |     | V v -> v
- 6 |   in
- 7 |   (* all void *)
- 8 |   let rec v1 = cons_r 1; v
- 9 |   and v2 = cons_r 2; v
-10 |   and v3 = cons_r 3; v
-11 |   in
-12 |   (x, V v1, V v2, V v3)
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
+Line 8, characters 25-26:
+8 |   let rec v1 = cons_r 1; v
+                             ^
+Error: This expression has type t_void but an expression was expected of type
+         ('a : value)
        The layout of t_void is void
          because of the definition of t_void at line 1, characters 0-18.
        But the layout of t_void must be a sublayout of value
-         because it has to be value for the V1 safety check.
+         because it's the type of the recursive variable v1.
 |}]
 (* CR layouts v5: This was the expected behavior before removing the handling of
    void for lambda, and we expected it to be the expected behavior again after

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -1298,6 +1298,8 @@ module Format_history = struct
       fprintf ppf
         "it's the type of the first argument to a function in a recursive \
          module"
+    | Let_rec_variable v ->
+      fprintf ppf "it's the type of the recursive variable %s" (Ident.name v)
     | Unknown s ->
       fprintf ppf
         "unknown @[(please alert the Jane Street@;\
@@ -1706,6 +1708,7 @@ module Debug_printers = struct
     | Class_term_argument -> fprintf ppf "Class_term_argument"
     | Debug_printer_argument -> fprintf ppf "Debug_printer_argument"
     | Recmod_fun_arg -> fprintf ppf "Recmod_fun_arg"
+    | Let_rec_variable v -> fprintf ppf "Let_rec_variable %a" Ident.print v
     | Unknown s -> fprintf ppf "Unknown %s" s
 
   let creation_reason ppf : History.creation_reason -> unit = function

--- a/ocaml/typing/jkind_intf.ml
+++ b/ocaml/typing/jkind_intf.ml
@@ -236,6 +236,7 @@ module History = struct
     | Class_term_argument
     | Debug_printer_argument
     | Recmod_fun_arg
+    | Let_rec_variable of Ident.t
     | Unknown of string (* CR layouts: get rid of these *)
 
   type immediate_creation_reason =

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -172,7 +172,8 @@ type error =
       Datatype_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string
   | Not_an_object of type_expr * type_forcing_context option
-  | Not_a_value of Jkind.Violation.t * type_forcing_context option
+  | Non_value_object of Jkind.Violation.t * type_forcing_context option
+  | Non_value_let_rec of Jkind.Violation.t * type_expr
   | Undefined_method of type_expr * string * string list option
   | Undefined_self_method of string * string list
   | Virtual_class of Longident.t
@@ -8287,7 +8288,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
             List.split (List.map (fun _ -> new_rep_var ~why:Let_binding ())
                           spatl)
           in
-          let (pat_list, _new_env, _force, _pvs, _mvs as res) =
+          let (pat_list, _new_env, _force, pvs, _mvs as res) =
             with_local_level_if is_recursive (fun () ->
               type_pattern_list Value existential_context env spatl nvs
                 allow_modules
@@ -8309,6 +8310,19 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
                 let bound_expr = vb_exp_constraint binding in
                 type_approx env bound_expr pat.pat_type)
               pat_list spat_sexp_list;
+          (* If recursive, all pattern variables must have layout value. This
+             could be relaxed in some cases, like let recs that aren't actually
+             recusive. But, if making that change, delete [Lambda.layout_letrec]
+             and route the appropriate sorts through to its uses. *)
+          if is_recursive then begin
+            List.iter (fun { pv_id; pv_loc; pv_type; _ } ->
+              let value = Jkind.Builtin.value ~why:(Let_rec_variable pv_id) in
+              match constrain_type_jkind env pv_type value with
+              | Ok () -> ()
+              | Error e ->
+                raise (Error(pv_loc, env, Non_value_let_rec (e, pv_type)))
+            ) pvs
+          end;
           (* Polymorphic variant processing *)
           List.iter
             (fun (_, pat) ->
@@ -9201,7 +9215,7 @@ and type_send env loc explanation e met =
                     in
                     Undefined_method(obj.exp_type, met, valid_methods)
                 | Not_a_value err ->
-                    Not_a_value (err, explanation)
+                    Non_value_object (err, explanation)
               in
               raise (Error(e.pexp_loc, env, error))
         in
@@ -9752,12 +9766,18 @@ let report_error ~loc env = function
         Printtyp.type_expr ty;
       report_type_expected_explanation_opt explanation ppf
     ) ()
-  | Not_a_value (err, explanation) ->
+  | Non_value_object (err, explanation) ->
     Location.error_of_printer ~loc (fun ppf () ->
       fprintf ppf "Object types must have layout value.@ %a"
         (Jkind.Violation.report_with_name ~name:"the type of this expression")
         err;
       report_type_expected_explanation_opt explanation ppf)
+      ()
+  | Non_value_let_rec (err, ty) ->
+    Location.error_of_printer ~loc (fun ppf () ->
+      fprintf ppf "Variables bound in a \"let rec\" must have layout value.@ %a"
+        (Jkind.Violation.report_with_offender
+           ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) err)
       ()
   | Undefined_method (ty, me, valid_methods) ->
       Location.error_of_printer ~loc (fun ppf () ->

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -230,7 +230,8 @@ type error =
       Datatype_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string
   | Not_an_object of type_expr * type_forcing_context option
-  | Not_a_value of Jkind.Violation.t * type_forcing_context option
+  | Non_value_object of Jkind.Violation.t * type_forcing_context option
+  | Non_value_let_rec of Jkind.Violation.t * type_expr
   | Undefined_method of type_expr * string * string list option
   | Undefined_self_method of string * string list
   | Virtual_class of Longident.t


### PR DESCRIPTION
Per discussion on the [unboxed tuples PR](https://github.com/ocaml-flambda/flambda-backend/pull/2879), this requires all pattern variables bound by a `let rec` to have layout value.

This isn't really a change: the existence of `Lambda.layout_letrec` shows we thought things bound by a let-rec had layout value.  But we have been relying on `Value_rec_check` to enforce it, and that will no longer be sufficient in the presence of unboxed tuples (there is a test case in that PR showing this - I will rebase it once this is merged).

@liam923 perhaps you could review?  It's mostly changes to error messages.  This is lower priority than the 5.2 merge or current compiler release.