### PR TITLE
Changes to the root testsuite directory

### DIFF
--- a/testsuite/tools/dune
+++ b/testsuite/tools/dune
@@ -1,0 +1,32 @@
+(executable
+ (name expect)
+ (modes byte)
+ (libraries ocamlcommon ocamltoplevel)
+ (flags -linkall)
+ (modules expect))
+
+(ocamllex
+ (modules lexcmm))
+
+(ocamlyacc
+ (modules parsecmm))
+
+(executable
+ (name codegen_main)
+ (modes byte)
+ (libraries ocamlcommon ocamloptcomp unix)
+ (modules codegen_main lexcmm parsecmm parsecmmaux))
+
+(rule
+ (targets asmgen_arm64.o)
+ (deps asmgen_arm64.S)
+ (action
+  (bash
+   "%{env:ASPP=aspp-env-var-not-set} %{env:ASPPFLAGS=asppflags-env-var-not-set} -DSYS_%{env:SYSTEM=system-env-var-not-set} -DMODEL_%{env:MODEL=model-env-var-not-set} -o asmgen_arm64.o asmgen_arm64.S")))
+
+(rule
+ (targets asmgen_amd64.o)
+ (deps asmgen_amd64.S)
+ (action
+  (bash
+   "%{env:ASPP=aspp-env-var-not-set} %{env:ASPPFLAGS=asppflags-env-var-not-set} -DSYS_%{env:SYSTEM=system-env-var-not-set} -DMODEL_%{env:MODEL=model-env-var-not-set} -o asmgen_amd64.o asmgen_amd64.S")))

--- a/testsuite/tools/expect.ml
+++ b/testsuite/tools/expect.ml
@@ -30,7 +30,7 @@
    ]}
 *)
 
-[@@@ocaml.warning "-40"]
+[@@@ocaml.warning "-40-69"]
 
 open StdLabels
 
@@ -222,6 +222,7 @@ let eval_expect_file _fname ~file_contents =
   in
   let buf = Buffer.create 1024 in
   let ppf = Format.formatter_of_buffer buf in
+  let () = Misc.Style.set_tag_handling ppf in
   let exec_phrases phrases =
     let phrases =
       match min_line_number phrases with
@@ -384,13 +385,17 @@ let usage = "Usage: expect_test <options> [script-file [arguments]]\n\
              options are:"
 
 let () =
-  Clflags.color := Some Misc.Color.Never;
+(* Early disabling of colors in any output *)
+  let () =
+    Clflags.color := Some Misc.Color.Never;
+    Misc.Style.(setup @@ Some Never)
+  in
   try
     Arg.parse args read_anonymous_arg usage;
     match !main_file with
     | Some fname -> main fname
     | None ->
-      Printf.eprintf "expect_test: no input file\n";
+      Printf.eprintf "expect: no input file\n";
       exit 2
   with exn ->
     Location.report_exception Format.err_formatter exn;

--- a/testsuite/tools/expect.ml
+++ b/testsuite/tools/expect.ml
@@ -30,7 +30,7 @@
    ]}
 *)
 
-[@@@ocaml.warning "-40-69"]
+[@@@ocaml.warning "-40"]
 
 open StdLabels
 


### PR DESCRIPTION
As subject.  Some tools are now built using dune instead of the makefiles, which seemed the easiest route given upstream changes in 5.2.