### PR TITLE
Run compiler build for profiling in temporary directory

### DIFF
--- a/scripts/profile-compiler-build.sh
+++ b/scripts/profile-compiler-build.sh
@@ -39,7 +39,11 @@ build_compiler() {
   make install
 }
 
-temp_dir=$(mktemp -d -p "$root"/.. -t tmp.XXXXXXX)
+if [ -v TMPDIR ] && [ ! -z "$TMPDIR" ]; then
+  temp_dir=$(mktemp -d)
+else
+  temp_dir=$(mktemp -d -p "$root"/.. -t tmp.XXXXXXX)
+fi
 trap "rm -rf "$temp_dir"" EXIT
 cp -r --reflink=auto "$root" "$temp_dir"
 

--- a/scripts/profile-compiler-build.sh
+++ b/scripts/profile-compiler-build.sh
@@ -5,9 +5,9 @@ set -e -u -o pipefail
 # Works regardless of where script run from
 scripts_dir=$( cd "$( dirname "$0" )" &> /dev/null && pwd )
 
-root=$scripts_dir/..
-dump_dir="$root/_profile"
-summary_path="$root/summary.csv"
+root="$scripts_dir"/..
+dump_dir="$root"/_profile
+summary_path="$root"/summary.csv
 
 if [ -d "$dump_dir" ] && [ "$(ls -A "$dump_dir")" ]; then
   echo "$dump_dir is not empty."
@@ -35,19 +35,19 @@ export BUILD_OCAMLPARAM="$OCAMLPARAM"
 build_compiler() {
   git clean -Xdf
   autoconf
-  ./configure --enable-ocamltest --enable-warn-error --enable-dev --prefix=`pwd`/_install
+  ./configure --enable-ocamltest --enable-warn-error --enable-dev --prefix="$(pwd)"/_install
   make install
 }
 
-temp_dir=$(mktemp -d -p $root/.. -t tmp.XXXXXXX)
-trap "rm -rf $temp_dir" EXIT
-cp -r --reflink=auto $root $temp_dir
+temp_dir=$(mktemp -d -p "$root"/.. -t tmp.XXXXXXX)
+trap "rm -rf "$temp_dir"" EXIT
+cp -r --reflink=auto "$root" "$temp_dir"
 
-cd $temp_dir
+cd "$temp_dir"
 build_compiler
 
-cd $root
-python3 ./scripts/combine-profile-information.py "$dump_dir" -o "$summary_path"
+cd "$root"
+python3 "$scripts_dir"/combine-profile-information.py "$dump_dir" -o "$summary_path"
 
 rm "$dump_dir/"*.csv
 rmdir "$dump_dir"

--- a/scripts/profile-compiler-build.sh
+++ b/scripts/profile-compiler-build.sh
@@ -4,8 +4,9 @@
 
 set -e -u -o pipefail
 
-dump_dir="`pwd`/_profile"
-summary_path="`pwd`/summary.csv"
+root="`pwd`"
+dump_dir="$root/_profile"
+summary_path="$root/summary.csv"
 
 if [ -d "$dump_dir" ] && [ "$(ls -A "$dump_dir")" ]; then
   echo "$dump_dir is not empty."
@@ -37,7 +38,14 @@ build_compiler() {
   make install
 }
 
+temp_dir="`mktemp -d`"
+trap "rm -rf $temp_dir" EXIT
+git clone $root $temp_dir
+
+cd $temp_dir
 build_compiler
+
+cd $root
 python3 ./scripts/combine-profile-information.py "$dump_dir" -o "$summary_path"
 
 rm "$dump_dir/"*.csv

--- a/scripts/profile-compiler-build.sh
+++ b/scripts/profile-compiler-build.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-# To be run from the root of the Flambda backend repo
-
 set -e -u -o pipefail
 
-root="`pwd`"
+# Works regardless of where script run from
+scripts_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+root=$scripts_dir/..
 dump_dir="$root/_profile"
 summary_path="$root/summary.csv"
 
@@ -38,9 +39,9 @@ build_compiler() {
   make install
 }
 
-temp_dir="`mktemp -d`"
+temp_dir=$(mktemp -d -p $root/.. -t tmp.XXXXXXX)
 trap "rm -rf $temp_dir" EXIT
-git clone $root $temp_dir
+cp -r --reflink=auto $root $temp_dir
 
 cd $temp_dir
 build_compiler

--- a/scripts/profile-compiler-build.sh
+++ b/scripts/profile-compiler-build.sh
@@ -3,7 +3,7 @@
 set -e -u -o pipefail
 
 # Works regardless of where script run from
-scripts_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+scripts_dir=$( cd "$( dirname "$0" )" &> /dev/null && pwd )
 
 root=$scripts_dir/..
 dump_dir="$root/_profile"


### PR DESCRIPTION
If the compiler build fails during profiling or the script is terminated during the build, this leaves the build in the repository being developed on in a bad state. This PR fixes this problem by cloning the repository to a temporary directory (another directory within the parent of the directory that the local repository is stored in i.e. a sibling) and then running the build in that temporary directory leaving the original unchanged (aside from changes in the profile file dump directory and the summary CSV being added).