### PR TITLE
Arrows should cross modes when passed as arguments

### DIFF
--- a/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/ocaml/testsuite/tests/typing-modal-kinds/basics.ml
@@ -835,3 +835,21 @@ let bytes_mutable_data_left x =
 [%%expect{|
 val bytes_mutable_data_left : bytes -> unit = <fun>
 |}]
+
+let use_uncontended_arrow : ('a -> 'a) @ uncontended -> unit = fun _ -> ()
+[%%expect{|
+val use_uncontended_arrow : ('a : any). ('a -> 'a) -> unit = <fun>
+|}]
+
+let arrow_as_argument (f @ contended) = use_uncontended_arrow f
+[%%expect{|
+val arrow_as_argument : ('a : any). ('a -> 'a) @ contended -> unit = <fun>
+|}]
+
+(* f is added to environment as uncontended *)
+let arrow_left () =
+  let (f @ contended) () = () in
+  f
+[%%expect{|
+val arrow_left : unit -> unit -> unit = <fun>
+|}]

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -467,7 +467,7 @@ let get_single_mode_exn {mode; tuple_modes; _} =
 
 let mode_morph f expected_mode =
   let mode = as_single_mode expected_mode in
-  let mode = f mode in
+  let mode = f mode |> Mode.Value.disallow_left in
   let tuple_modes = None in
   {expected_mode with mode; tuple_modes}
 
@@ -7316,7 +7316,13 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
       let exp_mode, _ = Value.newvar_below (as_single_mode mode) in
       let texp =
         with_local_level_if_principal ~post:generalize_structure_exp
-          (fun () -> type_exp env {mode with mode = Value.disallow_left exp_mode} sarg)
+          (fun () ->
+            let expected_mode =
+              mode
+              |> mode_morph (fun _mode -> exp_mode)
+              |> expect_mode_cross env ty_expected'
+            in
+            type_exp env expected_mode sarg)
       in
       let rec make_args args ty_fun =
         match get_desc (expand_head env ty_fun) with


### PR DESCRIPTION
This PR adds mode crossing when a function is passed as argument. This triggers the `may_coerce` branch in `type_argument` which wasn't mode crossing.

I'm suspicious about the choice of `expected_mode` here - in particular, I think `expected_mode.position`  should depend on if `args` is empty. But this is orthogonal to the current PR, so I will leave to future work.
