### PR TITLE
Migrate `include_functor` from `jane_syntax` to `parsetree`

### DIFF
--- a/ocaml/ocamldoc/odoc_ast.ml
+++ b/ocaml/ocamldoc/odoc_ast.ml
@@ -1012,13 +1012,9 @@ module Analyser =
      in
      (0, env, [ Element_included_module im ]) (* FIXME: extend the environment? With what? *)
 
-   and analyse_structure_item_jst env _current_module_name _loc _pos_limit comment_opt jstritem _typedtree
+   and analyse_structure_item_jst _env _current_module_name _loc _pos_limit _comment_opt jstritem _typedtree
         _table _table_values =
      match (jstritem : Jane_syntax.Structure_item.t) with
-      | Jstr_include_functor ifincl -> begin match ifincl with
-          | Ifstr_include_functor incl ->
-              analyse_structure_item_include ~env ~comment_opt incl
-        end
       | Jstr_layout (Lstr_kind_abbrev _) ->
         Misc.fatal_error "Lstr_kind_abbrev"
 

--- a/ocaml/ocamldoc/odoc_sig.ml
+++ b/ocaml/ocamldoc/odoc_sig.ml
@@ -556,9 +556,8 @@ module Analyser =
            pmty_attributes = []
          }
 
-    let filter_out_erased_item_from_signature_jst _erased acc
+    let filter_out_erased_item_from_signature_jst _erased _acc
       : Jane_syntax.Signature_item.t -> _ = function
-      | Jsig_include_functor (Ifsig_include_functor _) -> acc
       | Jsig_layout (Lsig_kind_abbrev _) ->
         Misc.fatal_error "Lsig_kind_abbrev"
 
@@ -577,9 +576,10 @@ module Analyser =
         | Parsetree.Psig_typext _
         | Parsetree.Psig_exception _
         | Parsetree.Psig_open _
-        | Parsetree.Psig_include _
+        | Parsetree.Psig_include {pincl_kind=Structure;_}
         | Parsetree.Psig_class _
         | Parsetree.Psig_class_type _ as tp -> take_item tp
+        | Parsetree.Psig_include {pincl_kind=Functor;_}
         | Parsetree.Psig_typesubst _ -> acc
         | Parsetree.Psig_type (rf, types) ->
           (match List.filter (fun td -> not (is_erased td.Parsetree.ptype_name.txt erased)) types with
@@ -867,7 +867,8 @@ module Analyser =
               Pmod_ident longident -> Name.from_longident longident.txt
             | Pmod_structure [
                 {pstr_desc=Pstr_include
-                     {pincl_mod={pmod_desc=Pmod_ident longident}}
+                     {pincl_mod={pmod_desc=Pmod_ident longident};
+                      pincl_kind=Structure}
                 }] -> (* include module type of struct include M end*)
                 Name.from_longident longident.txt
             | _ -> "??"
@@ -885,13 +886,9 @@ module Analyser =
       in
       (0, env, [ Element_included_module im ]) (* FIXME : extend the environment? How? *)
 
-    and analyse_signature_item_desc_jst env _signat _table _current_module_name
-        _sig_item_loc _pos_start_ele _pos_end_ele _pos_limit comment_opt
+    and analyse_signature_item_desc_jst _env _signat _table _current_module_name
+        _sig_item_loc _pos_start_ele _pos_end_ele _pos_limit _comment_opt
         : Jane_syntax.Signature_item.t -> _ = function
-      | Jsig_include_functor ifincl -> begin match ifincl with
-          | Ifsig_include_functor incl ->
-              analyse_signature_item_desc_include ~env ~comment_opt incl
-        end
       | Jsig_layout (Lsig_kind_abbrev _) ->
         Misc.fatal_error "Lsig_kind_abbrev"
 

--- a/ocaml/parsing/ast_helper.ml
+++ b/ocaml/parsing/ast_helper.ml
@@ -483,8 +483,9 @@ module Opn = struct
 end
 
 module Incl = struct
-  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs) mexpr =
+  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs) kind mexpr =
     {
+     pincl_kind = kind;
      pincl_mod = mexpr;
      pincl_loc = loc;
      pincl_attributes = add_docs_attrs docs attrs;

--- a/ocaml/parsing/ast_helper.ml
+++ b/ocaml/parsing/ast_helper.ml
@@ -483,7 +483,8 @@ module Opn = struct
 end
 
 module Incl = struct
-  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs) kind mexpr =
+  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
+    ?(kind = Structure) mexpr =
     {
      pincl_kind = kind;
      pincl_mod = mexpr;

--- a/ocaml/parsing/ast_helper.mli
+++ b/ocaml/parsing/ast_helper.mli
@@ -370,7 +370,7 @@ module Opn:
 (** Includes *)
 module Incl:
   sig
-    val mk: ?loc: loc -> ?attrs:attrs -> ?docs:docs -> include_kind -> 'a
+    val mk: ?loc: loc -> ?attrs:attrs -> ?docs:docs -> ?kind:include_kind -> 'a
       -> 'a include_infos
   end
 

--- a/ocaml/parsing/ast_helper.mli
+++ b/ocaml/parsing/ast_helper.mli
@@ -370,7 +370,8 @@ module Opn:
 (** Includes *)
 module Incl:
   sig
-    val mk: ?loc: loc -> ?attrs:attrs -> ?docs:docs -> 'a -> 'a include_infos
+    val mk: ?loc: loc -> ?attrs:attrs -> ?docs:docs -> include_kind -> 'a
+      -> 'a include_infos
   end
 
 (** Value bindings *)

--- a/ocaml/parsing/ast_iterator.ml
+++ b/ocaml/parsing/ast_iterator.ml
@@ -350,10 +350,6 @@ module MT = struct
     | Pwith_modtypesubst (lid, mty) ->
         iter_loc sub lid; sub.module_type sub mty
 
-  let iter_sig_include_functor sub
-    : Jane_syntax.Include_functor.signature_item -> unit = function
-    | Ifsig_include_functor incl -> sub.include_description sub incl
-
   let iter_sig_layout sub
     : Jane_syntax.Layouts.signature_item -> unit = function
     | Lsig_kind_abbrev (name, jkind) ->
@@ -362,7 +358,6 @@ module MT = struct
 
   let iter_signature_item_jst sub : Jane_syntax.Signature_item.t -> unit =
     function
-    | Jsig_include_functor ifincl -> iter_sig_include_functor sub ifincl
     | Jsig_layout sigi -> iter_sig_layout sub sigi
 
   let iter_signature_item sub ({psig_desc = desc; psig_loc = loc} as sigi) =
@@ -421,10 +416,6 @@ module M = struct
     | Pmod_unpack e -> sub.expr sub e
     | Pmod_extension x -> sub.extension sub x
 
-  let iter_str_include_functor sub
-    : Jane_syntax.Include_functor.structure_item -> unit = function
-    | Ifstr_include_functor incl -> sub.include_declaration sub incl
-
   let iter_str_layout sub
     : Jane_syntax.Layouts.structure_item -> unit = function
     | Lstr_kind_abbrev (name, jkind) ->
@@ -433,7 +424,6 @@ module M = struct
 
   let iter_structure_item_jst sub : Jane_syntax.Structure_item.t -> unit =
     function
-    | Jstr_include_functor ifincl -> iter_str_include_functor sub ifincl
     | Jstr_layout stri -> iter_str_layout sub stri
 
   let iter_structure_item sub ({pstr_loc = loc; pstr_desc = desc} as stri) =
@@ -859,14 +849,14 @@ let default_iterator =
 
 
     include_description =
-      (fun this {pincl_mod; pincl_attributes; pincl_loc} ->
+      (fun this {pincl_mod; pincl_attributes; pincl_loc; pincl_kind = _} ->
          this.module_type this pincl_mod;
          this.location this pincl_loc;
          this.attributes this pincl_attributes
       );
 
     include_declaration =
-      (fun this {pincl_mod; pincl_attributes; pincl_loc} ->
+      (fun this {pincl_mod; pincl_attributes; pincl_loc; pincl_kind = _} ->
          this.module_expr this pincl_mod;
          this.location this pincl_loc;
          this.attributes this pincl_attributes

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -972,14 +972,14 @@ let default_mapper =
 
     include_description =
       (fun this {pincl_mod; pincl_attributes; pincl_loc; pincl_kind} ->
-         Incl.mk pincl_kind (this.module_type this pincl_mod)
+         Incl.mk ~kind:pincl_kind (this.module_type this pincl_mod)
            ~loc:(this.location this pincl_loc)
            ~attrs:(this.attributes this pincl_attributes)
       );
 
     include_declaration =
       (fun this {pincl_mod; pincl_attributes; pincl_loc; pincl_kind} ->
-         Incl.mk pincl_kind (this.module_expr this pincl_mod)
+         Incl.mk ~kind:pincl_kind (this.module_expr this pincl_mod)
            ~loc:(this.location this pincl_loc)
            ~attrs:(this.attributes this pincl_attributes)
       );

--- a/ocaml/parsing/ast_mapper.ml
+++ b/ocaml/parsing/ast_mapper.ml
@@ -408,13 +408,6 @@ module MT = struct
     | Pwith_modtypesubst (lid, mty) ->
         Pwith_modtypesubst (map_loc sub lid, sub.module_type sub mty)
 
-  module IF = Jane_syntax.Include_functor
-
-  let map_sig_include_functor sub : IF.signature_item -> IF.signature_item =
-    function
-    | Ifsig_include_functor incl ->
-        Ifsig_include_functor (sub.include_description sub incl)
-
   module L = Jane_syntax.Layouts
 
   let map_sig_layout sub : L.signature_item -> L.signature_item =
@@ -428,8 +421,6 @@ module MT = struct
   let map_signature_item_jst sub :
     Jane_syntax.Signature_item.t -> Jane_syntax.Signature_item.t =
     function
-    | Jsig_include_functor ifincl ->
-        Jsig_include_functor (map_sig_include_functor sub ifincl)
     | Jsig_layout sigi ->
         Jsig_layout (map_sig_layout sub sigi)
 
@@ -439,8 +430,6 @@ module MT = struct
     match Jane_syntax.Signature_item.of_ast sigi with
     | Some jsigi -> begin
         match sub.signature_item_jane_syntax sub jsigi with
-        | Jsig_include_functor incl ->
-            Jane_syntax.Include_functor.sig_item_of ~loc incl
         | Jsig_layout sigi ->
             Jane_syntax.Layouts.sig_item_of ~loc sigi
     end
@@ -503,13 +492,6 @@ module M = struct
     | Pmod_unpack e -> unpack ~loc ~attrs (sub.expr sub e)
     | Pmod_extension x -> extension ~loc ~attrs (sub.extension sub x)
 
-  module IF = Jane_syntax.Include_functor
-
-  let map_str_include_functor sub : IF.structure_item -> IF.structure_item =
-    function
-    | Ifstr_include_functor incl ->
-        Ifstr_include_functor (sub.include_declaration sub incl)
-
   module L = Jane_syntax.Layouts
 
   let map_str_layout sub : L.structure_item -> L.structure_item =
@@ -523,8 +505,6 @@ module M = struct
   let map_structure_item_jst sub :
     Jane_syntax.Structure_item.t -> Jane_syntax.Structure_item.t =
     function
-    | Jstr_include_functor ifincl ->
-        Jstr_include_functor (map_str_include_functor sub ifincl)
     | Jstr_layout stri ->
         Jstr_layout (map_str_layout sub stri)
 
@@ -534,8 +514,6 @@ module M = struct
     match Jane_syntax.Structure_item.of_ast stri with
     | Some jstri -> begin
         match sub.structure_item_jane_syntax sub jstri with
-        | Jstr_include_functor incl ->
-            Jane_syntax.Include_functor.str_item_of ~loc incl
         | Jstr_layout stri ->
             Jane_syntax.Layouts.str_item_of ~loc stri
     end
@@ -993,15 +971,15 @@ let default_mapper =
       );
 
     include_description =
-      (fun this {pincl_mod; pincl_attributes; pincl_loc} ->
-         Incl.mk (this.module_type this pincl_mod)
+      (fun this {pincl_mod; pincl_attributes; pincl_loc; pincl_kind} ->
+         Incl.mk pincl_kind (this.module_type this pincl_mod)
            ~loc:(this.location this pincl_loc)
            ~attrs:(this.attributes this pincl_attributes)
       );
 
     include_declaration =
-      (fun this {pincl_mod; pincl_attributes; pincl_loc} ->
-         Incl.mk (this.module_expr this pincl_mod)
+      (fun this {pincl_mod; pincl_attributes; pincl_loc; pincl_kind} ->
+         Incl.mk pincl_kind (this.module_expr this pincl_mod)
            ~loc:(this.location this pincl_loc)
            ~attrs:(this.attributes this pincl_attributes)
       );

--- a/ocaml/parsing/depend.ml
+++ b/ocaml/parsing/depend.ml
@@ -521,10 +521,6 @@ and add_include_description (bv, m) incl =
   (add bv, add m)
 
 and add_sig_item_jst (bv, m) : Jane_syntax.Signature_item.t -> _ = function
-  | Jsig_include_functor (Ifsig_include_functor incl) ->
-      (* It seems to be correct to treat [include functor] the same as
-         [include], but it's possible we could do something cleverer. *)
-      add_include_description (bv, m) incl
   | Jsig_layout (Lsig_kind_abbrev (_, jkind)) ->
       add_jkind bv jkind; (bv, m)
 
@@ -677,10 +673,6 @@ and add_include_declaration (bv, m) incl =
   (add bv, add m)
 
 and add_struct_item_jst (bv, m) : Jane_syntax.Structure_item.t -> _ = function
-  | Jstr_include_functor (Ifstr_include_functor incl) ->
-      (* It seems to be correct to treat [include functor] the same as
-         [include], but it's possible we could do something cleverer. *)
-      add_include_declaration (bv, m) incl
   | Jstr_layout (Lstr_kind_abbrev (_name, jkind)) ->
       add_jkind bv jkind; (bv, m)
 

--- a/ocaml/parsing/jane_syntax.ml
+++ b/ocaml/parsing/jane_syntax.ml
@@ -944,37 +944,6 @@ module Labeled_tuples = struct
     | _ -> Desugaring_error.raise pat.ppat_loc Malformed
 end
 
-(** [include functor] *)
-module Include_functor = struct
-  type signature_item = Ifsig_include_functor of include_description
-
-  type structure_item = Ifstr_include_functor of include_declaration
-
-  let feature : Feature.t = Language_extension Include_functor
-
-  let sig_item_of ~loc = function
-    | Ifsig_include_functor incl ->
-      (* See Note [Wrapping with make_entire_jane_syntax] *)
-      Signature_item.make_entire_jane_syntax ~loc feature (fun () ->
-          Ast_helper.Sig.include_ incl)
-
-  let of_sig_item sigi =
-    match sigi.psig_desc with
-    | Psig_include incl -> Ifsig_include_functor incl
-    | _ -> failwith "Malformed [include functor] in signature"
-
-  let str_item_of ~loc = function
-    | Ifstr_include_functor incl ->
-      (* See Note [Wrapping with make_entire_jane_syntax] *)
-      Structure_item.make_entire_jane_syntax ~loc feature (fun () ->
-          Ast_helper.Str.include_ incl)
-
-  let of_str_item stri =
-    match stri.pstr_desc with
-    | Pstr_include incl -> Ifstr_include_functor incl
-    | _ -> failwith "Malformed [include functor] in structure"
-end
-
 (** Module strengthening *)
 module Strengthen = struct
   type nonrec module_type =
@@ -1597,14 +1566,10 @@ module Module_type = struct
 end
 
 module Signature_item = struct
-  type t =
-    | Jsig_include_functor of Include_functor.signature_item
-    | Jsig_layout of Layouts.signature_item
+  type t = Jsig_layout of Layouts.signature_item
 
   let of_ast_internal (feat : Feature.t) sigi =
     match feat with
-    | Language_extension Include_functor ->
-      Some (Jsig_include_functor (Include_functor.of_sig_item sigi))
     | Language_extension Layouts ->
       Some (Jsig_layout (Layouts.of_sig_item sigi))
     | _ -> None
@@ -1613,14 +1578,10 @@ module Signature_item = struct
 end
 
 module Structure_item = struct
-  type t =
-    | Jstr_include_functor of Include_functor.structure_item
-    | Jstr_layout of Layouts.structure_item
+  type t = Jstr_layout of Layouts.structure_item
 
   let of_ast_internal (feat : Feature.t) stri =
     match feat with
-    | Language_extension Include_functor ->
-      Some (Jstr_include_functor (Include_functor.of_str_item stri))
     | Language_extension Layouts ->
       Some (Jstr_layout (Layouts.of_str_item stri))
     | _ -> None

--- a/ocaml/parsing/jane_syntax.mli
+++ b/ocaml/parsing/jane_syntax.mli
@@ -186,19 +186,6 @@ module Labeled_tuples : sig
   val pat_of : loc:Location.t -> pattern -> Parsetree.pattern
 end
 
-(** The ASTs for [include functor].  When we merge this upstream, we'll merge
-    these into the existing [P{sig,str}_include] constructors (similar to what
-    we did with [T{sig,str}_include], but without depending on typechecking). *)
-module Include_functor : sig
-  type signature_item = Ifsig_include_functor of Parsetree.include_description
-
-  type structure_item = Ifstr_include_functor of Parsetree.include_declaration
-
-  val sig_item_of : loc:Location.t -> signature_item -> Parsetree.signature_item
-
-  val str_item_of : loc:Location.t -> structure_item -> Parsetree.structure_item
-end
-
 (** The ASTs for module type strengthening. *)
 module Strengthen : sig
   type module_type =
@@ -491,18 +478,14 @@ end
 
 (** Novel syntax in signature items *)
 module Signature_item : sig
-  type t =
-    | Jsig_include_functor of Include_functor.signature_item
-    | Jsig_layout of Layouts.signature_item
+  type t = Jsig_layout of Layouts.signature_item
 
   include AST with type t := t and type ast := Parsetree.signature_item
 end
 
 (** Novel syntax in structure items *)
 module Structure_item : sig
-  type t =
-    | Jstr_include_functor of Include_functor.structure_item
-    | Jstr_layout of Layouts.structure_item
+  type t = Jstr_layout of Layouts.structure_item
 
   include AST with type t := t and type ast := Parsetree.structure_item
 end

--- a/ocaml/parsing/jane_syntax_parsing.ml
+++ b/ocaml/parsing/jane_syntax_parsing.ml
@@ -667,7 +667,8 @@ module Signature_item0 = Make_with_extension_node (struct
     Ast_helper.Sig.include_
       { pincl_mod = Ast_helper.Mty.signature [extension_node; sigi];
         pincl_loc = !Ast_helper.default_loc;
-        pincl_attributes = []
+        pincl_attributes = [];
+        pincl_kind = Structure
       }
 
   let match_extension_use sigi =
@@ -679,6 +680,7 @@ module Signature_item0 = Make_with_extension_node (struct
                   [{ psig_desc = Psig_extension (ext, []); _ }; sigi];
               _
             };
+          pincl_kind = Structure;
           _
         } ->
       Some (ext, sigi)
@@ -704,7 +706,8 @@ module Structure_item0 = Make_with_extension_node (struct
     Ast_helper.Str.include_
       { pincl_mod = Ast_helper.Mod.structure [extension_node; stri];
         pincl_loc = !Ast_helper.default_loc;
-        pincl_attributes = []
+        pincl_attributes = [];
+        pincl_kind = Structure
       }
 
   let match_extension_use stri =
@@ -716,6 +719,7 @@ module Structure_item0 = Make_with_extension_node (struct
                   [{ pstr_desc = Pstr_extension (ext, []); _ }; stri];
               _
             };
+          pincl_kind = Structure;
           _
         } ->
       Some (ext, stri)

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -1725,13 +1725,8 @@ structure_item:
     )
     { $1 }
   | include_statement(module_expr)
-      { let is_functor, incl, ext = $1 in
-        let item =
-          if is_functor
-          then Jane_syntax.Include_functor.str_item_of ~loc:(make_loc $sloc)
-                (Ifstr_include_functor incl)
-          else mkstr ~loc:$sloc (Pstr_include incl)
-        in
+      { let incl, ext = $1 in
+        let item = mkstr ~loc:$sloc (Pstr_include incl) in
         wrap_str_ext ~loc:$sloc item ext
       }
   | kind_abbreviation_decl
@@ -1817,17 +1812,17 @@ module_binding_body:
 
 (* Shared material between structures and signatures. *)
 
-include_maybe_functor:
+include_kind:
   | INCLUDE %prec below_FUNCTOR
-      { false }
+      { Structure }
   | INCLUDE FUNCTOR
-      { true }
+      { Functor }
 ;
 
 (* An [include] statement can appear in a structure or in a signature,
    which is why this definition is parameterized. *)
 %inline include_statement(thing):
-  is_functor = include_maybe_functor
+  kind = include_kind
   ext = ext
   attrs1 = attributes
   thing = thing
@@ -1836,8 +1831,8 @@ include_maybe_functor:
     let attrs = attrs1 @ attrs2 in
     let loc = make_loc $sloc in
     let docs = symbol_docs $sloc in
-    let incl = Incl.mk thing ~attrs ~loc ~docs in
-    is_functor, incl, ext
+    let incl = Incl.mk kind thing ~attrs ~loc ~docs in
+    incl, ext
   }
 ;
 
@@ -2004,13 +1999,8 @@ signature_item:
     )
     { $1 }
   | include_statement(module_type)
-      { let is_functor, incl, ext = $1 in
-        let item =
-          if is_functor
-          then Jane_syntax.Include_functor.sig_item_of ~loc:(make_loc $sloc)
-                 (Ifsig_include_functor incl)
-          else mksig ~loc:$sloc (Psig_include incl)
-        in
+      { let incl, ext = $1 in
+        let item = mksig ~loc:$sloc (Psig_include incl) in
         wrap_sig_ext ~loc:$sloc item ext
       }
   | kind_abbreviation_decl

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -1831,7 +1831,7 @@ include_kind:
     let attrs = attrs1 @ attrs2 in
     let loc = make_loc $sloc in
     let docs = symbol_docs $sloc in
-    let incl = Incl.mk kind thing ~attrs ~loc ~docs in
+    let incl = Incl.mk ~kind thing ~attrs ~loc ~docs in
     incl, ext
   }
 ;

--- a/ocaml/parsing/parsetree.mli
+++ b/ocaml/parsing/parsetree.mli
@@ -51,6 +51,8 @@ type modalities = modality loc list
 type mode = | Mode of string [@@unboxed]
 type modes = mode loc list
 
+type include_kind = Structure | Functor
+
 (** {1 Extension points} *)
 
 type attribute = {
@@ -1026,6 +1028,7 @@ and open_declaration = module_expr open_infos
 
 and 'a include_infos =
     {
+     pincl_kind : include_kind;
      pincl_mod: 'a;
      pincl_loc: Location.t;
      pincl_attributes: attributes;

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -389,6 +389,10 @@ let modalities_type pty ctxt f pca =
     (pty ctxt) pca.pca_type
     optional_atat_modalities m
 
+let include_kind f = function
+  | Functor -> pp f "@ functor"
+  | Structure -> ()
+
 (* c ['a,'b] *)
 let rec class_params_def ctxt f =  function
   | [] -> ()
@@ -1365,13 +1369,12 @@ and class_expr ctxt f x =
           (class_expr ctxt) e
 
 and include_ : 'a. ctxt -> formatter ->
-                   functor_:bool ->
                    contents:(ctxt -> formatter -> 'a -> unit) ->
                    'a include_infos ->
                    unit =
-  fun ctxt f ~functor_ ~contents incl ->
-    pp f "@[<hov2>include%t@ %a@]%a"
-      (if functor_ then fun f -> pp f "@ functor" else fun _ -> ())
+  fun ctxt f ~contents incl ->
+    pp f "@[<hov2>include%a@ %a@]%a"
+      include_kind incl.pincl_kind
       (contents ctxt) incl.pincl_mod
       (item_attributes ctxt) incl.pincl_attributes
 
@@ -1464,11 +1467,6 @@ and module_type_jane_syntax1 ctxt attrs f : Jane_syntax.Module_type.t -> _ =
 
 and signature ctxt f x =  list ~sep:"@\n" (signature_item ctxt) f x
 
-and sig_include_functor ctxt f
-  : Jane_syntax.Include_functor.signature_item -> _ = function
-  | Ifsig_include_functor incl ->
-      include_ ctxt f ~functor_:true ~contents:module_type incl
-
 and sig_layout ctxt f
   : Jane_syntax.Layouts.signature_item -> _ = function
   | Lsig_kind_abbrev (name, jkind) ->
@@ -1476,7 +1474,6 @@ and sig_layout ctxt f
 
 and signature_item_jane_syntax ctxt f : Jane_syntax.Signature_item.t -> _ =
   function
-  | Jsig_include_functor ifincl -> sig_include_functor ctxt f ifincl
   | Jsig_layout sigi -> sig_layout ctxt f sigi
 
 and signature_item ctxt f x : unit =
@@ -1538,7 +1535,7 @@ and signature_item ctxt f x : unit =
         longident_loc od.popen_expr
         (item_attributes ctxt) od.popen_attributes
   | Psig_include incl ->
-      include_ ctxt f ~functor_:false ~contents:module_type incl
+      include_ ctxt f ~contents:module_type incl
   | Psig_modtype {pmtd_name=s; pmtd_type=md; pmtd_attributes=attrs} ->
       pp f "@[<hov2>module@ type@ %s%a@]%a"
         s.txt
@@ -1778,11 +1775,6 @@ and binding_op ctxt f x =
      pp f "@[<2>%s %a@;=@;%a@]"
        x.pbop_op.txt (pattern ctxt) pat (expression ctxt) exp
 
-and str_include_functor ctxt f
-  : Jane_syntax.Include_functor.structure_item -> _ = function
-  | Ifstr_include_functor incl ->
-      include_ ctxt f ~functor_:true ~contents:module_expr incl
-
 and str_layout ctxt f
   : Jane_syntax.Layouts.structure_item -> _ = function
   | Lstr_kind_abbrev (name, jkind) ->
@@ -1790,7 +1782,6 @@ and str_layout ctxt f
 
 and structure_item_jane_syntax ctxt f : Jane_syntax.Structure_item.t -> _ =
   function
-  | Jstr_include_functor ifincl -> str_include_functor ctxt f ifincl
   | Jstr_layout stri -> str_layout ctxt f stri
 
 and structure_item ctxt f x =
@@ -1895,7 +1886,7 @@ and structure_item ctxt f x =
         (value_description ctxt) vd
         (item_attributes ctxt) vd.pval_attributes
   | Pstr_include incl ->
-      include_ ctxt f ~functor_:false ~contents:module_expr incl
+      include_ ctxt f ~contents:module_expr incl
   | Pstr_recmodule decls -> (* 3.07 *)
       let aux f = function
         | ({pmb_expr={pmod_desc=Pmod_constraint (expr, typ)}} as pmb) ->

--- a/ocaml/parsing/printast.ml
+++ b/ocaml/parsing/printast.ml
@@ -149,6 +149,10 @@ let mode i ppf mode =
 let modes i ppf modes =
   List.iter (fun m -> mode i ppf m) modes
 
+let include_kind i ppf = function
+  | Structure -> line i ppf "Structure\n"
+  | Functor -> line i ppf "Functor\n"
+
 let rec core_type i ppf x =
   line i ppf "core_type %a\n" fmt_location x.ptyp_loc;
   attributes i ppf x.ptyp_attributes;
@@ -799,6 +803,7 @@ and signature_item i ppf x =
       attributes i ppf od.popen_attributes
   | Psig_include incl ->
       line i ppf "Psig_include\n";
+      include_kind i ppf incl.pincl_kind;
       module_type i ppf incl.pincl_mod;
       attributes i ppf incl.pincl_attributes
   | Psig_class (l) ->
@@ -924,6 +929,7 @@ and structure_item i ppf x =
       list i class_type_declaration ppf l;
   | Pstr_include incl ->
       line i ppf "Pstr_include";
+      include_kind i ppf incl.pincl_kind;
       attributes i ppf incl.pincl_attributes;
       module_expr i ppf incl.pincl_mod
   | Pstr_extension ((s, arg), attrs) ->

--- a/ocaml/testsuite/tests/parsing/attributes.compilers.reference
+++ b/ocaml/testsuite/tests/parsing/attributes.compilers.reference
@@ -167,6 +167,7 @@
                       None
           signature_item (attributes.ml[39,498+2]..[40,566+11])
             Psig_include
+            Structure
             module_type (attributes.ml[39,498+10]..[39,498+61])
               attribute "foo"
                 []

--- a/ocaml/testsuite/tests/parsing/extensions.compilers.reference
+++ b/ocaml/testsuite/tests/parsing/extensions.compilers.reference
@@ -252,6 +252,7 @@
           [
             signature_item (extensions.ml[23,534+11]..[23,534+36])
               Psig_include
+              Structure
               module_type (extensions.ml[23,534+19]..[23,534+36])
                 Pmty_with
                 module_type (extensions.ml[23,534+19]..[23,534+20])

--- a/ocaml/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
+++ b/ocaml/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
@@ -759,7 +759,8 @@
     Pstr_extension "foo"
     [
       structure_item (shortcut_ext_attr.ml[93,1885+0]..[93,1885+19])
-        Pstr_include          attribute "foo"
+        Pstr_include        Structure
+          attribute "foo"
             []
         module_expr (shortcut_ext_attr.ml[93,1885+18]..[93,1885+19])
           Pmod_ident "M" (shortcut_ext_attr.ml[93,1885+18]..[93,1885+19])
@@ -936,6 +937,7 @@
             [
               signature_item (shortcut_ext_attr.ml[114,2245+2]..[114,2245+21])
                 Psig_include
+                Structure
                 module_type (shortcut_ext_attr.ml[114,2245+20]..[114,2245+21])
                   Pmty_ident "M" (shortcut_ext_attr.ml[114,2245+20]..[114,2245+21])
                   attribute "foo"

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -1064,15 +1064,8 @@ and approx_module_declaration env pmd =
     md_uid = Uid.internal_not_actually_unique;
   }
 
-and approx_include_functor
-      env (ifincl : Jane_syntax.Include_functor.signature_item) _srem =
-  match ifincl with
-  | Ifsig_include_functor sincl ->
-      raise (Error(sincl.pincl_loc, env, Recursive_include_functor))
-
-and approx_sig_jst' env (jitem : Jane_syntax.Signature_item.t) srem =
+and approx_sig_jst' _env (jitem : Jane_syntax.Signature_item.t) _srem =
   match jitem with
-  | Jsig_include_functor ifincl -> approx_include_functor env ifincl srem
   | Jsig_layout (Lsig_kind_abbrev _) ->
       Misc.fatal_error "kind_abbrev not supported!"
 
@@ -1159,13 +1152,18 @@ and approx_sig env ssg =
       | Psig_open sod ->
           let _, env = type_open_descr env sod in
           approx_sig env srem
-      | Psig_include sincl ->
-          let smty = sincl.pincl_mod in
-          let mty = approx_modtype env smty in
-          let scope = Ctype.create_scope () in
-          let sg, newenv = Env.enter_signature ~scope
-              (extract_sig env smty.pmty_loc mty) env in
-          sg @ approx_sig newenv srem
+      | Psig_include {pincl_loc=loc; pincl_mod=mod_; pincl_kind=kind; _} ->
+          begin match kind with
+          | Functor ->
+              Jane_syntax_parsing.assert_extension_enabled ~loc Include_functor ();
+              raise (Error(loc, env, Recursive_include_functor))
+          | Structure ->
+              let mty = approx_modtype env mod_ in
+              let scope = Ctype.create_scope () in
+              let sg, newenv = Env.enter_signature ~scope
+                  (extract_sig env loc mty) env in
+              sg @ approx_sig newenv srem
+          end
       | Psig_class sdecls | Psig_class_type sdecls ->
           let decls, env = Typeclass.approx_class_declarations env sdecls in
           let rem = approx_sig env srem in
@@ -1659,7 +1657,7 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
 and transl_signature env (sg : Parsetree.signature) =
   let names = Signature_names.create () in
 
-  let transl_include ~functor_ ~loc env sig_acc sincl =
+  let transl_include ~loc env sig_acc sincl =
     let smty = sincl.pincl_mod in
     let tmty =
       Builtin_attributes.warning_scope sincl.pincl_attributes
@@ -1668,12 +1666,14 @@ and transl_signature env (sg : Parsetree.signature) =
     let mty = tmty.mty_type in
     let scope = Ctype.create_scope () in
     let incl_kind, sg =
-      if functor_ then
+      match sincl.pincl_kind with
+      | Functor ->
+        Jane_syntax_parsing.assert_extension_enabled ~loc Include_functor ();
         let sg, incl_kind =
           extract_sig_functor_open false env smty.pmty_loc mty sig_acc
         in
         incl_kind, sg
-      else
+      | Structure ->
         Tincl_structure, extract_sig env smty.pmty_loc mty
     in
     let sg, newenv = Env.enter_signature ~scope sg env in
@@ -1691,16 +1691,8 @@ and transl_signature env (sg : Parsetree.signature) =
     mksig (Tsig_include incl) env loc, sg, newenv
   in
 
-  let transl_include_functor ~loc env sig_acc
-    : Jane_syntax.Include_functor.signature_item -> _ = function
-    | Ifsig_include_functor sincl ->
-        transl_include ~functor_:true ~loc env sig_acc sincl
-  in
-
-  let transl_sig_item_jst ~loc env sig_acc : Jane_syntax.Signature_item.t -> _ =
+  let transl_sig_item_jst ~loc:_ _env _sig_acc : Jane_syntax.Signature_item.t -> _ =
     function
-    | Jsig_include_functor ifincl ->
-        transl_include_functor ~loc env sig_acc ifincl
     | Jsig_layout (Lsig_kind_abbrev _) ->
         Misc.fatal_error "kind_abbrev not supported!"
   in
@@ -1914,7 +1906,7 @@ and transl_signature env (sg : Parsetree.signature) =
         let (od, newenv) = type_open_descr env sod in
         mksig (Tsig_open od) env loc, [], newenv
     | Psig_include sincl ->
-        transl_include ~functor_:false ~loc env sig_acc sincl
+        transl_include ~loc env sig_acc sincl
     | Psig_class cl ->
         let (classes, newenv) = Typeclass.class_descriptions env cl in
         List.iter (fun cls ->
@@ -2827,7 +2819,7 @@ and type_open_decl_aux ?used_slot ?toplevel funct_body names env od =
 and type_structure ?(toplevel = None) funct_body anchor env sstr =
   let names = Signature_names.create () in
 
-  let type_str_include ~functor_ ~loc env shape_map sincl sig_acc =
+  let type_str_include ~loc env shape_map sincl sig_acc =
     let smodl = sincl.pincl_mod in
     let modl, modl_shape =
       Builtin_attributes.warning_scope sincl.pincl_attributes
@@ -2835,13 +2827,15 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
     in
     let scope = Ctype.create_scope () in
     let incl_kind, sg =
-      if functor_ then
+      match sincl.pincl_kind with
+      | Functor ->
+        Jane_syntax_parsing.assert_extension_enabled ~loc Include_functor ();
         let sg, incl_kind =
           extract_sig_functor_open funct_body env smodl.pmod_loc
             modl.mod_type sig_acc
         in
         incl_kind, sg
-      else
+      | Structure ->
         Tincl_structure, extract_sig_open env smodl.pmod_loc modl.mod_type
     in
     (* Rename all identifiers bound by this signature to avoid clashes *)
@@ -2861,16 +2855,8 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
     Tstr_include incl, sg, shape, new_env
   in
 
-  let type_str_include_functor ~loc env shape_map ifincl sig_acc =
-    match (ifincl : Jane_syntax.Include_functor.structure_item) with
-    | Ifstr_include_functor incl ->
-        type_str_include ~functor_:true ~loc env shape_map incl sig_acc
-  in
-
-  let type_str_item_jst ~loc env shape_map jitem sig_acc =
+  let type_str_item_jst ~loc:_ _env _shape_map jitem _sig_acc =
     match (jitem : Jane_syntax.Structure_item.t) with
-    | Jstr_include_functor ifincl ->
-        type_str_include_functor ~loc env shape_map ifincl sig_acc
     | Jstr_layout (Lstr_kind_abbrev _) ->
         Misc.fatal_error "kind_abbrev not supported!"
   in
@@ -3250,7 +3236,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
         shape_map,
         new_env
     | Pstr_include sincl ->
-        type_str_include ~functor_:false ~loc env shape_map sincl sig_acc
+        type_str_include ~loc env shape_map sincl sig_acc
     | Pstr_extension (ext, _attrs) ->
         raise (Error_forward (Builtin_attributes.error_of_extension ext))
     | Pstr_attribute attr ->

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -200,17 +200,7 @@ let structure_item sub item =
              (fun (_id, _name, ct) -> sub.class_type_declaration sub ct)
              list)
     | Tstr_include incl ->
-        let pincl = sub.include_declaration sub incl in
-        begin match incl.incl_kind with
-        | Tincl_structure ->
-            Pstr_include pincl
-        | Tincl_functor _ | Tincl_gen_functor _ ->
-          let stri =
-            Jane_syntax.Include_functor.str_item_of ~loc
-              (Jane_syntax.Include_functor.Ifstr_include_functor pincl)
-          in
-          stri.pstr_desc
-        end
+        Pstr_include (sub.include_declaration sub incl)
     | Tstr_attribute x ->
         Pstr_attribute x
   in
@@ -815,17 +805,7 @@ let signature_item sub item =
     | Tsig_open od ->
         Psig_open (sub.open_description sub od)
     | Tsig_include incl ->
-        let pincl = sub.include_description sub incl in
-        begin match incl.incl_kind with
-        | Tincl_structure ->
-            Psig_include pincl
-        | Tincl_functor _ | Tincl_gen_functor _ ->
-          let sigi =
-            Jane_syntax.Include_functor.sig_item_of ~loc
-              (Jane_syntax.Include_functor.Ifsig_include_functor pincl)
-          in
-          sigi.psig_desc
-        end
+        Psig_include (sub.include_description sub incl)
     | Tsig_class list ->
         Psig_class (List.map (sub.class_description sub) list)
     | Tsig_class_type list ->
@@ -852,7 +832,12 @@ let module_substitution sub ms =
 let include_infos f sub incl =
   let loc = sub.location sub incl.incl_loc in
   let attrs = sub.attributes sub incl.incl_attributes in
-  Incl.mk ~loc ~attrs (f sub incl.incl_mod)
+  let kind =
+    match incl.incl_kind with
+    | Tincl_structure -> Structure
+    | Tincl_functor _ | Tincl_gen_functor _ -> Functor
+  in
+  Incl.mk ~loc ~attrs kind (f sub incl.incl_mod)
 
 let include_declaration sub = include_infos sub.module_expr sub
 let include_description sub = include_infos sub.module_type sub

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -837,7 +837,7 @@ let include_infos f sub incl =
     | Tincl_structure -> Structure
     | Tincl_functor _ | Tincl_gen_functor _ -> Functor
   in
-  Incl.mk ~loc ~attrs kind (f sub incl.incl_mod)
+  Incl.mk ~loc ~attrs ~kind (f sub incl.incl_mod)
 
 let include_declaration sub = include_infos sub.module_expr sub
 let include_description sub = include_infos sub.module_type sub

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -165,6 +165,10 @@ let mode i ppf mode =
 let modes i ppf modes =
   List.iter (fun m -> mode i ppf m) modes
 
+let include_kind i ppf = function
+  | Structure -> line i ppf "Structure\n"
+  | Functor -> line i ppf "Functor\n"
+
 let rec core_type i ppf x =
   with_location_mapping ~loc:x.ptyp_loc ppf (fun () ->
   line i ppf "core_type %a\n" fmt_location x.ptyp_loc;
@@ -847,6 +851,7 @@ and signature_item i ppf x =
       attributes i ppf od.popen_attributes
   | Psig_include incl ->
       line i ppf "Psig_include\n";
+      include_kind i ppf incl.pincl_kind;
       module_type i ppf incl.pincl_mod;
       attributes i ppf incl.pincl_attributes
   | Psig_class (l) ->
@@ -976,6 +981,7 @@ and structure_item i ppf x =
       list i class_type_declaration ppf l;
   | Pstr_include incl ->
       line i ppf "Pstr_include";
+      include_kind i ppf incl.pincl_kind;
       attributes i ppf incl.pincl_attributes;
       module_expr i ppf incl.pincl_mod
   | Pstr_extension ((s, arg), attrs) ->


### PR DESCRIPTION
This PR migrates the `include_functor` extension from `jane_syntax` to `parsetree`.

**_Please do not merge until I finish the internal migration._**