### PR TITLE
Fixes for the debugger

### DIFF
--- a/ocaml/debugger/command_line.ml
+++ b/ocaml/debugger/command_line.ml
@@ -264,18 +264,9 @@ let instr_dir ppf lexbuf =
   let new_directory = argument_list_eol argument lexbuf in
     if new_directory = [] then begin
       if yes_or_no "Reinitialize directory list" then begin
-<<<<<<< HEAD
         Load_path.init ~auto_include:Compmisc.auto_include
           ~visible:!default_load_path ~hidden:[];
         Envaux.reset_cache ~preserve_persistent_env:false;
-||||||| 121bedcfd2
-        Load_path.init ~auto_include:Compmisc.auto_include !default_load_path;
-        Envaux.reset_cache ();
-=======
-        Load_path.init ~auto_include:Compmisc.auto_include
-          ~visible:!default_load_path ~hidden:[];
-        Envaux.reset_cache ();
->>>>>>> 5.2.0
         Hashtbl.clear Debugger_config.load_path_for;
         flush_buffer_list ()
         end

--- a/ocaml/debugger/eval.ml
+++ b/ocaml/debugger/eval.ml
@@ -22,7 +22,8 @@ open Parser_aux
 open Events
 
 type error =
-    Unbound_identifier of Ident.t
+    Unbound_global of Symtable.Global.t
+  | Unbound_identifier of Ident.t
   | Not_initialized_yet of Path.t
   | Unbound_long_identifier of Longident.t
   | Unknown_name of int
@@ -39,40 +40,23 @@ exception Error of error
 
 let abstract_type =
   Btype.newgenty (Tconstr (Pident (Ident.create_local "<abstr>"), [], ref Mnil))
-let get_global_or_predef id =
+
+let get_global glob =
   try
-    Debugcom.Remote_value.global (Symtable.get_global_position id)
-  with Symtable.Error _ -> raise(Error(Unbound_identifier id))
+    Debugcom.Remote_value.global (Symtable.get_global_position glob)
+  with Symtable.Error _ ->
+    raise(Error(Unbound_global glob))
 
 let rec address path event = function
-<<<<<<< HEAD
-  | Env.Aunit cu ->
-      get_global_or_predef (cu |> Compilation_unit.to_global_ident_for_bytecode)
+  | Env.Aunit cu -> get_global (Glob_compunit cu)
   | Env.Alocal id ->
-      if Ident.is_predef id then get_global_or_predef id
-      else
-||||||| 121bedcfd2
-  | Env.Aident id ->
-      if Ident.global id then
-        try
-          Debugcom.Remote_value.global (Symtable.get_global_position id)
-        with Symtable.Error _ -> raise(Error(Unbound_identifier id))
-      else
-=======
-  | Env.Aident id ->
     begin
       match Symtable.Global.of_ident id with
-        | Some global ->
-          begin
-            try Debugcom.Remote_value.global (Symtable.get_global_position
-              global)
-            with Symtable.Error _ -> raise(Error(Unbound_identifier id))
-          end
+      | Some global -> get_global global
       | None ->
         let not_found () =
           raise(Error(Unbound_identifier id))
         in
->>>>>>> 5.2.0
         begin match event with
           Some {ev_ev = ev} ->
             begin try
@@ -210,6 +194,9 @@ open Format
 module Style = Misc.Style
 
 let report_error ppf = function
+  | Unbound_global glob ->
+      fprintf ppf "@[Unbound identifier %a@]@."
+        Style.inline_code (Symtable.Global.name glob)
   | Unbound_identifier id ->
       fprintf ppf "@[Unbound identifier %a@]@."
         Style.inline_code (Ident.name id)

--- a/ocaml/debugger/eval.mli
+++ b/ocaml/debugger/eval.mli
@@ -23,6 +23,7 @@ val expression :
     Debugcom.Remote_value.t * type_expr
 
 type error =
+  | Unbound_global of Symtable.Global.t
   | Unbound_identifier of Ident.t
   | Not_initialized_yet of Path.t
   | Unbound_long_identifier of Longident.t

--- a/ocaml/debugger/loadprinter.ml
+++ b/ocaml/debugger/loadprinter.ml
@@ -77,9 +77,7 @@ let rec eval_address = function
     in
     begin match Dynlink.unsafe_get_global_value ~bytecode_or_asm_symbol with
     | None ->
-      raise (Symtable.Error (Symtable.Undefined_global
-        (Symtable.Global.Glob_compunit (Cmo_format.Compunit
-          bytecode_or_asm_symbol))))
+      raise (Symtable.Error (Symtable.Undefined_global (Glob_compunit cu)))
     | Some obj -> obj
     end
   | Env.Alocal _ -> assert false

--- a/ocaml/debugger/parameters.ml
+++ b/ocaml/debugger/parameters.ml
@@ -31,16 +31,8 @@ let time = ref true
 let version = ref true
 
 let add_path dir =
-<<<<<<< HEAD
   Load_path.add_dir ~hidden:false dir;
   Envaux.reset_cache ~preserve_persistent_env:false
-||||||| 121bedcfd2
-  Load_path.add_dir dir;
-  Envaux.reset_cache()
-=======
-  Load_path.add_dir ~hidden:false dir;
-  Envaux.reset_cache()
->>>>>>> 5.2.0
 
 let add_path_for mdl dir =
   let old = try Hashtbl.find load_path_for mdl with Not_found -> [] in

--- a/ocaml/debugger/printval.ml
+++ b/ocaml/debugger/printval.ml
@@ -51,25 +51,7 @@ module EvalPath =
     exception Error
 
     let eval_id id =
-      try
-        Debugcom.Remote_value.global (Symtable.get_global_position id)
-      with Symtable.Error _ ->
-        raise Error
-
-    let rec eval_address = function
-<<<<<<< HEAD
-    | Env.Aunit cu -> eval_id (cu |> Compilation_unit.to_global_ident_for_bytecode)
-    | Env.Alocal id -> eval_id id
-||||||| 121bedcfd2
-    | Env.Aident id ->
-        begin try
-          Debugcom.Remote_value.global (Symtable.get_global_position id)
-        with Symtable.Error _ ->
-          raise Error
-        end
-=======
-    | Env.Aident id ->
-      begin match Symtable.Global.of_ident id with
+      match Symtable.Global.of_ident id with
         | Some global ->
           begin
             try Debugcom.Remote_value.global (Symtable.get_global_position
@@ -77,8 +59,10 @@ module EvalPath =
             with Symtable.Error _ -> raise Error
           end
         | None -> raise Error
-      end
->>>>>>> 5.2.0
+
+    let rec eval_address = function
+    | Env.Aunit cu -> eval_id (cu |> Compilation_unit.to_global_ident_for_bytecode)
+    | Env.Alocal id -> eval_id id
     | Env.Adot(root, pos) ->
         let v = eval_address root in
         if not (Debugcom.Remote_value.is_block v)

--- a/ocaml/debugger/program_management.ml
+++ b/ocaml/debugger/program_management.ml
@@ -128,21 +128,10 @@ let initialize_loading () =
   end;
   Symbols.clear_symbols ();
   Symbols.read_symbols Debugcom.main_frag !program_name;
-<<<<<<< HEAD
   let Load_path.{visible; hidden} = Load_path.get_paths () in
   let visible = visible @ !Symbols.program_source_dirs in
   Load_path.init ~auto_include:Compmisc.auto_include ~visible ~hidden;
   Envaux.reset_cache ~preserve_persistent_env:false;
-||||||| 121bedcfd2
-  let dirs = Load_path.get_paths () @ !Symbols.program_source_dirs in
-  Load_path.init ~auto_include:Compmisc.auto_include dirs;
-  Envaux.reset_cache ();
-=======
-  let Load_path.{visible; hidden} = Load_path.get_paths () in
-  let visible = visible @ !Symbols.program_source_dirs in
-  Load_path.init ~auto_include:Compmisc.auto_include ~visible ~hidden;
-  Envaux.reset_cache ();
->>>>>>> 5.2.0
   if !debug_loading then
     prerr_endline "Opening a socket...";
   open_connection !socket_name

--- a/ocaml/debugger4/eval.ml
+++ b/ocaml/debugger4/eval.ml
@@ -22,7 +22,8 @@ open Parser_aux
 open Events
 
 type error =
-    Unbound_identifier of Ident.t
+  | Unbound_global of Symtable.Global.t
+  | Unbound_identifier of Ident.t
   | Not_initialized_yet of Path.t
   | Unbound_long_identifier of Longident.t
   | Unknown_name of int
@@ -40,32 +41,43 @@ exception Error of error
 let abstract_type =
   Btype.newgenty (Tconstr (Pident (Ident.create_local "<abstr>"), [], ref Mnil))
 
-let get_global_or_predef id =
+let get_global glob =
   try
-    Debugcom.Remote_value.global (Symtable.get_global_position id)
-  with Symtable.Error _ -> raise(Error(Unbound_identifier id))
+    Debugcom.Remote_value.global (Symtable.get_global_position glob)
+  with Symtable.Error _ ->
+    raise(Error(Unbound_global glob))
 
 let rec address path event = function
-  | Env.Aunit cu ->
-      get_global_or_predef (cu |> Compilation_unit.to_global_ident_for_bytecode)
+  | Env.Aunit cu -> get_global (Glob_compunit cu)
   | Env.Alocal id ->
-      if Ident.is_predef id then get_global_or_predef id
-      else
+    begin
+      match Symtable.Global.of_ident id with
+      | Some global -> get_global global
+      | None ->
+        let not_found () =
+          raise(Error(Unbound_identifier id))
+        in
         begin match event with
           Some {ev_ev = ev} ->
             begin try
               let pos = Ident.find_same id ev.ev_compenv.ce_stack in
               Debugcom.Remote_value.local (ev.ev_stacksize - pos)
             with Not_found ->
-            try
-              let pos = Ident.find_same id ev.ev_compenv.ce_heap in
-              Debugcom.Remote_value.from_environment pos
-            with Not_found ->
-              raise(Error(Unbound_identifier id))
+            match ev.ev_compenv.ce_closure with
+            | Not_in_closure -> not_found ()
+            | In_closure { entries; env_pos } ->
+              match Ident.find_same id entries with
+              | Free_variable pos ->
+                Debugcom.Remote_value.from_environment (pos - env_pos)
+              | Function _pos ->
+                (* Recursive functions seem to be unhandled *)
+                not_found ()
+              | exception Not_found -> not_found ()
             end
         | None ->
-            raise(Error(Unbound_identifier id))
+            not_found ()
         end
+    end
   | Env.Adot(root, pos) ->
       let v = address path event root in
       if not (Debugcom.Remote_value.is_block v) then
@@ -183,6 +195,8 @@ open Format
 let report_error ppf = function
   | Unbound_identifier id ->
       fprintf ppf "@[Unbound identifier %s@]@." (Ident.name id)
+  | Unbound_global glob ->
+      fprintf ppf "@[Unbound identifier %s@]@." (Symtable.Global.name glob)
   | Not_initialized_yet path ->
       fprintf ppf
         "@[The module path %a is not yet initialized.@ \

--- a/ocaml/debugger4/eval.mli
+++ b/ocaml/debugger4/eval.mli
@@ -23,6 +23,7 @@ val expression :
     Debugcom.Remote_value.t * type_expr
 
 type error =
+  | Unbound_global of Symtable.Global.t
   | Unbound_identifier of Ident.t
   | Not_initialized_yet of Path.t
   | Unbound_long_identifier of Longident.t

--- a/ocaml/debugger4/loadprinter.ml
+++ b/ocaml/debugger4/loadprinter.ml
@@ -77,7 +77,7 @@ let rec eval_address = function
     in
     begin match Dynlink.unsafe_get_global_value ~bytecode_or_asm_symbol with
     | None ->
-      raise (Symtable.Error (Symtable.Undefined_global bytecode_or_asm_symbol))
+      raise (Symtable.Error (Symtable.Undefined_global (Glob_compunit cu)))
     | Some obj -> obj
     end
   | Env.Alocal _ -> assert false
@@ -119,7 +119,8 @@ let install_printer ppf lid =
   let v =
     try
       eval_value_path Env.empty path
-    with Symtable.Error(Symtable.Undefined_global s) ->
+    with Symtable.Error(Symtable.Undefined_global global) ->
+      let s = Symtable.Global.name global in
       raise(Error(Unavailable_module(s, lid))) in
   let print_function =
     if is_old_style then

--- a/ocaml/debugger4/printval.ml
+++ b/ocaml/debugger4/printval.ml
@@ -51,10 +51,14 @@ module EvalPath =
     exception Error
 
     let eval_id id =
-      try
-        Debugcom.Remote_value.global (Symtable.get_global_position id)
-      with Symtable.Error _ ->
-        raise Error
+      match Symtable.Global.of_ident id with
+        | Some global ->
+          begin
+            try Debugcom.Remote_value.global (Symtable.get_global_position
+              global)
+            with Symtable.Error _ -> raise Error
+          end
+        | None -> raise Error
 
     let rec eval_address = function
     | Env.Aunit cu -> eval_id (cu |> Compilation_unit.to_global_ident_for_bytecode)

--- a/ocaml/debugger4/source.ml
+++ b/ocaml/debugger4/source.ml
@@ -52,7 +52,7 @@ let source_of_module pos mdle =
       function
         | [] -> raise Not_found
         | ext :: exts ->
-          try find_in_path_uncap path (innermost_module ^ ext)
+          try find_in_path_normalized path (innermost_module ^ ext)
           with Not_found -> loop exts
     in loop source_extensions
   else if Filename.is_relative fname then


### PR DESCRIPTION
The fixes were done for the runtime5 version of ocamldebug (in the `debugger/` directory) and then ported to the runtime4 version.

@lukemaurer please review, thanks.