### PR TITLE
Add block level profiling granularity

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -214,10 +214,6 @@ let rec regalloc ~ppf_dump round (fd : Mach.fundecl) =
     newfd
   end
 
-let (++) x f = f x
-
-let id x = x
-
 let count_duplicate_spills_reloads_in_block (block : Cfg.basic_block) =
   let count_per_inst
       ((dup_spills, dup_reloads, seen_spill_regs, seen_reload_regs) as acc)
@@ -275,7 +271,7 @@ let cfg_profile to_cfg =
         Profile.record_with_counters ~accumulate:true
           ~counter_f:cfg_block_counters
           (Format.sprintf "block .%d" label)
-          id block
+          Fun.id block
       in
       ()
     | File_level | Function_level ->
@@ -295,6 +291,8 @@ let cfg_with_layout_profile ?accumulate pass f x =
 
 let cfg_with_infos_profile ?accumulate pass f x =
   cfg_profile Cfg_with_infos.cfg ?accumulate pass f x
+
+let (++) x f = f x
 
 let ocamlcfg_verbose =
   match Sys.getenv_opt "OCAMLCFG_VERBOSE" with
@@ -540,7 +538,7 @@ let compile_phrases ~ppf_dump ps =
             let profile_wrapper = match !profile_granularity with
             | Function_level | Block_level ->
                 Profile.record ~accumulate:true fd.fun_name.sym_name
-            | File_level -> id
+            | File_level -> Fun.id
             in profile_wrapper (compile_fundecl ~ppf_dump ~funcnames) fd;
             compile ~funcnames:(String.Set.remove fd.fun_name.sym_name funcnames) ps
           | Cdata dl ->

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -270,7 +270,7 @@ let cfg_profile to_cfg =
       let (_ : Cfg.basic_block) =
         Profile.record_with_counters ~accumulate:true
           ~counter_f:cfg_block_counters
-          (Format.sprintf "block .%d" label)
+          (Format.sprintf "block %d" label)
           Fun.id block
       in
       ()

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -252,6 +252,8 @@ let count_spills_reloads (block : Cfg.basic_block) =
   in
   DLL.fold_left ~f ~init:(0, 0) block.body
 
+(** Returns all CFG counters that work on a single block and are summative over the
+    blocks. *)
 let cfg_block_counters block =
   let dup_spills, dup_reloads = count_duplicate_spills_reloads_in_block block in
   let spills, reloads = count_spills_reloads block in
@@ -261,7 +263,8 @@ let cfg_block_counters block =
   |> Profile.Counters.set "spill" spills
   |> Profile.Counters.set "reload" reloads
 
-let whole_cfg_counters _ = Profile.Counters.create ()
+(** Returns all CFG counters that require the whole CFG to produce a count. *)
+let whole_cfg_counters (_ : Cfg.t) = Profile.Counters.create ()
 
 let cfg_profile to_cfg =
   let total_counters = ref (Profile.Counters.create ()) in

--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -511,10 +511,11 @@ let compile_phrases ~ppf_dump ps =
           if !dump_cmm then fprintf ppf_dump "%a@." Printcmm.phrase p;
           match p with
           | Cfunction fd ->
-            (* Only profile if function level granularity selected*)
+            (* Only profile if selected granularity is either function or block level *)
             let profile_wrapper = match !profile_granularity with
-            | Function_level -> Profile.record ~accumulate:true fd.fun_name.sym_name
-            | File_level -> fun x -> x
+            | Function_level | Block_level ->
+                Profile.record ~accumulate:true fd.fun_name.sym_name
+            | File_level-> fun x -> x
             in profile_wrapper (compile_fundecl ~ppf_dump ~funcnames) fd;
             compile ~funcnames:(String.Set.remove fd.fun_name.sym_name funcnames) ps
           | Cdata dl ->

--- a/ocaml/driver/main_args.ml
+++ b/ocaml/driver/main_args.ml
@@ -536,7 +536,7 @@ let mk_dprofile f =
 
 let mk_dgranularity f =
   "-dgranularity",
-  Arg.Symbol (["file"; "func"], f),
+  Arg.Symbol (Clflags.all_profile_granularity_levels, f),
   " Specify granularity level for profile information (-dtimings, -dcounters, -dprofile)";
 ;;
 

--- a/ocaml/testsuite/tools/codegen_main.ml
+++ b/ocaml/testsuite/tools/codegen_main.ml
@@ -78,7 +78,10 @@ let main() =
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
      "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";
-     "-dgranularity", Arg.Symbol (["file"; "func"], Clflags.set_profile_granularity), "";
+     ( "-dgranularity",
+        Arg.Symbol
+          (Clflags.all_profile_granularity_levels, Clflags.set_profile_granularity),
+        "" );
     ] compile_file usage
 
 let () =

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -53,7 +53,7 @@ module Libloc = struct
 end
 
 type profile_column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap | `Counters ]
-type profile_granularity_level = File_level | Function_level
+type profile_granularity_level = File_level | Function_level | Block_level
 
 let compile_only = ref false            (* -c *)
 and output_name = ref (None : string option) (* -o *)
@@ -162,11 +162,18 @@ let timings_precision = ref default_timings_precision (* -dtimings-precision *)
 let profile_columns : profile_column list ref = ref [] (* -dprofile/-dtimings/-dcounters *)
 let profile_granularity : profile_granularity_level ref = ref File_level (* -dgranularity *)
 
+let profile_granularity_level_mapping = [
+  "file", File_level;
+  "func", Function_level;
+  "block", Block_level;
+]
+
+let all_profile_granularity_levels = List.map fst profile_granularity_level_mapping
+
 let set_profile_granularity v =
-  profile_granularity := match v with
-  | "file" -> File_level
-  | "func" -> Function_level
-  | _ -> raise (Invalid_argument (Format.sprintf "profile granularity: %s" v))
+  match List.assoc_opt v profile_granularity_level_mapping with
+  | Some granularity -> profile_granularity := granularity
+  | None -> raise (Invalid_argument (Format.sprintf "profile granularity: %s" v))
 
 let native_code = ref false             (* set to true under ocamlopt *)
 

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -60,7 +60,7 @@ module Libloc : sig
 end
 
 type profile_column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap | `Counters ]
-type profile_granularity_level = File_level | Function_level
+type profile_granularity_level = File_level | Function_level | Block_level
 
 val objfiles : string list ref
 val ccobjs : string list ref
@@ -205,6 +205,7 @@ val default_timings_precision : int
 val timings_precision : int ref
 val profile_columns : profile_column list ref
 val profile_granularity : profile_granularity_level ref
+val all_profile_granularity_levels : string list
 val set_profile_granularity : string -> unit
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -75,7 +75,10 @@ let main() =
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
      "-dcounters", Arg.Unit (fun () -> profile_columns := [ `Counters ]), "";
-     "-dgranularity", Arg.Symbol (["file"; "func"], Clflags.set_profile_granularity), "";
+     ( "-dgranularity",
+        Arg.Symbol
+          (Clflags.all_profile_granularity_levels, Clflags.set_profile_granularity),
+        "" );
     ] compile_file usage
 
 let () =


### PR DESCRIPTION
Depends on #2955.

Allows profiling counters at the level of CFG block. The previously available levels were at the file and function levels. 

# Example output
## `-dcounters -dgranularity=block`
```
test.ml
   generate
     compile_phrases
       camlTest__f_0_2_code
         regalloc
           cfg
             cfgize
              [reload = 4; spill = 3] block .1
              [reload = 4; spill = 3] block .100
             cfg_polling
              [reload = 4; spill = 3] block .1
              [reload = 4; spill = 3] block .100
             cfg_deadcode
              [reload = 4; spill = 3] block .1
              [reload = 4; spill = 3] block .100
             cfg_irc
              [reload = 4; spill = 3] block .1
              [reload = 4; spill = 3] block .100
             cfg_validate_description
              [reload = 4; spill = 3] block .1
              [reload = 4; spill = 3] block .100
             cfg_simplify
              [reload = 4; spill = 3] block .1
              [reload = 4; spill = 3] block .100
             peephole_optimize_cfg
              [reload = 4; spill = 3] block .1
              [reload = 4; spill = 3] block .100
             save_cfg
              [reload = 4; spill = 3] block .1
              [reload = 4; spill = 3] block .100
             cfg_reorder_blocks
              [reload = 4; spill = 3] block .1
              [reload = 4; spill = 3] block .100
       camlTest__foo_1_3_code
         regalloc
           cfg
             cfgize
              [reload = 4; spill = 3] block .1
              ....
```

The outputs at the file and function levels remain as before.

## `-dcounters -dgranularity=func`
```
 test.ml
   generate
     compile_phrases
       camlTest__f_0_2_code
         regalloc
           cfg
            [reload = 8; spill = 6] cfgize
            [reload = 8; spill = 6] cfg_polling
            [reload = 8; spill = 6] cfg_deadcode
            [reload = 8; spill = 6] cfg_irc
            [reload = 8; spill = 6] cfg_validate_description
            [reload = 8; spill = 6] cfg_simplify
            [reload = 8; spill = 6] peephole_optimize_cfg
            [reload = 8; spill = 6] save_cfg
            [reload = 8; spill = 6] cfg_reorder_blocks
       camlTest__foo_1_3_code
         regalloc
           cfg
            [reload = 48; spill = 36] cfgize
            [reload = 48; spill = 36] cfg_polling
            [reload = 48; spill = 36] cfg_deadcode
            [reload = 48; spill = 36] cfg_irc
            [reload = 48; spill = 36] cfg_validate_description
            [reload = 48; spill = 36] cfg_simplify
            [reload = 48; spill = 36] peephole_optimize_cfg
            [reload = 48; spill = 36] save_cfg
            [reload = 48; spill = 36] cfg_reorder_blocks
       camlTest__entry
         regalloc
           cfg
            [reload = 12; spill = 9] cfgize
            [reload = 12; spill = 9] cfg_polling
            [reload = 12; spill = 9] cfg_deadcode
            [reload = 12; spill = 9] cfg_irc
            [reload = 12; spill = 9] cfg_validate_description
            [reload = 12; spill = 9] cfg_simplify
            [reload = 12; spill = 9] peephole_optimize_cfg
            [reload = 12; spill = 9] save_cfg
            [reload = 12; spill = 9] cfg_reorder_blocks
```
## `-dcounters -dgranularity=file`
```
 test.ml
   generate
     compile_phrases
       regalloc
         cfg
          [reload = 68; spill = 51] cfgize
          [reload = 68; spill = 51] cfg_polling
          [reload = 68; spill = 51] cfg_deadcode
          [reload = 68; spill = 51] cfg_irc
          [reload = 68; spill = 51] cfg_validate_description
          [reload = 68; spill = 51] cfg_simplify
          [reload = 68; spill = 51] peephole_optimize_cfg
          [reload = 68; spill = 51] save_cfg
          [reload = 68; spill = 51] cfg_reorder_blocks
```