### PR TITLE
Fixes for ocaml/utils/ + regenerate configure

### DIFF
--- a/ocaml/build-aux/ocaml_version.m4
+++ b/ocaml/build-aux/ocaml_version.m4
@@ -97,7 +97,7 @@ m4_define([OCAML__RELEASE_EXTRA],
 # - A 3-bytes version number
 
 m4_define([MAGIC_NUMBER__PREFIX], [Caml1999])
-m4_define([MAGIC_NUMBER__VERSION], [034])
+m4_define([MAGIC_NUMBER__VERSION], [550])
 
 # The following macro is used to define all our magic numbers
 # Its first argument is the name of the file type described by that

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -3366,7 +3366,7 @@ OCAML_VERSION_SHORT=5.2
 
 printf "%s\n" "#define MAGIC_NUMBER_PREFIX \"Caml1999\"" >>confdefs.h
 
-printf "%s\n" "#define MAGIC_NUMBER_VERSION \"034\"" >>confdefs.h
+printf "%s\n" "#define MAGIC_NUMBER_VERSION \"550\"" >>confdefs.h
 
 MAGIC_NUMBER_LENGTH=12
 
@@ -3374,25 +3374,25 @@ printf "%s\n" "#define EXEC_MAGIC_LENGTH 12" >>confdefs.h
 
 printf "%s\n" "#define EXEC_FORMAT \"X\"" >>confdefs.h
 
-EXEC_MAGIC_NUMBER=Caml1999X034
+EXEC_MAGIC_NUMBER=Caml1999X550
 
-CMI_MAGIC_NUMBER=Caml1999I034
+CMI_MAGIC_NUMBER=Caml1999I550
 
-CMO_MAGIC_NUMBER=Caml1999O034
+CMO_MAGIC_NUMBER=Caml1999O550
 
-CMA_MAGIC_NUMBER=Caml1999A034
+CMA_MAGIC_NUMBER=Caml1999A550
 
 
 
-AST_IMPL_MAGIC_NUMBER=Caml1999M034
+AST_IMPL_MAGIC_NUMBER=Caml1999M550
 
-AST_INTF_MAGIC_NUMBER=Caml1999N034
+AST_INTF_MAGIC_NUMBER=Caml1999N550
 
-CMXS_MAGIC_NUMBER=Caml1999D034
+CMXS_MAGIC_NUMBER=Caml1999D550
 
-CMT_MAGIC_NUMBER=Caml1999T034
+CMT_MAGIC_NUMBER=Caml1999T550
 
-LINEAR_MAGIC_NUMBER=Caml1999L034
+LINEAR_MAGIC_NUMBER=Caml1999L550
 
 
 
@@ -15091,6 +15091,19 @@ then :
 fi
 
 
+case $host in #(
+  *-*-linux*) :
+    ac_fn_c_check_header_compile "$LINENO" "linux/futex.h" "ac_cv_header_linux_futex_h" "$ac_includes_default"
+if test "x$ac_cv_header_linux_futex_h" = xyes
+then :
+  printf "%s\n" "#define HAS_LINUX_FUTEX_H 1" >>confdefs.h
+
+fi
+ ;; #(
+  *) :
+     ;;
+esac
+
 # Checks for types
 
 ## off_t
@@ -21293,11 +21306,11 @@ fi
 
 if $flambda
 then :
-  CMX_MAGIC_NUMBER=Caml1999y034
-  CMXA_MAGIC_NUMBER=Caml1999z034
+  CMX_MAGIC_NUMBER=Caml1999y550
+  CMXA_MAGIC_NUMBER=Caml1999z550
 else case e in #(
-  e) CMX_MAGIC_NUMBER=Caml1999Y034
-  CMXA_MAGIC_NUMBER=Caml1999Z034 ;;
+  e) CMX_MAGIC_NUMBER=Caml1999Y550
+  CMXA_MAGIC_NUMBER=Caml1999Z550 ;;
 esac
 fi
 
@@ -21524,11 +21537,12 @@ ocamlc_cppflags="$common_cppflags $CPPFLAGS"
 
 case $host in #(
   *-*-mingw32*) :
-    cclibs="$cclibs -lole32 -luuid -lversion" ;; #(
+    cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi -lsynchronization" ;; #(
   *-pc-windows) :
-    # For whatever reason, flexlink includes -ladvapi32 for mingw-w64, but
-    # doesn't include advapi32.lib for MSVC
-    cclibs="$cclibs ole32.lib uuid.lib advapi32.lib version.lib" ;; #(
+    # For whatever reason, flexlink includes -ladvapi32 and -lshell32 for
+    # mingw-w64, but doesn't include advapi32.lib and shell32.lib for MSVC
+    cclibs="$cclibs ole32.lib uuid.lib advapi32.lib shell32.lib version.lib \
+shlwapi.lib synchronization.lib" ;; #(
   *) :
      ;;
 esac

--- a/ocaml/utils/config.common.ml.in
+++ b/ocaml/utils/config.common.ml.in
@@ -29,58 +29,8 @@ let standard_library =
   with Not_found ->
     standard_library_default
 
-<<<<<<< HEAD:utils/config.common.ml
-(* When artifacts are incompatible with upstream OCaml, ocaml-jst uses
-   magic numbers ending in 5xx. (The AST remains
-   compatible, so use upstream numbers) *)
-let exec_magic_number = "Caml1999X532"
-||||||| 121bedcfd2:utils/config.common.ml
-let exec_magic_number = "Caml1999X033"
-=======
 let exec_magic_number = {magic|@EXEC_MAGIC_NUMBER@|magic}
->>>>>>> 5.2.0:utils/config.common.ml.in
     (* exec_magic_number is duplicated in runtime/caml/exec.h *)
-<<<<<<< HEAD:utils/config.common.ml
-and cmi_magic_number = "Caml1999I532"
-and cmo_magic_number = "Caml1999O532"
-and cma_magic_number = "Caml1999A532"
-and cmx_magic_number =
-  if flambda || flambda2 then
-    "Caml2021y533"
-  else
-    "Caml2021Y532"
-and cmxa_magic_number =
-  if flambda || flambda2 then
-    "Caml2021z533"
-  else
-    "Caml2021Z532"
-and ast_impl_magic_number = "Caml1999M532"
-and ast_intf_magic_number = "Caml1999N532"
-and cmxs_magic_number = "Caml1999D532"
-and cmt_magic_number = "Caml1999T532"
-and cms_magic_number = "Caml1999S532"
-and linear_magic_number = "Caml1999L532"
-and cfg_magic_number = "Caml2021G532"
-||||||| 121bedcfd2:utils/config.common.ml
-and cmi_magic_number = "Caml1999I033"
-and cmo_magic_number = "Caml1999O033"
-and cma_magic_number = "Caml1999A033"
-and cmx_magic_number =
-  if flambda then
-    "Caml1999y033"
-  else
-    "Caml1999Y033"
-and cmxa_magic_number =
-  if flambda then
-    "Caml1999z033"
-  else
-    "Caml1999Z033"
-and ast_impl_magic_number = "Caml1999M033"
-and ast_intf_magic_number = "Caml1999N033"
-and cmxs_magic_number = "Caml1999D033"
-and cmt_magic_number = "Caml1999T033"
-and linear_magic_number = "Caml1999L033"
-=======
 and cmi_magic_number = {magic|@CMI_MAGIC_NUMBER@|magic}
 and cmo_magic_number = {magic|@CMO_MAGIC_NUMBER@|magic}
 and cma_magic_number = {magic|@CMA_MAGIC_NUMBER@|magic}
@@ -90,8 +40,9 @@ and ast_impl_magic_number = {magic|@AST_IMPL_MAGIC_NUMBER@|magic}
 and ast_intf_magic_number = {magic|@AST_INTF_MAGIC_NUMBER@|magic}
 and cmxs_magic_number = {magic|@CMXS_MAGIC_NUMBER@|magic}
 and cmt_magic_number = {magic|@CMT_MAGIC_NUMBER@|magic}
+and cms_magic_number = {magic|@CMS_MAGIC_NUMBER@|magic}
 and linear_magic_number = {magic|@LINEAR_MAGIC_NUMBER@|magic}
->>>>>>> 5.2.0:utils/config.common.ml.in
+and cfg_magic_number = {magic|@CFG_MAGIC_NUMBER@|magic}
 
 let safe_string = true
 let default_safe_string = true
@@ -170,15 +121,6 @@ let configuration_variables () =
   p_bool "supports_shared_libraries" supports_shared_libraries;
   p_bool "native_dynlink" native_dynlink;
   p_bool "naked_pointers" naked_pointers;
-<<<<<<< HEAD:utils/config.common.ml
-(*
-  Disabled in flambda-backend (for now)
-  p_bool "compression_supported" (Marshal.compression_supported());
-*)
-||||||| 121bedcfd2:utils/config.common.ml
-  p_bool "compression_supported" (Marshal.compression_supported());
-=======
->>>>>>> 5.2.0:utils/config.common.ml.in
 
   p "exec_magic_number" exec_magic_number;
   p "cmi_magic_number" cmi_magic_number;

--- a/ocaml/utils/config.generated.ml.in
+++ b/ocaml/utils/config.generated.ml.in
@@ -33,13 +33,7 @@ let ocamlc_cppflags = {@QS@|@ocamlc_cppflags@|@QS@}
           the two drivers should be identical. *)
 let ocamlopt_cflags = {@QS@|@ocamlc_cflags@|@QS@}
 let ocamlopt_cppflags = {@QS@|@ocamlc_cppflags@|@QS@}
-<<<<<<< HEAD
 let bytecomp_c_libraries = {@QS@|@cclibs@|@QS@}
-||||||| 121bedcfd2
-let bytecomp_c_libraries = {@QS@|@bytecclibs@|@QS@}
-=======
-let bytecomp_c_libraries = {@QS@|@zstd_libs@ @cclibs@|@QS@}
->>>>>>> 5.2.0
 (* bytecomp_c_compiler and native_c_compiler have been supported for a
    long time and are retained for backwards compatibility.
    For programs that don't need compatibility with older OCaml releases
@@ -50,14 +44,8 @@ let bytecomp_c_compiler =
   c_compiler ^ " " ^ ocamlc_cflags ^ " " ^ ocamlc_cppflags
 let native_c_compiler =
   c_compiler ^ " " ^ ocamlopt_cflags ^ " " ^ ocamlopt_cppflags
-<<<<<<< HEAD
-let native_c_libraries = {@QS@|@cclibs@|@QS@}
-||||||| 121bedcfd2
-let native_c_libraries = {@QS@|@nativecclibs@|@QS@}
-=======
 let native_c_libraries = {@QS@|@cclibs@|@QS@}
 let native_ldflags = {@QS@|@native_ldflags@|@QS@}
->>>>>>> 5.2.0
 let native_pack_linker = {@QS@|@PACKLD@|@QS@}
 let default_rpath = {@QS@|@rpath@|@QS@}
 let mksharedlibrpath = {@QS@|@mksharedlibrpath@|@QS@}
@@ -108,7 +96,6 @@ let systhread_supported = @systhread_support@
 let flexdll_dirs = [@flexdll_dir@]
 
 let ar_supports_response_files = @ar_supports_response_files@
-<<<<<<< HEAD
 
 let naked_pointers = "@naked_pointers@" = "true"
 let runtime5 = "@enable_runtime5@" = "yes"
@@ -118,8 +105,4 @@ let reserved_header_bits =
 
 let no_stack_checks = "@enable_stack_checks@" <> "yes"
 
-||||||| 121bedcfd2
-=======
-
 let tsan = @tsan@
->>>>>>> 5.2.0

--- a/ocaml/utils/load_path.ml
+++ b/ocaml/utils/load_path.ml
@@ -309,6 +309,6 @@ let find_normalized_with_visibility fn =
         (Misc.find_in_path_normalized (get_hidden_path_list ()) fn, Hidden)
   with Not_found ->
     let fn_uncap = String.uncapitalize_ascii fn in
-    (!auto_include_callback Dir.find_uncap fn_uncap, Visible)
+    (!auto_include_callback Dir.find_normalized fn_uncap, Visible)
 
 let find_normalized fn = fst (find_normalized_with_visibility fn)

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -1222,7 +1222,9 @@ module Magic_number = struct
     flambda : bool;
   }
   let native_obj_config = {
-    flambda = Config.flambda || Config.flambda2;
+    (* This must match the logic in the configure script for deciding
+       which magic numbers to use. *)
+    flambda = Config.flambda;
   }
 
   type version = int


### PR DESCRIPTION
This fixes conflicts relating to magic numbers, and a problem where `Misc` was out of sync with the `configure` logic.  Plus other minor fixes.