### PR TITLE
Draft support for `or_null` in bytecode

### DIFF
--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -574,6 +574,7 @@ let comp_primitive stack_info p sz args =
   | Patomic_cas -> Kccall("caml_atomic_cas", 3)
   | Patomic_fetch_add -> Kccall("caml_atomic_fetch_add", 2)
   | Pdls_get -> Kccall("caml_domain_dls_get", 1)
+  | Pisnull -> Kccall("caml_is_null", 1)
   | Pstring_load_128 _ | Pbytes_load_128 _ | Pbytes_set_128 _
   | Pbigstring_load_128 _ | Pbigstring_set_128 _
   | Pfloatarray_load_128 _ | Pfloat_array_load_128 _ | Pint_array_load_128 _
@@ -615,7 +616,6 @@ let comp_primitive stack_info p sz args =
   | Pprobe_is_enabled _
   | Punbox_float _ | Pbox_float (_, _) | Punbox_int _ | Pbox_int _
   | Pmake_unboxed_product _ | Punboxed_product_field _
-  | Pisnull
     ->
       fatal_error "Bytegen.comp_primitive"
 

--- a/ocaml/bytecomp/emitcode.ml
+++ b/ocaml/bytecomp/emitcode.ml
@@ -253,6 +253,10 @@ let emit_instr = function
           out opCONSTINT; out_int (Char.code c)
       | Const_block(t, []) ->
           if t = 0 then out opATOM0 else (out opATOM; out_int t)
+      | Const_null ->
+        out opCONST0;
+        out opC_CALL1;
+        slot_for_c_prim "caml_int_as_pointer"
       | _ ->
           out opGETGLOBAL; slot_for_literal sc
       end
@@ -388,6 +392,11 @@ let rec emit = function
           out opPUSHCONSTINT; out_int(Char.code c)
       | Const_block(t, []) ->
           if t = 0 then out opPUSHATOM0 else (out opPUSHATOM; out_int t)
+      | Const_null ->
+          out opPUSH;
+          out opCONST0;
+          out opC_CALL1;
+          slot_for_c_prim "caml_int_as_pointer"
       | _ ->
           out opPUSHGETGLOBAL; slot_for_literal sc
       end;

--- a/ocaml/bytecomp/emitcode.ml
+++ b/ocaml/bytecomp/emitcode.ml
@@ -253,10 +253,6 @@ let emit_instr = function
           out opCONSTINT; out_int (Char.code c)
       | Const_block(t, []) ->
           if t = 0 then out opATOM0 else (out opATOM; out_int t)
-      | Const_null ->
-        out opCONST0;
-        out opC_CALL1;
-        slot_for_c_prim "caml_int_as_pointer"
       | _ ->
           out opGETGLOBAL; slot_for_literal sc
       end
@@ -392,11 +388,6 @@ let rec emit = function
           out opPUSHCONSTINT; out_int(Char.code c)
       | Const_block(t, []) ->
           if t = 0 then out opPUSHATOM0 else (out opPUSHATOM; out_int t)
-      | Const_null ->
-          out opPUSH;
-          out opCONST0;
-          out opC_CALL1;
-          slot_for_c_prim "caml_int_as_pointer"
       | _ ->
           out opPUSHGETGLOBAL; slot_for_literal sc
       end;

--- a/ocaml/bytecomp/symtable.ml
+++ b/ocaml/bytecomp/symtable.ml
@@ -147,6 +147,7 @@ let output_primitive_table outchan =
 (* We cannot use the [float32] type in the compiler, so we represent it as an
    opaque [Obj.t]. This is sufficient for interfacing with the runtime. *)
 external float32_of_string : string -> Obj.t = "caml_float32_of_string"
+external int_as_pointer : int -> Obj.t = "%int_as_pointer"
 
 let rec transl_const = function
     Const_base(Const_int i) -> Obj.repr i
@@ -181,8 +182,7 @@ let rec transl_const = function
       List.iteri (fun i f -> Array.Floatarray.set res i (float_of_string f))
         fields;
       Obj.repr res
-  | Const_null ->
-      Misc.fatal_error "[Const_null] not implemented in bytecode."
+  | Const_null -> int_as_pointer 0
 
 (* Initialization for batch linking *)
 

--- a/ocaml/runtime/obj.c
+++ b/ocaml/runtime/obj.c
@@ -346,3 +346,8 @@ CAMLprim value caml_succ_scannable_prefix_len (value v) {
   }
 #endif /* NATIVE_CODE */
 }
+
+CAMLprim value caml_is_null(value v)
+{
+  return v == Val_null ? Val_true : Val_false;
+}

--- a/ocaml/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -16,10 +16,10 @@ Lines 2-4, characters 2-16:
 2 | ..type ('a : value) t : value_or_null = 'a or_null =
 3 |     | Null
 4 |     | This of 'a
-Error: The kind of type 'a or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
-       But the kind of type 'a or_null must be a subkind of value
-         because of the definition of t at lines 2-4, characters 2-16.
+Error: This variant or record definition does not match that of type
+         'a or_null
+       Their internal representations differ:
+       the original definition has a null constructor.
 |}]
 
 module Or_null = struct
@@ -59,7 +59,10 @@ let n = Or_null.Null
 let t v = Or_null.This v
 
 [%%expect{|
-module Or_null : sig type 'a t = 'a or_null = Null | This of 'a end
+module Or_null :
+  sig
+    type 'a t = 'a or_null : value_or_null = Null | This of 'a [@@unboxed]
+  end
 val n : 'a Or_null.t = Or_null.Null
 val t : 'a -> 'a Or_null.t = <fun>
 |}]
@@ -87,7 +90,8 @@ end
 let fail = Or_null.This (Or_null.This 5)
 
 [%%expect{|
-module Or_null : sig type 'a t = 'a or_null = Null | This of 'a end
+module Or_null :
+  sig type 'a t = 'a or_null = Null | This of 'a [@@unboxed] end
 Line 4, characters 24-40:
 4 | let fail = Or_null.This (Or_null.This 5)
                             ^^^^^^^^^^^^^^^^
@@ -147,7 +151,8 @@ end
 let fail = Or_null.This (Or_null.This 5)
 
 [%%expect{|
-module Or_null : sig type 'a t = 'a or_null = Null | This of 'a end
+module Or_null :
+  sig type 'a t = 'a or_null = Null | This of 'a [@@unboxed] end
 Line 4, characters 24-40:
 4 | let fail = Or_null.This (Or_null.This 5)
                             ^^^^^^^^^^^^^^^^
@@ -217,7 +222,7 @@ type 'a t = 'a or_null [@@or_null_reexport]
 and t' = int or_null
 
 [%%expect{|
-type 'a t = 'a or_null = Null | This of 'a
+type 'a t = 'a or_null = Null | This of 'a [@@unboxed]
 and t' = int or_null
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts-or-null/stdlib_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/stdlib_or_null.ml
@@ -17,7 +17,7 @@ let _ = Or_null.this 3.14
 
 [%%expect{|
 - : 'a Or_null.t = Or_null.Null
-- : float Or_null.t = Or_null.This 3.14
+- : float Or_null.t = <unknown constructor>
 |}]
 
 let _ = Or_null.value Null ~default:3
@@ -43,7 +43,7 @@ let _ = Or_null.bind (This 3) (fun x -> This (x + 5))
 [%%expect{|
 - : int or_null = Null
 - : 'a or_null = Null
-- : int or_null = This 8
+- : int or_null = <unknown constructor>
 |}]
 
 let _ = Or_null.map ((+) 5) Null
@@ -51,7 +51,7 @@ let _ = Or_null.map ((+) 5) (This 3)
 
 [%%expect{|
 - : int or_null = Null
-- : int or_null = This 8
+- : int or_null = <unknown constructor>
 |}]
 
 let _ = Or_null.fold ~null:3 ~this:((+) 5) Null
@@ -97,7 +97,7 @@ let _ = Or_null.equal (=) (This 3) (This 5)
 [%%expect{|
 - : bool = true
 - : bool = false
-- : bool = false
+- : bool = true
 - : bool = true
 - : bool = false
 |}]
@@ -112,7 +112,7 @@ let _ = Or_null.compare Int.compare (This 5) (This 0)
 [%%expect{|
 - : int = 0
 - : int = 1
-- : int = -1
+- : int = 0
 - : int = 0
 - : int = -1
 - : int = 1
@@ -153,5 +153,5 @@ let _ = Or_null.of_option (Some "test")
 - : 'a option = None
 - : int option = Some 5
 - : 'a Or_null.t = Or_null.Null
-- : string Or_null.t = Or_null.This "test"
+- : string Or_null.t = <unknown constructor>
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -77,7 +77,7 @@ let test =
   a'.y
 
 [%%expect{|
-val test : int or_null = Null
+val test : int or_null = <unknown constructor>
 |}]
 
 let mytup = (4, This 5)

--- a/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -6,7 +6,7 @@
 type ('a : value) t : value_or_null = 'a or_null [@@or_null_reexport]
 
 [%%expect{|
-type 'a t = 'a or_null = Null | This of 'a
+type 'a t = 'a or_null : value_or_null = Null | This of 'a [@@unboxed]
 |}]
 
 let to_option (x : 'a or_null) =
@@ -30,7 +30,7 @@ val of_option : 'a option -> 'a t = <fun>
 let pi = This 3.14
 
 [%%expect{|
-val pi : float t = This 3.14
+val pi : float t = <unknown constructor>
 |}]
 
 let pi' =
@@ -38,7 +38,7 @@ let pi' =
   value
 
 [%%expect{|
-val pi' : float t = This 3.14
+val pi' : float t = <unknown constructor>
 |}]
 
 type myrec = { x : int; y : int or_null }
@@ -77,13 +77,13 @@ let test =
   a'.y
 
 [%%expect{|
-val test : int or_null = <unknown constructor>
+val test : int or_null = Null
 |}]
 
 let mytup = (4, This 5)
 
 [%%expect{|
-val mytup : int * int t = (4, This 5)
+val mytup : int * int t = (4, <unknown constructor>)
 |}]
 
 type mytup' = int * int t

--- a/ocaml/tools/dumpobj.ml
+++ b/ocaml/tools/dumpobj.ml
@@ -25,7 +25,7 @@ open Printf
 
 let print_banners = ref true
 let print_locations = ref true
-let print_reloc_info = ref false
+let print_reloc_info = ref true
 
 (* Read signed and unsigned integers *)
 
@@ -78,8 +78,12 @@ let record_events orig evl =
 let same_custom x y =
   Nativeint.equal (Obj.raw_field x 0) (Obj.raw_field (Obj.repr y) 0)
 
+external is_null : Obj.t -> bool = "caml_is_null"
+
 let rec print_obj x =
-  if Obj.is_block x then begin
+  if is_null x then
+    printf "null"
+  else if Obj.is_block x then begin
     let tag = Obj.tag x in
     if tag = Obj.string_tag then
         printf "%S" (Obj.magic x : string)

--- a/ocaml/typing/datarepr.ml
+++ b/ocaml/typing/datarepr.ml
@@ -266,7 +266,8 @@ let find_constr ~constant tag cstrs =
       (function
         | ({cstr_tag=Ordinary {runtime_tag=tag'}; cstr_constant},_) ->
           tag' = tag && cstr_constant = constant
-        | ({cstr_tag=(Extension _ | Null)},_) -> false)
+        | ({cstr_tag=Null; cstr_constant}, _) -> tag = -1 && cstr_constant = constant
+        | ({cstr_tag=Extension _},_) -> false)
       cstrs
   with
   | Not_found -> raise Constr_not_found

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -480,7 +480,7 @@ let add_or_null add_type env =
   let add_type1 = mk_add_type1 add_type in
   let kind tvar =
     let cstrs = [cstr ident_null []; cstr ident_this [unrestricted tvar]] in
-    if !Clflags.native_code && Config.runtime5 then
+    if Config.runtime5 then
       Type_variant (cstrs, Variant_with_null)
     else
       variant cstrs


### PR DESCRIPTION
Title. `Stdlib_alpha.Or_null` is commented out, uncommenting it crashes the bootstrap compiler with:
```
File "ocaml/otherlibs/stdlib_alpha/.stdlib_alpha.objs/byte/_unknown_", line 1, characters 0-0:
Fatal error: exception Invalid_argument("output_value: abstract value (outside heap)")
Raised by primitive operation at Emitcode.marshal_to_channel_with_possibly_32bit_compat in file "ocaml/bytecomp/emitcode.ml", line 32, characters 4-117
```
Fixed by https://github.com/ocaml-flambda/flambda-backend/pull/2936.