### PR TITLE
Fix soundness bug allowing semi-arbitrary (non-`Tconstr`) manifests for datatypes

### DIFF
--- a/ocaml/testsuite/tests/typing-misc/datatype_manifests.ml
+++ b/ocaml/testsuite/tests/typing-misc/datatype_manifests.ml
@@ -1,0 +1,13 @@
+(* TEST
+ expect;
+*)
+
+type t = int * int = { foo : string }
+[%%expect{|
+type t = int * int = { foo : string; }
+|}];;
+
+let f (x : int * int) = (x : t)
+[%%expect{|
+val f : int * int -> t = <fun>
+|}];;

--- a/ocaml/testsuite/tests/typing-misc/datatype_manifests.ml
+++ b/ocaml/testsuite/tests/typing-misc/datatype_manifests.ml
@@ -4,10 +4,17 @@
 
 type t = int * int = { foo : string }
 [%%expect{|
-type t = int * int = { foo : string; }
+Line 1, characters 0-37:
+1 | type t = int * int = { foo : string }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         int * int
 |}];;
 
 let f (x : int * int) = (x : t)
 [%%expect{|
-val f : int * int -> t = <fun>
+Line 1, characters 29-30:
+1 | let f (x : int * int) = (x : t)
+                                 ^
+Error: Unbound type constructor t
 |}];;

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1181,7 +1181,7 @@ let check_kind_coherence env loc dpath decl =
       with Not_found ->
         raise(Error(loc, Unavailable_type_constructor path))
       end
-    | _ -> ()
+    | _ -> raise (Error(loc, Definition_mismatch (ty, env, None)))
     end
   | _ -> ()
 


### PR DESCRIPTION
```
# type t = int * int = { foo : string }
type t = int * int = { foo : string; } 
# let magic (t : t) = (t : int * int) ;;
val magic : t -> int * int = <fun> 
# magic { foo = "abc" } ;;
(undefined behaviour in utop - depending on the conversion, either fails an assert here or segfaults)
```

The bug allows the introduction of arbitrary non-Tconstr manifests for datatypes (so the case that used to check normally like `('a, 'b) t = ('a, 'b) s = ...` is still checked correctly), implementing Obj.magic

Seems to have been introduced by #2749 