### PR TITLE
Fix ocaml/otherlibs/unix/

### DIFF
--- a/ocaml/otherlibs/unix/dune
+++ b/ocaml/otherlibs/unix/dune
@@ -12,10 +12,7 @@
 ;*                                                                        *
 ;**************************************************************************
 
-(rule
- (deps unix_unix.ml)
- (targets unix.ml)
- (action (copy unix_unix.ml unix.ml)))
+(copy_files# caml/*.h)
 
 (library
  (name unix)

--- a/ocaml/otherlibs/unix/getnameinfo.c
+++ b/ocaml/otherlibs/unix/getnameinfo.c
@@ -44,7 +44,8 @@ CAMLprim value caml_unix_getnameinfo(value vaddr, value vopts)
   int opts, retcode;
 
   caml_unix_get_sockaddr(vaddr, &addr, &addr_len);
-  opts = caml_convert_flag_list(vopts, getnameinfo_flag_table);
+  // CR ocaml 5 all-runtime5: remove cast
+  opts = caml_convert_flag_list(vopts, (int*) getnameinfo_flag_table);
   caml_enter_blocking_section();
   retcode =
     getnameinfo((const struct sockaddr *) &addr.s_gen, addr_len,


### PR DESCRIPTION
The only notable thing here is that the process creation (etc) functions in `Unix` now rely on the `Mutex` module.  In the context of the way `Mutex` is handled in flambda-backend, following its move to the stdlib in OCaml 5, this means that the threads library must be linked before using these functions or a runtime failure will occur.  I think this is probably ok especially given that we're getting pretty close to being able to move to the OCaml 5 runtime by default.  We are testing on the JS tree.

I think this should be ok to merge and if this failure causes a problem, we can apply a subsequent fix (although it's not clear what that would be).