### PR TITLE
Minor fix to ocaml/file_formats/cmt_format.ml

### DIFF
--- a/ocaml/file_formats/cmt_format.ml
+++ b/ocaml/file_formats/cmt_format.ml
@@ -385,7 +385,11 @@ let index_occurrences binary_annots =
 
 exception Error of error
 
-let input_cmt ic = (Compression.input_value ic : cmt_infos)
+let input_cmt ic : cmt_infos =
+  (* CR ocaml 5 compressed-marshal mshinwell:
+     (Compression.input_value ic : cmt_infos)
+  *)
+  Marshal.from_channel ic
 
 let output_cmt oc cmt =
   output_string oc Config.cmt_magic_number;


### PR DESCRIPTION
Just to cope with the fact that we don't support compressed marshalling in flambda-backend at the moment.