### PR TITLE
Improve the modes of legacy `lazy`.

### DIFF
--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -6,7 +6,7 @@ let dummy_jkind = Jkind.Builtin.value ~why:(Unknown "dummy_layout")
 let dummy_value_mode = Value.disallow_right Value.legacy
 
 let dummy_alloc_mode =
-  { mode = Alloc.disallow_left Alloc.legacy; closure_context = None }
+  { mode = Alloc.disallow_left Alloc.legacy; locality_context = None }
 
 let mkTvar name = Tvar { name; jkind = dummy_jkind }
 

--- a/ocaml/testsuite/tests/tool-toplevel/pr6468.compilers.reference
+++ b/ocaml/testsuite/tests/tool-toplevel/pr6468.compilers.reference
@@ -8,17 +8,17 @@ Warning 21 [nonreturning-statement]: this statement never returns (or has an uns
 val g : unit -> int = <fun>
 Exception: Not_found.
 Raised at Stdlib__Map.Make.find in file "map.ml", line 146, characters 10-25
-Called from Env.find_type_data in file "ocaml/typing/env.ml", line 1271, characters 8-48
+Called from Env.find_type_data in file "ocaml/typing/env.ml", line 1274, characters 8-48
 Re-raised at Ident.find_same in file "ocaml/typing/ident.ml", line 297, characters 6-21
-Called from Env.IdTbl.find_same_without_locks in file "ocaml/typing/env.ml", line 425, characters 10-40
+Called from Env.IdTbl.find_same_without_locks in file "ocaml/typing/env.ml", line 428, characters 10-40
 Re-raised at Stdlib__Map.Make.find in file "map.ml", line 146, characters 10-25
-Called from Env.find_type_data in file "ocaml/typing/env.ml", line 1271, characters 8-48
+Called from Env.find_type_data in file "ocaml/typing/env.ml", line 1274, characters 8-48
 Re-raised at Ident.find_same in file "ocaml/typing/ident.ml", line 297, characters 6-21
-Called from Env.IdTbl.find_same_without_locks in file "ocaml/typing/env.ml", line 425, characters 10-40
+Called from Env.IdTbl.find_same_without_locks in file "ocaml/typing/env.ml", line 428, characters 10-40
 Re-raised at Stdlib__Map.Make.find in file "map.ml", line 146, characters 10-25
-Called from Env.find_type_data in file "ocaml/typing/env.ml", line 1271, characters 8-48
+Called from Env.find_type_data in file "ocaml/typing/env.ml", line 1274, characters 8-48
 Re-raised at Ident.find_same in file "ocaml/typing/ident.ml", line 297, characters 6-21
-Called from Env.IdTbl.find_same_without_locks in file "ocaml/typing/env.ml", line 425, characters 10-40
+Called from Env.IdTbl.find_same_without_locks in file "ocaml/typing/env.ml", line 428, characters 10-40
 Re-raised at Ident.find_same in file "ocaml/typing/ident.ml", line 297, characters 6-21
 Called from Translmod.toplevel_name in file "ocaml/lambda/translmod.ml", line 1599, characters 6-40
 Re-raised at Stdlib__Hashtbl.find in file "hashtbl.ml", line 547, characters 13-28

--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -549,7 +549,7 @@ let leak_ref_2 =
 Line 3, characters 39-40:
 3 |   use_locally (fun x -> let _ = local_ r in r.contents <- Some x; x) 42
                                            ^
-Error: The value "r" is local, so cannot be used inside a closure that might escape.
+Error: The value "r" is local, so cannot be used inside a function that might escape.
 |}]
 
 let leak_ref_3 =
@@ -881,8 +881,8 @@ val local_cb : local_ (unit -> 'a) -> 'a = <fun>
 Line 2, characters 41-42:
 2 | let foo (local_ x) = local_cb (fun () -> x := 17; 42)
                                              ^
-Error: The value "x" is local, so cannot be used inside a closure that might escape.
-Hint: The closure might escape because it is an argument to a tail call
+Error: The value "x" is local, so cannot be used inside a function that might escape.
+Hint: The function might escape because it is an argument to a tail call
 |}]
 
 let foo x =

--- a/ocaml/testsuite/tests/typing-modes/currying.ml
+++ b/ocaml/testsuite/tests/typing-modes/currying.ml
@@ -275,7 +275,7 @@ let bug3 () =
 Line 3, characters 63-64:
 3 |     fun ~a -> fun[@curry] ~b -> fun[@curry] ~c -> print_string a
                                                                    ^
-Error: The value "a" is local, so cannot be used inside a closure that might escape.
+Error: The value "a" is local, so cannot be used inside a function that might escape.
 |}]
 let overapp ~(local_ a) ~b = (); fun ~c ~d -> ()
 

--- a/ocaml/testsuite/tests/typing-modes/lazy.ml
+++ b/ocaml/testsuite/tests/typing-modes/lazy.ml
@@ -8,7 +8,8 @@ let use_portable : 'a @ portable -> unit = fun _ -> ()
 val use_portable : 'a @ portable -> unit = <fun>
 |}]
 
-(* The thunk and the result are required to be global *)
+(* The thunk and the result are required to be global. This is only because we
+don't support allocating lazy values on the stack. *)
 let foo () =
     lazy (let x @ local = "hello" in x)
 [%%expect{|

--- a/ocaml/testsuite/tests/typing-modes/lazy.ml
+++ b/ocaml/testsuite/tests/typing-modes/lazy.ml
@@ -2,24 +2,102 @@
     expect;
 *)
 
-(* lazy expression is legacy *)
-let u =
-    let _x @ portable = lazy "hello" in
-    ()
+let use_portable : 'a @ portable -> unit = fun _ -> ()
 [%%expect{|
-Line 2, characters 24-36:
-2 |     let _x @ portable = lazy "hello" in
-                            ^^^^^^^^^^^^
+val use_portable : 'a @ portable -> unit = <fun>
+|}]
+
+(* The thunk and the result are required to be global *)
+let foo () =
+    lazy (let x @ local = "hello" in x)
+[%%expect{|
+Line 2, characters 37-38:
+2 |     lazy (let x @ local = "hello" in x)
+                                         ^
+Error: This value escapes its region.
+  Hint: It is the result of a lazy expression.
+|}]
+
+let foo (local_ x) =
+    lazy (let _ = x in ())
+[%%expect{|
+Line 2, characters 18-19:
+2 |     lazy (let _ = x in ())
+                      ^
+Error: The value "x" is local, so cannot be used inside a lazy expression.
+|}]
+
+(* lazy expression is constructed as global *)
+let foo () =
+    lazy ("hello")
+[%%expect{|
+val foo : unit -> string lazy_t = <fun>
+|}]
+
+(* result of lazy is available as global always *)
+let foo (x @ local) =
+    match x with
+    | lazy y -> y
+[%%expect{|
+val foo : local_ 'a lazy_t -> 'a = <fun>
+|}]
+
+(* one can construct portable lazy, if both the thunk and the result are
+   portable *)
+let foo () =
+    let l = lazy (let x @ nonportable = fun x -> x in x) in
+    use_portable l
+[%%expect{|
+Line 3, characters 17-18:
+3 |     use_portable l
+                     ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-(* lazy body is legacy *)
-let x = lazy ("hello" : _ @@ local)
+let foo (x @ nonportable) =
+    let l = lazy (let _ = x in ()) in
+    use_portable l
 [%%expect{|
-Line 1, characters 13-35:
-1 | let x = lazy ("hello" : _ @@ local)
-                 ^^^^^^^^^^^^^^^^^^^^^^
-Error: This value escapes its region.
+Line 3, characters 17-18:
+3 |     use_portable l
+                     ^
+Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-(* Forcing lazy gives legacy, but that's in stdlib and not compiler *)
+let foo (x @ portable) =
+    let l = lazy (let _ = x in let y = fun () -> () in y) in
+    use_portable l
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+(* inside a portable lazy, things are available as contended *)
+let foo (x @ uncontended) =
+    let l @ portable = lazy ( let x' @ uncontended = x in ()) in
+    use_portable l
+[%%expect{|
+Line 2, characters 53-54:
+2 |     let l @ portable = lazy ( let x' @ uncontended = x in ()) in
+                                                         ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(* Portable lazy gives portable result *)
+let foo (x @ portable) =
+    match x with
+    | lazy r -> use_portable x
+[%%expect{|
+val foo : 'a lazy_t @ portable -> unit = <fun>
+|}]
+
+let foo (x @ nonportable) =
+    match x with
+    | lazy r -> use_portable x
+[%%expect{|
+Line 3, characters 29-30:
+3 |     | lazy r -> use_portable x
+                                 ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+(* stdlib's [Lazy.force] is a special case of lazy pattern *)

--- a/ocaml/testsuite/tests/typing-modes/lazy.ml
+++ b/ocaml/testsuite/tests/typing-modes/lazy.ml
@@ -1,4 +1,5 @@
 (* TEST
+    flags += "-extension unique";
     expect;
 *)
 
@@ -115,3 +116,19 @@ Error: This value is contended but expected to be uncontended.
 |}]
 
 (* stdlib's [Lazy.force] is a special case of lazy pattern *)
+
+(* thunk can close over [unique] values and be [once], even if the lazy itself is [many]. *)
+let use_unique (_ @ unique) = ()
+let use_many (_ @ many) = ()
+[%%expect{|
+val use_unique : unique_ 'a -> unit = <fun>
+val use_many : 'a -> unit = <fun>
+|}]
+
+let foo () =
+    let x = "hello" in
+    let t = lazy (use_unique x) in
+    use_many t
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]

--- a/ocaml/testsuite/tests/typing-modes/lazy.ml
+++ b/ocaml/testsuite/tests/typing-modes/lazy.ml
@@ -111,7 +111,7 @@ let foo (x @ contended) =
 Line 3, characters 6-12:
 3 |     | lazy _ -> ()
           ^^^^^^
-Error: This value is contended but expected to be uncontended.
+Error: This value is "contended" but expected to be "uncontended".
   Hint: In order to force the lazy expression,
   the lazy needs to be uncontended.
 |}]

--- a/ocaml/testsuite/tests/typing-modes/lazy.ml
+++ b/ocaml/testsuite/tests/typing-modes/lazy.ml
@@ -100,4 +100,18 @@ Line 3, characters 29-30:
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
+(* forcing a lazy is not concurrency-safe; therefore, we require uncontended
+   access *)
+let foo (x @ contended) =
+    match x with
+    | lazy _ -> ()
+[%%expect{|
+Line 3, characters 6-12:
+3 |     | lazy _ -> ()
+          ^^^^^^
+Error: This value is contended but expected to be uncontended.
+  Hint: In order to force the lazy expression,
+  the lazy needs to be uncontended.
+|}]
+
 (* stdlib's [Lazy.force] is a special case of lazy pattern *)

--- a/ocaml/testsuite/tests/typing-modes/portable-contend.ml
+++ b/ocaml/testsuite/tests/typing-modes/portable-contend.ml
@@ -239,7 +239,7 @@ let foo : 'a @ contended portable -> (string -> string) @ portable @@ uncontende
 Line 1, characters 104-114:
 1 | let foo : 'a @ contended portable -> (string -> string) @ portable @@ uncontended portable = fun a b -> best_bytes ()
                                                                                                             ^^^^^^^^^^
-Error: The value "best_bytes" is nonportable, so cannot be used inside a closure that is portable.
+Error: The value "best_bytes" is nonportable, so cannot be used inside a function that is portable.
 |}]
 
 (* immediates crosses portability and contention *)

--- a/ocaml/testsuite/tests/typing-modes/rec.ml
+++ b/ocaml/testsuite/tests/typing-modes/rec.ml
@@ -35,7 +35,7 @@ let te (local_ x) =
 Line 3, characters 12-13:
 3 |         bar x y
                 ^
-Error: The value "x" is local, so cannot be used inside a closure that might escape.
+Error: The value "x" is local, so cannot be used inside a function that might escape.
 |}]
 
 (* for mixed definitions, the other axes are not constrained. *)

--- a/ocaml/testsuite/tests/typing-modes/val_modalities.ml
+++ b/ocaml/testsuite/tests/typing-modes/val_modalities.ml
@@ -314,7 +314,7 @@ end
 Line 6, characters 12-15:
 6 |     let _ = M.x in
                 ^^^
-Error: The value "M.x" is nonportable, so cannot be used inside a closure that is portable.
+Error: The value "M.x" is nonportable, so cannot be used inside a function that is portable.
 |}]
 
 (* Modalities on primitives are supported. They are simpler than real values,

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -306,13 +306,17 @@ type locality_context =
   | Tailcall_argument
   | Partial_application
   | Return
+  | Lazy
+
+type closure_context =
+  | Function of locality_context option
+  | Lazy
 
 type escaping_context =
   | Letop
   | Probe
   | Class
   | Module
-  | Lazy
 
 type shared_context =
   | For_loop
@@ -323,12 +327,11 @@ type shared_context =
   | Class
   | Module
   | Probe
-  | Lazy
 
 type lock =
   | Escape_lock of escaping_context
   | Share_lock of shared_context
-  | Closure_lock of locality_context option * Mode.Value.Comonadic.r
+  | Closure_lock of closure_context * Mode.Value.Comonadic.r
   | Region_lock
   | Exclave_lock
   | Unboxed_lock (* to prevent capture of terms with non-value types *)
@@ -756,7 +759,7 @@ type lookup_error =
   | Local_value_escaping of lock_item * Longident.t * escaping_context
   | Once_value_used_in of lock_item * Longident.t * shared_context
   | Value_used_in_closure of lock_item * Longident.t *
-      Mode.Value.Comonadic.error * locality_context option
+      Mode.Value.Comonadic.error * closure_context
   | Local_value_used_in_exclave of lock_item * Longident.t
   | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
 
@@ -2455,9 +2458,9 @@ let add_share_lock shared_context env =
   let lock = Share_lock shared_context in
   add_lock lock env
 
-let add_closure_lock ?locality_context comonadic env =
+let add_closure_lock closure_context comonadic env =
   let lock = Closure_lock
-    (locality_context,
+    (closure_context,
      Mode.Value.Comonadic.disallow_left comonadic)
   in
   add_lock lock env
@@ -3989,7 +3992,6 @@ let string_of_escaping_context : escaping_context -> string =
   | Probe -> "a probe"
   | Class -> "a class"
   | Module -> "a module"
-  | Lazy -> "a lazy expression"
 
 let string_of_shared_context : shared_context -> string =
   function
@@ -4001,7 +4003,6 @@ let string_of_shared_context : shared_context -> string =
   | Class -> "a class"
   | Module -> "a module"
   | Probe -> "a probe"
-  | Lazy -> "a lazy expression"
 
 let sharedness_hint ppf : shared_context -> _ = function
   | For_loop ->
@@ -4037,10 +4038,6 @@ let sharedness_hint ppf : shared_context -> _ = function
     Format.fprintf ppf
         "@[Hint: This identifier cannot be used uniquely,@ \
           because it is defined outside of the probe.@]"
-  | Lazy ->
-    Format.fprintf ppf
-        "@[Hint: This identifier cannot be used uniquely,@ \
-          because it is defined outside of the lazy expression.@]"
 
 let print_lock_item ppf (item, lid) =
   match item with
@@ -4187,17 +4184,32 @@ let report_lookup_error _loc env ppf = function
         | Error (Linearity, _) -> "once", "is many"
         | Error (Portability, _) -> "nonportable", "is portable"
       in
+      let s, hint =
+        match context with
+        | Function context ->
+            let hint =
+              match error, context with
+              | Error (Areality, _), Some Tailcall_argument ->
+                  fun ppf ->
+                    fprintf ppf "@.@[Hint: The function might escape because it \
+                                is an argument to a tail call@]"
+              | _ -> fun _ppf -> ()
+            in
+            "function that " ^ e1, hint
+        | Lazy ->
+            let s =
+              match error with
+              | Error (Areality, _) -> "lazy expression"
+              | _ -> "lazy expression that " ^ e1
+            in
+            s, fun _ppf -> ()
+      in
       fprintf ppf
       "@[%a %s, so cannot be used \
-            inside a closure that %s.@]"
+            inside a %s.@]"
       print_lock_item (item, lid)
-      e0 e1;
-      begin match error, context with
-      | Error (Areality, _), Some Tailcall_argument ->
-         fprintf ppf "@.@[Hint: The closure might escape because it \
-                          is an argument to a tail call@]"
-      | _ -> ()
-      end
+      e0 s;
+      hint ppf
   | Local_value_used_in_exclave (item, lid) ->
       fprintf ppf "@[%a local, so it cannot be used \
                   inside an exclave_@]"

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -176,7 +176,7 @@ type unbound_value_hint =
   | No_hint
   | Missing_rec of Location.t
 
-type closure_context =
+type locality_context =
   | Tailcall_function
   | Tailcall_argument
   | Partial_application
@@ -229,7 +229,7 @@ type lookup_error =
   | Cannot_scrape_alias of Longident.t * Path.t
   | Local_value_escaping of lock_item * Longident.t * escaping_context
   | Once_value_used_in of lock_item * Longident.t * shared_context
-  | Value_used_in_closure of lock_item * Longident.t * Mode.Value.Comonadic.error * closure_context option
+  | Value_used_in_closure of lock_item * Longident.t * Mode.Value.Comonadic.error * locality_context option
   | Local_value_used_in_exclave of lock_item * Longident.t
   | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
 
@@ -457,7 +457,7 @@ val add_escape_lock : escaping_context -> t -> t
     `unique` variables beyond the lock can still be accessed, but will be
     relaxed to `shared` *)
 val add_share_lock : shared_context -> t -> t
-val add_closure_lock : ?closure_context:closure_context
+val add_closure_lock : ?locality_context:locality_context
   -> ('l * Mode.allowed) Mode.Value.Comonadic.t -> t -> t
 val add_region_lock : t -> t
 val add_exclave_lock : t -> t

--- a/ocaml/typing/env.mli
+++ b/ocaml/typing/env.mli
@@ -181,13 +181,17 @@ type locality_context =
   | Tailcall_argument
   | Partial_application
   | Return
+  | Lazy
+
+type closure_context =
+  | Function of locality_context option
+  | Lazy
 
 type escaping_context =
   | Letop
   | Probe
   | Class
   | Module
-  | Lazy
 
 type shared_context =
   | For_loop
@@ -198,7 +202,6 @@ type shared_context =
   | Class
   | Module
   | Probe
-  | Lazy
 
 (** Items whose accesses are affected by locks *)
 type lock_item =
@@ -229,7 +232,7 @@ type lookup_error =
   | Cannot_scrape_alias of Longident.t * Path.t
   | Local_value_escaping of lock_item * Longident.t * escaping_context
   | Once_value_used_in of lock_item * Longident.t * shared_context
-  | Value_used_in_closure of lock_item * Longident.t * Mode.Value.Comonadic.error * locality_context option
+  | Value_used_in_closure of lock_item * Longident.t * Mode.Value.Comonadic.error * closure_context
   | Local_value_used_in_exclave of lock_item * Longident.t
   | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
 
@@ -457,7 +460,7 @@ val add_escape_lock : escaping_context -> t -> t
     `unique` variables beyond the lock can still be accessed, but will be
     relaxed to `shared` *)
 val add_share_lock : shared_context -> t -> t
-val add_closure_lock : ?locality_context:locality_context
+val add_closure_lock : closure_context
   -> ('l * Mode.allowed) Mode.Value.Comonadic.t -> t -> t
 val add_region_lock : t -> t
 val add_exclave_lock : t -> t

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -6208,7 +6208,8 @@ and type_expect_
       with_explanation (fun () ->
         unify_exp_types loc env to_unify (generic_instance ty_expected));
       let closure_mode =
-        as_single_mode expected_mode
+        expected_mode
+        |> as_single_mode
         (* the thunk is evaluated only once, so we only require it to be [once],
            even if the [lazy] is [many]. *)
         |> Value.join_with (Comonadic Linearity) Linearity.Const.Once

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -2914,7 +2914,7 @@ and type_pat_aux
            pat_attributes = sp.ppat_attributes;
            pat_env = !!penv }
   | Ppat_lazy sp1 ->
-      submode ~loc ~env:!env alloc_mode.mode mode_force_lazy;
+      submode ~loc ~env:!!penv alloc_mode.mode mode_force_lazy;
       let nv = solve_Ppat_lazy ~refine:false loc penv expected_ty in
       let alloc_mode = global_pat_mode alloc_mode in
       let p1 = type_pat ~alloc_mode tps Value sp1 nv in

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -185,6 +185,7 @@ val self_coercion : (Path.t * Location.t list ref) list ref
 type contention_context =
   | Read_mutable
   | Write_mutable
+  | Force_lazy
 
 type unsupported_stack_allocation =
   | Lazy

--- a/ocaml/typing/typecore.mli
+++ b/ocaml/typing/typecore.mli
@@ -293,7 +293,7 @@ type error =
   | Expr_not_a_record_type of type_expr
   | Submode_failed of
       Mode.Value.error * submode_reason *
-      Env.closure_context option *
+      Env.locality_context option *
       contention_context option *
       Env.shared_context option
   | Curried_application_complete of
@@ -311,7 +311,7 @@ type error =
   | Function_type_not_rep of type_expr * Jkind.Violation.t
   | Invalid_label_for_src_pos of arg_label
   | Nonoptional_call_pos_label of string
-  | Cannot_stack_allocate of Env.closure_context option
+  | Cannot_stack_allocate of Env.locality_context option
   | Unsupported_stack_allocation of unsupported_stack_allocation
   | Not_allocation
 

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -56,7 +56,7 @@ type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
 type alloc_mode = {
   mode : Mode.Alloc.r;
-  closure_context : Env.closure_context option;
+  locality_context : Env.locality_context option;
 }
 
 type texp_field_boxing =

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -73,7 +73,7 @@ type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
 type alloc_mode = {
   mode : Mode.Alloc.r;
-  closure_context : Env.closure_context option;
+  locality_context : Env.locality_context option;
 }
 
 type texp_field_boxing =


### PR DESCRIPTION
This PR improves the modes of the existing `lazy` construction, without changing its runtime behaviour.

# Some analysis

- Upon cosntruction, the comonadic fragment of the lazy must be higher/weaker than both the thunk and the result.

- When projecting the result, the result will have the same mode as the lazy. Therefore, upon construction we should require the lazy to be higher/weaker than the result.

- The regionality axis is special: I'm not familiar with how the thunk is evaluated and the result allocated, so I conservatively require both to be `global`. That also means a global modality upon projection for better ergonomics.

- The lazy itself might be safe to be stack-allocated, but that involves middle-end changes which I leave to future work. For now, the lazy itself is also heap-allocated.

- Note that the existing legacy behaviour of lazy is a special case of the above.

# Review

Please review by commits.