### PR TITLE
Relax modes for `probe`

### DIFF
--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -696,7 +696,6 @@ type lambda =
   (* [Lexclave] closes the newest region opened.
      Note that [Lexclave] nesting is currently unsupported. *)
   | Lexclave of lambda
-  (** Exit the current region and proceed to the subexpression. *)
 
 and rec_binding = {
   id : Ident.t;
@@ -715,13 +714,8 @@ and lfunction = private
     loc : scoped_location;
     mode : alloc_mode;     (* alloc mode of the closure itself *)
     ret_mode: alloc_mode;
-    (** The mode of the return value. If [local], the function might allocate in
-        caller's region. *)
-    region : bool;
-    (** Does the function have a region? Even if this is [true], the function
-        can still allocate in caller's region via [Lexclave].
-
-        CR zqian: this field is always true and should be removed. *)
+    region : bool;         (* false if this function may locally
+                              allocate in the caller's region *)
   }
 
 and lambda_while =

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -696,6 +696,7 @@ type lambda =
   (* [Lexclave] closes the newest region opened.
      Note that [Lexclave] nesting is currently unsupported. *)
   | Lexclave of lambda
+  (** Exit the current region and proceed to the subexpression. *)
 
 and rec_binding = {
   id : Ident.t;
@@ -714,8 +715,13 @@ and lfunction = private
     loc : scoped_location;
     mode : alloc_mode;     (* alloc mode of the closure itself *)
     ret_mode: alloc_mode;
-    region : bool;         (* false if this function may locally
-                              allocate in the caller's region *)
+    (** The mode of the return value. If [local], the function might allocate in
+        caller's region. *)
+    region : bool;
+    (** Does the function have a region? Even if this is [true], the function
+        can still allocate in caller's region via [Lexclave].
+
+        CR zqian: this field is always true and should be removed. *)
   }
 
 and lambda_while =

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1128,7 +1128,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           ~attr
           ~mode:alloc_heap
           ~ret_mode:alloc_local
-          ~region:false
+          (* CR zqian: the handler function doesn't have a region. However, the
+             [region] field is currently broken. *)
+          ~region:true
       in
       let app =
         { ap_func = Lvar funcid;

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1096,10 +1096,6 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           ignore (Env.find_module_lazy path e.exp_env)
       ) arg_idents;
       let body = Lambda.rename map lam in
-      let body =
-        if Config.stack_allocation then Lexclave body
-        else body
-      in
       let attr =
         { inline = Never_inline;
           specialise = Always_specialise;
@@ -1127,7 +1123,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
              probes. *)
           ~params:(List.map (fun name -> { name; layout = layout_probe_arg; attributes = Lambda.default_param_attribute; mode = alloc_local }) param_idents)
           ~return:return_layout
-          ~body:(maybe_region_layout return_layout body)
+          ~body:body
           ~loc:(of_location ~scopes exp.exp_loc)
           ~attr
           ~mode:alloc_heap

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1128,7 +1128,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           ~attr
           ~mode:alloc_heap
           ~ret_mode:alloc_local
-          ~region:true
+          ~region:false
       in
       let app =
         { ap_func = Lvar funcid;

--- a/ocaml/testsuite/tests/typing-modes/probe.ml
+++ b/ocaml/testsuite/tests/typing-modes/probe.ml
@@ -1,0 +1,12 @@
+(* TEST
+    flags += "-extension unique";
+    expect;
+*)
+
+(* probe can refer to local,nonportable,once values *)
+
+let f (x @ local nonportable once) =
+    [%probe "a" (let _ = x in ())]
+[%%expect{|
+val f : local_ once_ 'a -> unit = <fun>
+|}]

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -6296,8 +6296,6 @@ and type_expect_
     | Error () -> raise (Error (loc, env, Probe_format))
     | Ok { name; name_loc; enabled_at_init; arg; } ->
         check_probe_name name name_loc env;
-        let env = Env.add_escape_lock Probe env in
-        let env = Env.add_share_lock Probe env in
         Env.add_probe name;
         let exp = type_expect env mode_legacy arg
                     (mk_expected Predef.type_unit) in


### PR DESCRIPTION
A prob `[%probe "hello" (a + b + c)]` is compiled (in `translcore.ml`) to:
```
let probe_hello a b c = a + b + c in
probe_hello a b c
```
Closure locks are not needed, because no closing-over is happening. Shared locks are not needed, because nothing is being run more than once. (Surely, this code could be in a loop or something, in which case the loop will add the shared lock as needed).

This PR removes the closure locks/shared locks constraints.