### PR TITLE
Fix mode zapping extra constraint

### DIFF
--- a/ocaml/testsuite/tests/typing-modes/pr2979.compilers.reference
+++ b/ocaml/testsuite/tests/typing-modes/pr2979.compilers.reference
@@ -1,4 +1,5 @@
-File "pr2979.ml", line 12, characters 23-35:
-12 | let[@tail_mod_cons]  f x = (42, 42)
+File "pr2979.ml", line 11, characters 23-35:
+11 | let[@tail_mod_cons]  f x = (42, 42)
                             ^^^^^^^^^^^^
-Error: [@tail_mod_cons]: Functions cannot be both local-returning and [@tail_mod_cons]
+Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons
+but is never applied in TMC position.

--- a/ocaml/testsuite/tests/typing-modes/pr2979.compilers.reference
+++ b/ocaml/testsuite/tests/typing-modes/pr2979.compilers.reference
@@ -1,0 +1,4 @@
+File "pr2979.ml", line 12, characters 23-35:
+12 | let[@tail_mod_cons]  f x = (42, 42)
+                            ^^^^^^^^^^^^
+Error: [@tail_mod_cons]: Functions cannot be both local-returning and [@tail_mod_cons]

--- a/ocaml/testsuite/tests/typing-modes/pr2979.ml
+++ b/ocaml/testsuite/tests/typing-modes/pr2979.ml
@@ -1,0 +1,12 @@
+(* TEST
+ readonly_files = "pr2979.ml pr2979.mli";
+setup-ocamlc.byte-build-env;
+module = "pr2979.mli";
+ocamlc.byte;
+module = "pr2979.ml";
+ocamlc_byte_exit_status = "2";
+ocamlc.byte;
+check-ocamlc.byte-output;
+*)
+
+let[@tail_mod_cons]  f x = (42, 42)

--- a/ocaml/testsuite/tests/typing-modes/pr2979.ml
+++ b/ocaml/testsuite/tests/typing-modes/pr2979.ml
@@ -4,7 +4,6 @@ setup-ocamlc.byte-build-env;
 module = "pr2979.mli";
 ocamlc.byte;
 module = "pr2979.ml";
-ocamlc_byte_exit_status = "2";
 ocamlc.byte;
 check-ocamlc.byte-output;
 *)

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -3044,9 +3044,8 @@ let share_mode ~errors ~env ~loc ~item ~lid vmode shared_context =
         (Once_value_used_in (item, lid, shared_context))
   | Ok () ->
     let mode =
-      Mode.Value.join [
-        Mode.Value.min_with (Monadic Uniqueness) Mode.Uniqueness.shared;
-        vmode.mode]
+      Mode.Value.join_with (Monadic Uniqueness) Mode.Uniqueness.Const.Shared
+        vmode.mode
     in
     {mode; context = Some shared_context}
 

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -444,7 +444,7 @@ let check_tail_call_local_returning loc env ap_mode {region_mode; _} =
 
 let meet_regional mode =
   let mode = Value.disallow_left mode in
-  Value.meet [mode; (Value.max_with (Comonadic Areality) Regionality.regional)]
+  Value.meet_with (Comonadic Areality) Regionality.Const.Regional mode
 
 let mode_default mode =
   { position = RNontail;
@@ -6534,9 +6534,7 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
-           register_allocation_mode
-             (Alloc.meet [Alloc.max_with (Comonadic Areality) mode;
-                          Alloc.max_with (Comonadic Linearity) Linearity.many])
+           register_allocation_mode (Alloc.max_with (Comonadic Areality) mode)
        | _ -> ()
        end;
        ty, Id_prim (Option.map Locality.disallow_right mode, sort)


### PR DESCRIPTION
# The problem

Currently the `zap_to_ceil/floor` in the mode solver impose extra constraints, and is triggering mode errors for sound programs. 

For example, if we have `m' = meet [regional, m]` where `m` is a variable between `global` and `local`. Calling `zap_to_ceil` on this  `meet` will propagate to calling `zap_to_ceil` on `m`, which pushes `m` to `local`. That is wrong, because the ceil of the `meet` is `regional`, so pushing `m` to `regional` is enough. Further pushing it to `local` is imposing extra constraint.

# The impact
It's possible that the extra constraints imposed is producing slower programs, but I don't know.

Because `zap_to_ceil/floor` is called after type checking, the extra constraints imposed aren't causing type errors usually. However, (reported by @ncik-roberts ) TMC rejects local-returning functions, and the check is done in middle-end instead of type checking. As a result, the following sound program (without `.mli`) is currently rejected:
```
let[@tail_mod_cons]  f x = (42, 42)

Error: [@tail_mod_cons]: Functions cannot be both local-returning and [@tail_mod_cons]
```
It should go like this: the allocation mode `m` of the tuple, and the function's return mode `r`, are roughly constrained by `m = regional_to_global (meet [regional, r])`. From this we derive `m = global` and `r` not constrained at all. It's sound for `r` to be `local`, but not desirable; in translcore we will push `r` to its floor(`global`). This `r = global` is accepted by TMC.

Currently, howerver, `optimize_allocation` will try to push `m` to its ceil, which propagates to pushing `r` to its ceil (`local`). This `r=local` is later rejected by TMC.


# Review

Please review by commits.
1. Add test showing the issue.
2. Moves things around without any changes. Can be skipped.
3. fixes the issue in question.
4. rewrites some usage of `meet` to `meet_with`. The latter requires one operand to be constant and is faster. Note that `meet` suffers from the discussed issue while `meet_with` doesn't. After the fix, the two are interchangable, except for performance. Therefore, in this commit we try to use `meet_with` whenever possible.