### PR TITLE
Do not export "fail.h" from "signals.h" in runtime4

### DIFF
--- a/ocaml/runtime4/caml/signals.h
+++ b/ocaml/runtime4/caml/signals.h
@@ -25,7 +25,6 @@
 #endif
 #include "misc.h"
 #include "mlvalues.h"
-#include "fail.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
`"fail.h"` is not re-exported in `"signals.h"` in the OCaml 5 runtime. This PR makes runtime4 consistent in this regard, which will prevent a class of errors in which a C stub compiles when building with runtime4, but not with the OCaml 5 runtime.

This can happen, for example, if a stub includes `"signals.h"` and calls `caml_failwith` without including `"fail.h"`.

Testing: compilation & CI suffices