### PR TITLE
Disable minimizer-upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,16 @@ ci: ci-no-coverage
 endif
 
 .PHONY: ci-no-coverage
-ci-no-coverage: runtest runtest-upstream minimizer-upstream minimizer
+ci-no-coverage: runtest runtest-upstream minimizer
 
 .PHONY: ci-coverage
 ci-coverage: boot-runtest coverage
 
-.PHONY: minimizer-upstream
-minimizer-upstream:
-	cp chamelon/dune.upstream chamelon/dune
-	RUNTIME_DIR=$(RUNTIME_DIR) $(dune) build $(ws_boot) @chamelon/all
+# CR mshinwell: build is broken
+# .PHONY: minimizer-upstream
+# minimizer-upstream:
+# 	cp chamelon/dune.upstream chamelon/dune
+# 	RUNTIME_DIR=$(RUNTIME_DIR) $(dune) build $(ws_main) @chamelon/all
 
 .PHONY: minimizer
 minimizer: _build/_bootinstall


### PR DESCRIPTION
The minimizer "upstream" build doesn't seem important at the moment and needs fixing for 5.2.  We can do that after we've moved to that version.  cc @Ekdohibs 