### PR TITLE
Fix allocation of mixed block closures 

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1375,6 +1375,18 @@ let setfield_unboxed_float32 arr ofs newval dbg =
          [array_indexing log2_size_addr arr ofs dbg; newval],
          dbg ))
 
+let setfield_unboxed_vec128 arr ofs newval dbg =
+  (* CR layouts v5.1: Properly support big-endian. *)
+  if Arch.big_endian
+  then
+    Misc.fatal_error
+      "Unboxed vec128 fields only supported on little-endian architectures";
+  return_unit dbg
+    (Cop
+       ( Cstore (Onetwentyeight_unaligned, Assignment),
+         [array_indexing log2_size_addr arr ofs dbg; newval],
+         dbg ))
+
 (* String length *)
 
 (* Length of string block *)
@@ -1585,9 +1597,8 @@ let make_alloc_generic ?(scannable_prefix = Scan_all) ~mode set_fn dbg tag
     let rec fill_fields idx = function
       | [] -> Cvar id
       | e1 :: el ->
-        Csequence
-          ( set_fn idx (Cvar id) (int_const dbg idx) e1 dbg,
-            fill_fields (idx + 1) el )
+        let set, adv = set_fn idx (Cvar id) (int_const dbg idx) e1 dbg in
+        Csequence (set, fill_fields (idx + adv) el)
     in
     let caml_alloc_func, caml_alloc_args =
       match Config.runtime5, scannable_prefix with
@@ -1634,15 +1645,59 @@ let addr_array_init arr ofs newval dbg =
 
 let make_alloc ~mode dbg ~tag args =
   make_alloc_generic ~mode
-    (fun _ arr ofs newval dbg -> addr_array_init arr ofs newval dbg)
+    (fun _ arr ofs newval dbg -> addr_array_init arr ofs newval dbg, 1)
     dbg tag (List.length args) args
 
 let make_float_alloc ~mode dbg ~tag args =
   make_alloc_generic ~mode
-    (fun _ -> float_array_set)
+    (fun _ arr ofs newval dbg -> float_array_set arr ofs newval dbg, 1)
     dbg tag
     (List.length args * size_float / size_addr)
     args
+
+module Flat_prefix_element = struct
+  type t =
+    | Naked_field
+    | Naked_float
+    | Naked_float32
+    | Naked_int32
+    | Naked_vec128
+
+  let words = function
+    | Naked_field | Naked_float | Naked_float32 | Naked_int32 -> 1
+    | Naked_vec128 -> 2
+
+  let total_words = Array.fold_left (fun len t -> len + words t) 0
+end
+
+let make_mixed_closure ~mode dbg ~value_suffix_size ~flat_prefix fields =
+  (* args with shape [Float] must already have been unboxed. *)
+  let flat_prefix_size = Flat_prefix_element.total_words flat_prefix in
+  let set_fn idx arr ofs newval dbg =
+    if idx >= flat_prefix_size
+    then addr_array_init arr ofs newval dbg, 1
+    else
+      let set =
+        match (flat_prefix.(idx) : Flat_prefix_element.t) with
+        | Naked_field -> int_array_set arr ofs newval dbg
+        | Naked_float -> float_array_set arr ofs newval dbg
+        | Naked_float32 -> setfield_unboxed_float32 arr ofs newval dbg
+        | Naked_int32 -> setfield_unboxed_int32 arr ofs newval dbg
+        | Naked_vec128 -> setfield_unboxed_vec128 arr ofs newval dbg
+      in
+      set, Flat_prefix_element.words flat_prefix.(idx)
+  in
+  let size =
+    (* CR layouts 5.1: When we pack int32s/float32s more efficiently, this code
+       will need to change. *)
+    flat_prefix_size + value_suffix_size
+  in
+  if size_float <> size_addr
+  then
+    Misc.fatal_error
+      "Unable to compile mixed closures on a platform where a float is not the \
+       same width as a value.";
+  make_alloc_generic ~mode set_fn dbg Obj.closure_tag size fields
 
 module Flat_suffix_element = struct
   type t =
@@ -1658,15 +1713,18 @@ let make_mixed_alloc ~mode dbg ~tag ~value_prefix_size
   (* args with shape [Float] must already have been unboxed. *)
   let set_fn idx arr ofs newval dbg =
     if idx < value_prefix_size
-    then addr_array_init arr ofs newval dbg
+    then addr_array_init arr ofs newval dbg, 1
     else
-      match flat_suffix.(idx - value_prefix_size) with
-      | Tagged_immediate -> int_array_set arr ofs newval dbg
-      | Naked_float -> float_array_set arr ofs newval dbg
-      | Naked_float32 -> setfield_unboxed_float32 arr ofs newval dbg
-      | Naked_int32 -> setfield_unboxed_int32 arr ofs newval dbg
-      | Naked_int64_or_nativeint ->
-        setfield_unboxed_int64_or_nativeint arr ofs newval dbg
+      let set =
+        match flat_suffix.(idx - value_prefix_size) with
+        | Tagged_immediate -> int_array_set arr ofs newval dbg
+        | Naked_float -> float_array_set arr ofs newval dbg
+        | Naked_float32 -> setfield_unboxed_float32 arr ofs newval dbg
+        | Naked_int32 -> setfield_unboxed_int32 arr ofs newval dbg
+        | Naked_int64_or_nativeint ->
+          setfield_unboxed_int64_or_nativeint arr ofs newval dbg
+      in
+      set, 1
   in
   let size =
     (* CR layouts 5.1: When we pack int32s/float32s more efficiently, this code

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -325,6 +325,30 @@ val make_float_alloc :
   expression list ->
   expression
 
+module Flat_prefix_element : sig
+  type t =
+    (* Naked int64, naked nativeint, immediate, code pointer, closinfo word *)
+    | Naked_field
+    | Naked_float
+    | Naked_float32
+    | Naked_int32
+    | Naked_vec128
+end
+
+(** Allocate a mixed closure block of the corresponding shape. Initial values
+    of the flat prefix should be provided unboxed.
+
+    Closures are required to have a flat prefix (whereas other blocks have flat suffixes)
+    because the second (closinfo) field indicates the index of the scannable suffix.
+    The caller is responsible for ensuring the closinfo word matches the prefix size. *)
+val make_mixed_closure :
+  mode:Lambda.alloc_mode ->
+  Debuginfo.t ->
+  value_suffix_size:int ->
+  flat_prefix:Flat_prefix_element.t array ->
+  expression list ->
+  expression
+
 module Flat_suffix_element : sig
   type t =
     | Tagged_immediate

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -318,7 +318,7 @@ end = struct
   type _ slot_desc =
     | Function_slot : Function_slot.t -> function_slot slot_desc
     | Unboxed_slot : Value_slot.t -> unboxed_slot slot_desc
-    | Value_slot : Value_slot.t -> value_slot slot_desc
+    | Scannable_value_slot : Value_slot.t -> value_slot slot_desc
 
   (* This module helps to distinguish between the two different notions of
      offsets that are used for function slots:
@@ -358,14 +358,15 @@ end = struct
       let offset =
         match slot with
         | Function_slot _ -> first_offset_used_including_header + 1
-        | Unboxed_slot _ | Value_slot _ -> first_offset_used_including_header
+        | Unboxed_slot _ | Scannable_value_slot _ ->
+          first_offset_used_including_header
       in
       Offset offset
 
     let range_used_by (type a) (slot : a slot_desc) (Offset pos) ~slot_size =
       match slot with
       | Function_slot _ -> pos - 1, pos + slot_size
-      | Unboxed_slot _ | Value_slot _ -> pos, pos + slot_size
+      | Unboxed_slot _ | Scannable_value_slot _ -> pos, pos + slot_size
 
     let add_slot_to_exported_offsets (type a) offsets (slot : a slot_desc)
         (Offset pos) ~slot_size =
@@ -381,7 +382,7 @@ end = struct
             { offset = pos; is_scanned = false; size = slot_size }
         in
         EO.add_value_slot_offset offsets unboxed_slot info
-      | Value_slot value_slot ->
+      | Scannable_value_slot value_slot ->
         let (info : EO.value_slot_info) =
           EO.Live_value_slot
             { offset = pos; is_scanned = true; size = slot_size }
@@ -488,7 +489,7 @@ end = struct
   let print_desc (type a) fmt (slot_desc : a slot_desc) =
     match slot_desc with
     | Function_slot c -> Format.fprintf fmt "%a" Function_slot.print c
-    | Unboxed_slot v | Value_slot v ->
+    | Unboxed_slot v | Scannable_value_slot v ->
       Format.fprintf fmt "%a" Value_slot.print v
 
   let print_slot_pos fmt = function
@@ -556,7 +557,7 @@ end = struct
     | Unassigned | Removed -> ()
     | Assigned offset -> (
       match slot.desc with
-      | Value_slot _ ->
+      | Scannable_value_slot _ ->
         if slot.size <> 1
         then
           Misc.fatal_errorf "Value slot has size %d, which is not 1." slot.size;
@@ -625,7 +626,7 @@ end = struct
         let (info : EO.function_slot_info) = EO.Dead_function_slot in
         state.used_offsets
           <- EO.add_function_slot_offset state.used_offsets function_slot info
-      | Unboxed_slot v | Value_slot v ->
+      | Unboxed_slot v | Scannable_value_slot v ->
         let (info : EO.value_slot_info) = EO.Dead_value_slot in
         state.used_offsets <- EO.add_value_slot_offset state.used_offsets v info
       )
@@ -642,7 +643,7 @@ end = struct
       state.function_slots_to_assign <- slot :: state.function_slots_to_assign
     | Unboxed_slot _ ->
       state.unboxed_slots_to_assign <- slot :: state.unboxed_slots_to_assign
-    | Value_slot _ ->
+    | Scannable_value_slot _ ->
       state.value_slots_to_assign <- slot :: state.value_slots_to_assign
 
   let add_allocated_slot_to_set slot set =
@@ -809,7 +810,9 @@ end = struct
   let create_value_slot set state value_slot =
     if Compilation_unit.is_current (Value_slot.get_compilation_unit value_slot)
     then (
-      let s = create_slot ~size:1 (Value_slot value_slot) Unassigned in
+      let s =
+        create_slot ~size:1 (Scannable_value_slot value_slot) Unassigned
+      in
       add_value_slot state value_slot s;
       add_unallocated_slot_to_set state s set;
       s)
@@ -837,7 +840,10 @@ end = struct
              in the original compilation unit, this should not happen."
             Value_slot.print value_slot;
         let offset = Exported_offset.from_exported_offset offset in
-        let s = create_slot ~size:1 (Value_slot value_slot) (Assigned offset) in
+        let s =
+          create_slot ~size:1 (Scannable_value_slot value_slot)
+            (Assigned offset)
+        in
         use_value_slot_info state value_slot info;
         add_value_slot state value_slot s;
         add_allocated_slot_to_set s set;
@@ -939,7 +945,7 @@ end = struct
     let needed_space =
       match slot.desc with
       | Function_slot _ -> slot.size + 1 (* header word *)
-      | Unboxed_slot _ | Value_slot _ -> slot.size
+      | Unboxed_slot _ | Scannable_value_slot _ -> slot.size
     in
     (* Ensure that for value slots, we are after all function slots. *)
     let curr =
@@ -949,7 +955,7 @@ end = struct
         (* first_slot_after_function_slots is always >=0, thus ensuring we do
            not place a value slot at offset -1 *)
         max start set.first_slot_after_function_slots
-      | Value_slot _ -> max start set.first_slot_after_unboxed_slots
+      | Scannable_value_slot _ -> max start set.first_slot_after_unboxed_slots
     in
     (* Adjust a starting position to not point in the middle of a block.
        Additionally, ensure the value slot slots are put after the function
@@ -1052,7 +1058,7 @@ end = struct
     state.value_slots_to_assign <- [];
     List.iter
       (function
-        | { desc = Value_slot v; _ } as slot ->
+        | { desc = Scannable_value_slot v; _ } as slot ->
           if value_slot_is_used ~used_value_slots v
           then assign_slot_offset state slot
           else mark_slot_as_removed state slot)


### PR DESCRIPTION
Currently, flambda2 allocates closures containing unboxed value slots using `Cmm.make_alloc`. This is problematic in two ways:
- Unboxed vec128 slots are assumed to only take up one word. This can cause the block header length to be shorter than the closinfo startenv index. Due to #2587, this can lead to memory corruption upon promotion.
- Unboxed numbers are written to closures directly allocated on the major heap using `caml_initialize`. If the unboxed numbers look like minor heap pointers, the gc will attempt to promote them. This can also lead to memory corruption.

Additionally, statically allocated closures containing dynamic naked vec128s would not reserve sufficient space for the 128-bit write.

Note these issues are unlikely to arise in practice since we don't yet expose unboxed vec128 types, and closures are only allocated directly on the major heap if they are larger than `max_young_wosize`.

This pr makes the following changes:

flambda2:
- Static value slots now properly use their size in words
- Dynamic closure allocation computes a mixed closure shape based on the slot kinds. Additional size and kind checks have been added here. 
- In the implementation of `Slot_offsets`, the more specific `Value_slot` constructor has been renamed `Scannable_value_slot`

cmm:
- `make_alloc` is now only used for unmixed blocks
- `make_mixed_closure` (analogus to `make_mixed_block`) is now used to allocate closures containing an unboxed prefix