### PR TITLE
Clean up `ret_mode` and `region` in `Lambda.lfunction`

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -851,7 +851,7 @@ and lfunction =
     loc: scoped_location;
     mode: locality_mode;
     ret_mode: locality_mode;
-    region: bool; }
+  }
 
 and lambda_while =
   { wh_cond : lambda;
@@ -938,7 +938,7 @@ let max_arity () =
   (* 126 = 127 (the maximal number of parameters supported in C--)
            - 1 (the hidden parameter containing the environment) *)
 
-let lfunction' ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode ~region =
+let lfunction' ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode =
   assert (List.length params > 0);
   assert (List.length params <= max_arity ());
   (* A curried function type with n parameters has n arrows. Of these,
@@ -959,14 +959,12 @@ let lfunction' ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode ~region =
      let nparams = List.length params in
      assert (0 <= nlocal);
      assert (nlocal <= nparams);
-     if not region then assert (nlocal >= 1);
      if is_local_mode mode then assert (nlocal = nparams)
   end;
-  { kind; params; return; body; attr; loc; mode; ret_mode; region }
+  { kind; params; return; body; attr; loc; mode; ret_mode }
 
-let lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode ~region =
-  Lfunction
-    (lfunction' ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode ~region)
+let lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode =
+  Lfunction (lfunction' ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode)
 
 let lambda_unit = Lconst const_unit
 
@@ -1601,9 +1599,9 @@ let duplicate_function =
      Ident.Map.empty).subst_lfunction
 
 let map_lfunction f { kind; params; return; body; attr; loc;
-                      mode; ret_mode; region } =
+                      mode; ret_mode } =
   let body = f body in
-  { kind; params; return; body; attr; loc; mode; ret_mode; region }
+  { kind; params; return; body; attr; loc; mode; ret_mode }
 
 let shallow_map ~tail ~non_tail:f = function
   | Lvar _

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -959,6 +959,7 @@ let lfunction' ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode =
      let nparams = List.length params in
      assert (0 <= nlocal);
      assert (nlocal <= nparams);
+     if is_local_mode ret_mode then assert (nlocal >= 1);
      if is_local_mode mode then assert (nlocal = nparams)
   end;
   { kind; params; return; body; attr; loc; mode; ret_mode }

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -665,7 +665,9 @@ type loop_attribute =
 type curried_function_kind = { nlocal: int } [@@unboxed]
 (* [nlocal] determines how many arguments may be partially applied
     before the resulting closure must be locally allocated.
-    See [lfunction] for details *)
+    See the implementation of [lfunction] for details *)
+(* CR mshinwell: this comment should presumably say that nlocal = 0 implies
+   that the function cannot allocate in the caller's region *)
 
 type function_kind = Curried of curried_function_kind | Tupled
 
@@ -797,8 +799,6 @@ and lfunction = private
     loc : scoped_location;
     mode : locality_mode;     (* locality of the closure itself *)
     ret_mode: locality_mode;
-    region : bool;         (* false if this function may locally
-                              allocate in the caller's region *)
   }
 
 and lambda_while =
@@ -1002,7 +1002,6 @@ val lfunction :
   loc:scoped_location ->
   mode:locality_mode ->
   ret_mode:locality_mode ->
-  region:bool ->
   lambda
 
 val lfunction' :
@@ -1014,7 +1013,6 @@ val lfunction' :
   loc:scoped_location ->
   mode:locality_mode ->
   ret_mode:locality_mode ->
-  region:bool ->
   lfunction
 
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -663,11 +663,33 @@ type loop_attribute =
   | Default_loop (* no [@loop] attribute *)
 
 type curried_function_kind = { nlocal: int } [@@unboxed]
-(* [nlocal] determines how many arguments may be partially applied
-    before the resulting closure must be locally allocated.
-    See the implementation of [lfunction] for details *)
-(* CR mshinwell: this comment should presumably say that nlocal = 0 implies
-   that the function cannot allocate in the caller's region *)
+(** A well-formed function parameter list is of the form
+     [G @ L @ [ Final_arg ]],
+    where the values of G and L are of the form [More_args { partial_mode }],
+    where [partial_mode] has locality Global in G and locality Local in L.
+
+    [nlocal] is defined as follows:
+      - if {v |L| > 0 v}, then {v nlocal = |L| + 1 v}.
+      - if {v |L| = 0 v},
+        * if the function returns at mode local, the final arg has mode local,
+          or the function itself is allocated locally, then {v nlocal = 1 v}.
+        * otherwise, {v nlocal = 0 v}.
+*)
+
+(* CR-someday: Now that some functions' arity won't be changed downstream of
+   lambda (see [may_fuse_arity = false]), we could change [nlocal] to be
+   more expressive. I suggest the variant:
+
+   {[
+     type partial_application_is_local_when =
+       | Applied_up_to_nth_argument_from_end of int
+       | Never
+   ]}
+
+   I believe this will allow us to get rid of the complicated logic for
+   |L| = 0, and help clarify how clients use this type. I plan on doing
+   this in a follow-on PR.
+*)
 
 type function_kind = Curried of curried_function_kind | Tupled
 
@@ -799,6 +821,8 @@ and lfunction = private
     loc : scoped_location;
     mode : locality_mode;     (* locality of the closure itself *)
     ret_mode: locality_mode;
+    (** alloc mode of the returned value. Also indicates if the function might
+        allocate in the caller's region. *)
   }
 
 and lambda_while =

--- a/lambda/simplif.mli
+++ b/lambda/simplif.mli
@@ -39,5 +39,4 @@ val split_default_wrapper
   -> loc:Lambda.scoped_location
   -> mode:Lambda.locality_mode
   -> ret_mode:Lambda.locality_mode
-  -> region:bool
   -> rec_binding list

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -1045,9 +1045,9 @@ and make_dps_variant var inner_ctx outer_ctx (lfun : lfunction) =
       (Debuginfo.Scoped_location.to_location lfun.loc)
       Warnings.Unused_tmc_attribute;
   let direct =
-    let { kind; params; return; body = _; attr; loc; mode; ret_mode; region } = lfun in
+    let { kind; params; return; body = _; attr; loc; mode; ret_mode } = lfun in
     let body = Choice.direct fun_choice in
-    lfunction' ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode ~region in
+    lfunction' ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode in
   let dps =
     let dst_param = {
       var = Ident.create_local "dst";
@@ -1076,7 +1076,6 @@ and make_dps_variant var inner_ctx outer_ctx (lfun : lfunction) =
       ~loc:lfun.loc
       ~mode:lfun.mode
       ~ret_mode:lfun.ret_mode
-      ~region:true
   in
   let dps_var = special.dps_id in
   [var, direct; dps_var, dps]

--- a/lambda/transl_list_comprehension.ml
+++ b/lambda/transl_list_comprehension.ml
@@ -252,8 +252,7 @@ let rec translate_bindings ~transl_exp ~scopes ~loc ~inner_body ~accumulator =
               mode = alloc_local
             } ]
         ~return:layout_any_value ~attr:default_function_attribute ~loc
-        ~mode:alloc_local ~ret_mode:alloc_local ~region:false
-        ~body:(add_bindings body)
+        ~mode:alloc_local ~ret_mode:alloc_local ~body:(add_bindings body)
     in
     let result =
       Lambda_utils.apply ~loc ~mode:alloc_local (Lazy.force builder)

--- a/lambda/translattribute.ml
+++ b/lambda/translattribute.ml
@@ -257,8 +257,8 @@ let check_opaque_local loc attr =
 
 
 let lfunction_with_attr ~attr
-  { kind; params; return; body; attr=_; loc; mode; ret_mode; region } =
-  lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode ~region
+  { kind; params; return; body; attr=_; loc; mode; ret_mode } =
+  lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode
 
 let add_inline_attribute expr loc attributes =
   match expr with

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -158,33 +158,8 @@ let is_alloc_heap = function Alloc_heap -> true | Alloc_local -> false
 let function_attribute_disallowing_arity_fusion =
   { default_function_attribute with may_fuse_arity = false }
 
-(** A well-formed function parameter list is of the form
-     [G @ L @ [ Final_arg ]],
-    where the values of G and L are of the form [More_args { partial_mode }],
-    where [partial_mode] has locality Global in G and locality Local in L.
-
-    [curried_function_kind p] checks the well-formedness of the list and returns
-    the corresponding [curried_function_kind]. [nlocal] is populated as follows:
-      - if {v |L| > 0 v}, then {v nlocal = |L| + 1 v}.
-      - if {v |L| = 0 v},
-        * if the function returns at mode local, the final arg has mode local,
-          or the function itself is allocated locally, then {v nlocal = 1 v}.
-        * otherwise, {v nlocal = 0 v}.
-*)
-(* CR-someday: Now that some functions' arity won't be changed downstream of
-   lambda (see [may_fuse_arity = false]), we could change [nlocal] to be
-   more expressive. I suggest the variant:
-
-   {[
-     type partial_application_is_local_when =
-       | Applied_up_to_nth_argument_from_end of int
-       | Never
-   ]}
-
-   I believe this will allow us to get rid of the complicated logic for
-   |L| = 0, and help clarify how clients use this type. I plan on doing
-   this in a follow-on PR.
-*)
+(** [curried_function_kind p] checks the well-formedness of the list and returns
+  the corresponding [curried_function_kind]. *)
 let curried_function_kind
     : (function_curry * Mode.Alloc.l) list
       -> return_mode:locality_mode

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -169,7 +169,6 @@ and apply_coercion_result loc strict funct params args cc_res =
              ~loc
              ~mode:alloc_heap
              ~ret_mode:alloc_heap
-             ~region:true
              ~body:(apply_coercion
                    loc Strict cc_res
                    (Lapply{
@@ -582,7 +581,6 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
     ~loc
     ~mode:alloc_heap
     ~ret_mode:alloc_heap
-    ~region:true
     ~body
 
 (* Compile a module expression *)

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -960,7 +960,6 @@ let add_runtime_parameters lam params =
     ~body:lam
     ~mode:alloc_heap
     ~ret_mode:alloc_heap
-    ~region:true
 
 let transl_implementation_module ~scopes module_id (str, cc, cc2) =
   let path = global_path module_id in

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1884,7 +1884,6 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
        ~body
        ~mode:alloc_heap
        ~ret_mode:(to_locality p.prim_native_repr_res)
-       ~region
 
 let lambda_primitive_needs_event_after = function
   (* We add an event after any primitive resulting in a C call that

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -421,8 +421,8 @@ let compute_static_size lam =
   compute_expression_size Ident.Map.empty lam
 
 let lfunction_with_body { kind; params; return; body = _; attr; loc;
-                          mode; ret_mode; region } body =
-  lfunction' ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode ~region
+                          mode; ret_mode } body =
+  lfunction' ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode
 
 (** {1. Function Lifting} *)
 
@@ -540,7 +540,6 @@ let rec split_static_function lfun block_var local_idents lam :
         ~loc:no_loc
         ~mode:lfun.mode
         ~ret_mode:lfun.ret_mode
-        ~region:lfun.region
     in
     let lifted = { lfun = wrapper; free_vars_block_size = 1 } in
     Reachable (lifted,

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -775,16 +775,14 @@ module Function_decls = struct
         recursive : Recursive.t;
         closure_alloc_mode : Lambda.locality_mode;
         first_complex_local_param : int;
-        result_mode : Lambda.locality_mode;
-        contains_no_escaping_local_allocs : bool
+        result_mode : Lambda.locality_mode
       }
 
     let create ~let_rec_ident ~function_slot ~kind ~params ~params_arity
         ~removed_params ~return ~calling_convention ~return_continuation
         ~exn_continuation ~my_region ~my_ghost_region ~body
         ~(attr : Lambda.function_attribute) ~loc ~free_idents_of_body recursive
-        ~closure_alloc_mode ~first_complex_local_param ~result_mode
-        ~contains_no_escaping_local_allocs =
+        ~closure_alloc_mode ~first_complex_local_param ~result_mode =
       let let_rec_ident =
         match let_rec_ident with
         | None -> Ident.create_local "unnamed_function"
@@ -809,8 +807,7 @@ module Function_decls = struct
         recursive;
         closure_alloc_mode;
         first_complex_local_param;
-        result_mode;
-        contains_no_escaping_local_allocs
+        result_mode
       }
 
     let let_rec_ident t = t.let_rec_ident
@@ -864,9 +861,6 @@ module Function_decls = struct
     let first_complex_local_param t = t.first_complex_local_param
 
     let result_mode t = t.result_mode
-
-    let contains_no_escaping_local_allocs t =
-      t.contains_no_escaping_local_allocs
   end
 
   type t =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -363,7 +363,6 @@ module Function_decls : sig
       closure_alloc_mode:Lambda.locality_mode ->
       first_complex_local_param:int ->
       result_mode:Lambda.locality_mode ->
-      contains_no_escaping_local_allocs:bool ->
       t
 
     val let_rec_ident : t -> Ident.t
@@ -415,8 +414,6 @@ module Function_decls : sig
     val first_complex_local_param : t -> int
 
     val result_mode : t -> Lambda.locality_mode
-
-    val contains_no_escaping_local_allocs : t -> bool
 
     (* Like [all_free_idents], but for just one function. *)
     val free_idents : t -> Ident.Set.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1158,14 +1158,13 @@ and cps_function_bindings env (bindings : Lambda.rec_binding list) =
                    loc;
                    ret_mode;
                    mode;
-                   region;
                    return;
                    _
                  }
              } ->
         match
           Simplif.split_default_wrapper ~id:fun_id ~kind ~params ~body:fbody
-            ~return ~attr ~loc ~ret_mode ~mode ~region
+            ~return ~attr ~loc ~ret_mode ~mode
         with
         | [{ id; def = lfun }] -> [id, lfun]
         | [{ id = id1; def = lfun1 }; { id = id2; def = lfun2 }] ->
@@ -1217,8 +1216,8 @@ and cps_function_bindings env (bindings : Lambda.rec_binding list) =
     bindings_with_wrappers
 
 and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
-    ({ kind; params; return; body; attr; loc; mode; ret_mode; region } :
-      L.lfunction) : Function_decl.t =
+    ({ kind; params; return; body; attr; loc; mode; ret_mode } : L.lfunction) :
+    Function_decl.t =
   let first_complex_local_param =
     List.length params
     - match kind with Curried { nlocal } -> nlocal | Tupled -> 0
@@ -1428,8 +1427,7 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
     ~params_arity ~removed_params ~return ~calling_convention
     ~return_continuation:body_cont ~exn_continuation ~my_region ~my_ghost_region
     ~body ~attr ~loc ~free_idents_of_body recursive ~closure_alloc_mode:mode
-    ~first_complex_local_param ~contains_no_escaping_local_allocs:region
-    ~result_mode:ret_mode
+    ~first_complex_local_param ~result_mode:ret_mode
 
 and cps_switch acc env ccenv (switch : L.lambda_switch) ~condition_dbg
     ~scrutinee (k : Continuation.t) (k_exn : Continuation.t) : Expr_with_acc.t =

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -962,8 +962,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
             ~newer_version_of ~params_arity ~param_modes
             ~first_complex_local_param:(Flambda_arity.num_params params_arity)
-            ~result_arity ~result_types:Unknown ~result_mode
-            ~contains_no_escaping_local_allocs:false ~stub:false ~inline
+            ~result_arity ~result_types:Unknown ~result_mode ~stub:false ~inline
             ~zero_alloc_attribute:Default_zero_alloc
               (* CR gyorsh: should [check] be set properly? *)
             ~is_a_functor:false ~is_opaque:false ~recursive

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -627,11 +627,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
               ~params_arity:remaining_param_arity
               ~param_modes:remaining_params_alloc_modes
               ~first_complex_local_param ~result_arity ~result_types:Unknown
-              ~result_mode
-              ~contains_no_escaping_local_allocs:
-                (Code_metadata.contains_no_escaping_local_allocs
-                   callee's_code_metadata)
-              ~stub:true ~inline:Default_inline ~poll_attribute:Default
+              ~result_mode ~stub:true ~inline:Default_inline
+              ~poll_attribute:Default
               ~zero_alloc_attribute:Zero_alloc_attribute.Default_zero_alloc
               ~is_a_functor:false ~is_opaque:false ~recursive
               ~cost_metrics:cost_metrics_of_body

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -465,8 +465,6 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       ~param_modes:(Code.param_modes code)
       ~first_complex_local_param:(Code.first_complex_local_param code)
       ~result_arity ~result_types ~result_mode:(Code.result_mode code)
-      ~contains_no_escaping_local_allocs:
-        (Code.contains_no_escaping_local_allocs code)
       ~stub:(Code.stub code) ~inline:(Code.inline code)
       ~zero_alloc_attribute:(Code.zero_alloc_attribute code)
       ~poll_attribute:(Code.poll_attribute code) ~is_a_functor ~is_opaque

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -26,7 +26,6 @@ type t =
     result_arity : [`Unarized] Flambda_arity.t;
     result_types : Result_types.t Or_unknown_or_bottom.t;
     result_mode : Lambda.locality_mode;
-    contains_no_escaping_local_allocs : bool;
     stub : bool;
     inline : Inline_attribute.t;
     zero_alloc_attribute : Zero_alloc_attribute.t;
@@ -98,9 +97,6 @@ module Code_metadata_accessors (X : Metadata_view_type) = struct
 
   let inlining_decision t = (metadata t).inlining_decision
 
-  let contains_no_escaping_local_allocs t =
-    (metadata t).contains_no_escaping_local_allocs
-
   let absolute_history t = (metadata t).absolute_history
 
   let relative_history t = (metadata t).relative_history
@@ -141,7 +137,6 @@ type 'a create_type =
   result_arity:[`Unarized] Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   result_mode:Lambda.locality_mode ->
-  contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
   zero_alloc_attribute:Zero_alloc_attribute.t ->
@@ -161,11 +156,11 @@ type 'a create_type =
   'a
 
 let createk k code_id ~newer_version_of ~params_arity ~param_modes
-    ~first_complex_local_param ~result_arity ~result_types ~result_mode
-    ~contains_no_escaping_local_allocs ~stub ~(inline : Inline_attribute.t)
-    ~zero_alloc_attribute ~poll_attribute ~is_a_functor ~is_opaque ~recursive
-    ~cost_metrics ~inlining_arguments ~dbg ~is_tupled ~is_my_closure_used
-    ~inlining_decision ~absolute_history ~relative_history ~loopify =
+    ~first_complex_local_param ~result_arity ~result_types ~result_mode ~stub
+    ~(inline : Inline_attribute.t) ~zero_alloc_attribute ~poll_attribute
+    ~is_a_functor ~is_opaque ~recursive ~cost_metrics ~inlining_arguments ~dbg
+    ~is_tupled ~is_my_closure_used ~inlining_decision ~absolute_history
+    ~relative_history ~loopify =
   (match stub, inline with
   | true, (Available_inline | Never_inline | Default_inline)
   | ( false,
@@ -198,7 +193,6 @@ let createk k code_id ~newer_version_of ~params_arity ~param_modes
       result_arity;
       result_types;
       result_mode;
-      contains_no_escaping_local_allocs;
       stub;
       inline;
       zero_alloc_attribute;
@@ -249,7 +243,7 @@ let [@ocamlformat "disable"] print ppf
        { code_id = _; newer_version_of; stub; inline; zero_alloc_attribute; poll_attribute;
          is_a_functor; is_opaque; params_arity; param_modes;
          first_complex_local_param; result_arity;
-         result_types; result_mode; contains_no_escaping_local_allocs;
+         result_types; result_mode;
          recursive; cost_metrics; inlining_arguments;
          dbg; is_tupled; is_my_closure_used; inlining_decision;
          absolute_history; relative_history; loopify } =
@@ -268,7 +262,6 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>%t(result_arity@ %t%a%t)%t@]@ \
       @[<hov 1>(result_types@ @[<hov 1>(%a)@])@]@ \
       @[<hov 1>(result_mode@ %s)@]@ \
-      @[<hov 1>(contains_no_escaping_local_allocs@ %b)@]@ \
       @[<hov 1>%t(recursive@ %a)%t@]@ \
       @[<hov 1>(cost_metrics@ %a)@]@ \
       @[<hov 1>(inlining_arguments@ %a)@]@ \
@@ -341,7 +334,6 @@ let [@ocamlformat "disable"] print ppf
     Flambda_colours.pop
     (Or_unknown_or_bottom.print Result_types.print) result_types
     (match result_mode with Alloc_heap -> "Heap" | Alloc_local -> "Local")
-    contains_no_escaping_local_allocs
     (match recursive with
     | Non_recursive -> Flambda_colours.elide
     | Recursive -> Flambda_colours.none)
@@ -371,7 +363,6 @@ let free_names
       result_arity = _;
       result_types;
       result_mode = _;
-      contains_no_escaping_local_allocs = _;
       stub = _;
       inline = _;
       zero_alloc_attribute = _;
@@ -414,7 +405,6 @@ let apply_renaming
        result_arity = _;
        result_types;
        result_mode = _;
-       contains_no_escaping_local_allocs = _;
        stub = _;
        inline = _;
        zero_alloc_attribute = _;
@@ -468,7 +458,6 @@ let ids_for_export
       result_arity = _;
       result_types;
       result_mode = _;
-      contains_no_escaping_local_allocs = _;
       stub = _;
       inline = _;
       zero_alloc_attribute = _;
@@ -508,7 +497,6 @@ let approx_equal
       result_arity = result_arity1;
       result_types = _;
       result_mode = result_mode1;
-      contains_no_escaping_local_allocs = contains_no_escaping_local_allocs1;
       stub = stub1;
       inline = inline1;
       zero_alloc_attribute = zero_alloc_attribute1;
@@ -534,7 +522,6 @@ let approx_equal
       result_arity = result_arity2;
       result_types = _;
       result_mode = result_mode2;
-      contains_no_escaping_local_allocs = contains_no_escaping_local_allocs2;
       stub = stub2;
       inline = inline2;
       zero_alloc_attribute = zero_alloc_attribute2;
@@ -559,8 +546,6 @@ let approx_equal
   && Int.equal first_complex_local_param1 first_complex_local_param2
   && Flambda_arity.equal_ignoring_subkinds result_arity1 result_arity2
   && Lambda.eq_locality_mode result_mode1 result_mode2
-  && Bool.equal contains_no_escaping_local_allocs1
-       contains_no_escaping_local_allocs2
   && Bool.equal stub1 stub2
   && Inline_attribute.equal inline1 inline2
   && Zero_alloc_attribute.equal zero_alloc_attribute1 zero_alloc_attribute2

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -72,8 +72,6 @@ module type Code_metadata_accessors_result_type = sig
 
   val inlining_decision : 'a t -> Function_decl_inlining_decision_type.t
 
-  val contains_no_escaping_local_allocs : 'a t -> bool
-
   val absolute_history : 'a t -> Inlining_history.Absolute.t
 
   val relative_history : 'a t -> Inlining_history.Relative.t
@@ -97,7 +95,6 @@ type 'a create_type =
   result_arity:[`Unarized] Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   result_mode:Lambda.locality_mode ->
-  contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
   zero_alloc_attribute:Zero_alloc_attribute.t ->


### PR DESCRIPTION
...and consequentially `contains_no_escaping_local_allocs` in Flambda 2, which was unused.

`Simplif` seemed to be the only place relying on this field.  @riaqn suggested that `ret_mode` could be used instead, which seems like it should be correct, but this part of the diff needs checking carefully.  The rest is straightforward.