### PR TITLE
Fixes for the toplevel

### DIFF
--- a/ocaml/toplevel/byte/topeval.ml
+++ b/ocaml/toplevel/byte/topeval.ml
@@ -268,7 +268,7 @@ and really_load_file recursive ppf name filename ic =
                   (Compilation_unit.Name.to_string (Compilation_unit.name cu))
                   ^ ".cmo"
                 in
-                begin match Load_path.find_uncap file with
+                begin match Load_path.find_normalized file with
                 | exception Not_found -> ()
                 | file ->
                     if not (load_file recursive ppf file) then raise Load_failed
@@ -303,8 +303,11 @@ and really_load_file recursive ppf name filename ic =
       end
   with Load_failed -> false
 
+external get_bytecode_sections : unit -> Symtable.bytecode_sections =
+  "caml_dynlink_get_bytecode_sections"
+
 let init () =
-  let crc_intfs = Symtable.init_toplevel() in
+  let crc_intfs = Symtable.init_toplevel ~get_bytecode_sections in
   Compmisc.init_path ();
   Env.import_crcs ~source:Sys.executable_name crc_intfs;
   ()

--- a/ocaml/toplevel/native/topeval.ml
+++ b/ocaml/toplevel/native/topeval.ml
@@ -39,29 +39,6 @@ let global_symbol comp_unit =
 
 let remembered = ref Ident.empty
 
-<<<<<<< HEAD
-let remember phrase_name signature =
-  let exported = List.filter Includemod.is_runtime_component signature in
-  List.iteri (fun i sg ->
-    match sg with
-    | Sig_value  (id, _, _)
-    | Sig_module (id, _, _, _, _)
-    | Sig_typext (id, _, _, _)
-    | Sig_class  (id, _, _, _) ->
-      remembered := Ident.add id (phrase_name, i) !remembered
-    | _ -> ())
-    exported
-||||||| 121bedcfd2
-let rec remember phrase_name i = function
-  | [] -> ()
-  | Sig_value  (id, _, _) :: rest
-  | Sig_module (id, _, _, _, _) :: rest
-  | Sig_typext (id, _, _, _) :: rest
-  | Sig_class  (id, _, _, _) :: rest ->
-      remembered := Ident.add id (phrase_name, i) !remembered;
-      remember phrase_name (succ i) rest
-  | _ :: rest -> remember phrase_name i rest
-=======
 let remember phrase_name signature =
   let exported = List.filter Includemod.is_runtime_component signature in
   List.iteri (fun i sg ->
@@ -70,10 +47,9 @@ let remember phrase_name signature =
       | Sig_module (id, _, _, _, _)
       | Sig_typext (id, _, _, _)
       | Sig_class  (id, _, _, _) ->
-          remembered := Ident.add id (phrase_name, i) !remembered
+        remembered := Ident.add id (phrase_name, i) !remembered
       | _ -> ())
     exported
->>>>>>> 5.2.0
 
 let toplevel_value id =
   try Ident.find_same id !remembered
@@ -161,14 +137,8 @@ let name_expression ~loc ~attrs sort exp =
    in
    let sg = [Sig_value(id, vd, Exported)] in
    let pat =
-<<<<<<< HEAD
      { pat_desc = Tpat_var(id, mknoloc name, vd.val_uid,
         Mode.Value.disallow_right Mode.Value.legacy);
-||||||| 121bedcfd2
-     { pat_desc = Tpat_var(id, mknoloc name);
-=======
-     { pat_desc = Tpat_var(id, mknoloc name, vd.val_uid);
->>>>>>> 5.2.0
        pat_loc = loc;
        pat_extra = [];
        pat_type = exp.exp_type;
@@ -178,13 +148,8 @@ let name_expression ~loc ~attrs sort exp =
    let vb =
      { vb_pat = pat;
        vb_expr = exp;
-<<<<<<< HEAD
        vb_rec_kind = Dynamic;
        vb_sort = sort;
-||||||| 121bedcfd2
-=======
-       vb_rec_kind = Dynamic;
->>>>>>> 5.2.0
        vb_attributes = attrs;
        vb_loc = loc; }
    in
@@ -250,16 +215,8 @@ let execute_phrase print_outcome ppf phr =
             Translmod.transl_implementation phrase_comp_unit (str, Tcoerce_none)
               ~style:Plain_block
           in
-<<<<<<< HEAD
           remember compilation_unit sg';
           compilation_unit, close_phrase res, required_globals, size
-||||||| 121bedcfd2
-          remember module_ident 0 sg';
-          module_ident, close_phrase res, required_globals, size
-=======
-          remember module_ident sg';
-          module_ident, close_phrase res, required_globals, size
->>>>>>> 5.2.0
         else
           let size, res = Translmod.transl_store_phrases phrase_comp_unit str in
           phrase_comp_unit, res, Compilation_unit.Set.empty, size

--- a/ocaml/toplevel/topcommon.ml
+++ b/ocaml/toplevel/topcommon.ml
@@ -415,7 +415,7 @@ let loading_hint_printer ppf cu =
     let leafname =
       (Compilation_unit.Name.to_string (Compilation_unit.name cu)) ^ ext
     in
-    try Some (Load_path.find_uncap leafname) with Not_found -> None
+    try Some (Load_path.find_normalized leafname) with Not_found -> None
   in
   fprintf ppf
     "@.Hint: @[\

--- a/ocaml/toplevel/topdirs.ml
+++ b/ocaml/toplevel/topdirs.ml
@@ -95,7 +95,7 @@ let _ = add_directive "directory" (Directive_string dir_directory)
 let dir_remove_directory s =
   let d = expand_directory Config.standard_library s in
   let keep id =
-    match Load_path.find_uncap (Ident.name id ^ ".cmi") with
+    match Load_path.find_normalized (Ident.name id ^ ".cmi") with
     | exception Not_found -> true
     | fn -> Filename.dirname fn <> d
   in


### PR DESCRIPTION
Minor fixes and conflict resolution for the toplevel.

The `get_bytecode_sections` change relates to the fact that part of `Symtable` has had to be parameterized over this function, to avoid a missing primitive when built with the system compiler (this C function is new in 5.2.0).