### PR TITLE
Fixes for ocaml/bytecomp/

### DIFF
--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -1296,19 +1296,4 @@ let compile_implementation modulename expr =
   fst (compile_gen ~modulename ~init_stack:0 expr)
 
 let compile_phrase expr =
-<<<<<<< HEAD
   compile_gen ~init_stack:1 expr
-||||||| 2572783060
-  reset ();
-  Fun.protect ~finally:reset (fun () ->
-  let init_code = comp_block empty_env expr 1 [Kreturn 1] in
-  let fun_code = comp_remainder [] in
-  (init_code, fun_code))
-=======
-  reset ();
-  Fun.protect ~finally:reset (fun () ->
-  let init_code = comp_block empty_env expr 1 [Kreturn 1] in
-  let fun_code = comp_remainder [] in
-  (init_code, fun_code))
-
->>>>>>> ocaml-jst/flambda-patches

--- a/ocaml/bytecomp/bytelink.ml
+++ b/ocaml/bytecomp/bytelink.ml
@@ -238,9 +238,17 @@ let link_compunit output_fun currpos_fun inchan file_name compunit =
   if !Clflags.debug && compunit.cu_debug > 0 then begin
     seek_in inchan compunit.cu_debug;
     let debug_event_list : Instruct.debug_event list =
-      Compression.input_value inchan in
+      (* CR ocaml 5 compressed-marshal:
+      Compression.input_value inchan
+      *)
+      Marshal.from_channel inchan
+    in
     let debug_dirs : string list =
-      Compression.input_value inchan in
+      (* CR ocaml 5 compressed-marshal:
+      Compression.input_value inchan
+      *)
+      Marshal.from_channel inchan
+    in
     let file_path = Filename.dirname (Location.absolute_path file_name) in
     let debug_dirs =
       if List.mem file_path debug_dirs

--- a/ocaml/bytecomp/bytepackager.ml
+++ b/ocaml/bytecomp/bytepackager.ml
@@ -155,13 +155,21 @@ let process_append_bytecode oc state objfile compunit =
     let events, debug_dirs =
       if !Clflags.debug && compunit.cu_debug > 0 then begin
         seek_in ic compunit.cu_debug;
+        (* CR ocaml 5 compressed-marshal:
         let unit_events = (Compression.input_value ic : debug_event list) in
+        *)
+        let unit_events = (Marshal.from_channel ic : debug_event list) in
         let events =
           rev_append_map
             (relocate_debug state.offset state.subst)
             unit_events
             state.events in
-        let unit_debug_dirs = (Compression.input_value ic : string list) in
+        let unit_debug_dirs =
+          (* CR ocaml 5 compressed-marshal:
+          (Compression.input_value ic : string list)
+          *)
+          (Marshal.from_channel ic : string list)
+        in
         let debug_dirs =
           String.Set.union
             state.debug_dirs

--- a/ocaml/bytecomp/symtable.ml
+++ b/ocaml/bytecomp/symtable.ml
@@ -343,12 +343,11 @@ type bytecode_sections =
     prim: string list;
     dlpt: string list }
 
-external get_bytecode_sections : unit -> bytecode_sections =
-  "caml_dynlink_get_bytecode_sections"
-
 (* Initialize the linker for toplevel use *)
 
-let init_toplevel () =
+(* In flambda-backend, [get_bytecode_sections] is passed in, because it is
+   absent from the 4.x runtime as used by the current system compiler. *)
+let init_toplevel ~get_bytecode_sections =
   let sect = get_bytecode_sections () in
   global_table := sect.symb;
   c_prim_table := PrimMap.empty;

--- a/ocaml/bytecomp/symtable.mli
+++ b/ocaml/bytecomp/symtable.mli
@@ -50,7 +50,18 @@ val transl_const: Lambda.structured_constant -> Obj.t
 
 (* Functions for the toplevel *)
 
-val init_toplevel: unit -> Import_info.t array
+type global_map
+
+(* See comment about [get_bytecode_sections] in the .ml file. *)
+type bytecode_sections = private
+  { symb: global_map;
+    crcs: Import_info.t array;
+    prim: string list;
+    dlpt: string list }
+
+val init_toplevel: get_bytecode_sections:(unit -> bytecode_sections)
+  -> Import_info.t array
+
 val update_global_table: unit -> unit
 val get_global_value: Global.t -> Obj.t
 val is_global_defined: Global.t -> bool
@@ -59,8 +70,6 @@ val get_global_position: Global.t -> int
 val check_global_initialized: (reloc_info * int) list -> unit
 val initialized_compunits: (reloc_info * int) list -> Compilation_unit.t list
 val required_compunits: (reloc_info * int) list -> Compilation_unit.t list
-
-type global_map
 
 val empty_global_map: global_map
 val current_state: unit -> global_map


### PR DESCRIPTION
Minor fixes and conflict resolution.
The `caml_get_bytecode_sections` change relates to the note in #2986 .