### PR TITLE
Fix yacc build

### DIFF
--- a/ocaml/yacc/defs.h
+++ b/ocaml/yacc/defs.h
@@ -16,6 +16,20 @@
 #ifndef YACC_DEFS_H
 #define YACC_DEFS_H
 
+/* CR mshinwell: When the build compiler is OCaml 5, remove this.
+   Alternatively fix the dune build so that ocamlyacc is only built in the
+   "main" build context. */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202300L    \
+    || defined(__cplusplus) && __cplusplus >= 201103L
+  #define CAMLnoret [[noreturn]]
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+  #define CAMLnoret _Noreturn
+#elif defined(__GNUC__)
+  #define CAMLnoret  __attribute__ ((noreturn))
+#else
+  #define CAMLnoret
+#endif
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
 
 /* Based on public-domain code from Berkeley Yacc */
 


### PR DESCRIPTION
This was the easiest way to get the `yacc` build to work, although another possibility is given in the comment.  The code is verbatim from runtime5.