### PR TITLE
Add language extensions counters

### DIFF
--- a/ocaml/compilerlibs/Makefile.compilerlibs
+++ b/ocaml/compilerlibs/Makefile.compilerlibs
@@ -40,6 +40,7 @@ UTILS = \
   utils/language_extension_kernel.cmo \
   utils/language_extension.cmo \
   utils/profile.cmo \
+  utils/profile_counters_functions.cmo \
   utils/terminfo.cmo \
   utils/ccomp.cmo \
   utils/warnings.cmo \

--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -60,7 +60,13 @@ let parse_intf i =
   |> print_if i.ppf_dump Clflags.dump_source Pprintast.signature
 
 let typecheck_intf info ast =
-  Profile.(record_call typing) @@ fun () ->
+  Profile.(
+    record_call_with_counters
+      ~counter_f:(fun signature ->
+        Profile_counters_functions.(
+          count_language_extensions (Typedtree_signature_input signature)))
+      typing)
+  @@ fun () ->
   let tsg =
     ast
     |> Typemod.type_interface
@@ -123,7 +129,13 @@ let parse_impl i =
 
 let typecheck_impl i parsetree =
   parsetree
-  |> Profile.(record typing)
+  |> Profile.(
+    record_with_counters
+      ~counter_f:(fun (typed_tree : Typedtree.implementation) ->
+        Profile_counters_functions.(
+          count_language_extensions
+            (Typedtree_implementation_input typed_tree)))
+      typing)
     (Typemod.type_implementation
        ~sourcefile:i.source_file i.output_prefix i.module_name i.env)
   |> print_if i.ppf_dump Clflags.dump_typedtree

--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -64,7 +64,7 @@ let typecheck_intf info ast =
     record_call_with_counters
       ~counter_f:(fun signature ->
         Profile_counters_functions.(
-          count_language_extensions (Typedtree_signature_input signature)))
+          count_language_extensions (Typedtree_signature_output signature)))
       typing)
   @@ fun () ->
   let tsg =
@@ -134,7 +134,7 @@ let typecheck_impl i parsetree =
       ~counter_f:(fun (typed_tree : Typedtree.implementation) ->
         Profile_counters_functions.(
           count_language_extensions
-            (Typedtree_implementation_input typed_tree)))
+            (Typedtree_implementation_output typed_tree)))
       typing)
     (Typemod.type_implementation
        ~sourcefile:i.source_file i.output_prefix i.module_name i.env)

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -88,12 +88,11 @@
  (modules
    ;; UTILS
    config build_path_prefix_map misc identifiable numbers arg_helper clflags
-   debug profile terminfo ccomp warnings consistbl strongly_connected_components
-   targetint load_path int_replace_polymorphic_compare domainstate binutils
-   local_store target_system compilation_unit import_info linkage_name symbol
-   lazy_backtrack diffing diffing_with_keys
-   language_extension_kernel language_extension
-   zero_alloc_utils zero_alloc_annotations
+   debug profile profile_counters_functions terminfo ccomp warnings consistbl
+   strongly_connected_components targetint load_path int_replace_polymorphic_compare
+   domainstate binutils local_store target_system compilation_unit import_info
+   linkage_name symbol lazy_backtrack diffing diffing_with_keys language_extension_kernel
+   language_extension zero_alloc_utils zero_alloc_annotations
 
    ;; PARSING
    location longident docstrings printast syntaxerr ast_helper
@@ -273,6 +272,7 @@
     (clflags.mli as compiler-libs/clflags.mli)
     (language_extension.mli as compiler-libs/language_extension.mli)
     (profile.mli as compiler-libs/profile.mli)
+    (profile_counters_functions.mli as compiler-libs/profile_counters_functions.mli)
     (terminfo.mli as compiler-libs/terminfo.mli)
     (ccomp.mli as compiler-libs/ccomp.mli)
     (warnings.mli as compiler-libs/warnings.mli)

--- a/ocaml/otherlibs/dynlink/Makefile
+++ b/ocaml/otherlibs/dynlink/Makefile
@@ -91,6 +91,7 @@ COMPILERLIBS_SOURCES=\
   utils/language_extension_kernel.ml \
   utils/language_extension.ml \
   utils/profile.ml \
+  utils/profile_counters_functions.ml \
   utils/consistbl.ml \
   utils/terminfo.ml \
   utils/warnings.ml \

--- a/ocaml/otherlibs/dynlink/dune
+++ b/ocaml/otherlibs/dynlink/dune
@@ -167,6 +167,7 @@
 (copy_files ../../utils/language_extension_kernel.ml)
 (copy_files ../../utils/language_extension.ml)
 (copy_files ../../utils/profile.ml)
+(copy_files ../../utils/profile_counters_functions.ml)
 (copy_files ../../utils/consistbl.ml)
 (copy_files ../../utils/terminfo.ml)
 (copy_files ../../utils/warnings.ml)
@@ -239,6 +240,7 @@
 (copy_files ../../utils/language_extension_kernel.mli)
 (copy_files ../../utils/language_extension.mli)
 (copy_files ../../utils/profile.mli)
+(copy_files ../../utils/profile_counters_functions.mli)
 (copy_files ../../utils/consistbl.mli)
 (copy_files ../../utils/terminfo.mli)
 (copy_files ../../utils/warnings.mli)
@@ -359,6 +361,7 @@
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Numbers.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Clflags.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Profile.cmo
+      ; .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Profile_counters_functions.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Debug.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Language_extension_kernel.cmo
       .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Language_extension.cmo
@@ -445,6 +448,7 @@
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Numbers.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Clflags.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Profile.cmx
+      ; .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Profile_counters_functions.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Debug.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Language_extension_kernel.cmx
       .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Language_extension.cmx

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/ml_counters.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/ml_counters.ml
@@ -1,0 +1,30 @@
+(* List comprehensions *)
+
+[x for x = 1 to 5];;
+
+[x * 2 for x = 1 to 5];;
+
+[x * 2 for x = 1 to 5 when x mod 2 <> 1];;
+
+[((x + y) * (x + y + 1)) / 2 + 1 for x = 1 to 5 for y = 1 to 5];;
+
+(* Array comprehensions *)
+
+[|x for x = 1 to 5|];;
+
+[|x * 2 for x = 1 to 5|];;
+
+[|x * 2 for x = 1 to 5 when x mod 2 <> 1|];;
+
+[|((x + y) * (x + y + 1)) / 2 + 1 for x = 1 to 5 for y = 1 to 5|];;
+
+(* Normal lists and arrays (should not be counted) *)
+
+[1; 2; 3; 4; 5];;
+[|1; 2; 3; 4; 5|];;
+
+module type M = sig
+  val x : 'a list
+
+  val y : 'a array
+end

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/ml_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ comprehensions/ml_counters.ml
+  [comprehensions = 8; immutable_arrays = 0; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/mli_counters.mli
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/mli_counters.mli
@@ -1,0 +1,11 @@
+(* Normal lists and arrays (should not be counted) *)
+
+val x : 'a list
+
+val y : 'a array
+
+module type M = sig
+  val x : 'a list
+
+  val y : 'a array
+end

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/mli_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ comprehensions/mli_counters.mli
+  [comprehensions = 0; immutable_arrays = 0; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_array_comprehensions/ml_counters.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_array_comprehensions/ml_counters.ml
@@ -1,0 +1,9 @@
+(* Immutable array comprehensions *)
+
+[:x for x = 1 to 5:];;
+
+[:x * 2 for x = 1 to 5:];;
+
+[:x * 2 for x = 1 to 5 when x mod 2 <> 1:];;
+
+[:((x + y) * (x + y + 1)) / 2 + 1 for x = 1 to 5 for y = 1 to 5:];;

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_array_comprehensions/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_array_comprehensions/ml_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ immutable_array_comprehensions/ml_counters.ml
+  [comprehensions = 4; immutable_arrays = 4; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ml
@@ -1,0 +1,13 @@
+(* Immutable arrays *)
+
+let a_iarray : int iarray = [: 1; 2; 3; 4; 5 :]
+
+let b_iarray : float iarray = [: 1.; 2.; 3.; 4.; 5. :]
+
+(* Mutable arrays (should not be counted) *)
+
+let c_array : int array = [| 1; 2; 3; 4; 5 |]
+
+let d_array : float array = [| 1.; 2.; 3.; 4.; 5. |]
+
+let e_array : bool array = [| true; false; true |]

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ml
@@ -1,8 +1,16 @@
 (* Immutable arrays *)
 
+(* 2 type, 1 expression *)
 let a_iarray : int iarray = [: 1; 2; 3; 4; 5 :]
 
+(* 2 type, 1 expression *)
 let b_iarray : float iarray = [: 1.; 2.; 3.; 4.; 5. :]
+
+(* 1 expression, 1 pattern *)
+let and_iarray =
+  match [: true; false :] with
+  | [: iarray_val_1; iarray_val_2 :] -> iarray_val_1 && iarray_val_2
+  | _ -> false
 
 (* CR-someday mitom: Add tests for [Iarray] module from stdlib *)
 
@@ -13,3 +21,8 @@ let c_array : int array = [| 1; 2; 3; 4; 5 |]
 let d_array : float array = [| 1.; 2.; 3.; 4.; 5. |]
 
 let e_array : bool array = [| true; false; true |]
+
+let and_array =
+  match [| true; false |] with
+  | [| array_val_1; array_val_2 |] -> array_val_1 && array_val_2
+  | _ -> false

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ml
@@ -4,6 +4,8 @@ let a_iarray : int iarray = [: 1; 2; 3; 4; 5 :]
 
 let b_iarray : float iarray = [: 1.; 2.; 3.; 4.; 5. :]
 
+(* CR-someday mitom: Add tests for [Iarray] module from stdlib *)
+
 (* Mutable arrays (should not be counted) *)
 
 let c_array : int array = [| 1; 2; 3; 4; 5 |]

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ immutable_arrays/ml_counters.ml
+  [comprehensions = 0; immutable_arrays = 2; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ocamlc.reference
@@ -1,2 +1,2 @@
  immutable_arrays/ml_counters.ml
-  [comprehensions = 0; immutable_arrays = 2; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing
+  [comprehensions = 0; immutable_arrays = 6; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ocamlc.reference
@@ -1,2 +1,2 @@
  immutable_arrays/ml_counters.ml
-  [comprehensions = 0; immutable_arrays = 6; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing
+  [comprehensions = 0; immutable_arrays = 8; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/mli_counters.mli
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/mli_counters.mli
@@ -1,0 +1,13 @@
+(* Immutable arrays *)
+
+val a_iarray : int iarray
+
+val b_iarray : float iarray
+
+val c_iarray : 'a iarray
+
+(* Mutable arrays (should not be counted) *)
+
+val a_array : int array
+
+val b_array : float array

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/mli_counters.mli
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/mli_counters.mli
@@ -1,9 +1,12 @@
 (* Immutable arrays *)
 
+(* 1 type *)
 val a_iarray : int iarray
 
+(* 1 type *)
 val b_iarray : float iarray
 
+(* 1 type *)
 val c_iarray : 'a iarray
 
 (* Mutable arrays (should not be counted) *)

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/mli_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ immutable_arrays/mli_counters.mli
+  [comprehensions = 0; immutable_arrays = 3; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/ml_counters.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/ml_counters.ml
@@ -1,0 +1,84 @@
+module type M = sig
+  type 'a t
+
+  val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
+end
+
+module type F_M = sig
+  include M
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
+end
+
+module F_Applicative (M : M) = struct
+  let map f = M.mapi (fun _ -> f)
+end
+
+module G_Applicative (M : M) = struct
+  let map_i_plus_one f = M.mapi (fun i -> f (i + 1))
+end
+
+module F_Genarative (M : M) () = struct
+  let map f = M.mapi (fun _ -> f)
+end
+
+module G_Generative (M : M) () = struct
+  let map_i_plus_one f = M.mapi (fun i -> f (i + 1))
+end
+
+
+(* Include applicative functors *)
+
+module Example_1 = struct
+  type 'a t = 'a list
+  let mapi = List.mapi
+
+  include functor F_Applicative
+  include functor G_Applicative
+end
+
+module Example_2 = struct
+  type 'a t = 'a list
+  let mapi = List.mapi
+
+  include functor F_Applicative
+end
+
+(* Include generative functors *)
+
+module Example_3 = struct
+  type 'a t = 'a list
+  let mapi = List.mapi
+
+  include functor F_Genarative
+  include functor G_Generative
+end
+
+module Example_4 = struct
+  type 'a t = 'a list
+  let mapi = List.mapi
+
+  include functor F_Genarative
+end
+
+(* Standard functor usage (should not be counted) *)
+
+module Example_5 = struct
+  module A = struct
+    type 'a t = 'a list
+    let mapi = List.mapi
+  end
+
+  include F_Applicative (A)
+  include G_Applicative (A)
+end
+
+module Example_6 = struct
+  module A = struct
+    type 'a t = 'a list
+    let mapi = List.mapi
+  end
+
+  include F_Genarative (A) ()
+  include G_Generative (A) ()
+end

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/ml_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ include_functor/ml_counters.ml
+  [comprehensions = 0; immutable_arrays = 0; include_functor = 6; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/mli_counters.mli
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/mli_counters.mli
@@ -1,0 +1,15 @@
+module type M = sig
+  type t = int
+end
+
+module type F = functor (M : M) -> sig
+  type t_list = M.t list
+end
+
+(* Include functor *)
+
+module type Example_1 = sig
+  type t = int
+
+  include functor F
+end

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/mli_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ include_functor/mli_counters.mli
+  [comprehensions = 0; immutable_arrays = 0; include_functor = 1; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/ml_counters.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/ml_counters.ml
@@ -1,0 +1,18 @@
+(* Labeled tuples usage *)
+
+(* 1 type, 1 expression*)
+let labeled_1 = ~x:1, ~y:2, 3
+
+(* 1 type, 1 expression*)
+let (labeled_2 : x:int * int * y:int) = ~x:4, 5, ~y:6
+
+(* 1 pattern *)
+let ~x, ~y, _ = labeled_1
+
+(* Unlabeled tuples usage (should not count) *)
+
+let (normal_1 : int * int * int) = 1, 2, 3
+
+let a, b, c = 4, 5, 6
+
+let _, b, _ = 7, 8, 9

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/ml_counters.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/ml_counters.ml
@@ -1,9 +1,9 @@
 (* Labeled tuples usage *)
 
-(* 1 type, 1 expression*)
+(* 1 expression *)
 let labeled_1 = ~x:1, ~y:2, 3
 
-(* 1 type, 1 expression*)
+(* 1 type, 1 expression *)
 let (labeled_2 : x:int * int * y:int) = ~x:4, 5, ~y:6
 
 (* 1 pattern *)

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/ml_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ labeled_tuples/ml_counters.ml
+  [comprehensions = 0; immutable_arrays = 0; include_functor = 0; labeled_tuples = 4; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/mli_counters.mli
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/mli_counters.mli
@@ -1,0 +1,11 @@
+(* Labeled tuples *)
+
+val labeled_1 : x:int * int * y:int
+
+val labeled_2 : z:float * bool
+
+(* Unlabeled tuples (should not count) *)
+
+val normal_1 : int * int * int
+
+val normal_2 : float * bool

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/mli_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ labeled_tuples/mli_counters.mli
+  [comprehensions = 0; immutable_arrays = 0; include_functor = 0; labeled_tuples = 2; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/ml_counters.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/ml_counters.ml
@@ -1,0 +1,15 @@
+(* Module strengthening syntax *)
+
+module type Example_2 = sig
+  module type T = sig type t end
+  module M : T
+  module N : T with M
+end
+
+(* Standard syntax (should not be counted) *)
+
+module type Example_1 = sig
+  module type T = sig type t end
+  module M : T
+  module N : sig type t = M.t end
+end

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/ml_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ module_strengthening/ml_counters.ml
+  [comprehensions = 0; immutable_arrays = 0; include_functor = 0; labeled_tuples = 0; module_strengthening = 1] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/mli_counters.mli
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/mli_counters.mli
@@ -1,0 +1,15 @@
+(* Module strengthening syntax *)
+
+module type Example_2 = sig
+  module type T = sig type t end
+  module M : T
+  module N : T with M
+end
+
+(* Standard syntax (should not be counted) *)
+
+module type Example_1 = sig
+  module type T = sig type t end
+  module M : T
+  module N : sig type t = M.t end
+end

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/mli_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ module_strengthening/mli_counters.mli
+  [comprehensions = 0; immutable_arrays = 0; include_functor = 0; labeled_tuples = 0; module_strengthening = 1] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/nested/ml_counters.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/nested/ml_counters.ml
@@ -1,0 +1,7 @@
+(* Nested language extensions *)
+
+(* 2 comprehensions *)
+[[x + y for y = 1 to 5] for x = 1 to 5];;
+
+(* 1 comprehension, 1 labeled tuple *)
+[(~y:5, ~z:2, x) for x = 1 to 5];;

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/nested/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/nested/ml_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ nested/ml_counters.ml
+  [comprehensions = 3; immutable_arrays = 0; include_functor = 0; labeled_tuples = 1; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/nested/mli_counters.mli
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/nested/mli_counters.mli
@@ -1,0 +1,7 @@
+(* Nested language extensions *)
+
+(* 2 labeled tuples *)
+val nested_labeled_tuple : z:(x:int * int * y:int) * int
+
+(* 1 labeled tuple, 1 immutable array *)
+val nested_labeled_tuple_iarray : (x:int * int * y:int) iarray

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/nested/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/nested/mli_counters.ocamlc.reference
@@ -1,0 +1,2 @@
+ nested/mli_counters.mli
+  [comprehensions = 0; immutable_arrays = 1; include_functor = 0; labeled_tuples = 3; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/test.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/test.ml
@@ -1,7 +1,7 @@
 (* TEST
 
 subdirectories = "include_functor immutable_array_comprehensions comprehensions \
-                  immutable_arrays module_strengthening labeled_tuples";
+                  immutable_arrays module_strengthening labeled_tuples nested";
 setup-ocamlc.byte-build-env;
 ocamlc_byte_exit_status = "0";
 flags = "-dcounters -extension include_functor -extension comprehensions \
@@ -112,6 +112,25 @@ flags = "-dcounters -extension include_functor -extension comprehensions \
   ocamlc.byte;
   compiler_reference =
     "${test_source_directory}/module_strengthening/mli_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+
+(* Nested language extensions *)
+
+{
+  module = "nested/ml_counters.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/nested/ml_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+{
+  module = "nested/mli_counters.mli";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/nested/mli_counters.ocamlc.reference";
   check-ocamlc.byte-output;
 }
 

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/test.ml
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/test.ml
@@ -1,0 +1,118 @@
+(* TEST
+
+subdirectories = "include_functor immutable_array_comprehensions comprehensions \
+                  immutable_arrays module_strengthening labeled_tuples";
+setup-ocamlc.byte-build-env;
+ocamlc_byte_exit_status = "0";
+flags = "-dcounters -extension include_functor -extension comprehensions \
+        -extension immutable_arrays -extension immutable_arrays \
+        -extension module_strengthening -extension labeled_tuples";
+
+
+
+(* Include functor *)
+{
+  module = "include_functor/ml_counters.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/include_functor/ml_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+{
+  module = "include_functor/mli_counters.mli";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/include_functor/mli_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+
+(* Immutable array comprehensions *)
+
+{
+  module = "immutable_array_comprehensions/ml_counters.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/immutable_array_comprehensions/ml_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+
+(* Comprehensions *)
+
+{
+  module = "comprehensions/ml_counters.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/comprehensions/ml_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+{
+  module = "comprehensions/mli_counters.mli";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/comprehensions/mli_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+
+(* Immutable arrays *)
+
+{
+  module = "immutable_arrays/ml_counters.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/immutable_arrays/ml_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+{
+  module = "immutable_arrays/mli_counters.mli";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/immutable_arrays/mli_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+
+(* Labeled tuples *)
+
+{
+  module = "labeled_tuples/ml_counters.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/labeled_tuples/ml_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+{
+  module = "labeled_tuples/mli_counters.mli";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/labeled_tuples/mli_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+
+(* Module strengthening *)
+
+{
+  module = "module_strengthening/ml_counters.ml";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/module_strengthening/ml_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+{
+  module = "module_strengthening/mli_counters.mli";
+  setup-ocamlc.byte-build-env;
+  ocamlc.byte;
+  compiler_reference =
+    "${test_source_directory}/module_strengthening/mli_counters.ocamlc.reference";
+  check-ocamlc.byte-output;
+}
+
+*)

--- a/ocaml/tools/Makefile
+++ b/ocaml/tools/Makefile
@@ -100,6 +100,7 @@ all: profiling.cmo
 opt.opt: profiling.cmx
 
 OCAMLCP = config.cmo build_path_prefix_map.cmo misc.cmo profile.cmo \
+		  profile_counters_functions.cmo \
           warnings.cmo identifiable.cmo numbers.cmo arg_helper.cmo \
           language_extension_kernel.cmo language_extension.cmo \
 	  	  zero_alloc_annotations.cmo local_store.cmo \
@@ -137,9 +138,9 @@ ocamlmklib.opt$(EXE): $(call byte2native, $(OCAMLMKLIB))
 # To make custom toplevels
 
 OCAMLMKTOP=config.cmo build_path_prefix_map.cmo misc.cmo \
-       identifiable.cmo numbers.cmo arg_helper.cmo zero_alloc_annotations.cmo \
-	   clflags.cmo local_store.cmo load_path.cmo profile.cmo ccomp.cmo \
-	   ocamlmktop.cmo
+       		 identifiable.cmo numbers.cmo arg_helper.cmo zero_alloc_annotations.cmo \
+	   			 clflags.cmo local_store.cmo load_path.cmo profile.cmo \
+					 profile_counters_functions.cmo ccomp.cmo ocamlmktop.cmo
 
 ocamlmktop$(EXE): $(OCAMLMKTOP)
 ocamlmktop.opt$(EXE): $(call byte2native, $(OCAMLMKTOP))

--- a/ocaml/tools/Makefile
+++ b/ocaml/tools/Makefile
@@ -100,10 +100,10 @@ all: profiling.cmo
 opt.opt: profiling.cmx
 
 OCAMLCP = config.cmo build_path_prefix_map.cmo misc.cmo profile.cmo \
-		  		profile_counters_functions.cmo \ warnings.cmo identifiable.cmo numbers.cmo \
-					arg_helper.cmo language_extension_kernel.cmo language_extension.cmo \
-	  	  	zero_alloc_annotations.cmo local_store.cmo \ terminfo.cmo location.cmo \
-					clflags.cmo load_path.cmo ccomp.cmo compenv.cmo main_args.cmo
+          profile_counters_functions.cmo \ warnings.cmo identifiable.cmo numbers.cmo \
+          arg_helper.cmo language_extension_kernel.cmo language_extension.cmo \
+          zero_alloc_annotations.cmo local_store.cmo \ terminfo.cmo location.cmo \
+          clflags.cmo load_path.cmo ccomp.cmo compenv.cmo main_args.cmo
 
 ocamlcp$(EXE): $(OCAMLCP) ocamlcp.cmo
 ocamlcp.opt$(EXE): $(call byte2native, $(OCAMLCP) ocamlcp.cmo)

--- a/ocaml/tools/Makefile
+++ b/ocaml/tools/Makefile
@@ -100,12 +100,10 @@ all: profiling.cmo
 opt.opt: profiling.cmx
 
 OCAMLCP = config.cmo build_path_prefix_map.cmo misc.cmo profile.cmo \
-		  profile_counters_functions.cmo \
-          warnings.cmo identifiable.cmo numbers.cmo arg_helper.cmo \
-          language_extension_kernel.cmo language_extension.cmo \
-	  	  zero_alloc_annotations.cmo local_store.cmo \
-          terminfo.cmo location.cmo clflags.cmo load_path.cmo ccomp.cmo compenv.cmo \
-          main_args.cmo
+		  		profile_counters_functions.cmo \ warnings.cmo identifiable.cmo numbers.cmo \
+					arg_helper.cmo language_extension_kernel.cmo language_extension.cmo \
+	  	  	zero_alloc_annotations.cmo local_store.cmo \ terminfo.cmo location.cmo \
+					clflags.cmo load_path.cmo ccomp.cmo compenv.cmo main_args.cmo
 
 ocamlcp$(EXE): $(OCAMLCP) ocamlcp.cmo
 ocamlcp.opt$(EXE): $(call byte2native, $(OCAMLCP) ocamlcp.cmo)
@@ -138,9 +136,9 @@ ocamlmklib.opt$(EXE): $(call byte2native, $(OCAMLMKLIB))
 # To make custom toplevels
 
 OCAMLMKTOP=config.cmo build_path_prefix_map.cmo misc.cmo \
-       		 identifiable.cmo numbers.cmo arg_helper.cmo zero_alloc_annotations.cmo \
-	   			 clflags.cmo local_store.cmo load_path.cmo profile.cmo \
-					 profile_counters_functions.cmo ccomp.cmo ocamlmktop.cmo
+           identifiable.cmo numbers.cmo arg_helper.cmo zero_alloc_annotations.cmo \
+           clflags.cmo local_store.cmo load_path.cmo profile.cmo \
+           profile_counters_functions.cmo ccomp.cmo ocamlmktop.cmo
 
 ocamlmktop$(EXE): $(OCAMLMKTOP)
 ocamlmktop.opt$(EXE): $(call byte2native, $(OCAMLMKTOP))

--- a/ocaml/utils/.ocamlformat-enable
+++ b/ocaml/utils/.ocamlformat-enable
@@ -6,3 +6,5 @@ language_extension.ml
 language_extension.mli
 zero_alloc_utils.ml
 zero_alloc_utils.mli
+profile_counters_functions.ml
+profile_counters_functions.mli

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -26,6 +26,12 @@ module Counters = struct
   let create () = String.Map.empty
   let get name t = String.Map.find_opt name t |> Option.value ~default:0
   let set name count t = String.Map.add name count t
+  let incr name t =
+    String.Map.update name
+      (fun count_opt ->
+        let count = Option.value ~default:0 count_opt in
+        Some (succ count))
+      t
   let is_empty = String.Map.is_empty
   let union = String.Map.union (fun _ count1 count2 -> Some (count1 + count2))
   let to_string t =
@@ -133,6 +139,9 @@ let record_call_internal ?(accumulate = false) ?counter_f name f =
         Hashtbl.add prev_hierarchy name (measure_diff, E this_table))
 
 let record_call = record_call_internal ?counter_f:None
+
+let record_call_with_counters ?accumulate ~counter_f =
+  record_call_internal ?accumulate ~counter_f
 
 let record ?accumulate pass f x = record_call ?accumulate pass (fun () -> f x)
 

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -43,8 +43,8 @@ val record_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 val record_call_with_counters :
   ?accumulate:bool -> counter_f:('a -> Counters.t) -> string -> (unit -> 'a) -> 'a
 (** [record_call_with_counters counter_f pass f] calls [f] and records its profile
-    information and records counter information given by calling [counter_f] on the
-    result of calling [f] *)
+    information (including counter information given by calling [counter_f] on the
+    result of calling [f]) *)
 
 val record : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [record pass f arg] records the profile information of [f arg] *)

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -29,6 +29,7 @@ module Counters : sig
   val is_empty : t -> bool
   val get : string -> t -> int
   val set : string -> int -> t -> t
+  val incr : string -> t -> t
   val union : t -> t -> t
   val to_string : t -> string
 end
@@ -38,6 +39,12 @@ val reset : unit -> unit
 
 val record_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 (** [record_call pass f] calls [f] and records its profile information. *)
+
+val record_call_with_counters :
+  ?accumulate:bool -> counter_f:('a -> Counters.t) -> string -> (unit -> 'a) -> 'a
+(** [record_call_with_counters counter_f pass f] calls [f] and records its profile
+    information and records counter information given by calling [counter_f] on the
+    result of calling [f] *)
 
 val record : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [record pass f arg] records the profile information of [f arg] *)

--- a/ocaml/utils/profile_counters_functions.ml
+++ b/ocaml/utils/profile_counters_functions.ml
@@ -40,7 +40,7 @@ let count_language_extensions typing_input =
       label_opt_pair_list
   in
   let check_array_mutability mutability =
-    if Types.is_mutable mutability then incr Immutable_arrays
+    if not (Types.is_mutable mutability) then incr Immutable_arrays
   in
   let iterator =
     Tast_iterator.

--- a/ocaml/utils/profile_counters_functions.ml
+++ b/ocaml/utils/profile_counters_functions.ml
@@ -1,6 +1,6 @@
-type typing_input =
-  | Typedtree_implementation_input of Typedtree.implementation
-  | Typedtree_signature_input of Typedtree.signature
+type typing_output_for_counters =
+  | Typedtree_implementation_output of Typedtree.implementation
+  | Typedtree_signature_output of Typedtree.signature
 
 let count_language_extensions typing_input =
   let counters = ref (Profile.Counters.create ()) in
@@ -108,7 +108,7 @@ let count_language_extensions typing_input =
       }
   in
   (match typing_input with
-  | Typedtree_implementation_input tree ->
+  | Typedtree_implementation_output tree ->
     iterator.structure iterator tree.structure
-  | Typedtree_signature_input signature -> iterator.signature iterator signature);
+  | Typedtree_signature_output signature -> iterator.signature iterator signature);
   !counters

--- a/ocaml/utils/profile_counters_functions.ml
+++ b/ocaml/utils/profile_counters_functions.ml
@@ -110,5 +110,6 @@ let count_language_extensions typing_input =
   (match typing_input with
   | Typedtree_implementation_output tree ->
     iterator.structure iterator tree.structure
-  | Typedtree_signature_output signature -> iterator.signature iterator signature);
+  | Typedtree_signature_output signature ->
+    iterator.signature iterator signature);
   !counters

--- a/ocaml/utils/profile_counters_functions.ml
+++ b/ocaml/utils/profile_counters_functions.ml
@@ -1,0 +1,118 @@
+type typing_input =
+  | Typedtree_implementation_input of Typedtree.implementation
+  | Typedtree_signature_input of Typedtree.signature
+
+let count_language_extensions typing_input =
+  let counters = ref (Profile.Counters.create ()) in
+  let to_string : type a. a Language_extension_kernel.t -> string =
+   fun lang_ext ->
+    match lang_ext with
+    | Comprehensions | Include_functor | Immutable_arrays | Module_strengthening
+    | Labeled_tuples ->
+      Language_extension_kernel.to_string lang_ext
+    | Mode | Unique | Polymorphic_parameters | Layouts | SIMD | Small_numbers ->
+      let error_msg =
+        Format.sprintf "No counters supported for language extension : %s."
+          (Language_extension_kernel.to_string lang_ext)
+      in
+      failwith error_msg
+  in
+  let incr lang_ext =
+    counters := Profile.Counters.incr (to_string lang_ext) !counters
+  in
+  let supported_lang_exts =
+    Language_extension_kernel.
+      [ Comprehensions;
+        Include_functor;
+        Immutable_arrays;
+        Module_strengthening;
+        Labeled_tuples;
+        Immutable_arrays ]
+  in
+  List.iter
+    (fun lang_ext ->
+      counters := Profile.Counters.set (to_string lang_ext) 0 !counters)
+    supported_lang_exts;
+  let check_for_labeled_tuples label_opt_pair_list =
+    List.iter
+      (fun (label_opt, _) ->
+        if Option.is_some label_opt then incr Labeled_tuples)
+      label_opt_pair_list
+  in
+  let check_array_mutability mutability =
+    if Types.is_mutable mutability then incr Immutable_arrays
+  in
+  let iterator =
+    Tast_iterator.
+      { default_iterator with
+        structure_item =
+          (fun sub ({ str_desc; _ } as si) ->
+            (match str_desc with
+            | Tstr_include include_declaration -> (
+              match include_declaration.incl_kind with
+              | Tincl_functor _ | Tincl_gen_functor _ -> incr Include_functor
+              | Tincl_structure -> ())
+            | _ -> ());
+            default_iterator.structure_item sub si);
+        signature_item =
+          (fun sub ({ sig_desc; _ } as si) ->
+            (match sig_desc with
+            | Tsig_include (include_declaration, _) -> (
+              match include_declaration.incl_kind with
+              | Tincl_functor _ | Tincl_gen_functor _ -> incr Include_functor
+              | Tincl_structure -> ())
+            | _ -> ());
+            default_iterator.signature_item sub si);
+        expr =
+          (fun sub ({ exp_desc; exp_extra; _ } as e) ->
+            (match exp_desc with
+            | Texp_list_comprehension _ -> incr Comprehensions
+            | Texp_array_comprehension (mutability, _, _) ->
+              incr Comprehensions;
+              check_array_mutability mutability
+            | Texp_array (mutability, _, _, _) ->
+              check_array_mutability mutability
+            | _ -> ());
+            let check_extra (extra : Typedtree.exp_extra) =
+              match extra with
+              | Texp_constraint (core_typ_opt, _) -> (
+                match core_typ_opt with
+                | Some { ctyp_desc; _ } -> (
+                  match ctyp_desc with
+                  | Ttyp_tuple label_opt_pair_list ->
+                    check_for_labeled_tuples label_opt_pair_list
+                  | _ -> ())
+                | None -> ())
+              | _ -> ()
+            in
+            List.iter (fun (extra, _, _) -> check_extra extra) exp_extra;
+            default_iterator.expr sub e);
+        module_type =
+          (fun sub ({ mty_desc; _ } as mty) ->
+            (match mty_desc with
+            | Tmty_strengthen _ -> incr Module_strengthening
+            | _ -> ());
+            default_iterator.module_type sub mty);
+        typ =
+          (fun sub ({ ctyp_desc; _ } as ctyp) ->
+            (match ctyp_desc with
+            | Ttyp_tuple label_opt_pair_list ->
+              check_for_labeled_tuples label_opt_pair_list
+            | _ -> ());
+            default_iterator.typ sub ctyp);
+        pat =
+          (fun (type k) sub
+               ({ pat_desc; _ } as gen_pat : k Typedtree.general_pattern) ->
+            (match pat_desc with
+            | Tpat_tuple label_opt_pair_list ->
+              check_for_labeled_tuples label_opt_pair_list
+            | Tpat_array (mutability, _, _) -> check_array_mutability mutability
+            | _ -> ());
+            default_iterator.pat sub gen_pat)
+      }
+  in
+  (match typing_input with
+  | Typedtree_implementation_input tree ->
+    iterator.structure iterator tree.structure
+  | Typedtree_signature_input signature -> iterator.signature iterator signature);
+  !counters

--- a/ocaml/utils/profile_counters_functions.ml
+++ b/ocaml/utils/profile_counters_functions.ml
@@ -20,6 +20,7 @@ let count_language_extensions typing_input =
   let incr lang_ext =
     counters := Profile.Counters.incr (to_string lang_ext) !counters
   in
+  (* CR-someday mitom: Add support for counting stdlib [Iarray] usages *)
   let supported_lang_exts =
     Language_extension_kernel.
       [ Comprehensions;
@@ -87,6 +88,12 @@ let count_language_extensions typing_input =
             (match ctyp_desc with
             | Ttyp_tuple label_opt_pair_list ->
               check_for_labeled_tuples label_opt_pair_list
+            (* CR-someday mitom: type occurence of [iarray] double counted in
+               [let a_iarray : int iarray = [: 1; 2; 3; 4; 5 :]] *)
+            | Ttyp_constr (Pident ident, _, _) ->
+              if Ident.is_predef ident
+                 && String.equal (Ident.name ident) "iarray"
+              then incr Immutable_arrays
             | _ -> ());
             default_iterator.typ sub ctyp);
         pat =

--- a/ocaml/utils/profile_counters_functions.mli
+++ b/ocaml/utils/profile_counters_functions.mli
@@ -1,5 +1,5 @@
-type typing_input =
-  | Typedtree_implementation_input of Typedtree.implementation
-  | Typedtree_signature_input of Typedtree.signature
+type typing_output_for_counters =
+  | Typedtree_implementation_output of Typedtree.implementation
+  | Typedtree_signature_output of Typedtree.signature
 
-val count_language_extensions : typing_input -> Profile.Counters.t
+val count_language_extensions : typing_output_for_counters -> Profile.Counters.t

--- a/ocaml/utils/profile_counters_functions.mli
+++ b/ocaml/utils/profile_counters_functions.mli
@@ -1,0 +1,5 @@
+type typing_input =
+  | Typedtree_implementation_input of Typedtree.implementation
+  | Typedtree_signature_input of Typedtree.signature
+
+val count_language_extensions : typing_input -> Profile.Counters.t


### PR DESCRIPTION
Adds some basic counters for the usages of the following language extensions:

- `comprehensions`
- `include functor`
- `immutable arrays`
- `module strengthening`
- `labeled tuples`
- `immutable arrays`