### PR TITLE
Support for or_null in Flambda 2 types

### DIFF
--- a/middle_end/flambda2/lattices/or_unknown_or_bottom.ml
+++ b/middle_end/flambda2/lattices/or_unknown_or_bottom.ml
@@ -20,10 +20,17 @@ type 'a t =
   | Bottom
 
 let print f ppf t =
+  let colour = Flambda_colours.top_or_bottom_type in
   match t with
-  | Unknown -> Format.pp_print_string ppf "Unknown"
-  | Ok contents -> Format.fprintf ppf "@[(Ok %a)@]" f contents
-  | Bottom -> Format.pp_print_string ppf "Bottom"
+  | Unknown ->
+    if Flambda_features.unicode ()
+    then Format.fprintf ppf "%t@<1>\u{22a4}%t" colour Flambda_colours.pop
+    else Format.fprintf ppf "%tT%t" colour Flambda_colours.pop
+  | Bottom ->
+    if Flambda_features.unicode ()
+    then Format.fprintf ppf "%t@<1>\u{22a5}%t" colour Flambda_colours.pop
+    else Format.fprintf ppf "%t_|_%t" colour Flambda_colours.pop
+  | Ok contents -> Format.fprintf ppf "@[(%a)@]" f contents
 
 let equal eq_contents t1 t2 =
   match t1, t2 with

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -615,9 +615,7 @@ let simplify_is_flat_float_array dacc ~original_term ~arg:_ ~arg_ty ~result_var
   (* CR mshinwell: see CRs in lambda_to_flambda_primitives.ml
 
      assert (Flambda_features.flat_float_array ()); *)
-  match
-    T.meet_is_naked_number_array (DA.typing_env dacc) arg_ty Naked_float
-  with
+  match T.meet_is_flat_float_array (DA.typing_env dacc) arg_ty with
   | Known_result is_flat_float_array ->
     let imm = Targetint_31_63.bool is_flat_float_array in
     let ty = T.this_naked_immediate imm in
@@ -750,9 +748,8 @@ let simplify_obj_dup dbg dacc ~original_term ~arg ~arg_ty ~result_var =
       ~try_reify:true dacc
   | Unknown -> (
     match T.prove_strings typing_env arg_ty with
-    | Proved (Heap, _) -> elide_primitive ()
-    | Proved ((Heap_or_local | Local), _) | Unknown ->
-      SPR.create_unknown dacc ~result_var K.value ~original_term)
+    | Proved _ -> elide_primitive ()
+    | Unknown -> SPR.create_unknown dacc ~result_var K.value ~original_term)
 
 let simplify_get_header ~original_prim dacc ~original_term ~arg:_ ~arg_ty:_
     ~result_var =

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1393,7 +1393,10 @@ end = struct
             ~const:(fun const -> VA.Value_const const)
             ~var:(fun _ ~coercion:_ -> VA.Value_unknown)
             ~symbol:(fun symbol ~coercion:_ -> VA.Value_symbol symbol)
-        | Ok (No_alias head) -> (
+        | Ok (No_alias { is_null = Maybe_null; _ })
+        | Ok (No_alias { non_null = Unknown | Bottom; _ }) ->
+          VA.Value_unknown
+        | Ok (No_alias { is_null = Not_null; non_null = Ok head }) -> (
           match head with
           | Mutable_block _ | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _
           | Boxed_int64 _ | Boxed_vec128 _ | Boxed_nativeint _ | String _

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -651,8 +651,12 @@ val prove_unique_fully_constructed_immutable_heap_block :
 
 val prove_is_int : Typing_env.t -> t -> bool proof_of_property
 
-val meet_is_naked_number_array :
-  Typing_env.t -> t -> Flambda_kind.Naked_number_kind.t -> bool meet_shortcut
+(* Returns the result of [Is_flat_float_array] *)
+val meet_is_flat_float_array : Typing_env.t -> t -> bool meet_shortcut
+
+(* Checks that it is an unboxed array of the corresponding kind *)
+val meet_is_non_empty_naked_number_array :
+  Flambda_kind.Naked_number_kind.t -> Typing_env.t -> t -> unit meet_shortcut
 
 val prove_is_immediates_array : Typing_env.t -> t -> unit proof_of_property
 
@@ -692,10 +696,7 @@ val prove_single_closures_entry :
 
 val meet_strings : Typing_env.t -> t -> String_info.Set.t meet_shortcut
 
-val prove_strings :
-  Typing_env.t ->
-  t ->
-  (Alloc_mode.For_types.t * String_info.Set.t) proof_of_property
+val prove_strings : Typing_env.t -> t -> String_info.Set.t proof_of_property
 
 (** Attempt to show that the provided type describes the tagged version of a
     unique naked immediate [Simple].

--- a/middle_end/flambda2/types/grammar/type_descr.ml
+++ b/middle_end/flambda2/types/grammar/type_descr.ml
@@ -263,17 +263,7 @@ end
 include T
 
 let print ~print_head ppf t =
-  let colour = Flambda_colours.top_or_bottom_type in
-  match descr t with
-  | Unknown ->
-    if Flambda_features.unicode ()
-    then Format.fprintf ppf "%t@<1>\u{22a4}%t" colour Flambda_colours.pop
-    else Format.fprintf ppf "%tT%t" colour Flambda_colours.pop
-  | Bottom ->
-    if Flambda_features.unicode ()
-    then Format.fprintf ppf "%t@<1>\u{22a5}%t" colour Flambda_colours.pop
-    else Format.fprintf ppf "%t_|_%t" colour Flambda_colours.pop
-  | Ok descr -> Descr.print ~print_head ppf descr
+  Or_unknown_or_bottom.print (Descr.print ~print_head) ppf (descr t)
 
 let[@inline always] apply_coercion ~apply_coercion_head coercion t :
     _ t Or_bottom.t =

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -38,6 +38,10 @@ module Block_size = struct
   let inter t1 t2 = Targetint_31_63.min t1 t2
 end
 
+type is_null =
+  | Not_null
+  | Maybe_null
+
 (* The grammar of Flambda types. *)
 type t =
   | Value of head_of_kind_value TD.t
@@ -52,6 +56,15 @@ type t =
   | Region of head_of_kind_region TD.t
 
 and head_of_kind_value =
+  { (* CR vlaviron: This Or_unknown_or_bottom is in part redundant with the one
+       introduced by Type_descr, but we need to be able to express things like
+       "unknown but not null" or "bottom but maybe null" (which is the type for
+       the Null constructor) *)
+    non_null : head_of_kind_value_non_null Or_unknown_or_bottom.t;
+    is_null : is_null
+  }
+
+and head_of_kind_value_non_null =
   | Variant of
       { immediates : t Or_unknown.t;
         blocks : row_like_for_blocks Or_unknown.t;
@@ -108,6 +121,7 @@ and head_of_kind_naked_immediate =
   | Naked_immediates of Targetint_31_63.Set.t
   | Is_int of t
   | Get_tag of t
+  | Is_null of t
 
 and head_of_kind_naked_float32 = Float32.Set.t
 
@@ -264,7 +278,14 @@ let rec free_names0 ~follow_value_slots t =
   | Region ty ->
     type_descr_free_names ~free_names_head:free_names_head_of_kind_region ty
 
-and free_names_head_of_kind_value0 ~follow_value_slots head =
+and free_names_head_of_kind_value0 ~follow_value_slots { non_null; is_null = _ }
+    =
+  match non_null with
+  | Unknown | Bottom -> Name_occurrences.empty
+  | Ok non_null ->
+    free_names_head_of_kind_value_non_null ~follow_value_slots non_null
+
+and free_names_head_of_kind_value_non_null ~follow_value_slots head =
   match head with
   | Variant { blocks; immediates; extensions; is_unique = _ } ->
     Name_occurrences.union_list
@@ -306,7 +327,7 @@ and free_names_head_of_kind_value0 ~follow_value_slots head =
 and free_names_head_of_kind_naked_immediate0 ~follow_value_slots head =
   match head with
   | Naked_immediates _ -> Name_occurrences.empty
-  | Is_int ty | Get_tag ty -> free_names0 ~follow_value_slots ty
+  | Is_int ty | Get_tag ty | Is_null ty -> free_names0 ~follow_value_slots ty
 
 and free_names_head_of_kind_naked_float32 _ = Name_occurrences.empty
 
@@ -550,6 +571,18 @@ let rec apply_renaming t renaming =
       if ty == ty' then t else Region ty'
 
 and apply_renaming_head_of_kind_value head renaming =
+  let { non_null; is_null = _ } = head in
+  match non_null with
+  | Unknown | Bottom -> head
+  | Ok non_null ->
+    let non_null' =
+      apply_renaming_head_of_kind_value_non_null non_null renaming
+    in
+    if non_null == non_null'
+    then head
+    else { non_null = Ok non_null'; is_null = head.is_null }
+
+and apply_renaming_head_of_kind_value_non_null head renaming =
   match head with
   | Variant { blocks; immediates; extensions; is_unique } ->
     let immediates' =
@@ -642,6 +675,9 @@ and apply_renaming_head_of_kind_naked_immediate head renaming =
   | Get_tag ty ->
     let ty' = apply_renaming ty renaming in
     if ty == ty' then head else Get_tag ty'
+  | Is_null ty ->
+    let ty' = apply_renaming ty renaming in
+    if ty == ty' then head else Is_null ty'
 
 and apply_renaming_head_of_kind_naked_float32 head _ = head
 
@@ -849,7 +885,13 @@ let rec print ppf t =
       (TD.print ~print_head:print_head_of_kind_region)
       ty
 
-and print_head_of_kind_value ppf head =
+and print_head_of_kind_value ppf { non_null; is_null } =
+  let null_string = match is_null with Maybe_null -> "?" | Not_null -> "!" in
+  Format.fprintf ppf "@[<hov 1> %a%s@]"
+    (Or_unknown_or_bottom.print print_head_of_kind_value_non_null)
+    non_null null_string
+
+and print_head_of_kind_value_non_null ppf head =
   match head with
   | Variant { blocks; immediates; extensions; is_unique } ->
     (* CR-someday mshinwell: Improve so that we elide blocks and/or immediates
@@ -918,6 +960,7 @@ and print_head_of_kind_naked_immediate ppf head =
     Format.fprintf ppf "@[<hov 1>(%a)@]" Targetint_31_63.Set.print is
   | Is_int ty -> Format.fprintf ppf "@[<hov 1>(Is_int@ %a)@]" print ty
   | Get_tag ty -> Format.fprintf ppf "@[<hov 1>(Get_tag@ %a)@]" print ty
+  | Is_null ty -> Format.fprintf ppf "@[<hov 1>(Is_null@ %a)@]" print ty
 
 and print_head_of_kind_naked_float32 ppf head =
   Format.fprintf ppf "@[(Naked_float32@ (%a))@]" Float32.Set.print head
@@ -1108,7 +1151,12 @@ let rec ids_for_export t =
   | Region ty ->
     TD.ids_for_export ~ids_for_export_head:ids_for_export_head_of_kind_region ty
 
-and ids_for_export_head_of_kind_value head =
+and ids_for_export_head_of_kind_value { non_null; is_null = _ } =
+  match non_null with
+  | Unknown | Bottom -> Ids_for_export.empty
+  | Ok non_null -> ids_for_export_head_of_kind_value_non_null non_null
+
+and ids_for_export_head_of_kind_value_non_null head =
   match head with
   | Variant { blocks; immediates; extensions; is_unique = _ } ->
     Ids_for_export.union_list
@@ -1145,7 +1193,7 @@ and ids_for_export_head_of_kind_value head =
 and ids_for_export_head_of_kind_naked_immediate head =
   match head with
   | Naked_immediates _ -> Ids_for_export.empty
-  | Is_int t | Get_tag t -> ids_for_export t
+  | Is_int t | Get_tag t | Is_null t -> ids_for_export t
 
 and ids_for_export_head_of_kind_naked_float32 _ = Ids_for_export.empty
 
@@ -1355,7 +1403,16 @@ let rec apply_coercion t coercion : t Or_bottom.t =
       in
       if ty == ty' then t else Region ty'
 
-and apply_coercion_head_of_kind_value head coercion : _ Or_bottom.t =
+and apply_coercion_head_of_kind_value ({ non_null; is_null } as head) coercion =
+  match non_null with
+  | Unknown | Bottom -> Or_bottom.Ok head
+  | Ok non_null ->
+    let<+ non_null =
+      apply_coercion_head_of_kind_value_non_null non_null coercion
+    in
+    { non_null = Ok non_null; is_null }
+
+and apply_coercion_head_of_kind_value_non_null head coercion : _ Or_bottom.t =
   match head with
   | Closures { by_function_slot; alloc_mode } ->
     let<+ by_function_slot' =
@@ -1701,6 +1758,20 @@ let rec remove_unused_value_slots_and_shortcut_aliases t ~used_value_slots
 
 and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value head
     ~used_value_slots ~canonicalise =
+  let { non_null; is_null = _ } = head in
+  match non_null with
+  | Unknown | Bottom -> head
+  | Ok non_null ->
+    let non_null' =
+      remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value_non_null
+        non_null ~used_value_slots ~canonicalise
+    in
+    if non_null == non_null'
+    then head
+    else { non_null = Ok non_null'; is_null = head.is_null }
+
+and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value_non_null
+    head ~used_value_slots ~canonicalise =
   match head with
   | Variant { blocks; immediates; extensions; is_unique } ->
     let immediates' =
@@ -1834,6 +1905,12 @@ and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_naked_immediate
         ~canonicalise
     in
     if ty == ty' then head else Get_tag ty'
+  | Is_null ty ->
+    let ty' =
+      remove_unused_value_slots_and_shortcut_aliases ty ~used_value_slots
+        ~canonicalise
+    in
+    if ty == ty' then head else Is_null ty'
 
 and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_naked_float32
     head ~used_value_slots:_ ~canonicalise:_ =
@@ -2281,6 +2358,18 @@ let rec project_variables_out ~to_project ~expand t =
     if ty == ty' then t else Region ty'
 
 and project_head_of_kind_value ~to_project ~expand head =
+  let { non_null; is_null = _ } = head in
+  match non_null with
+  | Unknown | Bottom -> head
+  | Ok non_null ->
+    let non_null' =
+      project_head_of_kind_value_non_null ~to_project ~expand non_null
+    in
+    if non_null == non_null'
+    then head
+    else { non_null = Ok non_null'; is_null = head.is_null }
+
+and project_head_of_kind_value_non_null ~to_project ~expand head =
   match head with
   | Variant { blocks; immediates; extensions; is_unique } ->
     let immediates' =
@@ -2375,6 +2464,9 @@ and project_head_of_kind_naked_immediate ~to_project ~expand head =
   | Get_tag ty ->
     let ty' = project_variables_out ~to_project ~expand ty in
     if ty == ty' then head else Get_tag ty'
+  | Is_null ty ->
+    let ty' = project_variables_out ~to_project ~expand ty in
+    if ty == ty' then head else Is_null ty'
 
 and project_head_of_kind_naked_float32 ~to_project:_ ~expand:_ head = head
 
@@ -2577,6 +2669,9 @@ let kind t =
   | Rec_info _ -> K.rec_info
   | Region _ -> K.region
 
+let non_null_value non_null =
+  Value (TD.create { non_null = Ok non_null; is_null = Not_null })
+
 let create_variant ~is_unique ~(immediates : _ Or_unknown.t) ~blocks ~extensions
     =
   (match immediates with
@@ -2588,12 +2683,12 @@ let create_variant ~is_unique ~(immediates : _ Or_unknown.t) ~blocks ~extensions
         "Cannot create [immediates] with type that is not of kind \
          [Naked_immediate]:@ %a"
         print immediates);
-  Value (TD.create (Variant { immediates; blocks; extensions; is_unique }))
+  non_null_value (Variant { immediates; blocks; extensions; is_unique })
 
-let mutable_block alloc_mode = Value (TD.create (Mutable_block { alloc_mode }))
+let mutable_block alloc_mode = non_null_value (Mutable_block { alloc_mode })
 
 let create_closures alloc_mode by_function_slot =
-  Value (TD.create (Closures { by_function_slot; alloc_mode }))
+  non_null_value (Closures { by_function_slot; alloc_mode })
 
 module Function_type = struct
   type t = function_type
@@ -3172,14 +3267,14 @@ let these_naked_vec128s vs =
 
 let box_float32 (t : t) alloc_mode : t =
   match t with
-  | Naked_float32 _ -> Value (TD.create (Boxed_float32 (t, alloc_mode)))
+  | Naked_float32 _ -> non_null_value (Boxed_float32 (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_int32 _ | Naked_float _ | Naked_int64 _
   | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _ ->
     Misc.fatal_errorf "Type of wrong kind for [box_float32]: %a" print t
 
 let box_float (t : t) alloc_mode : t =
   match t with
-  | Naked_float _ -> Value (TD.create (Boxed_float (t, alloc_mode)))
+  | Naked_float _ -> non_null_value (Boxed_float (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_int32 _ | Naked_float32 _
   | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _
     ->
@@ -3187,7 +3282,7 @@ let box_float (t : t) alloc_mode : t =
 
 let box_int32 (t : t) alloc_mode : t =
   match t with
-  | Naked_int32 _ -> Value (TD.create (Boxed_int32 (t, alloc_mode)))
+  | Naked_int32 _ -> non_null_value (Boxed_int32 (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_float32 _
   | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _
     ->
@@ -3195,7 +3290,7 @@ let box_int32 (t : t) alloc_mode : t =
 
 let box_int64 (t : t) alloc_mode : t =
   match t with
-  | Naked_int64 _ -> Value (TD.create (Boxed_int64 (t, alloc_mode)))
+  | Naked_int64 _ -> non_null_value (Boxed_int64 (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_float32 _
   | Naked_int32 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _
     ->
@@ -3203,17 +3298,22 @@ let box_int64 (t : t) alloc_mode : t =
 
 let box_nativeint (t : t) alloc_mode : t =
   match t with
-  | Naked_nativeint _ -> Value (TD.create (Boxed_nativeint (t, alloc_mode)))
+  | Naked_nativeint _ -> non_null_value (Boxed_nativeint (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_float32 _
   | Naked_int32 _ | Naked_int64 _ | Naked_vec128 _ | Rec_info _ | Region _ ->
     Misc.fatal_errorf "Type of wrong kind for [box_nativeint]: %a" print t
 
 let box_vec128 (t : t) alloc_mode : t =
   match t with
-  | Naked_vec128 _ -> Value (TD.create (Boxed_vec128 (t, alloc_mode)))
+  | Naked_vec128 _ -> non_null_value (Boxed_vec128 (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_float32 _
   | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _ | Rec_info _ | Region _ ->
     Misc.fatal_errorf "Type of wrong kind for [box_vec128]: %a" print t
+
+let null : t = Value (TD.create { non_null = Bottom; is_null = Maybe_null })
+
+let any_non_null_value : t =
+  Value (TD.create { non_null = Unknown; is_null = Not_null })
 
 let this_tagged_immediate imm : t =
   Value (TD.create_equals (Simple.const (RWC.tagged_immediate imm)))
@@ -3221,14 +3321,13 @@ let this_tagged_immediate imm : t =
 let tag_immediate t : t =
   match t with
   | Naked_immediate _ ->
-    Value
-      (TD.create
-         (Variant
-            { is_unique = false;
-              immediates = Known t;
-              extensions = No_extensions;
-              blocks = Known Row_like_for_blocks.bottom
-            }))
+    non_null_value
+      (Variant
+         { is_unique = false;
+           immediates = Known t;
+           extensions = No_extensions;
+           blocks = Known Row_like_for_blocks.bottom
+         })
   | Value _ | Naked_float _ | Naked_float32 _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Naked_vec128 _ | Rec_info _ | Region _ ->
     Misc.fatal_errorf "Type of wrong kind for [tag_immediate]: %a" print t
@@ -3242,6 +3341,9 @@ let is_int_for_scrutinee ~scrutinee : t =
 
 let get_tag_for_block ~block : t =
   Naked_immediate (TD.create (Get_tag (alias_type_of K.value block)))
+
+let is_null ~scrutinee : t =
+  Naked_immediate (TD.create (Is_null (alias_type_of K.value scrutinee)))
 
 let boxed_float32_alias_to ~naked_float32 =
   box_float32 (Naked_float32 (TD.create_equals (Simple.var naked_float32)))
@@ -3268,7 +3370,7 @@ let this_immutable_string str =
     String_info.Set.singleton
       (String_info.create ~contents:(Contents str) ~size)
   in
-  Value (TD.create (String string_info))
+  non_null_value (String string_info)
 
 let mutable_string ~size =
   let size = Targetint_31_63.of_int size in
@@ -3276,28 +3378,25 @@ let mutable_string ~size =
     String_info.Set.singleton
       (String_info.create ~contents:Unknown_or_mutable ~size)
   in
-  Value (TD.create (String string_info))
+  non_null_value (String string_info)
 
 let array_of_length ~element_kind ~length alloc_mode =
-  Value
-    (TD.create (Array { element_kind; length; contents = Unknown; alloc_mode }))
+  non_null_value
+    (Array { element_kind; length; contents = Unknown; alloc_mode })
 
 let mutable_array ~element_kind ~length alloc_mode =
-  Value
-    (TD.create
-       (Array { element_kind; length; contents = Known Mutable; alloc_mode }))
+  non_null_value
+    (Array { element_kind; length; contents = Known Mutable; alloc_mode })
 
 let immutable_array ~element_kind ~fields alloc_mode =
-  Value
-    (TD.create
-       (Array
-          { element_kind;
-            length =
-              this_tagged_immediate
-                (Targetint_31_63.of_int (List.length fields));
-            contents = Known (Immutable { fields = Array.of_list fields });
-            alloc_mode
-          }))
+  non_null_value
+    (Array
+       { element_kind;
+         length =
+           this_tagged_immediate (Targetint_31_63.of_int (List.length fields));
+         contents = Known (Immutable { fields = Array.of_list fields });
+         alloc_mode
+       })
 
 let this_rec_info (rec_info_expr : Rec_info_expr.t) =
   match rec_info_expr with
@@ -3357,6 +3456,53 @@ let create_from_head_region head = Region (TD.create head)
 
 module Head_of_kind_value = struct
   type t = head_of_kind_value
+
+  let mk_non_null non_null = { non_null = Ok non_null; is_null = Not_null }
+
+  let create_variant ~is_unique ~blocks ~immediates ~extensions =
+    mk_non_null (Variant { is_unique; blocks; immediates; extensions })
+
+  let create_mutable_block alloc_mode =
+    mk_non_null (Mutable_block { alloc_mode })
+
+  let create_boxed_float32 ty alloc_mode =
+    mk_non_null (Boxed_float32 (ty, alloc_mode))
+
+  let create_boxed_float ty alloc_mode =
+    mk_non_null (Boxed_float (ty, alloc_mode))
+
+  let create_boxed_int32 ty alloc_mode =
+    mk_non_null (Boxed_int32 (ty, alloc_mode))
+
+  let create_boxed_int64 ty alloc_mode =
+    mk_non_null (Boxed_int64 (ty, alloc_mode))
+
+  let create_boxed_nativeint ty alloc_mode =
+    mk_non_null (Boxed_nativeint (ty, alloc_mode))
+
+  let create_boxed_vec128 ty alloc_mode =
+    mk_non_null (Boxed_vec128 (ty, alloc_mode))
+
+  let create_tagged_immediate imm : t =
+    mk_non_null
+      (Variant
+         { is_unique = false;
+           immediates = Known (this_naked_immediate imm);
+           blocks = Known Row_like_for_blocks.bottom;
+           extensions = No_extensions
+         })
+
+  let create_closures by_function_slot alloc_mode =
+    mk_non_null (Closures { by_function_slot; alloc_mode })
+
+  let create_string info = mk_non_null (String info)
+
+  let create_array_with_contents ~element_kind ~length contents alloc_mode =
+    mk_non_null (Array { element_kind; length; contents; alloc_mode })
+end
+
+module Head_of_kind_value_non_null = struct
+  type t = head_of_kind_value_non_null
 
   let create_variant ~is_unique ~blocks ~immediates ~extensions =
     Variant { is_unique; blocks; immediates; extensions }
@@ -3431,6 +3577,8 @@ module Head_of_kind_naked_immediate = struct
   let create_is_int ty = Is_int ty
 
   let create_get_tag ty = Get_tag ty
+
+  let create_is_null ty = Is_null ty
 end
 
 module Make_head_of_kind_naked_number (N : Container_types.S) = struct
@@ -3472,15 +3620,25 @@ let rec recover_some_aliases t =
     match TD.descr ty with
     | Unknown | Bottom
     | Ok (Equals _)
+    (* CR vlaviron: Recover null aliases *)
+    | Ok (No_alias { is_null = Maybe_null; _ })
     | Ok
         (No_alias
-          ( Mutable_block _ | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _
-          | Boxed_int64 _ | Boxed_vec128 _ | Boxed_nativeint _ | String _
-          | Closures _ | Array _ )) ->
+          { is_null = Not_null;
+            non_null =
+              ( Unknown | Bottom
+              | Ok
+                  ( Mutable_block _ | Boxed_float _ | Boxed_float32 _
+                  | Boxed_int32 _ | Boxed_int64 _ | Boxed_vec128 _
+                  | Boxed_nativeint _ | String _ | Closures _ | Array _ ) )
+          }) ->
       t
     | Ok
         (No_alias
-          (Variant { immediates; blocks; extensions = _; is_unique = _ })) -> (
+          { is_null = Not_null;
+            non_null =
+              Ok (Variant { immediates; blocks; extensions = _; is_unique = _ })
+          }) -> (
       match blocks with
       | Unknown -> t
       | Known blocks -> (
@@ -3515,7 +3673,9 @@ let rec recover_some_aliases t =
                 t' ()))))
   | Naked_immediate ty -> (
     match TD.descr ty with
-    | Unknown | Bottom | Ok (Equals _) | Ok (No_alias (Is_int _ | Get_tag _)) ->
+    | Unknown | Bottom
+    | Ok (Equals _)
+    | Ok (No_alias (Is_int _ | Get_tag _ | Is_null _)) ->
       t
     | Ok (No_alias (Naked_immediates is)) -> (
       match Targetint_31_63.Set.get_singleton is with

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -568,9 +568,10 @@ and meet_head_of_kind_value initial_env
     | Bottom -> Bottom (New_result ())
     | Ok env -> (
       match is_null1, is_null2 with
-      | Not_null, Not_null | Maybe_null, Maybe_null -> Ok (Both_inputs, env)
-      | Not_null, Maybe_null -> Ok (Left_input, env)
-      | Maybe_null, Not_null -> Ok (Right_input, env))
+      | Not_null, Not_null -> Bottom Both_inputs
+      | Maybe_null, Maybe_null -> Ok (Both_inputs, env)
+      | Not_null, Maybe_null -> Bottom Left_input
+      | Maybe_null, Not_null -> Bottom Right_input)
   in
   match non_null_result, is_null_result with
   | Bottom r1, Bottom r2 ->

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -983,13 +983,16 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
         meet_with_shape ~rebuild is_int_ty MTC.any_tagged_immediate is_int_side
   in
   let is_null_immediate ~is_null_ty ~immediates ~is_null_side =
-    let rebuild = TG.Head_of_kind_naked_immediate.create_is_null in
-    match I.Set.mem I.zero immediates, I.Set.mem I.one immediates with
-    | false, false -> Bottom (New_result ())
-    | true, true -> keep_side is_null_side
-    | true, false ->
-      meet_with_shape ~rebuild is_null_ty TG.any_non_null_value is_null_side
-    | false, true -> meet_with_shape ~rebuild is_null_ty TG.null is_null_side
+    if I.Set.is_empty immediates
+    then bottom_other_side is_null_side
+    else
+      let rebuild = TG.Head_of_kind_naked_immediate.create_is_null in
+      match I.Set.mem I.zero immediates, I.Set.mem I.one immediates with
+      | false, false -> Bottom (New_result ())
+      | true, true -> keep_side is_null_side
+      | true, false ->
+        meet_with_shape ~rebuild is_null_ty TG.any_non_null_value is_null_side
+      | false, true -> meet_with_shape ~rebuild is_null_ty TG.null is_null_side
   in
   let get_tag_immediate ~get_tag_ty ~immediates ~get_tag_side =
     if I.Set.is_empty immediates

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -633,18 +633,18 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
     -> (
     match I.Set.elements is_null with
     | [] -> Bottom
-    | [is_int] -> (
+    | [is_null] -> (
       let shape =
-        if I.equal is_int I.zero
+        if I.equal is_null I.zero
         then Some TG.any_non_null_value
-        else if I.equal is_int I.one
+        else if I.equal is_null I.one
         then Some TG.null
         else None
       in
       match shape with
       | Some shape ->
         let<+ ty, env_extension = meet env ty shape in
-        TG.Head_of_kind_naked_immediate.create_is_int ty, env_extension
+        TG.Head_of_kind_naked_immediate.create_is_null ty, env_extension
       | None -> Bottom)
     | _ :: _ :: _ ->
       (* Note: we're potentially losing precision because the set could end up

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -345,7 +345,34 @@ and meet_expanded_head0 env (descr1 : ET.descr) (descr2 : ET.descr) :
     assert false
 
 and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
-    (head2 : TG.head_of_kind_value) : _ Or_bottom.t =
+    (head2 : TG.head_of_kind_value) :
+    (TG.head_of_kind_value * TEE.t) Or_bottom.t =
+  let non_null_result : _ Or_bottom.t =
+    match head1.non_null, head2.non_null with
+    | Bottom, _ | _, Bottom -> Bottom
+    | Unknown, non_null | non_null, Unknown -> Ok (non_null, TEE.empty)
+    | Ok non_null1, Ok non_null2 ->
+      let<+ non_null, env_extension =
+        meet_head_of_kind_value_non_null env non_null1 non_null2
+      in
+      Or_unknown_or_bottom.Ok non_null, env_extension
+  in
+  let is_null : TG.is_null =
+    match head1.is_null, head2.is_null with
+    | Not_null, _ | _, Not_null -> Not_null
+    | Maybe_null, Maybe_null -> Maybe_null
+  in
+  match non_null_result, is_null with
+  | Bottom, Maybe_null -> Ok ({ non_null = Bottom; is_null }, TEE.empty)
+  | Bottom, Not_null -> Bottom
+  | Ok (non_null, env_extension), Not_null ->
+    Ok ({ non_null; is_null }, env_extension)
+  | Ok (non_null, _env_extension), Maybe_null ->
+    Ok ({ non_null; is_null }, TEE.empty)
+
+and meet_head_of_kind_value_non_null env
+    (head1 : TG.head_of_kind_value_non_null)
+    (head2 : TG.head_of_kind_value_non_null) : _ Or_bottom.t =
   match head1, head2 with
   | ( Variant
         { blocks = blocks1;
@@ -365,13 +392,13 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
     (* Uniqueness tracks whether duplication/lifting is allowed. It must always
        be propagated, both for meet and join. *)
     let is_unique = is_unique1 || is_unique2 in
-    ( TG.Head_of_kind_value.create_variant ~is_unique ~blocks ~immediates
-        ~extensions:No_extensions,
+    ( TG.Head_of_kind_value_non_null.create_variant ~is_unique ~blocks
+        ~immediates ~extensions:No_extensions,
       env_extension )
   | ( Mutable_block { alloc_mode = alloc_mode1 },
       Mutable_block { alloc_mode = alloc_mode2 } ) ->
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_mutable_block alloc_mode, TEE.empty
+    TG.Head_of_kind_value_non_null.create_mutable_block alloc_mode, TEE.empty
   | ( Variant { blocks; _ },
       (Mutable_block { alloc_mode = alloc_mode_mut } as mut_block) )
   | ( (Mutable_block { alloc_mode = alloc_mode_mut } as mut_block),
@@ -380,31 +407,37 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
     | Unknown -> Ok (mut_block, TEE.empty)
     | Known { alloc_mode = alloc_mode_immut; _ } ->
       let<+ alloc_mode = meet_alloc_mode alloc_mode_mut alloc_mode_immut in
-      TG.Head_of_kind_value.create_mutable_block alloc_mode, TEE.empty)
+      TG.Head_of_kind_value_non_null.create_mutable_block alloc_mode, TEE.empty)
   | Boxed_float32 (n1, alloc_mode1), Boxed_float32 (n2, alloc_mode2) ->
     let<* n, env_extension = meet env n1 n2 in
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_float32 n alloc_mode, env_extension
+    ( TG.Head_of_kind_value_non_null.create_boxed_float32 n alloc_mode,
+      env_extension )
   | Boxed_float (n1, alloc_mode1), Boxed_float (n2, alloc_mode2) ->
     let<* n, env_extension = meet env n1 n2 in
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_float n alloc_mode, env_extension
+    ( TG.Head_of_kind_value_non_null.create_boxed_float n alloc_mode,
+      env_extension )
   | Boxed_int32 (n1, alloc_mode1), Boxed_int32 (n2, alloc_mode2) ->
     let<* n, env_extension = meet env n1 n2 in
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_int32 n alloc_mode, env_extension
+    ( TG.Head_of_kind_value_non_null.create_boxed_int32 n alloc_mode,
+      env_extension )
   | Boxed_int64 (n1, alloc_mode1), Boxed_int64 (n2, alloc_mode2) ->
     let<* n, env_extension = meet env n1 n2 in
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_int64 n alloc_mode, env_extension
+    ( TG.Head_of_kind_value_non_null.create_boxed_int64 n alloc_mode,
+      env_extension )
   | Boxed_nativeint (n1, alloc_mode1), Boxed_nativeint (n2, alloc_mode2) ->
     let<* n, env_extension = meet env n1 n2 in
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_nativeint n alloc_mode, env_extension
+    ( TG.Head_of_kind_value_non_null.create_boxed_nativeint n alloc_mode,
+      env_extension )
   | Boxed_vec128 (n1, alloc_mode1), Boxed_vec128 (n2, alloc_mode2) ->
     let<* n, env_extension = meet env n1 n2 in
     let<+ alloc_mode = meet_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_vec128 n alloc_mode, env_extension
+    ( TG.Head_of_kind_value_non_null.create_boxed_vec128 n alloc_mode,
+      env_extension )
   | ( Closures { by_function_slot = by_function_slot1; alloc_mode = alloc_mode1 },
       Closures
         { by_function_slot = by_function_slot2; alloc_mode = alloc_mode2 } ) ->
@@ -412,13 +445,14 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
     let<+ by_function_slot, env_extension =
       meet_row_like_for_closures env by_function_slot1 by_function_slot2
     in
-    ( TG.Head_of_kind_value.create_closures by_function_slot alloc_mode,
+    ( TG.Head_of_kind_value_non_null.create_closures by_function_slot alloc_mode,
       env_extension )
   | String strs1, String strs2 ->
     let strs = String_info.Set.inter strs1 strs2 in
     if String_info.Set.is_empty strs
     then Bottom
-    else Or_bottom.Ok (TG.Head_of_kind_value.create_string strs, TEE.empty)
+    else
+      Or_bottom.Ok (TG.Head_of_kind_value_non_null.create_string strs, TEE.empty)
   | ( Array
         { element_kind = element_kind1;
           length = length1;
@@ -442,8 +476,8 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
        length type with the constant 0 (only the empty array can have element
        kind Bottom). *)
     let<+ env_extension = meet_env_extension env env_extension env_extension' in
-    ( TG.Head_of_kind_value.create_array_with_contents ~element_kind ~length
-        contents alloc_mode,
+    ( TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
+        ~length contents alloc_mode,
       env_extension )
   | ( ( Variant _ | Mutable_block _ | Boxed_float _ | Boxed_float32 _
       | Boxed_int32 _ | Boxed_vec128 _ | Boxed_int64 _ | Boxed_nativeint _
@@ -595,7 +629,28 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
       TG.Head_of_kind_naked_immediate.create_get_tag ty, env_extension
     | Unknown ->
       Ok (TG.Head_of_kind_naked_immediate.create_get_tag ty, TEE.empty))
-  | (Is_int _ | Get_tag _), (Is_int _ | Get_tag _) ->
+  | Is_null ty, Naked_immediates is_null | Naked_immediates is_null, Is_null ty
+    -> (
+    match I.Set.elements is_null with
+    | [] -> Bottom
+    | [is_int] -> (
+      let shape =
+        if I.equal is_int I.zero
+        then Some TG.any_non_null_value
+        else if I.equal is_int I.one
+        then Some TG.null
+        else None
+      in
+      match shape with
+      | Some shape ->
+        let<+ ty, env_extension = meet env ty shape in
+        TG.Head_of_kind_naked_immediate.create_is_int ty, env_extension
+      | None -> Bottom)
+    | _ :: _ :: _ ->
+      (* Note: we're potentially losing precision because the set could end up
+         not containing either 0 or 1 or both, but this should be uncommon. *)
+      Ok (TG.Head_of_kind_naked_immediate.create_is_null ty, TEE.empty))
+  | (Is_int _ | Get_tag _ | Is_null _), (Is_int _ | Get_tag _ | Is_null _) ->
     (* We can't return Bottom, as it would be unsound, so we need to either do
        the actual meet with Naked_immediates, or just give up and return one of
        the arguments. N.B. Also see comment in meet_and_join_new.ml *)
@@ -1262,6 +1317,29 @@ and join_expanded_head env kind (expanded1 : ET.t) (expanded2 : ET.t) : ET.t =
 
 and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
     (head2 : TG.head_of_kind_value) : TG.head_of_kind_value Or_unknown.t =
+  let non_null : _ Or_unknown_or_bottom.t =
+    match head1.non_null, head2.non_null with
+    | Unknown, _ | _, Unknown -> Unknown
+    | Bottom, non_null | non_null, Bottom -> non_null
+    | Ok non_null1, Ok non_null2 -> (
+      match join_head_of_kind_value_non_null env non_null1 non_null2 with
+      | Unknown -> Unknown
+      | Known non_null -> Ok non_null)
+  in
+  let is_null : TG.is_null =
+    match head1.is_null, head2.is_null with
+    | Maybe_null, _ | _, Maybe_null -> Maybe_null
+    | Not_null, Not_null -> Not_null
+  in
+  match non_null, is_null with
+  | Unknown, Maybe_null -> Unknown
+  | (Unknown | Bottom | Ok _), (Maybe_null | Not_null) ->
+    Known { non_null; is_null }
+
+and join_head_of_kind_value_non_null env
+    (head1 : TG.head_of_kind_value_non_null)
+    (head2 : TG.head_of_kind_value_non_null) :
+    TG.head_of_kind_value_non_null Or_unknown.t =
   match head1, head2 with
   | ( Variant
         { blocks = blocks1;
@@ -1281,36 +1359,36 @@ and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
     (* Uniqueness tracks whether duplication/lifting is allowed. It must always
        be propagated, both for meet and join. *)
     let is_unique = is_unique1 || is_unique2 in
-    TG.Head_of_kind_value.create_variant ~is_unique ~blocks ~immediates
+    TG.Head_of_kind_value_non_null.create_variant ~is_unique ~blocks ~immediates
       ~extensions:No_extensions
   | ( Mutable_block { alloc_mode = alloc_mode1 },
       Mutable_block { alloc_mode = alloc_mode2 } ) ->
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    Known (TG.Head_of_kind_value.create_mutable_block alloc_mode)
+    Known (TG.Head_of_kind_value_non_null.create_mutable_block alloc_mode)
   | Boxed_float32 (n1, alloc_mode1), Boxed_float32 (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_float32 n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_float32 n alloc_mode
   | Boxed_float (n1, alloc_mode1), Boxed_float (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_float n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_float n alloc_mode
   | Boxed_int32 (n1, alloc_mode1), Boxed_int32 (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_int32 n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_int32 n alloc_mode
   | Boxed_int64 (n1, alloc_mode1), Boxed_int64 (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_int64 n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_int64 n alloc_mode
   | Boxed_nativeint (n1, alloc_mode1), Boxed_nativeint (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_nativeint n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_nativeint n alloc_mode
   | Boxed_vec128 (n1, alloc_mode1), Boxed_vec128 (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_vec128 n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_vec128 n alloc_mode
   | ( Closures { by_function_slot = by_function_slot1; alloc_mode = alloc_mode1 },
       Closures
         { by_function_slot = by_function_slot2; alloc_mode = alloc_mode2 } ) ->
@@ -1318,10 +1396,12 @@ and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
       join_row_like_for_closures env by_function_slot1 by_function_slot2
     in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    Known (TG.Head_of_kind_value.create_closures by_function_slot alloc_mode)
+    Known
+      (TG.Head_of_kind_value_non_null.create_closures by_function_slot
+         alloc_mode)
   | String strs1, String strs2 ->
     let strs = String_info.Set.union strs1 strs2 in
-    Known (TG.Head_of_kind_value.create_string strs)
+    Known (TG.Head_of_kind_value_non_null.create_string strs)
   | ( Array
         { element_kind = element_kind1;
           length = length1;
@@ -1341,8 +1421,8 @@ and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
         ~joined_element_kind:element_kind
     in
     let>+ length = join env length1 length2 in
-    TG.Head_of_kind_value.create_array_with_contents ~element_kind ~length
-      contents alloc_mode
+    TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
+      ~length contents alloc_mode
   | ( ( Variant _ | Mutable_block _ | Boxed_float _ | Boxed_float32 _
       | Boxed_int32 _ | Boxed_vec128 _ | Boxed_int64 _ | Boxed_nativeint _
       | Closures _ | String _ | Array _ ),
@@ -1414,6 +1494,9 @@ and join_head_of_kind_naked_immediate env
   | Get_tag ty1, Get_tag ty2 ->
     let>+ ty = join env ty1 ty2 in
     TG.Head_of_kind_naked_immediate.create_get_tag ty
+  | Is_null ty1, Is_null ty2 ->
+    let>+ ty = join env ty1 ty2 in
+    TG.Head_of_kind_naked_immediate.create_is_null ty
   (* From now on: Irregular cases *)
   (* CR vlaviron: There could be improvements based on reduction (trying to
      reduce the is_int and get_tag cases to naked_immediate sets, then joining
@@ -1437,7 +1520,23 @@ and join_head_of_kind_naked_immediate env
     if I.Set.is_empty tags
     then Known (TG.Head_of_kind_naked_immediate.create_get_tag ty)
     else Unknown
-  | (Is_int _ | Get_tag _), (Is_int _ | Get_tag _) -> Unknown
+  | Is_null ty, Naked_immediates is_null | Naked_immediates is_null, Is_null ty
+    -> (
+    if I.Set.is_empty is_null
+    then Known (TG.Head_of_kind_naked_immediate.create_is_null ty)
+    else
+      (* Slightly better than Unknown *)
+      let head =
+        TG.Head_of_kind_naked_immediate.create_naked_immediates
+          (I.Set.add I.zero (I.Set.add I.one is_null))
+      in
+      match head with
+      | Ok head -> Known head
+      | Bottom ->
+        Misc.fatal_error
+          "Did not expect [Bottom] from [create_naked_immediates]")
+  | (Is_int _ | Get_tag _ | Is_null _), (Is_int _ | Get_tag _ | Is_null _) ->
+    Unknown
 
 and join_head_of_kind_naked_float32 _env t1 t2 : _ Or_unknown.t =
   Known (TG.Head_of_kind_naked_float32.union t1 t2)

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -446,7 +446,6 @@ type boxed_or_tagged_number =
       Alloc_mode.For_types.t * Flambda_kind.Boxable_number.t * Type_grammar.t
   | Tagged_immediate
 
-(* CR pchambart: Remove fragile matchs and reuse this function *)
 let prove_is_a_boxed_or_tagged_number_value _env
     (value_head : TG.head_of_kind_value_non_null) :
     boxed_or_tagged_number generic_proof =

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -1057,6 +1057,10 @@ let prove_physical_equality env t1 t2 =
     | Value (Unknown | Bottom), _ | _, Value (Unknown | Bottom) -> Unknown
     | Value (Ok head1), Value (Ok head2) -> (
       match head1, head2 with
+      | ( { is_null = Maybe_null; non_null = Bottom },
+          { is_null = Maybe_null; non_null = Bottom } ) ->
+        (* Null is physically equal to Null *)
+        Proved true
       | { is_null = Maybe_null; _ }, _ | _, { is_null = Maybe_null; _ } ->
         Unknown
       | { is_null = Not_null; non_null = Unknown | Bottom }, _

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -129,17 +129,22 @@ val meet_is_int_variant_only :
 val prove_get_tag :
   Typing_env.t -> Type_grammar.t -> Tag.Set.t proof_of_property
 
+val meet_is_null : Typing_env.t -> Type_grammar.t -> bool meet_shortcut
+
 val prove_unique_fully_constructed_immutable_heap_block :
   Typing_env.t ->
   Type_grammar.t ->
   (Tag.t * Flambda_kind.Block_shape.t * Targetint_31_63.t * Simple.t list)
   proof_of_property
 
-val meet_is_naked_number_array :
+val meet_is_flat_float_array :
+  Typing_env.t -> Type_grammar.t -> bool meet_shortcut
+
+val meet_is_non_empty_naked_number_array :
+  Flambda_kind.Naked_number_kind.t ->
   Typing_env.t ->
   Type_grammar.t ->
-  Flambda_kind.Naked_number_kind.t ->
-  bool meet_shortcut
+  unit meet_shortcut
 
 val meet_is_immutable_array :
   Typing_env.t ->
@@ -182,9 +187,7 @@ val meet_strings :
   Typing_env.t -> Type_grammar.t -> String_info.Set.t meet_shortcut
 
 val prove_strings :
-  Typing_env.t ->
-  Type_grammar.t ->
-  (Alloc_mode.For_types.t * String_info.Set.t) proof_of_property
+  Typing_env.t -> Type_grammar.t -> String_info.Set.t proof_of_property
 
 val prove_tagging_of_simple :
   Typing_env.t ->

--- a/testsuite/tests/flambda/incompatible_arrays.ml
+++ b/testsuite/tests/flambda/incompatible_arrays.ml
@@ -1,0 +1,32 @@
+(* TEST
+ flambda2;
+ flags = "-extension layouts_beta";
+ native;
+*)
+
+
+type nonrec ('a : any) array = 'a array
+
+type t1 = int64# array
+type t2 = float32# array
+
+external geti : int64# array -> int -> int64# = "%array_unsafe_get"
+external getf : float32# array -> int -> float32# = "%array_unsafe_get"
+external ignorei : int64# -> unit = "%ignore"
+external ignoref : float32# -> unit = "%ignore"
+external opaquei : int64# -> int64# = "%opaque"
+external opaquef : float32# -> float32# = "%opaque"
+
+type _ wit =
+| A : t1 wit
+| B : t2 wit
+
+let[@inline] get : type a . a wit -> a -> int -> unit =
+  fun wit x idx ->
+  match wit with
+  | A -> ignorei (opaquei (geti x idx))
+  | B -> ignoref (opaquef (getf x idx))
+
+let () =
+  let a : t1 = [|#33L|] in
+  get (Sys.opaque_identity A) a 0

--- a/testsuite/tests/tool-ocamlobjinfo/question.reference
+++ b/testsuite/tests/tool-ocamlobjinfo/question.reference
@@ -42,25 +42,26 @@ Typing env:
  (type_equations
   {([0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion[0m[38;5;111;1m[0m
     (Val
-     (Variant
-      (blocks
-       ((alloc_mode Heap) (known
-         {(tag_0 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m))))})
-        (other Bottom))) (tagged_imms (Naked_immediate [0m[38;5;37;1m⊥[0m)))))
+     ( ((Variant
+         (blocks
+          ((alloc_mode Heap) (known
+            {(tag_0 => (Known 1),
+              ((Val (([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m)))))})
+           (other Bottom))) (tagged_imms (Naked_immediate [0m[38;5;37;1m⊥[0m))))!)))
    ([0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m
     (Val
-     ((alloc_mode Heap) (known
-       {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m
-         => (Known ((closures { [0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m }) (value_slots { }))),
-         ((function_types
-           {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m
-             (Ok (function_type (code_id [0m[38;5;169;1mcamlQuestion__answer_0_1_code[0m)
-                  (rec_info (Rec_info [0m[38;5;249;1m0[0m)))))})
-          (closure_types
-           ((function_slot_components_by_index
-             {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m)))})))
-          (value_slot_types ((value_slot_components_by_index {})))))})
-      (other Bottom))))})
+     ( (((alloc_mode Heap) (known
+          {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m
+            => (Known ((closures { [0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m }) (value_slots { }))),
+            ((function_types
+              {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m
+                ((function_type (code_id [0m[38;5;169;1mcamlQuestion__answer_0_1_code[0m)
+                  (rec_info (Rec_info ([0m[38;5;249;1m0[0m))))))})
+             (closure_types
+              ((function_slot_components_by_index
+                {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m (Val (([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m))))})))
+             (value_slot_types ((value_slot_components_by_index {})))))})
+         (other Bottom)))!)))})
  (aliases
   ((canonical_elements {}) (aliases_of_canonical_names {})
    (aliases_of_consts {}))))


### PR DESCRIPTION
This PR adds support in Flambda2 types to represent null values.
The external API isn't modified: all previous existing functions create non-null types, and it is not possible to create null types from the API at the moment.

Things to review carefully:
- The provers code has been very tedious to write. I think it is correct, but I suspect that there are cases where the handling of the null case is not great (i.e. the prover could return a more precise result).
- Some APIs need a bit more thought. The external API needs a way to define types for null values, and the internal API of `Type_grammar` needs to be thought about a bit more (currently I've duplicated the `Head_of_kind_value` module with a `Head_of_kind_value_non_null` version, I think things could be factored out).
- The choice of naming for the record fields is up to debate.