### PR TITLE
Fix for allocation of closures containing unboxed values

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1618,7 +1618,7 @@ let alloc_generic_set_fn block ofs newval memory_chunk dbg =
     if Arch.big_endian
     then
       Misc.fatal_errorf
-        "Fields with memory_chunk %s are not supported on little-endian \
+        "Fields with memory_chunk %s are not supported on big-endian \
          architecture"
         (Printcmm.chunk memory_chunk);
     generic_case ()
@@ -1652,7 +1652,7 @@ let make_alloc_generic ~block_kind ~mode dbg tag wordsize args
             fill_fields (idx + ofs) el ml )
       | _ ->
         Misc.fatal_errorf
-          "To_cmm_helpers.maake_alloc_generic: mismatched list size between \
+          "To_cmm_helpers.make_alloc_generic: mismatched list size between \
            fields and memory chunks"
     in
     let caml_alloc_func, caml_alloc_args =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1653,7 +1653,7 @@ let make_alloc_generic ~block_kind ~mode dbg tag wordsize args
       | _ ->
         Misc.fatal_errorf
           "To_cmm_helpers.maake_alloc_generic: mismatched list size between \
-           fiels and memory chunks"
+           fields and memory chunks"
     in
     let caml_alloc_func, caml_alloc_args =
       match Config.runtime5, block_kind with

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1613,7 +1613,7 @@ let alloc_generic_set_fn block ofs newval memory_chunk dbg =
     then
       Misc.fatal_errorf
         "Fields with memory_chunk %s are not supported on big-endian \
-         architecture"
+         architectures"
         (Printcmm.chunk memory_chunk);
     generic_case ()
   (* Forbidden cases *)
@@ -1646,7 +1646,7 @@ let make_alloc_generic ~block_kind ~mode dbg tag wordsize args
             fill_fields (idx + ofs) el ml )
       | _ ->
         Misc.fatal_errorf
-          "To_cmm_helpers.make_alloc_generic: mismatched list size between \
+          "To_cmm_helpers.make_alloc_generic: mismatched list sizes between \
            fields and memory chunks"
     in
     let caml_alloc_func, caml_alloc_args =
@@ -1727,7 +1727,7 @@ let make_mixed_alloc ~mode dbg ~tag ~value_prefix_size args args_memory_chunks =
             error "mixed blocks"
           | Thirtytwo_unsigned | Thirtytwo_signed | Single _ | Double
           | Onetwentyeight_unaligned | Onetwentyeight_aligned ->
-            error "value prefix of a mixed block"
+            error "the value prefix of a mixed block"
         else
           (* flat suffix part of the block *)
           match memory_chunk with
@@ -1736,7 +1736,7 @@ let make_mixed_alloc ~mode dbg ~tag ~value_prefix_size args args_memory_chunks =
             ok ()
           | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed ->
             error "mixed blocks"
-          | Word_val -> error "flat suffix of a mixed block")
+          | Word_val -> error "the flat suffix of a mixed block")
       0 args_memory_chunks
   in
   make_alloc_generic

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1706,9 +1706,17 @@ let make_mixed_alloc ~mode dbg ~tag ~value_prefix_size args args_memory_chunks =
           ofs + memory_chunk_size_in_words_for_mixed_block memory_chunk
         in
         let error situation =
-          Misc.fatal_errorf "Fields with memory chunk %s are not allowed in %s"
+          Misc.fatal_errorf
+            "Fields with memory chunk %s are not allowed in %s.@\n\
+             value_prefix_size: %d@\n\
+             args: @[<v>%a@]@\n\
+             chunks: @[<v>%a@]@."
             (Printcmm.chunk memory_chunk)
-            situation
+            situation value_prefix_size
+            (Format.pp_print_list Printcmm.expression)
+            args
+            (Format.pp_print_list Format.pp_print_string)
+            (List.map Printcmm.chunk args_memory_chunks)
         in
         if ofs < value_prefix_size
         then

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -325,15 +325,13 @@ val make_float_alloc :
   expression list ->
   expression
 
-(** Allocate a set of closures block.
+(** Allocate a closure block, to hold a set of closures.
 
-    Takes as argument both a list of expression [exprs] and a list of memory_chunks
-    [chunks], so that the expression [List.nth exprs i] can be written/stored with
-    the memory chunk [List.nth chunks i]. In particular both lists should have the
-    same size.
+    This takes a list of expressions [exprs] and a list of [memory_chunk]s
+    that correspond pairwise.  Both lists must be the same length.
 
-    The list of expression includes all fields of the set of closures, including code
-    pointers and closure information fields. *)
+    The list of expressions includes _all_ fields of the closure block,
+    including the code pointers and closure information fields. *)
 val make_closure_alloc :
   mode:Lambda.alloc_mode ->
   Debuginfo.t ->

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -325,7 +325,15 @@ val make_float_alloc :
   expression list ->
   expression
 
-(** Allocate a closure block. *)
+(** Allocate a set of closures block.
+
+    Takes as argument both a list of expression [exprs] and a list of memory_chunks
+    [chunks], so that the expression [List.nth exprs i] can be written/stored with
+    the memory chunk [List.nth chunks i]. In particular both lists should have the
+    same size.
+
+    The list of expression includes all fields of the set of closures, including code
+    pointers and closure information fields. *)
 val make_closure_alloc :
   mode:Lambda.alloc_mode ->
   Debuginfo.t ->

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -325,24 +325,25 @@ val make_float_alloc :
   expression list ->
   expression
 
-module Flat_suffix_element : sig
-  type t =
-    | Tagged_immediate
-    | Naked_float
-    | Naked_float32
-    | Naked_int32
-    | Naked_int64_or_nativeint
-end
+(** Allocate a closure block. *)
+val make_closure_alloc :
+  mode:Lambda.alloc_mode ->
+  Debuginfo.t ->
+  tag:int ->
+  expression list ->
+  memory_chunk list ->
+  expression
 
-(** Allocate an mixed block of the corresponding tag and shape. Initial values
-    of the flat suffix should be provided unboxed. *)
+(** Allocate an mixed block of the corresponding tag and scannable prefix size.
+    The [memory_chunk] list should give the memory_chunk corresponding to
+    each element from the [expression] list. *)
 val make_mixed_alloc :
   mode:Lambda.alloc_mode ->
   Debuginfo.t ->
   tag:int ->
   value_prefix_size:int ->
-  flat_suffix:Flat_suffix_element.t array ->
   expression list ->
+  memory_chunk list ->
   expression
 
 (** Sys.opaque_identity *)

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -318,7 +318,7 @@ end = struct
   type _ slot_desc =
     | Function_slot : Function_slot.t -> function_slot slot_desc
     | Unboxed_slot : Value_slot.t -> unboxed_slot slot_desc
-    | Value_slot : Value_slot.t -> value_slot slot_desc
+    | Scannable_value_slot : Value_slot.t -> value_slot slot_desc
 
   (* This module helps to distinguish between the two different notions of
      offsets that are used for function slots:
@@ -358,14 +358,15 @@ end = struct
       let offset =
         match slot with
         | Function_slot _ -> first_offset_used_including_header + 1
-        | Unboxed_slot _ | Value_slot _ -> first_offset_used_including_header
+        | Unboxed_slot _ | Scannable_value_slot _ ->
+          first_offset_used_including_header
       in
       Offset offset
 
     let range_used_by (type a) (slot : a slot_desc) (Offset pos) ~slot_size =
       match slot with
       | Function_slot _ -> pos - 1, pos + slot_size
-      | Unboxed_slot _ | Value_slot _ -> pos, pos + slot_size
+      | Unboxed_slot _ | Scannable_value_slot _ -> pos, pos + slot_size
 
     let add_slot_to_exported_offsets (type a) offsets (slot : a slot_desc)
         (Offset pos) ~slot_size =
@@ -381,7 +382,7 @@ end = struct
             { offset = pos; is_scanned = false; size = slot_size }
         in
         EO.add_value_slot_offset offsets unboxed_slot info
-      | Value_slot value_slot ->
+      | Scannable_value_slot value_slot ->
         let (info : EO.value_slot_info) =
           EO.Live_value_slot
             { offset = pos; is_scanned = true; size = slot_size }
@@ -488,7 +489,7 @@ end = struct
   let print_desc (type a) fmt (slot_desc : a slot_desc) =
     match slot_desc with
     | Function_slot c -> Format.fprintf fmt "%a" Function_slot.print c
-    | Unboxed_slot v | Value_slot v ->
+    | Unboxed_slot v | Scannable_value_slot v ->
       Format.fprintf fmt "%a" Value_slot.print v
 
   let print_slot_pos fmt = function
@@ -556,7 +557,7 @@ end = struct
     | Unassigned | Removed -> ()
     | Assigned offset -> (
       match slot.desc with
-      | Value_slot _ ->
+      | Scannable_value_slot _ ->
         if slot.size <> 1
         then
           Misc.fatal_errorf "Value slot has size %d, which is not 1." slot.size;
@@ -625,7 +626,7 @@ end = struct
         let (info : EO.function_slot_info) = EO.Dead_function_slot in
         state.used_offsets
           <- EO.add_function_slot_offset state.used_offsets function_slot info
-      | Unboxed_slot v | Value_slot v ->
+      | Unboxed_slot v | Scannable_value_slot v ->
         let (info : EO.value_slot_info) = EO.Dead_value_slot in
         state.used_offsets <- EO.add_value_slot_offset state.used_offsets v info
       )
@@ -642,7 +643,7 @@ end = struct
       state.function_slots_to_assign <- slot :: state.function_slots_to_assign
     | Unboxed_slot _ ->
       state.unboxed_slots_to_assign <- slot :: state.unboxed_slots_to_assign
-    | Value_slot _ ->
+    | Scannable_value_slot _ ->
       state.value_slots_to_assign <- slot :: state.value_slots_to_assign
 
   let add_allocated_slot_to_set slot set =
@@ -809,7 +810,9 @@ end = struct
   let create_value_slot set state value_slot =
     if Compilation_unit.is_current (Value_slot.get_compilation_unit value_slot)
     then (
-      let s = create_slot ~size:1 (Value_slot value_slot) Unassigned in
+      let s =
+        create_slot ~size:1 (Scannable_value_slot value_slot) Unassigned
+      in
       add_value_slot state value_slot s;
       add_unallocated_slot_to_set state s set;
       s)
@@ -837,7 +840,10 @@ end = struct
              in the original compilation unit, this should not happen."
             Value_slot.print value_slot;
         let offset = Exported_offset.from_exported_offset offset in
-        let s = create_slot ~size:1 (Value_slot value_slot) (Assigned offset) in
+        let s =
+          create_slot ~size:1 (Scannable_value_slot value_slot)
+            (Assigned offset)
+        in
         use_value_slot_info state value_slot info;
         add_value_slot state value_slot s;
         add_allocated_slot_to_set s set;
@@ -939,7 +945,7 @@ end = struct
     let needed_space =
       match slot.desc with
       | Function_slot _ -> slot.size + 1 (* header word *)
-      | Unboxed_slot _ | Value_slot _ -> slot.size
+      | Unboxed_slot _ | Scannable_value_slot _ -> slot.size
     in
     (* Ensure that for value slots, we are after all function slots. *)
     let curr =
@@ -949,7 +955,7 @@ end = struct
         (* first_slot_after_function_slots is always >=0, thus ensuring we do
            not place a value slot at offset -1 *)
         max start set.first_slot_after_function_slots
-      | Value_slot _ -> max start set.first_slot_after_unboxed_slots
+      | Scannable_value_slot _ -> max start set.first_slot_after_unboxed_slots
     in
     (* Adjust a starting position to not point in the middle of a block.
        Additionally, ensure the value slot slots are put after the function
@@ -1052,7 +1058,7 @@ end = struct
     state.value_slots_to_assign <- [];
     List.iter
       (function
-        | { desc = Value_slot v; _ } as slot ->
+        | { desc = Scannable_value_slot v; _ } as slot ->
           if value_slot_is_used ~used_value_slots v
           then assign_slot_offset state slot
           else mark_slot_as_removed state slot)

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -88,27 +88,27 @@ let check_alloc_fields = function
 let make_block ~dbg kind alloc_mode args =
   check_alloc_fields args;
   let mode = Alloc_mode.For_allocations.to_lambda alloc_mode in
-  let allocator, tag =
-    match (kind : P.Block_kind.t) with
-    | Values (tag, _) -> C.make_alloc, Tag.Scannable.to_tag tag
-    | Naked_floats -> C.make_float_alloc, Tag.double_array_tag
-    | Mixed (tag, shape) ->
-      let value_prefix_size = K.Mixed_block_shape.value_prefix_size shape in
-      let flat_suffix =
-        Array.map
-          (fun (flat_elt : K.Flat_suffix_element.t) : C.Flat_suffix_element.t ->
-            match flat_elt with
-            | Tagged_immediate -> Tagged_immediate
-            | Naked_float -> Naked_float
-            | Naked_float32 -> Naked_float32
-            | Naked_int32 -> Naked_int32
-            | Naked_int64 | Naked_nativeint -> Naked_int64_or_nativeint)
-          (K.Mixed_block_shape.flat_suffix shape)
-      in
-      ( C.make_mixed_alloc ~value_prefix_size ~flat_suffix,
-        Tag.Scannable.to_tag tag )
-  in
-  allocator ~mode dbg ~tag:(Tag.to_int tag) args
+  match (kind : P.Block_kind.t) with
+  | Values (tag, _) ->
+    let tag = Tag.Scannable.to_int tag in
+    C.make_alloc ~mode dbg ~tag args
+  | Naked_floats ->
+    let tag = Tag.to_int Tag.double_array_tag in
+    C.make_float_alloc ~mode dbg ~tag args
+  | Mixed (tag, shape) ->
+    let value_prefix_size = K.Mixed_block_shape.value_prefix_size shape in
+    let args_memory_chunks =
+      Array.fold_right
+        (fun kind acc ->
+          let chunk =
+            To_cmm_shared.memory_chunk_of_kind (K.With_subkind.anything kind)
+          in
+          chunk :: acc)
+        (K.Mixed_block_shape.field_kinds shape)
+        []
+    in
+    let tag = Tag.Scannable.to_int tag in
+    C.make_mixed_alloc ~mode dbg ~tag ~value_prefix_size args args_memory_chunks
 
 let block_load ~dbg (kind : P.Block_access_kind.t) (mutability : Mutability.t)
     ~block ~index =

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -97,7 +97,7 @@ module Make_layout_filler (P : sig
     To_cmm_env.t ->
     To_cmm_result.t ->
     Simple.t ->
-    [`Data of cmm_term list | `Var of Variable.t]
+    [`Expr of cmm_term | `Static_data of cmm_term list | `Var of Variable.t]
     * To_cmm_env.free_vars
     * To_cmm_env.t
     * To_cmm_result.t
@@ -121,6 +121,7 @@ end) : sig
     prev_updates:To_cmm_env.expr_with_info option ->
     (int * Slot_offsets.Layout.slot) list ->
     P.cmm_term list
+    * Cmm.memory_chunk list option
     * To_cmm_env.free_vars
     * int
     * Env.t
@@ -128,13 +129,18 @@ end) : sig
     * Ece.t
     * To_cmm_env.expr_with_info option
 end = struct
+  let rev_append_chunks l = function
+    | None -> None
+    | Some chunks -> Some (List.rev_append l chunks)
+
   (* The [offset]s here are measured in units of words. *)
   let fill_slot for_static_sets decls dbg ~startenv value_slots env res acc
-      ~slot_offset updates slot =
+      chunk_acc ~slot_offset updates slot =
     match (slot : Slot_offsets.Layout.slot) with
     | Infix_header ->
       let field = P.infix_header ~function_slot_offset:(slot_offset + 1) ~dbg in
       ( field :: acc,
+        rev_append_chunks [Cmm.Word_int] chunk_acc,
         Backend_var.Set.empty,
         slot_offset + 1,
         env,
@@ -154,18 +160,26 @@ end = struct
           "Value slot %a not of kind Value (%a) but is visible by GC"
           Simple.print simple Debuginfo.print_compact dbg;
       let contents, free_vars, env, res, eff = P.simple ~dbg env res simple in
-      let env, res, fields, updates =
+      let env, res, fields, chunk_acc, updates =
         match contents with
-        | `Data fields -> env, res, fields, updates
+        | `Expr field ->
+          let chunk = C.memory_chunk_of_kind kind in
+          let chunk_acc = rev_append_chunks [chunk] chunk_acc in
+          env, res, [field], chunk_acc, updates
+        | `Static_data fields -> (
+          match for_static_sets, chunk_acc with
+          | None, _ | _, Some _ -> assert false
+          | Some _, None -> env, res, fields, chunk_acc, updates)
         | `Var v -> (
           (* We should only get here in the static allocation case. *)
-          match for_static_sets with
-          | None -> assert false
-          | Some
-              { function_slot_offset_for_updates;
-                closure_symbol_for_updates;
-                _
-              } ->
+          match for_static_sets, chunk_acc with
+          | None, _ | _, Some _ -> assert false
+          | ( Some
+                { function_slot_offset_for_updates;
+                  closure_symbol_for_updates;
+                  _
+                },
+              None ) ->
             let update_kind =
               let module UK = C.Update_kind in
               match KS.kind kind with
@@ -194,9 +208,10 @@ end = struct
                 ~index:(slot_offset - function_slot_offset_for_updates)
                 ~prev_updates:updates
             in
-            env, res, [P.int ~dbg 1n], updates)
+            env, res, [P.int ~dbg 1n], chunk_acc, updates)
       in
       ( List.rev_append fields acc,
+        chunk_acc,
         free_vars,
         slot_offset + 1,
         env,
@@ -243,6 +258,7 @@ end = struct
             P.int ~dbg closure_info :: P.term_of_symbol ~dbg code_symbol :: acc
           in
           ( acc,
+            rev_append_chunks [Cmm.Word_int; Cmm.Word_int] chunk_acc,
             Backend_var.Set.empty,
             slot_offset + size,
             env,
@@ -265,6 +281,9 @@ end = struct
             :: acc
           in
           ( acc,
+            rev_append_chunks
+              [Cmm.Word_int; Cmm.Word_int; Cmm.Word_int]
+              chunk_acc,
             Backend_var.Set.empty,
             slot_offset + size,
             env,
@@ -283,14 +302,20 @@ end = struct
             ~arity:(if size = 2 then 1 else 2)
             ~startenv:(startenv - slot_offset) ~is_last:last_function_slot
         in
-        let acc =
+        let acc, chunk_acc =
           match size with
-          | 2 -> P.int ~dbg closure_info :: P.int ~dbg 0n :: acc
+          | 2 ->
+            ( P.int ~dbg closure_info :: P.int ~dbg 0n :: acc,
+              rev_append_chunks [Cmm.Word_int; Cmm.Word_int] chunk_acc )
           | 3 ->
-            P.int ~dbg 0n :: P.int ~dbg closure_info :: P.int ~dbg 0n :: acc
+            ( P.int ~dbg 0n :: P.int ~dbg closure_info :: P.int ~dbg 0n :: acc,
+              rev_append_chunks
+                [Cmm.Word_int; Cmm.Word_int; Cmm.Word_int]
+                chunk_acc )
           | _ -> assert false
         in
         ( acc,
+          chunk_acc,
           Backend_var.Set.empty,
           slot_offset + size,
           env,
@@ -299,38 +324,53 @@ end = struct
           updates ))
 
   let rec fill_layout0 for_static_sets decls dbg ~startenv value_slots env res
-      effs acc updates ~free_vars ~starting_offset slots =
+      effs acc chunk_acc updates ~free_vars ~starting_offset slots =
     match slots with
-    | [] -> List.rev acc, free_vars, starting_offset, env, res, effs, updates
+    | [] ->
+      ( List.rev acc,
+        Option.map List.rev chunk_acc,
+        free_vars,
+        starting_offset,
+        env,
+        res,
+        effs,
+        updates )
     | (slot_offset, slot) :: slots ->
-      let acc =
+      let acc, chunk_acc =
         if starting_offset > slot_offset
         then
           Misc.fatal_errorf "Starting offset %d is past slot offset %d"
             starting_offset slot_offset
         else if starting_offset = slot_offset
-        then acc
+        then acc, chunk_acc
         else
           (* The space between slot offsets has to be padded with precisely the
              value tagged 0, as it is scanned by the GC during compaction. This
              value can't be confused with either infix headers or inverted
              pointers, as noted in the comment in compact.c *)
-          List.init (slot_offset - starting_offset) (fun _ -> P.int ~dbg 1n)
-          @ acc
+          ( List.init (slot_offset - starting_offset) (fun _ -> P.int ~dbg 1n)
+            @ acc,
+            rev_append_chunks
+              (List.init (slot_offset - starting_offset) (fun _ -> Cmm.Word_int))
+              chunk_acc )
       in
-      let acc, slot_free_vars, next_offset, env, res, eff, updates =
+      let acc, chunk_acc, slot_free_vars, next_offset, env, res, eff, updates =
         fill_slot for_static_sets decls dbg ~startenv value_slots env res acc
-          ~slot_offset updates slot
+          chunk_acc ~slot_offset updates slot
       in
       let free_vars = Backend_var.Set.union free_vars slot_free_vars in
       let effs = Ece.join eff effs in
       fill_layout0 for_static_sets decls dbg ~startenv value_slots env res effs
-        acc updates ~free_vars ~starting_offset:next_offset slots
+        acc chunk_acc updates ~free_vars ~starting_offset:next_offset slots
 
   let fill_layout for_static_sets decls dbg ~startenv value_slots env res effs
       ~prev_updates slots =
+    let chunk_acc =
+      match for_static_sets with None -> Some [] | Some _ -> None
+    in
     fill_layout0 for_static_sets decls dbg ~startenv value_slots env res effs []
-      prev_updates ~free_vars:Backend_var.Set.empty ~starting_offset:0 slots
+      chunk_acc prev_updates ~free_vars:Backend_var.Set.empty ~starting_offset:0
+      slots
 end
 
 (* Filling-up of dynamically-allocated sets of closures. *)
@@ -350,7 +390,7 @@ module Dynamic = Make_layout_filler (struct
     let To_cmm_env.{ env; res; expr = { cmm; free_vars; effs } } =
       C.simple ~dbg env res simple
     in
-    `Data [cmm], free_vars, env, res, effs
+    `Expr cmm, free_vars, env, res, effs
 
   let infix_header ~dbg ~function_slot_offset =
     C.alloc_infix_header function_slot_offset dbg
@@ -547,11 +587,17 @@ let let_static_set_of_closures0 env res closure_symbols
       closure_symbol_for_updates
     }
   in
-  let l, free_vars, length, env, res, _effs, updates =
+  let l, memory_chunks, free_vars, length, env, res, _effs, updates =
     Static.fill_layout (Some for_static_sets) decls dbg
       ~startenv:layout.startenv value_slots env res Ece.pure ~prev_updates
       layout.slots
   in
+  (match memory_chunks with
+  | None -> ()
+  | Some _ ->
+    Misc.fatal_errorf
+      "Broken internal invariant: Static sets of closures do not need a list \
+       of memory chunks");
   if not (Backend_var.Set.is_empty free_vars)
   then
     Misc.fatal_errorf
@@ -650,7 +696,7 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
   let decl_map =
     decls |> Function_slot.Lmap.bindings |> Function_slot.Map.of_list
   in
-  let l, free_vars, _offset, env, res, effs, updates =
+  let l, memory_chunks, free_vars, _offset, env, res, effs, updates =
     Dynamic.fill_layout None decl_map dbg ~startenv:layout.startenv value_slots
       env res effs ~prev_updates:None layout.slots
   in
@@ -658,9 +704,15 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
   let csoc =
     assert (List.compare_length_with l 0 > 0);
     let tag = Tag.(to_int closure_tag) in
-    C.make_alloc
-      ~mode:(Alloc_mode.For_allocations.to_lambda closure_alloc_mode)
-      dbg ~tag l
+    match memory_chunks with
+    | None ->
+      Misc.fatal_errorf
+        "Broken internal invariant: missing memory chunks for dynamic set of \
+         closures"
+    | Some fields_memory_chunks ->
+      C.make_closure_alloc
+        ~mode:(Alloc_mode.For_allocations.to_lambda closure_alloc_mode)
+        dbg ~tag l fields_memory_chunks
   in
   let soc_var = Variable.create "*set_of_closures*" in
   let defining_expr = Env.simple csoc free_vars in

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -147,7 +147,7 @@ end = struct
         res,
         Ece.pure,
         updates )
-    | Value_slot { value_slot; is_scanned; size = _ } ->
+    | Value_slot { value_slot; is_scanned; size } ->
       let simple = Value_slot.Map.find value_slot value_slots in
       let kind = Value_slot.kind value_slot in
       if (not
@@ -208,12 +208,13 @@ end = struct
                 ~index:(slot_offset - function_slot_offset_for_updates)
                 ~prev_updates:updates
             in
-            env, res, [P.int ~dbg 1n], chunk_acc, updates)
+            let fields = List.init size (fun _ -> P.int ~dbg 1n) in
+            env, res, fields, chunk_acc, updates)
       in
       ( List.rev_append fields acc,
         chunk_acc,
         free_vars,
-        slot_offset + 1,
+        slot_offset + size,
         env,
         res,
         eff,

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -201,7 +201,8 @@ let simple ?consider_inlining_effectful_expressions ~dbg env res s =
 let name_static res name =
   Name.pattern_match name
     ~var:(fun v -> `Var v)
-    ~symbol:(fun s -> `Data [symbol_address (To_cmm_result.symbol res s)])
+    ~symbol:(fun s ->
+      `Static_data [symbol_address (To_cmm_result.symbol res s)])
 
 let const_static cst =
   match Reg_width_const.descr cst with
@@ -235,7 +236,7 @@ let const_static cst =
 let simple_static res s =
   Simple.pattern_match s
     ~name:(fun n ~coercion:_ -> name_static res n)
-    ~const:(fun c -> `Data (const_static c))
+    ~const:(fun c -> `Static_data (const_static c))
 
 let simple_list ?consider_inlining_effectful_expressions ~dbg env res l =
   (* Note that [To_cmm_primitive] relies on this function translating the

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -73,7 +73,7 @@ val simple :
 val simple_static :
   To_cmm_result.t ->
   Simple.t ->
-  [`Data of Cmm.data_item list | `Var of Variable.t]
+  [> `Static_data of Cmm.data_item list | `Var of Variable.t]
 
 (** This function translates the [Simple] at the head of the list first.
     Regarding [consider_inlining_effectful_expressions], see [simple] above. *)


### PR DESCRIPTION
The current code for allocating dynamic sets of closure did not properly take into account the fact that some of the env fields can now be unbxoed values. In some cases (particularly when the sets are bigger than Max_young_wosize), these unboxed fields require cmm code that sets the corresponding field, and that store operation need to be annotated with the correct memory_chunk.

This commit adds the necessary code to propagate enough information so that we have access to the memory_chunks of every field when allocating a dynmaic set of closures (static closures do not need that, which is helpful since it would be much harder to produce the memory_chunks in those cases).

At the same time, it reworks the current way these allocations are generated: the old code used a `set` function, which in effect was only there to distinguish on what is essentially the memory_chunk of the value being written and use the appropriate cmm expression to write the value. The code is simplified by instead providing the adequate memory_chunk, from which the set function can be deduced.

This fixes the same issue as #2983 , but in a more reasonable manner. It contains slightly more code partly because it also refactors the code for regular mixed block as well.