### PR TITLE
"fix" a regression in the 5.2 merge

### DIFF
--- a/ocaml/testsuite/tests/typing-modes/gadts.ml
+++ b/ocaml/testsuite/tests/typing-modes/gadts.ml
@@ -1,0 +1,24 @@
+(* TEST
+ expect;
+*)
+
+(* An example where [type_argument] can refine modes using a gadt equation. *)
+type _ t =
+  | A : bool t
+
+let id x = x
+
+let f (type output) ~(output : output t) =
+    match output with
+    | A -> (id : bool -> output)
+[%%expect{|
+type _ t = A : bool t
+val id : 'a -> 'a = <fun>
+Line 8, characters 11-32:
+8 |     | A -> (id : bool -> output)
+               ^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "bool -> output"
+       but an expression was expected of type "'a"
+       This instance of "bool" is ambiguous:
+       it would escape the scope of its equation
+|}]

--- a/ocaml/testsuite/tests/typing-modes/gadts.ml
+++ b/ocaml/testsuite/tests/typing-modes/gadts.ml
@@ -14,11 +14,5 @@ let f (type output) ~(output : output t) =
 [%%expect{|
 type _ t = A : bool t
 val id : 'a -> 'a = <fun>
-Line 8, characters 11-32:
-8 |     | A -> (id : bool -> output)
-               ^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "bool -> output"
-       but an expression was expected of type "'a"
-       This instance of "bool" is ambiguous:
-       it would escape the scope of its equation
+val f : output:'output t -> bool -> 'output = <fun>
 |}]

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -5831,6 +5831,7 @@ and type_expect_
         type_constraint env sty alloc_mode
       in
       let expected_mode = type_expect_mode ~loc ~env ~modes expected_mode in
+      let ty' = instance ty in
       let error_message_attr_opt =
         Builtin_attributes.error_message_attr sexp.pexp_attributes in
       let explanation = Option.map (fun msg -> Error_message_attr msg)
@@ -5839,7 +5840,7 @@ and type_expect_
       rue {
         exp_desc = arg.exp_desc;
         exp_loc = arg.exp_loc;
-        exp_type = instance ty;
+        exp_type = ty';
         exp_attributes = arg.exp_attributes;
         exp_env = env;
         exp_extra =


### PR DESCRIPTION
This adds a test that newly fails on the 5.2 branch, and a fix, in two commits.

The test passes upstream and seems fine, so I think this is a regression in the merge.  But I don't think the fix here (restoring a piece of the previous implementation of checking `Pexp_constraint`s in typecore) is correct.  I'm just posting this so @mshinwell  can use it to make more progress and so I can point to it for discussion.

What is happening is that `loosen_arrow_modes` in `type_argument` is updating the scope of the type, and the fact that the previous implementation was throwing away the old type meant we ignored that.  That seems wrong, instead, I think `type_argument` shouldn't need to use the equation for mode checking in this example, and so this program typechecks in 5.1 for the wrong reason.

Will discuss with modes people.