### PR TITLE
Backport upstream #13370

### DIFF
--- a/ocaml/runtime/gc_ctrl.c
+++ b/ocaml/runtime/gc_ctrl.c
@@ -106,7 +106,7 @@ CAMLprim value caml_gc_minor_words(value v)
 CAMLprim value caml_gc_counters(value v)
 {
   CAMLparam0 ();   /* v is ignored */
-  CAMLlocal1 (res);
+  CAMLlocal4 (minwords_, prowords_, majwords_, res);
 
   /* get a copy of these before allocating anything... */
   double minwords = Caml_state->stat_minor_words
@@ -116,11 +116,11 @@ CAMLprim value caml_gc_counters(value v)
   double majwords = Caml_state->stat_major_words +
                     (double) Caml_state->allocated_words;
 
-  res = caml_alloc_3(0,
-    caml_copy_double (minwords),
-    caml_copy_double (prowords),
-    caml_copy_double (majwords));
-  CAMLreturn (res);
+  minwords_ = caml_copy_double(minwords);
+  prowords_ = caml_copy_double(prowords);
+  majwords_ = caml_copy_double(majwords);
+  res = caml_alloc_3(0, minwords_, prowords_, majwords_);
+  CAMLreturn(res);
 }
 
 CAMLprim value caml_gc_get(value v)


### PR DESCRIPTION
Backport ocaml/ocaml#13370. The issue fixed by that PR could lead to unsafe behavior in user code that calls `Gc.counters`, e.g. `Core_bench`.