### PR TITLE
Fix specialization of float32 bigarray ref/set

### DIFF
--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -1034,16 +1034,14 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       if st = array_set_type then None
       else Some (Primitive (Parraysets (array_set_type, index_kind), arity))
     end
-  | Primitive (Pbigarrayref(unsafe, n, Pbigarray_unknown,
-                            Pbigarray_unknown_layout), arity), p1 :: _ -> begin
-      let (k, l) = bigarray_type_kind_and_layout env p1 in
+  | Primitive (Pbigarrayref(unsafe, n, kind, layout), arity), p1 :: _ -> begin
+      let (k, l) = bigarray_specialize_kind_and_layout env ~kind ~layout p1 in
       match k, l with
       | Pbigarray_unknown, Pbigarray_unknown_layout -> None
       | _, _ -> Some (Primitive (Pbigarrayref(unsafe, n, k, l), arity))
     end
-  | Primitive (Pbigarrayset(unsafe, n, Pbigarray_unknown,
-                            Pbigarray_unknown_layout), arity), p1 :: _ -> begin
-      let (k, l) = bigarray_type_kind_and_layout env p1 in
+  | Primitive (Pbigarrayset(unsafe, n, kind, layout), arity), p1 :: _ -> begin
+      let (k, l) = bigarray_specialize_kind_and_layout env ~kind ~layout p1 in
       match k, l with
       | Pbigarray_unknown, Pbigarray_unknown_layout -> None
       | _, _ -> Some (Primitive (Pbigarrayset(unsafe, n, k, l), arity))

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -227,14 +227,24 @@ let layout_table =
   ["c_layout", Pbigarray_c_layout;
    "fortran_layout", Pbigarray_fortran_layout]
 
-let bigarray_type_kind_and_layout env typ =
+let bigarray_specialize_kind_and_layout env ~kind ~layout typ =
   match scrape env typ with
   | Tconstr(_p, [_caml_type; elt_type; layout_type], _abbrev) ->
-      (bigarray_decode_type env elt_type kind_table Pbigarray_unknown,
-       bigarray_decode_type env layout_type layout_table
-                            Pbigarray_unknown_layout)
+      let kind =
+        match kind with
+        | Pbigarray_unknown ->
+          bigarray_decode_type env elt_type kind_table Pbigarray_unknown
+        | _ -> kind
+      in
+      let layout =
+        match layout with
+        | Pbigarray_unknown_layout ->
+          bigarray_decode_type env layout_type layout_table Pbigarray_unknown_layout
+        | _ -> layout
+      in
+      (kind, layout)
   | _ ->
-      (Pbigarray_unknown, Pbigarray_unknown_layout)
+      (kind, layout)
 
 let value_kind_of_value_jkind jkind =
   let const_jkind = Jkind.default_to_value_and_get jkind in

--- a/ocaml/typing/typeopt.mli
+++ b/ocaml/typing/typeopt.mli
@@ -32,8 +32,9 @@ val array_kind :
   Typedtree.expression -> Jkind.Sort.t -> Lambda.array_kind
 val array_pattern_kind :
   Typedtree.pattern -> Jkind.Sort.t -> Lambda.array_kind
-val bigarray_type_kind_and_layout :
-      Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
+val bigarray_specialize_kind_and_layout :
+  Env.t -> kind:Lambda.bigarray_kind -> layout:Lambda.bigarray_layout ->
+  Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
 
 (* CR layouts v7: [layout], [function_return_layout], [function2_return_layout],
    and [layout_of_sort] have had location arguments added just to support the


### PR DESCRIPTION
Currently, the following program calls the C function `caml_ba_float32_ref_1`:

```
open Stdlib.Bigarray

external get : ('a, float32_elt, 'c) Array1.t -> int -> float32
    = "%caml_ba_float32_ref_1"

let f (x : ('a, float32_elt, c_layout) Array1.t) = get x 0
```

The C call is emitted because the compiler isn't specializing the primitive with `c_layout`. That's because it only attempts to specialize when both the kind and the layout are unknown, but the custom float32 primitive sets the kind to float32_t. This leads to worse unboxing behavior.

This PR adjusts `specialize_primitive` to attempt to specialize `Pbigarrayref` and `Pbigarrayset` regardless of whether the kind and layout are known.

Flambda2 after the fix:
```
 (λ〈k14〉《k13》⟅my_region/27N⟆ ⟅my_ghost_region/26N⟆
      (x/29UV ∷ 𝕍) (my_closure/28N ∷ 𝕍) my_depth/25N .
    (prim/30N = ((Bigarray_length 1 x/29UV) test.ml:6,51--58)
     prim/33N = ((<u #0 prim/30N) test.ml:6,51--58)
     (switch prim/33N test.ml:6,51--58
     | 0 ↦ goto k18
     | 1 ↦ goto k19)
     k19 #One:
     prim/37N =
      (((Bigarray_load (num_dimensions 1) (kind Float32_t) (layout C)) x/29UV
        0) test.ml:6,51--58)
     Pbigarrayref/38N = ((Box_float32[Heap] prim/37N) test.ml:6,51--58)
     return k14 Pbigarrayref/38N
```
 