### PR TITLE
Make `OCaml Platform` default formatter for OCaml interface files in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,4 +12,7 @@
         "[ocaml]": {
                 "editor.defaultFormatter": "ocamllabs.ocaml-platform",
         },
+        "[ocaml.interface]": {
+                "editor.defaultFormatter": "ocamllabs.ocaml-platform",
+        },
 }


### PR DESCRIPTION
Ensures the default formatter setting applies to `.mli` files as well as `.ml` files.