### PR TITLE
Split the `Selectgen` class

### DIFF
--- a/backend/selectgen.mli
+++ b/backend/selectgen.mli
@@ -22,6 +22,20 @@ type environment = unit Select_utils.environment
 
 class virtual selector_generic :
   object
+    method is_store : Mach.operation -> bool
+
+    method lift_op : Mach.operation -> Mach.instruction_desc
+
+    method make_stack_offset : int -> Mach.instruction_desc
+
+    method make_name_for_debugger :
+      ident:Backend_var.t ->
+      which_parameter:int option ->
+      provenance:Backend_var.Provenance.t option ->
+      is_assignment:bool ->
+      regs:Reg.t array ->
+      Mach.instruction_desc
+
     (* The following methods must or can be overridden by the processor
        description *)
     method is_immediate : Mach.integer_operation -> int -> bool


### PR DESCRIPTION
As the title suggests, this pull request
split the class defined in `Selectgen`,
moving the element that do not depend
on `Mach` to a parent class. The class
is defined in the same file, and will be
moved in a follow-up pull request.