### PR TITLE
Disable stack switching on noalloc C calls

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1416,7 +1416,11 @@ let emit_instr ~first ~fallthrough i =
           I.mov (domain_field Domainstate.Domain_young_ptr) r15
         end
       end else begin
-        if Config.runtime5 then begin
+        let runtime5_should_stack_switch =
+          (* Must match amd64/proc.ml *)
+          Config.runtime5 && not Config.no_stack_checks
+        in
+        if runtime5_should_stack_switch then begin
           I.mov rsp rbx;
           cfi_remember_state ();
           cfi_def_cfa_register "rbx";
@@ -1426,7 +1430,7 @@ let emit_instr ~first ~fallthrough i =
           I.mov (domain_field Domainstate.Domain_c_stack) rsp;
         end;
         emit_call (Cmm.global_symbol func);
-        if Config.runtime5 then begin
+        if runtime5_should_stack_switch then begin
           I.mov rbx rsp;
           cfi_restore_state ();
         end;

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -364,7 +364,13 @@ let int_regs_destroyed_at_c_call_win64 =
   if Config.runtime5 then [|0;1;4;5;6;7;10;11;12|] else [|0;4;5;6;7;10;11|]
 
 let int_regs_destroyed_at_c_call =
-  if Config.runtime5 then [|0;1;2;3;4;5;6;7;10;11|] else [|0;2;3;4;5;6;7;10;11|]
+  let runtime5_should_stack_switch_on_noalloc_extcall =
+    (* Must match amd64/emit.mlp in the [Iextcall] case. *)
+    Config.runtime5 && not Config.no_stack_checks
+  in
+  if runtime5_should_stack_switch_on_noalloc_extcall
+  then [|0;1;2;3;4;5;6;7;10;11|]
+  else [|0;2;3;4;5;6;7;10;11|]
 
 let destroyed_at_c_call_win64 =
   (* Win64: rbx, rbp, rsi, rdi, r12-r15, xmm6-xmm15 preserved *)


### PR DESCRIPTION
On Intel hardware, stack switching in runtime5 seems to be causing (what we believe is likely to be) bad speculation in the CPU frontend, causing many more (150% compared to runtime4) L1 icache hits and misses despite only slightly elevated retired instructions.  We are still investigating, but a significant mitigation appears to be to disable stack switching on `noalloc` C calls.  With stack checks disabled, this should work fine -- the C code will continue to execute on the OCaml stack, which has a guard page -- although it remains to check what happens if there is a stack overflow, in terms of the detection code.

This change also means that `%rbx` can be released to the register allocator across such calls.