### PR TITLE
Selection: move the common parts of `emit_expr_aux` and `emit_tail` to the utility module

### DIFF
--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -474,6 +474,18 @@ class virtual ['env, 'op, 'instr] common_selector =
           regs:Reg.t array ->
           'instr
 
+    method virtual make_const_int : nativeint -> 'op
+
+    method virtual make_const_float32 : int32 -> 'op
+
+    method virtual make_const_float : int64 -> 'op
+
+    method virtual make_const_vec128 : vec128_bits -> 'op
+
+    method virtual make_const_symbol : symbol -> 'op
+
+    method virtual make_opaque : unit -> 'op
+
     (* A syntactic criterion used in addition to judgements about (co)effects as
        to whether the evaluation of a given expression may be deferred by
        [emit_parts]. This criterion is a property of the instruction selection
@@ -865,4 +877,295 @@ class virtual ['env, 'op, 'instr] common_selector =
                 [||];
               a := Arch.offset_addressing !a (size_expr env e)))
         data
+
+    (* Emit an expression.
+
+       [bound_name] is the name that will be bound to the result of evaluating
+       the expression, if such exists. This is used for emitting debugging info.
+
+       Returns: - [None] if the expression does not finish normally (e.g.
+       raises) - [Some rs] if the expression yields a result in registers
+       [rs] *)
+    method emit_expr (env : 'env environment) exp ~bound_name =
+      self#emit_expr_aux env exp ~bound_name
+
+    (* Emit an expression which may end some regions early.
+
+       Returns: - [None] if the expression does not finish normally (e.g.
+       raises) - [Some (rs, unclosed)] if the expression yields a result in
+       [rs], having left [unclosed] (a suffix of env.regions) regions open *)
+    method emit_expr_aux (env : 'env environment) exp ~bound_name
+        : Reg.t array option =
+      (* Normal case of returning a value: no regions are closed *)
+      let ret res = Some res in
+      match exp with
+      | Cconst_int (n, _dbg) ->
+        let r = self#regs_for typ_int in
+        ret
+          (self#insert_op env (self#make_const_int (Nativeint.of_int n)) [||] r)
+      | Cconst_natint (n, _dbg) ->
+        let r = self#regs_for typ_int in
+        ret (self#insert_op env (self#make_const_int n) [||] r)
+      | Cconst_float32 (n, _dbg) ->
+        let r = self#regs_for typ_float32 in
+        ret
+          (self#insert_op env
+             (self#make_const_float32 (Int32.bits_of_float n))
+             [||] r)
+      | Cconst_float (n, _dbg) ->
+        let r = self#regs_for typ_float in
+        ret
+          (self#insert_op env
+             (self#make_const_float (Int64.bits_of_float n))
+             [||] r)
+      | Cconst_vec128 (bits, _dbg) ->
+        let r = self#regs_for typ_vec128 in
+        ret (self#insert_op env (self#make_const_vec128 bits) [||] r)
+      | Cconst_symbol (n, _dbg) ->
+        (* Cconst_symbol _ evaluates to a statically-allocated address, so its
+           value fits in a typ_int register and is never changed by the GC.
+
+           Some Cconst_symbols point to statically-allocated blocks, some of
+           which may point to heap values. However, any such blocks will be
+           registered in the compilation unit's global roots structure, so
+           adding this register to the frame table would be redundant *)
+        let r = self#regs_for typ_int in
+        ret (self#insert_op env (self#make_const_symbol n) [||] r)
+      | Cvar v -> (
+        try ret (env_find v env)
+        with Not_found ->
+          Misc.fatal_error
+            ("Selection.emit_expr: unbound var " ^ V.unique_name v))
+      | Clet (v, e1, e2) -> (
+        match self#emit_expr env e1 ~bound_name:(Some v) with
+        | None -> None
+        | Some r1 -> self#emit_expr_aux (self#bind_let env v r1) e2 ~bound_name)
+      | Clet_mut (v, k, e1, e2) -> (
+        match self#emit_expr env e1 ~bound_name:(Some v) with
+        | None -> None
+        | Some r1 ->
+          self#emit_expr_aux (self#bind_let_mut env v k r1) e2 ~bound_name)
+      | Cphantom_let (_var, _defining_expr, body) ->
+        self#emit_expr_aux env body ~bound_name
+      | Cassign (v, e1) -> (
+        let rv, provenance =
+          try env_find_mut v env
+          with Not_found ->
+            Misc.fatal_error ("Selection.emit_expr: unbound var " ^ V.name v)
+        in
+        match self#emit_expr env e1 ~bound_name:None with
+        | None -> None
+        | Some r1 ->
+          (if Option.is_some provenance
+          then
+            let naming_op =
+              self#make_name_for_debugger ~ident:v ~provenance
+                ~which_parameter:None ~is_assignment:true ~regs:r1
+            in
+            self#insert_debug env naming_op Debuginfo.none [||] [||]);
+          self#insert_moves env r1 rv;
+          ret [||])
+      | Ctuple [] -> ret [||]
+      | Ctuple exp_list -> (
+        match self#emit_parts_list env exp_list with
+        | None -> None
+        | Some (simple_list, ext_env) ->
+          ret (self#emit_tuple ext_env simple_list))
+      | Cop (Craise k, [arg], dbg) -> self#emit_expr_aux_raise env k arg dbg
+      | Cop (Copaque, args, dbg) -> (
+        match self#emit_parts_list env args with
+        | None -> None
+        | Some (simple_args, env) ->
+          let rs = self#emit_tuple env simple_args in
+          ret (self#insert_op_debug env (self#make_opaque ()) dbg rs rs))
+      | Cop (Ctuple_field (field, fields_layout), [arg], _dbg) -> (
+        match self#emit_expr env arg ~bound_name:None with
+        | None -> None
+        | Some loc_exp ->
+          let flat_size a =
+            Array.fold_left (fun acc t -> acc + Array.length t) 0 a
+          in
+          assert (Array.length loc_exp = flat_size fields_layout);
+          let before = Array.sub fields_layout 0 field in
+          let size_before = flat_size before in
+          let field_slice =
+            Array.sub loc_exp size_before (Array.length fields_layout.(field))
+          in
+          ret field_slice)
+      | Cop (op, args, dbg) -> self#emit_expr_aux_op env bound_name op args dbg
+      | Csequence (e1, e2) -> (
+        match self#emit_expr env e1 ~bound_name:None with
+        | None -> None
+        | Some _ -> self#emit_expr_aux env e2 ~bound_name)
+      | Cifthenelse (econd, ifso_dbg, eif, ifnot_dbg, eelse, dbg, value_kind) ->
+        self#emit_expr_aux_ifthenelse env bound_name econd ifso_dbg eif
+          ifnot_dbg eelse dbg value_kind
+      | Cswitch (esel, index, ecases, dbg, value_kind) ->
+        self#emit_expr_aux_switch env bound_name esel index ecases dbg
+          value_kind
+      | Ccatch (_, [], e1, _) -> self#emit_expr_aux env e1 ~bound_name
+      | Ccatch (rec_flag, handlers, body, value_kind) ->
+        self#emit_expr_aux_catch env bound_name rec_flag handlers body
+          value_kind
+      | Cexit (lbl, args, traps) -> self#emit_expr_aux_exit env lbl args traps
+      | Ctrywith (e1, exn_cont, v, e2, dbg, value_kind) ->
+        self#emit_expr_aux_trywith env bound_name e1 exn_cont v e2 dbg
+          value_kind
+
+    method virtual emit_expr_aux_raise
+        : 'env environment ->
+          Lambda.raise_kind ->
+          expression ->
+          Debuginfo.t ->
+          Reg.t array option
+
+    method virtual emit_expr_aux_op
+        : 'env environment ->
+          VP.t option ->
+          operation ->
+          expression list ->
+          Debuginfo.t ->
+          Reg.t array option
+
+    method virtual emit_expr_aux_ifthenelse
+        : 'env environment ->
+          VP.t option ->
+          expression ->
+          Debuginfo.t ->
+          expression ->
+          Debuginfo.t ->
+          expression ->
+          Debuginfo.t ->
+          kind_for_unboxing ->
+          Reg.t array option
+
+    method virtual emit_expr_aux_switch
+        : 'env environment ->
+          VP.t option ->
+          expression ->
+          int array ->
+          (expression * Debuginfo.t) array ->
+          Debuginfo.t ->
+          kind_for_unboxing ->
+          Reg.t array option
+
+    method virtual emit_expr_aux_catch
+        : 'env environment ->
+          VP.t option ->
+          rec_flag ->
+          (Lambda.static_label
+          * (VP.t * machtype) list
+          * expression
+          * Debuginfo.t
+          * bool)
+          list ->
+          expression ->
+          kind_for_unboxing ->
+          Reg.t array option
+
+    method virtual emit_expr_aux_exit
+        : 'env environment ->
+          exit_label ->
+          expression list ->
+          trap_action list ->
+          Reg.t array option
+
+    method virtual emit_expr_aux_trywith
+        : 'env environment ->
+          VP.t option ->
+          expression ->
+          trywith_shared_label ->
+          VP.t ->
+          expression ->
+          Debuginfo.t ->
+          kind_for_unboxing ->
+          Reg.t array option
+
+    (* Emit an expression in tail position of a function, closing all regions in
+       [env.regions] *)
+    method emit_tail (env : 'env environment) exp =
+      match exp with
+      | Clet (v, e1, e2) -> (
+        match self#emit_expr env e1 ~bound_name:None with
+        | None -> ()
+        | Some r1 -> self#emit_tail (self#bind_let env v r1) e2)
+      | Clet_mut (v, k, e1, e2) -> (
+        match self#emit_expr env e1 ~bound_name:None with
+        | None -> ()
+        | Some r1 -> self#emit_tail (self#bind_let_mut env v k r1) e2)
+      | Cphantom_let (_var, _defining_expr, body) -> self#emit_tail env body
+      | Cop ((Capply (ty, Rc_normal) as op), args, dbg) ->
+        self#emit_tail_apply env ty op args dbg
+      | Csequence (e1, e2) -> (
+        match self#emit_expr env e1 ~bound_name:None with
+        | None -> ()
+        | Some _ -> self#emit_tail env e2)
+      | Cifthenelse (econd, ifso_dbg, eif, ifnot_dbg, eelse, dbg, value_kind) ->
+        self#emit_tail_ifthenelse env econd ifso_dbg eif ifnot_dbg eelse dbg
+          value_kind
+      | Cswitch (esel, index, ecases, dbg, value_kind) ->
+        self#emit_tail_switch env esel index ecases dbg value_kind
+      | Ccatch (_, [], e1, _) -> self#emit_tail env e1
+      | Ccatch (rec_flag, handlers, e1, value_kind) ->
+        self#emit_tail_catch env rec_flag handlers e1 value_kind
+      | Ctrywith (e1, exn_cont, v, e2, dbg, value_kind) ->
+        self#emit_tail_trywith env e1 exn_cont v e2 dbg value_kind
+      | Cop _ | Cconst_int _ | Cconst_natint _ | Cconst_float32 _
+      | Cconst_float _ | Cconst_symbol _ | Cconst_vec128 _ | Cvar _ | Cassign _
+      | Ctuple _ | Cexit _ ->
+        self#emit_return env exp (pop_all_traps env)
+
+    method virtual emit_tail_apply
+        : 'env environment ->
+          machtype ->
+          operation ->
+          expression list ->
+          Debuginfo.t ->
+          unit
+
+    method virtual emit_tail_ifthenelse
+        : 'env environment ->
+          expression ->
+          Debuginfo.t ->
+          expression ->
+          Debuginfo.t ->
+          expression ->
+          Debuginfo.t ->
+          kind_for_unboxing ->
+          unit
+
+    method virtual emit_tail_switch
+        : 'env environment ->
+          expression ->
+          int array ->
+          (expression * Debuginfo.t) array ->
+          Debuginfo.t ->
+          kind_for_unboxing ->
+          unit
+
+    method virtual emit_tail_catch
+        : 'env environment ->
+          rec_flag ->
+          (Lambda.static_label
+          * (VP.t * machtype) list
+          * expression
+          * Debuginfo.t
+          * bool)
+          list ->
+          expression ->
+          kind_for_unboxing ->
+          unit
+
+    method virtual emit_tail_trywith
+        : 'env environment ->
+          expression ->
+          trywith_shared_label ->
+          VP.t ->
+          expression ->
+          Debuginfo.t ->
+          kind_for_unboxing ->
+          unit
+
+    method virtual emit_return
+        : 'env environment -> expression -> trap_action list -> unit
   end

--- a/backend/select_utils.mli
+++ b/backend/select_utils.mli
@@ -196,6 +196,18 @@ class virtual ['env, 'op, 'instr] common_selector :
       regs:Reg.t array ->
       'instr
 
+    method virtual make_const_int : nativeint -> 'op
+
+    method virtual make_const_float32 : int32 -> 'op
+
+    method virtual make_const_float : int64 -> 'op
+
+    method virtual make_const_vec128 : Cmm.vec128_bits -> 'op
+
+    method virtual make_const_symbol : Cmm.symbol -> 'op
+
+    method virtual make_opaque : unit -> 'op
+
     method is_simple_expr : Cmm.expression -> bool
 
     method effects_of : Cmm.expression -> Effect_and_coeffect.t
@@ -248,7 +260,7 @@ class virtual ['env, 'op, 'instr] common_selector :
     method insert_op :
       'env environment -> 'op -> Reg.t array -> Reg.t array -> Reg.t array
 
-    method virtual emit_expr :
+    method emit_expr :
       'env environment ->
       Cmm.expression ->
       bound_name:Backend_var.With_provenance.t option ->
@@ -299,4 +311,141 @@ class virtual ['env, 'op, 'instr] common_selector :
       Cmm.expression list ->
       Reg.t array ->
       unit
+
+    method emit_expr :
+      'env environment ->
+      Cmm.expression ->
+      bound_name:Backend_var.With_provenance.t option ->
+      Reg.t array option
+
+    method emit_expr_aux :
+      'env environment ->
+      Cmm.expression ->
+      bound_name:Backend_var.With_provenance.t option ->
+      Reg.t array option
+
+    method virtual emit_expr_aux_raise :
+      'env environment ->
+      Lambda.raise_kind ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Reg.t array option
+
+    method virtual emit_expr_aux_op :
+      'env environment ->
+      Backend_var.With_provenance.t option ->
+      Cmm.operation ->
+      Cmm.expression list ->
+      Debuginfo.t ->
+      Reg.t array option
+
+    method virtual emit_expr_aux_ifthenelse :
+      'env environment ->
+      Backend_var.With_provenance.t option ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      Reg.t array option
+
+    method virtual emit_expr_aux_switch :
+      'env environment ->
+      Backend_var.With_provenance.t option ->
+      Cmm.expression ->
+      int array ->
+      (Cmm.expression * Debuginfo.t) array ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      Reg.t array option
+
+    method virtual emit_expr_aux_catch :
+      'env environment ->
+      Backend_var.With_provenance.t option ->
+      Cmm.rec_flag ->
+      (Lambda.static_label
+      * (Backend_var.With_provenance.t * Cmm.machtype) list
+      * Cmm.expression
+      * Debuginfo.t
+      * bool)
+      list ->
+      Cmm.expression ->
+      Cmm.kind_for_unboxing ->
+      Reg.t array option
+
+    method virtual emit_expr_aux_exit :
+      'env environment ->
+      Cmm.exit_label ->
+      Cmm.expression list ->
+      Cmm.trap_action list ->
+      Reg.t array option
+
+    method virtual emit_expr_aux_trywith :
+      'env environment ->
+      Backend_var.With_provenance.t option ->
+      Cmm.expression ->
+      Cmm.trywith_shared_label ->
+      Backend_var.With_provenance.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      Reg.t array option
+
+    method emit_tail : 'env environment -> Cmm.expression -> unit
+
+    method virtual emit_tail_apply :
+      'env environment ->
+      Cmm.machtype ->
+      Cmm.operation ->
+      Cmm.expression list ->
+      Debuginfo.t ->
+      unit
+
+    method virtual emit_tail_ifthenelse :
+      'env environment ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      unit
+
+    method virtual emit_tail_switch :
+      'env environment ->
+      Cmm.expression ->
+      int array ->
+      (Cmm.expression * Debuginfo.t) array ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      unit
+
+    method virtual emit_tail_catch :
+      'env environment ->
+      Cmm.rec_flag ->
+      (Lambda.static_label
+      * (Backend_var.With_provenance.t * Cmm.machtype) list
+      * Cmm.expression
+      * Debuginfo.t
+      * bool)
+      list ->
+      Cmm.expression ->
+      Cmm.kind_for_unboxing ->
+      unit
+
+    method virtual emit_tail_trywith :
+      'env environment ->
+      Cmm.expression ->
+      Cmm.trywith_shared_label ->
+      Backend_var.With_provenance.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      unit
+
+    method virtual emit_return :
+      'env environment -> Cmm.expression -> Cmm.trap_action list -> unit
   end

--- a/backend/selectgen.mli
+++ b/backend/selectgen.mli
@@ -39,6 +39,18 @@ class virtual selector_generic :
       regs:Reg.t array ->
       Mach.instruction_desc
 
+    method make_const_int : nativeint -> Mach.operation
+
+    method make_const_float32 : int32 -> Mach.operation
+
+    method make_const_float : int64 -> Mach.operation
+
+    method make_const_vec128 : Cmm.vec128_bits -> Mach.operation
+
+    method make_const_symbol : Cmm.symbol -> Mach.operation
+
+    method make_opaque : unit -> Mach.operation
+
     (* The following methods must or can be overridden by the processor
        description *)
     method is_immediate : Mach.integer_operation -> int -> bool
@@ -185,7 +197,130 @@ class virtual selector_generic :
       bound_name:Backend_var.With_provenance.t option ->
       Reg.t array option
 
+    method emit_expr_aux_raise :
+      environment ->
+      Lambda.raise_kind ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Reg.t array option
+
+    method emit_expr_aux_op :
+      environment ->
+      Backend_var.With_provenance.t option ->
+      Cmm.operation ->
+      Cmm.expression list ->
+      Debuginfo.t ->
+      Reg.t array option
+
+    method emit_expr_aux_ifthenelse :
+      environment ->
+      Backend_var.With_provenance.t option ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      Reg.t array option
+
+    method emit_expr_aux_switch :
+      environment ->
+      Backend_var.With_provenance.t option ->
+      Cmm.expression ->
+      int array ->
+      (Cmm.expression * Debuginfo.t) array ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      Reg.t array option
+
+    method emit_expr_aux_catch :
+      environment ->
+      Backend_var.With_provenance.t option ->
+      Cmm.rec_flag ->
+      (Lambda.static_label
+      * (Backend_var.With_provenance.t * Cmm.machtype) list
+      * Cmm.expression
+      * Debuginfo.t
+      * bool)
+      list ->
+      Cmm.expression ->
+      Cmm.kind_for_unboxing ->
+      Reg.t array option
+
+    method emit_expr_aux_exit :
+      environment ->
+      Cmm.exit_label ->
+      Cmm.expression list ->
+      Cmm.trap_action list ->
+      Reg.t array option
+
+    method emit_expr_aux_trywith :
+      environment ->
+      Backend_var.With_provenance.t option ->
+      Cmm.expression ->
+      Cmm.trywith_shared_label ->
+      Backend_var.With_provenance.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      Reg.t array option
+
     method emit_tail : environment -> Cmm.expression -> unit
+
+    method emit_tail_apply :
+      environment ->
+      Cmm.machtype ->
+      Cmm.operation ->
+      Cmm.expression list ->
+      Debuginfo.t ->
+      unit
+
+    method emit_tail_ifthenelse :
+      environment ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      unit
+
+    method emit_tail_switch :
+      environment ->
+      Cmm.expression ->
+      int array ->
+      (Cmm.expression * Debuginfo.t) array ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      unit
+
+    method emit_tail_catch :
+      environment ->
+      Cmm.rec_flag ->
+      (Lambda.static_label
+      * (Backend_var.With_provenance.t * Cmm.machtype) list
+      * Cmm.expression
+      * Debuginfo.t
+      * bool)
+      list ->
+      Cmm.expression ->
+      Cmm.kind_for_unboxing ->
+      unit
+
+    method emit_tail_trywith :
+      environment ->
+      Cmm.expression ->
+      Cmm.trywith_shared_label ->
+      Backend_var.With_provenance.t ->
+      Cmm.expression ->
+      Debuginfo.t ->
+      Cmm.kind_for_unboxing ->
+      unit
+
+    method emit_return :
+      environment -> Cmm.expression -> Cmm.trap_action list -> unit
 
     (* [contains_calls] is declared as a reference instance variable, instead of
        a mutable boolean instance variable, because the traversal uses


### PR DESCRIPTION
(Only for CI at this point.)