### PR TITLE
Selection: enable warnings in architecture-dependent modules

### DIFF
--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -15,9 +15,9 @@
 
 (* Instruction selection for the AMD64 *)
 
+[@@@ocaml.warning "+a-4-9-40-41-42"]
+
 open Arch
-open Proc
-open Cmm
 open Selection_utils
 
 (* The selector class *)
@@ -192,6 +192,7 @@ class selector =
     (* Recognize float arithmetic with mem *)
 
     method select_floatarith commutative width regular_op mem_op args =
+      let open Cmm in
       match width, args with
       | ( Float64,
           [arg1; Cop (Cload { memory_chunk = Double as chunk; _ }, [loc2], _)] )

--- a/backend/amd64/selection_utils.ml
+++ b/backend/amd64/selection_utils.ml
@@ -15,6 +15,8 @@
 
 (* Instruction selection for the AMD64 *)
 
+[@@@ocaml.warning "+a-4-9-40-41-42"]
+
 open Arch
 open Proc
 

--- a/backend/arm64/selection.ml
+++ b/backend/arm64/selection.ml
@@ -17,6 +17,8 @@
 
 (* Instruction selection for the ARM processor *)
 
+[@@@ocaml.warning "+a-4-9-40-41-42"]
+
 open Arch
 open Cmm
 open Selection_utils

--- a/backend/arm64/selection_utils.ml
+++ b/backend/arm64/selection_utils.ml
@@ -17,6 +17,8 @@
 
 (* Instruction selection for the ARM processor *)
 
+[@@@ocaml.warning "+a-4-9-40-41-42"]
+
 open Arch
 
 let is_offset chunk n =


### PR DESCRIPTION
(Follow-up to https://github.com/ocaml-flambda/flambda-backend/pull/3013)

As per title; to be consistent with the
other selection-related modules, this
pull request enables warnings in the
architecture-dependent files related
to selection.