### PR TITLE
Mark `Capsule.Mutex.t` as crossing portability and contention

### DIFF
--- a/ocaml/otherlibs/stdlib_alpha/capsule.ml
+++ b/ocaml/otherlibs/stdlib_alpha/capsule.ml
@@ -27,7 +27,7 @@ end
 
 (* Like [Stdlib.Mutex], but [portable]. *)
 module M = struct
-  type t
+  type t : value mod portable uncontended
   external create: unit -> t @@ portable = "caml_ml_mutex_new"
   external lock: t -> unit @@ portable = "caml_ml_mutex_lock"
   external unlock: t -> unit @@ portable = "caml_ml_mutex_unlock"
@@ -39,7 +39,10 @@ external reraise : exn -> 'a @ portable @@ portable = "%reraise"
 
 module Mutex = struct
 
-  type 'k t = { mutex : M.t; mutable poisoned : bool }
+  (* Illegal mode crossing: ['k t] has a mutable field [poisoned]. It's safe,
+     since [poisoned] protected by [mutex] and not exposed in the API, but
+     is not allowed by the type system. *)
+  type 'k t : value mod portable uncontended = { mutex : M.t; mutable poisoned : bool }
 
   type packed = P : 'k t -> packed
 

--- a/ocaml/otherlibs/stdlib_alpha/capsule.mli
+++ b/ocaml/otherlibs/stdlib_alpha/capsule.mli
@@ -64,7 +64,7 @@ end
       Requires OCaml 5 runtime. *)
 module Mutex : sig
 
-    type 'k t
+    type 'k t : value mod portable uncontended
     (** ['k t] is the type of the mutex that controls access to
         the capsule ['k]. This mutex is created when creating
         the capsule ['k] using {!create_with_mutex}. *)

--- a/ocaml/otherlibs/stdlib_alpha/dune
+++ b/ocaml/otherlibs/stdlib_alpha/dune
@@ -24,7 +24,9 @@
    -safe-string
    -strict-formats
    -extension-universe
-   alpha))
+   alpha
+   ;; Capsule API can't be defined legally.
+   -allow-illegal-crossing))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
  (library_flags

--- a/ocaml/testsuite/tests/capsule-api/basics.ml
+++ b/ocaml/testsuite/tests/capsule-api/basics.ml
@@ -8,9 +8,17 @@
 
 module Capsule = Stdlib_alpha.Capsule
 
+(* Both [Mutex.t] and [Data.t] are [value mod portable uncontended]. *)
+
+type 'k _mutex : value mod portable uncontended = 'k Capsule.Mutex.t
+
+type ('a, 'k) _data : value mod portable uncontended = ('a, 'k) Capsule.Data.t
+
 type 'a myref = { mutable v : 'a}
 
 module Cell = struct
+  (* CR: ['a Cell.t] should be [value mod portable uncontended],
+     but this can't be inferred yet. *)
   type 'a t =
     | Mk : 'k Capsule.Mutex.t * ('a myref, 'k) Capsule.Data.t -> 'a t
 


### PR DESCRIPTION
Title. Requires `-allow-illegal-crossing`, since the record has a mutable field `poisoned`, but the resulting API is still thread-safe.