### PR TITLE
Change profile output to simplify parsing for dynamic counters

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -282,7 +282,7 @@ let cfg_profile to_cfg =
       let (_ : Cfg.basic_block) =
         Profile.record_with_counters ~accumulate:true
           ~counter_f:cfg_block_counters
-          (Format.sprintf "block %d" label)
+          (Format.sprintf "block=%d" label)
           Fun.id block
       in
       ()
@@ -573,7 +573,7 @@ let compile_phrases ~ppf_dump ps =
         let profile_wrapper =
           match !profile_granularity with
           | Function_level | Block_level ->
-            Profile.record ~accumulate:true fd.fun_name.sym_name
+            Profile.record ~accumulate:true ("function=" ^ fd.fun_name.sym_name)
           | File_level -> Fun.id
         in
         profile_wrapper (compile_fundecl ~ppf_dump ~funcnames) fd;

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -389,10 +389,8 @@ let column_mapping = [
   `Counters, "counters"
 ]
 
-let chars_to_sanitise_for_csv = [|','; '/'|]
-
 let sanitise_for_csv =
-  String.map (fun c -> if Array.mem c chars_to_sanitise_for_csv then '_' else c)
+  String.map (fun c -> if Char.equal c ',' then '_' else c)
 
 let output_to_csv ppf columns =
   let to_csv cell_strings =

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -389,9 +389,15 @@ let column_mapping = [
   `Counters, "counters"
 ]
 
+let chars_to_sanitise_for_csv = [|','; '/'|]
+
+let sanitise_for_csv =
+  String.map (fun c -> if Array.mem c chars_to_sanitise_for_csv then '_' else c)
+
 let output_to_csv ppf columns =
-  let sanitise = String.map (fun c -> if c = ',' then '_' else c) in
-  let to_csv cell_strings = cell_strings |> List.map sanitise |> String.concat "," in
+  let to_csv cell_strings =
+    cell_strings |> List.map sanitise_for_csv |> String.concat ","
+  in
   let string_columns = List.map (fun col -> List.assoc col column_mapping) columns in
   Format.fprintf ppf "%s@\n" (to_csv ("pass name" :: string_columns));
   let output_row_f = output_rows

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -50,6 +50,11 @@ val record_with_counters :
 val print : Format.formatter -> Clflags.profile_column list -> timings_precision:int -> unit
 (** Prints the selected recorded profiling information to the formatter. *)
 
+(* CR mitom: Exported for use with external tools to create dynamic counters *)
+val sanitise_for_csv : string -> string
+(** Sanitises a given string such that it is suitable to be used as a field in outputted
+    CSV files *)
+
 val output_to_csv :
 Format.formatter -> Clflags.profile_column list -> timings_precision:int -> unit
 (** Outputs the selected recorded profiling information in CSV format to the formatter. *)


### PR DESCRIPTION
Changes the profile pass name output from something such as:
```
gen.ml/generate/compile_phrases/camlBin_prefix_gen__Gen__mem_17_29_code/regalloc/cfg/peephole_optimize_cfg/block 329
```
to:
```
gen.ml/generate/compile_phrases/function=camlBin_prefix_gen__Gen__mem_17_29_code/regalloc/cfg/peephole_optimize_cfg/block=329
```
This change includes `function=` and `block=` keys to make identification of function names and block labels in this hierarchy of pass names easier for parsers of this profile output.

This PR also exports the sanitisation function for fields used in the CSV profile output (most notably function symbol names) such that it can be re-used by external parsers.