### PR TITLE
Fix assertion failure: some reinterpret cast are not pure

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -281,7 +281,7 @@ let intop (op : Mach.integer_operation) =
   | Ictz _ -> " ctz "
   | Icomp cmp -> intcomp cmp
 
-let dump_op ppf = function
+let dump_operation ppf = function
   | Move -> Format.fprintf ppf "mov"
   | Spill -> Format.fprintf ppf "spill"
   | Reload -> Format.fprintf ppf "reload"
@@ -323,7 +323,7 @@ let dump_op ppf = function
 let dump_basic ppf (basic : basic) =
   let open Format in
   match basic with
-  | Op op -> dump_op ppf op
+  | Op op -> dump_operation ppf op
   | Reloadretaddr -> fprintf ppf "Reloadretaddr"
   | Pushtrap { lbl_handler } -> fprintf ppf "Pushtrap handler=%d" lbl_handler
   | Poptrap -> fprintf ppf "Poptrap"

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -202,6 +202,8 @@ val set_stack_offset : 'a instruction -> int -> unit
 
 val string_of_irc_work_list : irc_work_list -> string
 
+val dump_operation : Format.formatter -> operation -> unit
+
 val dump_basic : Format.formatter -> basic -> unit
 
 val dump_terminator : ?sep:string -> Format.formatter -> terminator -> unit

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2550,9 +2550,17 @@ end = struct
         | Intop
             ( Iadd | Isub | Imul | Imulh _ | Idiv | Imod | Iand | Ior | Ixor
             | Ilsl | Ilsr | Iasr | Ipopcnt | Iclz _ | Ictz _ | Icomp _ )
-        | Reinterpret_cast _ | Static_cast _ | Csel _ ->
-          assert (Cfg.is_pure_operation op);
+        | Reinterpret_cast
+            ( Float32_of_float | Float_of_float32 | Float_of_int64
+            | Int64_of_float | Float32_of_int32 | Int32_of_float32
+            | V128_of_v128 )
+        | Static_cast _ | Csel _ ->
+          if not (Cfg.is_pure_operation op)
+          then
+            Misc.fatal_errorf "Expected pure operation, got %a\n"
+              Cfg.dump_operation op;
           next
+        | Reinterpret_cast (Int_of_value | Value_of_int)
         | Name_for_debugger _ | Stackoffset _ | Probe_is_enabled _ | Opaque
         | Begin_region | End_region | Intop_atomic _ | Store _ ->
           next


### PR DESCRIPTION
A small fix for zero_alloc checker: `Reinterpret_cast (Int_of_value | Value_of_int)` are not pure but don't allocate, so the current handling is fine (i.e., returning `next`).  A similar change has recently been applied to Mach version of the analysis (in #2596), this PR does the same for CFG.

This PR also replaces the assertion with a more informative `fatal_error` that prints the operation that was expected to be pure.