### PR TITLE
Fix backup thread & systhreads interaction

### DIFF
--- a/ocaml/otherlibs/systhreads/st_pthreads.h
+++ b/ocaml/otherlibs/systhreads/st_pthreads.h
@@ -166,8 +166,8 @@ static void st_masterlock_acquire(st_masterlock *m)
     atomic_fetch_add(&m->waiters, -1);
   }
   m->busy = 1;
-  // CR ocaml 5 domains: we assume no backup thread
-  // st_bt_lock_acquire(m);
+  if (domain_lockmode == LOCKMODE_DOMAINS)
+    st_bt_lock_acquire(m);
   pthread_mutex_unlock(&m->lock);
 
   return;
@@ -177,8 +177,8 @@ static void st_masterlock_release(st_masterlock * m)
 {
   pthread_mutex_lock(&m->lock);
   m->busy = 0;
-  // CR ocaml 5 domains: we assume no backup thread
-  // st_bt_lock_release(m);
+  if (domain_lockmode == LOCKMODE_DOMAINS)
+    st_bt_lock_release(m);
   pthread_mutex_unlock(&m->lock);
   custom_condvar_signal(&m->is_free);
 
@@ -216,8 +216,8 @@ Caml_inline void st_thread_yield(st_masterlock * m)
      messaging the bt should not be required because yield assumes
      that a thread will resume execution (be it the yielding thread
      or a waiting thread */
-  // CR ocaml 5 domains
-  // caml_release_domain_lock();
+  if (domain_lockmode == LOCKMODE_DOMAINS)
+    caml_release_domain_lock();
 
   do {
     /* Note: the POSIX spec prevents the above signal from pairing with this
@@ -230,8 +230,8 @@ Caml_inline void st_thread_yield(st_masterlock * m)
   m->busy = 1;
   atomic_fetch_add(&m->waiters, -1);
 
-  // CR ocaml 5 domains
-  // caml_acquire_domain_lock();
+  if (domain_lockmode == LOCKMODE_DOMAINS)
+    caml_acquire_domain_lock();
 
   pthread_mutex_unlock(&m->lock);
 

--- a/ocaml/runtime/caml/domain.h
+++ b/ocaml/runtime/caml/domain.h
@@ -81,6 +81,7 @@ CAMLextern void caml_release_domain_lock(void);
 
 /* These hooks are not modified after other domains are spawned. */
 CAMLextern void (*caml_atfork_hook)(void);
+CAMLextern void (*caml_domain_spawn_hook)(void);
 CAMLextern void (*caml_domain_initialize_hook)(void);
 CAMLextern void (*caml_domain_stop_hook)(void);
 CAMLextern void (*caml_domain_external_interrupt_hook)(void);

--- a/ocaml/runtime/domain.c
+++ b/ocaml/runtime/domain.c
@@ -1131,6 +1131,11 @@ static void install_backup_thread (dom_internal* di)
   }
 }
 
+static void caml_domain_spawn_default(void)
+{
+  return;
+}
+
 static void caml_domain_initialize_default(void)
 {
   return;
@@ -1145,6 +1150,9 @@ static void caml_domain_external_interrupt_hook_default(void)
 {
   return;
 }
+
+CAMLexport void (*caml_domain_spawn_hook)(void)=
+  caml_domain_spawn_default;
 
 CAMLexport void (*caml_domain_initialize_hook)(void) =
    caml_domain_initialize_default;
@@ -1283,6 +1291,8 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   struct domain_startup_params p;
   pthread_t th;
   int err;
+
+  caml_domain_spawn_hook();
 
 #ifndef NATIVE_CODE
   if (caml_debugger_in_use)


### PR DESCRIPTION
The alternative runtime locking scheme remains incompatible with domains, but now programs can use one or the other and will get a reasonable error message if they try to use both.