### PR TITLE
Support for or_null value kinds in Lambda

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1578,7 +1578,7 @@ module Extended_machtype = struct
     | Punboxed_int _ ->
       (* Only 64-bit architectures, so this is always [typ_int] *)
       typ_any_int
-    | Pvalue Pintval -> typ_tagged_int
+    | Pvalue { raw_kind = Pintval; _ } -> typ_tagged_int
     | Pvalue _ -> typ_val
     | Punboxed_product fields -> Array.concat (List.map of_layout fields)
 end
@@ -4097,10 +4097,10 @@ let cmm_arith_size (e : Cmm.expression) =
 
 let kind_of_layout (layout : Lambda.layout) =
   match layout with
-  | Pvalue (Pboxedfloatval bf) -> Boxed_float bf
-  | Pvalue (Pboxedintval bi) -> Boxed_integer bi
-  | Pvalue (Pboxedvectorval vi) -> Boxed_vector vi
-  | Pvalue (Pgenval | Pintval | Pvariant _ | Parrayval _)
+  | Pvalue { raw_kind = Pboxedfloatval bf; _ } -> Boxed_float bf
+  | Pvalue { raw_kind = Pboxedintval bi; _ } -> Boxed_integer bi
+  | Pvalue { raw_kind = Pboxedvectorval vi; _ } -> Boxed_vector vi
+  | Pvalue { raw_kind = (Pgenval | Pintval | Pvariant _ | Parrayval _); _ }
   | Ptop | Pbottom | Punboxed_float _ | Punboxed_int _ | Punboxed_vector _
   | Punboxed_product _ ->
     Any

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -384,7 +384,19 @@ and array_index_kind =
   | Ptagged_int_index
   | Punboxed_int_index of unboxed_integer
 
+(** [Nullable] value kinds allow the special Null value in addition to the
+    values of its underlying type. [Non_nullable] only allows values of the
+    underlying type. *)
+and nullable =
+  | Nullable
+  | Non_nullable
+
 and value_kind =
+  { raw_kind : value_kind_non_null;
+    nullable : nullable;
+  }
+
+and value_kind_non_null =
   | Pgenval
   | Pintval
   | Pboxedfloatval of boxed_float
@@ -500,6 +512,8 @@ val compare_boxed_vector : boxed_vector -> boxed_vector -> int
 val print_boxed_vector : Format.formatter -> boxed_vector -> unit
 
 val must_be_value : layout -> value_kind
+
+val generic_value : value_kind
 
 (* This is the layout of ocaml values used as arguments to or returned from
    primitives for this [extern_repr].  So the legacy [Unboxed_float] - which is

--- a/ocaml/lambda/translclass.ml
+++ b/ocaml/lambda/translclass.ml
@@ -34,7 +34,7 @@ let layout_t = layout_any_value
 let layout_obj = layout_array Pgenarray
 let layout_table = layout_block
 let layout_meth = layout_any_value
-let layout_tables = Lambda.Pvalue Pgenval
+let layout_tables = layout_any_value
 
 
 let lfunction ?(kind=Curried {nlocal=0}) ?(region=true) ?(ret_mode=alloc_heap) return_layout params body =

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -1136,7 +1136,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
                                   Jkind.Sort.for_block_element typ))
           fields
       in
-      let useful = List.exists (fun knd -> knd <> Pgenval) shape in
+      let useful = List.exists (fun knd -> knd <> Lambda.generic_value) shape in
       if useful then
         Some (Primitive (Pmakeblock(tag, mut, Some shape, mode),arity))
       else None


### PR DESCRIPTION
This PR adds the Lambda structures to represent value kinds with or without null.
It does not (yet) contain the code to forward this to the middle-end (which results in compilation errors in Flambda2), nor the code to type-check or_null types.