### PR TITLE
Fix bug with update_field and mixed blocks

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -35,22 +35,22 @@ let or_variable f default v cont =
   | Const c -> f c cont
   | Var _ -> f default cont
 
-let update_field symb env res acc i field =
+let update_field symb env res acc i update_kind field =
   Simple.pattern_match'
     (Simple.With_debuginfo.simple field)
     ~var:(fun var ~coercion:_ ->
       (* CR mshinwell/mslater: It would be nice to know if [var] is an
          immediate. *)
       let dbg = Simple.With_debuginfo.dbg field in
-      C.make_update env res dbg UK.pointers ~symbol:(C.symbol ~dbg symb) var
+      C.make_update env res dbg update_kind ~symbol:(C.symbol ~dbg symb) var
         ~index:i ~prev_updates:acc)
     ~symbol:(fun _sym ~coercion:_ -> env, res, acc)
     ~const:(fun _cst -> env, res, acc)
 
 let rec static_block_updates symb env res acc i = function
   | [] -> env, res, acc
-  | sv :: r ->
-    let env, res, acc = update_field symb env res acc i sv in
+  | (simple, update_kind) :: r ->
+    let env, res, acc = update_field symb env res acc i update_kind simple in
     static_block_updates symb env res acc (i + 1) r
 
 type maybe_int32 =
@@ -231,7 +231,31 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     in
     let static_fields = List.concat_map (static_field res) fields in
     let block = C.emit_block sym header static_fields in
-    let env, res, updates = static_block_updates sym env res updates 0 fields in
+    let update_kinds =
+      match shape with
+      | Value_only -> List.map (fun _ -> UK.pointers) fields
+      | Mixed_record shape ->
+        let value_prefix =
+          List.init (Flambda_kind.Mixed_block_shape.value_prefix_size shape)
+            (fun _ -> UK.pointers)
+        in
+        let flat_suffix =
+          List.map
+            (fun (flat_suffix_elt : Flambda_kind.flat_suffix_element) ->
+              match flat_suffix_elt with
+              | Tagged_immediate -> UK.tagged_immediates
+              | Naked_float -> UK.naked_floats
+              | Naked_float32 -> UK.naked_float32_fields
+              | Naked_int32 -> UK.naked_int32_fields
+              | Naked_int64 | Naked_nativeint -> UK.naked_int64s)
+            (Flambda_kind.Mixed_block_shape.flat_suffix shape |> Array.to_list)
+        in
+        value_prefix @ flat_suffix
+    in
+    let env, res, updates =
+      static_block_updates sym env res updates 0
+        (List.combine fields update_kinds)
+    in
     env, R.set_data res block, updates
   | Set_of_closures closure_symbols, Set_of_closures set_of_closures ->
     let res, updates, env =
@@ -332,7 +356,11 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let header = C.black_block_header 0 (List.length fields) in
     let static_fields = List.concat_map (static_field res) fields in
     let block = C.emit_block sym header static_fields in
-    let env, res, updates = static_block_updates sym env res updates 0 fields in
+    let update_kinds = List.map (fun _ -> UK.pointers) fields in
+    let env, res, updates =
+      static_block_updates sym env res updates 0
+        (List.combine fields update_kinds)
+    in
     env, R.set_data res block, updates
   | Block_like s, Empty_array Values_or_immediates_or_naked_floats ->
     (* Recall: empty arrays have tag zero, even if their kind is naked float. *)

--- a/ocaml/testsuite/tests/mixed-blocks/structural_constants.ml
+++ b/ocaml/testsuite/tests/mixed-blocks/structural_constants.ml
@@ -13,6 +13,7 @@ type v =
   | B of string * float#
   | C of string * float# * int
   | D of string
+  | E of int * int32# * int64# * nativeint#
 
 let r1           = { x1 = "x1"; y1 = #1.0 }
 let create_r1 () = { x1 = "x1"; y1 = #1.0 }
@@ -63,8 +64,16 @@ let () =
   let s = Sys.opaque_identity "foo" in
   let bytes_start0 = Gc.allocated_bytes () in
   let bytes_start1 = Gc.allocated_bytes () in
+  (* These variables ensure that we test the [make_update] code for
+     static inconstant blocks. *)
+  let imm = Sys.opaque_identity 42 in
+  let i32 = Sys.opaque_identity #3l in
+  let i64 = Sys.opaque_identity #4L in
+  let nat = Sys.opaque_identity #5n in
+  let f = Sys.opaque_identity #6. in
   let _ =
-    Sys.opaque_identity [A #4.0; B ("B", #5.0); C ("C", #6.0, 6); D s]
+    Sys.opaque_identity [A #4.0; B ("B", #5.0); C ("C", f, 6); D s;
+      E (imm, i32, i64, nat)]
   in
   match Sys.backend_type with
   | Bytecode -> ()


### PR DESCRIPTION
Surprisingly, the code in `To_cmm_static.update_field` was not being exercised by the testsuite, and contained an error: it was always using update kind `pointers` even when the corresponding fields formed part of a mixed block flat suffix.  In some cases this is luckily caught by a check in the x86-64 backend that detects illegal moves between float and int registers (it was trying to pass a naked float to `caml_initialize` in the original failing test during initialization of an inconstant statically-allocated mixed block).

The relevant testsuite test has been updated and confirmed to fail on current `main` on x86-64.