### PR TITLE
Add directory and file annotation to profile output

### DIFF
--- a/backend/asmgen.ml
+++ b/backend/asmgen.ml
@@ -573,7 +573,8 @@ let compile_phrases ~ppf_dump ps =
         let profile_wrapper =
           match !profile_granularity with
           | Function_level | Block_level ->
-            Profile.record ~accumulate:true ("function=" ^ fd.fun_name.sym_name)
+            Profile.record ~accumulate:true
+              ("function=" ^ X86_proc.string_of_symbol "" fd.fun_name.sym_name)
           | File_level -> Fun.id
         in
         profile_wrapper (compile_fundecl ~ppf_dump ~funcnames) fd;

--- a/backend/asmlink.ml
+++ b/backend/asmlink.ml
@@ -435,7 +435,7 @@ let call_linker_shared ?(native_toplevel = false) file_list output_name =
   then raise(Error(Linking_error exitcode))
 
 let link_shared unix ~ppf_dump objfiles output_name =
-  Profile.record_call output_name (fun () ->
+  Profile.(record_call (annotate_file_name output_name)) (fun () ->
     if !Flambda_backend_flags.use_cached_generic_functions then
       (* When doing shared linking do not use the shared generated startup file.
          Frametables for the imported functions needs to be initialized, which is a bit
@@ -522,7 +522,7 @@ let reset () =
 let link unix ~ppf_dump objfiles output_name =
   if !Flambda_backend_flags.internal_assembler then
       Emitaux.binary_backend_available := true;
-  Profile.record_call output_name (fun () ->
+  Profile.(record_call (annotate_file_name output_name)) (fun () ->
     let stdlib = "stdlib.cmxa" in
     let stdexit = "std_exit.cmx" in
     let objfiles =

--- a/ocaml/asmcomp/asmlink.ml
+++ b/ocaml/asmcomp/asmlink.ml
@@ -328,7 +328,7 @@ let call_linker_shared file_list output_name =
   then raise(Error(Linking_error exitcode))
 
 let link_shared ~ppf_dump objfiles output_name =
-  Profile.record_call output_name (fun () ->
+  Profile.(record_call (annotate_filename output_name)) (fun () ->
     let obj_infos = List.map read_file objfiles in
     let units_tolink = List.fold_right scan_file obj_infos [] in
     List.iter
@@ -381,7 +381,7 @@ let call_linker file_list startup_file output_name =
 (* Main entry point *)
 
 let link ~ppf_dump objfiles output_name =
-  Profile.record_call output_name (fun () ->
+  Profile.(record_call (annotate_filename output_name)) (fun () ->
     let stdlib = "stdlib.cmxa" in
     let stdexit = "std_exit.cmx" in
     let objfiles =

--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -108,7 +108,7 @@ let emit_signature info ast tsg =
     info.output_prefix info.source_file info.env sg
 
 let interface ~hook_parse_tree ~hook_typed_tree info =
-  Profile.record_call info.source_file @@ fun () ->
+  Profile.(record_call (annotate_file_name info.source_file)) @@ fun () ->
   let ast = parse_intf info in
   hook_parse_tree ast;
   if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
@@ -144,7 +144,7 @@ let typecheck_impl i parsetree =
     (fun fmt {Typedtree.shape; _} -> Shape.print fmt shape)
 
 let implementation ~hook_parse_tree ~hook_typed_tree info ~backend =
-  Profile.record_call info.source_file @@ fun () ->
+  Profile.(record_call (annotate_file_name info.source_file)) @@ fun () ->
   let exceptionally () =
     let sufs = if info.native then [ cmx; obj ] else [ cmo ] in
     List.iter (fun suf -> remove_file (suf info)) sufs;

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/ml_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- comprehensions/ml_counters.ml
+ file=comprehensions/ml_counters.ml
   [comprehensions = 8; immutable_arrays = 0; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/comprehensions/mli_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- comprehensions/mli_counters.mli
+ file=comprehensions/mli_counters.mli
   [comprehensions = 0; immutable_arrays = 0; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_array_comprehensions/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_array_comprehensions/ml_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- immutable_array_comprehensions/ml_counters.ml
+ file=immutable_array_comprehensions/ml_counters.ml
   [comprehensions = 4; immutable_arrays = 4; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/ml_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- immutable_arrays/ml_counters.ml
+ file=immutable_arrays/ml_counters.ml
   [comprehensions = 0; immutable_arrays = 8; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/immutable_arrays/mli_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- immutable_arrays/mli_counters.mli
+ file=immutable_arrays/mli_counters.mli
   [comprehensions = 0; immutable_arrays = 3; include_functor = 0; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/ml_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- include_functor/ml_counters.ml
+ file=include_functor/ml_counters.ml
   [comprehensions = 0; immutable_arrays = 0; include_functor = 6; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/include_functor/mli_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- include_functor/mli_counters.mli
+ file=include_functor/mli_counters.mli
   [comprehensions = 0; immutable_arrays = 0; include_functor = 1; labeled_tuples = 0; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/ml_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- labeled_tuples/ml_counters.ml
+ file=labeled_tuples/ml_counters.ml
   [comprehensions = 0; immutable_arrays = 0; include_functor = 0; labeled_tuples = 4; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/labeled_tuples/mli_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- labeled_tuples/mli_counters.mli
+ file=labeled_tuples/mli_counters.mli
   [comprehensions = 0; immutable_arrays = 0; include_functor = 0; labeled_tuples = 2; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/ml_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- module_strengthening/ml_counters.ml
+ file=module_strengthening/ml_counters.ml
   [comprehensions = 0; immutable_arrays = 0; include_functor = 0; labeled_tuples = 0; module_strengthening = 1] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/module_strengthening/mli_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- module_strengthening/mli_counters.mli
+ file=module_strengthening/mli_counters.mli
   [comprehensions = 0; immutable_arrays = 0; include_functor = 0; labeled_tuples = 0; module_strengthening = 1] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/nested/ml_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/nested/ml_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- nested/ml_counters.ml
+ file=nested/ml_counters.ml
   [comprehensions = 3; immutable_arrays = 0; include_functor = 0; labeled_tuples = 1; module_strengthening = 0] typing

--- a/ocaml/testsuite/tests/profile/counters/language_extensions/nested/mli_counters.ocamlc.reference
+++ b/ocaml/testsuite/tests/profile/counters/language_extensions/nested/mli_counters.ocamlc.reference
@@ -1,2 +1,2 @@
- nested/mli_counters.mli
+ file=nested/mli_counters.mli
   [comprehensions = 0; immutable_arrays = 1; include_functor = 0; labeled_tuples = 3; module_strengthening = 0] typing

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -148,6 +148,16 @@ let record ?accumulate pass f x = record_call ?accumulate pass (fun () -> f x)
 let record_with_counters ?accumulate ~counter_f pass f x =
   record_call_internal ?accumulate ~counter_f pass (fun () -> f x)
 
+let file_prefix = "file="
+
+let annotate_file_name name =
+  let file_path =
+    match !Clflags.directory with
+    | Some directory -> Filename.concat directory name
+    | None -> name
+  in
+  file_prefix ^ file_path
+
 type display = {
   to_string : max:float -> width:int -> string;
   worth_displaying : max:float -> bool;

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -408,10 +408,9 @@ let column_mapping = [
   `Counters, "counters"
 ]
 
-let sanitise_for_csv =
-  String.map (fun c -> if Char.equal c ',' then '_' else c)
-
 let output_to_csv ppf columns =
+  let sanitise_for_csv =
+    String.map (fun c -> if Char.equal c ',' then '_' else c) in
   let to_csv cell_strings =
     cell_strings |> List.map sanitise_for_csv |> String.concat ","
   in

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -417,13 +417,19 @@ let output_to_csv ppf columns =
   in
   let string_columns = List.map (fun col -> List.assoc col column_mapping) columns in
   Format.fprintf ppf "%s@\n" (to_csv ("pass name" :: string_columns));
-  let output_row_f = output_rows
-    ~output_row:(fun ~prefix ~cell_strings ~name ->
-      Format.fprintf ppf "%s@\n" (to_csv ((prefix ^ name) :: cell_strings)))
-    ~new_prefix:(fun ~prev ~curr_name -> Format.sprintf "%s%s/" prev curr_name)
-    ~always_output_ancestors:false
-    ~pad_empty:false
-  in output_columns output_row_f columns
+  let add_suffix pass =
+    let suffix = if String.starts_with ~prefix:file_prefix pass then "/" else "" in
+    pass ^ suffix
+  in
+  let output_row_f =
+    output_rows
+      ~output_row:(fun ~prefix ~cell_strings ~name ->
+        Format.fprintf ppf "%s@\n" (to_csv ((prefix ^ add_suffix name) :: cell_strings)))
+      ~new_prefix:(fun ~prev ~curr_name ->
+        Format.sprintf "%s%s/" prev (add_suffix curr_name))
+      ~always_output_ancestors:false ~pad_empty:false
+  in
+  output_columns output_row_f columns
 
 let all_columns = List.map fst column_mapping
 let column_names = List.map snd column_mapping

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -54,6 +54,9 @@ val record_with_counters :
 (** [record_with_counters counter_f pass f arg] records the profile information of [f arg]
   and records counter information given by calling [counter_f] on the result of [f arg] *)
 
+val annotate_file_name : string -> string
+(** Annotates profiling pass for file names. *)
+
 val print : Format.formatter -> Clflags.profile_column list -> timings_precision:int -> unit
 (** Prints the selected recorded profiling information to the formatter. *)
 

--- a/ocaml/utils/profile.mli
+++ b/ocaml/utils/profile.mli
@@ -60,11 +60,6 @@ val annotate_file_name : string -> string
 val print : Format.formatter -> Clflags.profile_column list -> timings_precision:int -> unit
 (** Prints the selected recorded profiling information to the formatter. *)
 
-(* CR mitom: Exported for use with external tools to create dynamic counters *)
-val sanitise_for_csv : string -> string
-(** Sanitises a given string such that it is suitable to be used as a field in outputted
-    CSV files *)
-
 val output_to_csv :
 Format.formatter -> Clflags.profile_column list -> timings_precision:int -> unit
 (** Outputs the selected recorded profiling information in CSV format to the formatter. *)


### PR DESCRIPTION
Changes:
- Adds directory (from clflag `directory` if passed in) to file in profile output.
- Adds `file=<FILE_NAME>//` annotation to profile CSV output for `.ml`, `.mli` and linked files.
- Changes summary CSV generation script to include file as separate column.
- Uses `x86_proc.string_of_symbol` to sanitise function names rather than ad-hoc sanitiser