### PR TITLE
Only use block temporaries when they will not worsen spills and reloads

### DIFF
--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -37,6 +37,63 @@ type direction =
   | Load_after_list of Cfg.basic_instruction_list
   | Store_before_list of Cfg.basic_instruction_list
 
+module type Optimization_reg = sig
+  type t
+
+  val of_reg : Reg.t -> t
+
+  val to_reg : t -> Reg.t
+
+  val cl : t -> int
+
+  module Set : Set.S with type elt = t
+
+  module Tbl : Hashtbl.S with type key = t
+end
+
+module Optimization_reg : Optimization_reg = struct
+  type t = { reg : Reg.t }
+
+  type reg = t
+
+  let[@inline] of_reg (reg : Reg.t) = { reg }
+
+  let[@inline] to_reg { reg } = reg
+
+  let cl { reg } = Proc.register_class reg
+
+  module RegOrder = struct
+    type t = reg
+
+    let compare r1 r2 = (to_reg r1).stamp - (to_reg r2).stamp
+  end
+
+  module Set = Set.Make (RegOrder)
+
+  module Tbl = Hashtbl.Make (struct
+    type t = reg
+
+    let equal r1 r2 = Reg.same (to_reg r1) (to_reg r2)
+
+    let hash (r : t) = r.reg.stamp
+  end)
+end
+
+module Inst_temporary : Optimization_reg = Optimization_reg
+
+module Block_temporary : Optimization_reg = Optimization_reg
+
+module Spilled_var : Optimization_reg = Optimization_reg
+
+module Actual_var : Optimization_reg = Optimization_reg
+
+module Unspilled_reg : Optimization_reg = Optimization_reg
+
+let[@inline] convert_reg (type a b)
+    (module A : Optimization_reg with type t = a)
+    (module B : Optimization_reg with type t = b) x =
+  x |> A.to_reg |> B.of_reg
+
 (* Applies an optimization on the CFG outputted by [rewrite_gen] having one
    temporary per variable per block rather than one per use of the variable,
    reducing the number of spills and reloads needed for variables used multiple
@@ -58,55 +115,250 @@ type direction =
    that are now redundant (due to being replaced by block temporaries) are
    removed from the list of new instruction temporaries. *)
 let coalesce_temp_spills_and_reloads (block : Cfg.basic_block)
-    ~new_inst_temporaries ~new_block_temporaries =
-  (* CR-soon mitom: Avoid cases where optimisation worsens spills and reloads
-     due to assigning block temporaries for spilled registers that have live
-     ranges interfering with things that have already been register allocated *)
-  let removed_inst_temporaries = Reg.Tbl.create 128 in
-  let var_to_block_temp = Reg.Tbl.create 8 in
-  let replacements = Reg.Tbl.create 8 in
-  let last_spill = Reg.Tbl.create 8 in
-  let replace to_replace replace_with =
-    if not (Reg.same to_replace replace_with)
-    then Reg.Tbl.add replacements to_replace replace_with
+    spilled_map_external cfg_with_infos ~new_inst_temporaries
+    ~new_block_temporaries =
+  let spilled_map = Spilled_var.Tbl.create 8 in
+  Reg.Tbl.iter
+    (fun spilled actual ->
+      Spilled_var.Tbl.add spilled_map
+        (Spilled_var.of_reg spilled)
+        (Actual_var.of_reg actual))
+    spilled_map_external;
+  let actual_to_spilled =
+    spilled_map |> Spilled_var.Tbl.to_seq
+    |> Seq.map (fun (k, v) -> v, k)
+    |> Actual_var.Tbl.of_seq
   in
+  let block_temp_to_inst_temps = Block_temporary.Tbl.create 8 in
+  let link_to_block_temp inst_temp block_temp =
+    if not
+         (Reg.same
+            (Inst_temporary.to_reg inst_temp)
+            (Block_temporary.to_reg block_temp))
+    then
+      Block_temporary.Tbl.replace block_temp_to_inst_temps block_temp
+        (inst_temp
+        :: (Block_temporary.Tbl.find_opt block_temp_to_inst_temps block_temp
+           |> Option.value ~default:[]))
+  in
+  let instrs_to_remove_for_var = Actual_var.Tbl.create 8 in
+  let remove_instr var instr_cell =
+    let existing =
+      Actual_var.Tbl.find_opt instrs_to_remove_for_var var
+      |> Option.value ~default:[]
+    in
+    Actual_var.Tbl.replace instrs_to_remove_for_var var (instr_cell :: existing)
+  in
+  let var_to_block_temp = Actual_var.Tbl.create 8 in
+  let last_spill = Actual_var.Tbl.create 8 in
   let update_info_using_inst (inst_cell : Cfg.basic Cfg.instruction DLL.cell) =
     let inst = DLL.value inst_cell in
+    let promote_to_block =
+      convert_reg (module Inst_temporary) (module Block_temporary)
+    in
+    let add_if_needed var =
+      if not (Actual_var.Tbl.mem actual_to_spilled var)
+      then (
+        let var_as_spilled =
+          convert_reg (module Actual_var) (module Spilled_var) var
+        in
+        Spilled_var.Tbl.replace spilled_map var_as_spilled var;
+        Actual_var.Tbl.replace actual_to_spilled var var_as_spilled)
+    in
     match inst.desc with
     | Op Reload -> (
-      let var = inst.arg.(0) in
-      let temp = inst.res.(0) in
-      match Reg.Tbl.find_opt var_to_block_temp var with
-      | None -> Reg.Tbl.add var_to_block_temp var temp
+      let var = Actual_var.of_reg inst.arg.(0) in
+      let temp = Inst_temporary.of_reg inst.res.(0) in
+      add_if_needed var;
+      match Actual_var.Tbl.find_opt var_to_block_temp var with
+      | None -> Actual_var.Tbl.add var_to_block_temp var (promote_to_block temp)
       | Some block_temp ->
-        DLL.delete_curr inst_cell;
-        replace temp block_temp)
+        remove_instr var inst_cell;
+        link_to_block_temp temp block_temp)
     | Op Spill -> (
-      let var = inst.res.(0) in
-      let temp = inst.arg.(0) in
-      (match Reg.Tbl.find_opt last_spill var with
+      let var = Actual_var.of_reg inst.res.(0) in
+      let temp = Inst_temporary.of_reg inst.arg.(0) in
+      add_if_needed var;
+      (match Actual_var.Tbl.find_opt last_spill var with
       | None -> ()
-      | Some prev_inst_cell -> DLL.delete_curr prev_inst_cell);
-      Reg.Tbl.replace last_spill var inst_cell;
-      match Reg.Tbl.find_opt var_to_block_temp var with
-      | None -> Reg.Tbl.add var_to_block_temp var temp
-      | Some block_temp -> replace temp block_temp)
+      | Some prev_inst_cell -> remove_instr var prev_inst_cell);
+      Actual_var.Tbl.replace last_spill var inst_cell;
+      match Actual_var.Tbl.find_opt var_to_block_temp var with
+      | None -> Actual_var.Tbl.add var_to_block_temp var (promote_to_block temp)
+      | Some block_temp -> link_to_block_temp temp block_temp)
     | _ -> ()
   in
   DLL.iter_cell block.body ~f:update_info_using_inst;
-  if Reg.Tbl.length replacements <> 0
+  let spilled_in_this_block =
+    var_to_block_temp |> Actual_var.Tbl.to_seq_keys
+    |> Seq.map (Actual_var.Tbl.find actual_to_spilled)
+    |> Spilled_var.Set.of_seq
+  in
+  let (spilled_to_unspilled_things_crossed
+        : Unspilled_reg.Set.t Spilled_var.Tbl.t) =
+    Spilled_var.Tbl.create 8
+  in
+  let (spilled_to_spilled_things_crossed : Spilled_var.Set.t Spilled_var.Tbl.t)
+      =
+    Spilled_var.Tbl.create 8
+  in
+  Spilled_var.Set.iter
+    (fun spilled ->
+      Spilled_var.Tbl.replace spilled_to_unspilled_things_crossed spilled
+        Unspilled_reg.Set.empty)
+    spilled_in_this_block;
+  Spilled_var.Set.iter
+    (fun spilled ->
+      Spilled_var.Tbl.replace spilled_to_spilled_things_crossed spilled
+        Spilled_var.Set.empty)
+    spilled_in_this_block;
+  let update_live_info_using_inst (inst : Cfg.basic Cfg.instruction) =
+    match inst.desc with
+    | Op Reload | Op Spill -> ()
+    | _ ->
+      let liveness_domain =
+        Cfg_with_infos.liveness_find cfg_with_infos inst.id
+      in
+      let live = Reg.Set.union liveness_domain.before liveness_domain.across in
+      let spilled_things_live =
+        Spilled_var.Set.filter
+          (Spilled_var.Tbl.mem spilled_map)
+          (Reg.Set.to_seq live |> Seq.map Spilled_var.of_reg
+         |> Spilled_var.Set.of_seq)
+      in
+      let spilled_things_from_this_block_live =
+        Spilled_var.Set.filter
+          (fun (original_var : Spilled_var.t) ->
+            let (actual : Actual_var.t) =
+              match Spilled_var.Tbl.find_opt spilled_map original_var with
+              | Some x -> x
+              | None ->
+                convert_reg
+                  (module Spilled_var)
+                  (module Actual_var)
+                  original_var
+            in
+            Actual_var.Tbl.mem var_to_block_temp actual)
+          spilled_things_live
+      in
+      let (unspilled_things_live : Unspilled_reg.Set.t) =
+        Spilled_var.Set.to_seq spilled_things_live
+        |> Seq.map Spilled_var.to_reg |> Reg.Set.of_seq |> Reg.Set.diff live
+        |> Reg.Set.to_seq
+        |> Seq.map Unspilled_reg.of_reg
+        |> Unspilled_reg.Set.of_seq
+      in
+      let update_live (original_var : Spilled_var.t) =
+        let update_spilled_to_spilled to_add =
+          let remove_self = Spilled_var.Set.remove original_var in
+          let remove_diff_class =
+            Spilled_var.Set.filter (fun var ->
+                Spilled_var.cl original_var = Spilled_var.cl var)
+          in
+          Spilled_var.Tbl.find_opt spilled_to_spilled_things_crossed
+            original_var
+          |> Option.value ~default:Spilled_var.Set.empty
+          |> Spilled_var.Set.union (to_add |> remove_self |> remove_diff_class)
+          |> Spilled_var.Tbl.replace spilled_to_spilled_things_crossed
+               original_var
+        in
+        let update_spilled_to_unspilled to_add =
+          let remove_diff_class =
+            Unspilled_reg.Set.filter (fun unspilled ->
+                Spilled_var.cl original_var = Unspilled_reg.cl unspilled)
+          in
+          Spilled_var.Tbl.find_opt spilled_to_unspilled_things_crossed
+            original_var
+          |> Option.value ~default:Unspilled_reg.Set.empty
+          |> Unspilled_reg.Set.union (remove_diff_class to_add)
+          |> Spilled_var.Tbl.replace spilled_to_unspilled_things_crossed
+               original_var
+        in
+        if Spilled_var.Tbl.mem spilled_map original_var
+        then (
+          update_spilled_to_spilled spilled_things_from_this_block_live;
+          update_spilled_to_unspilled unspilled_things_live)
+      in
+      Spilled_var.Set.iter update_live spilled_things_from_this_block_live
+  in
+  DLL.iter block.body ~f:update_live_info_using_inst;
+  let convert_spilled_to_unspilled (spilled : Spilled_var.t) =
+    let unspilled = spilled |> Spilled_var.to_reg |> Unspilled_reg.of_reg in
+    Spilled_var.Tbl.remove spilled_to_unspilled_things_crossed spilled;
+    Spilled_var.Tbl.remove spilled_to_spilled_things_crossed spilled;
+    Spilled_var.Tbl.iter
+      (fun other_spilled spilled_things_crossed ->
+        if Spilled_var.Set.mem spilled spilled_things_crossed
+        then (
+          Spilled_var.Tbl.replace spilled_to_spilled_things_crossed
+            other_spilled
+            (Spilled_var.Set.remove spilled spilled_things_crossed);
+          Spilled_var.Tbl.replace spilled_to_unspilled_things_crossed
+            other_spilled
+            (let existing =
+               Spilled_var.Tbl.find_opt spilled_to_unspilled_things_crossed
+                 other_spilled
+               |> Option.value ~default:Unspilled_reg.Set.empty
+             in
+             Unspilled_reg.Set.add unspilled existing)))
+      spilled_to_spilled_things_crossed
+  in
+  let substitution = Reg.Tbl.create 8 in
+  let make_block_temp spilled =
+    let var = Spilled_var.Tbl.find spilled_map spilled in
+    let block_temp = Actual_var.Tbl.find var_to_block_temp var in
+    Block_temporary.Tbl.find_opt block_temp_to_inst_temps block_temp
+    |> Option.value ~default:[]
+    |> List.iter ~f:(fun inst_temp ->
+           Reg.Tbl.add substitution
+             (Inst_temporary.to_reg inst_temp)
+             (Block_temporary.to_reg block_temp));
+    List.iter ~f:DLL.delete_curr
+      (Actual_var.Tbl.find_opt instrs_to_remove_for_var var
+      |> Option.value ~default:[])
+  in
+  let rec pick_block_temporaries () =
+    let eligible spilled unspilled_things_crossed =
+      Unspilled_reg.Set.cardinal unspilled_things_crossed
+      < Proc.num_available_registers.(Spilled_var.cl spilled)
+    in
+    let score spilled_var =
+      Actual_var.Tbl.find_opt instrs_to_remove_for_var
+        (Spilled_var.Tbl.find spilled_map spilled_var)
+      |> Option.value ~default:[] |> List.length
+    in
+    let best =
+      Spilled_var.Tbl.fold
+        (fun spilled_var unspilled_things_crossed acc ->
+          if eligible spilled_var unspilled_things_crossed
+          then
+            let curr_score = score spilled_var in
+            match acc with
+            | Some (_, prev_score) when curr_score <= prev_score -> acc
+            | _ -> Some (spilled_var, curr_score)
+          else acc)
+        spilled_to_unspilled_things_crossed None
+    in
+    match best with
+    | Some (spilled, _) ->
+      convert_spilled_to_unspilled spilled;
+      make_block_temp spilled;
+      pick_block_temporaries ()
+    | None -> ()
+  in
+  pick_block_temporaries ();
+  if Reg.Tbl.length substitution <> 0
   then (
-    Substitution.apply_block_in_place replacements block;
+    Substitution.apply_block_in_place substitution block;
     Reg.Tbl.iter
-      (fun temp block_temp ->
-        Reg.Tbl.replace removed_inst_temporaries temp ();
-        Reg.Tbl.replace removed_inst_temporaries block_temp ();
+      (fun inst_temp block_temp ->
+        let remove_inst_temporary temp =
+          new_inst_temporaries := Reg.Set.remove temp !new_inst_temporaries
+        in
+        remove_inst_temporary inst_temp;
+        remove_inst_temporary block_temp;
         new_block_temporaries := block_temp :: !new_block_temporaries)
-      replacements);
-  new_inst_temporaries
-    := List.filter
-         ~f:(fun temp -> not (Reg.Tbl.mem removed_inst_temporaries temp))
-         !new_inst_temporaries
+      substitution)
 
 let rewrite_gen :
     type s.
@@ -143,13 +395,13 @@ let rewrite_gen :
         Reg.Tbl.replace spilled_map reg spilled;
         spilled_map)
   in
-  let new_inst_temporaries : Reg.t list ref = ref [] in
+  let new_inst_temporaries : Reg.Set.t ref = ref Reg.Set.empty in
   let new_block_temporaries = ref [] in
   let make_new_temporary ~(move : Move.t) (reg : Reg.t) : Reg.t =
     let res =
       make_temporary ~same_class_and_base_name_as:reg ~name_prefix:"temp"
     in
-    new_inst_temporaries := res :: !new_inst_temporaries;
+    new_inst_temporaries := Reg.Set.add res !new_inst_temporaries;
     if Utils.debug
     then
       Utils.log ~indent:2 "adding temporary %a (to %s %a)" Printmach.reg res
@@ -287,15 +539,17 @@ let rewrite_gen :
             block_insertion := true);
       if !block_rewritten && should_coalesce_temp_spills_and_reloads
       then
-        coalesce_temp_spills_and_reloads block ~new_inst_temporaries
-          ~new_block_temporaries;
+        coalesce_temp_spills_and_reloads block spilled_map cfg_with_infos
+          ~new_inst_temporaries ~new_block_temporaries;
       if Utils.debug
       then (
         Utils.log ~indent:2 "and after:";
         Utils.log_body_and_terminator ~indent:3 block.body block.terminator
           liveness;
         Utils.log ~indent:2 "end"));
-  !new_inst_temporaries, !new_block_temporaries, !block_insertion
+  ( !new_inst_temporaries |> Reg.Set.to_seq |> List.of_seq,
+    !new_block_temporaries,
+    !block_insertion )
 
 (* CR-soon xclerc for xclerc: investigate exactly why this threshold is
    necessary. *)


### PR DESCRIPTION
Initial idea for PR to avoid causing registers that have already been register allocated to be spilled due to additional register pressure created by adding block temporaries