### PR TITLE
Refactor constrain_type_jkind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,5 +184,5 @@ ocamlopt:
 	ln  -s $(prefix)/bin/ocamlopt.byte ocamlopt
 
 .ocamldebug: install
-	find _build/main -name '*.cmo' -type f -printf 'directory %h\n' | sort -u > .ocamldebug
+	find _build/main -name '*.cmo' -type f -exec dirname {} \; | sort -u | sed 's/^/directory /' > .ocamldebug
 	echo "source _build/main/$(ocamldir)/tools/debug_printers" >> .ocamldebug

--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
@@ -135,14 +135,7 @@ let d (x : 'a array) = get x 0
 
 [%%expect{|
 external get : ('a : any). 'a array -> int -> float = "%floatarray_safe_get"
-Line 2, characters 23-30:
-2 | let d (x : 'a array) = get x 0
-                           ^^^^^^^
-Error: A representable layout is required here.
-       The layout of 'a is any
-         because of the definition of d at line 2, characters 6-30.
-       But the layout of 'a must be representable
-         because it's the type of an array element.
+val d : 'a array -> float = <fun>
 |}];;
 
 external get : int32# array -> int -> float = "%floatarray_safe_get"

--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics.ml
@@ -90,8 +90,7 @@ Error: This expression has type "float# array"
        but an expression was expected of type "'a array"
        The layout of float# is float64
          because it is the primitive type float#.
-       But the layout of float# must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of float# must be a sublayout of value.
 |}];;
 
 let f (x : float# array) = Array.length x
@@ -103,8 +102,7 @@ Error: This expression has type "float# array"
        but an expression was expected of type "'a array"
        The layout of float# is float64
          because it is the primitive type float#.
-       But the layout of float# must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of float# must be a sublayout of value.
 |}];;
 
 (*****************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
@@ -133,14 +133,7 @@ let d (x : 'a array) = get x 0
 [%%expect{|
 external get : ('a : any_non_null). 'a array -> int -> float
   = "%floatarray_safe_get"
-Line 2, characters 23-30:
-2 | let d (x : 'a array) = get x 0
-                           ^^^^^^^
-Error: A representable layout is required here.
-       The layout of 'a is any
-         because of the definition of d at line 2, characters 6-30.
-       But the layout of 'a must be representable
-         because it's the type of an array element.
+val d : 'a array -> float = <fun>
 |}];;
 
 external get : int32# array -> int -> float = "%floatarray_safe_get"

--- a/ocaml/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
@@ -87,8 +87,7 @@ Error: This expression has type "float# array"
        but an expression was expected of type "'a array"
        The layout of float# is float64
          because it is the primitive type float#.
-       But the layout of float# must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of float# must be a sublayout of value.
 |}];;
 
 let f (x : float# array) = Array.length x
@@ -100,8 +99,7 @@ Error: This expression has type "float# array"
        but an expression was expected of type "'a array"
        The layout of float# is float64
          because it is the primitive type float#.
-       But the layout of float# must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of float# must be a sublayout of value.
 |}];;
 
 (*****************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-arrays/exp_and_pat_failing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/exp_and_pat_failing.ml
@@ -50,21 +50,9 @@ val ( = ) : Float_u.t -> Float_u.t -> bool = <fun>
 Line 25, characters 13-29:
 25 | let f () = [|Float_u.of_int e for e = 0 to 9|]
                   ^^^^^^^^^^^^^^^^
-<<<<<<< HEAD
 Error: This expression has type "Float_u.t" = "float#"
        but an expression was expected of type "('a : value)"
-       The layout of Float_u.t is float64
-         because it is the primitive type float#.
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type Float_u.t = float#
-       but an expression was expected of type ('a : value)
-       The layout of Float_u.t is float64
-         because it is the primitive type float#.
-=======
-Error: This expression has type Float_u.t = float#
-       but an expression was expected of type ('a : value)
        The layout of Float_u.t is float64.
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Float_u.t must be a sublayout of value
          because it's the element type of array comprehension.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-arrays/exp_and_pat_failing.ml
+++ b/ocaml/testsuite/tests/typing-layouts-arrays/exp_and_pat_failing.ml
@@ -50,10 +50,21 @@ val ( = ) : Float_u.t -> Float_u.t -> bool = <fun>
 Line 25, characters 13-29:
 25 | let f () = [|Float_u.of_int e for e = 0 to 9|]
                   ^^^^^^^^^^^^^^^^
+<<<<<<< HEAD
 Error: This expression has type "Float_u.t" = "float#"
        but an expression was expected of type "('a : value)"
        The layout of Float_u.t is float64
          because it is the primitive type float#.
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type Float_u.t = float#
+       but an expression was expected of type ('a : value)
+       The layout of Float_u.t is float64
+         because it is the primitive type float#.
+=======
+Error: This expression has type Float_u.t = float#
+       but an expression was expected of type ('a : value)
+       The layout of Float_u.t is float64.
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Float_u.t must be a sublayout of value
          because it's the element type of array comprehension.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -735,8 +735,7 @@ Error: This expression has type "t_bits32"
        but an expression was expected of type "('a : value)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits32 must be a sublayout of value.
 |}];;
 
 let f13_2 (x : t_bits32) = compare x x;;
@@ -748,8 +747,7 @@ Error: This expression has type "t_bits32"
        but an expression was expected of type "('a : value)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits32 must be a sublayout of value.
 |}];;
 
 let f13_3 (x : t_bits32) = Marshal.to_bytes x;;
@@ -761,8 +759,7 @@ Error: This expression has type "t_bits32"
        but an expression was expected of type "('a : value)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits32 must be a sublayout of value.
 |}];;
 
 let f13_4 (x : t_bits32) = Hashtbl.hash x;;
@@ -774,6 +771,5 @@ Error: This expression has type "t_bits32"
        but an expression was expected of type "('a : value)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits32 must be a sublayout of value.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -130,7 +130,7 @@ Error: This expression has type "'a t_bits32_id" = "('a : bits32)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_bits32_id is bits32
          because of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value
+       But the layout of 'a t_bits32_id must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -336,7 +336,7 @@ Error: This expression has type "'a t_bits32_id" = "('a : bits32)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_bits32_id is bits32
          because of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value
+       But the layout of 'a t_bits32_id must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
 
@@ -413,8 +413,8 @@ Line 1, characters 20-41:
 Error: This expression has type "'a t_bits32_id" = "('a : bits32)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_bits32_id is bits32
-         because of the definition of make_t_bits32_id at line 2, characters 21-55.
-       But the layout of 'a t_bits32_id must overlap with value
+         because of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must be a sublayout of value
          because of the definition of id_value at line 5, characters 13-18.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
@@ -724,8 +724,7 @@ Error: This expression has type "t_bits32"
        but an expression was expected of type "('a : value)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits32 must be a sublayout of value.
 |}];;
 
 let f13_2 (x : t_bits32) = compare x x;;
@@ -737,8 +736,7 @@ Error: This expression has type "t_bits32"
        but an expression was expected of type "('a : value)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits32 must be a sublayout of value.
 |}];;
 
 let f13_3 (x : t_bits32) = Marshal.to_bytes x;;
@@ -750,8 +748,7 @@ Error: This expression has type "t_bits32"
        but an expression was expected of type "('a : value)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits32 must be a sublayout of value.
 |}];;
 
 let f13_4 (x : t_bits32) = Hashtbl.hash x;;
@@ -763,6 +760,5 @@ Error: This expression has type "t_bits32"
        but an expression was expected of type "('a : value)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
-       But the layout of t_bits32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits32 must be a sublayout of value.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
@@ -128,7 +128,7 @@ Error: This expression has type "'a t_bits32_id" = "('a : bits32)"
        but an expression was expected of type "('b : value_or_null)"
        The layout of 'a t_bits32_id is bits32
          because of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value
+       But the layout of 'a t_bits32_id must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -325,7 +325,7 @@ Error: This expression has type "'a t_bits32_id" = "('a : bits32)"
        but an expression was expected of type "('b : value_or_null)"
        The layout of 'a t_bits32_id is bits32
          because of the definition of t_bits32_id at line 2, characters 0-35.
-       But the layout of 'a t_bits32_id must overlap with value
+       But the layout of 'a t_bits32_id must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
 
@@ -402,8 +402,8 @@ Line 1, characters 20-41:
 Error: This expression has type "'a t_bits32_id" = "('a : bits32)"
        but an expression was expected of type "('b : value_or_null)"
        The layout of 'a t_bits32_id is bits32
-         because of the definition of make_t_bits32_id at line 2, characters 21-55.
-       But the layout of 'a t_bits32_id must overlap with value
+         because of the definition of t_bits32_id at line 2, characters 0-35.
+       But the layout of 'a t_bits32_id must be a sublayout of value
          because of the definition of id_value at line 5, characters 13-18.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -130,7 +130,7 @@ Error: This expression has type "'a t_bits64_id" = "('a : bits64)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_bits64_id is bits64
          because of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value
+       But the layout of 'a t_bits64_id must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -336,7 +336,7 @@ Error: This expression has type "'a t_bits64_id" = "('a : bits64)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_bits64_id is bits64
          because of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value
+       But the layout of 'a t_bits64_id must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
 
@@ -413,8 +413,8 @@ Line 1, characters 20-41:
 Error: This expression has type "'a t_bits64_id" = "('a : bits64)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_bits64_id is bits64
-         because of the definition of make_t_bits64_id at line 2, characters 21-55.
-       But the layout of 'a t_bits64_id must overlap with value
+         because of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must be a sublayout of value
          because of the definition of id_value at line 5, characters 13-18.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -737,8 +737,7 @@ Error: This expression has type "t_bits64"
        but an expression was expected of type "('a : value)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits64 must be a sublayout of value.
 |}];;
 
 let f13_2 (x : t_bits64) = compare x x;;
@@ -750,8 +749,7 @@ Error: This expression has type "t_bits64"
        but an expression was expected of type "('a : value)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits64 must be a sublayout of value.
 |}];;
 
 let f13_3 (x : t_bits64) = Marshal.to_bytes x;;
@@ -763,8 +761,7 @@ Error: This expression has type "t_bits64"
        but an expression was expected of type "('a : value)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits64 must be a sublayout of value.
 |}];;
 
 let f13_4 (x : t_bits64) = Hashtbl.hash x;;
@@ -776,6 +773,5 @@ Error: This expression has type "t_bits64"
        but an expression was expected of type "('a : value)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits64 must be a sublayout of value.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
@@ -726,8 +726,7 @@ Error: This expression has type "t_bits64"
        but an expression was expected of type "('a : value)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits64 must be a sublayout of value.
 |}];;
 
 let f13_2 (x : t_bits64) = compare x x;;
@@ -739,8 +738,7 @@ Error: This expression has type "t_bits64"
        but an expression was expected of type "('a : value)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits64 must be a sublayout of value.
 |}];;
 
 let f13_3 (x : t_bits64) = Marshal.to_bytes x;;
@@ -752,8 +750,7 @@ Error: This expression has type "t_bits64"
        but an expression was expected of type "('a : value)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits64 must be a sublayout of value.
 |}];;
 
 let f13_4 (x : t_bits64) = Hashtbl.hash x;;
@@ -765,6 +762,5 @@ Error: This expression has type "t_bits64"
        but an expression was expected of type "('a : value)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
-       But the layout of t_bits64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_bits64 must be a sublayout of value.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
@@ -128,7 +128,7 @@ Error: This expression has type "'a t_bits64_id" = "('a : bits64)"
        but an expression was expected of type "('b : value_or_null)"
        The layout of 'a t_bits64_id is bits64
          because of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value
+       But the layout of 'a t_bits64_id must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -325,7 +325,7 @@ Error: This expression has type "'a t_bits64_id" = "('a : bits64)"
        but an expression was expected of type "('b : value_or_null)"
        The layout of 'a t_bits64_id is bits64
          because of the definition of t_bits64_id at line 2, characters 0-35.
-       But the layout of 'a t_bits64_id must overlap with value
+       But the layout of 'a t_bits64_id must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
 
@@ -402,8 +402,8 @@ Line 1, characters 20-41:
 Error: This expression has type "'a t_bits64_id" = "('a : bits64)"
        but an expression was expected of type "('b : value_or_null)"
        The layout of 'a t_bits64_id is bits64
-         because of the definition of make_t_bits64_id at line 2, characters 21-55.
-       But the layout of 'a t_bits64_id must overlap with value
+         because of the definition of t_bits64_id at line 2, characters 0-35.
+       But the layout of 'a t_bits64_id must be a sublayout of value
          because of the definition of id_value at line 5, characters 13-18.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/annots.ml
@@ -21,7 +21,7 @@ Error: This type "t_void" = "('a : void)" should be an instance of type
          "('b : value)"
        The layout of t_void is void
          because of the annotation on the declaration of the type t_void.
-       But the layout of t_void must overlap with value
+       But the layout of t_void must be a sublayout of value
          because of the definition of value at line 1, characters 0-30.
 |}]
 

--- a/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/test.ml
@@ -174,8 +174,7 @@ Error: This expression has type "t_void" but an expression was expected of type
          "('a : value_or_null)"
        The layout of t_void is void
          because of the definition of t_void at line 2, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_void must be a sublayout of value.
 |}]
 
 type ('a : value) t_v = 'a

--- a/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
@@ -784,8 +784,7 @@ Error: This expression has type "t_float32"
        but an expression was expected of type "('a : value)"
        The layout of t_float32 is float32
          because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_float32 must be a sublayout of value.
 |}];;
 
 let f13_2 (x : t_float32) = compare x x;;
@@ -797,8 +796,7 @@ Error: This expression has type "t_float32"
        but an expression was expected of type "('a : value)"
        The layout of t_float32 is float32
          because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_float32 must be a sublayout of value.
 |}];;
 
 let f13_3 (x : t_float32) = Marshal.to_bytes x;;
@@ -810,8 +808,7 @@ Error: This expression has type "t_float32"
        but an expression was expected of type "('a : value)"
        The layout of t_float32 is float32
          because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_float32 must be a sublayout of value.
 |}];;
 
 let f13_4 (x : t_float32) = Hashtbl.hash x;;
@@ -823,8 +820,7 @@ Error: This expression has type "t_float32"
        but an expression was expected of type "('a : value)"
        The layout of t_float32 is float32
          because of the definition of t_float32 at line 1, characters 0-24.
-       But the layout of t_float32 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_float32 must be a sublayout of value.
 |}];;
 
 (***********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float32/basics.ml
@@ -128,7 +128,7 @@ Error: This expression has type "'a t_float32_id" = "('a : float32)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_float32_id is float32
          because of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of 'a t_float32_id must overlap with value
+       But the layout of 'a t_float32_id must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -358,7 +358,7 @@ Error: This expression has type "'a t_float32_id" = "('a : float32)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_float32_id is float32
          because of the definition of t_float32_id at line 2, characters 0-37.
-       But the layout of 'a t_float32_id must overlap with value
+       But the layout of 'a t_float32_id must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
 
@@ -435,8 +435,8 @@ Line 1, characters 20-42:
 Error: This expression has type "'a t_float32_id" = "('a : float32)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_float32_id is float32
-         because of the definition of make_t_float32_id at line 2, characters 22-57.
-       But the layout of 'a t_float32_id must overlap with value
+         because of the definition of t_float32_id at line 2, characters 0-37.
+       But the layout of 'a t_float32_id must be a sublayout of value
          because of the definition of id_value at line 5, characters 13-18.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -128,7 +128,7 @@ Error: This expression has type "'a t_float64_id" = "('a : float64)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_float64_id is float64
          because of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of 'a t_float64_id must overlap with value
+       But the layout of 'a t_float64_id must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -363,7 +363,7 @@ Error: This expression has type "'a t_float64_id" = "('a : float64)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_float64_id is float64
          because of the definition of t_float64_id at line 2, characters 0-37.
-       But the layout of 'a t_float64_id must overlap with value
+       But the layout of 'a t_float64_id must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
 
@@ -440,8 +440,8 @@ Line 1, characters 20-42:
 Error: This expression has type "'a t_float64_id" = "('a : float64)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_float64_id is float64
-         because of the definition of make_t_float64_id at line 2, characters 22-57.
-       But the layout of 'a t_float64_id must overlap with value
+         because of the definition of t_float64_id at line 2, characters 0-37.
+       But the layout of 'a t_float64_id must be a sublayout of value
          because of the definition of id_value at line 5, characters 13-18.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-float64/basics.ml
@@ -792,8 +792,7 @@ Error: This expression has type "t_float64"
        but an expression was expected of type "('a : value)"
        The layout of t_float64 is float64
          because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_float64 must be a sublayout of value.
 |}];;
 
 let f13_2 (x : t_float64) = compare x x;;
@@ -805,8 +804,7 @@ Error: This expression has type "t_float64"
        but an expression was expected of type "('a : value)"
        The layout of t_float64 is float64
          because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_float64 must be a sublayout of value.
 |}];;
 
 let f13_3 (x : t_float64) = Marshal.to_bytes x;;
@@ -818,8 +816,7 @@ Error: This expression has type "t_float64"
        but an expression was expected of type "('a : value)"
        The layout of t_float64 is float64
          because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_float64 must be a sublayout of value.
 |}];;
 
 let f13_4 (x : t_float64) = Hashtbl.hash x;;
@@ -831,8 +828,7 @@ Error: This expression has type "t_float64"
        but an expression was expected of type "('a : value)"
        The layout of t_float64 is float64
          because of the definition of t_float64 at line 1, characters 0-24.
-       But the layout of t_float64 must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_float64 must be a sublayout of value.
 |}];;
 
 (***********************************************************)

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test.compilers.reference
@@ -5,5 +5,4 @@ Error: This expression has type "t_void -> unit"
        but an expression was expected of type "'a -> unit"
        The layout of t_void is void
          because of the definition of t_void at file "insert.ml", line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_void must be a sublayout of value.

--- a/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
+++ b/ocaml/testsuite/tests/typing-layouts-gadt-sort-var/test_extensible.compilers.reference
@@ -5,5 +5,4 @@ Error: This expression has type "t_void -> unit"
        but an expression was expected of type "'a -> unit"
        The layout of t_void is void
          because of the definition of t_void at file "insert_extensible.ml", line 1, characters 0-18.
-       But the layout of t_void must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_void must be a sublayout of value.

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -42,11 +42,21 @@ type err1 = b_value imm_arg;;
 Line 1, characters 12-19:
 1 | type err1 = b_value imm_arg;;
                 ^^^^^^^
+<<<<<<< HEAD
 Error: This type "B.b_value" = "A.a_value" should be an instance of type
          "('a : immediate)"
        The kind of B.b_value is value
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This type B.b_value = A.a_value should be an instance of type
+         ('a : immediate)
+       The kind of B.b_value is value
+=======
+Error: This type B.b_value = A.a_value should be an instance of type
+         ('a : immediate)
+       The layout of B.b_value is any
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because the .cmi file for A.a_value is missing.
-       But the kind of B.b_value must be a subkind of immediate
+       But the layout of B.b_value must be a sublayout of value
          because of the definition of imm_arg at line 3, characters 0-29.
        No .cmi file found containing A.a_value.
        Hint: Adding "a" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
+++ b/ocaml/testsuite/tests/typing-layouts-missing-cmi/c.ml
@@ -42,19 +42,9 @@ type err1 = b_value imm_arg;;
 Line 1, characters 12-19:
 1 | type err1 = b_value imm_arg;;
                 ^^^^^^^
-<<<<<<< HEAD
 Error: This type "B.b_value" = "A.a_value" should be an instance of type
          "('a : immediate)"
-       The kind of B.b_value is value
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This type B.b_value = A.a_value should be an instance of type
-         ('a : immediate)
-       The kind of B.b_value is value
-=======
-Error: This type B.b_value = A.a_value should be an instance of type
-         ('a : immediate)
        The layout of B.b_value is any
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because the .cmi file for A.a_value is missing.
        But the layout of B.b_value must be a sublayout of value
          because of the definition of imm_arg at line 3, characters 0-29.

--- a/ocaml/testsuite/tests/typing-layouts-products/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-products/basics.ml
@@ -810,8 +810,7 @@ Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
        The layout of #('a * 'b) is '_representable_layout_404 & '_representable_layout_405
          because it is an unboxed tuple.
-       But the layout of #('a * 'b) must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of #('a * 'b) must be a sublayout of value.
 |}]
 
 external make : ('a : value & value) . int -> 'a -> 'a array = "caml_make_vect"

--- a/ocaml/testsuite/tests/typing-layouts-products/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-products/basics.ml
@@ -229,19 +229,9 @@ let poly_var_term = `Foo #(1,2)
 Line 1, characters 25-31:
 1 | let poly_var_term = `Foo #(1,2)
                              ^^^^^^
-<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_158 & '_representable_layout_159
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
-       The layout of #('a * 'b) is '_representable_layout_158 & '_representable_layout_159
-=======
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
        The layout of #('a * 'b) is '_representable_layout_86 & '_representable_layout_87
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
@@ -264,19 +254,9 @@ let tuple_term = ("hi", #(1, 2))
 Line 1, characters 24-31:
 1 | let tuple_term = ("hi", #(1, 2))
                             ^^^^^^^
-<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_165 & '_representable_layout_166
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
-       The layout of #('a * 'b) is '_representable_layout_165 & '_representable_layout_166
-=======
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
        The layout of #('a * 'b) is '_representable_layout_89 & '_representable_layout_90
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a tuple element.
@@ -366,19 +346,9 @@ class class_ =
 Line 3, characters 15-21:
 3 |     method x = #(1,2)
                    ^^^^^^
-<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_194 & '_representable_layout_195
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
-       The layout of #('a * 'b) is '_representable_layout_194 & '_representable_layout_195
-=======
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
        The layout of #('a * 'b) is '_representable_layout_102 & '_representable_layout_103
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of an object field.
@@ -393,19 +363,9 @@ end;;
 Line 3, characters 17-21:
 3 |     let #(x,y) = utup in
                      ^^^^
-<<<<<<< HEAD
 Error: This expression has type "('a : value)"
        but an expression was expected of type "#('b * 'c)"
-       The layout of #('a * 'b) is '_representable_layout_206 & '_representable_layout_207
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type ('a : value)
-       but an expression was expected of type #('b * 'c)
-       The layout of #('a * 'b) is '_representable_layout_206 & '_representable_layout_207
-=======
-Error: This expression has type ('a : value)
-       but an expression was expected of type #('b * 'c)
        The layout of #('a * 'b) is '_representable_layout_110 & '_representable_layout_111
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a variable captured in an object.
@@ -739,19 +699,9 @@ val e1 : unit = ()
 Line 2, characters 37-44:
 2 | let[@warning "-26"] e2 = let rec x = #(1, y) and y = 42 in ()
                                          ^^^^^^^
-<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_366 & '_representable_layout_367
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
-       The layout of #('a * 'b) is '_representable_layout_366 & '_representable_layout_367
-=======
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
        The layout of #('a * 'b) is '_representable_layout_190 & '_representable_layout_191
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of the recursive variable x.
@@ -765,19 +715,9 @@ let _ = let rec _x = #(3, 10) and _y = 42 in 42
 Line 1, characters 21-29:
 1 | let _ = let rec _x = #(3, 10) and _y = 42 in 42
                          ^^^^^^^^
-<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_373 & '_representable_layout_374
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
-       The layout of #('a * 'b) is '_representable_layout_373 & '_representable_layout_374
-=======
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
        The layout of #('a * 'b) is '_representable_layout_195 & '_representable_layout_196
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of the recursive variable _x.
@@ -844,33 +784,9 @@ let _ = [| #(1,2) |]
 [%%expect{|
 Line 1, characters 8-20:
 1 | let _ = [| #(1,2) |]
-<<<<<<< HEAD
-               ^^^^^^
-Error: This expression has type "#('a * 'b)"
-       but an expression was expected of type
-         "('c : '_representable_layout_397 & '_representable_layout_398)"
-       The kind of #('a * 'b) is
-         '_representable_layout_397 & '_representable_layout_398
-         because it is an unboxed tuple.
-       But the kind of #('a * 'b) must be a subkind of
-         '_representable_layout_397 & '_representable_layout_398
-         because it's the type of an array element.
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-               ^^^^^^
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type
-         ('c : '_representable_layout_397 & '_representable_layout_398)
-       The kind of #('a * 'b) is
-         '_representable_layout_397 & '_representable_layout_398
-         because it is an unboxed tuple.
-       But the kind of #('a * 'b) must be a subkind of
-         '_representable_layout_397 & '_representable_layout_398
-         because it's the type of an array element.
-=======
             ^^^^^^^^^^^^
 Error: Product layout value & value detected in structure in [Typeopt.Layout]
        Please report this error to the Jane Street compilers team.
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
 |}]
 
 let _ = Array.init 3 (fun _ -> #(1,2))
@@ -878,19 +794,9 @@ let _ = Array.init 3 (fun _ -> #(1,2))
 Line 1, characters 31-37:
 1 | let _ = Array.init 3 (fun _ -> #(1,2))
                                    ^^^^^^
-<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_404 & '_representable_layout_405
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
-       The layout of #('a * 'b) is '_representable_layout_404 & '_representable_layout_405
-=======
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
        The layout of #('a * 'b) is '_representable_layout_210 & '_representable_layout_211
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value.
 |}]
@@ -955,19 +861,9 @@ class product_instance_variable x =
 Line 2, characters 25-26:
 2 |   let sum = let #(a,b) = x in a + b in
                              ^
-<<<<<<< HEAD
 Error: This expression has type "('a : value)"
        but an expression was expected of type "#('b * 'c)"
-       The layout of #('a * 'b) is '_representable_layout_450 & '_representable_layout_451
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type ('a : value)
-       but an expression was expected of type #('b * 'c)
-       The layout of #('a * 'b) is '_representable_layout_450 & '_representable_layout_451
-=======
-Error: This expression has type ('a : value)
-       but an expression was expected of type #('b * 'c)
        The layout of #('a * 'b) is '_representable_layout_246 & '_representable_layout_247
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a term-level argument to a class constructor.
@@ -982,19 +878,9 @@ let x = lazy #(1,2)
 Line 1, characters 13-19:
 1 | let x = lazy #(1,2)
                  ^^^^^^
-<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_455 & '_representable_layout_456
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
-       The layout of #('a * 'b) is '_representable_layout_455 & '_representable_layout_456
-=======
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
        The layout of #('a * 'b) is '_representable_layout_249 & '_representable_layout_250
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a lazy expression.
@@ -1042,19 +928,9 @@ let f_optional_utuple ?(x = #(1,2)) () = x
 Line 1, characters 28-34:
 1 | let f_optional_utuple ?(x = #(1,2)) () = x
                                 ^^^^^^
-<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_485 & '_representable_layout_486
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
-       The layout of #('a * 'b) is '_representable_layout_485 & '_representable_layout_486
-=======
-Error: This expression has type #('a * 'b)
-       but an expression was expected of type ('c : value)
        The layout of #('a * 'b) is '_representable_layout_267 & '_representable_layout_268
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because the type argument of option has layout value.
@@ -1083,8 +959,8 @@ type should_fail = string t needs_any_mod_global
 Line 1, characters 19-27:
 1 | type should_fail = string t needs_any_mod_global
                        ^^^^^^^^
-Error: This type string t = #(string u * string u)
-       should be an instance of type ('a : any mod global)
+Error: This type "string t" = "#(string u * string u)"
+       should be an instance of type "('a : any mod global)"
        The kind of string t is immutable_data
          because it is the primitive type string.
        But the kind of string t must be a subkind of any mod global

--- a/ocaml/testsuite/tests/typing-layouts-products/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-products/basics.ml
@@ -229,9 +229,19 @@ let poly_var_term = `Foo #(1,2)
 Line 1, characters 25-31:
 1 | let poly_var_term = `Foo #(1,2)
                              ^^^^^^
+<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
        The layout of #('a * 'b) is '_representable_layout_158 & '_representable_layout_159
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_158 & '_representable_layout_159
+=======
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_86 & '_representable_layout_87
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
@@ -254,9 +264,19 @@ let tuple_term = ("hi", #(1, 2))
 Line 1, characters 24-31:
 1 | let tuple_term = ("hi", #(1, 2))
                             ^^^^^^^
+<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
        The layout of #('a * 'b) is '_representable_layout_165 & '_representable_layout_166
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_165 & '_representable_layout_166
+=======
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_89 & '_representable_layout_90
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a tuple element.
@@ -346,9 +366,19 @@ class class_ =
 Line 3, characters 15-21:
 3 |     method x = #(1,2)
                    ^^^^^^
+<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
        The layout of #('a * 'b) is '_representable_layout_194 & '_representable_layout_195
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_194 & '_representable_layout_195
+=======
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_102 & '_representable_layout_103
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of an object field.
@@ -363,9 +393,19 @@ end;;
 Line 3, characters 17-21:
 3 |     let #(x,y) = utup in
                      ^^^^
+<<<<<<< HEAD
 Error: This expression has type "('a : value)"
        but an expression was expected of type "#('b * 'c)"
        The layout of #('a * 'b) is '_representable_layout_206 & '_representable_layout_207
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type ('a : value)
+       but an expression was expected of type #('b * 'c)
+       The layout of #('a * 'b) is '_representable_layout_206 & '_representable_layout_207
+=======
+Error: This expression has type ('a : value)
+       but an expression was expected of type #('b * 'c)
+       The layout of #('a * 'b) is '_representable_layout_110 & '_representable_layout_111
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a variable captured in an object.
@@ -699,9 +739,19 @@ val e1 : unit = ()
 Line 2, characters 37-44:
 2 | let[@warning "-26"] e2 = let rec x = #(1, y) and y = 42 in ()
                                          ^^^^^^^
+<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
        The layout of #('a * 'b) is '_representable_layout_366 & '_representable_layout_367
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_366 & '_representable_layout_367
+=======
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_190 & '_representable_layout_191
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of the recursive variable x.
@@ -715,9 +765,19 @@ let _ = let rec _x = #(3, 10) and _y = 42 in 42
 Line 1, characters 21-29:
 1 | let _ = let rec _x = #(3, 10) and _y = 42 in 42
                          ^^^^^^^^
+<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
        The layout of #('a * 'b) is '_representable_layout_373 & '_representable_layout_374
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_373 & '_representable_layout_374
+=======
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_195 & '_representable_layout_196
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of the recursive variable _x.
@@ -778,17 +838,13 @@ type t3 = #(int * bool) array
 type t4 = #(string * #(float# * bool option)) array
 |}]
 
-(* CR layouts v7.1: This example demonstrates a bug in type inference that we
-   should fix.  The issue is the way typing of tuple expressions works - we
-   create type variables at generic level and then constrain them by the
-   expected type.  This will fail if it requires to refine the kind, because we
-   don't allow refining kinds at generic level.  We need to remove the
-   restriction that kinds of things at generic level can't be modified, but that
-   is orthogonal to unboxed tuples so we leave in this sad bug for now. *)
+(* CR layouts v7.1: This should be accepted, or the error message should
+   be improved. *)
 let _ = [| #(1,2) |]
 [%%expect{|
-Line 1, characters 11-17:
+Line 1, characters 8-20:
 1 | let _ = [| #(1,2) |]
+<<<<<<< HEAD
                ^^^^^^
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type
@@ -799,6 +855,22 @@ Error: This expression has type "#('a * 'b)"
        But the kind of #('a * 'b) must be a subkind of
          '_representable_layout_397 & '_representable_layout_398
          because it's the type of an array element.
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+               ^^^^^^
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type
+         ('c : '_representable_layout_397 & '_representable_layout_398)
+       The kind of #('a * 'b) is
+         '_representable_layout_397 & '_representable_layout_398
+         because it is an unboxed tuple.
+       But the kind of #('a * 'b) must be a subkind of
+         '_representable_layout_397 & '_representable_layout_398
+         because it's the type of an array element.
+=======
+            ^^^^^^^^^^^^
+Error: Product layout value & value detected in structure in [Typeopt.Layout]
+       Please report this error to the Jane Street compilers team.
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
 |}]
 
 let _ = Array.init 3 (fun _ -> #(1,2))
@@ -806,9 +878,19 @@ let _ = Array.init 3 (fun _ -> #(1,2))
 Line 1, characters 31-37:
 1 | let _ = Array.init 3 (fun _ -> #(1,2))
                                    ^^^^^^
+<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
        The layout of #('a * 'b) is '_representable_layout_404 & '_representable_layout_405
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_404 & '_representable_layout_405
+=======
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_210 & '_representable_layout_211
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value.
 |}]
@@ -873,9 +955,19 @@ class product_instance_variable x =
 Line 2, characters 25-26:
 2 |   let sum = let #(a,b) = x in a + b in
                              ^
+<<<<<<< HEAD
 Error: This expression has type "('a : value)"
        but an expression was expected of type "#('b * 'c)"
        The layout of #('a * 'b) is '_representable_layout_450 & '_representable_layout_451
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type ('a : value)
+       but an expression was expected of type #('b * 'c)
+       The layout of #('a * 'b) is '_representable_layout_450 & '_representable_layout_451
+=======
+Error: This expression has type ('a : value)
+       but an expression was expected of type #('b * 'c)
+       The layout of #('a * 'b) is '_representable_layout_246 & '_representable_layout_247
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a term-level argument to a class constructor.
@@ -890,9 +982,19 @@ let x = lazy #(1,2)
 Line 1, characters 13-19:
 1 | let x = lazy #(1,2)
                  ^^^^^^
+<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
        The layout of #('a * 'b) is '_representable_layout_455 & '_representable_layout_456
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_455 & '_representable_layout_456
+=======
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_249 & '_representable_layout_250
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a lazy expression.
@@ -940,10 +1042,51 @@ let f_optional_utuple ?(x = #(1,2)) () = x
 Line 1, characters 28-34:
 1 | let f_optional_utuple ?(x = #(1,2)) () = x
                                 ^^^^^^
+<<<<<<< HEAD
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
        The layout of #('a * 'b) is '_representable_layout_485 & '_representable_layout_486
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_485 & '_representable_layout_486
+=======
+Error: This expression has type #('a * 'b)
+       but an expression was expected of type ('c : value)
+       The layout of #('a * 'b) is '_representable_layout_267 & '_representable_layout_268
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because the type argument of option has layout value.
+|}]
+
+(******************************)
+(* Test 16: Decomposing [any] *)
+
+type ('a : value) u = U of 'a [@@unboxed]
+type ('a : value) t = #('a u * 'a u)
+
+type ('a : any mod global) needs_any_mod_global
+
+type should_work = int t needs_any_mod_global
+
+[%%expect{|
+type 'a u = U of 'a [@@unboxed]
+type 'a t = #('a u * 'a u)
+type ('a : any mod global) needs_any_mod_global
+type should_work = int t needs_any_mod_global
+|}]
+
+type should_fail = string t needs_any_mod_global
+
+[%%expect{|
+Line 1, characters 19-27:
+1 | type should_fail = string t needs_any_mod_global
+                       ^^^^^^^^
+Error: This type string t = #(string u * string u)
+       should be an instance of type ('a : any mod global)
+       The kind of string t is immutable_data
+         because it is the primitive type string.
+       But the kind of string t must be a subkind of any mod global
+         because of the definition of needs_any_mod_global at line 4, characters 0-47.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts-word/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics.ml
@@ -735,8 +735,7 @@ Error: This expression has type "t_word" but an expression was expected of type
          "('a : value)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_word must be a sublayout of value.
 |}];;
 
 let f13_2 (x : t_word) = compare x x;;
@@ -748,8 +747,7 @@ Error: This expression has type "t_word" but an expression was expected of type
          "('a : value)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_word must be a sublayout of value.
 |}];;
 
 let f13_3 (x : t_word) = Marshal.to_bytes x;;
@@ -761,8 +759,7 @@ Error: This expression has type "t_word" but an expression was expected of type
          "('a : value)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_word must be a sublayout of value.
 |}];;
 
 let f13_4 (x : t_word) = Hashtbl.hash x;;
@@ -774,6 +771,5 @@ Error: This expression has type "t_word" but an expression was expected of type
          "('a : value)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_word must be a sublayout of value.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-word/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics.ml
@@ -130,7 +130,7 @@ Error: This expression has type "'a t_word_id" = "('a : word)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_word_id is word
          because of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value
+       But the layout of 'a t_word_id must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -335,7 +335,7 @@ Error: This expression has type "'a t_word_id" = "('a : word)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_word_id is word
          because of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value
+       But the layout of 'a t_word_id must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
 
@@ -412,8 +412,8 @@ Line 1, characters 20-39:
 Error: This expression has type "'a t_word_id" = "('a : word)"
        but an expression was expected of type "('b : value)"
        The layout of 'a t_word_id is word
-         because of the definition of make_t_word_id at line 2, characters 19-51.
-       But the layout of 'a t_word_id must overlap with value
+         because of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must be a sublayout of value
          because of the definition of id_value at line 5, characters 13-18.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
@@ -724,8 +724,7 @@ Error: This expression has type "t_word" but an expression was expected of type
          "('a : value)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_word must be a sublayout of value.
 |}];;
 
 let f13_2 (x : t_word) = compare x x;;
@@ -737,8 +736,7 @@ Error: This expression has type "t_word" but an expression was expected of type
          "('a : value)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_word must be a sublayout of value.
 |}];;
 
 let f13_3 (x : t_word) = Marshal.to_bytes x;;
@@ -750,8 +748,7 @@ Error: This expression has type "t_word" but an expression was expected of type
          "('a : value)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_word must be a sublayout of value.
 |}];;
 
 let f13_4 (x : t_word) = Hashtbl.hash x;;
@@ -763,6 +760,5 @@ Error: This expression has type "t_word" but an expression was expected of type
          "('a : value)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
-       But the layout of t_word must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of t_word must be a sublayout of value.
 |}];;

--- a/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-word/basics_alpha.ml
@@ -128,7 +128,7 @@ Error: This expression has type "'a t_word_id" = "('a : word)"
        but an expression was expected of type "('b : value_or_null)"
        The layout of 'a t_word_id is word
          because of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value
+       But the layout of 'a t_word_id must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 
@@ -324,7 +324,7 @@ Error: This expression has type "'a t_word_id" = "('a : word)"
        but an expression was expected of type "('b : value_or_null)"
        The layout of 'a t_word_id is word
          because of the definition of t_word_id at line 2, characters 0-31.
-       But the layout of 'a t_word_id must overlap with value
+       But the layout of 'a t_word_id must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
 
@@ -401,8 +401,8 @@ Line 1, characters 20-39:
 Error: This expression has type "'a t_word_id" = "('a : word)"
        but an expression was expected of type "('b : value_or_null)"
        The layout of 'a t_word_id is word
-         because of the definition of make_t_word_id at line 2, characters 19-51.
-       But the layout of 'a t_word_id must overlap with value
+         because of the definition of t_word_id at line 2, characters 0-31.
+       But the layout of 'a t_word_id must be a sublayout of value
          because of the definition of id_value at line 5, characters 13-18.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/allow_illegal_crossing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/allow_illegal_crossing.ml
@@ -677,8 +677,7 @@ Line 2, characters 10-18:
               ^^^^^^^^
 Error: This expression has type "int ref"
        but an expression was expected of type "('a : value mod uncontended)"
-       The kind of int ref is value
-         because of kind requirements from an imported definition.
+       The kind of int ref is value.
        But the kind of int ref must be a subkind of value mod uncontended
          because of the definition of f at line 1, characters 4-5.
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -262,9 +262,18 @@ Line 4, characters 72-73:
                                                                             ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type
+<<<<<<< HEAD
          "Stdlib_upstream_compatible.Float_u.t" = "float#"
        The layout of Stdlib_upstream_compatible.Float_u.t is float64
          because it is the primitive type float#.
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+         Stdlib_upstream_compatible.Float_u.t = float#
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive type float#.
+=======
+         Stdlib_upstream_compatible.Float_u.t = float#
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64.
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
          because of the definition of s at line 2, characters 2-55.
 |}]
@@ -297,9 +306,18 @@ Line 4, characters 67-68:
                                                                        ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type
+<<<<<<< HEAD
          "Stdlib_upstream_compatible.Float_u.t" = "float#"
        The layout of Stdlib_upstream_compatible.Float_u.t is float64
          because it is the primitive type float#.
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+         Stdlib_upstream_compatible.Float_u.t = float#
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive type float#.
+=======
+         Stdlib_upstream_compatible.Float_u.t = float#
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64.
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
          because of the definition of s at line 2, characters 2-50.
 |}]
@@ -316,9 +334,18 @@ Line 4, characters 74-75:
                                                                               ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type
+<<<<<<< HEAD
          "Stdlib_upstream_compatible.Float_u.t" = "float#"
        The layout of Stdlib_upstream_compatible.Float_u.t is float64
          because it is the primitive type float#.
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+         Stdlib_upstream_compatible.Float_u.t = float#
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive type float#.
+=======
+         Stdlib_upstream_compatible.Float_u.t = float#
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64.
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
          because of the definition of s at line 2, characters 2-70.
 |}]
@@ -335,9 +362,18 @@ Line 4, characters 69-70:
                                                                          ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type
+<<<<<<< HEAD
          "Stdlib_upstream_compatible.Float_u.t" = "float#"
        The layout of Stdlib_upstream_compatible.Float_u.t is float64
          because it is the primitive type float#.
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+         Stdlib_upstream_compatible.Float_u.t = float#
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive type float#.
+=======
+         Stdlib_upstream_compatible.Float_u.t = float#
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64.
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
          because of the definition of s at line 2, characters 2-65.
 |}]
@@ -728,9 +764,18 @@ Line 5, characters 16-17:
                     ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type
+<<<<<<< HEAD
          "Stdlib_upstream_compatible.Float_u.t" = "float#"
        The layout of Stdlib_upstream_compatible.Float_u.t is float64
          because it is the primitive type float#.
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+         Stdlib_upstream_compatible.Float_u.t = float#
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64
+         because it is the primitive type float#.
+=======
+         Stdlib_upstream_compatible.Float_u.t = float#
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64.
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
@@ -1009,8 +1054,8 @@ Line 4, characters 19-33:
 Error: This expression has type "('a : value)"
        but an expression was expected of type "'b t" = "('b : float64)"
        The layout of 'a t is float64
-         because of the definition of f_id at line 3, characters 11-25.
-       But the layout of 'a t must overlap with value
+         because of the definition of t at line 2, characters 2-28.
+       But the layout of 'a t must be a sublayout of value
          because it's the type of an object field.
 |}];;
 
@@ -2373,12 +2418,32 @@ and 'a t2 = 'a
 Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
-Error:
-       The kind of 'a t2 is value
-         because it instantiates an unannotated type parameter of t2,
-         defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate
-         because of the annotation on the wildcard _ at line 1, characters 28-37.
+Error: Layout mismatch in checking consistency of mutually recursive groups.
+       This is most often caused by the fact that type inference is not
+       clever enough to propagate layouts through variables in different
+       declarations. It is also not clever enough to produce a good error
+       message, so we'll say this instead:
+         The kind of 'a t2 is value
+           because it instantiates an unannotated type parameter of t2,
+           defaulted to kind value.
+         But the kind of 'a t2 must be a subkind of immediate
+           because of the annotation on the wildcard _ at line 1, characters 28-37.
+       A good next step is to add a layout annotation on a parameter to
+       the declaration where this error is reported.
+|}]
+
+type t1 = string t2 as (_ : immediate)
+and ('a : immediate) t2 = 'a
+
+[%%expect{|
+Line 1, characters 10-16:
+1 | type t1 = string t2 as (_ : immediate)
+              ^^^^^^
+Error: This type string should be an instance of type ('a : immediate)
+       The kind of string is immutable_data
+         because it is the primitive type string.
+       But the kind of string must be a subkind of immediate
+         because of the annotation on 'a in the declaration of the type t2.
 |}]
 
 (* This example is unfortunately rejected as a consequence of the fix for the
@@ -2392,12 +2457,26 @@ and 'a t2 = 'a
 Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
-Error:
-       The kind of 'a t2 is value
-         because it instantiates an unannotated type parameter of t2,
-         defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate
-         because of the annotation on the wildcard _ at line 1, characters 27-36.
+Error: Layout mismatch in checking consistency of mutually recursive groups.
+       This is most often caused by the fact that type inference is not
+       clever enough to propagate layouts through variables in different
+       declarations. It is also not clever enough to produce a good error
+       message, so we'll say this instead:
+         The kind of 'a t2 is value
+           because it instantiates an unannotated type parameter of t2,
+           defaulted to kind value.
+         But the kind of 'a t2 must be a subkind of immediate
+           because of the annotation on the wildcard _ at line 1, characters 27-36.
+       A good next step is to add a layout annotation on a parameter to
+       the declaration where this error is reported.
+|}]
+
+type 'a t1 = 'a t2 as (_ : immediate)
+and ('a : immediate) t2 = 'a
+
+[%%expect{|
+type ('a : immediate) t1 = 'a t2
+and ('a : immediate) t2 = 'a
 |}]
 
 (* This one also unfortunately rejected for the same reason. *)
@@ -2408,12 +2487,26 @@ and 'a t2 = 'a
 Line 2, characters 0-14:
 2 | and 'a t2 = 'a
     ^^^^^^^^^^^^^^
-Error:
-       The kind of 'a t2 is value
-         because it instantiates an unannotated type parameter of t2,
-         defaulted to kind value.
-       But the kind of 'a t2 must be a subkind of immediate
-         because of the annotation on the wildcard _ at line 1, characters 25-34.
+Error: Layout mismatch in checking consistency of mutually recursive groups.
+       This is most often caused by the fact that type inference is not
+       clever enough to propagate layouts through variables in different
+       declarations. It is also not clever enough to produce a good error
+       message, so we'll say this instead:
+         The kind of 'a t2 is value
+           because it instantiates an unannotated type parameter of t2,
+           defaulted to kind value.
+         But the kind of 'a t2 must be a subkind of immediate
+           because of the annotation on the wildcard _ at line 1, characters 25-34.
+       A good next step is to add a layout annotation on a parameter to
+       the declaration where this error is reported.
+|}]
+
+type t1 = int t2 as (_ : immediate)
+and ('a : immediate) t2 = 'a
+
+[%%expect{|
+type t1 = int t2
+and ('a : immediate) t2 = 'a
 |}]
 
 (**********************************************************************)

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -262,18 +262,8 @@ Line 4, characters 72-73:
                                                                             ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type
-<<<<<<< HEAD
          "Stdlib_upstream_compatible.Float_u.t" = "float#"
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive type float#.
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-         Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive type float#.
-=======
-         Stdlib_upstream_compatible.Float_u.t = float#
        The layout of Stdlib_upstream_compatible.Float_u.t is float64.
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
          because of the definition of s at line 2, characters 2-55.
 |}]
@@ -306,18 +296,8 @@ Line 4, characters 67-68:
                                                                        ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type
-<<<<<<< HEAD
          "Stdlib_upstream_compatible.Float_u.t" = "float#"
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive type float#.
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-         Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive type float#.
-=======
-         Stdlib_upstream_compatible.Float_u.t = float#
        The layout of Stdlib_upstream_compatible.Float_u.t is float64.
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
          because of the definition of s at line 2, characters 2-50.
 |}]
@@ -334,18 +314,8 @@ Line 4, characters 74-75:
                                                                               ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type
-<<<<<<< HEAD
          "Stdlib_upstream_compatible.Float_u.t" = "float#"
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive type float#.
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-         Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive type float#.
-=======
-         Stdlib_upstream_compatible.Float_u.t = float#
        The layout of Stdlib_upstream_compatible.Float_u.t is float64.
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
          because of the definition of s at line 2, characters 2-70.
 |}]
@@ -362,18 +332,8 @@ Line 4, characters 69-70:
                                                                          ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type
-<<<<<<< HEAD
          "Stdlib_upstream_compatible.Float_u.t" = "float#"
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive type float#.
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-         Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive type float#.
-=======
-         Stdlib_upstream_compatible.Float_u.t = float#
        The layout of Stdlib_upstream_compatible.Float_u.t is float64.
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
          because of the definition of s at line 2, characters 2-65.
 |}]
@@ -764,18 +724,8 @@ Line 5, characters 16-17:
                     ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type
-<<<<<<< HEAD
          "Stdlib_upstream_compatible.Float_u.t" = "float#"
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive type float#.
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-         Stdlib_upstream_compatible.Float_u.t = float#
-       The layout of Stdlib_upstream_compatible.Float_u.t is float64
-         because it is the primitive type float#.
-=======
-         Stdlib_upstream_compatible.Float_u.t = float#
        The layout of Stdlib_upstream_compatible.Float_u.t is float64.
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
 |}];;
@@ -2439,7 +2389,7 @@ and ('a : immediate) t2 = 'a
 Line 1, characters 10-16:
 1 | type t1 = string t2 as (_ : immediate)
               ^^^^^^
-Error: This type string should be an instance of type ('a : immediate)
+Error: This type "string" should be an instance of type "('a : immediate)"
        The kind of string is immutable_data
          because it is the primitive type string.
        But the kind of string must be a subkind of immediate

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -558,7 +558,7 @@ Line 2, characters 54-78:
 Error: The type constraints are not consistent.
        Type "('a : value)" is not compatible with type "void_unboxed_record"
        The layout of void_unboxed_record is void
-         because of the definition of t_void at line 6, characters 0-19.
+         because of the definition of void_unboxed_record at line 12, characters 0-60.
        But the layout of void_unboxed_record must be a sublayout of value
          because it instantiates an unannotated type parameter of t,
          defaulted to layout value.
@@ -604,9 +604,19 @@ Line 2, characters 31-50:
 2 |   type result = V of (string * void_unboxed_record) | I of int
                                    ^^^^^^^^^^^^^^^^^^^
 Error: Tuple element types must have layout value.
+<<<<<<< HEAD
        The layout of "void_unboxed_record" is void
          because of the definition of t_void at line 6, characters 0-19.
        But the layout of "void_unboxed_record" must be a sublayout of value
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+       The layout of void_unboxed_record is void
+         because of the definition of t_void at line 6, characters 0-19.
+       But the layout of void_unboxed_record must be a sublayout of value
+=======
+       The layout of void_unboxed_record is void
+         because of the definition of void_unboxed_record at line 12, characters 0-60.
+       But the layout of void_unboxed_record must be a sublayout of value
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
          because it's the type of a tuple element.
 |}];;
 
@@ -625,7 +635,7 @@ Line 7, characters 13-14:
 Error: This expression has type "void_unboxed_record"
        but an expression was expected of type "('a : value_or_null)"
        The layout of void_unboxed_record is void
-         because of the definition of t_void at line 6, characters 0-19.
+         because of the definition of void_unboxed_record at line 12, characters 0-60.
        But the layout of void_unboxed_record must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
@@ -642,7 +652,7 @@ Line 4, characters 8-16:
 Error: The record field "vur_void" belongs to the type "void_unboxed_record"
        but is mixed here with fields of type "('a : value)"
        The layout of void_unboxed_record is void
-         because of the definition of t_void at line 6, characters 0-19.
+         because of the definition of void_unboxed_record at line 12, characters 0-60.
        But the layout of void_unboxed_record must be a sublayout of value
          because it's a boxed record type.
 |}];;
@@ -673,7 +683,7 @@ Line 2, characters 34-58:
 Error: The type constraints are not consistent.
        Type "('a : value)" is not compatible with type "void_unboxed_record"
        The layout of void_unboxed_record is void
-         because of the definition of t_void at line 6, characters 0-19.
+         because of the definition of void_unboxed_record at line 12, characters 0-60.
        But the layout of void_unboxed_record must be a sublayout of value
          because it instantiates an unannotated type parameter of t,
          defaulted to layout value.

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -604,19 +604,9 @@ Line 2, characters 31-50:
 2 |   type result = V of (string * void_unboxed_record) | I of int
                                    ^^^^^^^^^^^^^^^^^^^
 Error: Tuple element types must have layout value.
-<<<<<<< HEAD
        The layout of "void_unboxed_record" is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of "void_unboxed_record" must be a sublayout of value
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-       The layout of void_unboxed_record is void
-         because of the definition of t_void at line 6, characters 0-19.
-       But the layout of void_unboxed_record must be a sublayout of value
-=======
-       The layout of void_unboxed_record is void
          because of the definition of void_unboxed_record at line 12, characters 0-60.
-       But the layout of void_unboxed_record must be a sublayout of value
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
+       But the layout of "void_unboxed_record" must be a sublayout of value
          because it's the type of a tuple element.
 |}];;
 

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -72,10 +72,21 @@ let f x =
 Line 3, characters 19-20:
 3 |   Float_u.to_float x
                        ^
+<<<<<<< HEAD
 Error: This expression has type "('a : value)"
        but an expression was expected of type "Float_u.t" = "float#"
        The layout of Float_u.t is float64
          because it is the primitive type float#.
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+Error: This expression has type ('a : value)
+       but an expression was expected of type Float_u.t = float#
+       The layout of Float_u.t is float64
+         because it is the primitive type float#.
+=======
+Error: This expression has type ('a : value)
+       but an expression was expected of type Float_u.t = float#
+       The layout of Float_u.t is float64.
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Float_u.t must be a sublayout of value
          because of the annotation on the wildcard _ at line 2, characters 15-26.
          Custom message

--- a/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
+++ b/ocaml/testsuite/tests/typing-layouts/error_message_attr.ml
@@ -72,21 +72,9 @@ let f x =
 Line 3, characters 19-20:
 3 |   Float_u.to_float x
                        ^
-<<<<<<< HEAD
 Error: This expression has type "('a : value)"
        but an expression was expected of type "Float_u.t" = "float#"
-       The layout of Float_u.t is float64
-         because it is the primitive type float#.
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-Error: This expression has type ('a : value)
-       but an expression was expected of type Float_u.t = float#
-       The layout of Float_u.t is float64
-         because it is the primitive type float#.
-=======
-Error: This expression has type ('a : value)
-       but an expression was expected of type Float_u.t = float#
        The layout of Float_u.t is float64.
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
        But the layout of Float_u.t must be a sublayout of value
          because of the annotation on the wildcard _ at line 2, characters 15-26.
          Custom message

--- a/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/void_alpha.ml
@@ -74,7 +74,7 @@ Lines 14-21, characters 2-3:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
+         because of the definition of void_rec at line 3, characters 0-42.
        But the layout of void_rec must be a sublayout of value
          because it has to be value for the V1 safety check.
 |}]
@@ -136,7 +136,7 @@ Lines 4-11, characters 2-3:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
+         because of the definition of void_rec at line 3, characters 0-42.
        But the layout of void_rec must be a sublayout of value
          because it has to be value for the V1 safety check.
 |}]
@@ -485,7 +485,7 @@ Lines 4-11, characters 2-24:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
+         because of the definition of void_rec at line 3, characters 0-42.
        But the layout of void_rec must be a sublayout of value
          because it has to be value for the V1 safety check.
 |}]
@@ -786,7 +786,7 @@ Lines 9-18, characters 2-29:
 Error: Non-value detected in [value_kind].
        Please report this error to the Jane Street compilers team.
        The layout of unboxed_inlined_void_rec is void
-         because of the definition of t_void at line 1, characters 0-18.
+         because of the definition of unboxed_inlined_void_rec at lines 3-4, characters 0-43.
        But the layout of unboxed_inlined_void_rec must be a sublayout of value
          because it has to be value for the V1 safety check.
 |}]

--- a/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/ocaml/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -5,7 +5,6 @@ Error: This expression has type "M.a" but an expression was expected of type
          "('a : value)"
        The layout of M.a is any
          because the .cmi file for M.a is missing.
-       But the layout of M.a must be a sublayout of value
-         because of layout requirements from an imported definition.
+       But the layout of M.a must be a sublayout of value.
        No .cmi file found containing M.a.
        Hint: Adding "m" to your dependencies might help.

--- a/ocaml/testsuite/tests/typing-modes/rec.ml
+++ b/ocaml/testsuite/tests/typing-modes/rec.ml
@@ -35,7 +35,7 @@ let te (local_ x) =
 Line 3, characters 12-13:
 3 |         bar x y
                 ^
-Error: The value x is local, so cannot be used inside a closure that might escape.
+Error: The value "x" is local, so cannot be used inside a closure that might escape.
 |}]
 
 (* for mixed definitions, the other axes are not constrained. *)

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2322,61 +2322,6 @@ let constrain_type_jkind_exn env texn ty jkind =
   | Ok _ -> ()
   | Error err -> raise_for texn (Bad_jkind (ty,err))
 
-<<<<<<< HEAD
-let type_jkind env ty =
-  estimate_type_jkind env
-    ~expand_components:(get_unboxed_type_approximation env)
-    (get_unboxed_type_approximation env ty)
-
-let type_jkind_purely env ty =
-  if !Clflags.principal || Env.has_local_constraints env then
-    (* We snapshot to keep this pure; see the test in [typing-local/crossing.ml]
-       that mentions snapshotting for an example. *)
-    let snap = Btype.snapshot () in
-    let jkind = type_jkind env ty in
-    Btype.backtrack snap;
-    jkind
-  else
-    type_jkind env ty
-
-let estimate_type_jkind env ty =
-  estimate_type_jkind env ~expand_components:(fun x -> x) ty
-
-let type_sort ~why env ty =
-  let jkind, sort = Jkind.of_new_sort_var ~why in
-  match constrain_type_jkind env ty jkind with
-  | Ok _ -> Ok sort
-  | Error _ as e -> e
-
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-let type_jkind env ty =
-  estimate_type_jkind env
-    ~expand_components:(get_unboxed_type_approximation env)
-    (get_unboxed_type_approximation env ty)
-
-let type_jkind_purely env ty =
-  if !Clflags.principal || Env.has_local_constraints env then
-    (* We snapshot to keep this pure; see the test in [typing-local/crossing.ml]
-       that mentions snapshotting for an example. *)
-    let snap = Btype.snapshot () in
-    let jkind = type_jkind env ty in
-    Btype.backtrack snap;
-    jkind
-  else
-    type_jkind env ty
-
-let estimate_type_jkind env ty =
-  estimate_type_jkind env ~expand_components:(fun x -> x)
-    (get_unboxed_type_approximation env ty)
-
-let type_sort ~why env ty =
-  let jkind, sort = Jkind.of_new_sort_var ~why in
-  match constrain_type_jkind env ty jkind with
-  | Ok _ -> Ok sort
-  | Error _ as e -> e
-
-=======
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
 let type_legacy_sort ~why env ty =
   let jkind, sort = Jkind.of_new_legacy_sort_var ~why in
   match constrain_type_jkind env ty jkind with

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -563,13 +563,14 @@ val type_jkind : Env.t -> type_expr -> jkind
    expansion. *)
 val type_jkind_purely : Env.t -> type_expr -> jkind
 
-(* Find a type's sort (constraining it to be an arbitrary sort variable, if
-   needed) *)
+(* Find a type's sort (if fixed is false: constraining it to be an
+   arbitrary sort variable, if needed) *)
 val type_sort :
   why:Jkind.History.concrete_creation_reason ->
+  fixed:bool ->
   Env.t -> type_expr -> (Jkind.sort, Jkind.Violation.t) result
 
-(* As [type_sort], but constrain the jkind to be non-null.
+(* As [type_sort ~fixed:false], but constrain the jkind to be non-null.
    Used for checking array elements. *)
 val type_legacy_sort :
   why:Jkind.History.concrete_legacy_creation_reason ->

--- a/ocaml/typing/jkind.ml
+++ b/ocaml/typing/jkind.ml
@@ -264,9 +264,7 @@ module History = struct
   (* CR layouts: Anything that returns false here could probably just be removed,
      but let's keep the info around at least during development. *)
   let is_informative t =
-    match t.history with
-    | Creation Imported -> false
-    | _ -> true
+    match t.history with Creation Imported -> false | _ -> true
 
   let update_reason t reason = { t with history = Creation reason }
 
@@ -1272,6 +1270,25 @@ let get_externality_upper_bound jk = jk.jkind.externality_upper_bound
 let set_externality_upper_bound jk externality_upper_bound =
   { jk with jkind = { jk.jkind with externality_upper_bound } }
 
+let decompose_product ({ jkind; _ } as jk) =
+  let mk_jkind layout = { jk with jkind = { jkind with layout } } in
+  let deal_with_sort : Sort.t -> _ = function
+    | Var _ -> None (* we've called [get] and there's *still* a variable *)
+    | Base _ -> None
+    | Product sorts -> Some (List.map (fun sort -> mk_jkind (Sort sort)) sorts)
+  in
+  match jkind.layout with
+  | Any -> None
+  | Product layouts ->
+    (* CR layouts v7.1: The histories here are wrong (we are giving each
+       component the history of the whole product).  They don't show up in
+       errors, so it's fine for now, but we'll probably need to fix this as
+       part of improving errors around products. A couple options: re-work the
+       relevant bits of [Ctype.type_jkind_sub] to just work on layouts, or
+       introduce product histories. *)
+    Some (List.map mk_jkind layouts)
+  | Sort s -> deal_with_sort (Sort.get s)
+
 (*********************************)
 (* pretty printing *)
 
@@ -1584,14 +1601,18 @@ module Format_history = struct
     fprintf ppf "@[<v 2>%t" intro;
     (match t.history with
     | Creation reason ->
-       if History.is_informative t then
-         (fprintf ppf "@ because %a" (format_creation_reason ~layout_or_kind) reason;
-          match reason, jkind_desc with
-          | Concrete_legacy_creation _, Const _ ->
-             fprintf ppf ",@ defaulted to %s %a" layout_or_kind Desc.format
-               jkind_desc
-          | _ -> ())
-    | Interact _ -> Misc.fatal_error "Non-flat history in format_flattened_history");
+      if History.is_informative t
+      then (
+        fprintf ppf "@ because %a"
+          (format_creation_reason ~layout_or_kind)
+          reason;
+        match reason, jkind_desc with
+        | Concrete_legacy_creation _, Const _ ->
+          fprintf ppf ",@ defaulted to %s %a" layout_or_kind Desc.format
+            jkind_desc
+        | _ -> ())
+    | Interact _ ->
+      Misc.fatal_error "Non-flat history in format_flattened_history");
     fprintf ppf ".";
     (match t.history with
     | Creation (Annotated (With_error_message (message, _), _)) ->
@@ -1810,8 +1831,22 @@ let check_sub sub super = Jkind_desc.sub sub.jkind super.jkind
 
 let sub sub super = Misc.Le_result.is_le (check_sub sub super)
 
+type sub_or_intersect =
+  | Sub
+  | Disjoint
+  | Has_intersection
+
+let sub_or_intersect t1 t2 =
+  if sub t1 t2
+  then Sub
+  else if has_intersection t1 t2
+  then Has_intersection
+  else Disjoint
+
 let sub_or_error t1 t2 =
-  if sub t1 t2 then Ok () else Error (Violation.of_ (Not_a_subjkind (t1, t2)))
+  match sub_or_intersect t1 t2 with
+  | Sub -> Ok ()
+  | _ -> Error (Violation.of_ (Not_a_subjkind (t1, t2)))
 
 let sub_with_history sub super =
   match check_sub sub super with
@@ -1829,27 +1864,6 @@ let is_max jkind = sub Builtin.any_dummy_jkind jkind
 
 let has_layout_any jkind =
   match jkind.jkind.layout with Any -> true | _ -> false
-
-let is_nary_product n t =
-  let components =
-    List.init n (fun _ -> Jkind_types.Layout.Sort (Sort.new_var ()))
-  in
-  let bound =
-    { Jkind_desc.max with layout = Jkind_types.Layout.Product components }
-  in
-  if Misc.Le_result.is_le (Jkind_desc.sub t.jkind bound)
-  then
-    (* CR layouts v7.1: The histories here are wrong (we are giving each
-       component the history of the whole product).  They don't show up in
-       errors, so it's fine for now, but we'll probably need to fix this as
-       part of improving errors around products. A couple options: re-work the
-       relevant bits of [Ctype.type_jkind_sub] to just work on layouts, or
-       introduce product histories. *)
-    Some
-      (List.map
-         (fun l -> { t with jkind = { t.jkind with layout = l } })
-         components)
-  else None
 
 (*********************************)
 (* debugging *)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -3671,7 +3671,7 @@ let collect_unknown_apply_args env funct ty_fun mode_fun rev_args sargs ret_tvar
         | Tarrow ((l, mode_arg, mode_ret), ty_arg, ty_res, _)
           when labels_match ~param:l ~arg:lbl ->
             let sort_arg =
-              match type_sort ~why:Function_argument env ty_arg with
+              match type_sort ~why:Function_argument ~fixed:false env ty_arg with
               | Ok sort -> sort
               | Error err -> raise(Error(funct.exp_loc, env,
                                          Function_type_not_rep (ty_arg,err)))
@@ -3746,7 +3746,8 @@ let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs ret
             Location.prerr_warning loc w
           end
         in
-        let sort_arg = match type_sort ~why:Function_argument env ty_arg with
+        let sort_arg =
+          match type_sort ~why:Function_argument ~fixed:false env ty_arg with
           | Ok sort -> sort
           | Error err -> raise(Error(sarg1.pexp_loc, env,
                                      Function_type_not_rep(ty_arg, err)))
@@ -4942,7 +4943,7 @@ let split_function_ty
   let arg_value_mode = alloc_to_value_l2r arg_mode in
   let expected_pat_mode = simple_pat_mode arg_value_mode in
   let type_sort ~why ty =
-    match Ctype.type_sort ~why env ty with
+    match Ctype.type_sort ~why ~fixed:false env ty with
     | Ok sort -> sort
     | Error err -> raise (Error (loc_fun, env, Function_type_not_rep (ty, err)))
   in
@@ -7511,7 +7512,7 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
          cases, look toward the end of
          typing-layouts-missing-cmi/function_arg.ml *)
       let type_sort ~why ty =
-        match type_sort ~why env ty with
+        match type_sort ~why ~fixed:false env ty with
         | Ok sort -> sort
         | Error err ->
           raise(Error(sarg.pexp_loc, env, Function_type_not_rep (ty, err)))
@@ -7673,7 +7674,7 @@ and type_application env app_loc expected_mode position_and_mode
         ) ~post:(fun {ty_ret; _} -> generalize_structure ty_ret)
       in
       let type_sort ~why ty =
-        match Ctype.type_sort ~why env ty with
+        match Ctype.type_sort ~why ~fixed:false env ty with
         | Ok sort -> sort
         | Error err -> raise (Error (app_loc, env, Function_type_not_rep (ty, err)))
       in

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -404,7 +404,7 @@ let set_private_row env loc p decl =
    constructed.  We've been conservative here in the first version. This is the
    same issue as with arrows. *)
 let check_representable ~why ~allow_unboxed env loc kloc typ =
-  match Ctype.type_sort ~why env typ with
+  match Ctype.type_sort ~why ~fixed:false env typ with
   (* CR layouts v5: This is a convenient place to rule out non-value types in
       structures that don't support them yet. (A callsite passes
       [~allow_unboxed:true] to indicate that non-value types are allowed.)
@@ -2749,7 +2749,7 @@ let error_if_has_deep_native_repr_attributes core_type =
     [external f : ('a : any). 'a -> 'a = "%identity"]
    In such cases, we raise an expection. *)
 let type_sort_external ~is_layout_poly ~why env loc typ =
-  match Ctype.type_sort ~why env typ with
+  match Ctype.type_sort ~why ~fixed:true env typ with
   | Ok s -> Jkind.Sort.default_to_value_and_get s
   | Error err ->
     let kloc =

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -920,7 +920,7 @@ let report_error ppf = function
         Jkind.Sort.Const.format const
   | Unsupported_product_in_structure const ->
       fprintf ppf
-        "Product layout %a detected in structure in [Typeopt.Layout] \
+        "Product layout %a detected in structure in [Typeopt.Layout]@ \
          Please report this error to the Jane Street compilers team."
         Jkind.Sort.Const.format const
 

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -140,6 +140,7 @@ module Stdlib = struct
       in
       aux [] l1 l2
 
+<<<<<<< HEAD
     let rec iteri2 i f l1 l2 =
       match (l1, l2) with
         ([], []) -> ()
@@ -148,6 +149,17 @@ module Stdlib = struct
 
     let iteri2 f l1 l2 = iteri2 0 f l1 l2
 
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+=======
+    let map3 f =
+      let rec loop acc as_ bs cs = match as_, bs, cs with
+        | [], [], [] -> List.rev acc
+        | a :: as_, b :: bs, c :: cs -> loop (f a b c :: acc) as_ bs cs
+        | _ -> invalid_arg "map3"
+      in
+      loop []
+
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
     let some_if_all_elements_are_some l =
       let rec aux acc l =
         match l with
@@ -444,6 +456,59 @@ module Stdlib = struct
   end
 
   external compare : 'a -> 'a -> int = "%compare"
+
+  module Monad = struct
+    module type Basic2 = sig
+      (** Multi parameter monad. The second parameter gets unified across all the computation.
+          This is used to encode monads working on a multi parameter data structure like
+          ([('a,'b) result]). *)
+
+      type ('a, 'e) t
+
+      val bind : ('a, 'e) t -> ('a -> ('b, 'e) t) -> ('b, 'e) t
+
+      val return : 'a -> ('a, _) t
+    end
+
+    module type S2 = sig
+      type ('a, 'e) t
+
+      val bind : ('a, 'e) t -> ('a -> ('b, 'e) t) -> ('b, 'e) t
+      val return : 'a -> ('a, _) t
+      val map : ('a -> 'b) -> ('a, 'e) t -> ('b, 'e) t
+      val join : (('a, 'e) t, 'e) t -> ('a, 'e) t
+      val ignore_m : (_, 'e) t -> (unit, 'e) t
+      val all : ('a, 'e) t list -> ('a list, 'e) t
+      val all_unit : (unit, 'e) t list -> (unit, 'e) t
+    end
+
+    module Make2 (X : Basic2) = struct
+      include X
+
+      let map f m =
+        bind m (fun a -> return (f a))
+
+      let join m = bind m Fun.id
+
+      let ignore_m m = bind m (fun _ -> return ())
+
+      let all ms =
+        let rec loop acc = function
+          | [] -> return (List.rev acc)
+          | m :: ms -> bind m (fun a -> loop (a :: acc) ms)
+        in
+        loop [] ms
+
+      let all_unit ms =
+        let skip = return () in
+        List.fold_left (fun _ m -> bind m (fun _ -> skip)) skip ms
+    end
+
+    module Result = Make2(struct
+        include Result
+        let return = ok
+      end)
+  end
 end
 
 module Int = Stdlib.Int

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -140,17 +140,6 @@ module Stdlib = struct
       in
       aux [] l1 l2
 
-<<<<<<< HEAD
-    let rec iteri2 i f l1 l2 =
-      match (l1, l2) with
-        ([], []) -> ()
-      | (a1::l1, a2::l2) -> f i a1 a2; iteri2 (i + 1) f l1 l2
-      | (_, _) -> raise (Invalid_argument "iteri2")
-
-    let iteri2 f l1 l2 = iteri2 0 f l1 l2
-
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-=======
     let map3 f =
       let rec loop acc as_ bs cs = match as_, bs, cs with
         | [], [], [] -> List.rev acc
@@ -159,7 +148,14 @@ module Stdlib = struct
       in
       loop []
 
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
+    let rec iteri2 i f l1 l2 =
+      match (l1, l2) with
+        ([], []) -> ()
+      | (a1::l1, a2::l2) -> f i a1 a2; iteri2 (i + 1) f l1 l2
+      | (_, _) -> raise (Invalid_argument "iteri2")
+
+    let iteri2 f l1 l2 = iteri2 0 f l1 l2
+
     let some_if_all_elements_are_some l =
       let rec aux acc l =
         match l with

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -138,16 +138,12 @@ module Stdlib : sig
         If [l1] is of length n and [l2 = h2 @ t2] with h2 of length n,
         r1 is [List.map2 f l1 h1] and r2 is t2. *)
 
-<<<<<<< HEAD
+    val map3 : ('a -> 'b -> 'c -> 'd) -> 'a list -> 'b list -> 'c list -> 'd list
+
     val iteri2 : (int -> 'a -> 'b -> unit) -> 'a list -> 'b list -> unit
     (** Same as {!List.iter2}, but the function is applied to the index of
         the element as first argument (counting from 0) *)
 
-||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
-=======
-    val map3 : ('a -> 'b -> 'c -> 'd) -> 'a list -> 'b list -> 'c list -> 'd list
-
->>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
     val split_at : int -> 'a t -> 'a t * 'a t
     (** [split_at n l] returns the pair [before, after] where [before] is
         the [n] first elements of [l] and [after] the remaining ones.

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -138,10 +138,16 @@ module Stdlib : sig
         If [l1] is of length n and [l2 = h2 @ t2] with h2 of length n,
         r1 is [List.map2 f l1 h1] and r2 is t2. *)
 
+<<<<<<< HEAD
     val iteri2 : (int -> 'a -> 'b -> unit) -> 'a list -> 'b list -> unit
     (** Same as {!List.iter2}, but the function is applied to the index of
         the element as first argument (counting from 0) *)
 
+||||||| parent of 76f33d6615 (Simplify constrain_type_jkind.)
+=======
+    val map3 : ('a -> 'b -> 'c -> 'd) -> 'a list -> 'b list -> 'c list -> 'd list
+
+>>>>>>> 76f33d6615 (Simplify constrain_type_jkind.)
     val split_at : int -> 'a t -> 'a t * 'a t
     (** [split_at n l] returns the pair [before, after] where [before] is
         the [n] first elements of [l] and [after] the remaining ones.
@@ -278,6 +284,36 @@ module Stdlib : sig
   end
 
   external compare : 'a -> 'a -> int = "%compare"
+
+  module Monad : sig
+    module type Basic2 = sig
+      (** Multi parameter monad. The second parameter gets unified across all the computation.
+          This is used to encode monads working on a multi parameter data structure like
+          ([('a,'b) result]). *)
+
+      type ('a, 'e) t
+
+      val bind : ('a, 'e) t -> ('a -> ('b, 'e) t) -> ('b, 'e) t
+
+      val return : 'a -> ('a, _) t
+    end
+
+    module type S2 = sig
+      type ('a, 'e) t
+
+      val bind : ('a, 'e) t -> ('a -> ('b, 'e) t) -> ('b, 'e) t
+      val return : 'a -> ('a, _) t
+      val map : ('a -> 'b) -> ('a, 'e) t -> ('b, 'e) t
+      val join : (('a, 'e) t, 'e) t -> ('a, 'e) t
+      val ignore_m : (_, 'e) t -> (unit, 'e) t
+      val all : ('a, 'e) t list -> ('a list, 'e) t
+      val all_unit : (unit, 'e) t list -> (unit, 'e) t
+    end
+
+    module Make2 (X : Basic2) : S2 with type ('a, 'e) t = ('a, 'e) X.t
+
+    module Result : S2 with type ('a, 'e) t = ('a, 'e) result
+  end
 end
 
 (** {1 Operations on files and file paths} *)


### PR DESCRIPTION
In #2879 (unboxed tuples), I [wondered](https://github.com/ocaml-flambda/flambda-backend/pull/2879/files#r1716234850) if there wasn't a simplification available for `constrain_type_jkind`. @ccasin rightly told me (in person) that blithely wondering that aloud is more annoying than helpful. So I took a stab at the refactor. This PR is the result.

I don't think I would have embarked on this during the workday. But it did make some fun hacking during holiday. I recognize I'm now asking @ccasin to spend workday time on this, but I think the result is enough of an improvement to motivate doing so.

The starting point was to change `estimate_type_jkind` to just return a jkind instead of also noting down whether the jkind was in a `Tvar` or `Tunboxed_tuple`. The rest seemed to follow from there. A high-level explanation is that the new algorithm is a little more akin to unification, where descs are checked multiple times at multiple different stages of trying. The new implementation is all in one function instead of the stratification into `unify1` through `unify3`, but there is a similar spirit between unification and my new approach here.

You might worry that the new approach has asymptotic complexity worries in the unboxed-tuple case: because `estimate_type_jkind` is now deep, it would be easy to call the function at every step while descending through nested unboxed tuples. This patch is careful to avoid this pitfall: the recursive descent carries with it the jkind of the type it's descending into. Most of the time, this jkind is produced by a fresh call to `estimate_type_jkind`, but in the unboxed-tuple case, the jkind comes straight from the previous call, thus avoiding repeating work.

Here are some benefits of the new approach:
- The new code is, I believe, simpler than the old. It is definitely shorter.
- The new approach does less expansion. Previously, `constrain_type_jkind` expanded the type whenever the jkind wasn't `any`. Now it checks before doing any expansion, skipping expansion if expanding has no hope of improving the situation. (Hope happens when the jkind of the type and the desired jkind have an intersection. There is no hope when there is no intersection.)
- The new approach does not allocate a node for the return value from `estimate_type_jkind` (though the node is quickly matched on and so probably doesn't matter much).
- The old approach unified more type variables in `external` declarations. I'm not sure why. But this new approach accepts a declaration that was previously rejected (but seems fine to me). I did not investigate this change in behavior; didn't seem a good use of time.
- There is no longer a special case for type variables at `generic_level`. I'm not sure why this need disappeared, but I'm not sorry to see it go.
- The bug in type inference noted in typing-layouts-products/basics.ml seems to have disappeared. Yay! But the new error message is bad -- this might need some discussion with @ccasin.

Here are some drawbacks of the new approach:
- Because there is less expansion, some error messages are less detailed than they were previously. For example, if we're checking whether `Float_u.t < value`, we never learn that `Float_u.t` is really `float#`, and so we can't say so in the error message. We could, in theory, do some expansion just to improve error messages (preferably in some mode that won't load new cmi files), but that expansion could be done in error message generation instead of during the jkind check.
- Because there is less expansion, we sometimes don't know that two jkinds simply need an intersection rather than a subjkind relationship. For example, if we have `type ('a : float64) t = 'a` and we're checking whether `'a t : value`, we'll report that `float64` must be a subjkind of `value` for this to work. Actually, it would be sufficient for the two to have an intersection. Yet discovering this requires expansion (which is otherwise fruitless). Again, this could probably be improved by doing more expansion on the way to generating error messages, but it would be harder than the above case. I think this subtle distinction will wash over users and isn't worth pursuing, but I could be wrong.
- The new algorithm triggers the "I don't know how to do type inference" error in typedecl more often. But the cases where it does actually seem sensible. And the old error message starts with a blank line, which has been (in other cases) associated with some confusion in error message generation.
- The new algorithm calls `get_desc` more. Yet `get_desc` does path compression, and e.g. `unify` already calls `get_desc` a lot, so this seems OK.

Other notes:
- This patch refactors the old `unbox_once` not to expand, because sometimes expansion has already been done.
- This patch adds a new parameter to `type_sort` saying whether it should consider type variables fixed. This is used when type-checking `external`s, because we compute the sort of the arguments *after* type-checking is done, and thus after the check that any generalized variables in the type can actually be generalized. This is a bit unfortunate, but it seems the easiest way forward. (The principled approach would be to compute the sorts in `transl_type_scheme`, but that seems like it would require installation of a lot of plumbing.)
- I added some support in Misc for treating `result` as the monad it is. This is overkill. But I'm very tired of not being able to use the effective idioms I grew up with. The code is adapted from `base`. I predict that if we leave this in, more people will eventually use it.