### PR TITLE
Fix `unique_barrier` assertion

### DIFF
--- a/ocaml/testsuite/tests/typing-unique/pr3038.ml
+++ b/ocaml/testsuite/tests/typing-unique/pr3038.ml
@@ -1,0 +1,19 @@
+(* TEST
+ readonly_files = "pr3038.ml";
+setup-ocamlc.byte-build-env;
+module = "pr3038.ml";
+ocamlc.byte;
+check-ocamlc.byte-output;
+*)
+
+type r = {a : string}
+type t =
+    | Foo of r
+    | Bar of r
+
+let f _ = ()
+
+let foo t =
+    match t with
+    | Foo x | Bar x ->
+    let _ = x.a in f x

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -50,7 +50,7 @@ type _ pattern_category =
 | Value : value pattern_category
 | Computation : computation pattern_category
 
-type unique_barrier = Mode.Uniqueness.r option
+type unique_barrier = Mode.Uniqueness.r
 
 type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -63,12 +63,12 @@ type _ pattern_category =
 | Value : value pattern_category
 | Computation : computation pattern_category
 
-(* The following will be used in the future when overwriting is introduced and
-  code-motion need to be checked. This will be associated to each field
-  projection, and represents the usage of the record immediately after this
-  projection. If it points to unique, that means this projection must be
-  borrowed and cannot be moved *)
-type unique_barrier = Mode.Uniqueness.r option
+(* CR zqian: use this field when overwriting is supported. *)
+(** Access mode for a field projection, represented by the usage of the record
+  immediately following the projection. If the following usage is unique, the
+  projection must be borrowed and cannot be moved. If the following usage is
+  shared, the projection can be shared and moved. *)
+type unique_barrier = Mode.Uniqueness.r
 
 type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 


### PR DESCRIPTION
This PR fixes an assertion failure in the UA.

The assertion thinks that `unique_barrier ref` can be written to only once, which is wrong. For example:
```
match t with
| Foo x | Bar x -> x.a; f x
```
The `x` here will map to two `Path.t`, one for `Foo x` and one for `Bar x`.  The field projection `x.a` generates a usage tree where both `Path.t` maps to the same unique_barrier. This followed by `f x` causes the unique_barrier being written to twice.

Request review from @anfelor