### PR TITLE
Improves the modes of mixed recursive definitions

### DIFF
--- a/ocaml/testsuite/tests/typing-modes/rec.ml
+++ b/ocaml/testsuite/tests/typing-modes/rec.ml
@@ -1,0 +1,58 @@
+(* TEST
+ expect;
+*)
+
+(* for entirely-function definitions, they will share the same mode that can be
+   at any mode *)
+let te (local_ x) =
+    let use_portable (_ @ portable) = () in
+    let rec foo x' y =
+        use_portable bar;
+        bar x y
+    and bar x' y =
+        use_portable foo;
+        foo x y
+    in
+    use_portable bar;
+    use_portable foo;
+    ()
+[%%expect{|
+val te : local_ 'a @ portable -> unit = <fun>
+|}]
+
+(* for mixed definitions, they will still share the same mode, but the locality
+   must be global. *)
+
+let te (local_ x) =
+    let rec foo x' y =
+        bar x y
+    and bar x' y =
+        foo x y
+    and baz = "hello"
+    in
+    ()
+[%%expect{|
+Line 3, characters 12-13:
+3 |         bar x y
+                ^
+Error: The value "x" is local, so cannot be used inside a closure that might escape.
+|}]
+
+(* for mixed definitions, the other axes are not constrained. *)
+let te (x) =
+    let use_portable (_ @ portable) = () in
+    let rec foo x' y =
+        use_portable bar;
+        bar x y
+    and bar x' y =
+        use_portable foo;
+        foo x y
+    and baz = "hello"
+    in
+    use_portable bar;
+    use_portable foo;
+    use_portable baz;
+    ()
+[%%expect{|
+val te : 'a @ portable -> unit = <fun>
+|}]

--- a/ocaml/testsuite/tests/typing-modes/rec.ml
+++ b/ocaml/testsuite/tests/typing-modes/rec.ml
@@ -35,7 +35,7 @@ let te (local_ x) =
 Line 3, characters 12-13:
 3 |         bar x y
                 ^
-Error: The value "x" is local, so cannot be used inside a closure that might escape.
+Error: The value x is local, so cannot be used inside a closure that might escape.
 |}]
 
 (* for mixed definitions, the other axes are not constrained. *)

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -8440,7 +8440,16 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   let rec_mode_var =
     match rec_flag with
     | Recursive when entirely_functions -> Some (Value.newvar ())
-    | Recursive -> Some Value.legacy
+    | Recursive ->
+        (* If the definitions are not purely functions, this involves multiple
+           allocations pointing to each other. For this to be safe, they are all
+           heap-allocated. *)
+        (* CR zqian: the multiple allocations should enjoy their own modes. *)
+        let m, _ =
+          Value.newvar_below (Value.max_with (Comonadic Areality)
+            Regionality.global)
+        in
+        Some m
     | Nonrecursive -> None
   in
   let spatl = List.map vb_pat_constraint spat_sexp_list in


### PR DESCRIPTION
This PR improves the modes of mixed (not entirely functions) recursive definitions.

When a group of recursive definitions are all functions, they are allocated as a single block, and this block can be any mode. All functions will have that mode.

When the group is not entirely functions, they are allocated separately. If they are genuiely mutually recursive, they will contain backward pointers (old pointing to new) that our GC currently cannot handle. To prevent that, they will all be allocated on heap. 

This PR does two things:
- Each entry in the mixed definitions has its own mode.
- Currently, axes other than `locality` are set to legacy as well. This PR removes this restriction.