### PR TITLE
Remove an unnecessary expansion

### DIFF
--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -2387,8 +2387,7 @@ let type_jkind_purely env ty =
     type_jkind env ty
 
 let estimate_type_jkind env ty =
-  estimate_type_jkind env ~expand_components:(fun x -> x)
-    (get_unboxed_type_approximation env ty)
+  estimate_type_jkind env ~expand_components:(fun x -> x) ty
 
 let type_sort ~why env ty =
   let jkind, sort = Jkind.of_new_sort_var ~why in


### PR DESCRIPTION
I didn't know why we called `get_unboxed_type_approximation` from `estimate_type_jkind`, so I removed it. Nothing bad happened.

Review: @ccasin (mostly because he's the person most likely to know if there are any worms under this stone)

History: This was added in the unboxed tuples patch.