### PR TITLE
Reorder fields in block header

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -74,6 +74,12 @@ type t =
 (* Mixed blocks, that need special header to specify the length of the scannable
    prefix. *)
 
+let addr_size_bits = Arch.size_addr * 8
+
+let header_wosize_bits = addr_size_bits - Config.reserved_header_bits - 10
+
+let header_max_size = (1 lsl header_wosize_bits) - 1
+
 module Mixed_block_support : sig
   val assert_mixed_block_support : unit -> unit
 
@@ -93,16 +99,11 @@ end = struct
      the all-0 pattern, and we must subtract 2 instead. *)
   let max_scannable_prefix = (1 lsl required_reserved_header_bits) - 2
 
-  let max_header =
-    (1 lsl (required_addr_size_bits - required_reserved_header_bits)) - 1
-    |> Nativeint.of_int
-
   let assert_mixed_block_support =
     lazy
       (if not Config.native_compiler
        then Misc.fatal_error "Mixed blocks are only supported in native code";
        let reserved_header_bits = Config.reserved_header_bits in
-       let addr_size_bits = Arch.size_addr * 8 in
        match
          ( reserved_header_bits = required_reserved_header_bits,
            addr_size_bits = required_addr_size_bits )
@@ -119,32 +120,32 @@ end = struct
 
   let assert_mixed_block_support () = Lazy.force assert_mixed_block_support
 
+  let scannable_prefix_position = 10
+
   let make_header header ~scannable_prefix =
     assert_mixed_block_support ();
     if scannable_prefix > max_scannable_prefix
     then
       Misc.fatal_errorf "Scannable prefix too big (%d > %d)" scannable_prefix
         max_scannable_prefix;
-    (* This means we crash the compiler if someone tries to write a mixed record
-       with too many fields, but you effectively can't: you'd need something
-       like 2^46 fields. *)
-    if header > max_header
-    then
-      Misc.fatal_errorf
-        "Header too big for the mixed block encoding to be added (%nd > %nd)"
-        header max_header;
     Nativeint.add
       (Nativeint.shift_left
          (Nativeint.of_int (scannable_prefix + 1))
-         (required_addr_size_bits - required_reserved_header_bits))
+         scannable_prefix_position)
       header
 end
 
 (* CR mshinwell: update to use NOT_MARKABLE terminology *)
 let block_header ?(block_kind = Regular_block) tag sz =
+  (* This means we crash the compiler if someone tries to write a record with
+     too many fields, but you effectively can't: you'd need something like 2^46
+     fields. *)
+  if sz > header_max_size
+  then Misc.fatal_errorf "Size too large to encode in header %d" sz;
   let hdr =
     Nativeint.add
-      (Nativeint.shift_left (Nativeint.of_int sz) 10)
+      (Nativeint.shift_left (Nativeint.of_int sz)
+         (10 + Config.reserved_header_bits))
       (Nativeint.of_int tag)
   in
   match block_kind with
@@ -948,13 +949,6 @@ let get_header ptr dbg =
       [Cop (Cadda, [ptr; Cconst_int (-size_int, dbg)], dbg)],
       dbg )
 
-let get_header_masked ptr dbg =
-  if Config.reserved_header_bits > 0
-  then
-    let header_mask = (1 lsl (64 - Config.reserved_header_bits)) - 1 in
-    Cop (Cand, [get_header ptr dbg; Cconst_int (header_mask, dbg)], dbg)
-  else get_header ptr dbg
-
 let tag_offset = if big_endian then -1 else -size_int
 
 let get_tag ptr dbg =
@@ -973,7 +967,10 @@ let get_tag ptr dbg =
         dbg )
 
 let get_size ptr dbg =
-  Cop (Clsr, [get_header_masked ptr dbg; Cconst_int (10, dbg)], dbg)
+  Cop
+    ( Clsr,
+      [get_header ptr dbg; Cconst_int (10 + Config.reserved_header_bits, dbg)],
+      dbg )
 
 (* Array indexing *)
 
@@ -981,9 +978,9 @@ let log2_size_addr = Misc.log2 size_addr
 
 let log2_size_float = Misc.log2 size_float
 
-let wordsize_shift = 9
+let wordsize_shift = 9 + Config.reserved_header_bits
 
-let numfloat_shift = 9 + log2_size_float - log2_size_addr
+let numfloat_shift = wordsize_shift + log2_size_float - log2_size_addr
 
 let addr_array_length_shifted hdr dbg =
   Cop (Clsr, [hdr; Cconst_int (wordsize_shift, dbg)], dbg)
@@ -3237,7 +3234,7 @@ let raise_prim raise_kind arg dbg =
 let negint arg dbg = Cop (Csubi, [Cconst_int (2, dbg); arg], dbg)
 
 let addr_array_length arg dbg =
-  let hdr = get_header_masked arg dbg in
+  let hdr = get_header arg dbg in
   Cop (Cor, [addr_array_length_shifted hdr dbg; Cconst_int (1, dbg)], dbg)
 
 (* CR-soon gyorsh: effects and coeffects for primitives are set conservatively

--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -735,6 +735,7 @@ let get_header ptr dbg =
     [Cop(Cadda, [ptr; Cconst_int(-size_int, dbg)], dbg)], dbg)
 
 let get_header_masked ptr dbg =
+  if true then failwith "this code has not been updated for runtime changes, but isn't used";
   if Config.reserved_header_bits > 0 then
     let header_mask = (1 lsl (64 - Config.reserved_header_bits)) - 1
     in Cop(Cand, [get_header ptr dbg; Cconst_int (header_mask, dbg)], dbg)

--- a/ocaml/asmcomp/cmm_helpers.mli
+++ b/ocaml/asmcomp/cmm_helpers.mli
@@ -227,9 +227,6 @@ val set_field :
 (** Load a block's header *)
 val get_header : expression -> Debuginfo.t -> expression
 
-(** Same as [get_header], but also clear all reserved bits of the result *)
-val get_header_masked : expression -> Debuginfo.t -> expression
-
 (** Load a block's tag *)
 val get_tag : expression -> Debuginfo.t -> expression
 

--- a/ocaml/debugger/debugcom.ml
+++ b/ocaml/debugger/debugcom.ml
@@ -299,8 +299,8 @@ module Remote_value =
         flush !conn.io_out;
         let header = input_binary_int !conn.io_in in
         if header land 0xFF = Obj.double_array_tag && Sys.word_size = 32
-        then header lsr 11
-        else header lsr 10
+        then header lsr (11 + Config.reserved_header_bits)
+        else header lsr (10 + Config.reserved_header_bits)
 
     let field v n =
       match v with

--- a/ocaml/debugger4/debugcom.ml
+++ b/ocaml/debugger4/debugcom.ml
@@ -357,8 +357,8 @@ module Remote_value =
         flush !conn.io_out;
         let header = input_binary_int !conn.io_in in
         if header land 0xFF = Obj.double_array_tag && Sys.word_size = 32
-        then header lsr 11
-        else header lsr 10
+        then header lsr (11 + Config.reserved_header_bits)
+        else header lsr (10 + Config.reserved_header_bits)
 
     let field v n =
       match v with

--- a/ocaml/runtime/alloc.c
+++ b/ocaml/runtime/alloc.c
@@ -31,6 +31,10 @@
 #include "caml/fiber.h"
 #include "caml/domain.h"
 
+/* When you update this macro, be sure to also update the exported value. */
+Assert_mixed_block_layout_v2;
+value caml_mixed_block_layout_version = 2;
+
 CAMLexport value caml_alloc_with_reserved (mlsize_t wosize, tag_t tag,
                                            reserved_t reserved)
 {

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -590,13 +590,13 @@ CAMLextern value caml_set_oo_id(value obj);
 
    Users can write:
 
-   Assert_mixed_block_layout_v1;
+   Assert_mixed_block_layout_v2;
 
    (Hack: we define using _Static_assert rather than just an empty
    definition so that users can write a semicolon, which is treated
    better by C formatters.)
  */
-#define Assert_mixed_block_layout_v1 _Static_assert(1, "")
+#define Assert_mixed_block_layout_v2 _Static_assert(1, "")
 
 /* Header for out-of-heap blocks. */
 

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -123,9 +123,12 @@ mixed blocks. In the upstream compiler, R is set with the
 #define HEADER_COLOR_MASK (((1ull << HEADER_COLOR_BITS) - 1ull) \
                             << HEADER_COLOR_SHIFT)
 
+// HEADER_RESERVED_BITS is defined by configuration
+#define HEADER_RESERVED_SHIFT (HEADER_COLOR_SHIFT + HEADER_COLOR_BITS)
+
 #define HEADER_WOSIZE_BITS (HEADER_BITS - HEADER_TAG_BITS \
                             - HEADER_COLOR_BITS - HEADER_RESERVED_BITS)
-#define HEADER_WOSIZE_SHIFT (HEADER_COLOR_SHIFT  + HEADER_COLOR_BITS + HEADER_RESERVED_BITS)
+#define HEADER_WOSIZE_SHIFT (HEADER_RESERVED_BITS + HEADER_RESERVED_SHIFT)
 #define HEADER_WOSIZE_MASK (((1ull << HEADER_WOSIZE_BITS) - 1ull) \
                              << HEADER_WOSIZE_SHIFT)
 
@@ -142,12 +145,11 @@ mixed blocks. In the upstream compiler, R is set with the
 
 #if HEADER_RESERVED_BITS > 0
 
-#define HEADER_RESERVED_SHIFT (HEADER_BITS - HEADER_RESERVED_BITS)
 #define HEADER_RESERVED_MASK  (((1ull << HEADER_RESERVED_BITS) - 1ull) \
                              << HEADER_RESERVED_SHIFT)
 
-#define Reserved_hd(hd)   ((((header_t) (hd)) >> HEADER_RESERVED_SHIFT) \
-                             & HEADER_RESERVED_MASK)
+#define Reserved_hd(hd)   ((((header_t) (hd)) & HEADER_RESERVED_MASK) \
+                             >> HEADER_RESERVED_SHIFT)
 
 #define Hd_reserved(res)  ((header_t)(res) << HEADER_RESERVED_SHIFT)
 

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -599,6 +599,7 @@ CAMLextern value caml_set_oo_id(value obj);
    better by C formatters.)
  */
 #define Assert_mixed_block_layout_v2 _Static_assert(1, "")
+CAMLextern value mixed_block_layout_version;
 
 /* Header for out-of-heap blocks. */
 

--- a/ocaml/runtime/extern.c
+++ b/ocaml/runtime/extern.c
@@ -627,7 +627,17 @@ Caml_inline void extern_header(struct caml_extern_state* s,
   if (tag < 16 && sz < 8) {
     writebyte(s, PREFIX_SMALL_BLOCK + tag + (sz << 4));
   } else {
-    header_t hd = Make_header(sz, tag, NOT_MARKABLE);
+    /* This is the equivalent of [Make_header] before our changes to reorder
+       mixed-block related fields.
+
+       Is marshalling guaranteed to be stable? I'm uncertain if there's a rule
+       about this or a guarantee made by Ocaml. But, as a matter of practice,
+       one can't build the compiler without crossming marshal/unmarshal
+       boundaries where one end is from system ocamlc and one end is from the
+       built one. As such, it is in practice unsafe to use our new headers in
+       marshalling.
+    */
+    header_t hd = (sz << 10) + tag;
 #ifdef ARCH_SIXTYFOUR
     if (sz > 0x3FFFFF && (s->extern_flags & COMPAT_32))
       extern_failwith(s, "output_value: array cannot be read back on "

--- a/ocaml/runtime/intern.c
+++ b/ocaml/runtime/intern.c
@@ -591,13 +591,15 @@ static void intern_rec(struct caml_intern_state* s,
       case CODE_BLOCK32:
         header = (header_t) read32u(s);
         tag = Tag_hd(header);
-        size = Wosize_hd(header);
+        /* See comment in extern.c extern_header() */
+        size = header >> 10;
         goto read_block;
 #ifdef ARCH_SIXTYFOUR
       case CODE_BLOCK64:
         header = (header_t) read64u(s);
         tag = Tag_hd(header);
-        size = Wosize_hd(header);
+        /* See comment in extern.c extern_header() */
+        size = header >> 10;
         goto read_block;
 #endif
       case CODE_STRING8:

--- a/ocaml/runtime4/alloc.c
+++ b/ocaml/runtime4/alloc.c
@@ -32,6 +32,10 @@
 #define Setup_for_gc
 #define Restore_after_gc
 
+/* When you update this macro, be sure to also update the exported value. */
+Assert_mixed_block_layout_v2;
+value caml_mixed_block_layout_version = 2;
+
 CAMLexport value caml_alloc_with_reserved (mlsize_t wosize, tag_t tag,
                                            reserved_t reserved)
 {

--- a/ocaml/runtime4/caml/gc.h
+++ b/ocaml/runtime4/caml/gc.h
@@ -41,7 +41,7 @@
 /* This depends on the layout of the header.  See [mlvalues.h]. */
 #define Make_header(wosize, tag, color)                                       \
       (/*CAMLassert ((wosize) <= Max_wosize),*/                               \
-       ((header_t) (((header_t) (wosize) << 10)                               \
+       ((header_t) (((header_t) (wosize) << (10+PROFINFO_WIDTH))              \
                     + (color)                                                 \
                     + (tag_t) (tag)))                                         \
       )

--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -564,6 +564,7 @@ CAMLextern value caml_set_oo_id(value obj);
    better by C formatters.)
  */
 #define Assert_mixed_block_layout_v2 _Static_assert(1, "")
+CAMLextern value mixed_block_layout_version; /* To help us in coredumps. */
 
 /* Header for out-of-heap blocks. */
 

--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -557,13 +557,13 @@ CAMLextern value caml_set_oo_id(value obj);
 
    Users can write:
 
-   Assert_mixed_block_layout_v1;
+   Assert_mixed_block_layout_v2;
 
    (Hack: we define using _Static_assert rather than just an empty
    definition so that users can write a semicolon, which is treated
    better by C formatters.)
  */
-#define Assert_mixed_block_layout_v1 _Static_assert(1, "")
+#define Assert_mixed_block_layout_v2 _Static_assert(1, "")
 
 /* Header for out-of-heap blocks. */
 

--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -110,10 +110,10 @@ bits  63    10 9     8 7   0
 
 For 64-bit architectures with mixed block support enabled:
   P = PROFINFO_WIDTH (as set by "configure", currently 8 bits)
-     +----------------+----------------+-------------+
-     | scannable size | wosize         | color | tag |
-     +----------------+----------------+-------------+
-bits  63        (64-P) (63-P)        10 9     8 7   0
+     +----- --+------------------------+-------------+
+     | wosize | scannable size         | color | tag |
+     +--------+------------------------+-------------+
+bits  63      (P+10)                 10 9     8 7   0
 
 Mixed block support uses the PROFINFO_WIDTH functionality
 originally built for Spacetime profiling, hence the odd name.
@@ -121,7 +121,7 @@ originally built for Spacetime profiling, hence the odd name.
 
 #define Tag_hd(hd) ((tag_t) ((hd) & 0xFF))
 
-#define Gen_profinfo_shift(width) (64 - (width))
+#define Gen_profinfo_shift(width) (10)
 #define Gen_profinfo_mask(width) ((1ull << (width)) - 1ull)
 #define Gen_profinfo_hd(width, hd) \
   (((mlsize_t) ((hd) >> (Gen_profinfo_shift(width)))) \
@@ -131,8 +131,9 @@ originally built for Spacetime profiling, hence the odd name.
 #define PROFINFO_SHIFT (Gen_profinfo_shift(PROFINFO_WIDTH))
 #define PROFINFO_MASK (Gen_profinfo_mask(PROFINFO_WIDTH))
 #define NO_PROFINFO 0
-#define Hd_no_profinfo(hd) ((hd) & ~(PROFINFO_MASK << PROFINFO_SHIFT))
-#define Allocated_wosize_hd(hd) ((mlsize_t) ((Hd_no_profinfo(hd)) >> 10))
+
+#define HD_WOSIZE_SHIFT (PROFINFO_SHIFT + PROFINFO_WIDTH)
+#define Allocated_wosize_hd(hd) ((mlsize_t) ((hd) >> HD_WOSIZE_SHIFT))
 #define Profinfo_hd(hd) (Gen_profinfo_hd(PROFINFO_WIDTH, hd))
 #else
 #define NO_PROFINFO 0

--- a/ocaml/runtime4/extern.c
+++ b/ocaml/runtime4/extern.c
@@ -549,7 +549,17 @@ Caml_inline void extern_header(mlsize_t sz, tag_t tag)
   if (tag < 16 && sz < 8) {
     write(PREFIX_SMALL_BLOCK + tag + (sz << 4));
   } else {
-    header_t hd = Make_header(sz, tag, Caml_white);
+    /* This is the equivalent of [Make_header] before our changes to reorder
+       mixed-block related fields.
+
+       Is marshalling guaranteed to be stable? I'm uncertain if there's a rule
+       about this or a guarantee made by Ocaml. But, as a matter of practice,
+       one can't build the compiler without crossming marshal/unmarshal
+       boundaries where one end is from system ocamlc and one end is from the
+       built one. As such, it is in practice unsafe to use our new headers in
+       marshalling.
+    */
+    header_t hd = (sz << 10) + tag;
 #ifdef ARCH_SIXTYFOUR
     if (sz > 0x3FFFFF && (extern_flags & COMPAT_32))
       extern_failwith("output_value: array cannot be read back on "

--- a/ocaml/runtime4/hash.c
+++ b/ocaml/runtime4/hash.c
@@ -175,6 +175,12 @@ CAMLexport uint32_t caml_hash_mix_string(uint32_t h, value s)
   return h;
 }
 
+/* A version of Whitehd_hd that's compatible with what upstream does.
+   This allows us to avoid changing the output of polymorphic hash,
+   at a performance cost to users of polymorphic hash.
+ */
+#define Stable_whitehd_hd(hd) ((Wosize_hd(hd) << 10) | Tag_hd(hd))
+
 /* Maximal size of the queue used for breadth-first traversal.  */
 #define HASH_QUEUE_SIZE 256
 /* Maximal number of Forward_tag links followed in one step */
@@ -274,7 +280,7 @@ CAMLprim value caml_hash_exn(value count, value limit, value seed, value obj)
         startenv = Start_env_closinfo(Closinfo_val(v));
         CAMLassert (startenv <= len);
         /* Mix in the tag and size, but do not count this towards [num] */
-        h = caml_hash_mix_uint32(h, Whitehd_hd(Hd_val(v)));
+        h = caml_hash_mix_uint32(h, Stable_whitehd_hd(Hd_val(v)));
         /* Mix the code pointers, closure info fields, and infix headers */
         for (i = 0; i < startenv; i++) {
           h = caml_hash_mix_intnat(h, Field(v, i));
@@ -294,7 +300,7 @@ CAMLprim value caml_hash_exn(value count, value limit, value seed, value obj)
 	  caml_invalid_argument("hash: mixed block value");
 	}
         /* Mix in the tag and size, but do not count this towards [num] */
-        h = caml_hash_mix_uint32(h, Whitehd_hd(Hd_val(v)));
+        h = caml_hash_mix_uint32(h, Stable_whitehd_hd(Hd_val(v)));
         /* Copy fields into queue, not exceeding the total size [sz] */
         for (i = 0, len = Wosize_val(v); i < len; i++) {
           if (wr >= sz) break;

--- a/ocaml/runtime4/intern.c
+++ b/ocaml/runtime4/intern.c
@@ -459,13 +459,15 @@ static void intern_rec(value *dest)
       case CODE_BLOCK32:
         header = (header_t) read32u();
         tag = Tag_hd(header);
-        size = Wosize_hd(header);
+        /* See comment in extern.c extern_header() */
+        size = header >> 10;
         goto read_block;
 #ifdef ARCH_SIXTYFOUR
       case CODE_BLOCK64:
         header = (header_t) read64u();
         tag = Tag_hd(header);
-        size = Wosize_hd(header);
+        /* See comment in extern.c extern_header() */
+        size = header >> 10;
         goto read_block;
 #endif
       case CODE_STRING8:

--- a/ocaml/testsuite/tests/lib-obj/get_header.ml
+++ b/ocaml/testsuite/tests/lib-obj/get_header.ml
@@ -31,11 +31,14 @@ type header = {
   tag : int
 }
 
+(* for mixed block size *)
+let reserved_bits = 8
+
 let parse_header : nativeint -> header =
   fun header ->
     let wosize =
       Nativeint.to_int
-        (Nativeint.shift_right_logical header 10)
+        (Nativeint.shift_right_logical header (10 + reserved_bits))
     in
 
     let color =


### PR DESCRIPTION
Place wosize above scannable prefix, simplifying expressions like [Array.length].

[Array.length] and other block-size-computing expressions are fairly common in real code, and this shrinks them in code size and also operations executed, a rough diff being before:

      movabs  rbx, 72057594037927935
        mov     rax, qword ptr [rax - 8]
        and     rax, rbx
        shr     rax, 9
        or      rax, 1

and after:

	mov    rdx,QWORD PTR [rax-0x8]
 	shr    rdx,0x11
 	or     rdx,0x1

In addition I think this is just more readable when trying to pore over generated assembly.

Getting the scannable prefix size is, I think, as bad as getting block sizes is now: but the only time we do that is in GC scanning, and we also need lengths, so the total cost should be unch'd.

I tested both runtime4 and runtime5 via `make runtest`, and inspected some amount of generated assembly.