### PR TITLE
mode crossing in inclusion check

### DIFF
--- a/ocaml/testsuite/tests/typing-modes/crossing.ml
+++ b/ocaml/testsuite/tests/typing-modes/crossing.ml
@@ -2,13 +2,58 @@
  expect;
 *)
 
+(* mode crossing during inclusion check is according to the written type, not
+the inferred type. *)
+
+(* In this example, the inferred type does not allow mode crossing, but the
+written type does. *)
 module M : sig
     val f : int @ nonportable -> int @ portable
 end = struct
-    let f (_ @ portable) = (42 : _ @@ nonportable)
+    let f (x @ portable) = (x : _ @@ nonportable)
 end
 [%%expect{|
 module M : sig val f : int -> int @ portable end
+|}]
+
+(* In this example, the inferred type allows crossing to portable, but the
+written type does not. *)
+module M : sig
+    val f : unit -> [`A | `B of 'a -> 'a] @ portable
+end = struct
+    let f () = (`A : _ @@ nonportable)
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |     let f () = (`A : _ @@ nonportable)
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : unit -> [> `A ] end
+       is not included in
+         sig val f : unit -> [ `A | `B of 'a -> 'a ] @ portable end
+       Values do not match:
+         val f : unit -> [> `A ]
+       is not included in
+         val f : unit -> [ `A | `B of 'a -> 'a ] @ portable
+       The type unit -> [ `A | `B of 'a -> 'a ]
+       is not compatible with the type
+         unit -> [ `A | `B of 'a -> 'a ] @ portable
+|}]
+
+(* In this example, the inferred type does not allow crossing portability, but
+the written type does. *)
+module M : sig
+    val f : [`A] @ nonportable -> unit
+end = struct
+    let f (x : [< `A | `B of string -> string] @@ portable) =
+        match x with
+        | `A -> ()
+        | `B f -> ()
+end
+[%%expect{|
+module M : sig val f : [ `A ] -> unit end
 |}]
 
 module M : sig

--- a/ocaml/testsuite/tests/typing-modes/crossing.ml
+++ b/ocaml/testsuite/tests/typing-modes/crossing.ml
@@ -1,0 +1,44 @@
+(* TEST
+ expect;
+*)
+
+module M : sig
+    val f : int @ nonportable -> int @ portable
+end = struct
+    let f (_ @ portable) = (42 : _ @@ nonportable)
+end
+[%%expect{|
+module M : sig val f : int -> int @ portable end
+|}]
+
+module M : sig
+    val f : unit -> int
+end = struct
+    let f () = exclave_ 42
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |     let f () = exclave_ 42
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : unit -> local_ int end
+       is not included in
+         sig val f : unit -> int end
+       Values do not match:
+         val f : unit -> local_ int
+       is not included in
+         val f : unit -> int
+       The type unit -> local_ int is not compatible with the type
+         unit -> int
+|}]
+
+module M : sig
+    val f : local_ int -> int
+end = struct
+    let f (_ @ global) = 42
+end
+[%%expect{|
+module M : sig val f : local_ int -> int end
+|}]

--- a/ocaml/testsuite/tests/typing-modules/pr7726.ml
+++ b/ocaml/testsuite/tests/typing-modules/pr7726.ml
@@ -123,7 +123,6 @@ M.f 5;;
 [%%expect{|
 module Foo :
   functor (F : T -> T) -> sig val f : Fix(F).Fixed.t -> Fix(F).Fixed.t end
-module M : sig val f : Fix(Id).Fixed.t -> Fix(Id).Fixed.t end
 Line 1:
 Error: In the signature of Fix(Id):
        The definition of Fixed.t contains a cycle:

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -4749,6 +4749,9 @@ let submode_with_cross env ~is_ret ty l r =
   let r' = mode_cross_right env ty r in
   let r' =
     if is_ret then
+      (* the locality axis of the return mode cannot cross modes, because a
+         local-returning function might allocate in the caller's region, and
+         this info must be preserved. *)
       Alloc.meet [r'; Alloc.max_with (Comonadic Areality) (Alloc.proj (Comonadic Areality) r)]
     else
       r'
@@ -4812,7 +4815,8 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
               moregen inst_nongen (neg_variance variance) type_pairs env t1 t2;
               moregen inst_nongen variance type_pairs env u1 u2;
               (* [t2] and [u2] is the user-written interface, which we deem as
-                 more "principal". *)
+                 more "principal" and used for mode crossing. See
+                 [typing-modes/crossing.ml]. *)
               moregen_alloc_mode env t2 ~is_ret:false (neg_variance variance) a1 a2;
               moregen_alloc_mode env u2 ~is_ret:true variance r1 r2
           | (Ttuple labeled_tl1, Ttuple labeled_tl2) ->

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -4817,6 +4817,8 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
               (* [t2] and [u2] is the user-written interface, which we deem as
                  more "principal" and used for mode crossing. See
                  [typing-modes/crossing.ml]. *)
+              (* CR zqian: should use the meet of [t1] and [t2] for mode
+              crossing. Similar for [u1] and [u2]. *)
               moregen_alloc_mode env t2 ~is_ret:false (neg_variance variance) a1 a2;
               moregen_alloc_mode env u2 ~is_ret:true variance r1 r2
           | (Ttuple labeled_tl1, Ttuple labeled_tl2) ->


### PR DESCRIPTION
This PR adds the support for mode crossing in inclusion check.

The special case is the locality axis of the return mode of an arrow type, where mode crossing is not allowed. This is because a local-returning function might allocate in the caller's region, which is unsafe to forget. 

This also contains a fix to a test which I think is an improvement.