### PR TITLE
Add summary comments on recursive value compilation

### DIFF
--- a/ocaml/lambda/value_rec_compiler.mli
+++ b/ocaml/lambda/value_rec_compiler.mli
@@ -12,6 +12,29 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Overview of the compilation scheme
+
+    Given a set of recursive definitions, we sort them into four categories:
+
+    - Non-recursive definitions (more precisely, definitions classified as
+      [Dynamic] by [Value_rec_check]). These are compiled as regular
+      let-bindings, inserted before the rest.
+    - Constant definitions. These are definitions that have been classified
+      as [Static], but cannot be pre-allocated and cannot end up actually using
+      recursive values (i.e. let rec x = let _ = x in 0). These are compiled to
+      regular bindings too, modulo some renaming to remove references to
+      recursive variables.
+    - Blocks of static size. These are pre-allocated, new values are computed
+      from the definitions, and the contents of the new values is copied back
+      to the original allocation.
+    - Functional values. These are defined together in a single recursive block
+      full of functions. The definition occurs after the pre-allocation
+      (so the functions can refer to the recursive blocks) but before the
+      back-patching (so the block definitions can refer to the functions).
+
+    More detailed comments are available in the implementation.
+*)
+
 val compile_letrec :
   (Ident.t * Value_rec_types.recursive_binding_kind * Lambda.lambda) list ->
   Lambda.lambda ->

--- a/ocaml/typing/value_rec_types.mli
+++ b/ocaml/typing/value_rec_types.mli
@@ -21,7 +21,8 @@ type recursive_binding_kind =
 | Static
   (** Bindings for which some kind of pre-allocation scheme is possible.
       The expression is allowed to be recursive, as long as its definition does
-      not inspect recursively defined values. *)
+      not inspect recursively defined values.
+      See [Value_rec_compiler] for more details on the compilation scheme. *)
 | Dynamic
   (** Bindings for which pre-allocation is not possible.
       The expression is not allowed to refer to any recursive variable. *)


### PR DESCRIPTION
Following a suggestion from @mshinwell, I have put a summary  of the recursive value compilation scheme in `value_rec_compiler.mli`. The text is mostly taken from my comment in #3039.
