### PR TITLE
Support default modalities for signatures

### DIFF
--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -1628,15 +1628,15 @@ module Analyser =
           Module_type_alias { mta_name = Odoc_env.full_module_name env name ;
                               mta_module = None }
 
-      | Parsetree.Pmty_signature {psig_items; _} ->
+      | Parsetree.Pmty_signature {psg_items; _} ->
           (
-           let psig_items = filter_out_erased_items_from_signature erased psig_items in
+           let psg_items = filter_out_erased_items_from_signature erased psg_items in
            (* we must have a signature in the module type *)
            match sig_module_type with
              Types.Mty_signature signat ->
                let pos_start = Loc.start module_type.Parsetree.pmty_loc in
                let pos_end = Loc.end_ module_type.Parsetree.pmty_loc in
-               let elements = analyse_parsetree env signat current_module_name pos_start pos_end psig_items in
+               let elements = analyse_parsetree env signat current_module_name pos_start pos_end psg_items in
                Module_type_struct elements
            | _ ->
                raise (Failure "Parsetree.Pmty_signature signature but not Types.Mty_signature signat")
@@ -1725,9 +1725,9 @@ module Analyser =
             | _ ->
               raise (Failure "Parsetree.Pmty_alias _ but not Types.Mty_alias _")
            end
-      | Parsetree.Pmty_signature {psig_items; _} ->
+      | Parsetree.Pmty_signature {psg_items; _} ->
           (
-           let psig_items = filter_out_erased_items_from_signature erased psig_items in
+           let psg_items = filter_out_erased_items_from_signature erased psg_items in
            match sig_module_type with
              Types.Mty_signature signat ->
                Module_struct
@@ -1737,7 +1737,7 @@ module Analyser =
                     current_module_name
                     (Loc.start module_type.Parsetree.pmty_loc)
                     (Loc.end_ module_type.Parsetree.pmty_loc)
-                    psig_items
+                    psg_items
                  )
            | _ ->
                (* if we're here something's wrong *)
@@ -1906,15 +1906,15 @@ module Analyser =
           raise (Failure "analyse_class_type_kind: match failure")
 
     let analyse_signature source_file input_file
-        ({psig_items; _} : Parsetree.signature) (signat : Types.signature) =
+        ({psg_items; _} : Parsetree.signature) (signat : Types.signature) =
       prepare_file source_file input_file;
       (* We create the t_module for this file. *)
       let mod_name = Unit_info.modname_from_source source_file in
       let len, info_opt = preamble !file_name !file
-          (fun x -> x.Parsetree.psig_loc) psig_items in
-      let info_opt = analyze_toplevel_alerts info_opt psig_items in
+          (fun x -> x.Parsetree.psig_loc) psg_items in
+      let info_opt = analyze_toplevel_alerts info_opt psg_items in
       let elements =
-        analyse_parsetree Odoc_env.empty signat mod_name len (String.length !file) psig_items
+        analyse_parsetree Odoc_env.empty signat mod_name len (String.length !file) psg_items
       in
       let code_intf =
         if !Odoc_global.keep_code then

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -1628,15 +1628,15 @@ module Analyser =
           Module_type_alias { mta_name = Odoc_env.full_module_name env name ;
                               mta_module = None }
 
-      | Parsetree.Pmty_signature ast ->
+      | Parsetree.Pmty_signature {psig_items; _} ->
           (
-           let ast = filter_out_erased_items_from_signature erased ast in
+           let psig_items = filter_out_erased_items_from_signature erased psig_items in
            (* we must have a signature in the module type *)
            match sig_module_type with
              Types.Mty_signature signat ->
                let pos_start = Loc.start module_type.Parsetree.pmty_loc in
                let pos_end = Loc.end_ module_type.Parsetree.pmty_loc in
-               let elements = analyse_parsetree env signat current_module_name pos_start pos_end ast in
+               let elements = analyse_parsetree env signat current_module_name pos_start pos_end psig_items in
                Module_type_struct elements
            | _ ->
                raise (Failure "Parsetree.Pmty_signature signature but not Types.Mty_signature signat")
@@ -1725,9 +1725,9 @@ module Analyser =
             | _ ->
               raise (Failure "Parsetree.Pmty_alias _ but not Types.Mty_alias _")
            end
-      | Parsetree.Pmty_signature signature ->
+      | Parsetree.Pmty_signature {psig_items; _} ->
           (
-           let signature = filter_out_erased_items_from_signature erased signature in
+           let psig_items = filter_out_erased_items_from_signature erased psig_items in
            match sig_module_type with
              Types.Mty_signature signat ->
                Module_struct
@@ -1737,7 +1737,7 @@ module Analyser =
                     current_module_name
                     (Loc.start module_type.Parsetree.pmty_loc)
                     (Loc.end_ module_type.Parsetree.pmty_loc)
-                    signature
+                    psig_items
                  )
            | _ ->
                (* if we're here something's wrong *)
@@ -1906,15 +1906,15 @@ module Analyser =
           raise (Failure "analyse_class_type_kind: match failure")
 
     let analyse_signature source_file input_file
-        (ast : Parsetree.signature) (signat : Types.signature) =
+        ({psig_items; _} : Parsetree.signature) (signat : Types.signature) =
       prepare_file source_file input_file;
       (* We create the t_module for this file. *)
       let mod_name = Unit_info.modname_from_source source_file in
       let len, info_opt = preamble !file_name !file
-          (fun x -> x.Parsetree.psig_loc) ast in
-      let info_opt = analyze_toplevel_alerts info_opt ast in
+          (fun x -> x.Parsetree.psig_loc) psig_items in
+      let info_opt = analyze_toplevel_alerts info_opt psig_items in
       let elements =
-        analyse_parsetree Odoc_env.empty signat mod_name len (String.length !file) ast
+        analyse_parsetree Odoc_env.empty signat mod_name len (String.length !file) psig_items
       in
       let code_intf =
         if !Odoc_global.keep_code then

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -318,6 +318,11 @@ module Sig = struct
       f_txt
 end
 
+module Sg = struct
+  let mk ?(loc = !default_loc) ?(modalities = []) a =
+    {psig_items = a; psig_modalities = modalities; psig_sloc = loc}
+end
+
 module Str = struct
   let mk ?(loc = !default_loc) d = {pstr_desc = d; pstr_loc = loc}
 

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -320,7 +320,7 @@ end
 
 module Sg = struct
   let mk ?(loc = !default_loc) ?(modalities = []) a =
-    {psig_items = a; psig_modalities = modalities; psig_sloc = loc}
+    {psg_items = a; psg_modalities = modalities; psg_loc = loc}
 end
 
 module Str = struct

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -330,6 +330,12 @@ module Sig:
     val text: text -> signature_item list
   end
 
+module Sg:
+  sig
+    val mk : ?loc:loc -> ?modalities:modality with_loc list ->
+      signature_item list -> signature
+  end
+
 (** Structure items *)
 module Str:
   sig

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -712,7 +712,8 @@ let default_iterator =
     module_expr = M.iter;
     module_expr_jane_syntax = M.iter_ext;
     signature =
-      (fun this {psg_items; psg_modalities} ->
+      (fun this {psg_loc; psg_items; psg_modalities} ->
+        this.location this psg_loc;
         this.modalities this psg_modalities;
         List.iter (this.signature_item this) psg_items
       );

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -712,9 +712,9 @@ let default_iterator =
     module_expr = M.iter;
     module_expr_jane_syntax = M.iter_ext;
     signature =
-      (fun this {psig_items; psig_modalities} ->
-        this.modalities this psig_modalities;
-        List.iter (this.signature_item this) psig_items
+      (fun this {psg_items; psg_modalities} ->
+        this.modalities this psg_modalities;
+        List.iter (this.signature_item this) psg_items
       );
     signature_item = MT.iter_signature_item;
     module_type = MT.iter;

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -711,7 +711,11 @@ let default_iterator =
     structure_item = M.iter_structure_item;
     module_expr = M.iter;
     module_expr_jane_syntax = M.iter_ext;
-    signature = (fun this l -> List.iter (this.signature_item this) l);
+    signature =
+      (fun this {psig_items; psig_modalities} ->
+        this.modalities this psig_modalities;
+        List.iter (this.signature_item this) psig_items
+      );
     signature_item = MT.iter_signature_item;
     module_type = MT.iter;
     module_type_jane_syntax = MT.iter_jane_syntax;

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -1106,6 +1106,7 @@ module PpxContext = struct
     make_list (make_pair make_string (fun x -> x))
       (String.Map.bindings !cookies)
 
+  (* CR zqian: add [psg_attributes] to `Parsetree.signature`, and use that. *)
   let mk fields =
     {
       attr_name = { txt = "ocaml.ppx.context"; loc = Location.none };
@@ -1288,13 +1289,14 @@ let apply_lazy ~source ~target mapper =
       | _ -> [], psg_items
     in
     PpxContext.restore fields;
-    let psg_items =
+    let {psg_items; psg_modalities; psg_loc} =
       try
         let mapper = mapper () in
-        List.map (mapper.signature_item mapper) psg_items
+        mapper.signature mapper {psg_items; psg_modalities; psg_loc}
       with exn ->
-        [{psig_desc = Psig_extension (extension_of_exn exn, []);
-          psig_loc  = Location.none}]
+        { psg_items = [{psig_desc = Psig_extension (extension_of_exn exn, []);
+          psig_loc = Location.none}];
+          psg_modalities = []; psg_loc = Location.none }
     in
     let fields = PpxContext.update_cookies fields in
     let psg_items = Sig.attribute (PpxContext.mk fields) :: psg_items in

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -808,11 +808,11 @@ let default_mapper =
     module_expr = M.map;
     module_expr_jane_syntax = M.map_ext;
     signature =
-      (fun this {psig_items; psig_modalities; psig_sloc} ->
-        let psig_modalities = this.modalities this psig_modalities in
-        let psig_items = List.map (this.signature_item this) psig_items in
-        let psig_sloc = this.location this psig_sloc in
-        {psig_items; psig_modalities; psig_sloc}
+      (fun this {psg_items; psg_modalities; psg_loc} ->
+        let psg_modalities = this.modalities this psg_modalities in
+        let psg_items = List.map (this.signature_item this) psg_items in
+        let psg_loc = this.location this psg_loc in
+        {psg_items; psg_modalities; psg_loc}
       );
     signature_item = MT.map_signature_item;
     module_type = MT.map;
@@ -1278,27 +1278,27 @@ let apply_lazy ~source ~target mapper =
     let fields = PpxContext.update_cookies fields in
     Str.attribute (PpxContext.mk fields) :: ast
   in
-  let iface {psig_items; psig_modalities; psig_sloc} =
-    let fields, psig_items =
-      match psig_items with
+  let iface {psg_items; psg_modalities; psg_loc} =
+    let fields, psg_items =
+      match psg_items with
       | {psig_desc = Psig_attribute ({attr_name = {txt = "ocaml.ppx.context"};
                                       attr_payload = x;
                                       attr_loc = _})} :: l ->
           PpxContext.get_fields x, l
-      | _ -> [], psig_items
+      | _ -> [], psg_items
     in
     PpxContext.restore fields;
-    let psig_items =
+    let psg_items =
       try
         let mapper = mapper () in
-        List.map (mapper.signature_item mapper) psig_items
+        List.map (mapper.signature_item mapper) psg_items
       with exn ->
         [{psig_desc = Psig_extension (extension_of_exn exn, []);
           psig_loc  = Location.none}]
     in
     let fields = PpxContext.update_cookies fields in
-    let psig_items = Sig.attribute (PpxContext.mk fields) :: psig_items in
-    {psig_items; psig_modalities; psig_sloc}
+    let psg_items = Sig.attribute (PpxContext.mk fields) :: psg_items in
+    {psg_items; psg_modalities; psg_loc}
   in
 
   let ic = open_in_bin source in
@@ -1349,9 +1349,9 @@ let drop_ppx_context_sig_items ~restore = function
       items
   | items -> items
 
-let drop_ppx_context_sig ~restore {psig_items; psig_modalities; psig_sloc} =
-  let psig_items = drop_ppx_context_sig_items ~restore psig_items in
-  {psig_items; psig_modalities; psig_sloc}
+let drop_ppx_context_sig ~restore {psg_items; psg_modalities; psg_loc} =
+  let psg_items = drop_ppx_context_sig_items ~restore psg_items in
+  {psg_items; psg_modalities; psg_loc}
 
 let add_ppx_context_str ~tool_name ast =
   Ast_helper.Str.attribute (ppx_context ~tool_name ()) :: ast
@@ -1359,9 +1359,9 @@ let add_ppx_context_str ~tool_name ast =
 let add_ppx_context_sig_items ~tool_name ast =
     Ast_helper.Sig.attribute (ppx_context ~tool_name ()) :: ast
 
-let add_ppx_context_sig ~tool_name {psig_items; psig_modalities; psig_sloc} =
-  let psig_items = add_ppx_context_sig_items ~tool_name psig_items in
-  {psig_items; psig_modalities; psig_sloc}
+let add_ppx_context_sig ~tool_name {psg_items; psg_modalities; psg_loc} =
+  let psg_items = add_ppx_context_sig_items ~tool_name psg_items in
+  {psg_items; psg_modalities; psg_loc}
 
 let apply ~source ~target mapper =
   apply_lazy ~source ~target (fun () -> mapper)

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -807,7 +807,13 @@ let default_mapper =
     structure_item = M.map_structure_item;
     module_expr = M.map;
     module_expr_jane_syntax = M.map_ext;
-    signature = (fun this l -> List.map (this.signature_item this) l);
+    signature =
+      (fun this {psig_items; psig_modalities; psig_sloc} ->
+        let psig_modalities = this.modalities this psig_modalities in
+        let psig_items = List.map (this.signature_item this) psig_items in
+        let psig_sloc = this.location this psig_sloc in
+        {psig_items; psig_modalities; psig_sloc}
+      );
     signature_item = MT.map_signature_item;
     module_type = MT.map;
     with_constraint = MT.map_with_constraint;
@@ -1272,26 +1278,27 @@ let apply_lazy ~source ~target mapper =
     let fields = PpxContext.update_cookies fields in
     Str.attribute (PpxContext.mk fields) :: ast
   in
-  let iface ast =
-    let fields, ast =
-      match ast with
+  let iface {psig_items; psig_modalities; psig_sloc} =
+    let fields, psig_items =
+      match psig_items with
       | {psig_desc = Psig_attribute ({attr_name = {txt = "ocaml.ppx.context"};
                                       attr_payload = x;
                                       attr_loc = _})} :: l ->
           PpxContext.get_fields x, l
-      | _ -> [], ast
+      | _ -> [], psig_items
     in
     PpxContext.restore fields;
-    let ast =
+    let psig_items =
       try
         let mapper = mapper () in
-        mapper.signature mapper ast
+        List.map (mapper.signature_item mapper) psig_items
       with exn ->
         [{psig_desc = Psig_extension (extension_of_exn exn, []);
           psig_loc  = Location.none}]
     in
     let fields = PpxContext.update_cookies fields in
-    Sig.attribute (PpxContext.mk fields) :: ast
+    let psig_items = Sig.attribute (PpxContext.mk fields) :: psig_items in
+    {psig_items; psig_modalities; psig_sloc}
   in
 
   let ic = open_in_bin source in
@@ -1331,7 +1338,7 @@ let drop_ppx_context_str ~restore = function
       items
   | items -> items
 
-let drop_ppx_context_sig ~restore = function
+let drop_ppx_context_sig_items ~restore = function
   | {psig_desc = Psig_attribute
                    {attr_name = {Location.txt = "ocaml.ppx.context"};
                     attr_payload = a;
@@ -1342,12 +1349,19 @@ let drop_ppx_context_sig ~restore = function
       items
   | items -> items
 
+let drop_ppx_context_sig ~restore {psig_items; psig_modalities; psig_sloc} =
+  let psig_items = drop_ppx_context_sig_items ~restore psig_items in
+  {psig_items; psig_modalities; psig_sloc}
+
 let add_ppx_context_str ~tool_name ast =
   Ast_helper.Str.attribute (ppx_context ~tool_name ()) :: ast
 
-let add_ppx_context_sig ~tool_name ast =
-  Ast_helper.Sig.attribute (ppx_context ~tool_name ()) :: ast
+let add_ppx_context_sig_items ~tool_name ast =
+    Ast_helper.Sig.attribute (ppx_context ~tool_name ()) :: ast
 
+let add_ppx_context_sig ~tool_name {psig_items; psig_modalities; psig_sloc} =
+  let psig_items = add_ppx_context_sig_items ~tool_name psig_items in
+  {psig_items; psig_modalities; psig_sloc}
 
 let apply ~source ~target mapper =
   apply_lazy ~source ~target (fun () -> mapper)

--- a/parsing/ast_mapper.mli
+++ b/parsing/ast_mapper.mli
@@ -211,6 +211,9 @@ val add_ppx_context_sig:
     tool_name:string -> Parsetree.signature -> Parsetree.signature
 (** Same as [add_ppx_context_str], but for signatures. *)
 
+val add_ppx_context_sig_items:
+    tool_name:string -> Parsetree.signature_item list -> Parsetree.signature_item list
+
 val drop_ppx_context_str:
     restore:bool -> Parsetree.structure -> Parsetree.structure
 (** Drop the ocaml.ppx.context attribute from a structure.  If
@@ -220,6 +223,9 @@ val drop_ppx_context_str:
 val drop_ppx_context_sig:
     restore:bool -> Parsetree.signature -> Parsetree.signature
 (** Same as [drop_ppx_context_str], but for signatures. *)
+
+val drop_ppx_context_sig_items:
+    restore:bool -> Parsetree.signature_item list -> Parsetree.signature_item list
 
 (** {1 Cookies} *)
 

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -358,8 +358,8 @@ let rec attrs_of_sig_items = function
   | _ ->
       []
 
-let alerts_of_sig ~mark {psig_items; _} =
-  let a = attrs_of_sig_items psig_items in
+let alerts_of_sig ~mark {psg_items; _} =
+  let a = attrs_of_sig_items psg_items in
   if mark then mark_alerts_used a;
   alerts_of_attrs a
 

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -352,14 +352,14 @@ let check_deprecated_mutable_inclusion ~def ~use loc attrs1 attrs2 s =
       Location.deprecated ~def ~use loc
         (Printf.sprintf "mutating field %s" (cat s txt))
 
-let rec attrs_of_sig = function
+let rec attrs_of_sig_items = function
   | {psig_desc = Psig_attribute a} :: tl ->
-      a :: attrs_of_sig tl
+      a :: attrs_of_sig_items tl
   | _ ->
       []
 
-let alerts_of_sig ~mark sg =
-  let a = attrs_of_sig sg in
+let alerts_of_sig ~mark {psig_items; _} =
+  let a = attrs_of_sig_items psig_items in
   if mark then mark_alerts_used a;
   alerts_of_attrs a
 

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -498,7 +498,7 @@ and add_signature bv sg =
   ignore (add_signature_binding bv sg)
 
 and add_signature_binding bv sg =
-  snd (List.fold_left add_sig_item (bv, String.Map.empty) sg)
+  snd (List.fold_left add_sig_item (bv, String.Map.empty) sg.psig_items)
 
 (* When we merge [include functor] upstream this can get re-inlined *)
 and add_include_description (bv, m) incl =

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -498,7 +498,7 @@ and add_signature bv sg =
   ignore (add_signature_binding bv sg)
 
 and add_signature_binding bv sg =
-  snd (List.fold_left add_sig_item (bv, String.Map.empty) sg.psig_items)
+  snd (List.fold_left add_sig_item (bv, String.Map.empty) sg.psg_items)
 
 (* When we merge [include functor] upstream this can get re-inlined *)
 and add_include_description (bv, m) incl =

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -624,7 +624,9 @@ let wrap_mkstr_ext ~loc (item, ext) =
 let wrap_sig_ext ~loc body ext =
   match ext with
   | None -> body
-  | Some id -> ghsig ~loc (Psig_extension ((id, PSig [body]), []))
+  | Some id ->
+      ghsig ~loc (Psig_extension ((id, PSig {psig_items=[body];
+        psig_modalities=[]; psig_sloc=make_loc loc}), []))
 
 let wrap_mksig_ext ~loc (item, ext) =
   wrap_sig_ext ~loc (mksig ~loc item) ext
@@ -1934,8 +1936,10 @@ module_type:
 (* A signature, which appears between SIG and END (among other places),
    is a list of signature elements. *)
 signature:
-  extra_sig(flatten(signature_element*))
-    { $1 }
+  optional_atat_modalities_expr extra_sig(flatten(signature_element*))
+    { { psig_modalities = $1;
+        psig_items = $2;
+        psig_sloc = make_loc $sloc; } }
 ;
 
 (* A signature element is one of the following:

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -625,8 +625,8 @@ let wrap_sig_ext ~loc body ext =
   match ext with
   | None -> body
   | Some id ->
-      ghsig ~loc (Psig_extension ((id, PSig {psig_items=[body];
-        psig_modalities=[]; psig_sloc=make_loc loc}), []))
+      ghsig ~loc (Psig_extension ((id, PSig {psg_items=[body];
+        psg_modalities=[]; psg_loc=make_loc loc}), []))
 
 let wrap_mksig_ext ~loc (item, ext) =
   wrap_sig_ext ~loc (mksig ~loc item) ext
@@ -1937,9 +1937,9 @@ module_type:
    is a list of signature elements. *)
 signature:
   optional_atat_modalities_expr extra_sig(flatten(signature_element*))
-    { { psig_modalities = $1;
-        psig_items = $2;
-        psig_sloc = make_loc $sloc; } }
+    { { psg_modalities = $1;
+        psg_items = $2;
+        psg_loc = make_loc $sloc; } }
 ;
 
 (* A signature element is one of the following:

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -993,7 +993,12 @@ and functor_parameter =
             - [(X : MT)] when [name] is [Some X],
             - [(_ : MT)] when [name] is [None] *)
 
-and signature = signature_item list
+and signature =
+  {
+    psig_modalities : modalities;
+    psig_items : signature_item list;
+    psig_sloc : Location.t;
+  }
 
 and signature_item =
     {

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -995,9 +995,9 @@ and functor_parameter =
 
 and signature =
   {
-    psig_modalities : modalities;
-    psig_items : signature_item list;
-    psig_sloc : Location.t;
+    psg_modalities : modalities;
+    psg_items : signature_item list;
+    psg_loc : Location.t;
   }
 
 and signature_item =

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1494,10 +1494,10 @@ and module_type1 ctxt f x =
         pp f "%a" longident_loc li;
     | Pmty_alias li ->
         pp f "(module %a)" longident_loc li;
-    | Pmty_signature {psig_items; psig_modalities} ->
+    | Pmty_signature {psg_items; psg_modalities} ->
         pp f "@[<hv0>@[<hv2>sig%a@ %a@]@ end@]" (* "@[<hov>sig@ %a@ end@]" *)
-          optional_space_atat_modalities psig_modalities
-          (list (signature_item ctxt)) psig_items (* FIXME wrong indentation*)
+          optional_space_atat_modalities psg_modalities
+          (list (signature_item ctxt)) psg_items (* FIXME wrong indentation*)
     | Pmty_typeof me ->
         pp f "@[<hov2>module@ type@ of@ %a@]" (module_expr ctxt) me
     | Pmty_extension e -> extension ctxt f e
@@ -1508,9 +1508,9 @@ and module_type_jane_syntax1 ctxt attrs f : Jane_syntax.Module_type.t -> _ =
   | Jmty_strengthen _ as jmty ->
       paren true (module_type_jane_syntax ctxt attrs) f jmty
 
-and signature ctxt f {psig_items; psig_modalities} =
-  optional_atat_modalities_newline f psig_modalities;
-  signature_items ctxt f psig_items
+and signature ctxt f {psg_items; psg_modalities} =
+  optional_atat_modalities_newline f psg_modalities;
+  signature_items ctxt f psg_items
 
 and signature_items ctxt f items =
   list ~sep:"@\n" (signature_item ctxt) f items

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -379,10 +379,19 @@ let modality f m =
 let modalities f m =
   pp_print_list ~pp_sep:(fun f () -> pp f " ") modality f m
 
-let optional_atat_modalities f m =
+let optional_atat_modalities ?(pre = fun _ () -> ()) ?(post = fun _ () -> ()) f m =
   match m with
   | [] -> ()
-  | m -> pp f " %@%@ %a" modalities m
+  | m ->
+    pre f ();
+    pp f "%@%@ %a" modalities m;
+    post f ()
+
+let optional_space_atat_modalities f m =
+  optional_atat_modalities ~pre:pp_print_space f m
+
+let optional_atat_modalities_newline f m =
+  optional_atat_modalities ~post:pp_print_newline f m
 
 (* helpers for printing both legacy/new mode syntax *)
 let split_out_legacy_modes =
@@ -410,7 +419,7 @@ let modalities_type pty ctxt f pca =
   pp f "%a%a%a"
     optional_legacy_modalities legacy
     (pty ctxt) pca.pca_type
-    optional_atat_modalities m
+    optional_space_atat_modalities m
 
 let include_kind f = function
   | Functor -> pp f "@ functor"
@@ -1195,7 +1204,7 @@ and value_description ctxt f x =
   (* note: value_description has an attribute field,
            but they're already printed by the callers this method *)
   pp f "@[<hov2>%a%a%a@]" (core_type ctxt) x.pval_type
-    optional_atat_modalities x.pval_modalities
+    optional_space_atat_modalities x.pval_modalities
     (fun f x ->
        if x.pval_prim <> []
        then pp f "@ =@ %a" (list constant_string) x.pval_prim
@@ -1409,7 +1418,7 @@ and include_ : 'a. ctxt -> formatter ->
 
 and sig_include ctxt f incl moda =
   include_ ctxt f ~contents:module_type incl;
-  optional_atat_modalities f moda
+  optional_space_atat_modalities f moda
 
 and kind_abbrev ctxt f name jkind =
   pp f "@[<hov2>kind_abbrev_@ %a@ =@ %a@]"
@@ -1485,9 +1494,10 @@ and module_type1 ctxt f x =
         pp f "%a" longident_loc li;
     | Pmty_alias li ->
         pp f "(module %a)" longident_loc li;
-    | Pmty_signature (s) ->
-        pp f "@[<hv0>@[<hv2>sig@ %a@]@ end@]" (* "@[<hov>sig@ %a@ end@]" *)
-          (list (signature_item ctxt)) s (* FIXME wrong indentation*)
+    | Pmty_signature {psig_items; psig_modalities} ->
+        pp f "@[<hv0>@[<hv2>sig%a@ %a@]@ end@]" (* "@[<hov>sig@ %a@ end@]" *)
+          optional_space_atat_modalities psig_modalities
+          (list (signature_item ctxt)) psig_items (* FIXME wrong indentation*)
     | Pmty_typeof me ->
         pp f "@[<hov2>module@ type@ of@ %a@]" (module_expr ctxt) me
     | Pmty_extension e -> extension ctxt f e
@@ -1498,7 +1508,12 @@ and module_type_jane_syntax1 ctxt attrs f : Jane_syntax.Module_type.t -> _ =
   | Jmty_strengthen _ as jmty ->
       paren true (module_type_jane_syntax ctxt attrs) f jmty
 
-and signature ctxt f x =  list ~sep:"@\n" (signature_item ctxt) f x
+and signature ctxt f {psig_items; psig_modalities} =
+  optional_atat_modalities_newline f psig_modalities;
+  signature_items ctxt f psig_items
+
+and signature_items ctxt f items =
+  list ~sep:"@\n" (signature_item ctxt) f items
 
 and signature_item ctxt f x : unit =
   match x.psig_desc with
@@ -1976,7 +1991,7 @@ and record_declaration ctxt f lbls =
       optional_legacy_modalities legacy
       ident_of_name pld.pld_name.txt
       (core_type ctxt) pld.pld_type
-      optional_atat_modalities m
+      optional_space_atat_modalities m
       (attributes ctxt) pld.pld_attributes
   in
   pp f "{@\n%a}"
@@ -2325,6 +2340,7 @@ let class_type = print_reset_with_maximal_extensions class_type
 let class_signature = print_reset_with_maximal_extensions class_signature
 let structure_item = print_reset_with_maximal_extensions structure_item
 let signature_item = print_reset_with_maximal_extensions signature_item
+let signature_items = print_reset_with_maximal_extensions signature_items
 let binding = print_reset_with_maximal_extensions binding
 let payload = print_reset_with_maximal_extensions payload
 let type_declaration = print_reset_with_maximal_extensions type_declaration

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -47,6 +47,7 @@ val class_type: Format.formatter -> Parsetree.class_type -> unit
 val module_type: Format.formatter -> Parsetree.module_type -> unit
 val structure_item: Format.formatter -> Parsetree.structure_item -> unit
 val signature_item: Format.formatter -> Parsetree.signature_item -> unit
+val signature_items: Format.formatter -> Parsetree.signature_item list -> unit
 val binding: Format.formatter -> Parsetree.value_binding -> unit
 val payload: Format.formatter -> Parsetree.payload -> unit
 

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -791,7 +791,9 @@ and module_type i ppf x =
       line i ppf "Pmod_extension \"%s\"\n" s.txt;
       payload i ppf arg
 
-and signature i ppf x = list i signature_item ppf x
+and signature i ppf {psig_items; psig_modalities} =
+  modalities i ppf psig_modalities;
+  list i signature_item ppf psig_items
 
 and signature_item i ppf x =
   line i ppf "signature_item %a\n" fmt_location x.psig_loc;
@@ -1108,7 +1110,9 @@ and directive_argument i ppf x =
   | Pdir_ident (li) -> line i ppf "Pdir_ident %a\n" fmt_longident li
   | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b)
 
-let interface ppf x = list 0 signature_item ppf x
+let interface ppf {psig_items; psig_modalities} =
+  modalities 0 ppf psig_modalities;
+  list 0 signature_item ppf psig_items
 
 let implementation ppf x = list 0 structure_item ppf x
 

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -791,9 +791,9 @@ and module_type i ppf x =
       line i ppf "Pmod_extension \"%s\"\n" s.txt;
       payload i ppf arg
 
-and signature i ppf {psig_items; psig_modalities} =
-  modalities i ppf psig_modalities;
-  list i signature_item ppf psig_items
+and signature i ppf {psg_items; psg_modalities} =
+  modalities i ppf psg_modalities;
+  list i signature_item ppf psg_items
 
 and signature_item i ppf x =
   line i ppf "signature_item %a\n" fmt_location x.psig_loc;
@@ -1110,9 +1110,9 @@ and directive_argument i ppf x =
   | Pdir_ident (li) -> line i ppf "Pdir_ident %a\n" fmt_longident li
   | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b)
 
-let interface ppf {psig_items; psig_modalities} =
-  modalities 0 ppf psig_modalities;
-  list 0 signature_item ppf psig_items
+let interface ppf {psg_items; psg_modalities} =
+  modalities 0 ppf psg_modalities;
+  list 0 signature_item ppf psg_items
 
 let implementation ppf x = list 0 structure_item ppf x
 

--- a/parsing/printast.mli
+++ b/parsing/printast.mli
@@ -23,7 +23,7 @@
 open Parsetree
 open Format
 
-val interface : formatter -> signature_item list -> unit
+val interface : formatter -> signature -> unit
 val implementation : formatter -> structure_item list -> unit
 val top_phrase : formatter -> toplevel_phrase -> unit
 val constant: formatter -> constant -> unit
@@ -34,4 +34,3 @@ val structure: int -> formatter -> structure -> unit
 val payload: int -> formatter -> payload -> unit
 val core_type: int -> formatter -> core_type -> unit
 val extension_constructor: int -> formatter -> extension_constructor -> unit
-

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -837,7 +837,9 @@ and module_type i ppf x =
       payload i ppf arg
   )
 
-and signature i ppf x = list i signature_item ppf x
+and signature i ppf {psig_items; psig_modalities} =
+  modalities i ppf psig_modalities;
+  list i signature_item ppf psig_items
 
 and signature_item i ppf x =
   with_location_mapping ~loc:x.psig_loc ppf (fun () ->
@@ -1149,7 +1151,10 @@ and directive_argument i ppf x =
   | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b);
 ;;
 
-let interface ppf x = list 0 signature_item ppf x;;
+let interface ppf {psig_items; psig_modalities} =
+  modalities 0 ppf psig_modalities;
+  list 0 signature_item ppf psig_items
+;;
 
 let implementation ppf x = list 0 structure_item ppf x;;
 

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -837,9 +837,9 @@ and module_type i ppf x =
       payload i ppf arg
   )
 
-and signature i ppf {psig_items; psig_modalities} =
-  modalities i ppf psig_modalities;
-  list i signature_item ppf psig_items
+and signature i ppf {psg_items; psg_modalities} =
+  modalities i ppf psg_modalities;
+  list i signature_item ppf psg_items
 
 and signature_item i ppf x =
   with_location_mapping ~loc:x.psig_loc ppf (fun () ->
@@ -1151,9 +1151,9 @@ and directive_argument i ppf x =
   | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b);
 ;;
 
-let interface ppf {psig_items; psig_modalities} =
-  modalities 0 ppf psig_modalities;
-  list 0 signature_item ppf psig_items
+let interface ppf {psg_items; psg_modalities} =
+  modalities 0 ppf psg_modalities;
+  list 0 signature_item ppf psg_items
 ;;
 
 let implementation ppf x = list 0 structure_item ppf x;;

--- a/printer/printast_with_mappings.mli
+++ b/printer/printast_with_mappings.mli
@@ -23,7 +23,7 @@
 open Parsetree;;
 open Format;;
 
-val interface : formatter -> signature_item list -> unit;;
+val interface : formatter -> signature -> unit;;
 val implementation : formatter -> structure_item list -> unit;;
 val top_phrase : formatter -> toplevel_phrase -> unit;;
 

--- a/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -62,6 +62,7 @@ module Example = struct
                                }
                          ; psig_loc = loc
                          }
+  let signature_items  = [signature_item]
   let value_binding    = { pvb_pat = pattern
                          ; pvb_expr = expression
                          ; pvb_attributes = []
@@ -163,6 +164,7 @@ end = struct
   let module_type = test "module_type" module_type Example.module_type
   let structure_item = test "structure_item" structure_item Example.structure_item
   let signature_item = test "signature_item" signature_item Example.signature_item
+  let signature_items = test "signature_items" signature_items Example.signature_items
   let binding = test "binding" binding Example.value_binding
   let payload = test "payload" payload Example.payload
   let class_signature = test "class_signature" class_signature Example.class_signature

--- a/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -36,6 +36,8 @@ structure_item: ;;[x for x = 1 to 10]
 
 signature_item: module M : sig include functor F end
 
+signature_items: module M : sig include functor F end
+
 binding: [:_:] = [x for x = 1 to 10]
 
 payload: include functor F
@@ -98,6 +100,8 @@ module_type: sig include functor F end
 structure_item: ;;[x for x = 1 to 10]
 
 signature_item: module M : sig include functor F end
+
+signature_items: module M : sig include functor F end
 
 binding: [:_:] = [x for x = 1 to 10]
 

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -450,8 +450,8 @@ val f1 : ('a : value_or_null). local_ 'a -> unit @@ global many = <fun>
 val f2 : unit -> unit @@ global many = <fun>
 |}]
 
-module type S = sig
-  module type S0 = sig
+module type S = sig @@ portable contended
+  module type S0 = sig @@ portable contended
     val x1 : string -> string @@ local
     val x2 : string -> string @@ portable
     val x3 : string -> string @@ nonportable

--- a/testsuite/tests/typing-modes/portable_interface.mli
+++ b/testsuite/tests/typing-modes/portable_interface.mli
@@ -1,0 +1,15 @@
+(* TEST
+    readonly_files = "portable_interface.mli use_portable_interface.ml";
+    flags += "-extension mode_alpha";
+    setup-ocamlc.byte-build-env;
+    module = "portable_interface.mli";
+    ocamlc.byte;
+    module = "use_portable_interface.ml";
+    ocamlc.byte;
+    check-ocamlc.byte-output;
+*)
+
+@@portable
+
+val foo : 'a -> 'a
+val bar : 'a -> 'a @@ nonportable

--- a/testsuite/tests/typing-modes/use_portable_interface.ml
+++ b/testsuite/tests/typing-modes/use_portable_interface.ml
@@ -1,0 +1,3 @@
+let use_portable (_ @ portable) = ()
+
+let () = use_portable Portable_interface.foo

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -793,6 +793,21 @@ end
 module type T = sig val foo : 'a -> 'a @@ contended end
 |}]
 
+(* default modalities is a syntax sugar that doesn't constitute the meaning of
+   a module type *)
+module type SR = sig @@ portable
+  end
+
+module type SL = sig
+  end
+
+module F (X : SL) : SR = X
+[%%expect{|
+module type SR = sig end
+module type SL = sig end
+module F : functor (X : SL) -> SR
+|}]
+
 
 (* interaction between open and locks *)
 module M_nonportable = struct

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -742,6 +742,57 @@ module type S' =
   end
 |}]
 
+module type T = sig @@ portable
+  val foo : 'a -> 'a
+  val bar : 'a -> 'a @@ nonportable
+  val baz : 'a -> 'a @@ portable
+end
+[%%expect{|
+module type T =
+  sig
+    val foo : 'a -> 'a @@ portable
+    val bar : 'a -> 'a
+    val baz : 'a -> 'a @@ portable
+  end
+|}]
+
+(* default modalities does not go deep into module types *)
+module type T = sig @@ portable
+  module type T = sig
+    val foo : 'a -> 'a
+  end
+end
+[%%expect{|
+module type T = sig module type T = sig val foo : 'a -> 'a end end
+|}]
+
+(* default modalities does not go deep into modules *)
+module type T = sig @@ portable
+  module M : sig
+    val foo : 'a -> 'a
+  end
+end
+[%%expect{|
+module type T = sig module M : sig val foo : 'a -> 'a end end
+|}]
+
+(* default modalities affect include modalities, which is deep. *)
+module type T = sig @@ portable
+  include T
+end
+[%%expect{|
+module type T = sig module M : sig val foo : 'a -> 'a @@ portable end end
+|}]
+
+(* default modalities is overridden as a whole, not per-axis *)
+(* CR zqian: make overriding per-axis *)
+module type T = sig @@ portable
+  val foo : 'a -> 'a @@ contended
+end
+[%%expect{|
+module type T = sig val foo : 'a -> 'a @@ contended end
+|}]
+
 
 (* interaction between open and locks *)
 module M_nonportable = struct

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -35,7 +35,7 @@ val transl_type_extension:
     Typedtree.type_extension * Env.t * Shape.t list
 
 val transl_value_decl:
-    Env.t -> Location.t ->
+    Env.t -> sig_modalities:Mode.Modality.Value.Const.t -> Location.t ->
     Parsetree.value_description -> Typedtree.value_description * Env.t
 
 (* If the [fixed_row_path] optional argument is provided,

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -509,8 +509,10 @@ and primitive_coercion =
 
 and signature = {
   sig_items : signature_item list;
+  sig_modalities : Mode.Modality.Value.Const.t;
   sig_type : Types.signature;
   sig_final_env : Env.t;
+  sig_sloc : Location.t;
 }
 
 and signature_item =

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -782,8 +782,10 @@ and primitive_coercion =
 
 and signature = {
   sig_items : signature_item list;
+  sig_modalities : Mode.Modality.Value.Const.t;
   sig_type : Types.signature;
   sig_final_env : Env.t;
+  sig_sloc : Location.t;
 }
 
 and signature_item =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1105,7 +1105,7 @@ and approx_module_declaration env pmd =
     md_uid = Uid.internal_not_actually_unique;
   }
 
-and approx_sig env {psig_items; _} = approx_sig_items env psig_items
+and approx_sig env {psg_items; _} = approx_sig_items env psg_items
 
 and approx_sig_items env ssg=
   match ssg with
@@ -1701,16 +1701,16 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
   let tcstr = Option.get tcstr in
   ((path, lid, tcstr) :: rev_tcstrs, sg)
 
-and transl_signature env {psig_items; psig_modalities; psig_sloc} =
+and transl_signature env {psg_items; psg_modalities; psg_loc} =
   let names = Signature_names.create () in
 
   let has_sig_modalities =
-    match psig_modalities with
+    match psg_modalities with
     | [] -> false
     | _ :: _ -> true
   in
   let sig_modalities =
-      Typemode.transl_modalities ~maturity:Alpha Immutable [] psig_modalities
+      Typemode.transl_modalities ~maturity:Alpha Immutable [] psg_modalities
   in
 
   let transl_include ~loc env sig_acc sincl modalities =
@@ -2039,12 +2039,12 @@ and transl_signature env {psig_items; psig_modalities; psig_sloc} =
   Builtin_attributes.warning_scope []
     (fun () ->
        let (trem, rem, final_env) =
-         transl_sig (Env.in_signature true env) [] [] psig_items
+         transl_sig (Env.in_signature true env) [] [] psg_items
        in
        let rem = Signature_names.simplify final_env names rem in
        let sg =
          { sig_items = trem; sig_type = rem; sig_final_env = final_env;
-           sig_modalities; sig_sloc = psig_sloc }
+           sig_modalities; sig_sloc = psg_loc }
        in
        Cmt_format.set_saved_types
          ((Cmt_format.Partial_signature sg) :: previous_saved_types);
@@ -3831,7 +3831,7 @@ let save_signature target modname tsg initial_env cmi =
     (Cmt_format.Interface tsg) initial_env None
 
 let cms_register_toplevel_signature_attributes ~sourcefile ~uid ast =
-  cms_register_toplevel_attributes ~sourcefile ~uid ast.psig_items
+  cms_register_toplevel_attributes ~sourcefile ~uid ast.psg_items
     ~f:(function
         | { psig_desc = Psig_attribute attr; _ } -> Some attr
         | _ -> None)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1105,19 +1105,21 @@ and approx_module_declaration env pmd =
     md_uid = Uid.internal_not_actually_unique;
   }
 
-and approx_sig env ssg =
+and approx_sig env {psig_items; _} = approx_sig_items env psig_items
+
+and approx_sig_items env ssg=
   match ssg with
     [] -> []
   | item :: srem ->
       match item.psig_desc with
       | Psig_type (rec_flag, sdecls) ->
           let decls = Typedecl.approx_type_decl sdecls in
-          let rem = approx_sig env srem in
+          let rem = approx_sig_items env srem in
           map_rec_type ~rec_flag
             (fun rs (id, info) -> Sig_type(id, info, rs, Exported)) decls rem
-      | Psig_typesubst _ -> approx_sig env srem
+      | Psig_typesubst _ -> approx_sig_items env srem
       | Psig_module { pmd_name = { txt = None; _ }; _ } ->
-          approx_sig env srem
+          approx_sig_items env srem
       | Psig_module pmd ->
           let scope = Ctype.create_scope () in
           let md = approx_module_declaration env pmd in
@@ -1130,7 +1132,7 @@ and approx_sig env ssg =
             Env.enter_module_declaration ~scope (Option.get pmd.pmd_name.txt)
               pres md env
           in
-          Sig_module(id, pres, md, Trec_not, Exported) :: approx_sig newenv srem
+          Sig_module(id, pres, md, Trec_not, Exported) :: approx_sig_items newenv srem
       | Psig_modsubst pms ->
           let scope = Ctype.create_scope () in
           let _, md, _ =
@@ -1145,7 +1147,7 @@ and approx_sig env ssg =
           let _, newenv =
             Env.enter_module_declaration ~scope pms.pms_name.txt pres md env
           in
-          approx_sig newenv srem
+          approx_sig_items newenv srem
       | Psig_recmodule sdecls ->
           let scope = Ctype.create_scope () in
           let decls =
@@ -1167,24 +1169,24 @@ and approx_sig env ssg =
           map_rec
             (fun rs (id, md) -> Sig_module(id, Mp_present, md, rs, Exported))
             decls
-            (approx_sig newenv srem)
+            (approx_sig_items newenv srem)
       | Psig_modtype d ->
           let info = approx_modtype_info env d in
           let scope = Ctype.create_scope () in
           let (id, newenv) =
             Env.enter_modtype ~scope d.pmtd_name.txt info env
           in
-          Sig_modtype(id, info, Exported) :: approx_sig newenv srem
+          Sig_modtype(id, info, Exported) :: approx_sig_items newenv srem
       | Psig_modtypesubst d ->
           let info = approx_modtype_info env d in
           let scope = Ctype.create_scope () in
           let (_id, newenv) =
             Env.enter_modtype ~scope d.pmtd_name.txt info env
           in
-          approx_sig newenv srem
+          approx_sig_items newenv srem
       | Psig_open sod ->
           let _, env = type_open_descr env sod in
-          approx_sig env srem
+          approx_sig_items env srem
       | Psig_include ({pincl_loc=loc; pincl_mod=mod_; pincl_kind=kind;
             pincl_attributes=attrs}, moda) ->
           begin match kind with
@@ -1208,11 +1210,11 @@ and approx_sig env ssg =
                   apply_modalities_signature ~recursive env modalities sg
               in
               let sg, newenv = Env.enter_signature ~scope sg env in
-              sg @ approx_sig newenv srem
+              sg @ approx_sig_items newenv srem
           end
       | Psig_class sdecls | Psig_class_type sdecls ->
           let decls, env = Typeclass.approx_class_declarations env sdecls in
-          let rem = approx_sig env srem in
+          let rem = approx_sig_items env srem in
           map_rec (fun rs decl ->
             let open Typeclass in [
               Sig_class_type(decl.clsty_ty_id, decl.clsty_ty_decl, rs,
@@ -1224,7 +1226,7 @@ and approx_sig env ssg =
       | Psig_kind_abbrev _ ->
           Misc.fatal_error "kind_abbrev not supported!"
       | _ ->
-          approx_sig env srem
+          approx_sig_items env srem
 
 and approx_modtype_info env sinfo =
   {
@@ -1699,10 +1701,17 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
   let tcstr = Option.get tcstr in
   ((path, lid, tcstr) :: rev_tcstrs, sg)
 
-
-
-and transl_signature env sg =
+and transl_signature env {psig_items; psig_modalities; psig_sloc} =
   let names = Signature_names.create () in
+
+  let has_sig_modalities =
+    match psig_modalities with
+    | [] -> false
+    | _ :: _ -> true
+  in
+  let sig_modalities =
+      Typemode.transl_modalities ~maturity:Alpha Immutable [] psig_modalities
+  in
 
   let transl_include ~loc env sig_acc sincl modalities =
     let smty = sincl.pincl_mod in
@@ -1723,18 +1732,21 @@ and transl_signature env sg =
       | Structure ->
         Tincl_structure, extract_sig env smty.pmty_loc mty
     in
-    let sg, modalities =
+    let has_modalities, modalities =
       match modalities with
-      | [] -> sg, Mode.Modality.Value.Const.id
+      | [] -> has_sig_modalities, sig_modalities
       | _ ->
-        let modalities =
-          Typemode.transl_modalities ~maturity:Alpha Immutable [] modalities
-        in
+        true, Typemode.transl_modalities ~maturity:Alpha Immutable [] modalities
+    in
+    let sg =
+      if has_modalities then
         let recursive =
           not @@ Builtin_attributes.has_attribute "no_recursive_modalities"
             sincl.pincl_attributes
         in
-        apply_modalities_signature ~recursive env modalities sg, modalities
+        apply_modalities_signature ~recursive env modalities sg
+      else
+        sg
     in
     let sg, newenv = Env.enter_signature ~scope sg env in
     Signature_group.iter
@@ -1756,7 +1768,7 @@ and transl_signature env sg =
     match item.psig_desc with
     | Psig_value sdesc ->
         let (tdesc, newenv) =
-          Typedecl.transl_value_decl env item.psig_loc sdesc
+          Typedecl.transl_value_decl env ~sig_modalities item.psig_loc sdesc
         in
         Signature_names.check_value names tdesc.val_loc tdesc.val_id;
         mksig (Tsig_value tdesc) env loc,
@@ -2027,11 +2039,12 @@ and transl_signature env sg =
   Builtin_attributes.warning_scope []
     (fun () ->
        let (trem, rem, final_env) =
-         transl_sig (Env.in_signature true env) [] [] sg
+         transl_sig (Env.in_signature true env) [] [] psig_items
        in
        let rem = Signature_names.simplify final_env names rem in
        let sg =
-         { sig_items = trem; sig_type = rem; sig_final_env = final_env }
+         { sig_items = trem; sig_type = rem; sig_final_env = final_env;
+           sig_modalities; sig_sloc = psig_sloc }
        in
        Cmt_format.set_saved_types
          ((Cmt_format.Partial_signature sg) :: previous_saved_types);
@@ -3033,7 +3046,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
         shape_map,
         newenv
     | Pstr_primitive sdesc ->
-        let (desc, newenv) = Typedecl.transl_value_decl env loc sdesc in
+        let (desc, newenv) = Typedecl.transl_value_decl env ~sig_modalities:Mode.Modality.Value.Const.id loc sdesc in
         Signature_names.check_value names desc.val_loc desc.val_id;
         Tstr_primitive desc,
         [Sig_value(desc.val_id, desc.val_val, Exported)],
@@ -3818,7 +3831,7 @@ let save_signature target modname tsg initial_env cmi =
     (Cmt_format.Interface tsg) initial_env None
 
 let cms_register_toplevel_signature_attributes ~sourcefile ~uid ast =
-  cms_register_toplevel_attributes ~sourcefile ~uid ast
+  cms_register_toplevel_attributes ~sourcefile ~uid ast.psig_items
     ~f:(function
         | { psig_desc = Psig_attribute attr; _ } -> Some attr
         | _ -> None)

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -755,10 +755,10 @@ let module_type_declaration sub mtd =
     (map_loc sub mtd.mtd_name)
 
 let signature sub {sig_items; sig_modalities; sig_sloc} =
-  let psig_items = List.map (sub.signature_item sub) sig_items in
-  let psig_modalities = Typemode.untransl_modalities Immutable [] sig_modalities in
-  let psig_sloc = sub.location sub sig_sloc in
-  {psig_items; psig_modalities; psig_sloc}
+  let psg_items = List.map (sub.signature_item sub) sig_items in
+  let psg_modalities = Typemode.untransl_modalities Immutable [] sig_modalities in
+  let psg_loc = sub.location sub sig_sloc in
+  {psg_items; psg_modalities; psg_loc}
 
 let signature_item sub item =
   let loc = sub.location sub item.sig_loc in

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -754,8 +754,11 @@ let module_type_declaration sub mtd =
     ?typ:(Option.map (sub.module_type sub) mtd.mtd_type)
     (map_loc sub mtd.mtd_name)
 
-let signature sub sg =
-  List.map (sub.signature_item sub) sg.sig_items
+let signature sub {sig_items; sig_modalities; sig_sloc} =
+  let psig_items = List.map (sub.signature_item sub) sig_items in
+  let psig_modalities = Typemode.untransl_modalities Immutable [] sig_modalities in
+  let psig_sloc = sub.location sub sig_sloc in
+  {psig_items; psig_modalities; psig_sloc}
 
 let signature_item sub item =
   let loc = sub.location sub item.sig_loc in


### PR DESCRIPTION
This PR adds the support for default modalities on signatures, including file-level signatures (`.mli`).

Please see added tests for syntax.

Please do not merge until I finish the internal migration.