### PR TITLE
Hacky front-end support for arrays of unboxed products

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -956,6 +956,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Pmakearray (array_kind, _, _mode) ->
         let array_kind = Empty_array_kind.of_lambda array_kind in
         register_const0 acc (Static_const.empty_array array_kind) "empty_array"
+      | Pmakearray_dynamic (_array_kind, _mode) ->
+        Misc.fatal_error "Closure_conversion.close_primitive: unimplemented"
       | Pbytes_to_string | Pbytes_of_string | Parray_of_iarray
       | Parray_to_iarray | Pignore | Pgetglobal _ | Psetglobal _ | Pgetpredef _
       | Pfield _ | Pfield_computed _ | Psetfield _ | Psetfield_computed _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -708,6 +708,7 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Punboxed_float_comp (_, _)
   | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu | Pbytessetu
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
+  | Pmakearray_dynamic _
   | Pisint _ | Pisout | Pbintofint _ | Pintofbint _ | Pcvtbint _ | Pnegbint _
   | Paddbint _ | Psubbint _ | Pmulbint _
   | Pdivbint { is_safe = Unsafe; _ }

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -134,6 +134,9 @@ let convert_array_kind (kind : L.array_kind) : converted_array_kind =
   | Punboxedintarray Pint64 -> Array_kind Naked_int64s
   | Punboxedintarray Pnativeint -> Array_kind Naked_nativeints
   | Punboxedvectorarray Pvec128 -> Array_kind Naked_vec128s
+  | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_kind: unimplemented"
 
 let convert_array_kind_for_length kind : P.Array_kind_for_length.t =
   match convert_array_kind kind with
@@ -178,6 +181,9 @@ let convert_array_ref_kind (kind : L.array_ref_kind) : converted_array_ref_kind
   | Punboxedintarray_ref Pint64 -> Array_ref_kind Naked_int64s
   | Punboxedintarray_ref Pnativeint -> Array_ref_kind Naked_nativeints
   | Punboxedvectorarray_ref Pvec128 -> Array_ref_kind Naked_vec128s
+  | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_ref_kind: unimplemented"
 
 let convert_array_ref_kind_for_length array_ref_kind : P.Array_kind_for_length.t
     =
@@ -241,6 +247,9 @@ let convert_array_set_kind (kind : L.array_set_kind) : converted_array_set_kind
   | Punboxedintarray_set Pint64 -> Array_set_kind Naked_int64s
   | Punboxedintarray_set Pnativeint -> Array_set_kind Naked_nativeints
   | Punboxedvectorarray_set Pvec128 -> Array_set_kind Naked_vec128s
+  | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_set_kind: unimplemented"
 
 let convert_array_set_kind_for_length array_set_kind : P.Array_kind_for_length.t
     =
@@ -280,6 +289,10 @@ let convert_array_kind_to_duplicate_array_kind (kind : L.array_kind) :
     Duplicate_array_kind (Naked_nativeints { length = None })
   | Punboxedvectorarray Pvec128 ->
     Duplicate_array_kind (Naked_vec128s { length = None })
+  | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_kind_to_duplicate_array_kind\
+       : unimplemented"
 
 let convert_field_read_semantics (sem : L.field_read_semantics) : Mutability.t =
   match sem with Reads_agree -> Immutable | Reads_vary -> Mutable
@@ -1066,6 +1079,9 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         | Punboxedvectorarray Pvec128 ->
           args
         | Pfloatarray -> List.map unbox_float args
+        | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+          Misc.fatal_error
+            "Lambda_to_flambda_primitives.convert_lprim: unimplemented"
       in
       [Variadic (Make_array (array_kind, mutability, mode), args)]
     | Float_array_opt_dynamic -> (
@@ -1086,6 +1102,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
                   List.map unbox_float args ),
               Variadic (Make_array (Values, mutability, mode), args),
               [K.With_subkind.any_value] ) ]))
+  | Pmakearray_dynamic (_lambda_array_kind, _mode), _ ->
+    Misc.fatal_error "Lambda_to_flambda_primitives.convert_lprim: unimplemented"
   | Popaque layout, [arg] -> opaque layout arg ~middle_end_only:false
   | Pobj_magic layout, [arg] -> opaque layout arg ~middle_end_only:true
   | Pduprecord (repr, num_fields), [[arg]] ->
@@ -2024,13 +2042,15 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       | Parrayrefu
           ( ( Pgenarray_ref _ | Paddrarray_ref | Pintarray_ref
             | Pfloatarray_ref _ | Punboxedfloatarray_ref _
-            | Punboxedintarray_ref _ | Punboxedvectorarray_ref _ ),
+            | Punboxedintarray_ref _ | Punboxedvectorarray_ref _
+            | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ),
             _,
             _ )
       | Parrayrefs
           ( ( Pgenarray_ref _ | Paddrarray_ref | Pintarray_ref
             | Pfloatarray_ref _ | Punboxedfloatarray_ref _
-            | Punboxedintarray_ref _ | Punboxedvectorarray_ref _ ),
+            | Punboxedintarray_ref _ | Punboxedvectorarray_ref _
+            | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ),
             _,
             _ )
       | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _ | Patomic_exchange
@@ -2048,12 +2068,14 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       | Parraysetu
           ( ( Pgenarray_set _ | Paddrarray_set _ | Pintarray_set
             | Pfloatarray_set | Punboxedfloatarray_set _
-            | Punboxedintarray_set _ | Punboxedvectorarray_set _ ),
+            | Punboxedintarray_set _ | Punboxedvectorarray_set _
+            | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ),
             _ )
       | Parraysets
           ( ( Pgenarray_set _ | Paddrarray_set _ | Pintarray_set
             | Pfloatarray_set | Punboxedfloatarray_set _
-            | Punboxedintarray_set _ | Punboxedvectorarray_set _ ),
+            | Punboxedintarray_set _ | Punboxedvectorarray_set _
+            | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ),
             _ )
       | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_f32 _ | Pbytes_set_64 _
       | Pbytes_set_128 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -915,6 +915,8 @@ module With_subkind = struct
     | Parrayval (Punboxedintarray Pint64) -> unboxed_int64_array
     | Parrayval (Punboxedintarray Pnativeint) -> unboxed_nativeint_array
     | Parrayval (Punboxedvectorarray Pvec128) -> unboxed_vec128_array
+    | Parrayval (Pgcscannableproductarray _ | Pgcignorableproductarray _) ->
+      Misc.fatal_errorf "Flambda_kind.from_lambda_value_kind: unimplemented"
 
   let from_lambda_values_and_unboxed_numbers_only (layout : Lambda.layout) =
     match layout with

--- a/middle_end/flambda2/term_basics/empty_array_kind.ml
+++ b/middle_end/flambda2/term_basics/empty_array_kind.ml
@@ -57,3 +57,5 @@ let of_lambda array_kind =
   | Punboxedintarray Pint64 -> Naked_int64s
   | Punboxedintarray Pnativeint -> Naked_nativeints
   | Punboxedvectorarray Pvec128 -> Naked_vec128s
+  | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+    Misc.fatal_errorf "Empty_array_kind.of_lambda: unimplemented"

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -169,6 +169,7 @@ let preserve_tailcall_for_prim = function
   | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
+  | Pmakearray_dynamic _
   | Parrayrefs _ | Parraysets _ | Pisint _ | Pisout | Pbintofint _ | Pintofbint _
   | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _
   | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
@@ -508,43 +509,69 @@ let comp_primitive stack_info p sz args =
      [Parrayset{s,u}]). *)
   | Parrayrefs (Pgenarray_ref _, index_kind, _)
   | Parrayrefs ((Paddrarray_ref | Pintarray_ref | Pfloatarray_ref _
-                | Punboxedfloatarray_ref (Pfloat64 | Pfloat32) | Punboxedintarray_ref _),
-                (Punboxed_int_index _ as index_kind), _) ->
+                | Punboxedfloatarray_ref (Pfloat64 | Pfloat32)
+                | Punboxedintarray_ref _
+                | Pgcscannableproductarray_ref _
+                | Pgcignorableproductarray_ref _),
+                (Punboxed_int_index _ as index_kind),
+                _) ->
       Kccall(indexing_primitive index_kind "caml_array_get", 2)
   | Parrayrefs ((Punboxedfloatarray_ref Pfloat64 | Pfloatarray_ref _), Ptagged_int_index, _) ->
       Kccall("caml_floatarray_get", 2)
   | Parrayrefs ((Punboxedfloatarray_ref Pfloat32 | Punboxedintarray_ref _
-                | Paddrarray_ref | Pintarray_ref), Ptagged_int_index, _) ->
+                | Paddrarray_ref | Pintarray_ref
+                | Pgcscannableproductarray_ref _
+                | Pgcignorableproductarray_ref _),
+                Ptagged_int_index,
+                _) ->
       Kccall("caml_array_get_addr", 2)
   | Parraysets (Pgenarray_set _, index_kind)
   | Parraysets ((Paddrarray_set _ | Pintarray_set | Pfloatarray_set
-                | Punboxedfloatarray_set (Pfloat64 | Pfloat32) | Punboxedintarray_set _),
+                | Punboxedfloatarray_set (Pfloat64 | Pfloat32)
+                | Punboxedintarray_set _
+                | Pgcscannableproductarray_set _
+                | Pgcignorableproductarray_set _),
                 (Punboxed_int_index _ as index_kind)) ->
       Kccall(indexing_primitive index_kind "caml_array_set", 3)
   | Parraysets ((Punboxedfloatarray_set Pfloat64 | Pfloatarray_set),
                 Ptagged_int_index) ->
       Kccall("caml_floatarray_set", 3)
   | Parraysets ((Punboxedfloatarray_set Pfloat32 | Punboxedintarray_set _
-                | Paddrarray_set _ | Pintarray_set), Ptagged_int_index) ->
+                | Paddrarray_set _ | Pintarray_set
+                | Pgcscannableproductarray_set _
+                | Pgcignorableproductarray_set _),
+                Ptagged_int_index) ->
     Kccall("caml_array_set_addr", 3)
   | Parrayrefu (Pgenarray_ref _, index_kind, _)
   | Parrayrefu ((Paddrarray_ref | Pintarray_ref | Pfloatarray_ref _
-                | Punboxedfloatarray_ref (Pfloat64 | Pfloat32) | Punboxedintarray_ref _),
+                | Punboxedfloatarray_ref (Pfloat64 | Pfloat32)
+                | Punboxedintarray_ref _
+                | Pgcscannableproductarray_ref _
+                | Pgcignorableproductarray_ref _),
                 (Punboxed_int_index _ as index_kind), _) ->
       Kccall(indexing_primitive index_kind "caml_array_unsafe_get", 2)
   | Parrayrefu ((Punboxedfloatarray_ref Pfloat64 | Pfloatarray_ref _), Ptagged_int_index, _) ->
     Kccall("caml_floatarray_unsafe_get", 2)
   | Parrayrefu ((Punboxedfloatarray_ref Pfloat32 | Punboxedintarray_ref _
-                | Paddrarray_ref | Pintarray_ref), Ptagged_int_index, _) -> Kgetvectitem
+                | Paddrarray_ref | Pintarray_ref
+                | Pgcscannableproductarray_ref _
+                | Pgcignorableproductarray_ref _),
+                Ptagged_int_index, _) -> Kgetvectitem
   | Parraysetu (Pgenarray_set _, index_kind)
   | Parraysetu ((Paddrarray_set _ | Pintarray_set | Pfloatarray_set
-                | Punboxedfloatarray_set (Pfloat64 | Pfloat32) | Punboxedintarray_set _),
+                | Punboxedfloatarray_set (Pfloat64 | Pfloat32)
+                | Punboxedintarray_set _
+                | Pgcscannableproductarray_set _
+                | Pgcignorableproductarray_set _),
                 (Punboxed_int_index _ as index_kind)) ->
       Kccall(indexing_primitive index_kind "caml_array_unsafe_set", 3)
   | Parraysetu ((Punboxedfloatarray_set Pfloat64 | Pfloatarray_set), Ptagged_int_index) ->
       Kccall("caml_floatarray_unsafe_set", 3)
   | Parraysetu ((Punboxedfloatarray_set Pfloat32 | Punboxedintarray_set _
-                | Paddrarray_set _ | Pintarray_set), Ptagged_int_index) -> Ksetvectitem
+                | Paddrarray_set _ | Pintarray_set
+                | Pgcscannableproductarray_set _
+                | Pgcignorableproductarray_set _),
+                Ptagged_int_index) -> Ksetvectitem
   | Parrayrefs (Punboxedvectorarray_ref _, _, _) | Parraysets (Punboxedvectorarray_set _, _)
   | Parrayrefu (Punboxedvectorarray_ref _, _, _) | Parraysetu (Punboxedvectorarray_set _, _) ->
       fatal_error "SIMD is not supported in bytecode mode."
@@ -655,6 +682,22 @@ let comp_primitive stack_info p sz args =
         "Preinterpret_unboxed_int64_as_tagged_int63 can only be used on 64-bit \
          targets";
     Kccall("caml_reinterpret_unboxed_int64_as_tagged_int63", 1)
+  | Pmakearray_dynamic(kind, locality) ->
+    (* CR layouts v4.0: This is "wrong" for unboxed types. It should construct
+       blocks that can't be marshalled. We've decided to ignore that problem in
+       the short term, as it's unlikely to cause issues - see the internal arrays
+       epic for out plan to deal with it. *)
+    begin match kind with
+    | Punboxedvectorarray _ ->
+      fatal_error "SIMD is not supported in bytecode mode."
+    | Pgenarray | Pintarray | Paddrarray | Punboxedintarray _
+    | Pfloatarray | Punboxedfloatarray _
+    | Pgcscannableproductarray _ | Pgcignorableproductarray _ -> ()
+    end;
+    begin match locality with
+    | Alloc_heap -> Kccall("caml_make_vect", 2)
+    | Alloc_local -> Kccall("caml_make_local_vect", 2)
+    end
   (* The cases below are handled in [comp_expr] before the [comp_primitive] call
      (in the order in which they appear below),
      so they should never be reached in this function. *)
@@ -878,7 +921,8 @@ let rec comp_expr stack_info env exp sz cont =
       (* arrays of unboxed types have the same representation
          as the boxed ones on bytecode *)
       | Pintarray | Paddrarray | Punboxedintarray _
-      | Punboxedfloatarray Pfloat32 ->
+      | Punboxedfloatarray Pfloat32
+      | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
           comp_args stack_info env args sz
             (Kmakeblock(List.length args, 0) :: cont)
       | Pfloatarray | Punboxedfloatarray Pfloat64 ->

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -178,6 +178,7 @@ type primitive =
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   (* Array operations *)
   | Pmakearray of array_kind * mutable_flag * locality_mode
+  | Pmakearray_dynamic of array_kind * locality_mode
   | Pduparray of array_kind * mutable_flag
   (** For [Pduparray], the argument must be an immutable array.
       The arguments of [Pduparray] give the kind and mutability of the
@@ -357,6 +358,8 @@ and array_kind =
   | Punboxedfloatarray of unboxed_float
   | Punboxedintarray of unboxed_integer
   | Punboxedvectorarray of unboxed_vector
+  | Pgcscannableproductarray of scannable_product_element_kind list
+  | Pgcignorableproductarray of ignorable_product_element_kind list
 
 (** When accessing a flat float array, we need to know the mode which we should
     box the resulting float at. *)
@@ -368,6 +371,8 @@ and array_ref_kind =
   | Punboxedfloatarray_ref of unboxed_float
   | Punboxedintarray_ref of unboxed_integer
   | Punboxedvectorarray_ref of unboxed_vector
+  | Pgcscannableproductarray_ref of scannable_product_element_kind list
+  | Pgcignorableproductarray_ref of ignorable_product_element_kind list
 
 (** When updating an array that might contain pointers, we need to know what
     mode they're at; otherwise, access is uniform. *)
@@ -379,6 +384,20 @@ and array_set_kind =
   | Punboxedfloatarray_set of unboxed_float
   | Punboxedintarray_set of unboxed_integer
   | Punboxedvectorarray_set of unboxed_vector
+  | Pgcscannableproductarray_set of
+      modify_mode * scannable_product_element_kind list
+  | Pgcignorableproductarray_set of ignorable_product_element_kind list
+
+and ignorable_product_element_kind =
+  | Pint_ignorable
+  | Punboxedfloat_ignorable of unboxed_float
+  | Punboxedint_ignorable of unboxed_integer
+  | Pproduct_ignorable of ignorable_product_element_kind list
+
+and scannable_product_element_kind =
+  | Pint_scannable
+  | Paddr_scannable
+  | Pproduct_scannable of scannable_product_element_kind list
 
 and array_index_kind =
   | Ptagged_int_index

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -907,7 +907,7 @@ let rec choice ctx t =
     | Punbox_vector _ | Pbox_vector (_, _)
 
     (* we don't handle array indices as destinations yet *)
-    | (Pmakearray _ | Pduparray _)
+    | (Pmakearray _ | Pduparray _ | Pmakearray_dynamic _)
 
     (* we don't handle { foo with x = ...; y = recursive-call } *)
     | Pduprecord _

--- a/ocaml/lambda/transl_array_comprehension.ml
+++ b/ocaml/lambda/transl_array_comprehension.ml
@@ -734,6 +734,9 @@ let initial_array ~loc ~array_kind ~array_size ~array_sizing =
       (* The above cases are not actually allowed/tested yet. *)
       Misc.fatal_error
         "Comprehensions on arrays of unboxed types are not yet supported."
+    | _, (Pgcscannableproductarray _ | Pgcignorableproductarray _) ->
+      Misc.fatal_error
+        "Transl_array_comprehension.initial_array: unboxed product array"
   in
   Let_binding.make array_let_kind (Pvalue Pgenval) "array" array_value
 
@@ -822,6 +825,8 @@ let body ~loc ~array_kind ~array_size ~array_sizing ~array ~index ~body =
     | Punboxedfloatarray (Pfloat64 | Pfloat32)
     | Punboxedintarray _ | Punboxedvectorarray _ ->
       set_element_in_bounds body
+    | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+      Misc.fatal_error "Transl_array_comprehension.body: unboxed product array"
   in
   Lsequence
     (set_element_known_kind_in_bounds, Lassign (index.id, index.var + l1))
@@ -841,7 +846,10 @@ let comprehension ~transl_exp ~scopes ~loc ~(array_kind : Lambda.array_kind)
       Misc.fatal_errorf
         "Array comprehensions for kind %s can only be compiled for 64-bit \
          native targets"
-        (Printlambda.array_kind array_kind));
+        (Printlambda.array_kind array_kind)
+  | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+    Misc.fatal_error
+      "Transl_array_comprehension.comprehension: unboxed product array");
   let { array_sizing_info; array_size; make_comprehension } =
     clauses ~transl_exp ~scopes ~loc comp_clauses
   in

--- a/ocaml/lambda/translcore.mli
+++ b/ocaml/lambda/translcore.mli
@@ -51,6 +51,8 @@ type error =
   | Illegal_void_record_field
   | Illegal_product_record_field of Jkind.Sort.Const.t
   | Void_sort of Types.type_expr
+  | Unboxed_vector_in_array_comprehension
+  | Unboxed_product_in_array_comprehension
 
 exception Error of Location.t * error
 

--- a/ocaml/lambda/value_rec_compiler.ml
+++ b/ocaml/lambda/value_rec_compiler.ml
@@ -255,9 +255,11 @@ let compute_static_size lam =
             Block (Regular_block size)
         | Pfloatarray ->
             Block (Float_record size)
-        | Punboxedfloatarray _ | Punboxedintarray _ | Punboxedvectorarray _ ->
+        | Punboxedfloatarray _ | Punboxedintarray _ | Punboxedvectorarray _
+        | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
             Misc.fatal_error "size_of_primitive"
         end
+    | Pmakearray_dynamic _ -> Misc.fatal_error "size_of_primitive"
     | Pduparray _ ->
         (* The size has to be recovered from the size of the argument *)
         begin match args with

--- a/ocaml/testsuite/tests/typing-layouts-products/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-products/basics.ml
@@ -779,13 +779,18 @@ type t3 = #(int * bool) array
 type t4 = #(string * #(float# * bool option)) array
 |}]
 
+(* CR layouts v7.1: The below error is nonsense - an artifact of the fact that
+   we have temporarily gated product arrays to alpha to stage the release. The
+   PR that adds support later in the compiler can allow this test. *)
 let _ = [| #(1,2) |]
 [%%expect{|
 Line 1, characters 8-20:
 1 | let _ = [| #(1,2) |]
             ^^^^^^^^^^^^
-Error: Unboxed products are not yet supported with array primitives.
-       Here, layout value & value was used.
+Error: Non-value layout value & value detected as sort for type #(int * int),
+       but this requires extension layouts_alpha, which is not enabled.
+       If you intended to use this layout, please add this flag to your build file.
+       Otherwise, please report this error to the Jane Street compilers team.
 |}]
 
 let _ = Array.init 3 (fun _ -> #(1,2))
@@ -821,6 +826,10 @@ Lines 1-2, characters 0-18:
 Error: Attribute "[@layout_poly]" can only be used on built-in primitives.
 |}]
 
+(* CR layouts v7.1: The errors in the next two tests are nonsense - an artifact
+   of the fact that we have temporarily gated product arrays to alpha to stage
+   the release. The PR that adds support later in the compiler can allow this
+   test. *)
 external[@layout_poly] array_get : ('a : any) . 'a array -> int -> 'a =
   "%array_safe_get"
 let f x : #(int * int) = array_get x 3
@@ -830,8 +839,10 @@ external array_get : ('a : any). 'a array -> int -> 'a = "%array_safe_get"
 Line 3, characters 25-38:
 3 | let f x : #(int * int) = array_get x 3
                              ^^^^^^^^^^^^^
-Error: Unboxed products are not yet supported with array primitives.
-       Here, layout value & value was used.
+Error: Non-value layout value & value detected as sort for type #(int * int),
+       but this requires extension layouts_alpha, which is not enabled.
+       If you intended to use this layout, please add this flag to your build file.
+       Otherwise, please report this error to the Jane Street compilers team.
 |}]
 
 external[@layout_poly] array_set : ('a : any) . 'a array -> int -> 'a -> unit =
@@ -843,8 +854,10 @@ external array_set : ('a : any). 'a array -> int -> 'a -> unit
 Line 3, characters 10-30:
 3 | let f x = array_set x 3 #(1,2)
               ^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed products are not yet supported with array primitives.
-       Here, layout value & value was used.
+Error: Non-value layout value & value detected as sort for type #(int * int),
+       but this requires extension layouts_alpha, which is not enabled.
+       If you intended to use this layout, please add this flag to your build file.
+       Otherwise, please report this error to the Jane Street compilers team.
 |}]
 
 

--- a/ocaml/testsuite/tests/typing-layouts-products/product_array_marshalling.ml
+++ b/ocaml/testsuite/tests/typing-layouts-products/product_array_marshalling.ml
@@ -1,0 +1,27 @@
+(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ flags = "-extension layouts_alpha";
+ {
+   bytecode;
+ } {
+   ocamlopt_byte_exit_status = "2";
+   setup-ocamlopt.byte-build-env;
+   compiler_reference =
+     "${test_source_directory}/product_array_marshalling.native.reference";
+   ocamlopt.byte;
+   check-ocamlopt.byte-output;
+ }
+*)
+
+(* Here we check that an attempt to marshal an unboxed product array is
+   rejected. *)
+(* CR layouts v7.1: This currently hits a middle end exception in native code.
+   That will be fixed by the follow-on PR that adds tuple array support to the
+   rest of the compiler. This can be moved to beta then. *)
+(* CR layouts v4.0: Except it is is not rejected by bytecode.  See the arrays
+   epic for our plan to fix that. *)
+
+let array = [| #(1, 2); #(3, 4) |]
+
+let _ = Marshal.to_string array []

--- a/ocaml/testsuite/tests/typing-layouts-products/product_array_marshalling.native.reference
+++ b/ocaml/testsuite/tests/typing-layouts-products/product_array_marshalling.native.reference
@@ -1,0 +1,36 @@
+>> Fatal error: Flambda_kind.from_lambda_value_kind: unimplemented
+Fatal error: exception Misc.Fatal_error
+Raised at Misc.fatal_errorf.(fun) in file "ocaml/utils/misc.ml", line 22, characters 14-31
+Called from Flambda2_from_lambda__Lambda_to_flambda.cps.(fun) in file "middle_end/flambda2/from_lambda/lambda_to_flambda.ml", lines 986-987, characters 20-117
+Called from Flambda2_from_lambda__Closure_conversion_aux.Acc.eval_branch_free_names in file "middle_end/flambda2/from_lambda/closure_conversion_aux.ml", line 676, characters 17-65
+Called from Flambda2_from_lambda__Closure_conversion_aux.Let_cont_with_acc.build_non_recursive in file "middle_end/flambda2/from_lambda/closure_conversion_aux.ml", line 1189, characters 6-44
+Called from Flambda2_from_lambda__Closure_conversion.close_program in file "middle_end/flambda2/from_lambda/closure_conversion.ml", lines 3528-3529, characters 4-124
+Called from Misc.try_finally in file "ocaml/utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "ocaml/utils/misc.ml", line 45, characters 10-56
+Called from Flambda2.lambda_to_cmm.run in file "middle_end/flambda2/flambda2.ml", lines 129-132, characters 6-238
+Called from Misc.try_finally in file "ocaml/utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "ocaml/utils/misc.ml", line 45, characters 10-56
+Called from Asmgen.compile_implementation.(fun) in file "backend/asmgen.ml", line 726, characters 26-69
+Called from Asmgen.compile_unit.(fun) in file "backend/asmgen.ml", line 650, characters 10-16
+Called from Misc.try_finally in file "ocaml/utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "ocaml/utils/misc.ml", line 45, characters 10-56
+Called from Asmgen.compile_unit.(fun) in file "backend/asmgen.ml", lines 648-656, characters 6-382
+Called from Misc.try_finally in file "ocaml/utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "ocaml/utils/misc.ml", line 45, characters 10-56
+Called from Optcompile.compile.(fun) in file "driver/optcompile.ml", lines 44-55, characters 6-523
+Called from Misc.try_finally in file "ocaml/utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "ocaml/utils/misc.ml", line 45, characters 10-56
+Called from Compile_common.implementation.(fun) in file "ocaml/driver/compile_common.ml", lines 159-161, characters 71-114
+Called from Misc.try_finally in file "ocaml/utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "ocaml/utils/misc.ml", line 45, characters 10-56
+Called from Misc.try_finally in file "ocaml/utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "ocaml/utils/misc.ml", line 45, characters 10-56
+Called from Misc.try_finally in file "ocaml/utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "ocaml/utils/misc.ml", line 45, characters 10-56
+Called from Compenv.process_action.impl in file "ocaml/driver/compenv.ml", lines 633-634, characters 4-95
+Called from Stdlib__List.iter in file "list.ml", line 117, characters 12-15
+Called from Compenv.process_deferred_actions in file "ocaml/driver/compenv.ml", lines 731-732, characters 2-85
+Called from Optmaindriver.main in file "driver/optmaindriver.ml", lines 68-73, characters 6-169
+Re-raised at Location.report_exception.loop in file "ocaml/parsing/location.ml", line 1085, characters 14-25
+Called from Optmaindriver.main in file "driver/optmaindriver.ml", line 154, characters 4-35
+Called from Flambda_backend_main in file "driver/flambda_backend_main.ml", lines 5-7, characters 7-140

--- a/ocaml/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/ocaml/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -1,0 +1,1808 @@
+(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ flags = "-extension layouts_alpha";
+ {
+   expect;
+ }
+*)
+
+(* Basic typing tests. Mainly we are checking that all array primitives reject
+   illegally mixed tuples. *)
+
+(* CR layouts v7.1: The PR with middle-end support for product arrays can move
+   this test to beta. *)
+
+(* CR layouts v7.1: Everywhere this file says "any_non_null" it should instead
+   say any. This is caused by [any] meaning different things alpha and beta - we
+   can fix it when we move this test to beta. *)
+
+(*******************************************************)
+(* Test 1: Some allowed scannable product array types. *)
+type t1 = #(int * bool option) array
+type t2 = #(int * string) array
+type t3 = #(string * int * int option) array
+
+type t4 : immediate & value
+type t4a = t4 array
+type t5 : value & immediate
+type t5a = t5 array
+type t6 : value & immediate & value & immediate
+type t6a = t6 array
+[%%expect{|
+type t1 = #(int * bool option) array
+type t2 = #(int * string) array
+type t3 = #(string * int * int option) array
+type t4 : immediate & value
+type t4a = t4 array
+type t5 : value & immediate
+type t5a = t5 array
+type t6 : value & immediate & value & immediate
+type t6a = t6 array
+|}]
+
+(*******************************************************)
+(* Test 2: Some allowed ignorable product array types. *)
+type t1 = #(int * int) array
+type t2 = #(int * float#) array
+type t3 = #(float# * int * int64# * bool) array
+
+type t4 : immediate & immediate
+type t4a = t4 array
+type t5 : immediate & float64
+type t5a = t5 array
+type t6 : bits64 & immediate & float64 & immediate
+type t6a = t6 array
+[%%expect{|
+type t1 = #(int * int) array
+type t2 = #(int * float#) array
+type t3 = #(float# * int * int64# * bool) array
+type t4 : immediate & immediate
+type t4a = t4 array
+type t5 : immediate & float64
+type t5a = t5 array
+type t6 : bits64 & immediate & float64 & immediate
+type t6a = t6 array
+|}]
+
+(******************************************************************************)
+(* Test 3: Some array types that are allowed even though you can't make them. *)
+type t1 = #(float# * string) array
+type t2 = #(string * int64#) array
+type t3 = #(string * int64# * int) array
+type t4 = #(int * int64# * string) array
+
+type t5 : value & float64
+type t5a = t5 array
+type t6 : bits64 & value
+type t6a = t6 array
+type t7 : value & bits64 & immediate
+type t7a = t7 array
+type t8 : immediate & bits64 & value
+type t8a = t8 array
+
+[%%expect{|
+type t1 = #(float# * string) array
+type t2 = #(string * int64#) array
+type t3 = #(string * int64# * int) array
+type t4 = #(int * int64# * string) array
+type t5 : value & float64
+type t5a = t5 array
+type t6 : bits64 & value
+type t6a = t6 array
+type t7 : value & bits64 & immediate
+type t7a = t7 array
+type t8 : immediate & bits64 & value
+type t8a = t8 array
+|}]
+
+(*****************************)
+(* Test 4: makearray_dynamic *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] make_vect : ('a : any_non_null) . int -> 'a -> 'a array =
+  "%makearray_dynamic"
+
+let f_scannable (x : #(int * float * string) array) = make_vect 42 x
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) = make_vect 42 x
+[%%expect{|
+external make_vect : ('a : any_non_null). int -> 'a -> 'a array
+  = "%makearray_dynamic" [@@layout_poly]
+val f_scannable :
+  #(int * float * string) array -> #(int * float * string) array array =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array ->
+  #(float# * int * int64# * bool) array array = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = make_vect 42 x
+[%%expect{|
+Line 1, characters 10-40:
+1 | let f_bad (x : #(string * float#) array) = make_vect 42 x
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external make_scannable :
+  int -> #(int * float * string) -> #(int * float * string) array =
+  "%makearray_dynamic"
+let make_scannable_app x = make_scannable x
+
+external make_ignorable :
+  int -> #(float# * int * int64# * bool)
+  -> #(float# * int * int64# * bool) array =
+  "%makearray_dynamic"
+let make_ignorable_app x = make_ignorable x
+[%%expect{|
+external make_scannable :
+  int -> #(int * float * string) -> #(int * float * string) array
+  = "%makearray_dynamic"
+val make_scannable_app :
+  int -> #(int * float * string) -> #(int * float * string) array = <fun>
+external make_ignorable :
+  int ->
+  #(float# * int * int64# * bool) -> #(float# * int * int64# * bool) array
+  = "%makearray_dynamic"
+val make_ignorable_app :
+  int ->
+  #(float# * int * int64# * bool) -> #(float# * int * int64# * bool) array =
+  <fun>
+|}]
+
+external make_bad : int -> #(string * float#) -> #(string * float#) array =
+  "%makearray_dynamic"
+let make_bad_app x = make_bad x
+[%%expect{|
+external make_bad : int -> #(string * float#) -> #(string * float#) array
+  = "%makearray_dynamic"
+Line 3, characters 21-29:
+3 | let make_bad_app x = make_bad x
+                         ^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = make_vect 42 x
+[%%expect{|
+Line 1, characters 10-39:
+1 | let f_bad (x : #(int * int32x4#) array) = make_vect 42 x
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external make_ignorable_with_vec :
+  int -> #(int * int32x4#) -> #(int * int32x4#) array = "%makearray_dynamic"
+let make_ignorable_with_vec_app x = make_ignorable_with_vec x
+[%%expect{|
+external make_ignorable_with_vec :
+  int -> #(int * int32x4#) -> #(int * int32x4#) array = "%makearray_dynamic"
+Line 3, characters 36-59:
+3 | let make_ignorable_with_vec_app x = make_ignorable_with_vec x
+                                        ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(************************)
+(* Test 5: array length *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] len : ('a : any_non_null) . 'a array -> int =
+  "%array_length"
+
+let f_scannable (x : #(int * float * string) array) = len x
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) = len x
+[%%expect{|
+external len : ('a : any_non_null). 'a array -> int = "%array_length"
+  [@@layout_poly]
+val f_scannable : #(int * float * string) array -> int = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> int = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = len x
+[%%expect{|
+Line 1, characters 43-48:
+1 | let f_bad (x : #(string * float#) array) = len x
+                                               ^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external len_scannable : #(int * float * string) array -> int = "%array_length"
+let len_scannable_app x = len_scannable x
+
+external len_ignorable : #(float# * int * int64# * bool) array -> int =
+  "%array_length"
+let len_ignorable_app x = len_ignorable x
+[%%expect{|
+external len_scannable : #(int * float * string) array -> int
+  = "%array_length"
+val len_scannable_app : #(int * float * string) array -> int = <fun>
+external len_ignorable : #(float# * int * int64# * bool) array -> int
+  = "%array_length"
+val len_ignorable_app : #(float# * int * int64# * bool) array -> int = <fun>
+|}]
+
+external len_bad : #(string * float#) array -> int = "%array_length"
+let len_bad_app x = len_bad x
+[%%expect{|
+external len_bad : #(string * float#) array -> int = "%array_length"
+Line 2, characters 20-29:
+2 | let len_bad_app x = len_bad x
+                        ^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = len x
+[%%expect{|
+Line 1, characters 42-47:
+1 | let f_bad (x : #(int * int32x4#) array) = len x
+                                              ^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external len_ignorable_with_vec :
+  #(int * int32x4#) array -> int = "%array_length"
+let len_ignorable_with_vec_app x = len_ignorable_with_vec x
+[%%expect{|
+external len_ignorable_with_vec : #(int * int32x4#) array -> int
+  = "%array_length"
+Line 3, characters 35-59:
+3 | let len_ignorable_with_vec_app x = len_ignorable_with_vec x
+                                       ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(********************)
+(* Test 6: safe get *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int -> 'a =
+  "%array_safe_get"
+
+let f_scannable (x : #(int * float * string) array) = get x 42
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x 42
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int -> 'a = "%array_safe_get"
+  [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x 42
+[%%expect{|
+Line 1, characters 43-51:
+1 | let f_bad (x : #(string * float#) array) = get x 42
+                                               ^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) =
+  "%array_safe_get"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int
+  -> #(float# * int * int64# * bool) =
+  "%array_safe_get"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int -> #(int * float * string)
+  = "%array_safe_get"
+val get_scannable_app :
+  #(int * float * string) array -> int -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) = "%array_safe_get"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int -> #(string * float#) =
+  "%array_safe_get"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int -> #(string * float#)
+  = "%array_safe_get"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x 42
+[%%expect{|
+Line 1, characters 42-50:
+1 | let f_bad (x : #(int * int32x4#) array) = get x 42
+                                              ^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) = "%array_safe_get"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) = "%array_safe_get"
+Line 3, characters 37-63:
+3 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(********************)
+(* Test 7: safe set *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> int -> 'a -> unit = "%array_safe_set"
+
+let f_scannable (x : #(int * float * string) array) = set x 42 #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x 42 #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int -> 'a -> unit
+  = "%array_safe_set" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-64:
+1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit =
+  "%array_safe_set"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_safe_set"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit
+  = "%array_safe_set"
+val set_scannable_app :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) -> unit = "%array_safe_set"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int -> #(string * float#) -> unit =
+  "%array_safe_set"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> int -> #(string * float#) -> unit
+  = "%array_safe_set"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
+[%%expect{|
+Line 1, characters 44-60:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
+                                                ^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) -> unit =
+  "%array_safe_set"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) -> unit
+  = "%array_safe_set"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(**********************)
+(* Test 8: unsafe get *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int -> 'a =
+  "%array_unsafe_get"
+
+let f_scannable (x : #(int * float * string) array) = get x 42
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x 42
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int -> 'a
+  = "%array_unsafe_get" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x 42
+[%%expect{|
+Line 1, characters 43-51:
+1 | let f_bad (x : #(string * float#) array) = get x 42
+                                               ^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) =
+  "%array_unsafe_get"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int
+  -> #(float# * int * int64# * bool) =
+  "%array_unsafe_get"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int -> #(int * float * string)
+  = "%array_unsafe_get"
+val get_scannable_app :
+  #(int * float * string) array -> int -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) = "%array_unsafe_get"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int -> #(string * float#) =
+  "%array_unsafe_get"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int -> #(string * float#)
+  = "%array_unsafe_get"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x 42
+[%%expect{|
+Line 1, characters 42-50:
+1 | let f_bad (x : #(int * int32x4#) array) = get x 42
+                                              ^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) =
+  "%array_unsafe_get"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) = "%array_unsafe_get"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(**********************)
+(* Test 9: unsafe set *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+
+let f_scannable (x : #(int * float * string) array) = set x 42 #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x 42 #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int -> 'a -> unit
+  = "%array_unsafe_set" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-64:
+1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit =
+  "%array_unsafe_set"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_unsafe_set"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit
+  = "%array_unsafe_set"
+val set_scannable_app :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) -> unit = "%array_unsafe_set"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int -> #(string * float#) -> unit =
+  "%array_unsafe_set"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> int -> #(string * float#) -> unit
+  = "%array_unsafe_set"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
+[%%expect{|
+Line 1, characters 44-60:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
+                                                ^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) -> unit =
+  "%array_unsafe_set"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) -> unit
+  = "%array_unsafe_set"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(***************************************)
+(* Test 10: safe get indexed by int64# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int64# -> 'a =
+  "%array_safe_get_indexed_by_int64#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42L
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42L
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int64# -> 'a
+  = "%array_safe_get_indexed_by_int64#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42L
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42L
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) =
+  "%array_safe_get_indexed_by_int64#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int64#
+  -> #(float# * int * int64# * bool) =
+  "%array_safe_get_indexed_by_int64#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string)
+  = "%array_safe_get_indexed_by_int64#"
+val get_scannable_app :
+  #(int * float * string) array -> int64# -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool)
+  = "%array_safe_get_indexed_by_int64#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int64# -> #(string * float#) =
+  "%array_safe_get_indexed_by_int64#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int64# -> #(string * float#)
+  = "%array_safe_get_indexed_by_int64#"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42L
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42L
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) =
+  "%array_safe_get_indexed_by_int64#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#)
+  = "%array_safe_get_indexed_by_int64#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(***************************************)
+(* Test 11: safe set indexed by int64# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> int64# -> 'a -> unit =
+  "%array_safe_set_indexed_by_int64#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42L #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42L #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int64# -> 'a -> unit
+  = "%array_safe_set_indexed_by_int64#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int64#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit
+  = "%array_safe_set_indexed_by_int64#"
+val set_scannable_app :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) -> unit
+  = "%array_safe_set_indexed_by_int64#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int64# -> #(string * float#) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> int64# -> #(string * float#) -> unit
+  = "%array_safe_set_indexed_by_int64#"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) -> unit
+  = "%array_safe_set_indexed_by_int64#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*****************************************)
+(* Test 12: unsafe get indexed by int64# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int64# -> 'a =
+  "%array_unsafe_get_indexed_by_int64#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42L
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42L
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int64# -> 'a
+  = "%array_unsafe_get_indexed_by_int64#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42L
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42L
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) =
+  "%array_unsafe_get_indexed_by_int64#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int64#
+  -> #(float# * int * int64# * bool) =
+  "%array_unsafe_get_indexed_by_int64#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string)
+  = "%array_unsafe_get_indexed_by_int64#"
+val get_scannable_app :
+  #(int * float * string) array -> int64# -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool)
+  = "%array_unsafe_get_indexed_by_int64#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int64# -> #(string * float#) =
+  "%array_unsafe_get_indexed_by_int64#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int64# -> #(string * float#)
+  = "%array_unsafe_get_indexed_by_int64#"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42L
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42L
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) =
+  "%array_unsafe_get_indexed_by_int64#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#)
+  = "%array_unsafe_get_indexed_by_int64#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*****************************************)
+(* Test 13: unsafe set indexed by int64# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set : ('a : any_non_null) . 'a array -> int64# -> 'a -> unit =
+  "%array_unsafe_set_indexed_by_int64#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42L #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42L #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int64# -> 'a -> unit
+  = "%array_unsafe_set_indexed_by_int64#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit =
+  "%array_unsafe_set_indexed_by_int64#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int64#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_unsafe_set_indexed_by_int64#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit
+  = "%array_unsafe_set_indexed_by_int64#"
+val set_scannable_app :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) -> unit
+  = "%array_unsafe_set_indexed_by_int64#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int64# -> #(string * float#) -> unit =
+  "%array_unsafe_set_indexed_by_int64#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> int64# -> #(string * float#) -> unit
+  = "%array_unsafe_set_indexed_by_int64#"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) -> unit =
+  "%array_unsafe_set_indexed_by_int64#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) -> unit
+  = "%array_unsafe_set_indexed_by_int64#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(***************************************)
+(* Test 14: safe get indexed by int32# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int32# -> 'a =
+  "%array_safe_get_indexed_by_int32#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42l
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42l
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int32# -> 'a
+  = "%array_safe_get_indexed_by_int32#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42l
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42l
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) =
+  "%array_safe_get_indexed_by_int32#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int32#
+  -> #(float# * int * int64# * bool) =
+  "%array_safe_get_indexed_by_int32#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string)
+  = "%array_safe_get_indexed_by_int32#"
+val get_scannable_app :
+  #(int * float * string) array -> int32# -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool)
+  = "%array_safe_get_indexed_by_int32#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int32# -> #(string * float#) =
+  "%array_safe_get_indexed_by_int32#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int32# -> #(string * float#)
+  = "%array_safe_get_indexed_by_int32#"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42l
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42l
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) =
+  "%array_safe_get_indexed_by_int32#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#)
+  = "%array_safe_get_indexed_by_int32#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(***************************************)
+(* Test 15: safe set indexed by int32# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> int32# -> 'a -> unit =
+  "%array_safe_set_indexed_by_int32#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42l #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42l #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int32# -> 'a -> unit
+  = "%array_safe_set_indexed_by_int32#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit =
+  "%array_safe_set_indexed_by_int32#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int32#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_safe_set_indexed_by_int32#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit
+  = "%array_safe_set_indexed_by_int32#"
+val set_scannable_app :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) -> unit
+  = "%array_safe_set_indexed_by_int32#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int32# -> #(string * float#) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+Line 2, characters 2-66:
+2 |   #(string * float#) array -> int32# -> #(string * float#) -> unit =
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [%array_safe_set_indexed_by_int64#] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) -> unit =
+  "%array_safe_set_indexed_by_int32#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) -> unit
+  = "%array_safe_set_indexed_by_int32#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*****************************************)
+(* Test 16: unsafe get indexed by int32# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int32# -> 'a =
+  "%array_unsafe_get_indexed_by_int32#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42l
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42l
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int32# -> 'a
+  = "%array_unsafe_get_indexed_by_int32#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42l
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42l
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) =
+  "%array_unsafe_get_indexed_by_int32#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int32#
+  -> #(float# * int * int64# * bool) =
+  "%array_unsafe_get_indexed_by_int32#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string)
+  = "%array_unsafe_get_indexed_by_int32#"
+val get_scannable_app :
+  #(int * float * string) array -> int32# -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool)
+  = "%array_unsafe_get_indexed_by_int32#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int32# -> #(string * float#) =
+  "%array_unsafe_get_indexed_by_int32#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int32# -> #(string * float#)
+  = "%array_unsafe_get_indexed_by_int32#"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42l
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42l
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) =
+  "%array_unsafe_get_indexed_by_int32#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#)
+  = "%array_unsafe_get_indexed_by_int32#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*****************************************)
+(* Test 17: unsafe set indexed by int32# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> int32# -> 'a -> unit =
+  "%array_unsafe_set_indexed_by_int32#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42l #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42l #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int32# -> 'a -> unit
+  = "%array_unsafe_set_indexed_by_int32#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit =
+  "%array_unsafe_set_indexed_by_int32#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int32#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_unsafe_set_indexed_by_int32#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit
+  = "%array_unsafe_set_indexed_by_int32#"
+val set_scannable_app :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) -> unit
+  = "%array_unsafe_set_indexed_by_int32#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int32# -> #(string * float#) -> unit =
+  "%array_unsafe_set_indexed_by_int32#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> int32# -> #(string * float#) -> unit
+  = "%array_unsafe_set_indexed_by_int32#"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) -> unit =
+  "%array_unsafe_set_indexed_by_int32#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) -> unit
+  = "%array_unsafe_set_indexed_by_int32#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*******************************************)
+(* Test 18: safe get indexed by nativeint# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get :
+  ('a : any_non_null) . 'a array -> nativeint# -> 'a =
+  "%array_safe_get_indexed_by_nativeint#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42n
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42n
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> nativeint# -> 'a
+  = "%array_safe_get_indexed_by_nativeint#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42n
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42n
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string) =
+  "%array_safe_get_indexed_by_nativeint#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> nativeint#
+  -> #(float# * int * int64# * bool) =
+  "%array_safe_get_indexed_by_nativeint#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string)
+  = "%array_safe_get_indexed_by_nativeint#"
+val get_scannable_app :
+  #(int * float * string) array -> nativeint# -> #(int * float * string) =
+  <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool)
+  = "%array_safe_get_indexed_by_nativeint#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#) =
+  "%array_safe_get_indexed_by_nativeint#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#)
+  = "%array_safe_get_indexed_by_nativeint#"
+Line 4, characters 22-33:
+4 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42n
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42n
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) =
+  "%array_safe_get_indexed_by_nativeint#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#)
+  = "%array_safe_get_indexed_by_nativeint#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*******************************************)
+(* Test 19: safe set indexed by nativeint# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> nativeint# -> 'a -> unit =
+  "%array_safe_set_indexed_by_nativeint#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42n #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42n #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> nativeint# -> 'a -> unit
+  = "%array_safe_set_indexed_by_nativeint#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string)
+  -> unit =
+  "%array_safe_set_indexed_by_nativeint#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> nativeint#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_safe_set_indexed_by_nativeint#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array ->
+  nativeint# -> #(int * float * string) -> unit
+  = "%array_safe_set_indexed_by_nativeint#"
+val set_scannable_app :
+  #(int * float * string) array ->
+  nativeint# -> #(int * float * string) -> unit = <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) -> unit
+  = "%array_safe_set_indexed_by_nativeint#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+Line 2, characters 2-70:
+2 |   #(string * float#) array -> nativeint# -> #(string * float#) -> unit =
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [%array_safe_set_indexed_by_int64#] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) -> unit =
+  "%array_safe_set_indexed_by_nativeint#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) -> unit
+  = "%array_safe_set_indexed_by_nativeint#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*********************************************)
+(* Test 20: unsafe get indexed by nativeint# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get :
+  ('a : any_non_null) . 'a array -> nativeint# -> 'a =
+  "%array_unsafe_get_indexed_by_nativeint#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42n
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42n
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> nativeint# -> 'a
+  = "%array_unsafe_get_indexed_by_nativeint#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42n
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42n
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string) =
+  "%array_unsafe_get_indexed_by_nativeint#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> nativeint#
+  -> #(float# * int * int64# * bool) =
+  "%array_unsafe_get_indexed_by_nativeint#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string)
+  = "%array_unsafe_get_indexed_by_nativeint#"
+val get_scannable_app :
+  #(int * float * string) array -> nativeint# -> #(int * float * string) =
+  <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool)
+  = "%array_unsafe_get_indexed_by_nativeint#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#) =
+  "%array_unsafe_get_indexed_by_nativeint#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#)
+  = "%array_unsafe_get_indexed_by_nativeint#"
+Line 4, characters 22-33:
+4 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42n
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42n
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) =
+  "%array_unsafe_get_indexed_by_nativeint#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#)
+  = "%array_unsafe_get_indexed_by_nativeint#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*********************************************)
+(* Test 21: unsafe set indexed by nativeint# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> nativeint# -> 'a -> unit =
+  "%array_unsafe_set_indexed_by_nativeint#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42n #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42n #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> nativeint# -> 'a -> unit
+  = "%array_unsafe_set_indexed_by_nativeint#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string)
+  -> unit =
+  "%array_unsafe_set_indexed_by_nativeint#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> nativeint#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_unsafe_set_indexed_by_nativeint#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array ->
+  nativeint# -> #(int * float * string) -> unit
+  = "%array_unsafe_set_indexed_by_nativeint#"
+val set_scannable_app :
+  #(int * float * string) array ->
+  nativeint# -> #(int * float * string) -> unit = <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) -> unit
+  = "%array_unsafe_set_indexed_by_nativeint#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#) -> unit =
+  "%array_unsafe_set_indexed_by_nativeint#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#) -> unit
+  = "%array_unsafe_set_indexed_by_nativeint#"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) -> unit =
+  "%array_unsafe_set_indexed_by_nativeint#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) -> unit
+  = "%array_unsafe_set_indexed_by_nativeint#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -383,6 +383,78 @@ type t : any mod global unique many uncontended portable external_ = nativeint#
 type t = nativeint#
 |}]
 
+type t : any mod global unique many uncontended portable external_ = int8x16#
+[%%expect{|
+Line 1, characters 0-77:
+1 | type t : any mod global unique many uncontended portable external_ = int8x16#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int8x16#" is vec128
+         because it is the primitive type int8x16#.
+       But the kind of type "int8x16#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-77.
+|}]
+
+type t : any mod global unique many uncontended portable external_ = int16x8#
+[%%expect{|
+Line 1, characters 0-77:
+1 | type t : any mod global unique many uncontended portable external_ = int16x8#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int16x8#" is vec128
+         because it is the primitive type int16x8#.
+       But the kind of type "int16x8#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-77.
+|}]
+
+type t : any mod global unique many uncontended portable external_ = int32x4#
+[%%expect{|
+Line 1, characters 0-77:
+1 | type t : any mod global unique many uncontended portable external_ = int32x4#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int32x4#" is vec128
+         because it is the primitive type int32x4#.
+       But the kind of type "int32x4#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-77.
+|}]
+
+type t : any mod global unique many uncontended portable external_ = int64x2#
+[%%expect{|
+Line 1, characters 0-77:
+1 | type t : any mod global unique many uncontended portable external_ = int64x2#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int64x2#" is vec128
+         because it is the primitive type int64x2#.
+       But the kind of type "int64x2#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-77.
+|}]
+
+type t : any mod global unique many uncontended portable external_ = float32x4#
+[%%expect{|
+Line 1, characters 0-79:
+1 | type t : any mod global unique many uncontended portable external_ = float32x4#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "float32x4#" is vec128
+         because it is the primitive type float32x4#.
+       But the kind of type "float32x4#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-79.
+|}]
+
+type t : any mod global unique many uncontended portable external_ = float64x2#
+[%%expect{|
+Line 1, characters 0-79:
+1 | type t : any mod global unique many uncontended portable external_ = float64x2#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "float64x2#" is vec128
+         because it is the primitive type float64x2#.
+       But the kind of type "float64x2#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-79.
+|}]
+
 type indirect_int = int
 type t : any mod global unique many uncontended portable external_ = indirect_int
 [%%expect{|

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -385,74 +385,32 @@ type t = nativeint#
 
 type t : any mod global unique many uncontended portable external_ = int8x16#
 [%%expect{|
-Line 1, characters 0-77:
-1 | type t : any mod global unique many uncontended portable external_ = int8x16#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int8x16#" is vec128
-         because it is the primitive type int8x16#.
-       But the kind of type "int8x16#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-77.
+type t = int8x16#
 |}]
 
 type t : any mod global unique many uncontended portable external_ = int16x8#
 [%%expect{|
-Line 1, characters 0-77:
-1 | type t : any mod global unique many uncontended portable external_ = int16x8#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int16x8#" is vec128
-         because it is the primitive type int16x8#.
-       But the kind of type "int16x8#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-77.
+type t = int16x8#
 |}]
 
 type t : any mod global unique many uncontended portable external_ = int32x4#
 [%%expect{|
-Line 1, characters 0-77:
-1 | type t : any mod global unique many uncontended portable external_ = int32x4#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int32x4#" is vec128
-         because it is the primitive type int32x4#.
-       But the kind of type "int32x4#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-77.
+type t = int32x4#
 |}]
 
 type t : any mod global unique many uncontended portable external_ = int64x2#
 [%%expect{|
-Line 1, characters 0-77:
-1 | type t : any mod global unique many uncontended portable external_ = int64x2#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int64x2#" is vec128
-         because it is the primitive type int64x2#.
-       But the kind of type "int64x2#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-77.
+type t = int64x2#
 |}]
 
 type t : any mod global unique many uncontended portable external_ = float32x4#
 [%%expect{|
-Line 1, characters 0-79:
-1 | type t : any mod global unique many uncontended portable external_ = float32x4#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "float32x4#" is vec128
-         because it is the primitive type float32x4#.
-       But the kind of type "float32x4#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-79.
+type t = float32x4#
 |}]
 
 type t : any mod global unique many uncontended portable external_ = float64x2#
 [%%expect{|
-Line 1, characters 0-79:
-1 | type t : any mod global unique many uncontended portable external_ = float64x2#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "float64x2#" is vec128
-         because it is the primitive type float64x2#.
-       But the kind of type "float64x2#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-79.
+type t = float64x2#
 |}]
 
 type indirect_int = int

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -540,28 +540,34 @@ let add_simd_stable_extension_types add_type env =
                 Jkind.Const.Builtin.immutable_data.jkind)
       ~jkind_annotation:Jkind.Const.Builtin.immutable_data
   |> add_type ident_unboxed_int8x16
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_int8x16)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_int8x16)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
   |> add_type ident_unboxed_int16x8
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_int16x8)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_int16x8)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
   |> add_type ident_unboxed_int32x4
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_int32x4)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_int32x4)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
   |> add_type ident_unboxed_int64x2
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_int64x2)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_int64x2)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
   |> add_type ident_unboxed_float32x4
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_float32x4)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_float32x4)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
   |> add_type ident_unboxed_float64x2
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_float64x2)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_float64x2)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
 
 let add_small_number_extension_types add_type env =

--- a/ocaml/typing/primitive.ml
+++ b/ocaml/typing/primitive.ml
@@ -648,7 +648,7 @@ let prim_has_valid_reprs ~loc prim =
         is (Same_as_ocaml_repr C.word);
         any;
         is (Same_as_ocaml_repr C.value)]
-    | "%make_unboxed_tuple_vect" ->
+    | "%makearray_dynamic" ->
       check [
         is (Same_as_ocaml_repr C.value);
         any;

--- a/ocaml/typing/typeopt.mli
+++ b/ocaml/typing/typeopt.mli
@@ -29,6 +29,9 @@ val array_type_kind :
   elt_sort:(Jkind.Sort.t option)
   -> Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
 val array_type_mut : Env.t -> Types.type_expr -> Lambda.mutable_flag
+val array_kind_of_elt :
+  elt_sort:(Jkind.Sort.t option)
+  -> Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
 val array_kind :
   Typedtree.expression -> Jkind.Sort.t -> Lambda.array_kind
 val array_pattern_kind :

--- a/ocaml/typing/value_rec_check.ml
+++ b/ocaml/typing/value_rec_check.ml
@@ -605,7 +605,8 @@ let array_mode exp elt_sort = match Typeopt.array_kind exp elt_sort with
     (* non-generic, non-float arrays act as constructors *)
     Guard
   | Lambda.Punboxedfloatarray _ | Lambda.Punboxedintarray _
-  | Lambda.Punboxedvectorarray _ ->
+  | Lambda.Punboxedvectorarray _
+  | Lambda.Pgcscannableproductarray _ | Lambda.Pgcignorableproductarray _ ->
     Dereference
 
 (* Expression judgment:

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -185,6 +185,19 @@ module Stdlib = struct
       in
       aux l []
 
+    let map2_option f l1 l2 =
+      let rec aux l1 l2 acc =
+        match l1, l2 with
+        | [], [] -> Some (List.rev acc)
+        | x :: xs, y :: ys ->
+          begin match f x y with
+          | None -> None
+          | Some z -> aux xs ys (z :: acc)
+          end
+        | _, _ -> invalid_arg "map2_option"
+      in
+      aux l1 l2 []
+
     let split_at n l =
       let rec aux n acc l =
         if n = 0

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -133,6 +133,8 @@ module Stdlib : sig
     (** [map_option f l] is [some_if_all_elements_are_some (map f l)], but with
         short circuiting. *)
 
+    val map2_option : ('a -> 'b -> 'c option) -> 'a t -> 'b t -> 'c t option
+
     val map2_prefix : ('a -> 'b -> 'c) -> 'a t -> 'b t -> ('c t * 'b t)
     (** [let r1, r2 = map2_prefix f l1 l2]
         If [l1] is of length n and [l2 = h2 @ t2] with h2 of length n,


### PR DESCRIPTION
This is a quickly-thrown-together implemenation of the front-end (through lambda) bits of our plan for arrays of unboxed products.  Putting it up just as a starting place for @mshinwell's work on the middle-end, having pushed through the agreed-upon lambda changes.  This will need substantial cleanup and additional tests before we make a real PR of it.

I haven't added the new creation primitive (but that should be only a few lines in the front-end).