### PR TITLE
Finish porting upstream PR 12754

### DIFF
--- a/ocaml/runtime4/caml/bigarray.h
+++ b/ocaml/runtime4/caml/bigarray.h
@@ -77,6 +77,12 @@ enum caml_ba_managed {
   CAML_BA_MANAGED_MASK = 0x600 /* Mask for "managed" bits in flags field */
 };
 
+enum caml_ba_subarray {
+  CAML_BA_SUBARRAY = 0         /* Data is shared with another bigarray
+                                  (Has no effect on runtime4, but present
+                                   for compatibility with runtime5) */
+};
+
 struct caml_ba_proxy {
   intnat refcount;              /* Reference count */
   void * data;                  /* Pointer to base of actual data */


### PR DESCRIPTION
PR 12754 upstream is a fixed version of my prior broken upstream PR 11022, and is part of OCaml 5.2.0. Part of it was dropped in the 5.2 merge, and this PR finishes it off.

The point of the patch is to ensure that bigarray allocations with non-NULL `data` and `CAML_BA_MANAGED` increase GC speed in the same way as normal bigarray allocations - both of these increase the memory that the GC has to manage.

The bug in the original version is that this GC speed increase also occurred on Bigarray.sub, where a new view of existing memory is being created and no GC speed up should occur. This is fixed by adding a new flag CAML_BA_SUBARRAY to indicate when this is happening. (Because we merged half of this patch in the 5.2 merge, we already have all of the places where CAML_BA_SUBARRAY is introduced, but it doesn't yet do anything).

This PR also adds a declaration of `CAML_BA_SUBARRAY` to runtime4, where it is a no-op but provided for compatibility.