### PR TITLE
Register separate code fragments

### DIFF
--- a/ocaml/runtime/gc_ctrl.c
+++ b/ocaml/runtime/gc_ctrl.c
@@ -51,6 +51,7 @@ extern uintnat caml_custom_minor_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_max_bsz; /* see custom.c */
 extern uintnat caml_minor_heap_max_wsz;   /* see domain.c */
 extern uintnat caml_custom_work_max_multiplier; /* see major_gc.c */
+extern uintnat caml_prelinking_in_use;    /* see startup_nat.c */
 
 CAMLprim value caml_gc_quick_stat(value v)
 {
@@ -426,7 +427,8 @@ struct gc_tweak {
   uintnat initial_value;
 };
 static struct gc_tweak gc_tweaks[] = {
-  { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 }
+  { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
+  { "prelinking_in_use", &caml_prelinking_in_use, 0 }
 };
 enum {N_GC_TWEAKS = sizeof(gc_tweaks)/sizeof(gc_tweaks[0])};
 

--- a/ocaml/runtime/startup_aux.c
+++ b/ocaml/runtime/startup_aux.c
@@ -245,3 +245,6 @@ void caml_init_section_table(const char* section_table,
   params.section_table = section_table;
   params.section_table_size = section_table_size;
 }
+
+/* Set to 1 if prelinking is in use. */
+uintnat caml_prelinking_in_use = 0;

--- a/ocaml/runtime/startup_nat.c
+++ b/ocaml/runtime/startup_nat.c
@@ -45,7 +45,7 @@ extern char caml_system__code_begin, caml_system__code_end;
    They use the old `__` separator convention because the new convention
    gives `caml_system.code_begin`, which is not a valid C identifier. */
 
-int caml_prelinking_in_use = 0;
+extern uintnat caml_prelinking_in_use;
 
 /* Initialize the static data and code area limits. */
 

--- a/ocaml/runtime/startup_nat.c
+++ b/ocaml/runtime/startup_nat.c
@@ -57,18 +57,27 @@ static void init_segments(void)
   char * caml_code_area_start, * caml_code_area_end;
   int i;
 
-  caml_code_area_start = caml_code_segments[0].begin;
-  caml_code_area_end = caml_code_segments[0].end;
-  for (i = 1; caml_code_segments[i].begin != 0; i++) {
-    if (caml_code_segments[i].begin < caml_code_area_start)
-      caml_code_area_start = caml_code_segments[i].begin;
-    if (caml_code_segments[i].end > caml_code_area_end)
-      caml_code_area_end = caml_code_segments[i].end;
+  if (caml_prelinking_in_use) {
+    /* Register each segment as a separate code fragment */
+    for (i = 0; caml_code_segments[i].begin != 0; i++) {
+      caml_register_code_fragment(caml_code_segments[i].begin,
+                                  caml_code_segments[i].end,
+                                  DIGEST_LATER, NULL);
+    }
+  } else {
+    caml_code_area_start = caml_code_segments[0].begin;
+    caml_code_area_end = caml_code_segments[0].end;
+    for (i = 1; caml_code_segments[i].begin != 0; i++) {
+      if (caml_code_segments[i].begin < caml_code_area_start)
+        caml_code_area_start = caml_code_segments[i].begin;
+      if (caml_code_segments[i].end > caml_code_area_end)
+        caml_code_area_end = caml_code_segments[i].end;
+    }
+    /* Register the code in the table of code fragments */
+    caml_register_code_fragment(caml_code_area_start,
+                                caml_code_area_end,
+                                DIGEST_LATER, NULL);
   }
-  /* Register the code in the table of code fragments */
-  caml_register_code_fragment(caml_code_area_start,
-                              caml_code_area_end,
-                              DIGEST_LATER, NULL);
   /* Also register the glue code written in assembly */
   caml_register_code_fragment(&caml_system__code_begin,
                               &caml_system__code_end,

--- a/ocaml/runtime/startup_nat.c
+++ b/ocaml/runtime/startup_nat.c
@@ -45,6 +45,8 @@ extern char caml_system__code_begin, caml_system__code_end;
    They use the old `__` separator convention because the new convention
    gives `caml_system.code_begin`, which is not a valid C identifier. */
 
+int caml_prelinking_in_use = 0;
+
 /* Initialize the static data and code area limits. */
 
 struct segment { char * begin; char * end; };

--- a/ocaml/runtime4/startup_aux.c
+++ b/ocaml/runtime4/startup_aux.c
@@ -196,3 +196,6 @@ CAMLexport void caml_shutdown(void)
 
   shutdown_happened = 1;
 }
+
+/* Set to 1 if prelinking is in use. */
+uintnat caml_prelinking_in_use = 0;

--- a/ocaml/runtime4/startup_nat.c
+++ b/ocaml/runtime4/startup_nat.c
@@ -70,18 +70,28 @@ static void init_static(void)
       caml_fatal_error("not enough memory for initial page table");
   }
 
-  caml_code_area_start = caml_code_segments[0].begin;
-  caml_code_area_end = caml_code_segments[0].end;
-  for (i = 1; caml_code_segments[i].begin != 0; i++) {
-    if (caml_code_segments[i].begin < caml_code_area_start)
-      caml_code_area_start = caml_code_segments[i].begin;
-    if (caml_code_segments[i].end > caml_code_area_end)
-      caml_code_area_end = caml_code_segments[i].end;
+  if (caml_prelinking_in_use) {
+    /* Register each segment as a separate code fragment */
+    for (i = 0; caml_code_segments[i].begin != 0; i++) {
+      caml_register_code_fragment(caml_code_segments[i].begin,
+                                  caml_code_segments[i].end,
+                                  DIGEST_LATER, NULL);
+    }
+  } else {
+    caml_code_area_start = caml_code_segments[0].begin;
+    caml_code_area_end = caml_code_segments[0].end;
+    for (i = 1; caml_code_segments[i].begin != 0; i++) {
+      if (caml_code_segments[i].begin < caml_code_area_start)
+        caml_code_area_start = caml_code_segments[i].begin;
+      if (caml_code_segments[i].end > caml_code_area_end)
+        caml_code_area_end = caml_code_segments[i].end;
+    }
+    /* Register the code in the table of code fragments */
+    caml_register_code_fragment(caml_code_area_start,
+                                caml_code_area_end,
+                                DIGEST_LATER, NULL);
   }
-  /* Register the code in the table of code fragments */
-  caml_register_code_fragment(caml_code_area_start,
-                              caml_code_area_end,
-                              DIGEST_LATER, NULL);
+
   /* Also register the glue code written in assembly */
   caml_register_code_fragment(&caml_system__code_begin,
                               &caml_system__code_end,

--- a/ocaml/runtime4/startup_nat.c
+++ b/ocaml/runtime4/startup_nat.c
@@ -46,6 +46,7 @@
 
 extern int caml_parser_trace;
 extern char caml_system__code_begin, caml_system__code_end;
+int caml_prelinking_in_use = 0;
 
 /* Initialize the atom table and the static data and code area limits. */
 

--- a/ocaml/runtime4/startup_nat.c
+++ b/ocaml/runtime4/startup_nat.c
@@ -46,7 +46,7 @@
 
 extern int caml_parser_trace;
 extern char caml_system__code_begin, caml_system__code_end;
-int caml_prelinking_in_use = 0;
+extern uintnat caml_prelinking_in_use;
 
 /* Initialize the atom table and the static data and code area limits. */
 


### PR DESCRIPTION
Add a special behavior for an experiment with prelinking to correctly handle closure marshalling. 
- Registering one big code fragment that covers all code segments in `caml_code_segments` is incorrect when the segments are not contiguous. Register each segment as a separate code fragment. 
- Add a global variable `caml_prelinking_in_use`, off by default. This PR does not affect normal compilation and execution. 