### PR TITLE
Promote the `unique` extension to `Stable`

### DIFF
--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags = "-extension unique";
  expect;
 *)
 

--- a/testsuite/tests/typing-modal-kinds/expected_mode.ml
+++ b/testsuite/tests/typing-modal-kinds/expected_mode.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags = "-extension unique";
  expect;
 *)
 

--- a/testsuite/tests/typing-modes/class.ml
+++ b/testsuite/tests/typing-modes/class.ml
@@ -1,5 +1,4 @@
 (* TEST
-    flags += "-extension unique";
     expect;
 *)
 

--- a/testsuite/tests/typing-modes/currying.ml
+++ b/testsuite/tests/typing-modes/currying.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags += "-extension unique";
  expect;
 *)
 

--- a/testsuite/tests/typing-modes/lazy.ml
+++ b/testsuite/tests/typing-modes/lazy.ml
@@ -1,5 +1,4 @@
 (* TEST
-    flags += "-extension unique";
     expect;
 *)
 

--- a/testsuite/tests/typing-modes/mutable.ml
+++ b/testsuite/tests/typing-modes/mutable.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension unique -w +53";
+ flags = "-w +53";
  expect;
 *)
 

--- a/testsuite/tests/typing-modes/probe.ml
+++ b/testsuite/tests/typing-modes/probe.ml
@@ -1,5 +1,4 @@
 (* TEST
-    flags += "-extension unique";
     expect;
 *)
 

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension unique -extension mode_alpha";
+ flags = "-extension mode_alpha";
  expect;
 *)
 

--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags += "-extension unique";
  expect;
 *)
 

--- a/testsuite/tests/typing-unique/unique_analysis.ml
+++ b/testsuite/tests/typing-unique/unique_analysis.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags += "-extension unique -extension layouts_beta";
+ flags += "-extension layouts_beta";
  expect;
 *)
 

--- a/testsuite/tests/typing-unique/unique_mod_class.ml
+++ b/testsuite/tests/typing-unique/unique_mod_class.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags += "-extension unique";
  expect;
 *)
 

--- a/testsuite/tests/typing-unique/unique_typedecl.ml
+++ b/testsuite/tests/typing-unique/unique_typedecl.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags += "-extension unique";
  expect;
 *)
 

--- a/utils/language_extension.ml
+++ b/utils/language_extension.ml
@@ -72,7 +72,7 @@ module Exist_pair = struct
   let maturity : t -> Maturity.t = function
     | Pair (Comprehensions, ()) -> Beta
     | Pair (Mode, m) -> m
-    | Pair (Unique, ()) -> Alpha
+    | Pair (Unique, ()) -> Stable
     | Pair (Include_functor, ()) -> Stable
     | Pair (Polymorphic_parameters, ()) -> Stable
     | Pair (Immutable_arrays, ()) -> Stable


### PR DESCRIPTION
This PR promotes the `unique` extension to `Stable`, which means it will be enabled by default.

Please do not merge until we finish benchmarking.