### PR TITLE
Clean up Cmm_helpers.arraylength

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -983,17 +983,8 @@ let wordsize_shift = 9
 
 let numfloat_shift = 9 + log2_size_float - log2_size_addr
 
-let is_addr_array_hdr hdr dbg =
-  Cop
-    ( Ccmpi Cne,
-      [Cop (Cand, [hdr; Cconst_int (255, dbg)], dbg); floatarray_tag dbg],
-      dbg )
-
 let addr_array_length_shifted hdr dbg =
   Cop (Clsr, [hdr; Cconst_int (wordsize_shift, dbg)], dbg)
-
-let float_array_length_shifted hdr dbg =
-  Cop (Clsr, [hdr; Cconst_int (numfloat_shift, dbg)], dbg)
 
 let lsl_const c n dbg =
   if n = 0 then c else Cop (Clsl, [c; Cconst_int (n, dbg)], dbg)
@@ -3227,35 +3218,9 @@ let raise_prim raise_kind arg dbg =
 
 let negint arg dbg = Cop (Csubi, [Cconst_int (2, dbg); arg], dbg)
 
-let arraylength kind arg dbg =
+let addr_array_length arg dbg =
   let hdr = get_header_masked arg dbg in
-  match (kind : Lambda.array_kind) with
-  | Pgenarray ->
-    let len =
-      if wordsize_shift = numfloat_shift
-      then Cop (Clsr, [hdr; Cconst_int (wordsize_shift, dbg)], dbg)
-      else
-        bind "header" hdr (fun hdr ->
-            Cifthenelse
-              ( is_addr_array_hdr hdr dbg,
-                dbg,
-                Cop (Clsr, [hdr; Cconst_int (wordsize_shift, dbg)], dbg),
-                dbg,
-                Cop (Clsr, [hdr; Cconst_int (numfloat_shift, dbg)], dbg),
-                dbg,
-                Any ))
-    in
-    Cop (Cor, [len; Cconst_int (1, dbg)], dbg)
-  | Paddrarray | Pintarray ->
-    Cop (Cor, [addr_array_length_shifted hdr dbg; Cconst_int (1, dbg)], dbg)
-  | Pfloatarray | Punboxedfloatarray Pfloat64 ->
-    (* Note: we only support 64 bit targets now, so this is ok for
-       Punboxedfloatarray *)
-    Cop (Cor, [float_array_length_shifted hdr dbg; Cconst_int (1, dbg)], dbg)
-  | Punboxedfloatarray Pfloat32 -> unboxed_float32_array_length arg dbg
-  | Punboxedintarray Pint64 | Punboxedintarray Pnativeint ->
-    unboxed_int64_or_nativeint_array_length arg dbg
-  | Punboxedintarray Pint32 -> unboxed_int32_array_length arg dbg
+  Cop (Cor, [addr_array_length_shifted hdr dbg; Cconst_int (1, dbg)], dbg)
 
 (* CR-soon gyorsh: effects and coeffects for primitives are set conservatively
    to Arbitrary_effects and Has_coeffects, resp. Check if this can be improved

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -464,7 +464,7 @@ val raise_prim : Lambda.raise_kind -> unary_primitive
 val negint : unary_primitive
 
 (** Return the length of the array argument, as an OCaml integer *)
-val arraylength : Lambda.array_kind -> unary_primitive
+val addr_array_length : unary_primitive
 
 (** Byte swap primitive Operates on Cmm integers (unboxed values) *)
 val bbswap : Primitive.boxed_integer -> unary_primitive

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -191,7 +191,7 @@ let array_length ~dbg arr (kind : P.Array_kind.t) =
     (* [Paddrarray] may be a lie sometimes, but we know for certain that the bit
        width of floats is equal to the machine word width (see flambda2.ml). *)
     assert (C.wordsize_shift = C.numfloat_shift);
-    C.arraylength Paddrarray arr dbg
+    C.addr_array_length arr dbg
   | Naked_float32s -> C.unboxed_float32_array_length arr dbg
   | Naked_int32s -> C.unboxed_int32_array_length arr dbg
   | Naked_int64s | Naked_nativeints ->


### PR DESCRIPTION
There was a lot of code in `Cmm_helpers.arraylength` that was never being called.  This deletes it.

(cherry picked from commit 0215e7af37e8cd66defe01fc07b32b48cfa2d221)