### PR TITLE
Add Sequence and Unboxed_product to primitive helper IR

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1054,7 +1054,7 @@ let close_named acc env ~let_bound_ids_with_kinds (named : IR.named)
       Unary (Tag_immediate, Prim (Unary (Get_tag, Simple named)))
     in
     Lambda_to_flambda_primitives_helpers.bind_recs acc None ~register_const0
-      [prim] Debuginfo.none k
+      prim Debuginfo.none k
   | Begin_region { is_try_region; ghost } ->
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
       Nullary
@@ -1063,7 +1063,7 @@ let close_named acc env ~let_bound_ids_with_kinds (named : IR.named)
         else Begin_region { ghost })
     in
     Lambda_to_flambda_primitives_helpers.bind_recs acc None ~register_const0
-      [prim] Debuginfo.none k
+      prim Debuginfo.none k
   | End_region { is_try_region; region; ghost } ->
     let named = find_simple_from_id env region in
     let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
@@ -1074,7 +1074,7 @@ let close_named acc env ~let_bound_ids_with_kinds (named : IR.named)
           Simple named )
     in
     Lambda_to_flambda_primitives_helpers.bind_recs acc None ~register_const0
-      [prim] Debuginfo.none k
+      prim Debuginfo.none k
   | Prim { prim; args; loc; exn_continuation; region; ghost_region } ->
     close_primitive acc env ~let_bound_ids_with_kinds named prim ~args loc
       exn_continuation

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -874,7 +874,7 @@ let[@inline always] match_on_array_set_kind ~array array_ref_kind f :
       ( Unary (Is_flat_float_array, array),
         f Array_set_kind.Naked_floats_to_be_unboxed,
         f (Array_set_kind.Values (Assignment mode)),
-        [K.With_subkind.any_value] )
+        [K.With_subkind.tagged_immediate] )
 
 (* Safe arith (div/mod by zero) *)
 let checked_arith_op ~dbg (bi : Lambda.boxed_integer option) op mode arg1 arg2

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -860,7 +860,8 @@ let[@inline always] match_on_array_ref_kind ~array array_ref_kind f :
     If_then_else
       ( Unary (Is_flat_float_array, array),
         f (Array_ref_kind.Naked_floats_to_be_boxed mode),
-        f Array_ref_kind.Values )
+        f Array_ref_kind.Values,
+        [K.With_subkind.any_value] )
 
 let[@inline always] match_on_array_set_kind ~array array_ref_kind f :
     H.expr_primitive =
@@ -872,7 +873,8 @@ let[@inline always] match_on_array_set_kind ~array array_ref_kind f :
     If_then_else
       ( Unary (Is_flat_float_array, array),
         f Array_set_kind.Naked_floats_to_be_unboxed,
-        f (Array_set_kind.Values (Assignment mode)) )
+        f (Array_set_kind.Values (Assignment mode)),
+        [K.With_subkind.any_value] )
 
 (* Safe arith (div/mod by zero) *)
 let checked_arith_op ~dbg (bi : Lambda.boxed_integer option) op mode arg1 arg2
@@ -1046,7 +1048,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
               Variadic
                 ( Make_array (Naked_floats, mutability, mode),
                   List.map unbox_float args ),
-              Variadic (Make_array (Values, mutability, mode), args) ) ]))
+              Variadic (Make_array (Values, mutability, mode), args),
+              [K.With_subkind.any_value] ) ]))
   | Popaque layout, [arg] -> opaque layout arg ~middle_end_only:false
   | Pobj_magic layout, [arg] -> opaque layout arg ~middle_end_only:true
   | Pduprecord (repr, num_fields), [[arg]] ->
@@ -1295,7 +1298,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
             Unary
               ( Duplicate_array
                   { kind = Values; source_mutability; destination_mutability },
-                arg ) ) ])
+                arg ),
+            [K.With_subkind.any_value] ) ])
   | Pstringlength, [[arg]] -> [tag_int (Unary (String_length String, arg))]
   | Pbyteslength, [[arg]] -> [tag_int (Unary (String_length Bytes, arg))]
   | Pstringrefu, [[str]; [index]] ->
@@ -2026,4 +2030,6 @@ let convert_and_bind acc ~big_endian exn_cont ~register_const0
     convert_lprim ~big_endian prim args dbg ~current_region
       ~current_ghost_region
   in
-  H.bind_recs acc exn_cont ~register_const0 exprs dbg cont
+  H.bind_recs acc exn_cont ~register_const0
+    (H.maybe_create_unboxed_product exprs)
+    dbg cont

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -350,16 +350,12 @@ let rec bind_recs acc exn_cont ~register_const0 (prim : expr_primitive)
       in
       let result_pats =
         List.map
-          (fun result_var ->
-            Bound_var.create result_var Name_mode.normal)
+          (fun result_var -> Bound_var.create result_var Name_mode.normal)
           result_vars
       in
-      let result_simples =
-        List.map Simple.var result_vars
-      in
+      let result_simples = List.map Simple.var result_vars in
       let acc, apply_cont =
-        Apply_cont_with_acc.create acc join_point_cont
-          ~args:result_simples ~dbg
+        Apply_cont_with_acc.create acc join_point_cont ~args:result_simples ~dbg
       in
       let acc, body = Expr_with_acc.create_apply_cont acc apply_cont in
       List.fold_left2
@@ -367,9 +363,7 @@ let rec bind_recs acc exn_cont ~register_const0 (prim : expr_primitive)
           Let_with_acc.create acc
             (Bound_pattern.singleton result_pat)
             ifso_or_ifnot ~body)
-        (acc, body)
-        (List.rev result_pats)
-        (List.rev ifso_or_ifnot)
+        (acc, body) (List.rev result_pats) (List.rev ifso_or_ifnot)
     in
     let ifso_handler_expr = ifso_or_ifnot_handler_expr ~name:"ifso" ifso in
     let ifnot_handler_expr = ifso_or_ifnot_handler_expr ~name:"ifnot" ifnot in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -40,11 +40,19 @@ type expr_primitive =
         (* Predefined exception *)
         dbg : Debuginfo.t
       }
-  | If_then_else of expr_primitive * expr_primitive * expr_primitive
+  | If_then_else of
+      expr_primitive
+      * expr_primitive
+      * expr_primitive
+      * Flambda_kind.With_subkind.t list
+  | Sequence of expr_primitive list
+  | Unboxed_product of expr_primitive list
 
 and simple_or_prim =
   | Simple of Simple.t
   | Prim of expr_primitive
+
+val maybe_create_unboxed_product : expr_primitive list -> expr_primitive
 
 val print_expr_primitive : Format.formatter -> expr_primitive -> unit
 
@@ -62,7 +70,7 @@ val bind_recs :
   Acc.t ->
   Exn_continuation.t option ->
   register_const0:(Acc.t -> Static_const.t -> string -> Acc.t * Symbol.t) ->
-  expr_primitive list ->
+  expr_primitive ->
   Debuginfo.t ->
   (Acc.t -> Flambda.Named.t list -> Expr_with_acc.t) ->
   Expr_with_acc.t


### PR DESCRIPTION
#3068 generates unboxed products inside the intermediate primitive helper IR terms in places where they couldn't exist before.  In addition it needs a sequencing construct.  To do that, it uses the support provided in this PR, which adds to `Lambda_to_flambda_primitive_helpers.expr_primitive` the following:
```diff
+|  | Sequence of expr_primitive list
+|  | Unboxed_product of expr_primitive list
 |
 |and simple_or_prim =
 |  | Simple of Simple.t
 |  | Prim of expr_primitive
 |
+|val maybe_create_unboxed_product : expr_primitive list -> expr_primitive
```
One consequence is that the if-then-else construct needs to take a result kind list.

I think this actually overall simplifies matters, as can be seen from the removal of the original `bind_rec` wrapper function.