### PR TITLE
Make bind `&` tighter than `mod` in jkind parsing

### DIFF
--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -1085,6 +1085,7 @@ The precedences must be listed from low to high.
 %left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ /* expr (e OP e OP e) */
 %left     PERCENT INFIXOP3 MOD STAR                 /* expr (e OP e OP e) */
 %right    INFIXOP4                      /* expr (e OP e OP e) */
+%nonassoc prec_unboxed_product_kind
 %nonassoc prec_unary_minus prec_unary_plus /* unary - */
 %nonassoc prec_constant_constructor     /* cf. simple_expr (C versus C x) */
 %nonassoc prec_constr_appl              /* above AS BAR COLONCOLON COMMA */
@@ -3911,11 +3912,11 @@ jkind:
 ;
 
 reverse_product_jkind :
-  | jkind1 = jkind AMPERSAND jkind2 = jkind %prec below_EQUAL
+  | jkind1 = jkind AMPERSAND jkind2 = jkind %prec prec_unboxed_product_kind
       { [jkind2; jkind1] }
   | jkinds = reverse_product_jkind
     AMPERSAND
-    jkind = jkind %prec below_EQUAL
+    jkind = jkind %prec prec_unboxed_product_kind
     { jkind :: jkinds }
 
 jkind_annotation: (* : jkind_annotation *)

--- a/ocaml/parsing/parser.mly
+++ b/ocaml/parsing/parser.mly
@@ -3881,19 +3881,8 @@ type_parameters:
       { ps }
 ;
 
-jkind:
-    jkind MOD mkrhs(LIDENT)+ { (* LIDENTs here are for modes *)
-      let modes =
-        List.map
-          (fun {txt; loc} -> {txt = Mode txt; loc})
-          $3
-      in
-      Jane_syntax.Jkind.Mod ($1, modes)
-    }
-  | jkind WITH core_type {
-      Jane_syntax.Jkind.With ($1, $3)
-    }
-  | mkrhs(ident) {
+jkind_no_mod_or_with:
+    mkrhs(ident) {
       let {txt; loc} = $1 in
       Jane_syntax.Jkind.(Abbreviation (Const.mk txt loc))
     }
@@ -3909,14 +3898,28 @@ jkind:
   | LPAREN jkind RPAREN {
       $2
     }
+
+jkind:
+    jkind MOD mkrhs(LIDENT)+ { (* LIDENTs here are for modes *)
+      let modes =
+        List.map
+          (fun {txt; loc} -> {txt = Mode txt; loc})
+          $3
+      in
+      Jane_syntax.Jkind.Mod ($1, modes)
+    }
+  | jkind WITH core_type {
+      Jane_syntax.Jkind.With ($1, $3)
+    }
+  | jkind_no_mod_or_with { $1 }
 ;
 
 reverse_product_jkind :
-  | jkind1 = jkind AMPERSAND jkind2 = jkind %prec prec_unboxed_product_kind
+  | jkind1 = jkind_no_mod_or_with AMPERSAND jkind2 = jkind_no_mod_or_with %prec prec_unboxed_product_kind
       { [jkind2; jkind1] }
   | jkinds = reverse_product_jkind
     AMPERSAND
-    jkind = jkind %prec prec_unboxed_product_kind
+    jkind = jkind_no_mod_or_with %prec prec_unboxed_product_kind
     { jkind :: jkinds }
 
 jkind_annotation: (* : jkind_annotation *)

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -437,21 +437,21 @@ and jkind ?(nested = false) ctxt f k = match (k : Jane_syntax.Jkind.t) with
     begin match modes with
     | [] -> Misc.fatal_error "malformed jkind annotation"
     | _ :: _ ->
-      if nested then pp f "(";
-      pp f "%a mod %a"
-        (jkind ~nested:true ctxt) t
-        (pp_print_list ~pp_sep:pp_print_space mode) modes;
-      if nested then pp f ")";
+      Misc.pp_parens_if nested (fun f (t, modes) ->
+        pp f "%a mod %a"
+          (jkind ~nested:true ctxt) t
+          (pp_print_list ~pp_sep:pp_print_space mode) modes
+      ) f (t, modes)
     end
   | With (t, ty) ->
-    if nested then pp f "(";
-    pp f "%a with %a" (jkind ~nested:true ctxt) t (core_type ctxt) ty;
-    if nested then pp f ")";
+    Misc.pp_parens_if nested (fun f (t, ty) ->
+      pp f "%a with %a" (jkind ~nested:true ctxt) t (core_type ctxt) ty
+    ) f (t, ty)
   | Kind_of ty -> pp f "kind_of_ %a" (core_type ctxt) ty
   | Product ts ->
-    if nested then pp f "(";
-    pp f "%a" (list (jkind ~nested:true ctxt) ~sep:"@;&@;") ts;
-    if nested then pp f ")"
+    Misc.pp_parens_if nested (fun f ts ->
+      pp f "%a" (list (jkind ~nested:true ctxt) ~sep:"@;&@;") ts
+    ) f ts
 
 and jkind_annotation ctxt f annot = jkind ctxt f annot.txt
 

--- a/ocaml/parsing/pprintast.ml
+++ b/ocaml/parsing/pprintast.ml
@@ -437,12 +437,16 @@ and jkind ?(nested = false) ctxt f k = match (k : Jane_syntax.Jkind.t) with
     begin match modes with
     | [] -> Misc.fatal_error "malformed jkind annotation"
     | _ :: _ ->
+      if nested then pp f "(";
       pp f "%a mod %a"
         (jkind ~nested:true ctxt) t
-        (pp_print_list ~pp_sep:pp_print_space mode) modes
+        (pp_print_list ~pp_sep:pp_print_space mode) modes;
+      if nested then pp f ")";
     end
   | With (t, ty) ->
-    pp f "%a with %a" (jkind ctxt) t (core_type ctxt) ty
+    if nested then pp f "(";
+    pp f "%a with %a" (jkind ~nested:true ctxt) t (core_type ctxt) ty;
+    if nested then pp f ")";
   | Kind_of ty -> pp f "kind_of_ %a" (core_type ctxt) ty
   | Product ts ->
     if nested then pp f "(";

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -50,8 +50,10 @@ module Example = struct
            () = () in f"
   let utuple_exp = parse expression
     "let #(x,y) : #(int * int) = #(1,2) in \
-     let #(a,#(b,c)) : ('a : value & (value & value)) = #(3,#(4,5)) in
-     x + y + a + b + c"
+     let #(a,#(b,c)) : ('a : value & (value & value)) = #(3,#(4,5)) in \
+     let #(i,j) : ('b : value mod m & (value mod l)) = #(6,7) in \
+     let #(s,t) : ('c : value mod m & value mod l) = #(7,8) in \
+     x + y + a + b + c + i + j + s + t"
 
   let modal_kind_struct =
     parse module_expr "struct \

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -53,7 +53,9 @@ module Example = struct
      let #(a,#(b,c)) : ('a : value & (value & value)) = #(3,#(4,5)) in \
      let #(i,j) : ('b : value mod m & (value mod l)) = #(6,7) in \
      let #(s,t) : ('c : value mod m & value mod l) = #(7,8) in \
-     x + y + a + b + c + i + j + s + t"
+     let #(k,l) : ('d : value with t & (value with t)) = #(6,7) in \
+     let #(u,v) : ('e : value with t & value with t) = #(7,8) in \
+     x + y + a + b + c + i + j + s + t + k + l + u + v"
 
   let modal_kind_struct =
     parse module_expr "struct \

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -42,9 +42,11 @@ fun_with_modes_on_arg:
 utuple_exp:
   let #(x, y) : #(int * int) = #(1, 2) in
   let #(a, #(b, c)) : ('a : value & (value & value)) = #(3, #(4, 5)) in
-  let #(i, j) : ('b : value mod m & value mod l) = #(6, 7) in
-  let #(s, t) : ('c : (value mod m & value) mod l) = #(7, 8) in
-  (((((((x + y) + a) + b) + c) + i) + j) + s) + t
+  let #(i, j) : ('b : (value mod m) & (value mod l)) = #(6, 7) in
+  let #(s, t) : ('c : ((value mod m) & value) mod l) = #(7, 8) in
+  let #(k, l) : ('d : (value with t) & (value with t)) = #(6, 7) in
+  let #(u, v) : ('e : ((value with t) & value) with t) = #(7, 8) in
+  (((((((((((x + y) + a) + b) + c) + i) + j) + s) + t) + k) + l) + u) + v
 
 longident: No.Longidents.Require.extensions
 
@@ -174,9 +176,11 @@ fun_with_modes_on_arg:
 utuple_exp:
   let #(x, y) : #(int * int) = #(1, 2) in
   let #(a, #(b, c)) : ('a : value & (value & value)) = #(3, #(4, 5)) in
-  let #(i, j) : ('b : value mod m & value mod l) = #(6, 7) in
-  let #(s, t) : ('c : (value mod m & value) mod l) = #(7, 8) in
-  (((((((x + y) + a) + b) + c) + i) + j) + s) + t
+  let #(i, j) : ('b : (value mod m) & (value mod l)) = #(6, 7) in
+  let #(s, t) : ('c : ((value mod m) & value) mod l) = #(7, 8) in
+  let #(k, l) : ('d : (value with t) & (value with t)) = #(6, 7) in
+  let #(u, v) : ('e : ((value with t) & value) with t) = #(7, 8) in
+  (((((((((((x + y) + a) + b) + c) + i) + j) + s) + t) + k) + l) + u) + v
 
 longident: No.Longidents.Require.extensions
 

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -42,7 +42,9 @@ fun_with_modes_on_arg:
 utuple_exp:
   let #(x, y) : #(int * int) = #(1, 2) in
   let #(a, #(b, c)) : ('a : value & (value & value)) = #(3, #(4, 5)) in
-  (((x + y) + a) + b) + c
+  let #(i, j) : ('b : value mod m & value mod l) = #(6, 7) in
+  let #(s, t) : ('c : (value mod m & value) mod l) = #(7, 8) in
+  (((((((x + y) + a) + b) + c) + i) + j) + s) + t
 
 longident: No.Longidents.Require.extensions
 
@@ -172,7 +174,9 @@ fun_with_modes_on_arg:
 utuple_exp:
   let #(x, y) : #(int * int) = #(1, 2) in
   let #(a, #(b, c)) : ('a : value & (value & value)) = #(3, #(4, 5)) in
-  (((x + y) + a) + b) + c
+  let #(i, j) : ('b : value mod m & value mod l) = #(6, 7) in
+  let #(s, t) : ('c : (value mod m & value) mod l) = #(7, 8) in
+  (((((((x + y) + a) + b) + c) + i) + j) + s) + t
 
 longident: No.Longidents.Require.extensions
 

--- a/ocaml/testsuite/tests/typing-layouts-products/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-products/basics_alpha.ml
@@ -47,6 +47,15 @@ type t2
 type t3 = #(t1 * t2)
 |}]
 
+type t1 : any
+type t2 : any mod non_null
+type t3 : any & (any mod non_null) = #(t1 * t2);;
+[%%expect{|
+type t1 : any
+type t2 : any mod non_null
+type t3 = #(t1 * t2)
+|}]
+
 (* Should not be allowed. *)
 type t1 : any
 type t2 : any mod non_null

--- a/ocaml/testsuite/tests/typing-layouts-products/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts-products/basics_alpha.ml
@@ -31,7 +31,7 @@ type t3 = #(t1 * t2)
 
 type t1 : any mod non_null
 type t2 : value
-type t3 : (any & value) mod non_null = #(t1 * t2);;
+type t3 : any & value mod non_null = #(t1 * t2);;
 [%%expect{|
 type t1 : any mod non_null
 type t2
@@ -40,7 +40,7 @@ type t3 = #(t1 * t2)
 
 type t1 : any mod non_null
 type t2 : value
-type t3 : any mod non_null & value mod non_null = #(t1 * t2);;
+type t3 : (any mod non_null) & (value mod non_null) = #(t1 * t2);;
 [%%expect{|
 type t1 : any mod non_null
 type t2
@@ -65,32 +65,32 @@ Error: The kind of type "#(t1 * t2)" is any & any
 
 type t1 : any
 type t2 : any mod non_null
-type t3 : (any & any) mod non_null = #(t1 * t2);;
+type t3 : any & any mod non_null = #(t1 * t2);;
 [%%expect{|
 type t1 : any
 type t2 : any mod non_null
-Line 3, characters 0-47:
-3 | type t3 : (any & any) mod non_null = #(t1 * t2);;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 3, characters 0-45:
+3 | type t3 : any & any mod non_null = #(t1 * t2);;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "#(t1 * t2)" is any & any
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of
          any_non_null & any_non_null
-         because of the definition of t3 at line 3, characters 0-47.
+         because of the definition of t3 at line 3, characters 0-45.
 |}]
 
 type t1 : any
 type t2 : any mod non_null
-type t3 : any mod non_null & any mod non_null = #(t1 * t2);;
+type t3 : (any mod non_null) & (any mod non_null) = #(t1 * t2);;
 [%%expect{|
 type t1 : any
 type t2 : any mod non_null
-Line 3, characters 0-58:
-3 | type t3 : any mod non_null & any mod non_null = #(t1 * t2);;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 3, characters 0-62:
+3 | type t3 : (any mod non_null) & (any mod non_null) = #(t1 * t2);;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "#(t1 * t2)" is any & any
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of
          any_non_null & any_non_null
-         because of the definition of t3 at line 3, characters 0-58.
+         because of the definition of t3 at line 3, characters 0-62.
 |}]

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -342,11 +342,13 @@ let print_out_jkind_const ppf ojkind =
     | Ojkind_const_default -> fprintf ppf "_"
     | Ojkind_const_abbreviation abbrev -> fprintf ppf "%s" abbrev
     | Ojkind_const_mod (base, modes) ->
-      fprintf ppf "%a mod @[%a@]" (pp_element ~nested) base
-        (pp_print_list
-            ~pp_sep:(fun ppf () -> fprintf ppf "@ ")
-            (fun ppf -> fprintf ppf "%s"))
-        modes
+      Misc.pp_parens_if nested (fun ppf (base, modes) ->
+        fprintf ppf "%a mod @[%a@]" (pp_element ~nested:true) base
+          (pp_print_list
+              ~pp_sep:(fun ppf () -> fprintf ppf "@ ")
+              (fun ppf -> fprintf ppf "%s"))
+          modes
+      ) ppf (base, modes)
     | Ojkind_const_product ts ->
       let pp_sep ppf () = Format.fprintf ppf "@ & " in
       Misc.pp_nested_list ~nested ~pp_element ~pp_sep ppf ts

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -661,6 +661,15 @@ val pp_two_columns :
     v}
 *)
 
+val pp_parens_if :
+     bool
+  -> (Format.formatter -> 'a -> unit)
+  -> Format.formatter
+  -> 'a
+  -> unit
+(** [pp_parens_if bool formatter ppf arg] prints [formatter ppf arg], wrapping it with
+    [()] if [bool] is true. *)
+
 val pp_nested_list :
      nested:bool
   -> pp_element:(nested:bool -> Format.formatter -> 'a -> unit)


### PR DESCRIPTION
Currently,
```ocaml
type t = j & k mod m
```
parses as
```ocaml
type t = j & (k mod m)
```

The crowdsourced concensus is that this is confusing. This PR makes it parse as
```ocaml
type t = (j & k) mod m
```
instead.

Why not require the user to be explicit and write parentheses either way? We'll likely make `ocamlformat` add more parentheses than are necessary, but feel that requiring parentheses in the parser would hurt approachability / discoverability of the new syntax.