### PR TITLE
Fix issue with section attributes produced for `.debug_str`

### DIFF
--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -103,8 +103,18 @@ let details t ~first_occurrence =
         | Debug_str -> ".debug_str"
         | Debug_line -> ".debug_line"
       in
-      let flags = if first_occurrence then Some "" else None in
-      let args = if first_occurrence then ["%progbits"] else [] in
+      let flags =
+        match first_occurrence, dwarf with
+        | true, Debug_str -> Some "MS"
+        | true, _ -> Some ""
+        | false, _ -> None
+      in
+      let args =
+        match first_occurrence, dwarf with
+        | true, Debug_str -> ["%progbits,1"]
+        | true, _ -> ["%progbits"]
+        | false, _ -> []
+      in
       [name], flags, args
     | Text, _ -> Misc.fatal_error "Not yet implemented"
   in


### PR DESCRIPTION
The section attributes we were producing for the `.debug_str` section were causing issues when using `clang` as an assembler. To reproduce the bug, you can run:
```sh
export CC=clang
export CXX=clang++
export AS='clang -c'
autoconf
./configure --enable-dev --prefix=$PWD/_install
make -s -j $(nproc) && make -s install

echo 'let () = print_endline "Hello world";;' > example.ml
_build/default/boot_ocamlopt.exe -g -gno-upstream-dwarf example.ml
```

This was producing an error of the form:
```txt
/tmp/camlasm010433.s:8:2: error: changed section flags for .debug_str, expected: 0x30
        .section .debug_str,"",%progbits
        ^
/tmp/camlasm010433.s:8:2: error: changed section entsize for .debug_str, expected: 1
        .section .debug_str,"",%progbits
        ^
File "example.ml", line 1:
Error: Assembler error, input left in file /tmp/camlasm010433.s
```

This commit fixes this issue by setting the section flags and section entsize to the expected values.