### PR TITLE
Simplify [sign_extend_63] immediately after [asr]

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1882,13 +1882,18 @@ let rec low_63 dbg e =
   | _ -> e
 
 (* CR-someday mshinwell/gbury: sign_extend_63 then tag_int should simplify to
-   just tag_int. Similarly, untag_int then sign_extend_63 should simplify to
-   untag_int. *)
+   just tag_int. *)
 let sign_extend_63 dbg e =
   check_64_bit_target "sign_extend_63";
-  let e = low_63 dbg e in
-  Cop
-    (Casr, [Cop (Clsl, [e; Cconst_int (1, dbg)], dbg); Cconst_int (1, dbg)], dbg)
+  match e with
+  | Cop (Casr, [_; Cconst_int (n, _)], _) when n > 0 ->
+    e (* [asr] by a positive constant is sign-preserving *)
+  | _ ->
+    let e = low_63 dbg e in
+    Cop
+      ( Casr,
+        [Cop (Clsl, [e; Cconst_int (1, dbg)], dbg); Cconst_int (1, dbg)],
+        dbg )
 
 (* zero_extend_32 zero-extends values from 32 bits to the word size. *)
 let zero_extend_32 dbg e =


### PR DESCRIPTION
There's a lingering `CR-someday` to make `untag_int` followed by `sign_extend_63` simplify to `untag_int` when translating to cmm. More generally, `asr` by a positive constant is sign-preserving, and so `sign_extend_63` on any such expression can be a no-op. This optimization is implemented here.

This PR is prompted by bad codegen in the following program:
```ocaml
type t = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t

external unsafe_get_64 : local_ t -> int -> (int64[@local_opt]) = "%caml_bigstring_get64u"

let unsafe_get t ~pos = Int64.to_int (unsafe_get_64 t pos)
```
The asm of `unsafe_get` before this PR:
```
movq    8(%rax), %rax
sarq    $1, %rbx
salq    $1, %rbx
sarq    $1, %rbx
movq    (%rax,%rbx), %rax
leaq    1(%rax,%rax), %rax
ret
```
(note the `sar; sal; sar`)
after this PR:
```
movq    8(%rax), %rax
sarq    $1, %rbx
movq    (%rax,%rbx), %rax
leaq    1(%rax,%rax), %rax
ret
```