### PR TITLE
Check for the labeled_tuples extension

### DIFF
--- a/ocaml/testsuite/tests/typing-labeled-tuples/no_extension.ml
+++ b/ocaml/testsuite/tests/typing-labeled-tuples/no_extension.ml
@@ -1,0 +1,58 @@
+(* TEST
+   flags = "-extension-universe no_extensions";
+   expect;
+*)
+
+type t = x:int * y:string
+
+[%%expect{|
+type t = x:int * y:string
+|}]
+
+let f x y = ~x, ~y
+
+[%%expect{|
+val f : 'a -> 'b -> x:'a * y:'b = <fun>
+|}]
+
+let x = ~x:5, ~y:"hi"
+
+[%%expect{|
+val x : x:int * y:string = (~x:5, ~y:"hi")
+|}]
+
+let f x y = ~(x : int), ~(y : string)
+
+[%%expect{|
+val f : int -> string -> x:int * y:string = <fun>
+|}]
+
+let f (~x, ~y) = x, y
+
+[%%expect{|
+val f : (x:'a * y:'b) -> 'a * 'b = <fun>
+|}]
+
+let f (~x:_, ~y:_) = ()
+
+[%%expect{|
+val f : (x:'a * y:'b) -> unit = <fun>
+|}]
+
+let f (~(x:int), ~(y:string)) = x, y
+
+[%%expect{|
+val f : (x:int * y:string) -> int * string = <fun>
+|}]
+
+let f ((x, ..) : (int * string * float)) = x
+
+[%%expect{|
+val f : int * string * float -> int = <fun>
+|}]
+
+let f ((x, y, ..) : (int * string * float)) = x, y
+
+[%%expect{|
+val f : int * string * float -> int * string = <fun>
+|}]

--- a/ocaml/testsuite/tests/typing-labeled-tuples/no_extension.ml
+++ b/ocaml/testsuite/tests/typing-labeled-tuples/no_extension.ml
@@ -6,53 +6,80 @@
 type t = x:int * y:string
 
 [%%expect{|
-type t = x:int * y:string
+Line 1, characters 9-25:
+1 | type t = x:int * y:string
+             ^^^^^^^^^^^^^^^^
+Error: The extension "labeled_tuples" is disabled and cannot be used
 |}]
 
 let f x y = ~x, ~y
 
 [%%expect{|
-val f : 'a -> 'b -> x:'a * y:'b = <fun>
+Line 1, characters 12-18:
+1 | let f x y = ~x, ~y
+                ^^^^^^
+Error: The extension "labeled_tuples" is disabled and cannot be used
 |}]
 
 let x = ~x:5, ~y:"hi"
 
 [%%expect{|
-val x : x:int * y:string = (~x:5, ~y:"hi")
+Line 1, characters 8-21:
+1 | let x = ~x:5, ~y:"hi"
+            ^^^^^^^^^^^^^
+Error: The extension "labeled_tuples" is disabled and cannot be used
 |}]
 
 let f x y = ~(x : int), ~(y : string)
 
 [%%expect{|
-val f : int -> string -> x:int * y:string = <fun>
+Line 1, characters 12-37:
+1 | let f x y = ~(x : int), ~(y : string)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The extension "labeled_tuples" is disabled and cannot be used
 |}]
 
 let f (~x, ~y) = x, y
 
 [%%expect{|
-val f : (x:'a * y:'b) -> 'a * 'b = <fun>
+Line 1, characters 6-14:
+1 | let f (~x, ~y) = x, y
+          ^^^^^^^^
+Error: The extension "labeled_tuples" is disabled and cannot be used
 |}]
 
 let f (~x:_, ~y:_) = ()
 
 [%%expect{|
-val f : (x:'a * y:'b) -> unit = <fun>
+Line 1, characters 6-18:
+1 | let f (~x:_, ~y:_) = ()
+          ^^^^^^^^^^^^
+Error: The extension "labeled_tuples" is disabled and cannot be used
 |}]
 
 let f (~(x:int), ~(y:string)) = x, y
 
 [%%expect{|
-val f : (x:int * y:string) -> int * string = <fun>
+Line 1, characters 6-29:
+1 | let f (~(x:int), ~(y:string)) = x, y
+          ^^^^^^^^^^^^^^^^^^^^^^^
+Error: The extension "labeled_tuples" is disabled and cannot be used
 |}]
 
 let f ((x, ..) : (int * string * float)) = x
 
 [%%expect{|
-val f : int * string * float -> int = <fun>
+Line 1, characters 7-14:
+1 | let f ((x, ..) : (int * string * float)) = x
+           ^^^^^^^
+Error: The extension "labeled_tuples" is disabled and cannot be used
 |}]
 
 let f ((x, y, ..) : (int * string * float)) = x, y
 
 [%%expect{|
-val f : int * string * float -> int * string = <fun>
+Line 1, characters 7-17:
+1 | let f ((x, y, ..) : (int * string * float)) = x, y
+           ^^^^^^^^^^
+Error: The extension "labeled_tuples" is disabled and cannot be used
 |}]

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -2530,6 +2530,11 @@ and type_pat_aux
       match get_desc (expand_head !!penv expected_ty) with
       (* If it's a principally-known tuple pattern, try to reorder *)
       | Ttuple labeled_tl when is_principal expected_ty ->
+        begin match closed with
+        | Open -> Jane_syntax_parsing.assert_extension_enabled ~loc
+                    Language_extension.Labeled_tuples ()
+        | Closed -> ()
+        end;
         reorder_pat loc penv spl closed labeled_tl expected_ty
       (* If not, it's not allowed to be open (partial) *)
       | _ ->
@@ -2542,6 +2547,8 @@ and type_pat_aux
     in
     let pl =
       List.map (fun (lbl, p, t, alloc_mode) ->
+        Option.iter (fun _ -> Jane_syntax_parsing.assert_extension_enabled ~loc
+                                Language_extension.Labeled_tuples ()) lbl;
         lbl, type_pat tps Value ~alloc_mode p t)
         spl_ann
     in
@@ -2559,6 +2566,11 @@ and type_pat_aux
       match get_desc (expand_head !!penv expected_ty) with
       (* If it's a principally-known tuple pattern, try to reorder *)
       | Tunboxed_tuple labeled_tl when is_principal expected_ty ->
+                begin match closed with
+        | Open -> Jane_syntax_parsing.assert_extension_enabled ~loc
+                    Language_extension.Labeled_tuples ()
+        | Closed -> ()
+        end;
         reorder_pat loc penv spl closed labeled_tl expected_ty
       (* If not, it's not allowed to be open (partial) *)
       | _ ->
@@ -2572,6 +2584,8 @@ and type_pat_aux
     in
     let pl =
       List.map (fun (lbl, p, t, alloc_mode, sort) ->
+        Option.iter (fun _ -> Jane_syntax_parsing.assert_extension_enabled ~loc
+                                Language_extension.Labeled_tuples ()) lbl;
         lbl, type_pat tps Value ~alloc_mode p t, sort)
         spl_ann
     in
@@ -7812,6 +7826,8 @@ and type_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
   let expl =
     List.map2
       (fun (label, body) ((_, ty), argument_mode) ->
+        Option.iter (fun _ -> Jane_syntax_parsing.assert_extension_enabled ~loc
+                                Language_extension.Labeled_tuples ()) label;
         let argument_mode = mode_default argument_mode in
         let argument_mode = expect_mode_cross env ty argument_mode in
           (label, type_expect env argument_mode body (mk_expected ty)))
@@ -7866,6 +7882,8 @@ and type_unboxed_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
   let expl =
     List.map2
       (fun (label, body) ((_, ty, sort), argument_mode) ->
+        Option.iter (fun _ -> Jane_syntax_parsing.assert_extension_enabled ~loc
+                                Language_extension.Labeled_tuples ()) label;
         let argument_mode = mode_default argument_mode in
         let argument_mode = expect_mode_cross env ty argument_mode in
           (label, type_expect env argument_mode body (mk_expected ty), sort))

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -717,7 +717,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       loop mode args
   | Ptyp_tuple stl ->
     let desc, typ =
-      transl_type_aux_tuple env ~policy ~row_context stl
+      transl_type_aux_tuple env ~loc ~policy ~row_context stl
     in
     ctyp desc typ
   | Ptyp_unboxed_tuple stl ->
@@ -1165,11 +1165,13 @@ and transl_type_alias env ~row_context ~policy mode attrs styp_loc styp name_opt
   Ttyp_alias (cty, name_opt, jkind_annot),
   cty.ctyp_type
 
-and transl_type_aux_tuple env ~policy ~row_context stl =
+and transl_type_aux_tuple env ~loc ~policy ~row_context stl =
   assert (List.length stl >= 2);
   let ctys =
     List.map
       (fun (label, t) ->
+         Option.iter (fun _ -> Jane_syntax_parsing.assert_extension_enabled ~loc
+                                 Language_extension.Labeled_tuples ()) label;
          label, transl_type env ~policy ~row_context Alloc.Const.legacy t)
       stl
   in


### PR DESCRIPTION
While working elsewhere, I noticed that the labeled tuples extension is not actually checked anywhere. The first commit observes this and the next one fixes it.

Review: either @ccasin or @rtjoa.