### PR TITLE
Document [@error_message]

### DIFF
--- a/ocaml/jane/doc/extensions/error_message.md
+++ b/ocaml/jane/doc/extensions/error_message.md
@@ -1,0 +1,38 @@
+# The `[@error_message]` attribute
+
+You can put the `[@error_message]` attribute on type or kind constraints
+to add custom text to error messages. This can be useful in the output
+of a ppx to better direct the user to the source of the error.
+
+For example, suppose we have a ppx that translates `[%i_have_a x]` to `Some x`.
+This makes sense only for `value`s. So we might actually translate
+
+```
+let f x = [%i_have_a x]
+```
+
+to
+
+```
+let f x = Some (x : ((_ : value)[@error_message "only works with values"]))
+```
+
+which will say `only works with values` to the user in the error message.
+
+This also works on type constraints like `(x : string)`,
+though the implementation on type constraints is more fragile, producing
+the custom message only if we already know the type of the expression
+before seeing the type constraint. For example, this produces a custom
+message:
+
+```
+let f (x : bool) = (x : int)[@error_message "custom"]
+```
+
+But this does not:
+
+```
+let f x = (x : bool)[@error_message "custom"] + 1
+```
+
+

--- a/ocaml/jane/doc/extensions/error_message.md
+++ b/ocaml/jane/doc/extensions/error_message.md
@@ -1,11 +1,10 @@
 # The `[@error_message]` attribute
 
 You can put the `[@error_message]` attribute on type or kind constraints
-to add custom text to error messages. This can be useful in the output
-of a ppx to better direct the user to the source of the error.
+to add custom text to error messages, useful when writing a ppx.
 
 For example, suppose we have a ppx that translates `[%i_have_a x]` to `Some x`.
-This makes sense only for `value`s. So we might actually translate
+This makes sense only for `value`s. So the ppx might actually translate
 
 ```
 let f x = [%i_have_a x]
@@ -17,7 +16,8 @@ to
 let f x = Some (x : ((_ : value)[@error_message "only works with values"]))
 ```
 
-which will say `only works with values` to the user in the error message.
+which will say `only works with values` to the user if the type of `x` does not
+have kind `value`.
 
 This also works on type constraints like `(x : string)`,
 though the implementation on type constraints is more fragile, producing


### PR DESCRIPTION
As title. We somehow missed this.

@TheNumbat is a good writer and I would be pleased for his feedback here.