### PR TITLE
Improve sort variable printing

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts-err-msg/concrete.ml
+++ b/ocaml/testsuite/tests/typing-layouts-err-msg/concrete.ml
@@ -19,7 +19,7 @@ Line 5, characters 15-37:
 5 | let () = match (assert false : t_any) with _ -> ()
                    ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_2)"
+         "('a : '_representable_layout_1)"
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-16.
        But the layout of t_any must be representable
@@ -63,7 +63,7 @@ Line 2, characters 9-14:
 2 | and t2 = t_any t
              ^^^^^
 Error: This type "t_any" should be an instance of type
-         "('a : '_representable_layout_5)"
+         "('a : '_representable_layout_2)"
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-16.
        But the layout of t_any must be representable
@@ -85,7 +85,7 @@ Line 1, characters 4-5:
         ^
 Error: This pattern matches values of type "t_any"
        but a pattern was expected which matches values of type
-         "('a : '_representable_layout_7)"
+         "('a : '_representable_layout_3)"
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-16.
        But the layout of t_any must be representable
@@ -101,7 +101,7 @@ Line 1, characters 6-16:
           ^^^^^^^^^^
 Error: This pattern matches values of type "t_any"
        but a pattern was expected which matches values of type
-         "('a : '_representable_layout_9)"
+         "('a : '_representable_layout_4)"
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-16.
        But the layout of t_any must be representable
@@ -116,7 +116,7 @@ Line 1, characters 18-30:
 1 | let f (): t_any = assert false
                       ^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_13)"
+         "('a : '_representable_layout_5)"
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-16.
        But the layout of t_any must be representable
@@ -170,7 +170,7 @@ Line 1, characters 9-21:
 1 | let _ = (assert false : t_any); ()
              ^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_21)"
+         "('a : '_representable_layout_6)"
        because it is in the left-hand side of a sequence
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-16.

--- a/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -26,7 +26,7 @@ Line 1, characters 6-26:
           ^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type "t_any_non_null"
        but a pattern was expected which matches values of type
-         "('a : '_representable_layout_2)"
+         "('a : '_representable_layout_1)"
        The layout of t_any_non_null is any
          because of the definition of t_any_non_null at line 2, characters 0-34.
        But the layout of t_any_non_null must be representable
@@ -79,7 +79,7 @@ Line 2, characters 13-19:
 2 |   let g () = X.g ()
                  ^^^^^^
 Error: This expression has type "t_any_non_null"
-       but an expression was expected of type "('a : '_representable_layout_7)"
+       but an expression was expected of type "('a : '_representable_layout_2)"
        The layout of t_any_non_null is any
          because of the definition of t_any_non_null at line 2, characters 0-34.
        But the layout of t_any_non_null must be representable

--- a/ocaml/testsuite/tests/typing-layouts-products/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts-products/basics.ml
@@ -231,7 +231,7 @@ Line 1, characters 25-31:
                              ^^^^^^
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_86 & '_representable_layout_87
+       The layout of #('a * 'b) is '_representable_layout_1 & '_representable_layout_2
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of the field of a polymorphic variant.
@@ -256,7 +256,7 @@ Line 1, characters 24-31:
                             ^^^^^^^
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_89 & '_representable_layout_90
+       The layout of #('a * 'b) is '_representable_layout_3 & '_representable_layout_4
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a tuple element.
@@ -348,7 +348,7 @@ Line 3, characters 15-21:
                    ^^^^^^
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_102 & '_representable_layout_103
+       The layout of #('a * 'b) is '_representable_layout_5 & '_representable_layout_6
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of an object field.
@@ -365,7 +365,7 @@ Line 3, characters 17-21:
                      ^^^^
 Error: This expression has type "('a : value)"
        but an expression was expected of type "#('b * 'c)"
-       The layout of #('a * 'b) is '_representable_layout_110 & '_representable_layout_111
+       The layout of #('a * 'b) is '_representable_layout_7 & '_representable_layout_8
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a variable captured in an object.
@@ -701,7 +701,7 @@ Line 2, characters 37-44:
                                          ^^^^^^^
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_190 & '_representable_layout_191
+       The layout of #('a * 'b) is '_representable_layout_9 & '_representable_layout_10
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of the recursive variable x.
@@ -717,7 +717,7 @@ Line 1, characters 21-29:
                          ^^^^^^^^
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_195 & '_representable_layout_196
+       The layout of #('a * 'b) is '_representable_layout_11 & '_representable_layout_12
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of the recursive variable _x.
@@ -796,7 +796,7 @@ Line 1, characters 31-37:
                                    ^^^^^^
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_210 & '_representable_layout_211
+       The layout of #('a * 'b) is '_representable_layout_13 & '_representable_layout_14
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value.
 |}]
@@ -863,7 +863,7 @@ Line 2, characters 25-26:
                              ^
 Error: This expression has type "('a : value)"
        but an expression was expected of type "#('b * 'c)"
-       The layout of #('a * 'b) is '_representable_layout_246 & '_representable_layout_247
+       The layout of #('a * 'b) is '_representable_layout_15 & '_representable_layout_16
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a term-level argument to a class constructor.
@@ -880,7 +880,7 @@ Line 1, characters 13-19:
                  ^^^^^^
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_249 & '_representable_layout_250
+       The layout of #('a * 'b) is '_representable_layout_17 & '_representable_layout_18
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because it's the type of a lazy expression.
@@ -930,7 +930,7 @@ Line 1, characters 28-34:
                                 ^^^^^^
 Error: This expression has type "#('a * 'b)"
        but an expression was expected of type "('c : value)"
-       The layout of #('a * 'b) is '_representable_layout_267 & '_representable_layout_268
+       The layout of #('a * 'b) is '_representable_layout_19 & '_representable_layout_20
          because it is an unboxed tuple.
        But the layout of #('a * 'b) must be a sublayout of value
          because the type argument of option has layout value.

--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -848,7 +848,7 @@ Line 1, characters 29-36:
                                  ^^^^^^^
 Error: This pattern matches values of type "a"
        but a pattern was expected which matches values of type
-         "('a : '_representable_layout_203)"
+         "('a : '_representable_layout_1)"
        The layout of a is any
          because of the annotation on the abstract type declaration for a.
        But the layout of a must be representable

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -88,7 +88,7 @@ Line 4, characters 35-41:
 4 |   type 'a s = 'a -> int constraint 'a = t
                                        ^^^^^^
 Error: The type constraints are not consistent.
-       Type "('a : '_representable_layout_2)" is not compatible with type "t"
+       Type "('a : '_representable_layout_1)" is not compatible with type "t"
        The layout of t is any
          because of the definition of t at line 2, characters 2-14.
        But the layout of t must be representable
@@ -348,7 +348,7 @@ Line 4, characters 35-41:
 4 |   type 'a s = 'a -> int constraint 'a = t
                                        ^^^^^^
 Error: The type constraints are not consistent.
-       Type "('a : '_representable_layout_219)" is not compatible with type "t"
+       Type "('a : '_representable_layout_2)" is not compatible with type "t"
        The layout of t is any
          because of the definition of t at line 2, characters 2-14.
        But the layout of t must be representable
@@ -365,7 +365,7 @@ Line 4, characters 35-41:
 4 |   type 'a s = int -> 'a constraint 'a = t
                                        ^^^^^^
 Error: The type constraints are not consistent.
-       Type "('a : '_representable_layout_221)" is not compatible with type "t"
+       Type "('a : '_representable_layout_3)" is not compatible with type "t"
        The layout of t is any
          because of the definition of t at line 2, characters 2-14.
        But the layout of t must be representable
@@ -378,7 +378,7 @@ Line 1, characters 20-32:
 1 | let f1 () : t_any = assert false;;
                         ^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_224)"
+         "('a : '_representable_layout_4)"
        The layout of t_any is any
          because of the definition of t_any at line 5, characters 0-18.
        But the layout of t_any must be representable
@@ -392,7 +392,7 @@ Line 1, characters 7-18:
            ^^^^^^^^^^^
 Error: This pattern matches values of type "t_any"
        but a pattern was expected which matches values of type
-         "('a : '_representable_layout_226)"
+         "('a : '_representable_layout_5)"
        The layout of t_any is any
          because of the definition of t_any at line 5, characters 0-18.
        But the layout of t_any must be representable
@@ -1899,7 +1899,7 @@ Line 1, characters 10-22:
 1 | let () = (assert false : t_any); ()
               ^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_614)"
+         "('a : '_representable_layout_6)"
        because it is in the left-hand side of a sequence
        The layout of t_any is any
          because of the definition of t_any at line 5, characters 0-18.
@@ -1918,7 +1918,7 @@ Line 1, characters 25-37:
 1 | let () = while false do (assert false : t_any); done
                              ^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_616)"
+         "('a : '_representable_layout_7)"
        because it is in the body of a while-loop
        The layout of t_any is any
          because of the definition of t_any at line 5, characters 0-18.
@@ -1937,7 +1937,7 @@ Line 1, characters 28-40:
 1 | let () = for i = 0 to 0 do (assert false : t_any); done
                                 ^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_618)"
+         "('a : '_representable_layout_8)"
        because it is in the body of a for-loop
        The layout of t_any is any
          because of the definition of t_any at line 5, characters 0-18.

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -74,7 +74,7 @@ Line 4, characters 35-41:
 4 |   type 'a s = 'a -> int constraint 'a = t
                                        ^^^^^^
 Error: The type constraints are not consistent.
-       Type "('a : '_representable_layout_6)" is not compatible with type "t"
+       Type "('a : '_representable_layout_1)" is not compatible with type "t"
        The layout of t is any
          because of the definition of t at line 2, characters 2-14.
        But the layout of t must be representable
@@ -91,7 +91,7 @@ Line 4, characters 35-41:
 4 |   type 'a s = int -> 'a constraint 'a = t
                                        ^^^^^^
 Error: The type constraints are not consistent.
-       Type "('a : '_representable_layout_8)" is not compatible with type "t"
+       Type "('a : '_representable_layout_2)" is not compatible with type "t"
        The layout of t is any
          because of the definition of t at line 2, characters 2-14.
        But the layout of t must be representable
@@ -104,7 +104,7 @@ Line 1, characters 20-32:
 1 | let f1 () : t_any = assert false;;
                         ^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_11)"
+         "('a : '_representable_layout_3)"
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-18.
        But the layout of t_any must be representable
@@ -118,7 +118,7 @@ Line 1, characters 7-18:
            ^^^^^^^^^^^
 Error: This pattern matches values of type "t_any"
        but a pattern was expected which matches values of type
-         "('a : '_representable_layout_13)"
+         "('a : '_representable_layout_4)"
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-18.
        But the layout of t_any must be representable
@@ -1831,7 +1831,7 @@ Line 1, characters 10-22:
 1 | let () = (assert false : t_any); ()
               ^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_529)"
+         "('a : '_representable_layout_5)"
        because it is in the left-hand side of a sequence
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-18.
@@ -1850,7 +1850,7 @@ Line 1, characters 25-37:
 1 | let () = while false do (assert false : t_any); done
                              ^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_531)"
+         "('a : '_representable_layout_6)"
        because it is in the body of a while-loop
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-18.
@@ -1869,7 +1869,7 @@ Line 1, characters 28-40:
 1 | let () = for i = 0 to 0 do (assert false : t_any); done
                                 ^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_533)"
+         "('a : '_representable_layout_7)"
        because it is in the body of a for-loop
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-18.

--- a/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/ocaml/testsuite/tests/typing-layouts/layout_poly.ml
@@ -34,7 +34,7 @@ Line 3, characters 14-36:
 3 | let f () = id (assert false : t_any)
                   ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type "t_any" but an expression was expected of type
-         "('a : '_representable_layout_9)"
+         "('a : '_representable_layout_1)"
        The layout of t_any is any
          because of the definition of t_any at line 3, characters 0-16.
        But the layout of t_any must be representable

--- a/ocaml/testsuite/tests/typing-layouts/printing.ml
+++ b/ocaml/testsuite/tests/typing-layouts/printing.ml
@@ -16,11 +16,11 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : ('a : '_representable_layout_4). unit -> 'a -> unit end
+         sig val f : ('a : '_representable_layout_1). unit -> 'a -> unit end
        is not included in
          sig val f : int -> bool -> char end
        Values do not match:
-         val f : ('a : '_representable_layout_4). unit -> 'a -> unit
+         val f : ('a : '_representable_layout_1). unit -> 'a -> unit
        is not included in
          val f : int -> bool -> char
        The type "unit -> 'a -> unit" is not compatible with the type

--- a/ocaml/typing/jkind_types.ml
+++ b/ocaml/typing/jkind_types.ml
@@ -99,7 +99,22 @@ module Sort = struct
   module Var = struct
     type t = var
 
-    let name { uid; _ } = "'_representable_layout_" ^ Int.to_string uid
+    (* Map var uids to smaller numbers for more consistent printing. *)
+    let next_id = ref 1
+
+    let names : (int, int) Hashtbl.t = Hashtbl.create 16
+
+    let name { uid; _ } =
+      let id =
+        match Hashtbl.find_opt names uid with
+        | Some n -> n
+        | None ->
+          let id = !next_id in
+          incr next_id;
+          Hashtbl.add names uid id;
+          id
+      in
+      "'_representable_layout_" ^ Int.to_string id
   end
 
   (*** debug printing **)


### PR DESCRIPTION
This PR improves the printing of sort variables to be more stable.

The unboxed tuples PR (#2879) added unique ids to sort variables, which is useful for debugging.  I also changed the printing of sort variables to print these unique ids, rather than generating new numbers.  But this has introduced too much churn in the tests as any change to jkind checking is likely to perturb the number of sort variables that are generated during typechecking of a random program.  So, this PR restores the old strategy (but still keeps the uids, as they are essential when inspecting jkind checking in the debugger).
