### PR TITLE
Add fields to newtype

### DIFF
--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -53,7 +53,8 @@ type texp_function_param_identifier = {
   param_sort : Jkind.Sort.t;
   param_mode : Alloc.l;
   param_curry : function_curry;
-  param_newtypes : (Ident.t * string Location.loc * Jkind.annotation option * Uid.t) list;
+  param_newtypes :
+    (Ident.t * string Location.loc * Jkind.annotation option * Uid.t) list;
 }
 
 type texp_function_param = {

--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -53,7 +53,7 @@ type texp_function_param_identifier = {
   param_sort : Jkind.Sort.t;
   param_mode : Alloc.l;
   param_curry : function_curry;
-  param_newtypes : (string Location.loc * Jkind.annotation option) list;
+  param_newtypes : (Ident.t * string Location.loc * Jkind.annotation option * Uid.t) list;
 }
 
 type texp_function_param = {

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -427,8 +427,8 @@ and expression_extra i ppf x attrs =
       line i ppf "Texp_poly\n";
       attributes i ppf attrs;
       option i core_type ppf cto;
-  | Texp_newtype (s, lay) ->
-      line i ppf "Texp_newtype %a\n" (typevar_jkind ~print_quote:false) (s, lay);
+  | Texp_newtype (_, s, lay, _) ->
+      line i ppf "Texp_newtype %a\n" (typevar_jkind ~print_quote:false) (s.txt, lay);
       attributes i ppf attrs;
   | Texp_stack ->
       line i ppf "Texp_stack\n";

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -287,7 +287,7 @@ let extra sub = function
 let function_param sub { fp_loc; fp_kind; fp_newtypes; _ } =
   sub.location sub fp_loc;
   List.iter
-    (fun (var, annot) ->
+    (fun (_, var, annot, _) ->
        iter_loc sub var;
        Option.iter (sub.jkind_annotation sub) annot)
     fp_newtypes;

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -349,8 +349,8 @@ let function_param sub
   in
   let fp_newtypes =
     List.map
-      (fun (var, annot) ->
-         map_loc sub var, Option.map (sub.jkind_annotation sub) annot)
+      (fun (id, var, annot, uid) ->
+         id, map_loc sub var, Option.map (sub.jkind_annotation sub) annot, uid)
       fp_newtypes
   in
   { fp_kind;

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -133,7 +133,7 @@ and exp_extra =
   | Texp_constraint of core_type option * Mode.Alloc.Const.Option.t
   | Texp_coerce of core_type option * core_type
   | Texp_poly of core_type option
-  | Texp_newtype of string * Jkind.annotation option
+  | Texp_newtype of Ident.t * string loc * Jkind.annotation option * Uid.t
   | Texp_stack
 
 and arg_label = Types.arg_label =
@@ -281,7 +281,7 @@ and function_param =
     fp_sort: Jkind.sort;
     fp_mode: Mode.Alloc.l;
     fp_curry: function_curry;
-    fp_newtypes: (string loc * Jkind.annotation option) list;
+    fp_newtypes: (Ident.t * string loc * Jkind.annotation option * Uid.t) list;
     fp_loc: Location.t;
   }
 

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -228,7 +228,7 @@ and exp_extra =
          *)
   | Texp_poly of core_type option
         (** Used for method bodies. *)
-  | Texp_newtype of string * Jkind.annotation option
+  | Texp_newtype of Ident.t * string loc * Jkind.annotation option * Uid.t
         (** fun (type t : immediate) ->  *)
   | Texp_stack
         (** stack_ E *)
@@ -454,7 +454,7 @@ and function_param =
     fp_sort: Jkind.sort;
     fp_mode: Mode.Alloc.l;
     fp_curry: function_curry;
-    fp_newtypes: (string loc * Jkind.annotation option) list;
+    fp_newtypes: (Ident.t * string loc * Jkind.annotation option * Uid.t) list;
     (** [fp_newtypes] are the new type declarations that come *after* that
         parameter. The newtypes that come before the first parameter are
         placed as exp_extras on the Texp_function node. This is just used in

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -229,7 +229,12 @@ and exp_extra =
   | Texp_poly of core_type option
         (** Used for method bodies. *)
   | Texp_newtype of Ident.t * string loc * Jkind.annotation option * Uid.t
-        (** fun (type t : immediate) ->  *)
+        (** fun (type t : immediate) ->
+
+        The [Ident.t] and [Uid.t] fields are unused by the compiler, but Merlin needs
+        them. Merlin cannot be cleanly patched to include these fields because Merlin
+        must be able to deserialize typedtrees produced by the compiler. Thus, we include
+        them here, as the cost of tracking this additional information is minimal. *)
   | Texp_stack
         (** stack_ E *)
 
@@ -458,7 +463,12 @@ and function_param =
     (** [fp_newtypes] are the new type declarations that come *after* that
         parameter. The newtypes that come before the first parameter are
         placed as exp_extras on the Texp_function node. This is just used in
-        {!Untypeast}. *)
+        {!Untypeast}.
+
+        The [Ident.t] and [Uid.t] fields are unused by the compiler, but Merlin needs
+        them. Merlin cannot be cleanly patched to include these fields because Merlin
+        must be able to deserialize typedtrees produced by the compiler. Thus, we include
+        them here, as the cost of tracking this additional information is minimal. *)
     fp_loc: Location.t;
     (** [fp_loc] is the location of the entire value parameter, not including
         the [fp_newtypes].

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -441,7 +441,6 @@ let exp_extra sub (extra, loc, attrs) sexp =
     attrs := pexp_attributes @ !attrs;
     pexp_desc
   in
-  let add_loc x = mkloc x loc in
   let desc =
     match extra with
       Texp_coerce (cty1, cty2) ->
@@ -454,11 +453,11 @@ let exp_extra sub (extra, loc, attrs) sexp =
          Option.map (sub.typ sub) cty,
          Typemode.untransl_mode_annots ~loc modes)
     | Texp_poly cto -> Pexp_poly (sexp, Option.map (sub.typ sub) cto)
-    | Texp_newtype (s, None) ->
-        Pexp_newtype (add_loc s, sexp)
-    | Texp_newtype (s, Some (_, jkind)) ->
+    | Texp_newtype (_, label_loc, None, _) ->
+        Pexp_newtype (label_loc, sexp)
+    | Texp_newtype (_, label_loc, Some (_, jkind), _) ->
         Jane_syntax.Layouts.expr_of ~loc
-          (Lexp_newtype(add_loc s, jkind, sexp))
+          (Lexp_newtype(label_loc, jkind, sexp))
         |> add_jane_syntax_attributes
     | Texp_stack -> Pexp_stack sexp
   in
@@ -587,7 +586,7 @@ let expression sub exp =
                let default_arg = Option.map (sub.expr sub) default_arg in
                let newtypes =
                  List.map
-                   (fun (x, annot) ->
+                   (fun (_, x, annot, _) ->
                       { pparam_desc = Pparam_newtype (x, Option.map snd annot);
                         pparam_loc = x.loc;
                       })


### PR DESCRIPTION
Merlin currently has a duplicate variant of `Typedtree.exp_extra` called `Texp_newtype'`. It is similar to `Texp_newtype` but contains a few extra fields that Merlin needs. Similarly, it defines a variant that it uses for elements of the `fp_newtypes` list in `Typedtree.function_param`. One case of the variant contains the existing fields, and the other contains the existing fields plus some additional ones.

Merlin relies on being able to deserialize typedtrees to be able to read cmt files. The aforementioned variants are added in such a way that Merlin can still correctly deserialize typedtrees produced by the compiler, but this is prone to breakage.

This PR adds the additional fields that Merlin needs to the type definitions in the compiler. This means that the compiler has to do a _little_ extra work, but its extremely small, so it seems well worth the cost for easier maintainability.