### PR TITLE
Fix misindex in finalisation

### DIFF
--- a/ocaml/runtime/finalise.c
+++ b/ocaml/runtime/finalise.c
@@ -262,7 +262,7 @@ static void generic_final_minor_update
     for (i = final->old; i < final->young; i++) {
       CAMLassert (Is_block (final->table[i].val));
       CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
-      if (Is_young(final->table[j].val) &&
+      if (Is_young(final->table[i].val) &&
           caml_get_header_val(final->table[i].val) != 0) {
         /** dead */
         fi->todo_tail->item[k] = final->table[i];


### PR DESCRIPTION
The runtime exposes multiple ways for the users to register finalisers; one way is `Gc.finalise_last`. The runtime occasionally checks whether any finaliser registered with `finalise_last` should be run. This check first counts how much work it should do:

https://github.com/ocaml-flambda/flambda-backend/blob/a413898b68e73d36a20a1e5516c2286a590b9bd9/ocaml/runtime/finalise.c#L241-L247

And then adds work to the queue:

https://github.com/ocaml-flambda/flambda-backend/blob/a413898b68e73d36a20a1e5516c2286a590b9bd9/ocaml/runtime/finalise.c#L262-L277

The if-conditions are slightly different, causing a bug. (See the diff of this PR!) One way this bug can trigger: the first condition is true less often than the second condition, leading to the extra work enqueued (because the second condition was true) being dropped (because the length of the work queue is calculated from the number of times the first condition was true).

In other words, sometimes finalisers aren't run!

Indeed, the debug runtime sometimes panics on this line:
https://github.com/ocaml-flambda/flambda-backend/blob/a413898b68e73d36a20a1e5516c2286a590b9bd9/ocaml/runtime/finalise.c#L279

We should upstream this after someone reviews this.