### PR TITLE
Reduce the need for the `pprintast_unconditional` test

### DIFF
--- a/.github/workflows/document-syntax.yml
+++ b/.github/workflows/document-syntax.yml
@@ -22,9 +22,8 @@ jobs:
           This PR modifies the parser. Please check that the following tests are updated:
 
           - [ ] \`parsetree/source_jane_street.ml\`
-          - [ ] \`language-extensions/pprintast_unconditional.ml\`
 
-          Both of these tests should have examples of every new bit of syntax you are adding. Feel free to just check these boxes if your PR does not actually change the syntax (because it is refactoring the parser, say)."
+          This test should have examples of every new bit of syntax you are adding. Feel free to just check the box if your PR does not actually change the syntax (because it is refactoring the parser, say)."
 
            # Check if comment already exists
           if ! gh pr view $PR_NUMBER --json comments -q '.comments[].body' --repo $REPO | grep -q "Parser Change Checklist"; then

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -3,10 +3,10 @@
  flags = "-I ${ocamlsrcdir}/parsing";
 *)
 
-(* This test is somewhat duplicative of [ocaml/testsuite/tests/parsetree/source_jane_street.ml].
-   Tests for new syntax elements should be added there, not here, unless there's a good reason
-   you can't add them there.
- *)
+(* See [ocaml/testsuite/tests/parsetree/source_jane_street.ml] for tests for
+   new language extensions. The present test is along a different axis: the
+   different syntax elements that we support in Pprintast.
+*)
 
 (******************************************************************************)
 (* Setup *)
@@ -22,35 +22,6 @@ module Example = struct
     let located =  Location.mknoloc
     let parse p str = p (Lexing.from_string str)
   end
-
-  let modal_kind_struct =
-    parse module_expr "struct \
-      type 'a list : immutable_data with 'a \
-      type ('a, 'b) either : immutable_data with 'a * 'b \
-      type 'a gel : kind_of_ 'a mod global \
-      type 'a t : _ \
-      kind_abbrev_ immediate = value mod global unique many sync uncontended \
-      kind_abbrev_ immutable_data = value mod sync uncontended many \
-      kind_abbrev_ immutable = value mod uncontended \
-      kind_abbrev_ data = value mod sync many \
-    end"
-
-  let modal_kind_sig =
-    parse module_type "sig \
-      type 'a list : immutable_data with 'a \
-      type ('a, 'b) either : immutable_data with 'a * 'b \
-      type 'a gel : kind_of_ 'a mod global \
-      type 'a t : _ \
-      kind_abbrev_ immediate = value mod global unique many sync uncontended \
-      kind_abbrev_ immutable_data = value mod sync uncontended many \
-      kind_abbrev_ immutable = value mod uncontended \
-      kind_abbrev_ data = value mod sync many \
-    end"
-
-  let instance_name =
-    parse module_expr "\
-      Base(Name1)(Value1)(Name2)(Value2(Name2_1)(Value2_1)) \
-        [@jane.non_erasable.instances]"
 
   let longident        = parse longident "No.Longidents.Require.extensions"
   let expression       = parse expression "[x for x = 1 to 10]"
@@ -191,9 +162,15 @@ end = struct
 
   let string_of_expression = test_string_of "string_of_expression" string_of_expression Example.expression
   let string_of_structure = test_string_of "string_of_structure" string_of_structure Example.structure
+<<<<<<< HEAD
   let modal_kind_struct = test "modal_kind_struct" module_expr Example.modal_kind_struct
   let modal_kind_sig = test "modal_kind_sig" module_type Example.modal_kind_sig
   let instance_name = test "instance_name" module_expr Example.instance_name
+||||||| parent of 5004e408bf (Update based on feedback from review)
+  let modal_kind_struct = test "modal_kind_struct" module_expr Example.modal_kind_struct
+  let modal_kind_sig = test "modal_kind_sig" module_type Example.modal_kind_sig
+=======
+>>>>>>> 5004e408bf (Update based on feedback from review)
 
   let tyvar_of_name =
     test_string_of "tyvar_of_name" tyvar_of_name Example.tyvar_of_name

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -3,6 +3,11 @@
  flags = "-I ${ocamlsrcdir}/parsing";
 *)
 
+(* This test is somewhat duplicative of [ocaml/testsuite/tests/parsetree/source_jane_street.ml].
+   Tests for new syntax elements should be added there, not here, unless there's a good reason
+   you can't add them there.
+ *)
+
 (******************************************************************************)
 (* Setup *)
 
@@ -17,45 +22,6 @@ module Example = struct
     let located =  Location.mknoloc
     let parse p str = p (Lexing.from_string str)
   end
-
-  let modality_record  = parse module_expr
-    "struct \
-      type t = {global_ x : string;
-                global_ y : int @@ local many once shared unique portable nonportable
-                                   contended uncontended;
-                z : bool @@ unique} \
-     end"
-  let modality_cstrarg = parse module_expr
-    "struct \
-      type t = Foo of global_ string * global_ string @@ portable * string @@ portable \
-      type u = Foo : global_ string * global_ string -> u \
-     end"
-
-  let modality_val  = parse module_type
-    "sig \
-      val t : string -> string @ local @@ foo bar \
-      include S @@ bar foo
-      include functor S @@ foo foo
-     end"
-
-  let local_exp = parse expression "let x = foo (local_ x) in local_ y"
-  let stack_exp = parse expression
-    "let x = stack_ 42 in \
-     let y = stack_ (f x) in \
-     let z = foo (stack_ 42) in \
-     foo (stack_ (f x))"
-  let fun_with_modes_on_arg = parse expression
-    "let f (a @ local) ~(b @ local) ?(c @ local) \
-          ?(d @ local = 1) ~e:(e @ local) ?f:(f @ local = 2) \
-           () = () in f"
-  let utuple_exp = parse expression
-    "let #(x,y) : #(int * int) = #(1,2) in \
-     let #(a,#(b,c)) : ('a : value & (value & value)) = #(3,#(4,5)) in \
-     let #(i,j) : ('b : value mod m & (value mod l)) = #(6,7) in \
-     let #(s,t) : ('c : value mod m & value mod l) = #(7,8) in \
-     let #(k,l) : ('d : value with t & (value with t)) = #(6,7) in \
-     let #(u,v) : ('e : value with t & value with t) = #(7,8) in \
-     x + y + a + b + c + i + j + s + t + k + l + u + v"
 
   let modal_kind_struct =
     parse module_expr "struct \
@@ -201,15 +167,6 @@ end = struct
     print_test_header Test.name;
     Test.setup ()
   ;;
-
-  let modality_record = test "modality_record" module_expr Example.modality_record
-  let modality_cstrarg = test "modality_cstrarg" module_expr Example.modality_cstrarg
-  let modality_val = test "modality_val" module_type Example.modality_val
-
-  let local_exp = test "local_exp" expression Example.local_exp
-  let stack_exp = test "stack_exp" expression Example.stack_exp
-  let fun_with_modes_on_arg = test "fun_with_modes_on_arg" expression Example.fun_with_modes_on_arg
-  let utuple_exp = test "utuple_exp" expression Example.utuple_exp
 
   let longident = test "longident" longident Example.longident
   let expression = test "expression" expression Example.expression

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -162,15 +162,6 @@ end = struct
 
   let string_of_expression = test_string_of "string_of_expression" string_of_expression Example.expression
   let string_of_structure = test_string_of "string_of_structure" string_of_structure Example.structure
-<<<<<<< HEAD
-  let modal_kind_struct = test "modal_kind_struct" module_expr Example.modal_kind_struct
-  let modal_kind_sig = test "modal_kind_sig" module_type Example.modal_kind_sig
-  let instance_name = test "instance_name" module_expr Example.instance_name
-||||||| parent of 5004e408bf (Update based on feedback from review)
-  let modal_kind_struct = test "modal_kind_struct" module_expr Example.modal_kind_struct
-  let modal_kind_sig = test "modal_kind_sig" module_type Example.modal_kind_sig
-=======
->>>>>>> 5004e408bf (Update based on feedback from review)
 
   let tyvar_of_name =
     test_string_of "tyvar_of_name" tyvar_of_name Example.tyvar_of_name

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -51,6 +51,7 @@ string_of_expression: [x for x = 1 to 10]
 
 string_of_structure: include functor F
 
+<<<<<<< HEAD
 modal_kind_struct:
   struct
     type 'a list : immutable_data with 'a
@@ -79,6 +80,33 @@ instance_name:
   ((((((Base)(Name1))(Value1))(Name2))(((Value2)(Name2_1))(Value2_1)))
   [@jane.non_erasable.instances ])
 
+||||||| parent of 5004e408bf (Update based on feedback from review)
+modal_kind_struct:
+  struct
+    type 'a list : immutable_data with 'a
+    type ('a, 'b) either : immutable_data with ('a * 'b)
+    type 'a gel : kind_of_ 'a mod global
+    type 'a t : _
+    kind_abbrev_ immediate = value mod global unique many sync uncontended
+    kind_abbrev_ immutable_data = value mod sync uncontended many
+    kind_abbrev_ immutable = value mod uncontended
+    kind_abbrev_ data = value mod sync many
+  end
+
+modal_kind_sig:
+  sig
+    type 'a list : immutable_data with 'a
+    type ('a, 'b) either : immutable_data with ('a * 'b)
+    type 'a gel : kind_of_ 'a mod global
+    type 'a t : _
+    kind_abbrev_ immediate = value mod global unique many sync uncontended
+    kind_abbrev_ immutable_data = value mod sync uncontended many
+    kind_abbrev_ immutable = value mod uncontended
+    kind_abbrev_ data = value mod sync many
+  end
+
+=======
+>>>>>>> 5004e408bf (Update based on feedback from review)
 tyvar_of_name: 'no_tyvars_require_extensions
 
 tyvar: 'no_tyvars_require_extensions
@@ -142,6 +170,7 @@ string_of_expression: [x for x = 1 to 10]
 
 string_of_structure: include functor F
 
+<<<<<<< HEAD
 modal_kind_struct:
   struct
     type 'a list : immutable_data with 'a
@@ -170,6 +199,33 @@ instance_name:
   ((((((Base)(Name1))(Value1))(Name2))(((Value2)(Name2_1))(Value2_1)))
   [@jane.non_erasable.instances ])
 
+||||||| parent of 5004e408bf (Update based on feedback from review)
+modal_kind_struct:
+  struct
+    type 'a list : immutable_data with 'a
+    type ('a, 'b) either : immutable_data with ('a * 'b)
+    type 'a gel : kind_of_ 'a mod global
+    type 'a t : _
+    kind_abbrev_ immediate = value mod global unique many sync uncontended
+    kind_abbrev_ immutable_data = value mod sync uncontended many
+    kind_abbrev_ immutable = value mod uncontended
+    kind_abbrev_ data = value mod sync many
+  end
+
+modal_kind_sig:
+  sig
+    type 'a list : immutable_data with 'a
+    type ('a, 'b) either : immutable_data with ('a * 'b)
+    type 'a gel : kind_of_ 'a mod global
+    type 'a t : _
+    kind_abbrev_ immediate = value mod global unique many sync uncontended
+    kind_abbrev_ immutable_data = value mod sync uncontended many
+    kind_abbrev_ immutable = value mod uncontended
+    kind_abbrev_ data = value mod sync many
+  end
+
+=======
+>>>>>>> 5004e408bf (Update based on feedback from review)
 tyvar_of_name: 'no_tyvars_require_extensions
 
 tyvar: 'no_tyvars_require_extensions

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -51,62 +51,6 @@ string_of_expression: [x for x = 1 to 10]
 
 string_of_structure: include functor F
 
-<<<<<<< HEAD
-modal_kind_struct:
-  struct
-    type 'a list : immutable_data with 'a
-    type ('a, 'b) either : immutable_data with ('a * 'b)
-    type 'a gel : kind_of_ 'a mod global
-    type 'a t : _
-    kind_abbrev_ immediate = value mod global unique many sync uncontended
-    kind_abbrev_ immutable_data = value mod sync uncontended many
-    kind_abbrev_ immutable = value mod uncontended
-    kind_abbrev_ data = value mod sync many
-  end
-
-modal_kind_sig:
-  sig
-    type 'a list : immutable_data with 'a
-    type ('a, 'b) either : immutable_data with ('a * 'b)
-    type 'a gel : kind_of_ 'a mod global
-    type 'a t : _
-    kind_abbrev_ immediate = value mod global unique many sync uncontended
-    kind_abbrev_ immutable_data = value mod sync uncontended many
-    kind_abbrev_ immutable = value mod uncontended
-    kind_abbrev_ data = value mod sync many
-  end
-
-instance_name:
-  ((((((Base)(Name1))(Value1))(Name2))(((Value2)(Name2_1))(Value2_1)))
-  [@jane.non_erasable.instances ])
-
-||||||| parent of 5004e408bf (Update based on feedback from review)
-modal_kind_struct:
-  struct
-    type 'a list : immutable_data with 'a
-    type ('a, 'b) either : immutable_data with ('a * 'b)
-    type 'a gel : kind_of_ 'a mod global
-    type 'a t : _
-    kind_abbrev_ immediate = value mod global unique many sync uncontended
-    kind_abbrev_ immutable_data = value mod sync uncontended many
-    kind_abbrev_ immutable = value mod uncontended
-    kind_abbrev_ data = value mod sync many
-  end
-
-modal_kind_sig:
-  sig
-    type 'a list : immutable_data with 'a
-    type ('a, 'b) either : immutable_data with ('a * 'b)
-    type 'a gel : kind_of_ 'a mod global
-    type 'a t : _
-    kind_abbrev_ immediate = value mod global unique many sync uncontended
-    kind_abbrev_ immutable_data = value mod sync uncontended many
-    kind_abbrev_ immutable = value mod uncontended
-    kind_abbrev_ data = value mod sync many
-  end
-
-=======
->>>>>>> 5004e408bf (Update based on feedback from review)
 tyvar_of_name: 'no_tyvars_require_extensions
 
 tyvar: 'no_tyvars_require_extensions
@@ -170,62 +114,6 @@ string_of_expression: [x for x = 1 to 10]
 
 string_of_structure: include functor F
 
-<<<<<<< HEAD
-modal_kind_struct:
-  struct
-    type 'a list : immutable_data with 'a
-    type ('a, 'b) either : immutable_data with ('a * 'b)
-    type 'a gel : kind_of_ 'a mod global
-    type 'a t : _
-    kind_abbrev_ immediate = value mod global unique many sync uncontended
-    kind_abbrev_ immutable_data = value mod sync uncontended many
-    kind_abbrev_ immutable = value mod uncontended
-    kind_abbrev_ data = value mod sync many
-  end
-
-modal_kind_sig:
-  sig
-    type 'a list : immutable_data with 'a
-    type ('a, 'b) either : immutable_data with ('a * 'b)
-    type 'a gel : kind_of_ 'a mod global
-    type 'a t : _
-    kind_abbrev_ immediate = value mod global unique many sync uncontended
-    kind_abbrev_ immutable_data = value mod sync uncontended many
-    kind_abbrev_ immutable = value mod uncontended
-    kind_abbrev_ data = value mod sync many
-  end
-
-instance_name:
-  ((((((Base)(Name1))(Value1))(Name2))(((Value2)(Name2_1))(Value2_1)))
-  [@jane.non_erasable.instances ])
-
-||||||| parent of 5004e408bf (Update based on feedback from review)
-modal_kind_struct:
-  struct
-    type 'a list : immutable_data with 'a
-    type ('a, 'b) either : immutable_data with ('a * 'b)
-    type 'a gel : kind_of_ 'a mod global
-    type 'a t : _
-    kind_abbrev_ immediate = value mod global unique many sync uncontended
-    kind_abbrev_ immutable_data = value mod sync uncontended many
-    kind_abbrev_ immutable = value mod uncontended
-    kind_abbrev_ data = value mod sync many
-  end
-
-modal_kind_sig:
-  sig
-    type 'a list : immutable_data with 'a
-    type ('a, 'b) either : immutable_data with ('a * 'b)
-    type 'a gel : kind_of_ 'a mod global
-    type 'a t : _
-    kind_abbrev_ immediate = value mod global unique many sync uncontended
-    kind_abbrev_ immutable_data = value mod sync uncontended many
-    kind_abbrev_ immutable = value mod uncontended
-    kind_abbrev_ data = value mod sync many
-  end
-
-=======
->>>>>>> 5004e408bf (Update based on feedback from review)
 tyvar_of_name: 'no_tyvars_require_extensions
 
 tyvar: 'no_tyvars_require_extensions

--- a/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
+++ b/ocaml/testsuite/tests/language-extensions/pprintast_unconditional.reference
@@ -1,53 +1,6 @@
 ##### All extensions enabled
 --------------------------------
 
-modality_record:
-  struct
-    type t =
-      {
-      global_ x: string ;
-      global_ y:
-        int @@ local many once shared unique portable nonportable contended uncontended
-        ;
-      z: bool @@ unique }
-  end
-
-modality_cstrarg:
-  struct
-    type t =
-      | Foo of global_ string * global_ string @@ portable *
-      string @@ portable 
-    type u =
-      | Foo: global_ string * global_ string -> u 
-  end
-
-modality_val:
-  sig
-    val t : string -> local_ string @@ foo bar
-    include S @@ bar foo
-    include functor S @@ foo foo
-  end
-
-local_exp: let x = foo (local_ x) in (local_ y)
-
-stack_exp:
-  let x = stack_ 42 in
-  let y = stack_ (f x) in let z = foo (stack_ 42) in foo (stack_ (f x))
-
-fun_with_modes_on_arg:
-  let f (local_ a) ~b:(local_ b) ?c:(local_ c) ?d:(local_ d= 1) ~e:(local_ e)
-    ?f:(local_ f= 2) () = () in
-  f
-
-utuple_exp:
-  let #(x, y) : #(int * int) = #(1, 2) in
-  let #(a, #(b, c)) : ('a : value & (value & value)) = #(3, #(4, 5)) in
-  let #(i, j) : ('b : (value mod m) & (value mod l)) = #(6, 7) in
-  let #(s, t) : ('c : ((value mod m) & value) mod l) = #(7, 8) in
-  let #(k, l) : ('d : (value with t) & (value with t)) = #(6, 7) in
-  let #(u, v) : ('e : ((value with t) & value) with t) = #(7, 8) in
-  (((((((((((x + y) + a) + b) + c) + i) + j) + s) + t) + k) + l) + u) + v
-
 longident: No.Longidents.Require.extensions
 
 expression: [x for x = 1 to 10]
@@ -138,53 +91,6 @@ mode: global
 
 ##### Extensions disallowed
 --------------------------------
-
-modality_record:
-  struct
-    type t =
-      {
-      global_ x: string ;
-      global_ y:
-        int @@ local many once shared unique portable nonportable contended uncontended
-        ;
-      z: bool @@ unique }
-  end
-
-modality_cstrarg:
-  struct
-    type t =
-      | Foo of global_ string * global_ string @@ portable *
-      string @@ portable 
-    type u =
-      | Foo: global_ string * global_ string -> u 
-  end
-
-modality_val:
-  sig
-    val t : string -> local_ string @@ foo bar
-    include S @@ bar foo
-    include functor S @@ foo foo
-  end
-
-local_exp: let x = foo (local_ x) in (local_ y)
-
-stack_exp:
-  let x = stack_ 42 in
-  let y = stack_ (f x) in let z = foo (stack_ 42) in foo (stack_ (f x))
-
-fun_with_modes_on_arg:
-  let f (local_ a) ~b:(local_ b) ?c:(local_ c) ?d:(local_ d= 1) ~e:(local_ e)
-    ?f:(local_ f= 2) () = () in
-  f
-
-utuple_exp:
-  let #(x, y) : #(int * int) = #(1, 2) in
-  let #(a, #(b, c)) : ('a : value & (value & value)) = #(3, #(4, 5)) in
-  let #(i, j) : ('b : (value mod m) & (value mod l)) = #(6, 7) in
-  let #(s, t) : ('c : ((value mod m) & value) mod l) = #(7, 8) in
-  let #(k, l) : ('d : (value with t) & (value with t)) = #(6, 7) in
-  let #(u, v) : ('e : ((value with t) & value) with t) = #(7, 8) in
-  (((((((((((x + y) + a) + b) + c) + i) + j) + s) + t) + k) + l) + u) + v
 
 longident: No.Longidents.Require.extensions
 

--- a/ocaml/testsuite/tests/parsetree/source_jane_street.ml
+++ b/ocaml/testsuite/tests/parsetree/source_jane_street.ml
@@ -4,13 +4,21 @@
    expect;
 *)
 
-(* This file is two tests in one! It's both an expect-test, run in the
-   normal way. It *also* is processed by [test.ml] (in this same directory)
-   to make sure that Pprintast round-trips. *)
-
 (* There should be examples of all Jane Street syntax here. This file can
    thus additionally serve as a cheap-and-cheerful documentation for all of
    our features. *)
+
+(* This file is three tests in one!
+    - It's an expect-test, run in the normal way.
+    - It is processed by [test.ml] (in this same directory) to make sure that Pprintast round-trips.
+    - It is processed by [test_ppx.ml] (in this same directory) to make sure that ppxes run properly
+      on examples of Jane Street syntax.
+*)
+
+(* Use [language-extensions/pprintast_unconditional.ml] to document pieces of syntax that
+   can't be added to this file (e.g. because you haven't yet implemented type-checking for
+   your feature).
+*)
 
 (***********)
 (* Layouts *)

--- a/ocaml/testsuite/tests/parsetree/test.ml
+++ b/ocaml/testsuite/tests/parsetree/test.ml
@@ -52,17 +52,23 @@ let to_tmp_file print_fun ast =
   close_out oc;
   fn
 
-let test parse_fun pprint print map filename =
+let format_lexing_position ppf lexing_pos =
+  let (filename, line, col) = Location.get_pos_info lexing_pos in
+  Printf.fprintf ppf "%s %d:%d" filename line col
+
+let test ~here parse_fun pprint print map filename =
   match from_file parse_fun filename with
   | exception exn ->
-      Printf.printf "%s: FAIL, CANNOT PARSE\n" filename;
+      Printf.printf "%s: FAIL, CANNOT PARSE (%a)\n" filename
+        format_lexing_position here;
       report_err exn;
       print_endline "====================================================="
   | ast ->
       let str = to_string pprint ast in
       match from_string parse_fun str with
       | exception exn ->
-          Printf.printf "%s: FAIL, CANNOT REPARSE\n" filename;
+          Printf.printf "%s: FAIL, CANNOT REPARSE (%a)\n" filename
+            format_lexing_position here;
           report_err exn;
           print_endline str;
           print_endline "====================================================="
@@ -70,7 +76,9 @@ let test parse_fun pprint print map filename =
           let ast = map remove_locs remove_locs ast in
           let ast2 = map remove_locs remove_locs ast2 in
           if ast <> ast2 then begin
-            Printf.printf "%s:  FAIL, REPARSED AST IS DIFFERENT\n%!" filename;
+            Printf.printf "%s:  FAIL, REPARSED AST IS DIFFERENT (%a)\n%!"
+              filename
+              format_lexing_position here;
             let f1 = to_tmp_file print ast in
             let f2 = to_tmp_file print ast2 in
             let cmd = Printf.sprintf "%s %s %s" diff
@@ -79,16 +87,17 @@ let test parse_fun pprint print map filename =
             print_endline"====================================================="
           end
 
-let test parse_fun pprint print map filename =
-  try test parse_fun pprint print map filename
+let test ~here parse_fun pprint print map filename =
+  try test ~here parse_fun pprint print map filename
   with exn -> report_err exn
 
-let rec process path =
+let rec process ~(here : [%call_pos]) path =
   if Sys.is_directory path then
     let files = Sys.readdir path in
-    Array.iter (fun s -> process (Filename.concat path s)) files
+    Array.iter (fun s -> process ~here (Filename.concat path s)) files
   else if Filename.check_suffix path ".ml" then
     test
+      ~here
       Parse.implementation
       Pprintast.structure
       Printast.implementation
@@ -96,6 +105,7 @@ let rec process path =
       path
   else if Filename.check_suffix path ".mli" then
     test
+      ~here
       Parse.interface
       Pprintast.signature
       Printast.interface
@@ -107,20 +117,28 @@ let () =
   Language_extension.set_universe_and_enable_all
     Language_extension.Universe.maximal;
   process "source_jane_street.ml";
-  (* Additionally check that merely parsing doesn't attempt
+  (* Additionally check that merely parsing and printing doesn't attempt
      to check extensions enabledness. This is actually an important property.
-     That's because ppxes run the parser code in a separate process from the
-     compiler, and ppxes always enable extensions to the max. So checks
-     in the parser are ineffective in a common mode of running the
-     compiler.
+
+     For parsing:
+       ppxes run the parser code in a separate process from the
+       compiler, and ppxes always enable extensions to the max. So checks
+       in the parser are ineffective in a common mode of running the
+       compiler.
+
+     For printing:
+       It's a shame if disabling an extension makes it the toolchain
+       can't print the source code that includes the extension. I can't
+       remember a detailed reason why, but we thought this check was
+       important at some point.
   *)
   Language_extension.disable_all ();
-  match from_file Parse.implementation "source_jane_street.ml" with
-  | (_ : _ list) -> ()
+  match process "source_jane_street.ml" with
+  | () -> ()
   | exception _ ->
       print_endline
-        "Failed to parse with all extensions disabled after successfully\
-        \ parsing with all extensions enabled. Does the parser check for\
+        "Failed to parse or print with all extensions disabled after successfully\
+        \ parsing/print with all extensions enabled. Does the parser (or Pprintast) check for\
         \ extension enabledness, which is almost certainly a bug? (See the\
         \ comment by this test.)"
 ;;

--- a/ocaml/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/ocaml/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -1,5 +1,5 @@
-File "source_jane_street.ml", line 161, characters 0-24:
-161 | type t = #(int * float#)
+File "source_jane_street.ml", line 156, characters 0-24:
+156 | type t = #(int * float#)
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the type name "t".
        Names must be unique in a given structure or signature.

--- a/ocaml/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/ocaml/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -1,5 +1,5 @@
-File "source_jane_street.ml", line 153, characters 0-24:
-153 | type t = #(int * float#)
+File "source_jane_street.ml", line 161, characters 0-24:
+161 | type t = #(int * float#)
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the type name "t".
        Names must be unique in a given structure or signature.


### PR DESCRIPTION
Simplify the checklist suggested by GitHub Actions (introduced in #3085) when a PR touches the parser. It's nice to eliminate redundancy from checklists we'll frequently follow.

I do this by encouraging that tests be added just to `source_jane_street.ml` and not also to `pprintast_unconditional.ml`. `pprintast_unconditional` is mostly a worse version of `parsetree/source_jane_street.ml`. This statement isn't 100% true. Here are ways that it is/was false:
 
  * `source_jane_street` didn't used to check that `Pprintast` still works even when all extensions are disabled. **Response:** I make it check that. 
  * `source_jane_street` runs the type-checker in addition to the parser, so can't accept some programs that can be pretty-printed. **Response**: I don't delete the `pprintast_unconditional` test, and capture this nuance in a comment.