### PR TITLE
Fix no-partial-inlining cflags detection

### DIFF
--- a/ocaml/configure
+++ b/ocaml/configure
@@ -20530,7 +20530,7 @@ then :
 fi
 
 # Only gcc supports -fno-partial-inlining
-case $ocaml_cv_cc_vendor in #(
+case $ocaml_cc_vendor in #(
   gcc-*) :
     no_partial_inlining_cflags="-fno-partial-inlining" ;; #(
   *) :

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -2583,7 +2583,7 @@ AC_DEFINE_UNQUOTED([PROFINFO_WIDTH], [$profinfo_width])
 AS_IF([$profinfo], [AC_DEFINE([WITH_PROFINFO])])
 
 # Only gcc supports -fno-partial-inlining
-AS_CASE([$ocaml_cv_cc_vendor],
+AS_CASE([$ocaml_cc_vendor],
   [gcc-*],
     [no_partial_inlining_cflags="-fno-partial-inlining"],
   [no_partial_inlining_cflags=""])


### PR DESCRIPTION
A variable used by the no-partial-inlining C compiler flags detection had been renamed upstream in 5.2, meaning that gcc's partial inlining optimization would never be disabled.

Tested manually, checking that the generated `Makefile.config` sets `NO_PARTIAL_INLINING_CFLAGS` to the correct C compiler flag, unlike previously.

This will be cherry-picked to the 5.2 microbranch, will self approve to avoid delays.