### PR TITLE
Reader-writer lock and capsule API with shared

### DIFF
--- a/otherlibs/stdlib_alpha/capsule.ml
+++ b/otherlibs/stdlib_alpha/capsule.ml
@@ -143,7 +143,7 @@ module Rwlock = struct
         match f (ReaderPassword.unsafe_mk()) with
         | x -> Rw.unlock t.rwlock; x
         | exception exn ->
-          t.poisoned <- true;
+          (* Here we are not poisoning the RwLock, see [capsule.mli] for explanation *)
           Rw.unlock t.rwlock;
           reraise exn
 

--- a/otherlibs/stdlib_alpha/capsule.ml
+++ b/otherlibs/stdlib_alpha/capsule.ml
@@ -25,12 +25,37 @@ end = struct
   let unsafe_mk () = ()
 end
 
+module ReaderPassword : sig
+  (* CR layouts v5: this should have layout [void], but
+     [void] can't be used for function argument and return types yet. *)
+  type 'k t
+
+  (* Can break the soundness of the API. *)
+  val unsafe_mk : unit -> 'k t @@ portable
+end = struct
+  type 'k t = unit
+
+  let unsafe_mk () = ()
+end
+
+let weaken_password : 'k Password.t @ local -> 'k ReaderPassword.t @ local @@ portable =
+  fun _ -> ReaderPassword.unsafe_mk ()
+
 (* Like [Stdlib.Mutex], but [portable]. *)
 module M = struct
   type t : value mod portable uncontended
   external create: unit -> t @@ portable = "caml_ml_mutex_new"
   external lock: t -> unit @@ portable = "caml_ml_mutex_lock"
   external unlock: t -> unit @@ portable = "caml_ml_mutex_unlock"
+end
+
+(* Reader writer lock *)
+module Rw = struct
+  type t : value mod portable uncontended
+  external create: unit -> t @@ portable = "caml_ml_rwlock_new"
+  external lock_read: t -> unit @@ portable = "caml_ml_rwlock_rdlock"
+  external lock_write: t -> unit @@ portable = "caml_ml_rwlock_wrlock"
+  external unlock: t -> unit @@ portable = "caml_ml_rwlock_unlock"
 end
 
 (* Like [Stdlib.raise], but [portable], and the value
@@ -80,8 +105,66 @@ module Mutex = struct
       Password.unsafe_mk ()
 end
 
+module Rwlock = struct
+
+  type 'k t : value mod portable uncontended = { rwlock : Rw.t; mutable poisoned : bool }
+
+  type packed : value mod portable uncontended = P : 'k t -> packed
+
+  exception Poisoned
+
+  let with_write_lock :
+    'k t
+    -> ('k Password.t @ local -> 'a) @ local
+    -> 'a
+    @@ portable
+    = fun t f ->
+      Rw.lock_write t.rwlock;
+      match t.poisoned with
+      | true -> Rw.unlock t.rwlock; reraise Poisoned
+      | false ->
+        match f (Password.unsafe_mk ()) with
+        | x -> Rw.unlock t.rwlock; x
+        | exception exn ->
+          t.poisoned <- true;
+          Rw.unlock t.rwlock;
+          reraise exn
+
+  let with_read_lock :
+    'k t
+    -> ('k ReaderPassword.t @ local -> 'a) @ local
+    -> 'a
+    @@ portable
+    = fun t f ->
+      Rw.lock_read t.rwlock;
+      match t.poisoned with
+      | true -> Rw.unlock t.rwlock; reraise Poisoned
+      | false ->
+        match f (ReaderPassword.unsafe_mk()) with
+        | x -> Rw.unlock t.rwlock; x
+        | exception exn ->
+          t.poisoned <- true;
+          Rw.unlock t.rwlock;
+          reraise exn
+
+  let destroy t =
+    Rw.lock_write t.rwlock;
+    match t.poisoned with
+    | true ->
+      Rw.unlock t.rwlock;
+      reraise Poisoned
+    | false ->
+      t.poisoned <- true;
+      Rw.unlock t.rwlock;
+      Password.unsafe_mk ()
+
+end
+
 let create_with_mutex () =
   Mutex.P { mutex = M.create (); poisoned = false }
+
+let create_with_rwlock () =
+  Rwlock.P { rwlock = Rw.create (); poisoned = false }
 
 module Data = struct
   type ('a, 'k) t : value mod portable uncontended
@@ -122,4 +205,15 @@ module Data = struct
     | exn -> reraise (Contended exn)
 
   let expose _ t = unsafe_get t
+
+  let map_shared _ f t =
+    let v = unsafe_get t in
+    match f v with
+    | res -> unsafe_mk res
+    | exception exn -> reraise (Contended exn)
+
+  let extract_shared _ f t =
+    let v = unsafe_get t in
+    try f v with
+    | exn -> reraise (Contended exn)
 end

--- a/otherlibs/stdlib_alpha/capsule.mli
+++ b/otherlibs/stdlib_alpha/capsule.mli
@@ -132,12 +132,26 @@ module Rwlock : sig
         -> ('k Password.t @ local -> 'a) @ local
         -> 'a
         @@ portable
+    (** [with_write_lock rw f] tries to write acquire the rwlock [rw]. If [rw] is already
+        write or read locked, blocks the current thread until it's unlocked. If successful,
+        provides [f] a password for the capsule ['k] associated with [rw].
+
+        If [f] raises an exception, the mutex is marked as poisoned. *)
 
     val with_read_lock :
         'k t
         -> ('k ReaderPassword.t @ local -> 'a) @ local
         -> 'a
         @@ portable
+    (** [with_read_lock rw f] tries to read acquire the rwlock [rw]. If [rw] is already
+        write locked, increases the reader count by one until it's unlocked. If successful,
+        provides [f] a password for the capsule ['k] associated with [rw].
+
+        If [f] raises an exception, the reader-writer lock decreases the reader count,
+        and reraises the exception. Note that unlike [with_write_lock], [rw] is not
+        poisoned: doing so would create a data-race with other readers trying to read
+        from the [poison] bit. Since readers can't write into a capsule, they should not
+        be able to leave protected data in a bad state  *)
 
     val destroy : 'k t -> 'k Password.t @@ portable
 end

--- a/otherlibs/stdlib_alpha/capsule.mli
+++ b/otherlibs/stdlib_alpha/capsule.mli
@@ -59,6 +59,21 @@ module Password : sig
 
 end
 
+(** ReaderPasswords represent read access to a capsule. *)
+module ReaderPassword : sig
+
+    type 'k t
+    (** ['k t] is the type of "reader passwords" representing the ability of the
+        current domain to have [shared] access to the capsule ['k]. As with [Password.t],
+        they don't have a runtime representation and they can't be passed between
+        domains.
+
+        Obtaining a ['k t] requires read acquire the reader-writer lock associate
+        with ['k]. *)
+end
+
+val weaken_password : 'k Password.t @ local -> 'k ReaderPassword.t @ local @@ portable
+
   (** Mutual exclusion primtives for controlling uncontended access to a capsule.
 
       Requires OCaml 5 runtime. *)
@@ -96,8 +111,42 @@ module Mutex : sig
         It marks the lock as poisoned. *)
 end
 
+module Rwlock : sig
+
+    type 'k t : value mod portable uncontended
+    (** ['k t] is the type of the reader-writer lock that controls reader and writer
+        access to the capsule ['k]. This reader-writer lock can be created when creating
+        the capsule ['k] using {!create_with_rwlock} *)
+
+    type packed : value mod portable uncontended = P : 'k t -> packed
+    (** [packed] is the type of a reader-writer lock for some unknown capsule.
+        Unpacking one provides a ['k Rwlock.t] together with a fresh existential type
+        brand for ['k]. *)
+
+    exception Poisoned
+    (** Reader-writer locks can get marked as poisoned. Any operations on a poisoned
+        reader-writer lock raise the [Poisoned] exception. *)
+
+    val with_write_lock :
+        'k t
+        -> ('k Password.t @ local -> 'a) @ local
+        -> 'a
+        @@ portable
+
+    val with_read_lock :
+        'k t
+        -> ('k ReaderPassword.t @ local -> 'a) @ local
+        -> 'a
+        @@ portable
+
+    val destroy : 'k t -> 'k Password.t @@ portable
+end
+
 val create_with_mutex : unit -> Mutex.packed @@ portable
 (** [create_with_mutex ()] creates a new capsule with an associated mutex. *)
+
+val create_with_rwlock : unit -> Rwlock.packed @@ portable
+(** [create_with_rwlock ()] creates a new capsule with an associated reader-writer lock. *)
 
 (** Pointers to data within a capsule. *)
 module Data : sig
@@ -184,4 +233,27 @@ module Data : sig
     (** [expose p t] retrieves the value stored by [Ptr.t]. It requires
         a [global] [Password.t] leaked by [Mutex.destroy]. *)
 
+    val map_shared :
+      ('a : value mod portable) 'b 'k.
+      'k ReaderPassword.t @ local
+      -> ('a @ shared -> 'b) @ local portable
+      -> ('a, 'k) t
+      -> ('b, 'k) t
+      @@ portable
+    (** [map_shared p f t] applies [f] to the shared parts of [p] within the capsule ['k],
+        creating a pointer to the result. Since [nonportable] functions may enclose
+        [uncontended] (and thus write) access to data, ['a] must cross [portability] *)
+
+    val extract_shared :
+      ('a : value mod portable) 'b 'k.
+      'k ReaderPassword.t @ local
+      -> ('a @ shared -> 'b @ portable contended) @ local portable
+      -> ('a, 'k) t
+      -> 'b @ portable contended
+      @@ portable
+    (** [extract p f t] applies [f] to the value of [t] within
+        the capsule ['k] and returns the result. The result is within ['k]
+        so it must be [portable] and it is marked [contended]. Since [nonportable]
+        functions may enclose [uncontended] (and thus write) access to data,
+        ['a] must cross [portability] *)
   end

--- a/otherlibs/stdlib_alpha/dune
+++ b/otherlibs/stdlib_alpha/dune
@@ -29,6 +29,13 @@
    -allow-illegal-crossing))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
+ (foreign_stubs
+  (language c)
+  (names rwlock)
+  (flags
+   ((:include %{project_root}/oc_cflags.sexp)
+    (:include %{project_root}/sharedlib_cflags.sexp)
+    (:include %{project_root}/oc_cppflags.sexp))))
  (library_flags
   (:standard -linkall)))
 
@@ -40,3 +47,19 @@
   (with-stdout-to
    to_install.sexp
    (run "%{first-dep}" "stdlib_alpha"))))
+
+(install
+ (files
+  (.stdlib_alpha.objs/native/stdlib_alpha.cmx as stdlib_alpha.cmx)
+  (stdlib_alpha.cmxa as stdlib_alpha.cmxa)
+  (stdlib_alpha.a as stdlib_alpha.a)
+  (stdlib_alpha.cma as stdlib_alpha.cma)
+  (.stdlib_alpha.objs/byte/stdlib_alpha.cmi as stdlib_alpha.cmi)
+  (.stdlib_alpha.objs/byte/stdlib_alpha.cmt as stdlib_alpha.cmt)
+  (.stdlib_alpha.objs/byte/stdlib_alpha.cmti as stdlib_alpha.cmti)
+  (stdlib_alpha.cmxs as stdlib_alpha.cmxs)
+  (dllstdlib_alpha_stubs.so as dllstdlib_alpha_stubs.so)
+  (stdlib_alpha.mli as stdlib_alpha.mli)
+  (rwlock.h as rwlock.h))
+ (section lib)
+ (package ocaml))

--- a/otherlibs/stdlib_alpha/dune
+++ b/otherlibs/stdlib_alpha/dune
@@ -50,16 +50,6 @@
 
 (install
  (files
-  (.stdlib_alpha.objs/native/stdlib_alpha.cmx as stdlib_alpha.cmx)
-  (stdlib_alpha.cmxa as stdlib_alpha.cmxa)
-  (stdlib_alpha.a as stdlib_alpha.a)
-  (stdlib_alpha.cma as stdlib_alpha.cma)
-  (.stdlib_alpha.objs/byte/stdlib_alpha.cmi as stdlib_alpha.cmi)
-  (.stdlib_alpha.objs/byte/stdlib_alpha.cmt as stdlib_alpha.cmt)
-  (.stdlib_alpha.objs/byte/stdlib_alpha.cmti as stdlib_alpha.cmti)
-  (stdlib_alpha.cmxs as stdlib_alpha.cmxs)
-  (dllstdlib_alpha_stubs.so as dllstdlib_alpha_stubs.so)
-  (stdlib_alpha.mli as stdlib_alpha.mli)
-  (rwlock.h as rwlock.h))
+  (dllstdlib_alpha_stubs.so as stublibs/dllstdlib_alpha_stubs.so))
  (section lib)
  (package ocaml))

--- a/otherlibs/stdlib_alpha/rwlock.c
+++ b/otherlibs/stdlib_alpha/rwlock.c
@@ -9,6 +9,7 @@
 #include "caml/signals.h"
 #include "caml/sys.h"
 
+#ifdef CAML_RUNTIME_5
 #include "../../runtime/sync_posix.h"
 
 /* Rwlock ops */
@@ -86,3 +87,27 @@ CAMLprim value caml_ml_rwlock_unlock(value wrapper)
   sync_check_error(retcode, "Rwlock.unlock");
   return Val_unit;
 }
+
+#else
+
+CAMLprim value caml_ml_rwlock_new(value unit)
+{
+  caml_failwith("Must use runtime5 to use Rwlock");
+}
+
+CAMLprim value caml_ml_rwlock_rdlock(value wrapper)
+{
+  caml_failwith("Must use runtime5 to use Rwlock");
+}
+
+CAMLprim value caml_ml_rwlock_wrlock(value wrapper)
+{
+  caml_failwith("Must use runtime5 to use Rwlock");
+}
+
+CAMLprim value caml_ml_rwlock_unlock(value wrapper)
+{
+  caml_failwith("Must use runtime5 to use Rwlock");
+}
+
+#endif // CAML_RUNTIME_5

--- a/otherlibs/stdlib_alpha/rwlock.c
+++ b/otherlibs/stdlib_alpha/rwlock.c
@@ -56,7 +56,7 @@ CAMLprim value caml_ml_rwlock_rdlock(value wrapper)
   CAMLparam1(wrapper);
   sync_retcode retcode;
   sync_rwlock rwl = Rwlock_val(wrapper);
-  if (sync_rwlock_tryrdlock(rwl) != RWLOCK_PREVIOUSLY_UNLOCKED) {
+  if (sync_rwlock_tryrdlock(rwl) != RWLOCK_SUCCESS) {
     caml_enter_blocking_section();
     retcode = sync_rwlock_rdlock(rwl);
     caml_leave_blocking_section();
@@ -70,7 +70,7 @@ CAMLprim value caml_ml_rwlock_wrlock(value wrapper)
   CAMLparam1(wrapper);
   sync_retcode retcode;
   sync_rwlock rwl = Rwlock_val(wrapper);
-  if (sync_rwlock_trywrlock(rwl) != RWLOCK_PREVIOUSLY_UNLOCKED) {
+  if (sync_rwlock_trywrlock(rwl) != RWLOCK_SUCCESS) {
     caml_enter_blocking_section();
     retcode = sync_rwlock_wrlock(rwl);
     caml_leave_blocking_section();

--- a/otherlibs/stdlib_alpha/rwlock.c
+++ b/otherlibs/stdlib_alpha/rwlock.c
@@ -1,0 +1,88 @@
+#define CAML_INTERNALS
+
+#include "rwlock.h"
+#include "caml/fail.h"
+#include "caml/alloc.h"
+#include "caml/custom.h"
+#include "caml/domain_state.h"
+
+#include "caml/signals.h"
+#include "caml/sys.h"
+
+#include "../../runtime/sync_posix.h"
+
+/* Rwlock ops */
+static void caml_rwlock_finalize(value wrapper)
+{
+  sync_rwlock_destroy(Rwlock_val(wrapper));
+}
+
+static int caml_rwlock_compare(value wrapper1, value wrapper2)
+{
+  sync_rwlock rwl1 = Rwlock_val(wrapper1);
+  sync_rwlock rwl2 = Rwlock_val(wrapper2);
+  return rwl1 == rwl2 ? 0 : rwl1 < rwl2 ? -1 : 1;
+}
+
+static intnat caml_rwlock_hash(value wrapper)
+{
+  return (intnat) (Rwlock_val(wrapper));
+}
+
+static struct custom_operations caml_rwlock_ops = {
+  "_rwlock",
+  caml_rwlock_finalize,
+  caml_rwlock_compare,
+  caml_rwlock_hash,
+  custom_serialize_default,
+  custom_deserialize_default,
+  custom_compare_ext_default,
+  custom_fixed_length_default
+};
+
+CAMLprim value caml_ml_rwlock_new(value unit)
+{
+  sync_rwlock rwl = NULL;
+  value wrapper;
+  sync_check_error(sync_rwlock_create(&rwl), "Rwlock.create");
+  wrapper = caml_alloc_custom(&caml_rwlock_ops, sizeof(pthread_rwlock_t *), 0, 1);
+  Rwlock_val(wrapper) = rwl;
+  return wrapper;
+}
+
+CAMLprim value caml_ml_rwlock_rdlock(value wrapper)
+{
+  CAMLparam1(wrapper);
+  sync_retcode retcode;
+  sync_rwlock rwl = Rwlock_val(wrapper);
+  if (sync_rwlock_tryrdlock(rwl) != RWLOCK_PREVIOUSLY_UNLOCKED) {
+    caml_enter_blocking_section();
+    retcode = sync_rwlock_rdlock(rwl);
+    caml_leave_blocking_section();
+    sync_check_error(retcode, "Rwlock.rdlock");
+  }
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value caml_ml_rwlock_wrlock(value wrapper)
+{
+  CAMLparam1(wrapper);
+  sync_retcode retcode;
+  sync_rwlock rwl = Rwlock_val(wrapper);
+  if (sync_rwlock_trywrlock(rwl) != RWLOCK_PREVIOUSLY_UNLOCKED) {
+    caml_enter_blocking_section();
+    retcode = sync_rwlock_wrlock(rwl);
+    caml_leave_blocking_section();
+    sync_check_error(retcode, "Rwlock.wrlock");
+  }
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value caml_ml_rwlock_unlock(value wrapper)
+{
+  sync_rwlock rwl = Rwlock_val(wrapper);
+  sync_retcode retcode;
+  retcode = sync_rwlock_unlock(rwl);
+  sync_check_error(retcode, "Rwlock.unlock");
+  return Val_unit;
+}

--- a/otherlibs/stdlib_alpha/rwlock.h
+++ b/otherlibs/stdlib_alpha/rwlock.h
@@ -13,7 +13,7 @@ typedef pthread_rwlock_t * sync_rwlock;
 
 typedef int sync_retcode;
 
-#define RWLOCK_PREVIOUSLY_UNLOCKED 0
+#define RWLOCK_SUCCESS 0
 
 Caml_inline int sync_rwlock_rdlock(sync_rwlock m)
 {

--- a/otherlibs/stdlib_alpha/rwlock.h
+++ b/otherlibs/stdlib_alpha/rwlock.h
@@ -1,0 +1,68 @@
+/* Operations on mutexes from the OCaml stdlib */
+
+#include <pthread.h>
+#include <string.h>
+#include <errno.h>
+
+#ifdef CAML_INTERNALS
+#include "caml/mlvalues.h"
+#include "caml/memory.h"
+
+typedef pthread_rwlock_t * sync_rwlock;
+#define Rwlock_val(v) (* ((sync_rwlock *) Data_custom_val(v)))
+
+typedef int sync_retcode;
+
+#define RWLOCK_PREVIOUSLY_UNLOCKED 0
+
+Caml_inline int sync_rwlock_rdlock(sync_rwlock m)
+{
+  return pthread_rwlock_rdlock(m);
+}
+
+Caml_inline int sync_rwlock_wrlock(sync_rwlock m)
+{
+  return pthread_rwlock_wrlock(m);
+}
+
+Caml_inline int sync_rwlock_unlock(sync_rwlock m)
+{
+  return pthread_rwlock_unlock(m);
+}
+
+Caml_inline int sync_rwlock_tryrdlock(sync_rwlock m)
+{
+  return pthread_rwlock_tryrdlock(m);
+}
+
+Caml_inline int sync_rwlock_trywrlock(sync_rwlock m)
+{
+  return pthread_rwlock_trywrlock(m);
+}
+
+/* c code to allocate a rwlock */
+Caml_inline int sync_rwlock_create(sync_rwlock * res)
+{
+  int rc;
+  sync_rwlock m;
+  m = caml_stat_alloc_noexc(sizeof(pthread_rwlock_t));
+  if (m == NULL) { rc = ENOMEM; goto error2; }
+  rc = pthread_rwlock_init(m, NULL); // default read-write lock attributes are used
+  if (rc != 0) { goto error1; }
+  *res = m;
+  return 0;
+error1:
+  caml_stat_free(m);
+error2:
+  return rc;
+}
+
+Caml_inline int sync_rwlock_destroy(sync_rwlock m)
+{
+  int rc;
+  rc = pthread_rwlock_destroy(m);
+  caml_stat_free(m);
+  return rc;
+}
+
+#endif /* CAML_INTERNALS */

--- a/testsuite/tests/capsule-api/rwlock_capsule.ml
+++ b/testsuite/tests/capsule-api/rwlock_capsule.ml
@@ -1,0 +1,215 @@
+(* TEST
+ include stdlib_alpha;
+ flags = "-extension-universe alpha -allow-illegal-crossing";
+ runtime5;
+ { bytecode; }
+ { native; }
+*)
+
+module Capsule = Stdlib_alpha.Capsule
+
+(* [Rwlock.t] and [Data.t] are [value mod portable uncontended]. *)
+
+type 'k _rwlock : value mod portable uncontended = 'k Capsule.Rwlock.t
+
+type ('a, 'k) _data : value mod portable uncontended = ('a, 'k) Capsule.Data.t
+
+(* Packed rwlocks are [value mod portable uncontended]. *)
+
+type _packed :  value mod portable uncontended = Capsule.Rwlock.packed
+
+(* CR: without [with] syntax and mode crossing inference, we need to depend on
+  [allow-illegal-crossing] to determine that 'a myref crosses portabilility.
+  This only holds when 'a also crosses portability *)
+
+type 'a myref : value mod portable = { mutable v : 'a}
+
+
+module RwCell = struct
+  type 'a t =
+    | Mk : 'k Capsule.Rwlock.t * ('a myref, 'k) Capsule.Data.t -> 'a t
+
+    let create (type a : value mod portable uncontended) (x : a) : a t =
+      let (P m) = Capsule.create_with_rwlock () in
+      let p = Capsule.Data.create (fun () -> {v = x}) in
+      Mk (m, p)
+
+    let read (type a : value mod portable uncontended) (t : a t) : a =
+      let (Mk (m, p)) = t in
+      Capsule.Rwlock.with_read_lock m (fun k ->
+        let read' : a myref @ shared -> a @ portable contended = (fun r -> r.v) in
+        Capsule.Data.extract_shared k read' p)
+
+    let write (type a : value mod portable uncontended) (t : a t) (x : a) =
+      let (Mk (m, p)) = t in
+      Capsule.Rwlock.with_write_lock m (fun k ->
+        Capsule.Data.iter k (fun r -> r.v <- x) p)
+
+    let copy (type a : value mod portable uncontended) (t : a t) : a t =
+      let (Mk (m, p)) = t in
+      Capsule.Rwlock.with_read_lock m (fun k ->
+        let p = Capsule.Data.map_shared k (fun r ->
+          let v : a = r.v in {v = v}) p
+        in
+        Mk (m, p))
+end
+
+let () =
+  let ptr = RwCell.create 42 in
+  let ptr' = RwCell.copy ptr in
+  assert (RwCell.read ptr = 42);
+  RwCell.write ptr 43;
+  assert (RwCell.read ptr = 43);
+  assert (RwCell.read ptr' = 42)
+
+(** Testing individual capsule operations over a password captured by a rwlock *)
+
+external reraise : exn -> 'a @ portable @@ portable = "%reraise"
+
+type 'a guarded =
+  | Mk : 'k Capsule.Rwlock.t * ('a, 'k) Capsule.Data.t -> 'a guarded
+
+let with_write_guarded x (f : 'k . 'k Capsule.Password.t @ local -> ('a, 'k) Capsule.Data.t -> 'b) =
+  let (Mk (m, p)) = x in
+  Capsule.Rwlock.with_write_lock m (fun k -> f k p)
+;;
+
+let with_read_guarded x (f : 'k . 'k Capsule.ReaderPassword.t @ local -> ('a, 'k) Capsule.Data.t -> 'b) =
+  let (Mk (m, p)) = x in
+  Capsule.Rwlock.with_read_lock m (fun k -> f k p)
+;;
+
+(* reading from myref with the expected modes *)
+let read_ref : ('a : value mod portable) .
+  ('a myref @ shared -> 'a @ portable contended) @@ portable = fun r -> r.v
+
+(* writing to myref with the expected modes *)
+ let write_ref : ('a : value mod portable uncontended) .
+  'a -> ('a myref -> unit) @ portable = fun v r -> r.v <- v
+
+(* [create]. *)
+let ptr =
+  let (P m) = Capsule.create_with_rwlock () in
+  Mk (m, Capsule.Data.create (fun () -> { v = 42 }))
+;;
+
+(* [extract]. *)
+let () =
+  with_write_guarded ptr (fun k p ->
+    assert (Capsule.Data.extract k read_ref p = 42))
+;;
+
+let ptr' =
+  let (Mk (m, p)) = ptr in
+  Mk (m, Capsule.Data.create (fun () -> { v = 2 }))
+
+(* [iter]. *)
+let () =
+  with_write_guarded ptr (fun k p ->
+    Capsule.Data.iter k (write_ref 15) p)
+;;
+
+let () =
+  with_write_guarded ptr (fun k p ->
+    assert (Capsule.Data.extract k read_ref p = 15))
+;;
+
+let () =
+  with_write_guarded ptr' (fun k p ->
+    assert (Capsule.Data.extract k read_ref p = 2))
+;;
+
+(* [extract_shared]. *)
+let () =
+  with_read_guarded ptr (fun k p ->
+    assert (Capsule.Data.extract_shared k read_ref p = 15))
+;;
+
+external (+) : int -> int -> int @@ portable = "%addint"
+
+(* [map_shared]. *)
+let ptr2 =
+let (Mk (m, p)) = ptr in
+  let p' =
+    Capsule.Rwlock.with_read_lock m (fun k ->
+      Capsule.Data.map_shared k (fun (r @ shared) ->
+        let v : int = r.v in { v = v + 2 }) p)
+  in
+  Mk (m, p')
+
+(* [map_shared] and [extract_shared]. *)
+let () =
+  with_read_guarded ptr2 (fun k p ->
+    let ptr' = Capsule.Data.map_shared k (fun (r @ shared) -> { v = r.v + 3}) p in
+    assert (Capsule.Data.extract_shared k read_ref ptr' = 20))
+
+(* Using a Password.t as a ReaderPassword.t *)
+let () =
+  with_write_guarded ptr (fun k p ->
+    assert (Capsule.Data.extract_shared (Capsule.weaken_password k) read_ref p = 15))
+
+exception Leak of int myref
+
+(* An exception raised from [iter] is marked as [contended]: *)
+let () =
+  with_write_guarded ptr (fun k p ->
+    match Capsule.Data.iter k (fun r -> reraise (Leak r)) p with
+    | exception Capsule.Data.Contended (Leak r) -> ()
+    | _ -> assert false)
+;;
+
+(* [map], [both]. *)
+let ptr2 =
+  let (Mk (m, p)) = ptr in
+  let p' =
+    Capsule.Rwlock.with_write_lock m (fun k -> Capsule.Data.map k (fun _ -> { v = 3 }) p)
+  in
+  Mk (m, Capsule.Data.both p p')
+;;
+
+
+(* [expose]. *)
+let () =
+  let (Mk (m, p)) = ptr2 in
+  let k = Capsule.Rwlock.destroy m in
+  let (r1, r2) = Capsule.Data.expose k p in
+  assert (read_ref r1 = 15 && read_ref r2 = 3)
+;;
+
+let () =
+  match with_write_guarded ptr (fun _ _ -> ()) with
+  | exception Capsule.Rwlock.Poisoned -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match with_write_guarded ptr' (fun _ _ -> ()) with
+  | exception Capsule.Rwlock.Poisoned -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match with_write_guarded ptr2 (fun _ _ -> ()) with
+  | exception Capsule.Rwlock.Poisoned -> ()
+  | _ -> assert false
+;;
+
+(* [inject], [project]. *)
+let () =
+  let ptr = Capsule.Data.inject 100 in
+  assert (Capsule.Data.project ptr = 100)
+;;
+
+type lost_capsule = |
+
+(* [bind]. *)
+let ptr' : (int, lost_capsule) Capsule.Data.t =
+  let (P m) = Capsule.create_with_rwlock () in
+  let ptr = Capsule.Data.inject 100 in
+  Capsule.Rwlock.with_write_lock m (fun k ->
+    Capsule.Data.bind k (fun x -> Capsule.Data.inject (((+) x) 11)) ptr)
+;;
+
+let () =
+  assert (Capsule.Data.project ptr' = 111)
+;;


### PR DESCRIPTION
Added a `rwlock` to the capsule API to support many-readers with `shared` access, and one-writer with `uncontended` access.
 
`create_with_rwlock` creates a capsule with a reader-writer lock. 

The reader-writer lock module has three functions: `with_write_lock` works like `with_lock` using a mutex, `with_read_lock` grants access to a new `ReaderPassword.t` type, and `destroy` destroys a reader-writer lock by setting its poison bit to 1.

A ReaderPassword.t is required to call `Data.map_shared` and `Data.extract_shared`. It is safe to turn a `Password.t` into a `ReaderPassword.t`.

`Data.map_shared` and `Data.extract_shared` both grant `shared` access into a capsule. Note that the internal type of the `Data.t` input must cross portability. This is to prevent indirect write access via closures that might enclose `uncontended` access to the capsule's data. 