### PR TITLE
Stop counting immediates as part of the non-scannable suffix (to stop misleading the optimizer)

### DIFF
--- a/ocaml/testsuite/tests/mixed-blocks/test_mixed_blocks.reference
+++ b/ocaml/testsuite/tests/mixed-blocks/test_mixed_blocks.reference
@@ -1,3 +1,5 @@
 Test large mixed blocks: sum (33670) = 33670.000
   at end, sum (33670) = 33670.000
 Test opt: result (42) = 42.000 = 42.000 = 42.000 = 42.000
+Test mismatch: result (4) = 4.000
+Test mismatch: result (3) = 3

--- a/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_constructor_arguments.ml
@@ -521,10 +521,10 @@ type t_cstr_capped =
     ptr * ptr * ptr * ptr * ptr * ptr * ptr * ptr *
     ptr * ptr * ptr * ptr * ptr * ptr * ptr * ptr *
     ptr * ptr * ptr * ptr * ptr * ptr * ptr *
-    int * float#
+    float#
 [%%expect{|
 type ptr = string
-Lines 3-36, characters 2-16:
+Lines 3-36, characters 2-10:
  3 | ..A of
  4 |     ptr * ptr * ptr * ptr * ptr * ptr * ptr * ptr *
  5 |     ptr * ptr * ptr * ptr * ptr * ptr * ptr * ptr *
@@ -534,7 +534,7 @@ Lines 3-36, characters 2-16:
 33 |     ptr * ptr * ptr * ptr * ptr * ptr * ptr * ptr *
 34 |     ptr * ptr * ptr * ptr * ptr * ptr * ptr * ptr *
 35 |     ptr * ptr * ptr * ptr * ptr * ptr * ptr *
-36 |     int * float#
+36 |     float#
 Error: Mixed constructors may contain at most 254 value fields prior to the flat suffix, but this one contains 255.
 |}];;
 
@@ -565,7 +565,7 @@ type t_cstr_capped_record = A of {
  x0:ptr; x1:ptr; x2:ptr; x3:ptr; x4:ptr; x5:ptr; x6:ptr; x7:ptr; x8:ptr; x9:ptr;
  y0:ptr; y1:ptr; y2:ptr; y3:ptr; y4:ptr; y5:ptr; y6:ptr; y7:ptr; y8:ptr; y9:ptr;
  z0:ptr; z1:ptr; z2:ptr; z3:ptr; z4:ptr;
- int:int; unboxed:float#
+ unboxed:float#
  }
 [%%expect{|
 Lines 1-29, characters 28-2:
@@ -577,7 +577,7 @@ Lines 1-29, characters 28-2:
 ...
 26 |  y0:ptr; y1:ptr; y2:ptr; y3:ptr; y4:ptr; y5:ptr; y6:ptr; y7:ptr; y8:ptr; y9:ptr;
 27 |  z0:ptr; z1:ptr; z2:ptr; z3:ptr; z4:ptr;
-28 |  int:int; unboxed:float#
+28 |  unboxed:float#
 29 |  }
 Error: Mixed inline record arguments to constructors may contain at most 254 value fields prior to the flat suffix, but this one contains 255.
 |}];;
@@ -628,7 +628,7 @@ Lines 2-35, characters 2-16:
 33 |     ptr * ptr * ptr * ptr * ptr * ptr * ptr * ptr *
 34 |     ptr * ptr * ptr * ptr * ptr * ptr * ptr *
 35 |     int * float#
-Error: Mixed constructors may contain at most 254 value fields prior to the flat suffix, but this one contains 255.
+Error: Mixed constructors may contain at most 254 value fields prior to the flat suffix, but this one contains 256.
 |}];;
 
 (* GADT syntax *)

--- a/ocaml/testsuite/tests/typing-layouts/mixed_records.ml
+++ b/ocaml/testsuite/tests/typing-layouts/mixed_records.ml
@@ -301,7 +301,7 @@ type t =
     x233:ptr; x234:ptr; x235:ptr; x236:ptr; x237:ptr; x238:ptr; x239:ptr; x240:ptr;
     x241:ptr; x242:ptr; x243:ptr; x244:ptr; x245:ptr; x246:ptr; x247:ptr; x248:ptr;
     x249:ptr; x250:ptr; x251:ptr; x252:ptr; x253:ptr; x254:ptr; x255:ptr;
-    value_but_flat:int; unboxed:float#;
+    unboxed:float#;
   }
 [%%expect{|
 type ptr = string
@@ -314,7 +314,7 @@ Lines 2-37, characters 0-3:
 ...
 34 |     x241:ptr; x242:ptr; x243:ptr; x244:ptr; x245:ptr; x246:ptr; x247:ptr; x248:ptr;
 35 |     x249:ptr; x250:ptr; x251:ptr; x252:ptr; x253:ptr; x254:ptr; x255:ptr;
-36 |     value_but_flat:int; unboxed:float#;
+36 |     unboxed:float#;
 37 |   }
 Error: Mixed records may contain at most 254 value fields prior to the flat suffix, but this one contains 255.
 |}];;

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -711,14 +711,6 @@ module Record_diffing = struct
     =
     if v1 = v2 then None
     else
-      (* It's currently possible for the value prefix length to legally differ
-         between two compatible record declarations. The signature may hide
-         the fact that record fields are immediates, in which case its value
-         prefix length will be less than the implementation.
-
-         It's illegal for the difference to be in whether [float] fields
-         are boxed.
-      *)
       let has_float_boxed_on_read fields =
         Array.exists (function
             | Float_boxed -> true
@@ -729,7 +721,11 @@ module Record_diffing = struct
       then Some (Mixed_representation_with_flat_floats First)
       else if has_float_boxed_on_read s2
       then Some (Mixed_representation_with_flat_floats Second)
-      else None
+      else
+        Misc.fatal_error
+          "Impossible: the only way for mixed blocks to differ in \
+           representation is if one is a flat float record with a boxed float \
+           field, and the other isn't."
 
   let compare_with_representation ~loc env params1 params2 l r rep1 rep2 =
     if not (equal ~loc env params1 params2 l r) then

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -1355,6 +1355,7 @@ module Element_repr = struct
       | [] -> None
       | (t1, t1_extra) :: ts ->
           match t1 with
+          | Float_element | Imm_element | Value_element -> find_flat_suffix ts
           | Unboxed_element unboxed ->
               let suffix =
                 List.map (fun (t2, t2_extra) ->
@@ -1366,19 +1367,7 @@ module Element_repr = struct
                           ~boxed:t2_extra)
                   ts
               in
-              Some (`Continue (unboxed_to_flat unboxed :: suffix))
-          | Float_element
-          | Imm_element
-          | Value_element as repr -> begin
-              match find_flat_suffix ts with
-              | None -> None
-              | Some `Stop _ as stop -> stop
-              | Some `Continue suffix ->
-                  Some (
-                    match to_flat repr with
-                    | None -> `Stop suffix
-                    | Some flat -> `Continue (flat :: suffix))
-            end
+              Some (unboxed_to_flat unboxed :: suffix)
           (* CR layouts v7: Supporting void with mixed blocks will require
              updating some assumptions in lambda, e.g. the translation
              of [value_prefix_len]. *)
@@ -1393,8 +1382,7 @@ module Element_repr = struct
     in
     match find_flat_suffix ts with
     | None -> None
-    | Some (`Continue flat_suffix | `Stop flat_suffix) ->
-        Some (Array.of_list flat_suffix)
+    | Some flat_suffix -> Some (Array.of_list flat_suffix)
 
   let mixed_product_shape loc ts kind ~on_flat_field_expected =
     let flat_suffix = mixed_product_flat_suffix ts ~on_flat_field_expected in


### PR DESCRIPTION
A follow-up to #3099:
  * the optimizer considers two values to have incompatible representation if their scannable prefix length differs.
  * prior to this PR, immediates appearing just before the first unboxed field were included in the non-scannable suffix, and so if a signature hid which fields were immediate, it was possible to construct two values with the same tag but with different scannable prefix lengths.

Flambda2 thought it was impossible for this case to arise and would generate code that dumped core at runtime.

(We (i) didn't consciously make the choice to allow the representations to differ, and (ii) didn't communicate this fact to the people working on the optimizer, and in fact my first attempt at adding optimizer support for mixed blocks suffered from the same bug. So I'm not surprised that this problem arose!)

In principle I think it's possible to teach flambda2 to handle this case gracefully, but it's not clearly worth it just to be able to count some more fields as part of the non-scannable suffix. In any case, this PR is a simple workaround to an unseemly problem.