### PR TITLE
Zero alloc: better error widen witness

### DIFF
--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -1662,7 +1662,7 @@ end = struct
                0\" flags.\n\
                The \"-zero-alloc-checker-join 0\" flag may substantially \
                increase compilation time.\n\
-               (widenning applied in function %s%s)" t.fun_name component_msg,
+               (widening applied in function %s%s)" t.fun_name component_msg,
             [] )
         | Indirect_call | Indirect_tailcall | Direct_call _ | Direct_tailcall _
         | Extcall _ ->

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2115,6 +2115,7 @@ end = struct
     { dst with div }
 
   let transform t ~next ~exn ~(effect : Value.t) desc dbg =
+    report t effect ~msg:"transform effect" ~desc dbg;
     let next = transform_return ~effect:effect.nor next in
     let exn = transform_return ~effect:effect.exn exn in
     report t next ~msg:"transform new next" ~desc dbg;
@@ -2148,6 +2149,9 @@ end = struct
 
   (** Summary of target specific operations. *)
   let transform_specific t s ~next ~exn dbg =
+    let desc = "Arch.specific_operation" in
+    report t next ~msg:"transform_specific next" ~desc dbg;
+    report t exn ~msg:"transform_specific exn" ~desc dbg;
     let can_raise = Arch.operation_can_raise s in
     let effect =
       let w = create_witnesses t Arch_specific dbg in
@@ -2161,7 +2165,7 @@ end = struct
         let div = V.bot in
         { Value.nor; exn; div }
     in
-    transform t ~next ~exn ~effect "Arch.specific_operation" dbg
+    transform t ~next ~exn ~effect desc dbg
 
   let transform_operation t (op : Mach.operation) ~next ~exn dbg =
     match op with

--- a/backend/zero_alloc_checker.mli
+++ b/backend/zero_alloc_checker.mli
@@ -67,6 +67,7 @@ module Witness : sig
         { name : string;
           handler_code_sym : string
         }
+    | Widen
 
   type t =
     { dbg : Debuginfo.t;

--- a/tests/backend/zero_alloc_checker/test_bounded_join2.output
+++ b/tests/backend/zero_alloc_checker/test_bounded_join2.output
@@ -6,4 +6,4 @@ Error: details are not available. This may be a false alarm due to conservative 
 Hint: for more precise results, recompile this function with
 "-function-layout topological" or "-zero-alloc-checker-join 0" flags.
 The "-zero-alloc-checker-join 0" flag may substantially increase compilation time.
-(widenning applied in function camlTest_bounded_join2.foo_HIDE_STAMP)
+(widening applied in function camlTest_bounded_join2.foo_HIDE_STAMP)

--- a/tests/backend/zero_alloc_checker/test_bounded_join2.output
+++ b/tests/backend/zero_alloc_checker/test_bounded_join2.output
@@ -1,2 +1,9 @@
 File "test_bounded_join2.ml", line 8, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_bounded_join2.foo (camlTest_bounded_join2.foo_HIDE_STAMP)
+
+File "test_bounded_join2.ml", lines 8-29, characters 25-19:
+Error: details are not available. This may be a false alarm due to conservative analysis.
+Hint: for more precise results, recompile this function with
+"-function-layout topological" or "-zero-alloc-checker-join 0" flags.
+The "-zero-alloc-checker-join 0" flag may substantially increase compilation time.
+(widenning applied in function camlTest_bounded_join2.foo_HIDE_STAMP)


### PR DESCRIPTION
When zero_alloc checker applies widening to produce a value that leads to an annotation check failure, the error message doesn't have any witnesses, and this is very confusing to the user. 

This PR prints a nicer message. It's still not very helpful because it points to the entire function instead of a particular construct, but at the point when we perform widening we don't have the relevant debuginfo and it would be akward to pass through (because we would need to put it in the abstract value; widening can happen during join invoked from the dataflow analysis). 

Technically, we add a new `Witness.kind` for widening without any further detail, and then use debug info of the function during error printing. We rarely need this message because most of the time we have enough other witnesses or the function has no `zero_alloc` assert annotation, so we don't need to track its witnesses.