### PR TITLE
Make monadic mode crossings be lower bounds

### DIFF
--- a/otherlibs/stdlib_alpha/capsule.ml
+++ b/otherlibs/stdlib_alpha/capsule.ml
@@ -20,7 +20,7 @@ open Global
 
 (* Like [int Stdlib.Atomic.t], but [portable]. *)
 module A = struct
-  type t : value mod portable uncontended
+  type t : value mod portable contended
 
   external make : int -> t @@ portable = "%makemutable"
   external fetch_and_add : t -> int -> int @@ portable = "%atomic_fetch_add"
@@ -35,7 +35,7 @@ end
 external ( = ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%equal"
 
 module Name : sig
-  type 'k t : value mod external_ global portable many uncontended unique
+  type 'k t : value mod external_ global portable many contended aliased
   type packed = P : 'k t -> packed [@@unboxed]
 
   val make : unit -> packed @@ portable
@@ -56,7 +56,7 @@ end
 module Access : sig
   (* CR layouts v5: this should have layout [void], but
      [void] can't be used for function argument and return types yet. *)
-  type 'k t : value mod external_ global portable many unique
+  type 'k t : value mod external_ global portable many aliased
 
   type packed = P : 'k t -> packed [@@unboxed]
 
@@ -89,7 +89,7 @@ let initial = Access.unsafe_mk ()
 module Password : sig
   (* CR layouts v5: this should have layout [void], but
      [void] can't be used for function argument and return types yet. *)
-  type 'k t : value mod external_ portable many unique uncontended
+  type 'k t : value mod external_ portable many aliased contended
 
   type packed = P : 'k t -> packed [@@unboxed]
 
@@ -100,7 +100,7 @@ module Password : sig
   module Shared : sig
     (* CR layouts v5: this should have layout [void], but
        [void] can't be used for function argument and return types yet. *)
-    type 'k t : value mod external_ portable many unique uncontended
+    type 'k t : value mod external_ portable many aliased contended
 
     (* Can break the soundness of the API. *)
     val unsafe_mk : 'k Name.t -> 'k t @@ portable
@@ -134,7 +134,7 @@ external raise_with_backtrace: exn -> Printexc.raw_backtrace -> 'a @ portable @@
 external get_raw_backtrace: unit -> Printexc.raw_backtrace @@ portable = "caml_get_exception_raw_backtrace"
 
 module Data = struct
-  type ('a, 'k) t : value mod portable uncontended
+  type ('a, 'k) t : value mod portable contended
 
   exception Encapsulated : 'k Name.t * (exn, 'k) t -> exn
 
@@ -277,7 +277,7 @@ let[@inline] access_shared pw f =
 
 (* Like [Stdlib.Mutex], but [portable]. *)
 module M = struct
-  type t : value mod portable uncontended
+  type t : value mod portable contended
   external create: unit -> t @@ portable = "caml_capsule_mutex_new"
   external lock: t -> unit @@ portable = "caml_capsule_mutex_lock"
   external unlock: t -> unit @@ portable = "caml_capsule_mutex_unlock"
@@ -285,7 +285,7 @@ end
 
 (* Reader writer lock *)
 module Rw = struct
-  type t : value mod portable uncontended
+  type t : value mod portable contended
   external create: unit -> t @@ portable = "caml_capsule_rwlock_new"
   external lock_read: t -> unit @@ portable = "caml_capsule_rwlock_rdlock"
   external lock_write: t -> unit @@ portable = "caml_capsule_rwlock_wrlock"
@@ -297,14 +297,14 @@ module Mutex = struct
   (* Illegal mode crossing: ['k t] has a mutable field [poisoned]. It's safe,
      since [poisoned] protected by [mutex] and not exposed in the API, but
      is not allowed by the type system. *)
-  type 'k t : value mod portable uncontended =
+  type 'k t : value mod portable contended =
     { name : 'k Name.t
     ; mutex : M.t
     ; mutable poisoned : bool
     }
   [@@unsafe_allow_any_mode_crossing]
 
-  type packed : value mod portable uncontended = P : 'k t -> packed
+  type packed : value mod portable contended = P : 'k t -> packed
   [@@unsafe_allow_any_mode_crossing
     "CR layouts v2.8: illegal mode crossing on the current version of the compiler, but \
      should be legal."]
@@ -354,14 +354,14 @@ end
 
 module Rwlock = struct
 
-  type 'k t : value mod portable uncontended =
+  type 'k t : value mod portable contended =
     { name : 'k Name.t
     ; rwlock : Rw.t
     ; mutable poisoned : bool
     }
   [@@unsafe_allow_any_mode_crossing]
 
-  type packed : value mod portable uncontended = P : 'k t -> packed
+  type packed : value mod portable contended = P : 'k t -> packed
   [@@unsafe_allow_any_mode_crossing
     "CR layouts v2.8: This can go away once we have proper mode crossing \
      inference for GADT constructors "]
@@ -426,7 +426,7 @@ end
 
 module Condition = struct
 
-  type 'k t : value mod portable uncontended
+  type 'k t : value mod portable contended
 
   external create : unit -> 'k t @@ portable = "caml_capsule_condition_new"
   external wait : 'k t -> M.t -> unit @@ portable = "caml_capsule_condition_wait"

--- a/otherlibs/stdlib_alpha/capsule.mli
+++ b/otherlibs/stdlib_alpha/capsule.mli
@@ -43,7 +43,7 @@
 (** A [Name.t] is used to enable runtime identification of capsules. *)
 module Name : sig
 
-  type 'k t : value mod global portable many uncontended unique
+  type 'k t : value mod global portable many contended aliased
   (** A ['k Name.t] represents the identity of a capsule. *)
 
   val equality_witness : 'k1 t -> 'k2 t -> ('k1, 'k2) Type.eq option @@ portable
@@ -58,7 +58,7 @@ module Access : sig
 
   (* CR layouts v5: this should have layout [void], but
      [void] can't be used for function argument and return types yet. *)
-  type 'k t : value mod external_ global portable many unique
+  type 'k t : value mod external_ global portable many aliased
   (** ['k t] represents access to the current capsule, allowing wraping
       and unwraping [Data.t] values. An [uncontended] ['k t] indicates
       that ['k] is the current capsule. A [shared] ['k t] indicates that
@@ -93,7 +93,7 @@ module Password : sig
 
   (* CR layouts v5: this should have layout [void], but
      [void] can't be used for function argument and return types yet. *)
-  type 'k t : value mod external_ portable many unique uncontended
+  type 'k t : value mod external_ portable many aliased contended
   (** ['k t] is the type of "passwords" representing permission for the
      current fiber to have [uncontended] access to the capsule
      ['k]. They are only ever avilable locally, so that they cannot move
@@ -115,7 +115,7 @@ module Password : sig
   (** Shared passwords represent permission to get shared access to a capsule *)
   module Shared : sig
 
-    type 'k t : value mod external_ portable many unique uncontended
+    type 'k t : value mod external_ portable many aliased contended
     (** ['k t] is the type of "shared passwords" representing permission
         for the current fiber to have [shared] access to the capsule
         ['k]. They are only ever avilable locally, so that they cannot
@@ -174,12 +174,12 @@ val access_shared_local :
     does not provide mutual exclusion between systhreads.  *)
 module Mutex : sig
 
-    type 'k t : value mod portable uncontended
+    type 'k t : value mod portable contended
     (** ['k t] is the type of the mutex that controls access to
         the capsule ['k]. This mutex is created when creating
         the capsule ['k] using {!create_with_mutex}. *)
 
-    type packed : value mod portable uncontended = P : 'k t -> packed
+    type packed : value mod portable contended = P : 'k t -> packed
     [@@unsafe_allow_any_mode_crossing
       "CR layouts v2.8: This can go away once we have proper mode crossing \
        inference for GADT constructors "]
@@ -216,12 +216,12 @@ end
 (** Requires runtime5. *)
 module Rwlock : sig
 
-    type 'k t : value mod portable uncontended
+    type 'k t : value mod portable contended
     (** ['k t] is the type of the reader-writer lock that controls reader and writer
         access to the capsule ['k]. This reader-writer lock can be created when creating
         the capsule ['k] using {!create_with_rwlock} *)
 
-    type packed : value mod portable uncontended = P : 'k t -> packed
+    type packed : value mod portable contended = P : 'k t -> packed
     [@@unsafe_allow_any_mode_crossing
       "CR layouts v2.8: This can go away once we have proper mode crossing \
        inference for GADT constructors "]
@@ -268,7 +268,7 @@ end
 (** Requires runtime5. *)
 module Condition : sig
 
-  type 'k t : value mod portable uncontended
+  type 'k t : value mod portable contended
   (** ['k t] is the type of a condition variable associated with the capsule ['k].
       This condition may only be used with the matching ['k Mutex.t]. *)
 
@@ -309,7 +309,7 @@ val create_with_rwlock : unit -> Rwlock.packed @@ portable
 (** Pointers to data within a capsule. *)
 module Data : sig
 
-    type ('a, 'k) t : value mod portable uncontended
+    type ('a, 'k) t : value mod portable contended
     (** [('a, 'k) t] is the type of ['a]s within the capsule ['k]. It
         can be passed between domains.  Operations on [('a, 'k) t]
         require a ['k Password.t], created from the ['k Mutex.t]. *)
@@ -455,14 +455,14 @@ module Data : sig
         so it must be [portable] and it is marked [contended]. *)
 
     val inject :
-      ('a : value mod uncontended) 'k.
+      ('a : value mod contended) 'k.
       'a @ portable -> ('a, 'k) t
       @@ portable
     (** [inject v] is a pointer to an immutable value [v] injected
         into the capsule ['k]. *)
 
     val inject_local :
-      ('a : value mod uncontended) 'k.
+      ('a : value mod contended) 'k.
       'a @ local portable -> ('a, 'k) t @ local
       @@ portable
     (** [inject_local v] is a pointer to an immutable value [v] injected

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type !'a t : value mod portable uncontended
+type !'a t : value mod portable contended
 
 module Unsafe = struct
   external make : 'a -> 'a t = "%makemutable"

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -25,7 +25,7 @@
 *)
 
 (** An atomic (mutable) reference to a value of type ['a]. *)
-type !'a t : value mod portable uncontended
+type !'a t : value mod portable contended
 
 (** Create an atomic reference. *)
 val make : 'a -> 'a t @@ nonportable

--- a/stdlib/condition.ml
+++ b/stdlib/condition.ml
@@ -15,7 +15,7 @@
 
 open! Stdlib
 
-type t : value mod portable uncontended
+type t : value mod portable contended
 external create: unit -> t @@ portable = "caml_ml_condition_new"
 external wait: t -> Mutex.t -> unit @@ portable = "caml_ml_condition_wait"
 external signal: t -> unit @@ portable = "caml_ml_condition_signal"

--- a/stdlib/condition.mli
+++ b/stdlib/condition.mli
@@ -143,7 +143,7 @@ open! Stdlib
    that would be a problematic situation,
    known as a {i deadlock}. *)
 
-type t : value mod portable uncontended
+type t : value mod portable contended
 (** The type of condition variables. *)
 
 val create : unit -> t

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -44,7 +44,7 @@ module Runtime_4 = struct
 
     let init () = ()
 
-    type 'a key : value mod portable uncontended = Key of (int * (Access.t -> 'a))
+    type 'a key : value mod portable contended = Key of (int * (Access.t -> 'a))
     [@@unboxed]
     [@@unsafe_allow_any_mode_crossing "runtime4 only"]
 
@@ -228,13 +228,13 @@ module Runtime_5 = struct
     let init () = create_dls ()
 
     (* CR with-kinds: Remove [Key] wrapper. *)
-    type 'a key : value mod portable uncontended =
+    type 'a key : value mod portable contended =
         Key of (int * (Access.t -> 'a) Modes.Portable.t) [@@unboxed]
     [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 
     let key_counter = Atomic.Safe.make 0
 
-    type key_initializer : value mod portable uncontended =
+    type key_initializer : value mod portable contended =
         KI: 'a key * ('a -> (Access.t -> 'a) @ portable) @@ portable -> key_initializer
     [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 
@@ -329,7 +329,7 @@ module Runtime_5 = struct
         end
       end
 
-    type key_value : value mod portable uncontended =
+    type key_value : value mod portable contended =
         KV : 'a key * (Access.t -> 'a) @@ portable -> key_value
     [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 
@@ -458,7 +458,7 @@ module type S = sig
       val for_initial_domain : t @@ nonportable
     end
 
-    type 'a key : value mod portable uncontended
+    type 'a key : value mod portable contended
 
     val access
       :  (Access.t -> 'a @ portable contended) @ local portable

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -99,7 +99,7 @@ let temp_file_key = Domain.DLS.new_key (fun _ ->
 module DLS : sig
 (** Domain-local Storage *)
 
-    type 'a key : value mod portable uncontended
+    type 'a key : value mod portable contended
     (** Type of a DLS key *)
 
     val new_key : ?split_from_parent:('a -> 'a) -> (unit -> 'a) -> 'a key @@ nonportable
@@ -186,7 +186,7 @@ module Safe : sig
           executed on the primary domain. *)
     end
 
-    type 'a key : value mod portable uncontended = 'a DLS.key
+    type 'a key : value mod portable contended = 'a DLS.key
     (** See {!DLS.key}. *)
 
     (* CR: Update this to use the Capsule API when that is merged into stdlib. *)

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -32,7 +32,7 @@ let id x = x
 (* A devoted type for sizes to avoid confusion
    between sizes and mere integers. *)
 module Size : sig @@ portable
-  type t : value mod portable uncontended
+  type t : value mod portable contended
 
   val to_int : t -> int
   val of_int : int -> t
@@ -821,7 +821,7 @@ let pp_set_margin state n =
 
 
 (** Geometry functions and types *)
-type geometry : value mod portable uncontended = { max_indent:int; margin: int}
+type geometry : value mod portable contended = { max_indent:int; margin: int}
 [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 
 let validate_geometry {margin; max_indent} =
@@ -1195,10 +1195,10 @@ let formatter_of_symbolic_output_buffer sob =
 
 let[@inline] apply1 f v = f (Domain.DLS.get std_formatter_key) v
 let[@inline] apply2 f v w = f (Domain.DLS.get std_formatter_key) v w
-let[@inline] apply1' (type a : value mod portable uncontended) f (v : a) =
+let[@inline] apply1' (type a : value mod portable contended) f (v : a) =
   DLS.access (fun access -> f (DLS.get access std_formatter_key) v)
 let[@inline] apply2'
-      (type (a : value mod portable uncontended) (b : value mod portable uncontended))
+      (type (a : value mod portable contended) (b : value mod portable contended))
       f (v : a) (w : b) =
   DLS.access (fun access -> f (DLS.get access std_formatter_key) v w)
 

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -508,7 +508,7 @@ coupled variables, margin and maximum indentation limit.
 
 *)
 
-type geometry : value mod portable uncontended = { max_indent:int; margin: int}
+type geometry : value mod portable contended = { max_indent:int; margin: int}
 [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 (** @since 4.08 *)
 

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -114,7 +114,7 @@ external finalise_release : unit -> unit @@ portable = "caml_final_release"
 
 
 type alarm = bool Atomic.t
-type alarm_rec : value mod uncontended = {active : alarm; f : unit -> unit}
+type alarm_rec : value mod contended = {active : alarm; f : unit -> unit}
 [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 
 let rec call_alarm arec =

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -464,7 +464,7 @@ val finalise_release : unit -> unit
     GC that it can launch the next finalisation function without waiting
     for the current one to return. *)
 
-type alarm : value mod portable uncontended
+type alarm : value mod portable contended
 (** An alarm is a piece of data that calls a user function at the end of
    major GC cycle.  The following functions are provided to create
    and delete alarms. *)

--- a/stdlib/modes.ml
+++ b/stdlib/modes.ml
@@ -22,12 +22,12 @@ module Portable = struct
 end
 
 module Contended = struct
-  type 'a t : value mod uncontended = { contended : 'a @@ contended } [@@unboxed]
+  type 'a t : value mod contended = { contended : 'a @@ contended } [@@unboxed]
   [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 end
 
 module Portended = struct
-  type 'a t : value mod portable uncontended = { portended : 'a @@ portable contended }
+  type 'a t : value mod portable contended = { portended : 'a @@ portable contended }
   [@@unboxed]
   [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 end

--- a/stdlib/modes.mli
+++ b/stdlib/modes.mli
@@ -33,13 +33,13 @@ module Portable : sig
 end
 
 module Contended : sig
-  type 'a t : value mod uncontended = { contended : 'a @@ contended } [@@unboxed]
+  type 'a t : value mod contended = { contended : 'a @@ contended } [@@unboxed]
   [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
   (** Wraps values in the [contended] mode, even in an [uncontended] context. *)
 end
 
 module Portended : sig
-  type 'a t : value mod portable uncontended = { portended : 'a @@ portable contended }
+  type 'a t : value mod portable contended = { portended : 'a @@ portable contended }
   [@@unboxed]
   [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
   (** Wraps values in the [portable contended] mode, even in a [nonportable uncontended]

--- a/stdlib/mutex.ml
+++ b/stdlib/mutex.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t : value mod portable uncontended
+type t : value mod portable contended
 external create: unit -> t @@ portable = "caml_ml_mutex_new"
 external lock: t -> unit @@ portable = "caml_ml_mutex_lock"
 external try_lock: t -> bool @@ portable = "caml_ml_mutex_try_lock"

--- a/stdlib/mutex.mli
+++ b/stdlib/mutex.mli
@@ -28,7 +28,7 @@
    ]}
 *)
 
-type t : value mod portable uncontended
+type t : value mod portable contended
 (** The type of mutexes. *)
 
 val create : unit -> t

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -352,10 +352,10 @@ let random_key =
 
 let[@inline] apply0 f () = DLS.access (fun access -> f (DLS.get access random_key))
 
-let[@inline] apply1 (type (a : value mod portable uncontended)) (f : State.t -> a -> a) v =
+let[@inline] apply1 (type (a : value mod portable contended)) (f : State.t -> a -> a) v =
   DLS.access (fun access -> f (DLS.get access random_key) v)
 
-let[@inline] apply_in_range (type (a : value mod portable uncontended))
+let[@inline] apply_in_range (type (a : value mod portable contended))
       (f : State.t -> min:a -> max:a -> a) ~min ~max =
   DLS.access (fun access -> f (DLS.get access random_key) ~min ~max)
 

--- a/stdlib/semaphore.ml
+++ b/stdlib/semaphore.ml
@@ -17,7 +17,7 @@ open! Stdlib
 
 (** Semaphores *)
 
-type sem : value mod portable uncontended = {
+type sem : value mod portable contended = {
   mut: Mutex.t;                         (* protects [v] *)
   mutable v: int;                       (* the current value *)
   nonzero: Condition.t                  (* signaled when [v > 0] *)

--- a/stdlib/semaphore.mli
+++ b/stdlib/semaphore.mli
@@ -47,7 +47,7 @@ open! Stdlib
 
 module Counting : sig
 
-type t : value mod portable uncontended
+type t : value mod portable contended
 (** The type of counting semaphores. *)
 
 val make : int -> t
@@ -113,7 +113,7 @@ end
 
 module Binary : sig
 
-type t : value mod portable uncontended
+type t : value mod portable contended
 (** The type of binary semaphores. *)
 
 val make : bool -> t

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -311,8 +311,8 @@ let[@tail_mod_cons] rec ( @ ) l1 l2 =
 
 (* I/O operations *)
 
-type in_channel : value mod portable uncontended
-type out_channel : value mod portable uncontended
+type in_channel : value mod portable contended
+type out_channel : value mod portable contended
 
 external open_descriptor_out : int -> out_channel @@ portable
                              = "caml_ml_open_descriptor_out"
@@ -557,7 +557,7 @@ let ( ^^ ) (Format (fmt1, str1)) (Format (fmt2, str2)) =
 external sys_exit : int -> 'a = "caml_sys_exit"
 
 (* for at_exit *)
-type 'a atomic_t : value mod portable uncontended
+type 'a atomic_t : value mod portable contended
 external atomic_make : 'a @ contended portable -> 'a atomic_t @@ portable = "%makemutable"
 external atomic_get : 'a atomic_t -> 'a @ contended portable @@ portable = "%atomic_load"
 external atomic_compare_and_set : 'a atomic_t -> 'a @ contended portable -> 'a @ contended portable -> bool @@ portable

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -834,10 +834,10 @@ val ( @ ) : 'a list -> 'a list -> 'a list
     Note: all input/output functions can raise [Sys_error] when the system
     calls they invoke fail. *)
 
-type in_channel : value mod portable uncontended
+type in_channel : value mod portable contended
 (** The type of input channel. *)
 
-type out_channel : value mod portable uncontended
+type out_channel : value mod portable contended
 (** The type of output channel. *)
 
 val stdin : in_channel

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -17,7 +17,7 @@
 
 open! Stdlib
 
-type backend_type : value mod portable uncontended =
+type backend_type : value mod portable contended =
   | Native
   | Bytecode
   | Other of string
@@ -109,7 +109,7 @@ external readdir : string -> string array @@ portable = "caml_sys_read_directory
 
 let interactive = ref false
 
-type signal_behavior : value mod uncontended =
+type signal_behavior : value mod contended =
     Signal_default
   | Signal_ignore
   | Signal_handle of (int -> unit)
@@ -185,7 +185,7 @@ type extra_prefix = Plus | Tilde
 
 type extra_info = extra_prefix * string
 
-type ocaml_release_info : value mod portable uncontended = {
+type ocaml_release_info : value mod portable contended = {
   major : int;
   minor : int;
   patchlevel : int;

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -145,7 +145,7 @@ val os_type : string
 -  ["Win32"] (for MS-Windows, OCaml compiled with MSVC++ or MinGW-w64),
 -  ["Cygwin"] (for MS-Windows, OCaml compiled with Cygwin). *)
 
-type backend_type : value mod portable uncontended =
+type backend_type : value mod portable contended =
   | Native
   | Bytecode
   | Other of string (**)
@@ -245,7 +245,7 @@ external poll_actions : unit -> unit = "%poll"
 (** {1 Signal handling} *)
 
 
-type signal_behavior : value mod uncontended =
+type signal_behavior : value mod contended =
     Signal_default
   | Signal_ignore
   | Signal_handle of (int -> unit)   (** *)
@@ -419,7 +419,7 @@ type extra_prefix = Plus | Tilde
 type extra_info = extra_prefix * string
 (** @since 4.14 *)
 
-type ocaml_release_info : value mod portable uncontended = {
+type ocaml_release_info : value mod portable contended = {
   major : int;
   minor : int;
   patchlevel : int;

--- a/testsuite/tests/capsule-api/data.ml
+++ b/testsuite/tests/capsule-api/data.ml
@@ -19,9 +19,9 @@ let mk_ref : ('a -> 'a myref) @@ portable = fun v -> {v}
 let read_ref : ('a : value mod portable) .
   ('a myref -> 'a @ portable contended) @@ portable = fun r -> r.v
 
-(* We need ['a] to be [portable] and [uncontended] to capture it in
+(* We need ['a] to be [portable] and [contended] to capture it in
    a [portable] closure like this.*)
-let write_ref : ('a : value mod portable uncontended) .
+let write_ref : ('a : value mod portable contended) .
   'a -> ('a myref -> unit) @ portable = fun v r -> r.v <- v
 
 type 'a guarded =

--- a/testsuite/tests/capsule-api/rwlock_capsule.ml
+++ b/testsuite/tests/capsule-api/rwlock_capsule.ml
@@ -8,15 +8,15 @@
 
 module Capsule = Stdlib_alpha.Capsule
 
-(* [Rwlock.t] and [Data.t] are [value mod portable uncontended]. *)
+(* [Rwlock.t] and [Data.t] are [value mod portable contended]. *)
 
-type 'k _rwlock : value mod portable uncontended = 'k Capsule.Rwlock.t
+type 'k _rwlock : value mod portable contended = 'k Capsule.Rwlock.t
 
-type ('a, 'k) _data : value mod portable uncontended = ('a, 'k) Capsule.Data.t
+type ('a, 'k) _data : value mod portable contended = ('a, 'k) Capsule.Data.t
 
-(* Packed rwlocks are [value mod portable uncontended]. *)
+(* Packed rwlocks are [value mod portable contended]. *)
 
-type _packed :  value mod portable uncontended = Capsule.Rwlock.packed
+type _packed :  value mod portable contended = Capsule.Rwlock.packed
 
 (* CR: without [with] syntax and mode crossing inference, we need to depend on
    [@@unsafe_allow_any_mode_crossing] to determine that 'a myref crosses portabilility.
@@ -31,23 +31,23 @@ module RwCell = struct
   type 'a t =
     | Mk : 'k Capsule.Rwlock.t * ('a myref, 'k) Capsule.Data.t -> 'a t
 
-    let create (type a : value mod portable uncontended) (x : a) : a t =
+    let create (type a : value mod portable contended) (x : a) : a t =
       let (P m) = Capsule.create_with_rwlock () in
       let p = Capsule.Data.create (fun () -> {v = x}) in
       Mk (m, p)
 
-    let read (type a : value mod portable uncontended) (t : a t) : a =
+    let read (type a : value mod portable contended) (t : a t) : a =
       let (Mk (m, p)) = t in
       Capsule.Rwlock.with_read_lock m (fun k ->
         let read' : a myref @ shared -> a @ portable contended = (fun r -> r.v) in
         Capsule.Data.extract_shared k read' p)
 
-    let write (type a : value mod portable uncontended) (t : a t) (x : a) =
+    let write (type a : value mod portable contended) (t : a t) (x : a) =
       let (Mk (m, p)) = t in
       Capsule.Rwlock.with_write_lock m (fun k ->
         Capsule.Data.iter k (fun r -> r.v <- x) p)
 
-    let copy (type a : value mod portable uncontended) (t : a t) : a t =
+    let copy (type a : value mod portable contended) (t : a t) : a t =
       let (Mk (m, p)) = t in
       Capsule.Rwlock.with_read_lock m (fun k ->
         let p = Capsule.Data.map_shared k (fun r ->
@@ -86,7 +86,7 @@ let read_ref : ('a : value mod portable) .
   ('a myref @ shared -> 'a @ portable contended) @@ portable = fun r -> r.v
 
 (* writing to myref with the expected modes *)
- let write_ref : ('a : value mod portable uncontended) .
+ let write_ref : ('a : value mod portable contended) .
   'a -> ('a myref -> unit) @ portable = fun v r -> r.v <- v
 
 (* [create]. *)

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -297,8 +297,8 @@ type (_ : float64) t2_float64'
 type t3 = float# t2_float64
 type ('a : value mod global) t2_global
 type (_ : value mod global) t2_global'
-type ('a : word mod external_ many unique) t2_complex
-type (_ : word mod external_ many unique) t2_complex'
+type ('a : word mod external_ many aliased) t2_complex
+type (_ : word mod external_ many aliased) t2_complex'
 
 
 [%%expect {|
@@ -367,15 +367,15 @@ module M2 : sig type (_ : value mod global) t end
 |}]
 
 module M1 : sig
-  type ('a : word mod external_ many unique) t
+  type ('a : word mod external_ many aliased) t
 end = struct
-  type (_ : word mod external_ many unique) t
+  type (_ : word mod external_ many aliased) t
 end
 
 module M2 : sig
-  type (_ : word mod external_ many unique) t
+  type (_ : word mod external_ many aliased) t
 end = struct
-  type ('a : word mod external_ many unique) t
+  type ('a : word mod external_ many aliased) t
 end
 
 [%%expect {|
@@ -428,7 +428,7 @@ val f : ('a : word). 'a t2_complex -> 'a t2_complex = <fun>
 
 let f : ('a : immediate) t2_imm -> ('a : value) t2_imm = fun x -> x
 let f : ('a : value mod global) t2_global -> ('a : value) t2_global = fun x -> x
-let f : ('a : word mod external_ many unique) t2_complex -> ('a : word) t2_complex = fun x -> x
+let f : ('a : word mod external_ many aliased) t2_complex -> ('a : word) t2_complex = fun x -> x
 [%%expect {|
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
@@ -446,7 +446,7 @@ val f : ('a : word). 'a t2_complex -> 'a t2_complex = <fun>
 
 let f : ('a : immediate). 'a t2_imm -> 'a t2_imm = fun x -> x
 let f : ('a : value mod global). 'a t2_global -> 'a t2_global = fun x -> x
-let f : ('a : word mod external_ many unique). 'a t2_complex -> 'a t2_complex = fun x -> x
+let f : ('a : word mod external_ many aliased). 'a t2_complex -> 'a t2_complex = fun x -> x
 [%%expect {|
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
@@ -501,7 +501,7 @@ type ('a : word) t = 'a t2_complex
 
 type ('a : immediate) t = 'a t2_imm
 type ('a : value mod global) t = 'a t2_global
-type ('a : word mod external_ many unique) t = 'a t2_complex
+type ('a : word mod external_ many aliased) t = 'a t2_complex
 [%%expect {|
 type ('a : immediate) t = 'a t2_imm
 type ('a : value mod global) t = 'a t2_global
@@ -515,7 +515,7 @@ let f : (_ : value) t2_global -> unit = fun _ -> ()
 let g : (_ : value mod global) t2_global -> unit = fun _ -> ()
 
 let f : (_ : word) t2_complex -> unit = fun _ -> ()
-let g : (_ : word mod external_ many unique) t2_complex -> unit = fun _ -> ()
+let g : (_ : word mod external_ many aliased) t2_complex -> unit = fun _ -> ()
 
 [%%expect {|
 val f : ('a : immediate). 'a t2_imm -> unit = <fun>
@@ -528,7 +528,7 @@ val g : ('a : word). 'a t2_complex -> unit = <fun>
 
 let f : (_ : immediate) -> unit = fun _ -> ()
 let f : (_ : value mod global) -> unit = fun _ -> ()
-let f : (_ : word mod external_ many unique) -> unit = fun _ -> ()
+let f : (_ : word mod external_ many aliased) -> unit = fun _ -> ()
 let g : (_ : value) -> unit = fun _ -> ()
 
 [%%expect {|
@@ -544,8 +544,8 @@ let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 let f : (_ : value mod global) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : value mod global) = fun _ -> assert false
 
-let f : (_ : word mod external_ many unique) -> (_ : value) = fun _ -> assert false
-let g : (_ : value) -> (_ : word mod external_ many unique) = fun _ -> assert false
+let f : (_ : word mod external_ many aliased) -> (_ : value) = fun _ -> assert false
+let g : (_ : value) -> (_ : word mod external_ many aliased) = fun _ -> assert false
 
 [%%expect {|
 val f : ('a : immediate) 'b. 'a -> 'b = <fun>
@@ -612,9 +612,9 @@ type rg = { fieldg : ('a : value mod global). 'a -> 'a; }
 val f : rg -> int = <fun>
 |}]
 
-type rc = { fieldc : ('a : word mod external_ many unique). 'a -> 'a }
+type rc = { fieldc : ('a : word mod external_ many aliased). 'a -> 'a }
 let f { fieldc } =
-  let x : _ as (_ : word mod external_ many unique) = assert false in
+  let x : _ as (_ : word mod external_ many aliased) = assert false in
   fieldc x;;
 [%%expect {|
 type rc = { fieldc : ('a : word). 'a -> 'a; }
@@ -660,7 +660,7 @@ Error: This expression has type "string" but an expression was expected of type
        The layout of string is value
          because it is the primitive type string.
        But the layout of string must be a sublayout of word
-         because of the definition of rc at line 1, characters 0-70.
+         because of the definition of rc at line 1, characters 0-71.
 |}]
 
 let r = { field = fun x -> x }
@@ -765,7 +765,7 @@ Error: Layout mismatch in final type declaration consistency check.
        the declaration where this error is reported.
 |}]
 
-type ('a : word mod external_ many unique) t_complex
+type ('a : word mod external_ many aliased) t_complex
 
 type s = { f : ('a : word). 'a -> 'a u }
 and 'a u = 'a t_complex
@@ -802,7 +802,7 @@ let f = fun (type (a : value mod global)) (x : a) -> x
 val f : ('a : value mod global). 'a -> 'a = <fun>
 |}]
 
-let f = fun (type (a : word mod external_ many unique)) (x : a) -> x
+let f = fun (type (a : word mod external_ many aliased)) (x : a) -> x
 ;;
 [%%expect {|
 val f : ('a : word). 'a -> 'a = <fun>
@@ -850,7 +850,7 @@ let f : type (a : value mod global). a -> a = fun x -> x
 val f : ('a : value mod global). 'a -> 'a = <fun>
 |}]
 
-let f : type (a : word mod external_ many unique). a -> a = fun x -> x
+let f : type (a : word mod external_ many aliased). a -> a = fun x -> x
 ;;
 [%%expect {|
 val f : ('a : word). 'a -> 'a = <fun>
@@ -945,7 +945,7 @@ Error: This type "('a : value)" should be an instance of type "('b : word)"
        The layout of 'a is value
          because of the annotation on the universal variable 'a.
        But the layout of 'a must overlap with word
-         because of the definition of t2_complex at line 10, characters 0-53.
+         because of the definition of t2_complex at line 10, characters 0-54.
 |}]
 
 module type S = sig
@@ -997,7 +997,7 @@ module type S =
 
 module type S = sig
   val f : 'a t2_complex -> 'a t2_complex
-  val g : ('a : word mod external_ many unique). 'a t2_complex -> 'a t2_complex
+  val g : ('a : word mod external_ many aliased). 'a t2_complex -> 'a t2_complex
   val h : ('a : word mod external_ many). 'a t2_complex -> 'a t2_complex
 end
 ;;
@@ -1019,7 +1019,7 @@ let f (x : ('a : value). 'a -> 'a) = x "string", x 5
 val f : ('a. 'a -> 'a) -> string * int = <fun>
 |}]
 
-let f (x : ('a : word mod external_ many unique). 'a -> 'a) =
+let f (x : ('a : word mod external_ many aliased). 'a -> 'a) =
   let native_int : nativeint# = assert false in
   x native_int
 
@@ -1125,9 +1125,9 @@ Error: The kind of type "t" is immutable_data
 
 type t : value mod aliased = { x : t_value }
 [%%expect {|
-Line 1, characters 0-43:
+Line 1, characters 0-44:
 1 | type t : value mod aliased = { x : t_value }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod aliased
@@ -1158,9 +1158,9 @@ Error: The kind of type "t" is immutable_data
 
 type t : value mod contended = { x : t_value }
 [%%expect {|
-Line 1, characters 0-48:
+Line 1, characters 0-46:
 1 | type t : value mod contended = { x : t_value }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod contended
@@ -1264,9 +1264,9 @@ Error: The kind of type "t" is immutable_data
 
 type t : value mod aliased = Foo of t_value
 [%%expect {|
-Line 1, characters 0-42:
+Line 1, characters 0-43:
 1 | type t : value mod aliased = Foo of t_value
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod aliased
@@ -1297,9 +1297,9 @@ Error: The kind of type "t" is immutable_data
 
 type t : value mod contended = Foo of t_value
 [%%expect {|
-Line 1, characters 0-47:
+Line 1, characters 0-45:
 1 | type t : value mod contended = Foo of t_value
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod contended
@@ -1468,7 +1468,7 @@ let f (type a : value) (x : a) = x
 let f (type a : immediate) (x : a) = x
 let f (type a : value mod global) (x : a) = x
 let f (type a : immediate mod global) (x : a) = x
-let f (type a : word mod external_ many unique) (x : a) = x
+let f (type a : word mod external_ many aliased) (x : a) = x
 
 [%%expect{|
 val f : 'a -> 'a = <fun>
@@ -1482,7 +1482,7 @@ let f = fun (type a : value) (x : a) -> x
 let f = fun (type a : immediate) (x : a) -> x
 let f = fun (type a : value mod global) (x : a) -> x
 let f = fun (type a : immediate mod global) (x : a) -> x
-let f = fun (type a : word mod external_ many unique) (x : a) -> x
+let f = fun (type a : word mod external_ many aliased) (x : a) -> x
 
 [%%expect{|
 val f : 'a -> 'a = <fun>
@@ -1505,7 +1505,7 @@ let o = object
   method m : type (a : immediate mod global). a -> a = fun x -> x
 end
 let o = object
-  method m : type (a : word mod external_ many unique). a -> a = fun x -> x
+  method m : type (a : word mod external_ many aliased). a -> a = fun x -> x
 end
 
 [%%expect{|
@@ -1520,7 +1520,7 @@ let f : type (a : value). a -> a = fun x -> x
 let f : type (a : immediate). a -> a = fun x -> x
 let f : type (a : value mod global). a -> a = fun x -> x
 let f : type (a : immediate mod global). a -> a = fun x -> x
-let f : type (a : word mod external_ many unique). a -> a = fun x -> x
+let f : type (a : word mod external_ many aliased). a -> a = fun x -> x
 
 [%%expect{|
 val f : 'a -> 'a = <fun>
@@ -1547,7 +1547,7 @@ let f x =
   g x [@nontail]
 
 let f x =
-  let local_ g (type a : word mod external_ many unique) (x : a) = x in
+  let local_ g (type a : word mod external_ many aliased) (x : a) = x in
   g x [@nontail]
 
 [%%expect{|
@@ -1562,7 +1562,7 @@ let f = fun x y (type (a : value)) (z : a) -> z
 let f = fun x y (type (a : immediate)) (z : a) -> z
 let f = fun x y (type (a : value mod global)) (z : a) -> z
 let f = fun x y (type (a : immediate mod global)) (z : a) -> z
-let f = fun x y (type (a : word mod external_ many unique)) (z : a) -> z
+let f = fun x y (type (a : word mod external_ many aliased)) (z : a) -> z
 
 [%%expect{|
 val f : 'b -> 'c -> 'a -> 'a = <fun>
@@ -1576,7 +1576,7 @@ let f = fun x y (type a : value) (z : a) -> z
 let f = fun x y (type a : immediate) (z : a) -> z
 let f = fun x y (type a : value mod global) (z : a) -> z
 let f = fun x y (type a : immediate mod global) (z : a) -> z
-let f = fun x y (type a : word mod external_ many unique) (z : a) -> z
+let f = fun x y (type a : word mod external_ many aliased) (z : a) -> z
 
 [%%expect{|
 val f : 'b -> 'c -> 'a -> 'a = <fun>
@@ -1592,7 +1592,7 @@ external f : ('a : value). 'a -> 'a = "%identity"
 external f : ('a : immediate). 'a -> 'a = "%identity"
 external f : ('a : value mod global). 'a -> 'a = "%identity"
 external f : ('a : immediate mod global). 'a -> 'a = "%identity"
-external f : ('a : word mod external_ many unique). 'a -> 'a = "%identity"
+external f : ('a : word mod external_ many aliased). 'a -> 'a = "%identity"
 
 [%%expect{|
 external f : 'a -> 'a = "%identity"
@@ -1679,7 +1679,7 @@ type t = int as (_ : value)
 type t = int as (_ : immediate)
 type t = int as (_ : value mod global)
 type t = int as (_ : immediate mod global)
-type t = nativeint# as (_ : word mod external_ many unique)
+type t = nativeint# as (_ : word mod external_ many aliased)
 
 [%%expect {|
 type t = int

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -64,20 +64,20 @@ type t_value_mod_global : value mod global
 type t_value_mod_local
 type t_value_mod_many : value mod many
 type t_value_mod_once
-type t_value_mod_unique : value mod unique
-type t_value_mod_aliased
+type t_value_mod_unique
+type t_value_mod_aliased : value mod aliased
 type t_value_mod_internal
-type t_value_mod_contended
-type t_value_mod_uncontended : value mod uncontended
+type t_value_mod_contended : value mod contended
+type t_value_mod_uncontended
 type t_value_mod_portable : value mod portable
 type t_value_mod_nonportable
 type t_value_mod_external : value mod external_
 type t_value_mod_external64 : value mod external64
 |}]
 
-type t1 : float32 mod internal aliased many local
-type t2 : bits64 mod once external64 unique
-type t3 : immediate mod local unique
+type t1 : float32 mod internal unique many local
+type t2 : bits64 mod once external64 aliased
+type t3 : immediate mod local aliased
 
 [%%expect {|
 type t1 : float32
@@ -117,11 +117,11 @@ Line 1, characters 28-33:
 Error: The locality axis has already been specified.
 |}]
 
-type t8 : value mod local many unique uncontended nonportable external64 local
+type t8 : value mod local many aliased contended nonportable external64 local
 [%%expect {|
-Line 1, characters 73-78:
-1 | type t8 : value mod local many unique uncontended nonportable external64 local
-                                                                             ^^^^^
+Line 1, characters 72-77:
+1 | type t8 : value mod local many aliased contended nonportable external64 local
+                                                                            ^^^^^
 Error: The locality axis has already been specified.
 |}]
 
@@ -181,18 +181,18 @@ Line 1, characters 19-22:
 Error: Unrecognized modifier foo.
 |}]
 
-type t : value mod global aliased bar
+type t : value mod global unique bar
 [%%expect {|
-Line 1, characters 34-37:
-1 | type t : value mod global aliased bar
-                                      ^^^
+Line 1, characters 33-36:
+1 | type t : value mod global unique bar
+                                     ^^^
 Error: Unrecognized modifier bar.
 |}]
 
-type t : value mod foobar unique many
+type t : value mod foobar aliased many
 [%%expect {|
 Line 1, characters 19-25:
-1 | type t : value mod foobar unique many
+1 | type t : value mod foobar aliased many
                        ^^^^^^
 Error: Unrecognized modifier foobar.
 |}]
@@ -211,7 +211,7 @@ Error: Unrecognized modifier fizzbuzz.
 let x : int as ('a: value) = 5
 let x : int as ('a : immediate) = 5
 let x : int as ('a : any) = 5;;
-let x : int as ('a: value mod global aliased many uncontended portable external_) = 5
+let x : int as ('a: value mod global aliased many contended portable external_) = 5
 
 [%%expect{|
 val x : int = 5
@@ -297,8 +297,8 @@ type (_ : float64) t2_float64'
 type t3 = float# t2_float64
 type ('a : value mod global) t2_global
 type (_ : value mod global) t2_global'
-type ('a : word mod external_ many aliased) t2_complex
-type (_ : word mod external_ many aliased) t2_complex'
+type ('a : word mod external_ many unique) t2_complex
+type (_ : word mod external_ many unique) t2_complex'
 
 
 [%%expect {|
@@ -367,15 +367,15 @@ module M2 : sig type (_ : value mod global) t end
 |}]
 
 module M1 : sig
-  type ('a : word mod external_ many aliased) t
+  type ('a : word mod external_ many unique) t
 end = struct
-  type (_ : word mod external_ many aliased) t
+  type (_ : word mod external_ many unique) t
 end
 
 module M2 : sig
-  type (_ : word mod external_ many aliased) t
+  type (_ : word mod external_ many unique) t
 end = struct
-  type ('a : word mod external_ many aliased) t
+  type ('a : word mod external_ many unique) t
 end
 
 [%%expect {|
@@ -428,7 +428,7 @@ val f : ('a : word). 'a t2_complex -> 'a t2_complex = <fun>
 
 let f : ('a : immediate) t2_imm -> ('a : value) t2_imm = fun x -> x
 let f : ('a : value mod global) t2_global -> ('a : value) t2_global = fun x -> x
-let f : ('a : word mod external_ many aliased) t2_complex -> ('a : word) t2_complex = fun x -> x
+let f : ('a : word mod external_ many unique) t2_complex -> ('a : word) t2_complex = fun x -> x
 [%%expect {|
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
@@ -446,7 +446,7 @@ val f : ('a : word). 'a t2_complex -> 'a t2_complex = <fun>
 
 let f : ('a : immediate). 'a t2_imm -> 'a t2_imm = fun x -> x
 let f : ('a : value mod global). 'a t2_global -> 'a t2_global = fun x -> x
-let f : ('a : word mod external_ many aliased). 'a t2_complex -> 'a t2_complex = fun x -> x
+let f : ('a : word mod external_ many unique). 'a t2_complex -> 'a t2_complex = fun x -> x
 [%%expect {|
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
@@ -501,7 +501,7 @@ type ('a : word) t = 'a t2_complex
 
 type ('a : immediate) t = 'a t2_imm
 type ('a : value mod global) t = 'a t2_global
-type ('a : word mod external_ many aliased) t = 'a t2_complex
+type ('a : word mod external_ many unique) t = 'a t2_complex
 [%%expect {|
 type ('a : immediate) t = 'a t2_imm
 type ('a : value mod global) t = 'a t2_global
@@ -515,7 +515,7 @@ let f : (_ : value) t2_global -> unit = fun _ -> ()
 let g : (_ : value mod global) t2_global -> unit = fun _ -> ()
 
 let f : (_ : word) t2_complex -> unit = fun _ -> ()
-let g : (_ : word mod external_ many aliased) t2_complex -> unit = fun _ -> ()
+let g : (_ : word mod external_ many unique) t2_complex -> unit = fun _ -> ()
 
 [%%expect {|
 val f : ('a : immediate). 'a t2_imm -> unit = <fun>
@@ -528,7 +528,7 @@ val g : ('a : word). 'a t2_complex -> unit = <fun>
 
 let f : (_ : immediate) -> unit = fun _ -> ()
 let f : (_ : value mod global) -> unit = fun _ -> ()
-let f : (_ : word mod external_ many aliased) -> unit = fun _ -> ()
+let f : (_ : word mod external_ many unique) -> unit = fun _ -> ()
 let g : (_ : value) -> unit = fun _ -> ()
 
 [%%expect {|
@@ -544,8 +544,8 @@ let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 let f : (_ : value mod global) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : value mod global) = fun _ -> assert false
 
-let f : (_ : word mod external_ many aliased) -> (_ : value) = fun _ -> assert false
-let g : (_ : value) -> (_ : word mod external_ many aliased) = fun _ -> assert false
+let f : (_ : word mod external_ many unique) -> (_ : value) = fun _ -> assert false
+let g : (_ : value) -> (_ : word mod external_ many unique) = fun _ -> assert false
 
 [%%expect {|
 val f : ('a : immediate) 'b. 'a -> 'b = <fun>
@@ -612,9 +612,9 @@ type rg = { fieldg : ('a : value mod global). 'a -> 'a; }
 val f : rg -> int = <fun>
 |}]
 
-type rc = { fieldc : ('a : word mod external_ many aliased). 'a -> 'a }
+type rc = { fieldc : ('a : word mod external_ many unique). 'a -> 'a }
 let f { fieldc } =
-  let x : _ as (_ : word mod external_ many aliased) = assert false in
+  let x : _ as (_ : word mod external_ many unique) = assert false in
   fieldc x;;
 [%%expect {|
 type rc = { fieldc : ('a : word). 'a -> 'a; }
@@ -660,7 +660,7 @@ Error: This expression has type "string" but an expression was expected of type
        The layout of string is value
          because it is the primitive type string.
        But the layout of string must be a sublayout of word
-         because of the definition of rc at line 1, characters 0-71.
+         because of the definition of rc at line 1, characters 0-70.
 |}]
 
 let r = { field = fun x -> x }
@@ -765,7 +765,7 @@ Error: Layout mismatch in final type declaration consistency check.
        the declaration where this error is reported.
 |}]
 
-type ('a : word mod external_ many aliased) t_complex
+type ('a : word mod external_ many unique) t_complex
 
 type s = { f : ('a : word). 'a -> 'a u }
 and 'a u = 'a t_complex
@@ -802,7 +802,7 @@ let f = fun (type (a : value mod global)) (x : a) -> x
 val f : ('a : value mod global). 'a -> 'a = <fun>
 |}]
 
-let f = fun (type (a : word mod external_ many aliased)) (x : a) -> x
+let f = fun (type (a : word mod external_ many unique)) (x : a) -> x
 ;;
 [%%expect {|
 val f : ('a : word). 'a -> 'a = <fun>
@@ -850,7 +850,7 @@ let f : type (a : value mod global). a -> a = fun x -> x
 val f : ('a : value mod global). 'a -> 'a = <fun>
 |}]
 
-let f : type (a : word mod external_ many aliased). a -> a = fun x -> x
+let f : type (a : word mod external_ many unique). a -> a = fun x -> x
 ;;
 [%%expect {|
 val f : ('a : word). 'a -> 'a = <fun>
@@ -945,7 +945,7 @@ Error: This type "('a : value)" should be an instance of type "('b : word)"
        The layout of 'a is value
          because of the annotation on the universal variable 'a.
        But the layout of 'a must overlap with word
-         because of the definition of t2_complex at line 10, characters 0-54.
+         because of the definition of t2_complex at line 10, characters 0-53.
 |}]
 
 module type S = sig
@@ -997,7 +997,7 @@ module type S =
 
 module type S = sig
   val f : 'a t2_complex -> 'a t2_complex
-  val g : ('a : word mod external_ many aliased). 'a t2_complex -> 'a t2_complex
+  val g : ('a : word mod external_ many unique). 'a t2_complex -> 'a t2_complex
   val h : ('a : word mod external_ many). 'a t2_complex -> 'a t2_complex
 end
 ;;
@@ -1019,7 +1019,7 @@ let f (x : ('a : value). 'a -> 'a) = x "string", x 5
 val f : ('a. 'a -> 'a) -> string * int = <fun>
 |}]
 
-let f (x : ('a : word mod external_ many aliased). 'a -> 'a) =
+let f (x : ('a : word mod external_ many unique). 'a -> 'a) =
   let native_int : nativeint# = assert false in
   x native_int
 
@@ -1123,14 +1123,14 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type t : value mod unique = { x : t_value }
+type t : value mod aliased = { x : t_value }
 [%%expect {|
 Line 1, characters 0-43:
-1 | type t : value mod unique = { x : t_value }
+1 | type t : value mod aliased = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod unique
+       But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -1156,14 +1156,14 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type t : value mod uncontended = { x : t_value }
+type t : value mod contended = { x : t_value }
 [%%expect {|
 Line 1, characters 0-48:
-1 | type t : value mod uncontended = { x : t_value }
+1 | type t : value mod contended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod uncontended
+       But the kind of type "t" must be a subkind of value mod contended
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -1262,14 +1262,14 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type t : value mod unique = Foo of t_value
+type t : value mod aliased = Foo of t_value
 [%%expect {|
 Line 1, characters 0-42:
-1 | type t : value mod unique = Foo of t_value
+1 | type t : value mod aliased = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod unique
+       But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -1295,14 +1295,14 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type t : value mod uncontended = Foo of t_value
+type t : value mod contended = Foo of t_value
 [%%expect {|
 Line 1, characters 0-47:
-1 | type t : value mod uncontended = Foo of t_value
+1 | type t : value mod contended = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod uncontended
+       But the kind of type "t" must be a subkind of value mod contended
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -1342,18 +1342,18 @@ type t = private int
 val f : t -> t = <fun>
 |}]
 
-type t : bits64 mod portable unique
+type t : bits64 mod portable aliased
 type u = private t
-let f (x : t) : _ as (_ : bits64 mod portable unique) = x
+let f (x : t) : _ as (_ : bits64 mod portable aliased) = x
 [%%expect {|
 type t : bits64
 type u = private t
 val f : t -> t = <fun>
 |}]
 
-type t : bits64 mod portable unique
+type t : bits64 mod portable aliased
 type u : bits64 = private t
-let f (x : t) : _ as (_ : bits64 mod portable unique) = x
+let f (x : t) : _ as (_ : bits64 mod portable aliased) = x
 [%%expect {|
 type t : bits64
 type u = private t
@@ -1361,9 +1361,9 @@ val f : t -> t = <fun>
 |}]
 (* CR layouts v2.8: This should fail since u is nominative *)
 
-type t : bits64 mod portable unique
-type u : bits64 mod portable unique = private t
-let f (x : t) : _ as (_ : bits64 mod portable unique) = x
+type t : bits64 mod portable aliased
+type u : bits64 mod portable aliased = private t
+let f (x : t) : _ as (_ : bits64 mod portable aliased) = x
 [%%expect {|
 type t : bits64
 type u = private t
@@ -1397,16 +1397,16 @@ Error: The kind of type "t" is value
 |}]
 
 type t : value
-type u : value mod unique = private t
+type u : value mod aliased = private t
 [%%expect {|
 type t
-Line 2, characters 0-37:
-2 | type u : value mod unique = private t
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 0-38:
+2 | type u : value mod aliased = private t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is value
          because of the definition of t at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of value mod unique
-         because of the definition of u at line 2, characters 0-37.
+       But the kind of type "t" must be a subkind of value mod aliased
+         because of the definition of u at line 2, characters 0-38.
 |}]
 
 type t : value
@@ -1436,16 +1436,16 @@ Error: The kind of type "t" is value
 |}]
 
 type t : value
-type u : value mod uncontended = private t
+type u : value mod contended = private t
 [%%expect {|
 type t
-Line 2, characters 0-42:
-2 | type u : value mod uncontended = private t
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 0-40:
+2 | type u : value mod contended = private t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is value
          because of the definition of t at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of value mod uncontended
-         because of the definition of u at line 2, characters 0-42.
+       But the kind of type "t" must be a subkind of value mod contended
+         because of the definition of u at line 2, characters 0-40.
 |}]
 
 type t : value
@@ -1468,7 +1468,7 @@ let f (type a : value) (x : a) = x
 let f (type a : immediate) (x : a) = x
 let f (type a : value mod global) (x : a) = x
 let f (type a : immediate mod global) (x : a) = x
-let f (type a : word mod external_ many aliased) (x : a) = x
+let f (type a : word mod external_ many unique) (x : a) = x
 
 [%%expect{|
 val f : 'a -> 'a = <fun>
@@ -1482,7 +1482,7 @@ let f = fun (type a : value) (x : a) -> x
 let f = fun (type a : immediate) (x : a) -> x
 let f = fun (type a : value mod global) (x : a) -> x
 let f = fun (type a : immediate mod global) (x : a) -> x
-let f = fun (type a : word mod external_ many aliased) (x : a) -> x
+let f = fun (type a : word mod external_ many unique) (x : a) -> x
 
 [%%expect{|
 val f : 'a -> 'a = <fun>
@@ -1505,7 +1505,7 @@ let o = object
   method m : type (a : immediate mod global). a -> a = fun x -> x
 end
 let o = object
-  method m : type (a : word mod external_ many aliased). a -> a = fun x -> x
+  method m : type (a : word mod external_ many unique). a -> a = fun x -> x
 end
 
 [%%expect{|
@@ -1520,7 +1520,7 @@ let f : type (a : value). a -> a = fun x -> x
 let f : type (a : immediate). a -> a = fun x -> x
 let f : type (a : value mod global). a -> a = fun x -> x
 let f : type (a : immediate mod global). a -> a = fun x -> x
-let f : type (a : word mod external_ many aliased). a -> a = fun x -> x
+let f : type (a : word mod external_ many unique). a -> a = fun x -> x
 
 [%%expect{|
 val f : 'a -> 'a = <fun>
@@ -1547,7 +1547,7 @@ let f x =
   g x [@nontail]
 
 let f x =
-  let local_ g (type a : word mod external_ many aliased) (x : a) = x in
+  let local_ g (type a : word mod external_ many unique) (x : a) = x in
   g x [@nontail]
 
 [%%expect{|
@@ -1562,7 +1562,7 @@ let f = fun x y (type (a : value)) (z : a) -> z
 let f = fun x y (type (a : immediate)) (z : a) -> z
 let f = fun x y (type (a : value mod global)) (z : a) -> z
 let f = fun x y (type (a : immediate mod global)) (z : a) -> z
-let f = fun x y (type (a : word mod external_ many aliased)) (z : a) -> z
+let f = fun x y (type (a : word mod external_ many unique)) (z : a) -> z
 
 [%%expect{|
 val f : 'b -> 'c -> 'a -> 'a = <fun>
@@ -1576,7 +1576,7 @@ let f = fun x y (type a : value) (z : a) -> z
 let f = fun x y (type a : immediate) (z : a) -> z
 let f = fun x y (type a : value mod global) (z : a) -> z
 let f = fun x y (type a : immediate mod global) (z : a) -> z
-let f = fun x y (type a : word mod external_ many aliased) (z : a) -> z
+let f = fun x y (type a : word mod external_ many unique) (z : a) -> z
 
 [%%expect{|
 val f : 'b -> 'c -> 'a -> 'a = <fun>
@@ -1592,7 +1592,7 @@ external f : ('a : value). 'a -> 'a = "%identity"
 external f : ('a : immediate). 'a -> 'a = "%identity"
 external f : ('a : value mod global). 'a -> 'a = "%identity"
 external f : ('a : immediate mod global). 'a -> 'a = "%identity"
-external f : ('a : word mod external_ many aliased). 'a -> 'a = "%identity"
+external f : ('a : word mod external_ many unique). 'a -> 'a = "%identity"
 
 [%%expect{|
 external f : 'a -> 'a = "%identity"
@@ -1679,7 +1679,7 @@ type t = int as (_ : value)
 type t = int as (_ : immediate)
 type t = int as (_ : value mod global)
 type t = int as (_ : immediate mod global)
-type t = nativeint# as (_ : word mod external_ many aliased)
+type t = nativeint# as (_ : word mod external_ many unique)
 
 [%%expect {|
 type t = int

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -223,12 +223,12 @@ type b = a
 type a : value mod global aliased once contended portable external_
 type b : value mod local unique many contended nonportable internal = a
 [%%expect{|
-type a : value mod global portable aliased contended external_
+type a : value mod global aliased contended portable external_
 Line 2, characters 0-71:
 2 | type b : value mod local unique many contended nonportable internal = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "a" is
-         value mod global portable aliased contended external_
+         value mod global aliased contended portable external_
          because of the definition of a at line 1, characters 0-67.
        But the kind of type "a" must be a subkind of value mod many contended
          because of the definition of b at line 2, characters 0-71.
@@ -362,58 +362,58 @@ type t : any mod global aliased many contended portable external_ = float#
 type t = float#
 |}]
 
-type t : any mod global aliased many uncontended portable external_ = float32#
+type t : any mod global aliased many contended portable external_ = float32#
 [%%expect{|
 type t = float32#
 |}]
 
-type t : any mod global unique many uncontended portable external_ = int64#
+type t : any mod global aliased many contended portable external_ = int64#
 [%%expect{|
 type t = int64#
 |}]
 
-type t : any mod global unique many uncontended portable external_ = int32#
+type t : any mod global aliased many contended portable external_ = int32#
 [%%expect{|
 type t = int32#
 |}]
 
-type t : any mod global unique many uncontended portable external_ = nativeint#
+type t : any mod global aliased many contended portable external_ = nativeint#
 [%%expect{|
 type t = nativeint#
 |}]
 
-type t : any mod global unique many uncontended portable external_ = int8x16#
+type t : any mod global aliased many contended portable external_ = int8x16#
 [%%expect{|
 type t = int8x16#
 |}]
 
-type t : any mod global unique many uncontended portable external_ = int16x8#
+type t : any mod global aliased many contended portable external_ = int16x8#
 [%%expect{|
 type t = int16x8#
 |}]
 
-type t : any mod global unique many uncontended portable external_ = int32x4#
+type t : any mod global aliased many contended portable external_ = int32x4#
 [%%expect{|
 type t = int32x4#
 |}]
 
-type t : any mod global unique many uncontended portable external_ = int64x2#
+type t : any mod global aliased many contended portable external_ = int64x2#
 [%%expect{|
 type t = int64x2#
 |}]
 
-type t : any mod global unique many uncontended portable external_ = float32x4#
+type t : any mod global aliased many contended portable external_ = float32x4#
 [%%expect{|
 type t = float32x4#
 |}]
 
-type t : any mod global unique many uncontended portable external_ = float64x2#
+type t : any mod global aliased many contended portable external_ = float64x2#
 [%%expect{|
 type t = float64x2#
 |}]
 
 type indirect_int = int
-type t : any mod global unique many uncontended portable external_ = indirect_int
+type t : any mod global aliased many contended portable external_ = indirect_int
 [%%expect{|
 type indirect_int = int
 type t = indirect_int
@@ -728,9 +728,9 @@ Error: The kind of type "t" is immutable_data
 
 type t : any mod aliased = { x : string }
 [%%expect{|
-Line 1, characters 0-40:
-1 | type t : any mod unique = { x : string }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-41:
+1 | type t : any mod aliased = { x : string }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of any mod aliased
@@ -770,9 +770,9 @@ Error: The kind of type "t" is immutable_data
 
 type t : any mod contended = { x : t_value }
 [%%expect{|
-Line 1, characters 0-46:
-1 | type t : any mod uncontended = { x : t_value }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-44:
+1 | type t : any mod contended = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of any mod contended
@@ -792,18 +792,18 @@ Error: The kind of type "t" is immutable_data
 
 type t : any mod many contended portable global = { x : t_value }
 [%%expect{|
-Line 1, characters 0-67:
-1 | type t : any mod many uncontended portable global = { x : t_value }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-65:
+1 | type t : any mod many contended portable global = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of
-         any mod global many portable contended
+         any mod global many contended portable
          because of the annotation on the declaration of the type t.
 |}]
 
 type u : immediate
-type t : value mod portable many uncontended = { x : string; y : int; z : u }
+type t : value mod portable many contended = { x : string; y : int; z : u }
 [%%expect {|
 type u : immediate
 type t = { x : string; y : int; z : u; }
@@ -857,9 +857,9 @@ Error: The kind of type "t" is immutable_data
 
 type t : any mod aliased = { x : int }
 [%%expect {|
-Line 1, characters 0-37:
-1 | type t : any mod unique = { x : int }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-38:
+1 | type t : any mod aliased = { x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of any mod aliased
@@ -998,9 +998,9 @@ Error: The kind of type "t" is mutable_data
 
 type ('a : immediate) t : value mod aliased = { mutable x : 'a }
 [%%expect {|
-Line 1, characters 0-63:
-1 | type ('a : immediate) t : value mod unique = { mutable x : 'a }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-64:
+1 | type ('a : immediate) t : value mod aliased = { mutable x : 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is mutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod aliased
@@ -1009,9 +1009,9 @@ Error: The kind of type "t" is mutable_data
 
 type ('a : immediate) t : value mod contended = { mutable x : 'a }
 [%%expect {|
-Line 1, characters 0-68:
-1 | type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-66:
+1 | type ('a : immediate) t : value mod contended = { mutable x : 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is mutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod contended
@@ -1069,9 +1069,9 @@ type t = Foo of int | Bar
 
 type t : any mod aliased = Foo of int | Bar
 [%%expect {|
-Line 1, characters 0-42:
-1 | type t : any mod unique = Foo of int | Bar
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-43:
+1 | type t : any mod aliased = Foo of int | Bar
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of any mod aliased
@@ -1139,12 +1139,12 @@ Error: The kind of type "t" is value
 (***********************************************)
 (* Test 7: Inference with modality annotations *)
 
-type 'a t : value mod global portable uncontended many unique unyielding =
-  { x : 'a @@ global portable uncontended many unique } [@@unboxed]
+type 'a t : value mod global portable contended many aliased unyielding =
+  { x : 'a @@ global portable contended many aliased } [@@unboxed]
 [%%expect {|
-Lines 1-2, characters 0-67:
-1 | type 'a t : value mod global portable uncontended many unique unyielding =
-2 |   { x : 'a @@ global portable uncontended many unique } [@@unboxed]
+Lines 1-2, characters 0-66:
+1 | type 'a t : value mod global portable contended many aliased unyielding =
+2 |   { x : 'a @@ global portable contended many aliased } [@@unboxed]
 Error: The kind of type "t" is value
          because it instantiates an unannotated type parameter of t,
          chosen to have kind value.
@@ -1154,12 +1154,12 @@ Error: The kind of type "t" is value
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
-type 'a t : value mod global portable uncontended many unique unyielding =
-  Foo of 'a @@ global portable uncontended many unique [@@unboxed]
+type 'a t : value mod global portable contended many aliased unyielding =
+  Foo of 'a @@ global portable contended many aliased [@@unboxed]
 [%%expect {|
-Lines 1-2, characters 0-66:
-1 | type 'a t : value mod global portable uncontended many unique unyielding =
-2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
+Lines 1-2, characters 0-65:
+1 | type 'a t : value mod global portable contended many aliased unyielding =
+2 |   Foo of 'a @@ global portable contended many aliased [@@unboxed]
 Error: The kind of type "t" is value
          because it instantiates an unannotated type parameter of t,
          chosen to have kind value.
@@ -1193,7 +1193,7 @@ Lines 1-2, characters 0-35:
 Error: The kind of type "t" is value mod many contended
          because of the annotation on 'a in the declaration of the type t.
        But the kind of type "t" must be a subkind of
-         value mod many aliased contended
+         value mod aliased many contended
          because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1212,7 +1212,7 @@ Error: The kind of type "t" is value mod external_
 (* CR layouts v2.8: this should be accepted *)
 
 type 'a t : value mod many = { x : 'a @@ many }
-type 'a t : value mod uncontended = { x : 'a @@ contended }
+type 'a t : value mod contended = { x : 'a @@ contended }
 type 'a t : value mod portable = { x : 'a @@ portable }
 [%%expect {|
 type 'a t = { x : 'a @@ many; }
@@ -1231,9 +1231,9 @@ type 'a t = { x : 'a @@ portable; }
 
 type 'a t : value mod aliased = { x : 'a @@ aliased }
 [%%expect {|
-Line 1, characters 0-51:
-1 | type 'a t : value mod unique = { x : 'a @@ unique }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-53:
+1 | type 'a t : value mod aliased = { x : 'a @@ aliased }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod aliased
@@ -1257,7 +1257,7 @@ Error: The kind of type "t" is immutable_data
 type ('a : value mod aliased) t = ('a : value mod global)
 type ('a : immediate) t = ('a : value)
 type ('a : value) t = ('a : immediate)
-type ('a : value mod external_ portable many unyielding) t = ('a : value mod uncontended global unique)
+type ('a : value mod external_ portable many unyielding) t = ('a : value mod contended global aliased)
 type ('a : value) t = ('a : any)
 type ('a : value) t = ('a : value)
 type ('a : bits32 mod aliased) t = ('a : any mod global)
@@ -1350,7 +1350,7 @@ let f (type a : value) (x : a t) =
 [%%expect{|
 type _ t =
     A : ('a : immediate). 'a t
-  | B : ('b : value mod portable aliased). 'b -> 'b t
+  | B : ('b : value mod aliased portable). 'b -> 'b t
   | C : 'c t
 val f : 'a t -> unit = <fun>
 |}]
@@ -1376,7 +1376,7 @@ let f (type a : value) (x : a t) =
 [%%expect{|
 type _ t =
     A : ('a : immediate). 'a t
-  | B : ('b : value mod portable aliased). 'b -> 'b t
+  | B : ('b : value mod aliased portable). 'b -> 'b t
   | C : 'c t
 Line 17, characters 6-7:
 17 |     f y

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -36,7 +36,7 @@ Line 1, characters 12-13:
 Error: Unimplemented kind syntax
 |}]
 
-kind_abbrev_ immediate = value mod global unique many sync uncontended
+kind_abbrev_ immediate = value mod global aliased many sync contended
 
 [%%expect{|
 >> Fatal error: kind_abbrev not supported!
@@ -44,7 +44,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-kind_abbrev_ immutable_data = value mod sync uncontended many
+kind_abbrev_ immutable_data = value mod sync contended many
 
 [%%expect{|
 >> Fatal error: kind_abbrev not supported!
@@ -52,7 +52,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-kind_abbrev_ immutable = value mod uncontended
+kind_abbrev_ immutable = value mod contended
 
 [%%expect{|
 >> Fatal error: kind_abbrev not supported!
@@ -73,9 +73,9 @@ module type S = sig
   type ('a, 'b) either : immutable_data with 'a * 'b
   type 'a gel : kind_of_ 'a mod global
   type 'a t : _
-  kind_abbrev_ immediate = value mod global unique many sync uncontended
-  kind_abbrev_ immutable_data = value mod sync uncontended many
-  kind_abbrev_ immutable = value mod uncontended
+  kind_abbrev_ immediate = value mod global aliased many sync contended
+  kind_abbrev_ immutable_data = value mod sync contended many
+  kind_abbrev_ immutable = value mod contended
   kind_abbrev_ data = value mod sync many
 end
 
@@ -213,25 +213,25 @@ Error: The layout of type "a" is value
          because of the definition of b at line 2, characters 0-30.
 |}]
 
-type a : value mod global unique many uncontended portable external_ unyielding
-type b : value mod local aliased once contended nonportable internal = a
+type a : value mod global aliased many contended portable external_ unyielding
+type b : value mod local unique once contended nonportable internal = a
 [%%expect{|
 type a : immediate
 type b = a
 |}]
 
-type a : value mod global unique once uncontended portable external_
-type b : value mod local aliased many uncontended nonportable internal = a
+type a : value mod global aliased once contended portable external_
+type b : value mod local unique many contended nonportable internal = a
 [%%expect{|
-type a : value mod global unique uncontended portable external_
-Line 2, characters 0-74:
-2 | type b : value mod local aliased many uncontended nonportable internal = a
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+type a : value mod global portable aliased contended external_
+Line 2, characters 0-71:
+2 | type b : value mod local unique many contended nonportable internal = a
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "a" is
-         value mod global unique uncontended portable external_
-         because of the definition of a at line 1, characters 0-68.
-       But the kind of type "a" must be a subkind of value mod many uncontended
-         because of the definition of b at line 2, characters 0-74.
+         value mod global portable aliased contended external_
+         because of the definition of a at line 1, characters 0-67.
+       But the kind of type "a" must be a subkind of value mod many contended
+         because of the definition of b at line 2, characters 0-71.
 |}]
 
 (********************************************************)
@@ -239,8 +239,8 @@ Error: The kind of type "a" is
 (* CR layouts: when we have abbreviations, these tests can become less verbose *)
 
 type a : any
-type b : any mod local aliased once contended nonportable internal = a
-type c : any mod local aliased once contended nonportable internal
+type b : any mod local unique once uncontended nonportable internal = a
+type c : any mod local unique once uncontended nonportable internal
 type d : any = c
 [%%expect{|
 type a : any
@@ -250,8 +250,8 @@ type d = c
 |}]
 
 type a : value
-type b : value mod local aliased once contended nonportable internal = a
-type c : value mod local aliased once contended nonportable internal
+type b : value mod local unique once uncontended nonportable internal = a
+type c : value mod local unique once uncontended nonportable internal
 type d : value = c
 [%%expect{|
 type a
@@ -261,8 +261,8 @@ type d = c
 |}]
 
 type a : void
-type b : void mod local aliased once contended nonportable internal = a
-type c : void mod local aliased once contended nonportable internal
+type b : void mod local unique once uncontended nonportable internal = a
+type c : void mod local unique once uncontended nonportable internal
 type d : void = c
 [%%expect{|
 Line 1, characters 9-13:
@@ -273,8 +273,8 @@ Error: Layout void is more experimental than allowed by the enabled layouts exte
 |}]
 
 type a : immediate
-type b : value mod global unique many uncontended portable unyielding external_ = a
-type c : value mod global unique many uncontended portable unyielding external_
+type b : value mod global aliased many contended portable unyielding external_ = a
+type c : value mod global aliased many contended portable unyielding external_
 type d : immediate = c
 [%%expect{|
 type a : immediate
@@ -284,8 +284,8 @@ type d = c
 |}]
 
 type a : immediate64
-type b : value mod global unique many uncontended portable unyielding external64 = a
-type c : value mod global unique many uncontended portable unyielding external64
+type b : value mod global aliased many contended portable unyielding external64 = a
+type c : value mod global aliased many contended portable unyielding external64
 type d : immediate64 = c
 [%%expect{|
 type a : immediate64
@@ -295,8 +295,8 @@ type d = c
 |}]
 
 type a : float64
-type b : float64 mod global unique many uncontended portable external_ = a
-type c : float64 mod global unique many uncontended portable external_
+type b : float64 mod global aliased many contended portable external_ = a
+type c : float64 mod global aliased many contended portable external_
 type d : float64 = c
 [%%expect{|
 type a : float64
@@ -306,8 +306,8 @@ type d = c
 |}]
 
 type a : float32
-type b : float32 mod global unique many uncontended portable external_ = a
-type c : float32 mod global unique many uncontended portable external_
+type b : float32 mod global aliased many contended portable external_ = a
+type c : float32 mod global aliased many contended portable external_
 type d : float32 = c
 [%%expect{|
 type a : float32
@@ -317,8 +317,8 @@ type d = c
 |}]
 
 type a : word
-type b : word mod local aliased once contended nonportable internal = a
-type c : word mod local aliased once contended nonportable internal
+type b : word mod local unique once uncontended nonportable internal = a
+type c : word mod local unique once uncontended nonportable internal
 type d : word = c
 [%%expect{|
 type a : word
@@ -328,8 +328,8 @@ type d = c
 |}]
 
 type a : bits32
-type b : bits32 mod local aliased once contended nonportable internal = a
-type c : bits32 mod local aliased once contended nonportable internal
+type b : bits32 mod local unique once uncontended nonportable internal = a
+type c : bits32 mod local unique once uncontended nonportable internal
 type d : bits32 = c
 [%%expect{|
 type a : bits32
@@ -339,8 +339,8 @@ type d = c
 |}]
 
 type a : bits64
-type b : bits64 mod local aliased once contended nonportable internal = a
-type c : bits64 mod local aliased once contended nonportable internal
+type b : bits64 mod local unique once uncontended nonportable internal = a
+type c : bits64 mod local unique once uncontended nonportable internal
 type d : bits64 = c
 [%%expect{|
 type a : bits64
@@ -352,17 +352,17 @@ type d = c
 (****************************************)
 (* Test 4: Appropriate types mode cross *)
 
-type t : any mod global unique many uncontended portable external_ = int
+type t : any mod global aliased many contended portable external_ = int
 [%%expect{|
 type t = int
 |}]
 
-type t : any mod global unique many uncontended portable external_ = float#
+type t : any mod global aliased many contended portable external_ = float#
 [%%expect{|
 type t = float#
 |}]
 
-type t : any mod global unique many uncontended portable external_ = float32#
+type t : any mod global aliased many uncontended portable external_ = float32#
 [%%expect{|
 type t = float32#
 |}]
@@ -419,13 +419,13 @@ type indirect_int = int
 type t = indirect_int
 |}]
 
-let x : (_ : value mod uncontended) = 10
+let x : (_ : value mod contended) = 10
 [%%expect {|
 val x : int = 10
 |}]
 
 let f (x : nativeint#) =
-  let _ : (_ : word mod portable many unique) = x in
+  let _ : (_ : word mod portable many aliased) = x in
   ()
 [%%expect {|
 val f : nativeint# -> unit = <fun>
@@ -447,15 +447,15 @@ Error: The kind of type "t_value" is value
          because of the definition of t at line 1, characters 0-33.
 |}]
 
-type t : any mod unique = t_value
+type t : any mod aliased = t_value
 [%%expect{|
-Line 1, characters 0-33:
-1 | type t : any mod unique = t_value
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-34:
+1 | type t : any mod aliased = t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t_value" is value
          because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type "t_value" must be a subkind of any mod unique
-         because of the definition of t at line 1, characters 0-33.
+       But the kind of type "t_value" must be a subkind of any mod aliased
+         because of the definition of t at line 1, characters 0-34.
 |}]
 
 type t : any mod many = t_value
@@ -469,15 +469,15 @@ Error: The kind of type "t_value" is value
          because of the definition of t at line 1, characters 0-31.
 |}]
 
-type t : any mod uncontended = t_value
+type t : any mod contended = t_value
 [%%expect{|
-Line 1, characters 0-38:
-1 | type t : any mod uncontended = t_value
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-36:
+1 | type t : any mod contended = t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t_value" is value
          because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type "t_value" must be a subkind of any mod uncontended
-         because of the definition of t at line 1, characters 0-38.
+       But the kind of type "t_value" must be a subkind of any mod contended
+         because of the definition of t at line 1, characters 0-36.
 |}]
 
 type t : any mod portable = t_value
@@ -502,19 +502,19 @@ Error: The kind of type "t_value" is value
          because of the definition of t at line 1, characters 0-36.
 |}]
 
-type ('a : value mod unique) t = { unique_field : 'a }
-let x = { unique_field = "string" }
+type ('a : value mod aliased) t = { aliased_field : 'a }
+let x = { aliased_field = "string" }
 [%%expect {|
-type ('a : value mod unique) t = { unique_field : 'a; }
-Line 2, characters 25-33:
-2 | let x = { unique_field = "string" }
-                             ^^^^^^^^
+type ('a : value mod aliased) t = { aliased_field : 'a; }
+Line 2, characters 26-34:
+2 | let x = { aliased_field = "string" }
+                              ^^^^^^^^
 Error: This expression has type "string" but an expression was expected of type
-         "('a : value mod unique)"
+         "('a : value mod aliased)"
        The kind of string is immutable_data
          because it is the primitive type string.
-       But the kind of string must be a subkind of value mod unique
-         because of the definition of t at line 1, characters 0-54.
+       But the kind of string must be a subkind of value mod aliased
+         because of the definition of t at line 1, characters 0-56.
 |}]
 
 type t : value mod global
@@ -539,30 +539,30 @@ Error: This expression has type "t" but an expression was expected of type
          because of the annotation on the type variable 'a.
 |}]
 
-type t : value mod unique
-let f (x : _ as (_ : value mod unique)) = ()
+type t : value mod aliased
+let f (x : _ as (_ : value mod aliased)) = ()
 let g (x : t) = f x
 [%%expect {|
-type t : value mod unique
-val f : ('a : value mod unique). 'a -> unit = <fun>
+type t : value mod aliased
+val f : ('a : value mod aliased). 'a -> unit = <fun>
 val g : t -> unit = <fun>
 |}]
 
 type t : value mod external64
-let f (x : _ as (_ : value mod unique)) = ()
+let f (x : _ as (_ : value mod aliased)) = ()
 let g (x : t) = f x
 [%%expect {|
 type t : value mod external64
-val f : ('a : value mod unique). 'a -> unit = <fun>
+val f : ('a : value mod aliased). 'a -> unit = <fun>
 Line 3, characters 18-19:
 3 | let g (x : t) = f x
                       ^
 Error: This expression has type "t" but an expression was expected of type
-         "('a : value mod unique)"
+         "('a : value mod aliased)"
        The kind of t is value mod external64
          because of the definition of t at line 1, characters 0-29.
-       But the kind of t must be a subkind of value mod unique
-         because of the definition of f at line 2, characters 6-44.
+       But the kind of t must be a subkind of value mod aliased
+         because of the definition of f at line 2, characters 6-45.
 |}]
 
 module A : sig
@@ -606,7 +606,7 @@ val f : t -> t = <fun>
 (* CR layouts v2.8: This should fail since t is nominative *)
 
 type t : value = private int
-let f (x : t) : _ as (_ : value mod unique) = x
+let f (x : t) : _ as (_ : value mod aliased) = x
 [%%expect {|
 type t = private int
 val f : t -> t = <fun>
@@ -630,7 +630,7 @@ val f : t -> t = <fun>
 (* CR layouts v2.8: This should fail since t is nominative *)
 
 type t : value = private int
-let f (x : t) : _ as (_ : value mod uncontended) = x
+let f (x : t) : _ as (_ : value mod contended) = x
 [%%expect {|
 type t = private int
 val f : t -> t = <fun>
@@ -647,10 +647,10 @@ val f : t -> t = <fun>
 
 type t = private int
 let f (x : t) : _ as (_ : value mod global) = x
-let f (x : t) : _ as (_ : value mod unique) = x
+let f (x : t) : _ as (_ : value mod aliased) = x
 let f (x : t) : _ as (_ : value mod many) = x
 let f (x : t) : _ as (_ : value mod portable) = x
-let f (x : t) : _ as (_ : value mod uncontended) = x
+let f (x : t) : _ as (_ : value mod contended) = x
 let f (x : t) : _ as (_ : value mod external_) = x
 let f (x : t) : _ as (_ : immediate) = x
 [%%expect {|
@@ -673,7 +673,7 @@ val f : t -> t = <fun>
 (* CR layouts v2.8: This should fail since t is nominative *)
 
 type t : value = private { x : int } [@@unboxed]
-let f (x : t) : _ as (_ : value mod unique) = x
+let f (x : t) : _ as (_ : value mod aliased) = x
 [%%expect {|
 type t = private { x : int; } [@@unboxed]
 val f : t -> t = <fun>
@@ -697,7 +697,7 @@ val f : t -> t = <fun>
 (* CR layouts v2.8: This should fail since t is nominative *)
 
 type t : value = private { x : int } [@@unboxed]
-let f (x : t) : _ as (_ : value mod uncontended) = x
+let f (x : t) : _ as (_ : value mod contended) = x
 [%%expect {|
 type t = private { x : int; } [@@unboxed]
 val f : t -> t = <fun>
@@ -726,14 +726,14 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type t : any mod unique = { x : string }
+type t : any mod aliased = { x : string }
 [%%expect{|
 Line 1, characters 0-40:
 1 | type t : any mod unique = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod unique
+       But the kind of type "t" must be a subkind of any mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -750,7 +750,7 @@ Error: The kind of type "t" is immutable_data
 
 type t : any mod many = { x : string }
 type t : any mod portable = { x : string }
-type t : any mod uncontended = { x : string }
+type t : any mod contended = { x : string }
 [%%expect {|
 type t = { x : string; }
 type t = { x : string; }
@@ -768,14 +768,14 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type t : any mod uncontended = { x : t_value }
+type t : any mod contended = { x : t_value }
 [%%expect{|
 Line 1, characters 0-46:
 1 | type t : any mod uncontended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod uncontended
+       But the kind of type "t" must be a subkind of any mod contended
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -790,7 +790,7 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type t : any mod many uncontended portable global = { x : t_value }
+type t : any mod many contended portable global = { x : t_value }
 [%%expect{|
 Line 1, characters 0-67:
 1 | type t : any mod many uncontended portable global = { x : t_value }
@@ -798,7 +798,7 @@ Line 1, characters 0-67:
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of
-         any mod global many uncontended portable
+         any mod global many portable contended
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -824,7 +824,7 @@ Error: This expression has type "t" but an expression was expected of type
          because of the annotation on the wildcard _ at line 2, characters 20-39.
 |}]
 
-type t : any mod uncontended = { x : int }
+type t : any mod contended = { x : int }
 type t : any mod portable = { x : int }
 type t : any mod many = { x : int }
 [%%expect{|
@@ -855,23 +855,23 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type t : any mod unique = { x : int }
+type t : any mod aliased = { x : int }
 [%%expect {|
 Line 1, characters 0-37:
 1 | type t : any mod unique = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod unique
+       But the kind of type "t" must be a subkind of any mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
 type t : any mod global = { x : int } [@@unboxed]
 type t : any mod portable = { x : int } [@@unboxed]
-type t : any mod uncontended = { x : int } [@@unboxed]
+type t : any mod contended = { x : int } [@@unboxed]
 type t : any mod external_ = { x : int } [@@unboxed]
 type t : any mod many = { x : int } [@@unboxed]
-type t : any mod unique = { x : int } [@@unboxed]
+type t : any mod aliased = { x : int } [@@unboxed]
 type t : immediate = { x : int } [@@unboxed]
 [%%expect {|
 type t = { x : int; } [@@unboxed]
@@ -885,10 +885,10 @@ type t = { x : int; } [@@unboxed]
 
 type ('a : immediate) t : any mod global = { x : 'a } [@@unboxed]
 type ('a : immediate) t : any mod portable = { x : 'a } [@@unboxed]
-type ('a : immediate) t : any mod uncontended = { x : 'a } [@@unboxed]
+type ('a : immediate) t : any mod contended = { x : 'a } [@@unboxed]
 type ('a : immediate) t : any mod external_ = { x : 'a } [@@unboxed]
 type ('a : immediate) t : any mod many = { x : 'a } [@@unboxed]
-type ('a : immediate) t : any mod unique = { x : 'a } [@@unboxed]
+type ('a : immediate) t : any mod aliased = { x : 'a } [@@unboxed]
 type ('a : immediate) t : immediate = { x : 'a } [@@unboxed]
 [%%expect {|
 type ('a : immediate) t = { x : 'a; } [@@unboxed]
@@ -927,14 +927,14 @@ Error: The kind of type "t" is value
          because of the annotation on the declaration of the type t.
 |}]
 
-type t : any mod uncontended = { x : u } [@@unboxed]
+type t : any mod contended = { x : u } [@@unboxed]
 [%%expect {|
-Line 1, characters 0-52:
-1 | type t : any mod uncontended = { x : u } [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-50:
+1 | type t : any mod contended = { x : u } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is value
          because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod uncontended
+       But the kind of type "t" must be a subkind of any mod contended
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -960,14 +960,14 @@ Error: The kind of type "t" is value
          because of the annotation on the declaration of the type t.
 |}]
 
-type t : any mod unique = { x : u } [@@unboxed]
+type t : any mod aliased = { x : u } [@@unboxed]
 [%%expect {|
-Line 1, characters 0-47:
-1 | type t : any mod unique = { x : u } [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-48:
+1 | type t : any mod aliased = { x : u } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is value
          because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod unique
+       But the kind of type "t" must be a subkind of any mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -996,25 +996,25 @@ Error: The kind of type "t" is mutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type ('a : immediate) t : value mod unique = { mutable x : 'a }
+type ('a : immediate) t : value mod aliased = { mutable x : 'a }
 [%%expect {|
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod unique = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is mutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod unique
+       But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
-type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
+type ('a : immediate) t : value mod contended = { mutable x : 'a }
 [%%expect {|
 Line 1, characters 0-68:
 1 | type ('a : immediate) t : value mod uncontended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is mutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod uncontended
+       But the kind of type "t" must be a subkind of value mod contended
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -1044,10 +1044,10 @@ Error: The kind of type "t" is mutable_data
 (* Test 6: Mode crossing of variants *)
 
 type t : any mod global = Foo | Bar
-type t : any mod unique = Foo | Bar
+type t : any mod aliased = Foo | Bar
 type t : any mod many = Foo | Bar
 type t : any mod portable = Foo | Bar
-type t : any mod uncontended = Foo | Bar
+type t : any mod contended = Foo | Bar
 type t : any mod external_ = Foo | Bar
 [%%expect {|
 type t = Foo | Bar
@@ -1058,7 +1058,7 @@ type t = Foo | Bar
 type t = Foo | Bar
 |}]
 
-type t : any mod uncontended = Foo of int | Bar
+type t : any mod contended = Foo of int | Bar
 type t : any mod portable = Foo of int | Bar
 type t : any mod many = Foo of int | Bar
 [%%expect {|
@@ -1067,14 +1067,14 @@ type t = Foo of int | Bar
 type t = Foo of int | Bar
 |}]
 
-type t : any mod unique = Foo of int | Bar
+type t : any mod aliased = Foo of int | Bar
 [%%expect {|
 Line 1, characters 0-42:
 1 | type t : any mod unique = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of any mod unique
+       But the kind of type "t" must be a subkind of any mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -1102,7 +1102,7 @@ Error: The kind of type "t" is immutable_data
 |}]
 
 type t : any mod portable = Foo of bool [@@unboxed]
-let x = (Foo true : _ as (_ : value mod portable uncontended unique))
+let x = (Foo true : _ as (_ : value mod portable contended aliased))
 [%%expect {|
 type t = Foo of bool [@@unboxed]
 val x : t = <unknown constructor>
@@ -1111,9 +1111,9 @@ val x : t = <unknown constructor>
 
 type t : value mod global = Foo of int [@@unboxed]
 type t : value mod many = Foo of int [@@unboxed]
-type t : value mod unique = Foo of int [@@unboxed]
+type t : value mod aliased = Foo of int [@@unboxed]
 type t : value mod portable = Foo of int [@@unboxed]
-type t : value mod uncontended = Foo of int [@@unboxed]
+type t : value mod contended = Foo of int [@@unboxed]
 type t : value mod external_ = Foo of int [@@unboxed]
 [%%expect {|
 type t = Foo of int [@@unboxed]
@@ -1149,7 +1149,7 @@ Error: The kind of type "t" is value
          because it instantiates an unannotated type parameter of t,
          chosen to have kind value.
        But the kind of type "t" must be a subkind of
-         immutable_data mod global unique
+         immutable_data mod global aliased
          because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1164,7 +1164,7 @@ Error: The kind of type "t" is value
          because it instantiates an unannotated type parameter of t,
          chosen to have kind value.
        But the kind of type "t" must be a subkind of
-         immutable_data mod global unique
+         immutable_data mod global aliased
          because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
@@ -1184,26 +1184,26 @@ type ('a : immediate) t = Foo of global_ 'a [@@unboxed]
 type ('a : value mod global) t = Foo of 'a [@@unboxed]
 |}]
 
-type ('a : value mod uncontended many) t : value mod uncontended many unique =
-  { x : 'a @@ unique } [@@unboxed]
+type ('a : value mod contended many) t : value mod contended many aliased =
+  { x : 'a @@ aliased } [@@unboxed]
 [%%expect {|
-Lines 1-2, characters 0-34:
-1 | type ('a : value mod uncontended many) t : value mod uncontended many unique =
-2 |   { x : 'a @@ unique } [@@unboxed]
-Error: The kind of type "t" is value mod many uncontended
+Lines 1-2, characters 0-35:
+1 | type ('a : value mod contended many) t : value mod contended many aliased =
+2 |   { x : 'a @@ aliased } [@@unboxed]
+Error: The kind of type "t" is value mod many contended
          because of the annotation on 'a in the declaration of the type t.
        But the kind of type "t" must be a subkind of
-         value mod unique many uncontended
+         value mod many aliased contended
          because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)
 
 type ('a : value mod external_) t : immediate =
-  Foo of 'a @@ global portable uncontended many unique [@@unboxed]
+  Foo of 'a @@ global portable contended many aliased [@@unboxed]
 [%%expect {|
-Lines 1-2, characters 0-66:
+Lines 1-2, characters 0-65:
 1 | type ('a : value mod external_) t : immediate =
-2 |   Foo of 'a @@ global portable uncontended many unique [@@unboxed]
+2 |   Foo of 'a @@ global portable contended many aliased [@@unboxed]
 Error: The kind of type "t" is value mod external_
          because of the annotation on 'a in the declaration of the type t.
        But the kind of type "t" must be a subkind of immediate
@@ -1229,14 +1229,14 @@ type 'a t = { x : 'a @@ contended; }
 type 'a t = { x : 'a @@ portable; }
 |}]
 
-type 'a t : value mod unique = { x : 'a @@ unique }
+type 'a t : value mod aliased = { x : 'a @@ aliased }
 [%%expect {|
 Line 1, characters 0-51:
 1 | type 'a t : value mod unique = { x : 'a @@ unique }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod unique
+       But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -1254,15 +1254,15 @@ Error: The kind of type "t" is immutable_data
 (*****************************)
 (* Test 8: Kind intersection *)
 
-type ('a : value mod unique) t = ('a : value mod global)
+type ('a : value mod aliased) t = ('a : value mod global)
 type ('a : immediate) t = ('a : value)
 type ('a : value) t = ('a : immediate)
 type ('a : value mod external_ portable many unyielding) t = ('a : value mod uncontended global unique)
 type ('a : value) t = ('a : any)
 type ('a : value) t = ('a : value)
-type ('a : bits32 mod unique) t = ('a : any mod global)
+type ('a : bits32 mod aliased) t = ('a : any mod global)
 [%%expect {|
-type ('a : value mod global unique) t = 'a
+type ('a : value mod global aliased) t = 'a
 type ('a : immediate) t = 'a
 type ('a : immediate) t = 'a
 type ('a : immediate) t = 'a
@@ -1283,11 +1283,11 @@ Error: Bad layout annotation:
            because of the annotation on the type variable 'a.
 |}]
 
-let f : ('a : any mod global unique) -> ('a: any mod uncontended) = fun x -> x
+let f : ('a : any mod global aliased) -> ('a: any mod contended) = fun x -> x
 let f : ('a : value mod external64) -> ('a: any mod external_) = fun x -> x
 let f : ('a : value) -> ('a: immediate) = fun x -> x
 [%%expect {|
-val f : ('a : value_or_null mod global unique uncontended). 'a -> 'a = <fun>
+val f : ('a : value_or_null mod global aliased contended). 'a -> 'a = <fun>
 val f : ('a : value mod external_). 'a -> 'a = <fun>
 val f : ('a : immediate). 'a -> 'a = <fun>
 |}]
@@ -1332,7 +1332,7 @@ val f : 'a t -> 'a = <fun>
 
 type _ t =
   | A : ('a : immediate) t
-  | B : ('b : value mod portable) -> ('b : value mod unique) t
+  | B : ('b : value mod portable) -> ('b : value mod aliased) t
   | C : _ t
 
 let f (type a : value) (x : a t) =
@@ -1342,7 +1342,7 @@ let f (type a : value) (x : a t) =
     let f (_ : _ as (_ : immediate)) = () in
     f y
   | B z ->
-    let f : ('a : value mod portable unique). 'a -> 'a -> _ = fun _ _ -> () in
+    let f : ('a : value mod portable aliased). 'a -> 'a -> _ = fun _ _ -> () in
     f y z
   | C ->
     ()
@@ -1350,14 +1350,14 @@ let f (type a : value) (x : a t) =
 [%%expect{|
 type _ t =
     A : ('a : immediate). 'a t
-  | B : ('b : value mod unique portable). 'b -> 'b t
+  | B : ('b : value mod portable aliased). 'b -> 'b t
   | C : 'c t
 val f : 'a t -> unit = <fun>
 |}]
 
 type _ t =
   | A : ('a : immediate) t
-  | B : ('b : value mod portable) -> ('b : value mod unique) t
+  | B : ('b : value mod portable) -> ('b : value mod aliased) t
   | C : _ t
 
 let f (type a : value) (x : a t) =
@@ -1367,7 +1367,7 @@ let f (type a : value) (x : a t) =
     let f (_ : _ as (_ : immediate)) = () in
     f y
   | B z ->
-    let f : ('a : value mod portable unique). 'a -> 'a -> _ = fun _ _ -> () in
+    let f : ('a : value mod portable aliased). 'a -> 'a -> _ = fun _ _ -> () in
     f y z
   | C ->
     let f (_ : _ as (_ : immediate)) = () in
@@ -1376,7 +1376,7 @@ let f (type a : value) (x : a t) =
 [%%expect{|
 type _ t =
     A : ('a : immediate). 'a t
-  | B : ('b : value mod unique portable). 'b -> 'b t
+  | B : ('b : value mod portable aliased). 'b -> 'b t
   | C : 'c t
 Line 17, characters 6-7:
 17 |     f y
@@ -1417,17 +1417,17 @@ let x : (_ as (_ : value mod many)) = object end
 val x : <  > = <obj>
 |}]
 
-let x : (_ as (_ : value mod unique)) = object end
+let x : (_ as (_ : value mod aliased)) = object end
 [%%expect {|
-Line 1, characters 40-50:
-1 | let x : (_ as (_ : value mod unique)) = object end
-                                            ^^^^^^^^^^
+Line 1, characters 41-51:
+1 | let x : (_ as (_ : value mod aliased)) = object end
+                                             ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
-         "('a : value mod unique)"
+         "('a : value mod aliased)"
        The kind of <  > is value mod global many unyielding
          because it's the type of an object.
-       But the kind of <  > must be a subkind of value mod unique
-         because of the annotation on the wildcard _ at line 1, characters 19-35.
+       But the kind of <  > must be a subkind of value mod aliased
+         because of the annotation on the wildcard _ at line 1, characters 19-36.
 |}]
 
 let x : (_ as (_ : value mod portable)) = object end
@@ -1443,17 +1443,17 @@ Error: This expression has type "<  >" but an expression was expected of type
          because of the annotation on the wildcard _ at line 1, characters 19-37.
 |}]
 
-let x : (_ as (_ : value mod uncontended)) = object end
+let x : (_ as (_ : value mod contended)) = object end
 [%%expect {|
-Line 1, characters 45-55:
-1 | let x : (_ as (_ : value mod uncontended)) = object end
-                                                 ^^^^^^^^^^
+Line 1, characters 43-53:
+1 | let x : (_ as (_ : value mod contended)) = object end
+                                               ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
-         "('a : value mod uncontended)"
+         "('a : value mod contended)"
        The kind of <  > is value mod global many unyielding
          because it's the type of an object.
-       But the kind of <  > must be a subkind of value mod uncontended
-         because of the annotation on the wildcard _ at line 1, characters 19-40.
+       But the kind of <  > must be a subkind of value mod contended
+         because of the annotation on the wildcard _ at line 1, characters 19-38.
 |}]
 
 let x : (_ as (_ : value mod external_)) = object end

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -10,8 +10,8 @@ let use_portable : 'a @ portable -> unit = fun _ -> ()
 let use_many : 'a @ many -> unit = fun _ -> ()
 
 type ('a : value mod global) require_global
-type ('a : value mod unique) require_unique
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod aliased) require_aliased
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 type ('a : value mod many) require_many
 type ('a : value mod non_null) require_nonnull
@@ -23,8 +23,8 @@ val use_uncontended : 'a -> unit = <fun>
 val use_portable : 'a @ portable -> unit = <fun>
 val use_many : 'a -> unit = <fun>
 type ('a : value mod global) require_global
-type ('a : value mod unique) require_unique
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod aliased) require_aliased
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 type ('a : value mod many) require_many
 type 'a require_nonnull
@@ -77,21 +77,21 @@ type u = { x : int; y : int; }
 type t = { z : u; }
 |}]
 
-type t_test = t require_uncontended
+type t_test = t require_contended
 [%%expect {|
-type t_test = t require_uncontended
+type t_test = t require_contended
 |}]
 
-type t_test = t require_unique
+type t_test = t require_aliased
 [%%expect {|
 Line 1, characters 14-15:
-1 | type t_test = t require_unique
+1 | type t_test = t require_aliased
                   ^
-Error: This type "t" should be an instance of type "('a : value mod unique)"
+Error: This type "t" should be an instance of type "('a : value mod aliased)"
        The kind of t is immutable_data
          because of the definition of t at line 2, characters 0-18.
-       But the kind of t must be a subkind of value mod unique
-         because of the definition of require_unique at line 8, characters 0-43.
+       But the kind of t must be a subkind of value mod aliased
+         because of the definition of require_aliased at line 8, characters 0-45.
 |}]
 
 let foo (t : t @@ once) = use_many t
@@ -182,7 +182,7 @@ Line 1, characters 13-20:
 1 | let foo (t : int ref t @@ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
-       The kind of int ref is value.
+       The kind of int ref is mutable_data.
        But the kind of int ref must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-46.
 |}]
@@ -197,7 +197,7 @@ Error: This value escapes its region.
 
 (***********************************************************************)
 
-type 'a t : value mod uncontended with 'a =
+type 'a t : value mod contended with 'a =
   { a : 'a
   ; f1 : int -> int
   ; f2 : int -> string
@@ -320,7 +320,7 @@ Line 1, characters 13-20:
 1 | let foo (t : int ref t @@ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
-       The kind of int ref is value.
+       The kind of int ref is mutable_data.
        But the kind of int ref must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-73.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -182,7 +182,7 @@ Line 1, characters 13-20:
 1 | let foo (t : int ref t @@ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
-       The kind of int ref is mutable_data.
+       The kind of int ref is value.
        But the kind of int ref must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-46.
 |}]
@@ -320,7 +320,7 @@ Line 1, characters 13-20:
 1 | let foo (t : int ref t @@ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
-       The kind of int ref is mutable_data.
+       The kind of int ref is value.
        But the kind of int ref must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-73.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -10,8 +10,8 @@ let use_portable : 'a @ portable -> unit = fun _ -> ()
 let use_many : 'a @ many -> unit = fun _ -> ()
 
 type ('a : value mod global) require_global
-type ('a : value mod unique) require_unique
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod aliased) require_aliased
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 type ('a : value mod many) require_many
 type ('a : value mod non_null) require_nonnull
@@ -23,8 +23,8 @@ val use_uncontended : 'a -> unit = <fun>
 val use_portable : 'a @ portable -> unit = <fun>
 val use_many : 'a -> unit = <fun>
 type ('a : value mod global) require_global
-type ('a : value mod unique) require_unique
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod aliased) require_aliased
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 type ('a : value mod many) require_many
 type 'a require_nonnull

--- a/testsuite/tests/typing-jkind-bounds/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/modalities.ml
@@ -4,13 +4,13 @@
 *)
 let use_uncontended : 'a @ uncontended -> unit = fun _ -> ()
 let use_portable : 'a @ portable -> unit = fun _ -> ()
-let cross_uncontended : ('a : value mod uncontended) -> unit = fun _ -> ()
-type ('a : value mod uncontended) require_uncontended
+let cross_contended : ('a : value mod contended) -> unit = fun _ -> ()
+type ('a : value mod contended) require_contended
 [%%expect{|
 val use_uncontended : 'a -> unit = <fun>
 val use_portable : 'a @ portable -> unit = <fun>
-val cross_uncontended : ('a : value mod uncontended). 'a -> unit = <fun>
-type ('a : value mod uncontended) require_uncontended
+val cross_contended : ('a : value mod contended). 'a -> unit = <fun>
+type ('a : value mod contended) require_contended
 |}]
 
 type 'a t = { contended : 'a @@ contended }
@@ -18,11 +18,11 @@ type 'a t = { contended : 'a @@ contended }
 type 'a t = { contended : 'a @@ contended; }
 |}]
 
-type t_test = int t require_uncontended
-type t_test = int ref t require_uncontended
+type t_test = int t require_contended
+type t_test = int ref t require_contended
 [%%expect{|
-type t_test = int t require_uncontended
-type t_test = int ref t require_uncontended
+type t_test = int t require_contended
+type t_test = int ref t require_contended
 |}]
 
 let foo (t : int ref t @@ contended) = use_uncontended t
@@ -38,7 +38,7 @@ Line 1, characters 55-66:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int ref t @@ contended) = cross_uncontended t
+let foo (t : int ref t @@ contended) = cross_contended t
 [%%expect{|
 val foo : int ref t @ contended -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
+++ b/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
@@ -17,8 +17,8 @@ let use_portable : 'a @ portable -> unit = fun _ -> ()
 let use_many : 'a @ many -> unit = fun _ -> ()
 
 type ('a : value mod global) require_global
-type ('a : value mod unique) require_unique
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod aliased) require_aliased
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 type ('a : value mod many) require_many
 type ('a : value mod non_null) require_nonnull
@@ -30,8 +30,8 @@ val use_uncontended : 'a -> unit = <fun>
 val use_portable : 'a @ portable -> unit = <fun>
 val use_many : 'a -> unit = <fun>
 type ('a : value mod global) require_global
-type ('a : value mod unique) require_unique
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod aliased) require_aliased
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 type ('a : value mod many) require_many
 type 'a require_nonnull
@@ -56,6 +56,8 @@ Error: This type "int Define_with_kinds.my_list" should be an instance of type
 
 type my_list_test = int ref my_list require_portable
 [%%expect{|
+type my_list_test = int ref Define_with_kinds.my_list require_portable
+|}, Principal{|
 Line 1, characters 20-35:
 1 | type my_list_test = int ref my_list require_portable
                         ^^^^^^^^^^^^^^^
@@ -93,31 +95,31 @@ Error: This type "int Define_with_kinds.my_list" should be an instance of type
          because of the definition of require_global at line 9, characters 0-43.
 |}]
 
-type my_list_test = int ref my_list require_uncontended
+type my_list_test = int ref my_list require_contended
 [%%expect{|
 Line 1, characters 20-35:
-1 | type my_list_test = int ref my_list require_uncontended
+1 | type my_list_test = int ref my_list require_contended
                         ^^^^^^^^^^^^^^^
 Error: This type "int ref Define_with_kinds.my_list"
-       should be an instance of type "('a : value mod uncontended)"
+       should be an instance of type "('a : value mod contended)"
        The kind of int ref Define_with_kinds.my_list is immutable_data.
        But the kind of int ref Define_with_kinds.my_list must be a subkind of
-         value mod uncontended
-         because of the definition of require_uncontended at line 11, characters 0-53.
+         value mod contended
+         because of the definition of require_contended at line 11, characters 0-49.
 |}]
 
-type my_list_test = int my_ref my_list require_uncontended
+type my_list_test = int my_ref my_list require_contended
 [%%expect{|
 Line 1, characters 20-38:
-1 | type my_list_test = int my_ref my_list require_uncontended
+1 | type my_list_test = int my_ref my_list require_contended
                         ^^^^^^^^^^^^^^^^^^
 Error: This type "int Define_with_kinds.my_ref Define_with_kinds.my_list"
-       should be an instance of type "('a : value mod uncontended)"
+       should be an instance of type "('a : value mod contended)"
        The kind of int Define_with_kinds.my_ref Define_with_kinds.my_list is
          immutable_data.
        But the kind of int Define_with_kinds.my_ref Define_with_kinds.my_list must be a subkind of
-         value mod uncontended
-         because of the definition of require_uncontended at line 11, characters 0-53.
+         value mod contended
+         because of the definition of require_contended at line 11, characters 0-49.
 |}]
 
 type my_list_test = int my_ref my_list require_portable

--- a/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
+++ b/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
@@ -56,8 +56,6 @@ Error: This type "int Define_with_kinds.my_list" should be an instance of type
 
 type my_list_test = int ref my_list require_portable
 [%%expect{|
-type my_list_test = int ref Define_with_kinds.my_list require_portable
-|}, Principal{|
 Line 1, characters 20-35:
 1 | type my_list_test = int ref my_list require_portable
                         ^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -38,9 +38,13 @@ type 'a t : immutable_data with 'a = 'a option
 type ('a : immutable_data) t : immutable_data = 'a option
 [%%expect {|
 type t = int option
-type t = int ref option
-type 'a t = 'a option
-type ('a : immutable_data) t = 'a option
+Line 2, characters 0-38:
+2 | type t : mutable_data = int ref option
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int ref option" is immutable_data
+         because it's a boxed variant type.
+       But the kind of type "int ref option" must be a subkind of mutable_data
+         because of the definition of t at line 2, characters 0-38.
 |}]
 
 type 'a t : immutable_data = 'a option
@@ -136,9 +140,12 @@ type t : mutable_data = int ref
 type 'a t : mutable_data with 'a = 'a ref
 type ('a : mutable_data) t : mutable_data = 'a list
 [%%expect {|
-type t = int ref
-type 'a t = 'a ref
-type ('a : mutable_data) t = 'a list
+Line 1, characters 0-31:
+1 | type t : mutable_data = int ref
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int ref" is value.
+       But the kind of type "int ref" must be a subkind of mutable_data
+         because of the definition of t at line 1, characters 0-31.
 |}]
 
 type t : immutable_data = int ref
@@ -146,7 +153,7 @@ type t : immutable_data = int ref
 Line 1, characters 0-33:
 1 | type t : immutable_data = int ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int ref" is mutable_data.
+Error: The kind of type "int ref" is value.
        But the kind of type "int ref" must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-33.
 |}]
@@ -156,7 +163,7 @@ type 'a t : mutable_data = 'a ref
 Line 1, characters 0-33:
 1 | type 'a t : mutable_data = 'a ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a ref" is mutable_data.
+Error: The kind of type "'a ref" is value.
        But the kind of type "'a ref" must be a subkind of mutable_data
          because of the definition of t at line 1, characters 0-33.
 |}]
@@ -166,16 +173,12 @@ type t_test = int ref require_many
 type ('a : value mod portable) t_test = 'a ref require_portable
 (* CR layouts v2.8: fix in principal case *)
 [%%expect {|
-type t_test = int ref require_portable
-type t_test = int ref require_many
-type ('a : value mod portable) t_test = 'a ref require_portable
-|}, Principal{|
 Line 1, characters 14-21:
 1 | type t_test = int ref require_portable
                   ^^^^^^^
 Error: This type "int ref" should be an instance of type
          "('a : value mod portable)"
-       The kind of int ref is mutable_data.
+       The kind of int ref is value.
        But the kind of int ref must be a subkind of value mod portable
          because of the definition of require_portable at line 10, characters 0-47.
 |}]
@@ -187,7 +190,7 @@ Line 1, characters 14-21:
                   ^^^^^^^
 Error: This type "int ref" should be an instance of type
          "('a : value mod uncontended)"
-       The kind of int ref is mutable_data.
+       The kind of int ref is value.
        But the kind of int ref must be a subkind of value mod uncontended
          because of the definition of require_uncontended at line 9, characters 0-53.
 |}]
@@ -196,7 +199,10 @@ let foo (t : int ref @@ portable once) =
   use_many t;
   use_portable t
 [%%expect {|
-val foo : int ref @ once portable -> unit = <fun>
+Line 2, characters 11-12:
+2 |   use_many t;
+               ^
+Error: This value is "once" but expected to be "many".
 |}]
 
 let foo (t : int ref @@ contended) = use_uncontended t
@@ -213,8 +219,13 @@ type t : mutable_data = int ref list
 type ('a : immutable_data) t : immutable_data = 'a list
 [%%expect {|
 type t = int list
-type t = int ref list
-type ('a : immutable_data) t = 'a list
+Line 2, characters 0-36:
+2 | type t : mutable_data = int ref list
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int ref list" is immutable_data
+         because it's a boxed variant type.
+       But the kind of type "int ref list" must be a subkind of mutable_data
+         because of the definition of t at line 2, characters 0-36.
 |}]
 
 type 'a t : immutable_data with 'a = 'a list
@@ -396,9 +407,13 @@ type 'a t : immutable_data with 'a = 'a iarray
 type ('a : immutable_data) t : immutable_data = 'a iarray
 [%%expect {|
 type t = int iarray
-type t = int ref iarray
-type 'a t = 'a iarray
-type ('a : immutable_data) t = 'a iarray
+Line 2, characters 0-38:
+2 | type t : mutable_data = int ref iarray
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int ref iarray" is immutable_data
+         because it is the primitive value type iarray.
+       But the kind of type "int ref iarray" must be a subkind of mutable_data
+         because of the definition of t at line 2, characters 0-38.
 |}]
 
 type 'a t : immutable_data = 'a iarray

--- a/testsuite/tests/typing-jkind-bounds/printing.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing.ml
@@ -50,7 +50,7 @@ Error: The kind of type "t" is immutable_data with 'a @@ portable
 
        The first mode-crosses less than the second along:
          linearity: mod many with 'a ≰ mod many
-         contention: mod uncontended with 'a ≰ mod uncontended
+         contention: mod contended with 'a ≰ mod contended
          yielding: mod unyielding with 'a ≰ mod unyielding
 |}]
 
@@ -169,7 +169,7 @@ Error: This type "a" = "int ref" should be an instance of type
          because of the definition of t at line 2, characters 0-28.
 
        The first mode-crosses less than the second along:
-         contention: mod contended ≰ mod uncontended
+         contention: mod uncontended ≰ mod contended
 |}, Principal{|
 type a = int ref
 type ('a : immutable_data) t
@@ -183,7 +183,7 @@ Error: This type "a" = "int ref" should be an instance of type
          because of the definition of t at line 2, characters 0-28.
 
        The first mode-crosses less than the second along:
-         contention: mod contended ≰ mod uncontended
+         contention: mod uncontended ≰ mod contended
          portability: mod portable with int ≰ mod portable
 |}]
 
@@ -223,31 +223,31 @@ Error: This type "(int -> int) u" should be an instance of type
 
        The first mode-crosses less than the second along:
          linearity: mod many with int -> int ≰ mod many
-         contention: mod uncontended with int -> int ≰ mod uncontended
+         contention: mod contended with int -> int ≰ mod contended
          yielding: mod unyielding with int -> int ≰ mod unyielding
 |}]
 
 module M : sig
   type t : value mod portable
 end = struct
-  type t : value mod uncontended
+  type t : value mod contended
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
 3 | ......struct
-4 |   type t : value mod uncontended
+4 |   type t : value mod contended
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type t : value mod uncontended end
+         sig type t : value mod contended end
        is not included in
          sig type t : value mod portable end
        Type declarations do not match:
-         type t : value mod uncontended
+         type t : value mod contended
        is not included in
          type t : value mod portable
-       The kind of the first is value mod uncontended
-         because of the definition of t at line 4, characters 2-32.
+       The kind of the first is value mod contended
+         because of the definition of t at line 4, characters 2-30.
        But the kind of the first must be a subkind of value mod portable
          because of the definition of t at line 2, characters 2-29.
 |}]
@@ -255,53 +255,53 @@ Error: Signature mismatch:
 module M : sig
   type 'a t : value mod portable with 'a
 end = struct
-  type 'a t : value mod uncontended with 'a
+  type 'a t : value mod contended with 'a
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
 3 | ......struct
-4 |   type 'a t : value mod uncontended with 'a
+4 |   type 'a t : value mod contended with 'a
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type 'a t : value mod uncontended with 'a end
+         sig type 'a t : value mod contended with 'a end
        is not included in
          sig type 'a t : value mod portable with 'a end
        Type declarations do not match:
-         type 'a t : value mod uncontended with 'a
+         type 'a t : value mod contended with 'a
        is not included in
          type 'a t : value mod portable with 'a
-       The kind of the first is value mod uncontended with 'a
-         because of the definition of t at line 4, characters 2-43.
+       The kind of the first is value mod contended with 'a
+         because of the definition of t at line 4, characters 2-41.
        But the kind of the first must be a subkind of value mod portable
          with 'a
          because of the definition of t at line 2, characters 2-40.
 |}]
 
 module M : sig
-  type 'a t : value mod portable uncontended with 'a
+  type 'a t : value mod portable contended with 'a
 end = struct
-  type 'a t : value mod uncontended with 'a
+  type 'a t : value mod contended with 'a
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
 3 | ......struct
-4 |   type 'a t : value mod uncontended with 'a
+4 |   type 'a t : value mod contended with 'a
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type 'a t : value mod uncontended with 'a end
+         sig type 'a t : value mod contended with 'a end
        is not included in
-         sig type 'a t : value mod uncontended portable with 'a end
+         sig type 'a t : value mod contended portable with 'a end
        Type declarations do not match:
-         type 'a t : value mod uncontended with 'a
+         type 'a t : value mod contended with 'a
        is not included in
-         type 'a t : value mod uncontended portable with 'a
-       The kind of the first is value mod uncontended with 'a
-         because of the definition of t at line 4, characters 2-43.
+         type 'a t : value mod contended portable with 'a
+       The kind of the first is value mod contended with 'a
+         because of the definition of t at line 4, characters 2-41.
        But the kind of the first must be a subkind of
-         value mod uncontended portable with 'a
-         because of the definition of t at line 2, characters 2-52.
+         value mod contended portable with 'a
+         because of the definition of t at line 2, characters 2-50.
 |}]
 
 module M : sig
@@ -436,5 +436,5 @@ Error: Signature mismatch:
          because of the definition of t at line 2, characters 2-56.
 
        The first mode-crosses less than the second along:
-         contention: mod contended ≰ mod uncontended with 'a
+         contention: mod uncontended ≰ mod contended with 'a
 |}]

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -82,12 +82,13 @@ type ('a : mutable_data) t : mutable_data = { x : 'a option }
 [%%expect {|
 type t = { mutable x : int; }
 type t = { x : int; y : int; mutable z : int; }
-type t = { mutable x : int ref; }
-type t = { x : int; }
-type ('a : mutable_data) t = { x : 'a; }
-type ('a : immutable_data) t = { x : 'a; }
-type t = { x : int ref; y : string; }
-type ('a : mutable_data) t = { x : 'a option; }
+Line 3, characters 0-47:
+3 | type t : mutable_data = { mutable x : int ref }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is value mod many unyielding
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of mutable_data
+         because of the annotation on the declaration of the type t.
 |}]
 
 (* annotations that aren't mutable_data or immutable_data *)
@@ -140,7 +141,7 @@ type t : immutable_data = { x : int ref }
 Line 1, characters 0-41:
 1 | type t : immutable_data = { x : int ref }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -250,14 +251,13 @@ type 'a t : immutable_data with 'a -> 'a = { x : 'a -> 'a }
 type 'a t = { x : int; }
 type 'a t = { x : 'a; }
 type 'a t = { mutable x : 'a; }
-type 'a t = { x : 'a ref; }
-type ('a, 'b) t = { x : 'a; y : 'b; z : 'a; }
-type ('a, 'b) t = { x : 'a; y : 'b; mutable z : 'a; }
-type 'a t = { x : unit -> unit; y : 'a; }
-type 'a t = { x : int; }
-type 'a t = { x : int; }
-type 'a t = { x : 'a option; }
-type 'a t = { x : 'a -> 'a; }
+Line 4, characters 0-49:
+4 | type 'a t : mutable_data with 'a = { x : 'a ref }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of mutable_data
+         because of the annotation on the declaration of the type t.
 |}]
 
 type 'a t : immutable_data with 'a = { mutable x : 'a }
@@ -838,7 +838,7 @@ Error: Signature mismatch:
          type t = { x : int ref; y : string; }
        is not included in
          type t : immutable_data
-       The kind of the first is mutable_data
+       The kind of the first is value
          because of the definition of t at line 4, characters 2-38.
        But the kind of the first must be a subkind of immutable_data
          because of the definition of t at line 2, characters 2-25.

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -10,16 +10,16 @@ let use_portable : 'a @ portable -> unit = fun _ -> ()
 let use_many : 'a @ many -> unit = fun _ -> ()
 
 let cross_global : ('a : value mod global) -> unit = fun _ -> ()
-let cross_unique : ('a : value mod unique) -> unit = fun _ -> ()
-let cross_uncontended : ('a : value mod uncontended) -> unit = fun _ -> ()
+let cross_aliased : ('a : value mod aliased) -> unit = fun _ -> ()
+let cross_contended : ('a : value mod contended) -> unit = fun _ -> ()
 let cross_portable : ('a : value mod portable) -> unit = fun _ -> ()
 let cross_many : ('a : value mod many) -> unit = fun _ -> ()
 let cross_nonnull : ('a : value mod non_null) -> unit = fun _ -> ()
 let cross_external : ('a : value mod external_) -> unit = fun _ -> ()
 
 type ('a : value mod global) require_global
-type ('a : value mod unique) require_unique
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod aliased) require_aliased
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 type ('a : value mod many) require_many
 type ('a : value mod non_null) require_nonnull
@@ -31,15 +31,15 @@ val use_uncontended : 'a -> unit = <fun>
 val use_portable : 'a @ portable -> unit = <fun>
 val use_many : 'a -> unit = <fun>
 val cross_global : ('a : value mod global). 'a -> unit = <fun>
-val cross_unique : ('a : value mod unique). 'a -> unit = <fun>
-val cross_uncontended : ('a : value mod uncontended). 'a -> unit = <fun>
+val cross_aliased : ('a : value mod aliased). 'a -> unit = <fun>
+val cross_contended : ('a : value mod contended). 'a -> unit = <fun>
 val cross_portable : ('a : value mod portable). 'a -> unit = <fun>
 val cross_many : ('a : value mod many). 'a -> unit = <fun>
 val cross_nonnull : 'a -> unit = <fun>
 val cross_external : ('a : value mod external_). 'a -> unit = <fun>
 type ('a : value mod global) require_global
-type ('a : value mod unique) require_unique
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod aliased) require_aliased
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 type ('a : value mod many) require_many
 type 'a require_nonnull
@@ -82,28 +82,27 @@ type ('a : mutable_data) t : mutable_data = { x : 'a option }
 [%%expect {|
 type t = { mutable x : int; }
 type t = { x : int; y : int; mutable z : int; }
-Line 3, characters 0-47:
-3 | type t : mutable_data = { mutable x : int ref }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod many unyielding
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of mutable_data
-         because of the annotation on the declaration of the type t.
+type t = { mutable x : int ref; }
+type t = { x : int; }
+type ('a : mutable_data) t = { x : 'a; }
+type ('a : immutable_data) t = { x : 'a; }
+type t = { x : int ref; y : string; }
+type ('a : mutable_data) t = { x : 'a option; }
 |}]
 
 (* annotations that aren't mutable_data or immutable_data *)
-type t : value mod uncontended = { x : unit -> unit }
-type 'a t : value mod uncontended = { x : 'a -> 'a }
-type ('a : value mod uncontended portable, 'b : value mod portable) t : value mod portable
+type t : value mod contended = { x : unit -> unit }
+type 'a t : value mod contended = { x : 'a -> 'a }
+type ('a : value mod contended portable, 'b : value mod portable) t : value mod portable
     = { x : 'a; y : 'b }
 type ('a : value mod many) t : value mod many = { x : 'a }
-type t : value mod uncontended portable = { x : int }
+type t : value mod contended portable = { x : int }
 type ('a : value mod portable many) t : value mod many = { mutable x : 'a }
 type 'a t : value mod non_null = { x : 'a }
 [%%expect {|
 type t = { x : unit -> unit; }
 type 'a t = { x : 'a -> 'a; }
-type ('a : value mod uncontended portable, 'b : value mod portable) t = {
+type ('a : value mod contended portable, 'b : value mod portable) t = {
   x : 'a;
   y : 'b;
 }
@@ -141,7 +140,7 @@ type t : immutable_data = { x : int ref }
 Line 1, characters 0-41:
 1 | type t : immutable_data = { x : int ref }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
+Error: The kind of type "t" is mutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -152,7 +151,7 @@ type t : immutable_data = { x : unit -> unit }
 Line 1, characters 0-46:
 1 | type t : immutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod uncontended
+Error: The kind of type "t" is value mod contended
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -185,7 +184,7 @@ type t : mutable_data = { x : unit -> unit }
 Line 1, characters 0-44:
 1 | type t : mutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod uncontended
+Error: The kind of type "t" is value mod contended
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -213,14 +212,14 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type ('a : value mod unique) t : value mod unique = { x : 'a }
+type ('a : value mod aliased) t : value mod aliased = { x : 'a }
 [%%expect {|
-Line 1, characters 0-62:
-1 | type ('a : value mod unique) t : value mod unique = { x : 'a }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-64:
+1 | type ('a : value mod aliased) t : value mod aliased = { x : 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod unique
+       But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -242,22 +241,23 @@ type 'a t : mutable_data with 'a = { mutable x : 'a }
 type 'a t : mutable_data with 'a = { x : 'a ref }
 type ('a, 'b) t : immutable_data with 'a with 'b = { x : 'a; y : 'b; z : 'a }
 type ('a, 'b) t : mutable_data with 'a with 'b = { x : 'a; y : 'b; mutable z : 'a }
-type 'a t : value mod uncontended with 'a = { x : unit -> unit; y : 'a }
+type 'a t : value mod contended with 'a = { x : unit -> unit; y : 'a }
 type 'a t : immutable_data with 'a = { x : int }
-type 'a t : value mod uncontended with 'a = { x : int }
+type 'a t : value mod contended with 'a = { x : int }
 type 'a t : immutable_data with 'a = { x : 'a option }
 type 'a t : immutable_data with 'a -> 'a = { x : 'a -> 'a }
 [%%expect {|
 type 'a t = { x : int; }
 type 'a t = { x : 'a; }
 type 'a t = { mutable x : 'a; }
-Line 4, characters 0-49:
-4 | type 'a t : mutable_data with 'a = { x : 'a ref }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of mutable_data
-         because of the annotation on the declaration of the type t.
+type 'a t = { x : 'a ref; }
+type ('a, 'b) t = { x : 'a; y : 'b; z : 'a; }
+type ('a, 'b) t = { x : 'a; y : 'b; mutable z : 'a; }
+type 'a t = { x : unit -> unit; y : 'a; }
+type 'a t = { x : int; }
+type 'a t = { x : int; }
+type 'a t = { x : 'a option; }
+type 'a t = { x : 'a -> 'a; }
 |}]
 
 type 'a t : immutable_data with 'a = { mutable x : 'a }
@@ -276,7 +276,7 @@ type 'a t : immutable_data with 'a = { x : 'a -> 'a }
 Line 1, characters 0-53:
 1 | type 'a t : immutable_data with 'a = { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod uncontended
+Error: The kind of type "t" is value mod contended
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -293,14 +293,14 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type 'a t : value mod unique with 'a = { x : 'a }
+type 'a t : value mod aliased with 'a = { x : 'a }
 [%%expect {|
-Line 1, characters 0-49:
-1 | type 'a t : value mod unique with 'a = { x : 'a }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-50:
+1 | type 'a t : value mod aliased with 'a = { x : 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod unique
+       But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -532,7 +532,7 @@ let t = { x = 10; y = "hello" }
 let () =
   cross_many t;
   cross_portable t;
-  cross_uncontended t
+  cross_contended t
 
 [%%expect{|
 type t = { x : int; y : string; }
@@ -565,11 +565,11 @@ val func : (unit -> unit) t = {x = <fun>}
 let () =
   cross_many int;
   cross_portable int;
-  cross_uncontended int;
+  cross_contended int;
   cross_nonnull int
 
 let () =
-  cross_uncontended func;
+  cross_contended func;
   cross_nonnull func
 (* CR layouts v2.8: fix in principal case *)
 [%%expect {|
@@ -585,17 +585,17 @@ Error: This expression has type "int t" but an expression was expected of type
          because of the definition of cross_many at line 11, characters 49-60.
 |}]
 
-let () = cross_unique int
+let () = cross_aliased int
 [%%expect {|
-Line 1, characters 22-25:
-1 | let () = cross_unique int
-                          ^^^
+Line 1, characters 23-26:
+1 | let () = cross_aliased int
+                           ^^^
 Error: This expression has type "int t" but an expression was expected of type
-         "('a : value mod unique)"
+         "('a : value mod aliased)"
        The kind of int t is immutable_data
          because of the definition of t at line 1, characters 0-22.
-       But the kind of int t must be a subkind of value mod unique
-         because of the definition of cross_unique at line 8, characters 53-64.
+       But the kind of int t must be a subkind of value mod aliased
+         because of the definition of cross_aliased at line 8, characters 55-66.
 |}]
 
 let () = cross_portable func
@@ -629,18 +629,18 @@ Error: This expression has type "(unit -> unit) t"
 type 'a t = { x : 'a }
 type t_test = int t require_many
 type t_test = int t require_portable
-type t_test = int t require_uncontended
-type t_test = (unit -> unit) t require_uncontended
-type ('a : value mod uncontended) t_test = 'a t require_uncontended
+type t_test = int t require_contended
+type t_test = (unit -> unit) t require_contended
+type ('a : value mod contended) t_test = 'a t require_contended
 type 'a t_test = 'a t require_nonnull
 (* CR layouts v2.8: fix principal case *)
 [%%expect {|
 type 'a t = { x : 'a; }
 type t_test = int t require_many
 type t_test = int t require_portable
-type t_test = int t require_uncontended
-type t_test = (unit -> unit) t require_uncontended
-type ('a : value mod uncontended) t_test = 'a t require_uncontended
+type t_test = int t require_contended
+type t_test = (unit -> unit) t require_contended
+type ('a : value mod contended) t_test = 'a t require_contended
 type 'a t_test = 'a t require_nonnull
 |}, Principal{|
 type 'a t = { x : 'a; }
@@ -666,16 +666,16 @@ Error: This type "int t" should be an instance of type "('a : value mod global)"
          because of the definition of require_global at line 15, characters 0-43.
 |}]
 
-type t_test = int t require_unique
+type t_test = int t require_aliased
 [%%expect {|
 Line 1, characters 14-19:
-1 | type t_test = int t require_unique
+1 | type t_test = int t require_aliased
                   ^^^^^
-Error: This type "int t" should be an instance of type "('a : value mod unique)"
+Error: This type "int t" should be an instance of type "('a : value mod aliased)"
        The kind of int t is immutable_data
          because of the definition of t at line 1, characters 0-22.
-       But the kind of int t must be a subkind of value mod unique
-         because of the definition of require_unique at line 16, characters 0-43.
+       But the kind of int t must be a subkind of value mod aliased
+         because of the definition of require_aliased at line 16, characters 0-45.
 |}]
 
 type t_test = (unit -> unit) t require_portable
@@ -692,11 +692,11 @@ Error: This type "(unit -> unit) t" should be an instance of type
          because of the definition of require_portable at line 18, characters 0-47.
 |}]
 
-type ('a : value mod uncontended) t_test = 'a t require_portable
+type ('a : value mod contended) t_test = 'a t require_portable
 [%%expect {|
-Line 1, characters 43-47:
-1 | type ('a : value mod uncontended) t_test = 'a t require_portable
-                                               ^^^^
+Line 1, characters 41-45:
+1 | type ('a : value mod contended) t_test = 'a t require_portable
+                                             ^^^^
 Error: This type "'a t" should be an instance of type "('b : value mod portable)"
        The kind of 'a t is immutable_data
          because of the definition of t at line 1, characters 0-22.
@@ -838,7 +838,7 @@ Error: Signature mismatch:
          type t = { x : int ref; y : string; }
        is not included in
          type t : immutable_data
-       The kind of the first is value
+       The kind of the first is mutable_data
          because of the definition of t at line 4, characters 2-38.
        But the kind of the first must be a subkind of immutable_data
          because of the definition of t at line 2, characters 2-25.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -224,7 +224,55 @@ end = struct
   type t : immutable_data mod aliased with d with d with b with d with c with a
 end
 [%%expect {|
-module M : sig type t : mutable_data end
+Lines 3-9, characters 6-3:
+3 | ......struct
+4 |   type a : immediate
+5 |   type b : immutable_data with a with int with string with a ref
+6 |   type c : mutable_data with b with a with b with a
+7 |   type d : immediate with a
+8 |   type t : immutable_data mod aliased with d with d with b with d with c with a
+9 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type a : immediate
+           type b : value with a @@ global aliased
+           type c
+             : mutable_data
+             with a @@ global aliased contended
+
+             with b @@ global aliased contended
+           type d : immediate with a
+           type t
+             : immutable_data
+             with a @@ global aliased
+
+             with b @@ global aliased
+
+             with c @@ global aliased
+
+             with d @@ global aliased
+         end
+       is not included in
+         sig type t : mutable_data end
+       Type declarations do not match:
+         type t
+           : immutable_data
+           with a @@ global aliased
+
+           with b @@ global aliased
+
+           with c @@ global aliased
+
+           with d @@ global aliased
+       is not included in
+         type t : mutable_data
+       The kind of the first is immutable_data with a @@ global aliased
+         with b @@ global aliased with c @@ global aliased
+         with d @@ global aliased
+         because of the definition of t at line 8, characters 2-79.
+       But the kind of the first must be a subkind of mutable_data
+         because of the definition of t at line 2, characters 2-23.
 |}]
 
 type u

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -224,55 +224,7 @@ end = struct
   type t : immutable_data mod aliased with d with d with b with d with c with a
 end
 [%%expect {|
-Lines 3-9, characters 6-3:
-3 | ......struct
-4 |   type a : immediate
-5 |   type b : immutable_data with a with int with string with a ref
-6 |   type c : mutable_data with b with a with b with a
-7 |   type d : immediate with a
-8 |   type t : immutable_data mod aliased with d with d with b with d with c with a
-9 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           type a : immediate
-           type b : value with a @@ global aliased
-           type c
-             : mutable_data
-             with a @@ global aliased contended
-
-             with b @@ global aliased contended
-           type d : immediate with a
-           type t
-             : immutable_data
-             with a @@ global aliased
-
-             with b @@ global aliased
-
-             with c @@ global aliased
-
-             with d @@ global aliased
-         end
-       is not included in
-         sig type t : mutable_data end
-       Type declarations do not match:
-         type t
-           : immutable_data
-           with a @@ global aliased
-
-           with b @@ global aliased
-
-           with c @@ global aliased
-
-           with d @@ global aliased
-       is not included in
-         type t : mutable_data
-       The kind of the first is immutable_data with a @@ global aliased
-         with b @@ global aliased with c @@ global aliased
-         with d @@ global aliased
-         because of the definition of t at line 8, characters 2-79.
-       But the kind of the first must be a subkind of mutable_data
-         because of the definition of t at line 2, characters 2-23.
+module M : sig type t : mutable_data end
 |}]
 
 type u

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -151,7 +151,7 @@ Error: Signature mismatch:
          because of the definition of t at line 2, characters 2-59.
 
        The first mode-crosses less than the second along:
-         contention: mod contended ≰ mod uncontended with 'b
+         contention: mod uncontended ≰ mod contended with 'b
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -71,49 +71,49 @@ module M :
 |}]
 
 module M : sig
-  type ('a : value mod portable, 'b : value mod uncontended) t : value mod portable uncontended constraint 'a = 'b
+  type ('a : value mod portable, 'b : value mod contended) t : value mod portable contended constraint 'a = 'b
 end = struct
-  type ('a : value mod portable, 'b : value mod uncontended) t = 'a constraint 'a = 'b
+  type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 end
 [%%expect{|
 module M :
   sig
-    type ('b : value mod uncontended portable, 'a) t
-      : value mod uncontended portable constraint 'a = 'b
+    type ('b : value mod contended portable, 'a) t
+      : value mod contended portable constraint 'a = 'b
   end
 |}]
 
 module M : sig
-  type ('a : value mod portable, 'b : value mod uncontended) t : value mod many constraint 'a = 'b
+  type ('a : value mod portable, 'b : value mod contended) t : value mod many constraint 'a = 'b
 end = struct
-  type ('a : value mod portable, 'b : value mod uncontended) t = 'a constraint 'a = 'b
+  type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 end
 [%%expect{|
 Lines 3-5, characters 6-3:
 3 | ......struct
-4 |   type ('a : value mod portable, 'b : value mod uncontended) t = 'a constraint 'a = 'b
+4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig
-           type ('b : value mod uncontended portable, 'a) t = 'b
+           type ('b : value mod contended portable, 'a) t = 'b
              constraint 'a = 'b
          end
        is not included in
          sig
-           type ('b : value mod uncontended portable, 'a) t : value mod many
+           type ('b : value mod contended portable, 'a) t : value mod many
              constraint 'a = 'b
          end
        Type declarations do not match:
-         type ('b : value mod uncontended portable, 'a) t = 'b
+         type ('b : value mod contended portable, 'a) t = 'b
            constraint 'a = 'b
        is not included in
-         type ('b : value mod uncontended portable, 'a) t : value mod many
+         type ('b : value mod contended portable, 'a) t : value mod many
            constraint 'a = 'b
-       The kind of the first is value mod uncontended portable
-         because of the definition of t at line 2, characters 2-98.
+       The kind of the first is value mod contended portable
+         because of the definition of t at line 2, characters 2-96.
        But the kind of the first must be a subkind of value mod many
-         because of the definition of t at line 2, characters 2-98.
+         because of the definition of t at line 2, characters 2-96.
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
@@ -65,7 +65,7 @@ Error: The kind of type "'a F(Ref).t" is mutable_data with 'a @@ many
          because of the definition of t at line 4, characters 0-48.
 
        The first mode-crosses less than the second along:
-         contention: mod contended ≰ mod uncontended with 'a
+         contention: mod uncontended ≰ mod contended with 'a
 |}]
 
 module Ref = struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
@@ -46,14 +46,7 @@ module F :
   functor (M : sig type 'a t end) ->
     sig type 'a t : immutable_data with 'a M.t end
 module Ref : sig type 'a t = 'a ref end
-Line 8, characters 0-46:
-8 | type 'a t : mutable_data with 'a = 'a F(Ref).t
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a F(Ref).t" is value
-         because of the definition of t at line 2, characters 2-40.
-       But the kind of type "'a F(Ref).t" must be a subkind of mutable_data
-         with 'a @@ global aliased contended
-         because of the definition of t at line 8, characters 0-46.
+type 'a t = 'a F(Ref).t
 |}]
 
 module Ref = struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
@@ -46,7 +46,14 @@ module F :
   functor (M : sig type 'a t end) ->
     sig type 'a t : immutable_data with 'a M.t end
 module Ref : sig type 'a t = 'a ref end
-type 'a t = 'a F(Ref).t
+Line 8, characters 0-46:
+8 | type 'a t : mutable_data with 'a = 'a F(Ref).t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "'a F(Ref).t" is value
+         because of the definition of t at line 2, characters 2-40.
+       But the kind of type "'a F(Ref).t" must be a subkind of mutable_data
+         with 'a @@ global aliased contended
+         because of the definition of t at line 8, characters 0-46.
 |}]
 
 module Ref = struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -378,7 +378,13 @@ end
 
 module type T = S with type t = t
 [%%expect {|
-type t : immutable_data
+type t : value mod uncontended
 module type S = sig type t : immutable_data end
-module type T = sig type t = t end
+Line 7, characters 23-33:
+7 | module type T = S with type t = t
+                           ^^^^^^^^^^
+Error: The kind of type "t" is value mod uncontended
+         because of the definition of t at line 1, characters 0-49.
+       But the kind of type "t" must be a subkind of immutable_data
+         because of the definition of t at line 4, characters 2-25.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -94,12 +94,12 @@ module M : sig type 'a t : value mod global end
 |}]
 
 module M : sig
-  type 'a t : value mod uncontended
+  type 'a t : value mod contended
 end = struct
   type 'a t : immutable_data with 'a @@ contended
 end
 [%%expect {|
-module M : sig type 'a t : value mod uncontended end
+module M : sig type 'a t : value mod contended end
 |}]
 
 type 'a u : immutable_data with 'a @@ many
@@ -110,22 +110,22 @@ type 'a t = 'a u
 |}]
 
 module M : sig
-  type 'a t : value mod unique
+  type 'a t : value mod aliased
 end = struct
   type 'a t : immediate with 'a @@ aliased
 end
 [%%expect {|
-module M : sig type 'a t : value mod unique end
+module M : sig type 'a t : value mod aliased end
 |}]
 
 module M : sig
-  type 'a t : value mod global unique many portable uncontended
+  type 'a t : value mod global aliased many portable contended
 end = struct
   type 'a t : immediate with 'a @@ aliased many contended global portable
 end
 [%%expect {|
 module M :
-  sig type 'a t : value mod global unique many uncontended portable end
+  sig type 'a t : value mod global aliased many contended portable end
 |}]
 
 module M : sig
@@ -242,15 +242,16 @@ end
 module M : sig type 'a t : immutable_data with 'a end
 |}]
 
-type 'a u : value mod uncontended with 'a @@ global
+type 'a u : value mod contended with 'a @@ global
 type 'a t : value mod global = 'a u
 [%%expect {|
-type 'a u : value mod uncontended with 'a
+type 'a u : value mod contended with 'a @@ global many portable aliased
 Line 2, characters 0-35:
 2 | type 'a t : value mod global = 'a u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a u" is value mod uncontended with 'a
-         because of the definition of u at line 1, characters 0-51.
+Error: The kind of type "'a u" is value mod contended
+         with 'a @@ global many portable aliased
+         because of the definition of u at line 1, characters 0-49.
        But the kind of type "'a u" must be a subkind of value mod global
          because of the definition of t at line 2, characters 0-35.
 |}]
@@ -378,13 +379,7 @@ end
 
 module type T = S with type t = t
 [%%expect {|
-type t : value mod uncontended
+type t : immutable_data
 module type S = sig type t : immutable_data end
-Line 7, characters 23-33:
-7 | module type T = S with type t = t
-                           ^^^^^^^^^^
-Error: The kind of type "t" is value mod uncontended
-         because of the definition of t at line 1, characters 0-49.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the definition of t at line 4, characters 2-25.
+module type T = sig type t = t end
 |}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -245,12 +245,11 @@ module M : sig type 'a t : immutable_data with 'a end
 type 'a u : value mod contended with 'a @@ global
 type 'a t : value mod global = 'a u
 [%%expect {|
-type 'a u : value mod contended with 'a @@ global many portable aliased
+type 'a u : value mod contended with 'a
 Line 2, characters 0-35:
 2 | type 'a t : value mod global = 'a u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a u" is value mod contended
-         with 'a @@ global many portable aliased
+Error: The kind of type "'a u" is value mod contended with 'a
          because of the definition of u at line 1, characters 0-49.
        But the kind of type "'a u" must be a subkind of value mod global
          because of the definition of t at line 2, characters 0-35.
@@ -282,7 +281,7 @@ Error: Signature mismatch:
          because of the definition of t at line 2, characters 2-58.
 
        The first mode-crosses less than the second along:
-         contention: mod uncontended with 'a ≰ mod uncontended
+         contention: mod contended with 'a ≰ mod contended
          portability: mod portable with 'a ≰ mod portable
 |}]
 
@@ -358,7 +357,7 @@ Error: Signature mismatch:
          because of the definition of t at line 2, characters 2-75.
 
        The first mode-crosses less than the second along:
-         contention: mod uncontended with 'b ≰ mod uncontended with 'a
+         contention: mod contended with 'b ≰ mod contended with 'a
          portability: mod portable with 'a ≰ mod portable with 'b
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -159,7 +159,7 @@ Error: Signature mismatch:
          because of the definition of t at line 13, characters 2-29.
        But the kind of the first must be a subkind of
          value mod contended portable with M.t @@ global many aliased
-         because of the definition of t at line 11, characters 2-50.
+         because of the definition of t at line 11, characters 2-48.
 |}]
 
 module type S = sig
@@ -205,7 +205,7 @@ Error: Signature mismatch:
          because of the definition of t at line 15, characters 2-29.
        But the kind of the first must be a subkind of
          value mod contended portable with M.u @@ global many aliased
-         because of the definition of t at line 13, characters 2-50.
+         because of the definition of t at line 13, characters 2-48.
 |}]
 
 module M : sig
@@ -423,14 +423,12 @@ Error: Signature mismatch:
        Type declarations do not match:
          type t
        is not included in
-         type t
-           : value mod contended
-           with a @@ global many portable aliased
+         type t : value mod contended with a @@ global many portable aliased
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
        But the kind of the first must be a subkind of value mod contended
          with a @@ global many portable aliased
-         because of the definition of t at line 3, characters 2-39.
+         because of the definition of t at line 3, characters 2-37.
 |}]
 
 module M : sig
@@ -493,14 +491,12 @@ Error: Signature mismatch:
        Type declarations do not match:
          type t
        is not included in
-         type t
-           : value mod contended
-           with a @@ global many portable aliased
+         type t : value mod contended with a @@ global many portable aliased
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
        But the kind of the first must be a subkind of value mod contended
          with a @@ global many portable aliased
-         because of the definition of t at line 3, characters 2-39.
+         because of the definition of t at line 3, characters 2-37.
 |}]
 
 module type S = sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -148,17 +148,15 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t : value mod portable end
        is not included in
-         sig type t : value mod uncontended portable with M.t end
+         sig type t : value mod contended portable with M.t end
        Type declarations do not match:
          type t : value mod portable
        is not included in
-         type t
-           : value mod contended portable
-           with M.t @@ global many aliased
+         type t : value mod contended portable with M.t
        The kind of the first is value mod portable
          because of the definition of t at line 13, characters 2-29.
        But the kind of the first must be a subkind of
-         value mod contended portable with M.t @@ global many aliased
+         value mod contended portable with M.t
          because of the definition of t at line 11, characters 2-48.
 |}]
 
@@ -190,21 +188,15 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t : value mod portable end
        is not included in
-         sig
-           type t
-             : value mod contended portable
-             with M.u @@ global many aliased
-         end
+         sig type t : value mod contended portable with M.u end
        Type declarations do not match:
          type t : value mod portable
        is not included in
-         type t
-           : value mod contended portable
-           with M.u @@ global many aliased
+         type t : value mod contended portable with M.u
        The kind of the first is value mod portable
          because of the definition of t at line 15, characters 2-29.
        But the kind of the first must be a subkind of
-         value mod contended portable with M.u @@ global many aliased
+         value mod contended portable with M.u
          because of the definition of t at line 13, characters 2-48.
 |}]
 
@@ -414,20 +406,15 @@ Error: Signature mismatch:
        Modules do not match:
          sig type a = int ref * int type t end
        is not included in
-         sig
-           type a = int ref * int
-           type t
-             : value mod contended
-             with a @@ global many portable aliased
-         end
+         sig type a = int ref * int type t : value mod contended with a end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod contended with a @@ global many portable aliased
+         type t : value mod contended with a
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
        But the kind of the first must be a subkind of value mod contended
-         with a @@ global many portable aliased
+         with a
          because of the definition of t at line 3, characters 2-37.
 |}]
 
@@ -484,18 +471,16 @@ Error: Signature mismatch:
        is not included in
          sig
            type a = { foo : 'a. 'a; } [@@unboxed]
-           type t
-             : value mod contended
-             with a @@ global many portable aliased
+           type t : value mod contended with a
          end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod contended with a @@ global many portable aliased
+         type t : value mod contended with a
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
        But the kind of the first must be a subkind of value mod contended
-         with a @@ global many portable aliased
+         with a
          because of the definition of t at line 3, characters 2-37.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -132,7 +132,7 @@ module M : S with type t = a = struct
 end
 
 module _ : sig
-  type t : value mod portable uncontended with M.t
+  type t : value mod portable contended with M.t
 end = struct
   type t : value mod portable
 end
@@ -152,11 +152,13 @@ Error: Signature mismatch:
        Type declarations do not match:
          type t : value mod portable
        is not included in
-         type t : value mod uncontended portable with M.t
+         type t
+           : value mod contended portable
+           with M.t @@ global many aliased
        The kind of the first is value mod portable
          because of the definition of t at line 13, characters 2-29.
        But the kind of the first must be a subkind of
-         value mod uncontended portable with M.t
+         value mod contended portable with M.t @@ global many aliased
          because of the definition of t at line 11, characters 2-50.
 |}]
 
@@ -172,7 +174,7 @@ module M : S with type t := a = struct
 end
 
 module M : sig
-  type t : value mod portable uncontended with M.u
+  type t : value mod portable contended with M.u
 end = struct
   type t : value mod portable
 end
@@ -188,15 +190,21 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t : value mod portable end
        is not included in
-         sig type t : value mod uncontended portable with M.u end
+         sig
+           type t
+             : value mod contended portable
+             with M.u @@ global many aliased
+         end
        Type declarations do not match:
          type t : value mod portable
        is not included in
-         type t : value mod uncontended portable with M.u
+         type t
+           : value mod contended portable
+           with M.u @@ global many aliased
        The kind of the first is value mod portable
          because of the definition of t at line 15, characters 2-29.
        But the kind of the first must be a subkind of
-         value mod uncontended portable with M.u
+         value mod contended portable with M.u @@ global many aliased
          because of the definition of t at line 13, characters 2-50.
 |}]
 
@@ -390,7 +398,7 @@ Error: Signature mismatch:
 
 module M : sig
   type a = int ref * int
-  type t : value mod uncontended with a
+  type t : value mod contended with a
 end = struct
   type a = int ref * int
   type t
@@ -406,21 +414,28 @@ Error: Signature mismatch:
        Modules do not match:
          sig type a = int ref * int type t end
        is not included in
-         sig type a = int ref * int type t : value mod uncontended with a end
+         sig
+           type a = int ref * int
+           type t
+             : value mod contended
+             with a @@ global many portable aliased
+         end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod uncontended with a
+         type t
+           : value mod contended
+           with a @@ global many portable aliased
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
-       But the kind of the first must be a subkind of value mod uncontended
-         with a
+       But the kind of the first must be a subkind of value mod contended
+         with a @@ global many portable aliased
          because of the definition of t at line 3, characters 2-39.
 |}]
 
 module M : sig
   type a = #(int ref * int)
-  type t : value mod uncontended with a
+  type t : value mod contended with a
 end = struct
   type a = #(int ref * int)
   type t
@@ -442,7 +457,7 @@ module M : sig type a = int -> int type t end
 
 module M : sig
   type a = { foo : 'a. 'a ref } [@@unboxed]
-  type t : value mod uncontended with a
+  type t : value mod contended with a
 end = struct
   type a = { foo : 'a. 'a ref } [@@unboxed]
   type t
@@ -453,7 +468,7 @@ module M : sig type a = { foo : 'a. 'a ref; } [@@unboxed] type t end
 
 module M : sig
   type a = { foo : ('a : value). 'a } [@@unboxed]
-  type t : value mod uncontended with a
+  type t : value mod contended with a
 end = struct
   type a = { foo : ('a : value). 'a } [@@unboxed]
   type t
@@ -471,16 +486,20 @@ Error: Signature mismatch:
        is not included in
          sig
            type a = { foo : 'a. 'a; } [@@unboxed]
-           type t : value mod uncontended with a
+           type t
+             : value mod contended
+             with a @@ global many portable aliased
          end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod uncontended with a
+         type t
+           : value mod contended
+           with a @@ global many portable aliased
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
-       But the kind of the first must be a subkind of value mod uncontended
-         with a
+       But the kind of the first must be a subkind of value mod contended
+         with a @@ global many portable aliased
          because of the definition of t at line 3, characters 2-39.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
@@ -48,7 +48,14 @@ Error: Layout mismatch in final type declaration consistency check.
 
 type 'a mutable_list : mutable_data with 'a = Nil | Cons of 'a ref * 'a mutable_list
 [%%expect {|
-type 'a mutable_list = Nil | Cons of 'a ref * 'a mutable_list
+Line 1, characters 0-84:
+1 | type 'a mutable_list : mutable_data with 'a = Nil | Cons of 'a ref * 'a mutable_list
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "mutable_list" is value
+         because it's a boxed variant type.
+       But the kind of type "mutable_list" must be a subkind of mutable_data
+         with 'a
+         because of the annotation on the declaration of the type mutable_list.
 |}]
 
 type 'a mutable_list : mutable_data with 'a = Nil | Cons of { mutable hd : 'a; tl : 'a mutable_list }
@@ -237,7 +244,13 @@ type 'a t = Leaf | Node of int * 'a t
 
 type 'a mutable_list : mutable_data  = Nil | Cons of int ref * 'a mutable_list
 [%%expect {|
-type 'a mutable_list = Nil | Cons of int ref * 'a mutable_list
+Line 1, characters 0-78:
+1 | type 'a mutable_list : mutable_data  = Nil | Cons of int ref * 'a mutable_list
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "mutable_list" is value
+         because it's a boxed variant type.
+       But the kind of type "mutable_list" must be a subkind of mutable_data
+         because of the annotation on the declaration of the type mutable_list.
 |}]
 
 type t1

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
@@ -48,14 +48,7 @@ Error: Layout mismatch in final type declaration consistency check.
 
 type 'a mutable_list : mutable_data with 'a = Nil | Cons of 'a ref * 'a mutable_list
 [%%expect {|
-Line 1, characters 0-84:
-1 | type 'a mutable_list : mutable_data with 'a = Nil | Cons of 'a ref * 'a mutable_list
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "mutable_list" is value
-         because it's a boxed variant type.
-       But the kind of type "mutable_list" must be a subkind of mutable_data
-         with 'a
-         because of the annotation on the declaration of the type mutable_list.
+type 'a mutable_list = Nil | Cons of 'a ref * 'a mutable_list
 |}]
 
 type 'a mutable_list : mutable_data with 'a = Nil | Cons of { mutable hd : 'a; tl : 'a mutable_list }
@@ -244,13 +237,7 @@ type 'a t = Leaf | Node of int * 'a t
 
 type 'a mutable_list : mutable_data  = Nil | Cons of int ref * 'a mutable_list
 [%%expect {|
-Line 1, characters 0-78:
-1 | type 'a mutable_list : mutable_data  = Nil | Cons of int ref * 'a mutable_list
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "mutable_list" is value
-         because it's a boxed variant type.
-       But the kind of type "mutable_list" must be a subkind of mutable_data
-         because of the annotation on the declaration of the type mutable_list.
+type 'a mutable_list = Nil | Cons of int ref * 'a mutable_list
 |}]
 
 type t1

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -10,16 +10,16 @@ let use_portable : 'a @ portable -> unit = fun _ -> ()
 let use_many : 'a @ many -> unit = fun _ -> ()
 
 let cross_global : ('a : value mod global) -> unit = fun _ -> ()
-let cross_unique : ('a : value mod unique) -> unit = fun _ -> ()
-let cross_uncontended : ('a : value mod uncontended) -> unit = fun _ -> ()
+let cross_aliased : ('a : value mod aliased) -> unit = fun _ -> ()
+let cross_contended : ('a : value mod contended) -> unit = fun _ -> ()
 let cross_portable : ('a : value mod portable) -> unit = fun _ -> ()
 let cross_many : ('a : value mod many) -> unit = fun _ -> ()
 let cross_nonnull : ('a : value mod non_null) -> unit = fun _ -> ()
 let cross_external : ('a : value mod external_) -> unit = fun _ -> ()
 
 type ('a : value mod global) require_global
-type ('a : value mod unique) require_unique
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod aliased) require_aliased
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 type ('a : value mod many) require_many
 type ('a : value mod non_null) require_nonnull
@@ -31,15 +31,15 @@ val use_uncontended : 'a -> unit = <fun>
 val use_portable : 'a @ portable -> unit = <fun>
 val use_many : 'a -> unit = <fun>
 val cross_global : ('a : value mod global). 'a -> unit = <fun>
-val cross_unique : ('a : value mod unique). 'a -> unit = <fun>
-val cross_uncontended : ('a : value mod uncontended). 'a -> unit = <fun>
+val cross_aliased : ('a : value mod aliased). 'a -> unit = <fun>
+val cross_contended : ('a : value mod contended). 'a -> unit = <fun>
 val cross_portable : ('a : value mod portable). 'a -> unit = <fun>
 val cross_many : ('a : value mod many). 'a -> unit = <fun>
 val cross_nonnull : 'a -> unit = <fun>
 val cross_external : ('a : value mod external_). 'a -> unit = <fun>
 type ('a : value mod global) require_global
-type ('a : value mod unique) require_unique
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod aliased) require_aliased
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 type ('a : value mod many) require_many
 type 'a require_nonnull
@@ -87,28 +87,27 @@ type ('a : mutable_data) t : mutable_data = Foo of { x : 'a option }
 [%%expect {|
 type t = Foo of { mutable x : int; }
 type t = Foo of { x : int; } | Bar of { y : int; mutable z : int; }
-Line 3, characters 0-54:
-3 | type t : mutable_data = Foo of { mutable x : int ref }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod many unyielding
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of mutable_data
-         because of the annotation on the declaration of the type t.
+type t = Foo of { mutable x : int ref; }
+type t = Foo of int
+type ('a : mutable_data) t = Foo of 'a
+type ('a : immutable_data) t = Foo of 'a | Bar
+type t = Foo of int ref | Bar of string
+type ('a : mutable_data) t = Foo of { x : 'a option; }
 |}]
 
 (* annotations that aren't mutable_data or immutable_data *)
-type t : value mod uncontended = Foo of { x : unit -> unit }
-type 'a t : value mod uncontended = Foo of ('a -> 'a) | Bar
-type ('a : value mod uncontended portable, 'b : value mod portable) t : value mod portable
+type t : value mod contended = Foo of { x : unit -> unit }
+type 'a t : value mod contended = Foo of ('a -> 'a) | Bar
+type ('a : value mod contended portable, 'b : value mod portable) t : value mod portable
     = Foo of 'a | Bar of 'b
 type ('a : value mod many) t : value mod many = Foo of { x : 'a }
-type t : value mod uncontended portable = Foo of int
+type t : value mod contended portable = Foo of int
 type ('a : value mod portable many) t : value mod many = Foo of { mutable x : 'a } | Bar
 type 'a t : value mod non_null = Foo of 'a
 [%%expect {|
 type t = Foo of { x : unit -> unit; }
 type 'a t = Foo of ('a -> 'a) | Bar
-type ('a : value mod uncontended portable, 'b : value mod portable) t =
+type ('a : value mod contended portable, 'b : value mod portable) t =
     Foo of 'a
   | Bar of 'b
 type ('a : value mod many) t = Foo of { x : 'a; }
@@ -145,7 +144,7 @@ type t : immutable_data = Foo | Bar of int ref
 Line 1, characters 0-46:
 1 | type t : immutable_data = Foo | Bar of int ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
+Error: The kind of type "t" is mutable_data
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -156,7 +155,7 @@ type t : immutable_data = Foo of (unit -> unit)
 Line 1, characters 0-47:
 1 | type t : immutable_data = Foo of (unit -> unit)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod uncontended
+Error: The kind of type "t" is value mod contended
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -189,7 +188,7 @@ type t : mutable_data = Foo of { x : unit -> unit }
 Line 1, characters 0-51:
 1 | type t : mutable_data = Foo of { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod uncontended
+Error: The kind of type "t" is value mod contended
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -217,14 +216,14 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type ('a : value mod unique) t : value mod unique = Foo of 'a
+type ('a : value mod aliased) t : value mod aliased = Foo of 'a
 [%%expect {|
-Line 1, characters 0-61:
-1 | type ('a : value mod unique) t : value mod unique = Foo of 'a
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-63:
+1 | type ('a : value mod aliased) t : value mod aliased = Foo of 'a
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod unique
+       But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -246,22 +245,23 @@ type 'a t : mutable_data with 'a = Bar of { mutable x : 'a }
 type 'a t : mutable_data with 'a = Foo of 'a ref
 type ('a, 'b) t : immutable_data with 'a with 'b = Foo of { x : 'a; y : 'b; z : 'a }
 type ('a, 'b) t : mutable_data with 'a with 'b = Foo of { x : 'a; y : 'b; mutable z : 'a }
-type 'a t : value mod uncontended with 'a = Foo of { x : unit -> unit; y : 'a }
+type 'a t : value mod contended with 'a = Foo of { x : unit -> unit; y : 'a }
 type 'a t : immutable_data with 'a = Foo | Bar of { x : int }
-type 'a t : value mod uncontended with 'a = Foo of int
+type 'a t : value mod contended with 'a = Foo of int
 type 'a t : immutable_data with 'a = Foo of 'a option
 type 'a t : immutable_data with 'a -> 'a = Foo of { x : 'a -> 'a } | Bar of ('a -> 'a)
 [%%expect {|
 type 'a t = Foo
 type 'a t = Foo of 'a
 type 'a t = Bar of { mutable x : 'a; }
-Line 4, characters 0-48:
-4 | type 'a t : mutable_data with 'a = Foo of 'a ref
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of mutable_data
-         because of the annotation on the declaration of the type t.
+type 'a t = Foo of 'a ref
+type ('a, 'b) t = Foo of { x : 'a; y : 'b; z : 'a; }
+type ('a, 'b) t = Foo of { x : 'a; y : 'b; mutable z : 'a; }
+type 'a t = Foo of { x : unit -> unit; y : 'a; }
+type 'a t = Foo | Bar of { x : int; }
+type 'a t = Foo of int
+type 'a t = Foo of 'a option
+type 'a t = Foo of { x : 'a -> 'a; } | Bar of ('a -> 'a)
 |}]
 
 type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
@@ -280,7 +280,7 @@ type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
 Line 1, characters 0-60:
 1 | type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod uncontended
+Error: The kind of type "t" is value mod contended
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -297,14 +297,14 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-type 'a t : value mod unique with 'a = Foo of 'a
+type 'a t : value mod aliased with 'a = Foo of 'a
 [%%expect {|
-Line 1, characters 0-48:
-1 | type 'a t : value mod unique with 'a = Foo of 'a
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 0-49:
+1 | type 'a t : value mod aliased with 'a = Foo of 'a
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod unique
+       But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -536,7 +536,7 @@ let t = Foo 10
 let () =
   cross_many t;
   cross_portable t;
-  cross_uncontended t
+  cross_contended t
 
 [%%expect{|
 type t = Foo of int | Bar of string
@@ -568,11 +568,11 @@ val func : (unit -> unit) t = Foo <fun>
 let () =
   cross_many int;
   cross_portable int;
-  cross_uncontended int;
+  cross_contended int;
   cross_nonnull int
 
 let () =
-  cross_uncontended func;
+  cross_contended func;
   cross_nonnull func
 (* CR layouts v2.8: fix in principal case *)
 [%%expect {|
@@ -588,17 +588,17 @@ Error: This expression has type "int t" but an expression was expected of type
          because of the definition of cross_many at line 11, characters 49-60.
 |}]
 
-let () = cross_unique int
+let () = cross_aliased int
 [%%expect {|
-Line 1, characters 22-25:
-1 | let () = cross_unique int
-                          ^^^
+Line 1, characters 23-26:
+1 | let () = cross_aliased int
+                           ^^^
 Error: This expression has type "int t" but an expression was expected of type
-         "('a : value mod unique)"
+         "('a : value mod aliased)"
        The kind of int t is immutable_data
          because of the definition of t at line 1, characters 0-21.
-       But the kind of int t must be a subkind of value mod unique
-         because of the definition of cross_unique at line 8, characters 53-64.
+       But the kind of int t must be a subkind of value mod aliased
+         because of the definition of cross_aliased at line 8, characters 55-66.
 |}]
 
 let () = cross_portable func
@@ -632,18 +632,18 @@ Error: This expression has type "(unit -> unit) t"
 type 'a t = Foo of 'a
 type t_test = int t require_many
 type t_test = int t require_portable
-type t_test = int t require_uncontended
-type t_test = (unit -> unit) t require_uncontended
-type ('a : value mod uncontended) t_test = 'a t require_uncontended
+type t_test = int t require_contended
+type t_test = (unit -> unit) t require_contended
+type ('a : value mod contended) t_test = 'a t require_contended
 type 'a t_test = 'a t require_nonnull
 (* CR layouts v2.8: fix principal case *)
 [%%expect {|
 type 'a t = Foo of 'a
 type t_test = int t require_many
 type t_test = int t require_portable
-type t_test = int t require_uncontended
-type t_test = (unit -> unit) t require_uncontended
-type ('a : value mod uncontended) t_test = 'a t require_uncontended
+type t_test = int t require_contended
+type t_test = (unit -> unit) t require_contended
+type ('a : value mod contended) t_test = 'a t require_contended
 type 'a t_test = 'a t require_nonnull
 |}, Principal{|
 type 'a t = Foo of 'a
@@ -669,16 +669,16 @@ Error: This type "int t" should be an instance of type "('a : value mod global)"
          because of the definition of require_global at line 15, characters 0-43.
 |}]
 
-type t_test = int t require_unique
+type t_test = int t require_aliased
 [%%expect {|
 Line 1, characters 14-19:
-1 | type t_test = int t require_unique
+1 | type t_test = int t require_aliased
                   ^^^^^
-Error: This type "int t" should be an instance of type "('a : value mod unique)"
+Error: This type "int t" should be an instance of type "('a : value mod aliased)"
        The kind of int t is immutable_data
          because of the definition of t at line 1, characters 0-21.
-       But the kind of int t must be a subkind of value mod unique
-         because of the definition of require_unique at line 16, characters 0-43.
+       But the kind of int t must be a subkind of value mod aliased
+         because of the definition of require_aliased at line 16, characters 0-45.
 |}]
 
 type t_test = (unit -> unit) t require_portable
@@ -695,11 +695,11 @@ Error: This type "(unit -> unit) t" should be an instance of type
          because of the definition of require_portable at line 18, characters 0-47.
 |}]
 
-type ('a : value mod uncontended) t_test = 'a t require_portable
+type ('a : value mod contended) t_test = 'a t require_portable
 [%%expect {|
-Line 1, characters 43-47:
-1 | type ('a : value mod uncontended) t_test = 'a t require_portable
-                                               ^^^^
+Line 1, characters 41-45:
+1 | type ('a : value mod contended) t_test = 'a t require_portable
+                                             ^^^^
 Error: This type "'a t" should be an instance of type "('b : value mod portable)"
        The kind of 'a t is immutable_data
          because of the definition of t at line 1, characters 0-21.
@@ -841,7 +841,7 @@ Error: Signature mismatch:
          type t = Foo of int ref | Bar of string
        is not included in
          type t : immutable_data
-       The kind of the first is value
+       The kind of the first is mutable_data
          because of the definition of t at line 4, characters 2-41.
        But the kind of the first must be a subkind of immutable_data
          because of the definition of t at line 2, characters 2-25.

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -87,12 +87,13 @@ type ('a : mutable_data) t : mutable_data = Foo of { x : 'a option }
 [%%expect {|
 type t = Foo of { mutable x : int; }
 type t = Foo of { x : int; } | Bar of { y : int; mutable z : int; }
-type t = Foo of { mutable x : int ref; }
-type t = Foo of int
-type ('a : mutable_data) t = Foo of 'a
-type ('a : immutable_data) t = Foo of 'a | Bar
-type t = Foo of int ref | Bar of string
-type ('a : mutable_data) t = Foo of { x : 'a option; }
+Line 3, characters 0-54:
+3 | type t : mutable_data = Foo of { mutable x : int ref }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is value mod many unyielding
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of mutable_data
+         because of the annotation on the declaration of the type t.
 |}]
 
 (* annotations that aren't mutable_data or immutable_data *)
@@ -144,7 +145,7 @@ type t : immutable_data = Foo | Bar of int ref
 Line 1, characters 0-46:
 1 | type t : immutable_data = Foo | Bar of int ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -254,14 +255,13 @@ type 'a t : immutable_data with 'a -> 'a = Foo of { x : 'a -> 'a } | Bar of ('a 
 type 'a t = Foo
 type 'a t = Foo of 'a
 type 'a t = Bar of { mutable x : 'a; }
-type 'a t = Foo of 'a ref
-type ('a, 'b) t = Foo of { x : 'a; y : 'b; z : 'a; }
-type ('a, 'b) t = Foo of { x : 'a; y : 'b; mutable z : 'a; }
-type 'a t = Foo of { x : unit -> unit; y : 'a; }
-type 'a t = Foo | Bar of { x : int; }
-type 'a t = Foo of int
-type 'a t = Foo of 'a option
-type 'a t = Foo of { x : 'a -> 'a; } | Bar of ('a -> 'a)
+Line 4, characters 0-48:
+4 | type 'a t : mutable_data with 'a = Foo of 'a ref
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is value
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of mutable_data
+         because of the annotation on the declaration of the type t.
 |}]
 
 type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
@@ -841,7 +841,7 @@ Error: Signature mismatch:
          type t = Foo of int ref | Bar of string
        is not included in
          type t : immutable_data
-       The kind of the first is mutable_data
+       The kind of the first is value
          because of the definition of t at line 4, characters 2-41.
        But the kind of the first must be a subkind of immutable_data
          because of the definition of t at line 2, characters 2-25.

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -8,7 +8,7 @@ let use_unique : 'a @ unique -> unit = fun _ -> ()
 let use_uncontended : 'a @ uncontended -> unit = fun _ -> ()
 let use_portable : 'a @ portable -> unit = fun _ -> ()
 let use_many : 'a @ many -> unit = fun _ -> ()
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 [%%expect{|
 val use_global : 'a -> unit = <fun>
@@ -16,7 +16,7 @@ val use_unique : 'a @ unique -> unit = <fun>
 val use_uncontended : 'a -> unit = <fun>
 val use_portable : 'a @ portable -> unit = <fun>
 val use_many : 'a -> unit = <fun>
-type ('a : value mod uncontended) require_uncontended
+type ('a : value mod contended) require_contended
 type ('a : value mod portable) require_portable
 |}]
 
@@ -111,10 +111,7 @@ let foo (t : int ref option @@ nonportable once) =
     use_portable t;
     use_many t
 [%%expect{|
-Line 2, characters 17-18:
-2 |     use_portable t;
-                     ^
-Error: This value is "once" but expected to be "many".
+val foo : int ref option @ once -> unit = <fun>
 |}]
 
 let foo (t : int ref option @@ local) =
@@ -238,25 +235,23 @@ Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (* looks at kinds *)
-let foo (type a : value mod uncontended portable)
+let foo (type a : value mod contended portable)
       (t : a option @@ contended nonportable) =
   use_uncontended t;
   use_portable t
 
 [%%expect{|
-val foo :
-  ('a : value mod uncontended portable). 'a option @ contended -> unit =
+val foo : ('a : value mod contended portable). 'a option @ contended -> unit =
   <fun>
 |}]
 
 (* CR layouts v2.8: This should be accepted *)
-let foo (t : ('a : value mod uncontended portable) option @@ contended nonportable) =
+let foo (t : ('a : value mod contended portable) option @@ contended nonportable) =
   use_uncontended t;
   use_portable t
 
 [%%expect{|
-val foo :
-  ('a : value mod uncontended portable). 'a option @ contended -> unit =
+val foo : ('a : value mod contended portable). 'a option @ contended -> unit =
   <fun>
 |}, Principal{|
 Line 2, characters 18-19:
@@ -265,7 +260,7 @@ Line 2, characters 18-19:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (type a : value mod uncontended portable) (t : a option @@ once) =
+let foo (type a : value mod contended portable) (t : a option @@ once) =
   use_many t
 
 [%%expect{|
@@ -275,7 +270,7 @@ Line 2, characters 11-12:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : ('a : value mod uncontended portable) option @@ local) =
+let foo (t : ('a : value mod contended portable) option @@ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -285,7 +280,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (type a : value mod unique) (t : a option @@ aliased) =
+let foo (type a : value mod aliased) (t : a option @@ aliased) =
   use_unique t
 
 [%%expect{|
@@ -386,10 +381,7 @@ let foo (t : int ref list @@ nonportable once) =
     use_portable t;
     use_many t
 [%%expect{|
-Line 2, characters 17-18:
-2 |     use_portable t;
-                     ^
-Error: This value is "once" but expected to be "many".
+val foo : int ref list @ once -> unit = <fun>
 |}]
 
 let foo (t : int ref list @@ local) =
@@ -513,17 +505,17 @@ Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (* looks at kinds *)
-let foo (type a : value mod uncontended portable)
+let foo (type a : value mod contended portable)
       (t : a list @@ contended nonportable) =
   use_uncontended t;
   use_portable t
 
 [%%expect{|
-val foo : ('a : value mod uncontended portable). 'a list @ contended -> unit =
+val foo : ('a : value mod contended portable). 'a list @ contended -> unit =
   <fun>
 |}]
 
-let foo (type a : value mod uncontended portable) (t : a list @@ once) =
+let foo (type a : value mod contended portable) (t : a list @@ once) =
   use_many t
 
 [%%expect{|
@@ -533,7 +525,7 @@ Line 2, characters 11-12:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (type a : value mod uncontended portable) (t : a list @@ local) =
+let foo (type a : value mod contended portable) (t : a list @@ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -543,7 +535,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (type a : value mod uncontended portable) (t : a list @@ aliased) =
+let foo (type a : value mod contended portable) (t : a list @@ aliased) =
   use_unique t
 
 [%%expect{|
@@ -620,15 +612,15 @@ val depth : 'a t -> int = <fun>
 (*************************)
 (* TEST: gadt refinement *)
 
-type 'a uncontended_with : value mod uncontended with 'a
+type 'a contended_with : value mod contended with 'a
 type _ t =
-  | Foo : ('a : value mod uncontended) t
+  | Foo : ('a : value mod contended) t
 [%%expect {|
-type 'a uncontended_with : value mod uncontended
-type _ t = Foo : ('a : value mod uncontended). 'a t
+type 'a contended_with : value mod contended
+type _ t = Foo : ('a : value mod contended). 'a t
 |}]
 
-let f (type a) (t : a t) (x : a uncontended_with @@ contended) : _ @@ uncontended =
+let f (type a) (t : a t) (x : a contended_with @@ contended) : _ @@ uncontended =
   match t with
   | _ -> x
 [%%expect {|
@@ -639,12 +631,11 @@ Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 
-let f (type a) (t : a t) (x : a uncontended_with @@ contended) : _ @@ uncontended =
+let f (type a) (t : a t) (x : a contended_with @@ contended) : _ @@ uncontended =
   match t with
   | Foo -> x
 [%%expect {|
-val f : 'a t -> 'a uncontended_with @ contended -> 'a uncontended_with =
-  <fun>
+val f : 'a t -> 'a contended_with @ contended -> 'a contended_with = <fun>
 |}]
 
 (**************************************)
@@ -683,14 +674,14 @@ Error: The kind of type "Value.t" is value
 (* TEST: abstract types *)
 
 (*********************)
-type t : value mod uncontended with int
+type t : value mod contended with int
 [%%expect {|
-type t : value mod uncontended
+type t : value mod contended
 |}]
 
-type t_test = t require_uncontended
+type t_test = t require_contended
 [%%expect {|
-type t_test = t require_uncontended
+type t_test = t require_contended
 |}]
 
 type t_test = t require_portable
@@ -699,8 +690,8 @@ Line 1, characters 14-15:
 1 | type t_test = t require_portable
                   ^
 Error: This type "t" should be an instance of type "('a : value mod portable)"
-       The kind of t is value mod uncontended
-         because of the definition of t at line 1, characters 0-39.
+       The kind of t is value mod contended
+         because of the definition of t at line 1, characters 0-37.
        But the kind of t must be a subkind of value mod portable
          because of the definition of require_portable at line 7, characters 0-47.
 |}]
@@ -719,9 +710,9 @@ Error: This value is "nonportable" but expected to be "portable".
 |}]
 
 (*********************)
-type 'a t : value mod uncontended with int
+type 'a t : value mod contended with int
 [%%expect {|
-type 'a t : value mod uncontended
+type 'a t : value mod contended
 |}]
 
 let foo (t : _ t @@ contended) = use_uncontended t
@@ -738,9 +729,9 @@ Error: This value is "nonportable" but expected to be "portable".
 |}]
 
 (*********************)
-type 'a t : value mod uncontended with 'a
+type 'a t : value mod contended with 'a
 [%%expect {|
-type 'a t : value mod uncontended
+type 'a t : value mod contended
 |}]
 
 let foo (t : int t @@ contended) = use_uncontended t
@@ -765,25 +756,25 @@ Error: This value is "nonportable" but expected to be "portable".
 |}]
 
 (*********************)
-type ('a : immutable_data) t : value mod uncontended with 'a
+type ('a : immutable_data) t : value mod contended with 'a
 [%%expect {|
-type ('a : immutable_data) t : value mod uncontended
+type ('a : immutable_data) t : value mod contended
 |}]
 
-type 'a t_test = 'a t require_uncontended
+type 'a t_test = 'a t require_contended
 (* CR layouts v2.8: fix principal case *)
 [%%expect {|
-type ('a : immutable_data) t_test = 'a t require_uncontended
+type ('a : immutable_data) t_test = 'a t require_contended
 |}, Principal{|
 Line 1, characters 17-21:
-1 | type 'a t_test = 'a t require_uncontended
+1 | type 'a t_test = 'a t require_contended
                      ^^^^
 Error: This type "'a t" should be an instance of type
-         "('b : value mod uncontended)"
-       The kind of 'a t is value mod uncontended
-         because of the definition of t at line 1, characters 0-60.
-       But the kind of 'a t must be a subkind of value mod uncontended
-         because of the definition of require_uncontended at line 6, characters 0-53.
+         "('b : value mod contended)"
+       The kind of 'a t is value mod contended
+         because of the definition of t at line 1, characters 0-58.
+       But the kind of 'a t must be a subkind of value mod contended
+         because of the definition of require_contended at line 6, characters 0-49.
 |}]
 
 let foo (t : int t @@ contended) = use_uncontended t
@@ -811,39 +802,38 @@ Error: This value is "nonportable" but expected to be "portable".
 |}]
 
 (*********************)
-type ('a, 'b) t : value mod uncontended with 'a with 'b
+type ('a, 'b) t : value mod contended with 'a with 'b
 [%%expect {|
-type ('a, 'b) t : value mod uncontended
+type ('a, 'b) t : value mod contended
 |}]
 
-type t_test = (int, int) t require_uncontended
+type t_test = (int, int) t require_contended
 (* CR layouts v2.8: fix principal case *)
 [%%expect {|
-type t_test = (int, int) t require_uncontended
+type t_test = (int, int) t require_contended
 |}, Principal{|
 Line 1, characters 14-26:
-1 | type t_test = (int, int) t require_uncontended
+1 | type t_test = (int, int) t require_contended
                   ^^^^^^^^^^^^
 Error: This type "(int, int) t" should be an instance of type
-         "('a : value mod uncontended)"
-       The kind of (int, int) t is value mod uncontended
-         because of the definition of t at line 1, characters 0-55.
-       But the kind of (int, int) t must be a subkind of
-         value mod uncontended
-         because of the definition of require_uncontended at line 6, characters 0-53.
+         "('a : value mod contended)"
+       The kind of (int, int) t is value mod contended
+         because of the definition of t at line 1, characters 0-53.
+       But the kind of (int, int) t must be a subkind of value mod contended
+         because of the definition of require_contended at line 6, characters 0-49.
 |}]
 
-type ('a, 'b) t_test = ('a, 'b) t require_uncontended
+type ('a, 'b) t_test = ('a, 'b) t require_contended
 [%%expect {|
 Line 1, characters 23-33:
-1 | type ('a, 'b) t_test = ('a, 'b) t require_uncontended
+1 | type ('a, 'b) t_test = ('a, 'b) t require_contended
                            ^^^^^^^^^^
 Error: This type "('a, 'b) t" should be an instance of type
-         "('c : value mod uncontended)"
-       The kind of ('a, 'b) t is value mod uncontended
-         because of the definition of t at line 1, characters 0-55.
-       But the kind of ('a, 'b) t must be a subkind of value mod uncontended
-         because of the definition of require_uncontended at line 6, characters 0-53.
+         "('c : value mod contended)"
+       The kind of ('a, 'b) t is value mod contended
+         because of the definition of t at line 1, characters 0-53.
+       But the kind of ('a, 'b) t must be a subkind of value mod contended
+         because of the definition of require_contended at line 6, characters 0-49.
 |}]
 
 let foo (t : (int, int) t @@ contended) = use_uncontended t
@@ -871,12 +861,12 @@ Error: This value is "contended" but expected to be "uncontended".
 (* TEST: abstract types can hide mode crossing behavior *)
 
 module T : sig
-  type t : value mod uncontended
+  type t : value mod contended
 end = struct
   type t = { x : int }
 end
 [%%expect {|
-module T : sig type t : value mod uncontended end
+module T : sig type t : value mod contended end
 |}]
 
 let foo (t : T.t @@ contended) = use_uncontended t
@@ -894,12 +884,12 @@ Error: This value is "nonportable" but expected to be "portable".
 
 (*********************)
 module T : sig
-  type 'a t : value mod uncontended with 'a
+  type 'a t : value mod contended with 'a
 end = struct
   type 'a t = { x : 'a }
 end
 [%%expect {|
-module T : sig type 'a t : value mod uncontended end
+module T : sig type 'a t : value mod contended end
 |}]
 
 let foo (t : int T.t @@ contended) = use_uncontended t

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -111,7 +111,10 @@ let foo (t : int ref option @@ nonportable once) =
     use_portable t;
     use_many t
 [%%expect{|
-val foo : int ref option @ once -> unit = <fun>
+Line 2, characters 17-18:
+2 |     use_portable t;
+                     ^
+Error: This value is "once" but expected to be "many".
 |}]
 
 let foo (t : int ref option @@ local) =
@@ -383,7 +386,10 @@ let foo (t : int ref list @@ nonportable once) =
     use_portable t;
     use_many t
 [%%expect{|
-val foo : int ref list @ once -> unit = <fun>
+Line 2, characters 17-18:
+2 |     use_portable t;
+                     ^
+Error: This value is "once" but expected to be "many".
 |}]
 
 let foo (t : int ref list @@ local) =

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -759,7 +759,7 @@ Line 1, characters 0-61:
 1 | type q : any mod portable = #{ x : int -> int; y : int -> q }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "q" is
-         value mod unique uncontended & value mod unique uncontended
+         value mod aliased contended & value mod aliased contended
          because it is an unboxed record.
        But the kind of type "q" must be a subkind of
          value_or_null mod portable & value_or_null mod portable

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -11,9 +11,9 @@ type t : value mod contended = { mutable contents : string }
 [%%expect{|
 val use_as_value : 'a -> 'a = <fun>
 val use_uncontended : 'a -> 'a = <fun>
-Line 5, characters 0-62:
+Line 5, characters 0-60:
 5 | type t : value mod contended = { mutable contents : string }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is mutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod contended
@@ -282,7 +282,7 @@ Lines 4-7, characters 6-3:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           type t : value mod portable contended = { mutable x : int; }
+           type t : value mod contended portable = { mutable x : int; }
            [@@unsafe_allow_any_mode_crossing]
          end
        is not included in
@@ -291,7 +291,7 @@ Error: Signature mismatch:
            [@@unsafe_allow_any_mode_crossing]
          end
        Type declarations do not match:
-         type t : value mod portable contended = { mutable x : int; }
+         type t : value mod contended portable = { mutable x : int; }
        [@@unsafe_allow_any_mode_crossing]
        is not included in
          type t : value mod contended = { mutable x : int; }
@@ -316,7 +316,7 @@ end
 module A : sig type t : mutable_data mod global external_ end
 module B :
   sig
-    type t : value mod portable contended = { a : A.t; }
+    type t : value mod contended portable = { a : A.t; }
     [@@unsafe_allow_any_mode_crossing]
     val a : t -> A.t
   end

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -7,25 +7,25 @@ let use_as_value : ('a : value) -> 'a = fun x -> x
 let use_uncontended : 'a @ uncontended -> 'a = fun x -> x
 
 (* Baseline: if the jkind doesn't match, we should get an error. *)
-type t : value mod uncontended = { mutable contents : string }
+type t : value mod contended = { mutable contents : string }
 [%%expect{|
 val use_as_value : 'a -> 'a = <fun>
 val use_uncontended : 'a -> 'a = <fun>
 Line 5, characters 0-62:
-5 | type t : value mod uncontended = { mutable contents : string }
+5 | type t : value mod contended = { mutable contents : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is mutable_data
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod uncontended
+       But the kind of type "t" must be a subkind of value mod contended
          because of the annotation on the declaration of the type t.
 |}]
 
 (* On the other hand, if we set the attribute, we shouldn't get an error. *)
-type t : value mod uncontended = { mutable contents : string }
+type t : value mod contended = { mutable contents : string }
 [@@unsafe_allow_any_mode_crossing]
 let f (x : t @@ contended) = use_uncontended x
 [%%expect{|
-type t : value mod uncontended = { mutable contents : string; }
+type t : value mod contended = { mutable contents : string; }
 [@@unsafe_allow_any_mode_crossing]
 val f : t @ contended -> t = <fun>
 |}]
@@ -42,11 +42,11 @@ Error: [@@unsafe_allow_any_mode_crossing] is not allowed on this kind of type de
 |}]
 
 (* The attribute shouldn't allow us to change the layout *)
-type t : float64 mod uncontended = { mutable contents : string }
+type t : float64 mod contended = { mutable contents : string }
 [@@unsafe_allow_any_mode_crossing]
 [%%expect{|
 Lines 1-2, characters 0-34:
-1 | type t : float64 mod uncontended = { mutable contents : string }
+1 | type t : float64 mod contended = { mutable contents : string }
 2 | [@@unsafe_allow_any_mode_crossing]
 Error: The layout of type "t" is value
          because it's a boxed record type.
@@ -66,15 +66,15 @@ Error: [@@unsafe_allow_any_mode_crossing] is not allowed with a kind annotation 
 
 (* Abstract types in signatures should work with the unsafe kind *)
 module M : sig
-  type t : value mod uncontended
+  type t : value mod contended
 end = struct
-  type t : value mod uncontended = { mutable contents : string }
+  type t : value mod contended = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
   let f (x : t @@ contended) = use_uncontended x
 end
 [%%expect{|
-module M : sig type t : value mod uncontended end
+module M : sig type t : value mod contended end
 |}]
 
 (* Setting the attribute on an open or abstract type is not allowed *)
@@ -100,19 +100,19 @@ Error: [@@unsafe_allow_any_mode_crossing] is not allowed on this kind of type de
 
 
 module M1 : sig
-  type t : value mod uncontended = { mutable contents : string }
+  type t : value mod contended = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 end = struct
-  type t : value mod uncontended = { mutable contents : string }
+  type t : value mod contended = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
   let f (x : t @@ contended) = use_uncontended x
 end
 module M2 : sig
-  type t : value mod uncontended = M1.t = { mutable contents : string }
+  type t : value mod contended = M1.t = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 end = struct
-  type t : value mod uncontended = M1.t = { mutable contents : string }
+  type t : value mod contended = M1.t = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
   let f (x : t @@ contended) = use_uncontended x
@@ -120,22 +120,22 @@ end
 [%%expect{|
 module M1 :
   sig
-    type t : value mod uncontended = { mutable contents : string; }
+    type t : value mod contended = { mutable contents : string; }
     [@@unsafe_allow_any_mode_crossing]
   end
 module M2 :
   sig
-    type t = M1.t : value mod uncontended = { mutable contents : string; }
+    type t = M1.t : value mod contended = { mutable contents : string; }
     [@@unsafe_allow_any_mode_crossing]
   end
 |}]
 
 (* Private types still require the attribute *)
 module Private : sig
-  type t : value mod uncontended = private { mutable contents : string }
+  type t : value mod contended = private { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 end = struct
-  type t  : value mod uncontended = { mutable contents : string }
+  type t  : value mod contended = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
   let f (x : t @@ contended) = use_uncontended x
@@ -143,31 +143,31 @@ end
 [%%expect{|
 module Private :
   sig
-    type t : value mod uncontended = private { mutable contents : string; }
+    type t : value mod contended = private { mutable contents : string; }
     [@@unsafe_allow_any_mode_crossing]
   end
 |}]
 
 (* Non-abstract types in signatures should work as long as they specify the attribute *)
 module M : sig
-  type t1 : value mod uncontended = { mutable contents : string }
+  type t1 : value mod contended = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
-  type t2 : value mod uncontended = private { mutable contents : string }
+  type t2 : value mod contended = private { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
-  type t3 : value mod uncontended =
+  type t3 : value mod contended =
     | Immut of string
     | Mut of { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 end = struct
-  type t1 : value mod uncontended = { mutable contents : string }
+  type t1 : value mod contended = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
-  type t2 : value mod uncontended = { mutable contents : string }
+  type t2 : value mod contended = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
-  type t3 : value mod uncontended =
+  type t3 : value mod contended =
     | Immut of string
     | Mut of { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
@@ -179,12 +179,12 @@ end
 [%%expect{|
 module M :
   sig
-    type t1 : value mod uncontended = { mutable contents : string; }
+    type t1 : value mod contended = { mutable contents : string; }
     [@@unsafe_allow_any_mode_crossing]
-    type t2 : value mod uncontended = private { mutable contents : string; }
+    type t2 : value mod contended = private { mutable contents : string; }
     [@@unsafe_allow_any_mode_crossing]
     type t3
-      : value mod uncontended =
+      : value mod contended =
         Immut of string
       | Mut of { mutable contents : string; }
     [@@unsafe_allow_any_mode_crossing]
@@ -194,7 +194,7 @@ module M :
 (* [@@unsafe_allow_any_mode_crossing] should not allow you to weaken the modal bounds on a
    kind in module inclusion *)
 module M : sig
-  type t : value mod uncontended = { mutable x : int } [@@unsafe_allow_any_mode_crossing]
+  type t : value mod contended = { mutable x : int } [@@unsafe_allow_any_mode_crossing]
 end = struct
   type t = { mutable x : int }
 end
@@ -208,13 +208,13 @@ Error: Signature mismatch:
          sig type t = { mutable x : int; } end
        is not included in
          sig
-           type t : value mod uncontended = { mutable x : int; }
+           type t : value mod contended = { mutable x : int; }
            [@@unsafe_allow_any_mode_crossing]
          end
        Type declarations do not match:
          type t = { mutable x : int; }
        is not included in
-         type t : value mod uncontended = { mutable x : int; }
+         type t : value mod contended = { mutable x : int; }
        [@@unsafe_allow_any_mode_crossing]
        They have different unsafe mode crossing behavior:
        the second has [@@unsafe_allow_any_mode_crossing], but the first does not
@@ -222,7 +222,7 @@ Error: Signature mismatch:
 
 
 module type S = sig
-  type t : value mod uncontended = { mutable x : int } [@@unsafe_allow_any_mode_crossing]
+  type t : value mod contended = { mutable x : int } [@@unsafe_allow_any_mode_crossing]
 end
 
 module M = struct
@@ -233,7 +233,7 @@ module _ = (M : S)
 [%%expect{|
 module type S =
   sig
-    type t : value mod uncontended = { mutable x : int; }
+    type t : value mod contended = { mutable x : int; }
     [@@unsafe_allow_any_mode_crossing]
   end
 module M : sig type t = { mutable x : int; } end
@@ -248,7 +248,7 @@ Error: Signature mismatch:
        Type declarations do not match:
          type t = M.t = { mutable x : int; }
        is not included in
-         type t : value mod uncontended = { mutable x : int; }
+         type t : value mod contended = { mutable x : int; }
        [@@unsafe_allow_any_mode_crossing]
        They have different unsafe mode crossing behavior:
        the second has [@@unsafe_allow_any_mode_crossing], but the first does not
@@ -267,34 +267,34 @@ Error: This variant or record definition does not match that of type "M.t"
 (** The mod-bounds must be equal if the attribute is specified in both the sig and the
     struct *)
 module M : sig
-  type t : value mod uncontended = { mutable x : int }
+  type t : value mod contended = { mutable x : int }
   [@@unsafe_allow_any_mode_crossing]
 end = struct
-  type t : value mod portable uncontended = { mutable x : int }
+  type t : value mod portable contended = { mutable x : int }
   [@@unsafe_allow_any_mode_crossing]
 end
 [%%expect{|
 Lines 4-7, characters 6-3:
 4 | ......struct
-5 |   type t : value mod portable uncontended = { mutable x : int }
+5 |   type t : value mod portable contended = { mutable x : int }
 6 |   [@@unsafe_allow_any_mode_crossing]
 7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig
-           type t : value mod uncontended portable = { mutable x : int; }
+           type t : value mod portable contended = { mutable x : int; }
            [@@unsafe_allow_any_mode_crossing]
          end
        is not included in
          sig
-           type t : value mod uncontended = { mutable x : int; }
+           type t : value mod contended = { mutable x : int; }
            [@@unsafe_allow_any_mode_crossing]
          end
        Type declarations do not match:
-         type t : value mod uncontended portable = { mutable x : int; }
+         type t : value mod portable contended = { mutable x : int; }
        [@@unsafe_allow_any_mode_crossing]
        is not included in
-         type t : value mod uncontended = { mutable x : int; }
+         type t : value mod contended = { mutable x : int; }
        [@@unsafe_allow_any_mode_crossing]
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their mod-bounds are not equal
@@ -307,16 +307,16 @@ end = struct
 end
 
 module B = struct
-  type t : value mod portable uncontended = { a : A.t }
+  type t : value mod portable contended = { a : A.t }
   [@@unsafe_allow_any_mode_crossing]
 
   let a t = t.a
 end
 [%%expect{|
-module A : sig type t : immediate end
+module A : sig type t : mutable_data mod global external_ end
 module B :
   sig
-    type t : value mod uncontended portable = { a : A.t; }
+    type t : value mod portable contended = { a : A.t; }
     [@@unsafe_allow_any_mode_crossing]
     val a : t -> A.t
   end

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -1876,7 +1876,7 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value mod unique uncontended
+       The kind of 'a -> 'b is value mod aliased contended
          because it's a function type.
        But the kind of 'a -> 'b must be a subkind of immediate
          because of the definition of t35 at line 1, characters 0-30.
@@ -2866,7 +2866,7 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression is used as a function, but its type "'a"
        has kind "bits64", which cannot be the kind of a function.
-       (Functions always have kind "value mod unique uncontended".)
+       (Functions always have kind "value mod aliased contended".)
 |}]
 
 let f (x : ('a : value mod portable)) = x ()
@@ -2877,7 +2877,7 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression is used as a function, but its type "'a"
        has kind "value mod portable", which cannot be the kind of a function.
-       (Functions always have kind "value mod unique uncontended".)
+       (Functions always have kind "value mod aliased contended".)
 |}]
 
 let f (x : ('a : value)) = x ()

--- a/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -1802,7 +1802,7 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value mod unique uncontended
+       The kind of 'a -> 'b is value mod aliased contended
          because it's a function type.
        But the kind of 'a -> 'b must be a subkind of immediate
          because of the definition of t35 at line 1, characters 0-30.

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -688,7 +688,7 @@ let ref_immutable_data_right x =
 Line 2, characters 30-53:
 2 |   take_strong_immutable_data (weaken_immutable_data x : float ref);
                                   ^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value is "contended" but expected to be "uncontended".
+Error: This value is "once" but expected to be "many".
 |}]
 
 let ref_immutable_data_left x =
@@ -698,7 +698,7 @@ let ref_immutable_data_left x =
 Line 3, characters 29-30:
 3 |   take_strong_immutable_data x
                                  ^
-Error: This value is "contended" but expected to be "uncontended".
+Error: This value is "once" but expected to be "many".
 |}]
 
 let float_immutable_data_right x =

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -688,7 +688,7 @@ let ref_immutable_data_right x =
 Line 2, characters 30-53:
 2 |   take_strong_immutable_data (weaken_immutable_data x : float ref);
                                   ^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value is "once" but expected to be "many".
+Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 let ref_immutable_data_left x =
@@ -698,7 +698,7 @@ let ref_immutable_data_left x =
 Line 3, characters 29-30:
 3 |   take_strong_immutable_data x
                                  ^
-Error: This value is "once" but expected to be "many".
+Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 let float_immutable_data_right x =

--- a/testsuite/tests/typing-modes/crossing.ml
+++ b/testsuite/tests/typing-modes/crossing.ml
@@ -87,3 +87,204 @@ end
 [%%expect{|
 module M : sig val f : local_ int -> int end
 |}]
+
+(* Check all the mode crossing coercions *)
+
+type cross_global : value mod global
+type cross_local : value mod local
+type cross_many : value mod many
+type cross_once : value mod once
+type cross_portable : value mod portable
+type cross_nonportable : value mod nonportable
+type cross_unyielding : value mod unyielding
+type cross_yielding : value mod yielding
+type cross_aliased : value mod aliased
+type cross_unique : value mod unique
+type cross_contended : value mod contended
+type cross_shared : value mod shared
+type cross_uncontended : value mod uncontended
+[%%expect{|
+type cross_global : value mod global
+type cross_local
+type cross_many : value mod many
+type cross_once
+type cross_portable : value mod portable
+type cross_nonportable
+type cross_unyielding : value mod unyielding
+type cross_yielding
+type cross_aliased
+type cross_unique : value mod unique
+type cross_contended
+type cross_shared : value mod shared
+type cross_uncontended : value mod uncontended
+|}]
+
+let cross_global (x : cross_global @@ local) : _ @@ global = x
+[%%expect{|
+val cross_global : local_ cross_global -> cross_global = <fun>
+|}]
+
+let cross_local (x : cross_local @@ local) : _ @@ global = x
+[%%expect{|
+Line 1, characters 59-60:
+1 | let cross_local (x : cross_local @@ local) : _ @@ global = x
+                                                               ^
+Error: This value escapes its region.
+|}]
+
+let cross_many (x : cross_many @@ once) : _ @@ many = x
+[%%expect{|
+val cross_many : cross_many @ once -> cross_many = <fun>
+|}]
+
+let cross_once (x : cross_once @@ once) : _ @@ many = x
+[%%expect{|
+Line 1, characters 54-55:
+1 | let cross_once (x : cross_once @@ once) : _ @@ many = x
+                                                          ^
+Error: This value is "once" but expected to be "many".
+|}]
+
+let cross_portable (x : cross_portable @@ nonportable) : _ @@ portable = x
+[%%expect{|
+val cross_portable : cross_portable -> cross_portable @ portable = <fun>
+|}]
+
+let cross_nonportable (x : cross_nonportable @@ nonportable) : _ @@ portable = x
+[%%expect{|
+Line 1, characters 79-80:
+1 | let cross_nonportable (x : cross_nonportable @@ nonportable) : _ @@ portable = x
+                                                                                   ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+let cross_unyielding (x : cross_unyielding @@ yielding) : _ @@ unyielding = x
+[%%expect{|
+val cross_unyielding : cross_unyielding @ yielding -> cross_unyielding =
+  <fun>
+|}]
+
+let cross_yielding (x : cross_yielding @@ yielding) : _ @@ unyielding = x
+[%%expect{|
+Line 1, characters 72-73:
+1 | let cross_yielding (x : cross_yielding @@ yielding) : _ @@ unyielding = x
+                                                                            ^
+Error: This value is "yielding" but expected to be "unyielding".
+|}]
+
+let cross_aliased (x : cross_aliased @@ aliased) : _ @@ unique = x
+[%%expect{|
+Line 1, characters 65-66:
+1 | let cross_aliased (x : cross_aliased @@ aliased) : _ @@ unique = x
+                                                                     ^
+Error: This value is "aliased" but expected to be "unique".
+|}]
+
+let cross_unique (x : cross_unique @@ aliased) : _ @@ unique = x
+[%%expect{|
+val cross_unique : cross_unique -> cross_unique @ unique = <fun>
+|}]
+
+let cross_contended1 (x : cross_contended @@ shared) : _ @@ uncontended = x
+[%%expect{|
+Line 1, characters 74-75:
+1 | let cross_contended1 (x : cross_contended @@ shared) : _ @@ uncontended = x
+                                                                              ^
+Error: This value is "shared" but expected to be "uncontended".
+|}]
+
+let cross_contended2 (x : cross_contended @@ contended) : _ @@ shared = x
+[%%expect{|
+Line 1, characters 72-73:
+1 | let cross_contended2 (x : cross_contended @@ contended) : _ @@ shared = x
+                                                                            ^
+Error: This value is "contended" but expected to be "shared".
+|}]
+
+let cross_shared1 (x : cross_shared @@ shared) : _ @@ uncontended = x
+[%%expect{|
+Line 1, characters 68-69:
+1 | let cross_shared1 (x : cross_shared @@ shared) : _ @@ uncontended = x
+                                                                        ^
+Error: This value is "shared" but expected to be "uncontended".
+|}]
+
+let cross_shared2 (x : cross_shared @@ contended) : _ @@ shared = x
+[%%expect{|
+val cross_shared2 : cross_shared @ contended -> cross_shared @ shared = <fun>
+|}]
+
+let cross_uncontended1 (x : cross_uncontended @@ shared) : _ @@ uncontended = x
+[%%expect{|
+val cross_uncontended1 : cross_uncontended @ shared -> cross_uncontended =
+  <fun>
+|}]
+
+let cross_uncontended2 (x : cross_uncontended @@ contended) : _ @@ shared = x
+[%%expect{|
+val cross_uncontended2 :
+  cross_uncontended @ contended -> cross_uncontended @ shared = <fun>
+|}]
+
+(* Check that all modalities cross modes -- does not currently work *)
+
+type t
+type s : value mod global = { v : t @@ global } [@@unboxed]
+[%%expect{|
+type t
+Line 2, characters 0-59:
+2 | type s : value mod global = { v : t @@ global } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "s" is value
+         because of the definition of t at line 1, characters 0-6.
+       But the kind of type "s" must be a subkind of value mod global
+         because of the annotation on the declaration of the type s.
+|}]
+type s : value mod many = { v : t @@ many } [@@unboxed]
+[%%expect{|
+Line 1, characters 0-55:
+1 | type s : value mod many = { v : t @@ many } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "s" is value
+         because of the definition of t at line 1, characters 0-6.
+       But the kind of type "s" must be a subkind of value mod many
+         because of the annotation on the declaration of the type s.
+|}]
+type s : value mod portable = { v : t @@ portable } [@@unboxed]
+[%%expect{|
+Line 1, characters 0-63:
+1 | type s : value mod portable = { v : t @@ portable } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "s" is value
+         because of the definition of t at line 1, characters 0-6.
+       But the kind of type "s" must be a subkind of value mod portable
+         because of the annotation on the declaration of the type s.
+|}]
+type s : value mod unyielding = { v : t @@ unyielding } [@@unboxed]
+[%%expect{|
+Line 1, characters 0-67:
+1 | type s : value mod unyielding = { v : t @@ unyielding } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "s" is value
+         because of the definition of t at line 1, characters 0-6.
+       But the kind of type "s" must be a subkind of value mod unyielding
+         because of the annotation on the declaration of the type s.
+|}]
+type s : value mod aliased = { v : t @@ aliased } [@@unboxed]
+[%%expect{|
+type s = { v : t @@ aliased; } [@@unboxed]
+|}]
+type s : value mod contended = { v : t @@ contended } [@@unboxed]
+[%%expect{|
+type s = { v : t @@ contended; } [@@unboxed]
+|}]
+type s : value mod shared = { v : t @@ shared } [@@unboxed]
+[%%expect{|
+Line 1, characters 0-59:
+1 | type s : value mod shared = { v : t @@ shared } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "s" is value
+         because of the definition of t at line 1, characters 0-6.
+       But the kind of type "s" must be a subkind of value mod shared
+         because of the annotation on the declaration of the type s.
+|}]

--- a/testsuite/tests/typing-modes/crossing.ml
+++ b/testsuite/tests/typing-modes/crossing.ml
@@ -112,11 +112,11 @@ type cross_portable : value mod portable
 type cross_nonportable
 type cross_unyielding : value mod unyielding
 type cross_yielding
-type cross_aliased
-type cross_unique : value mod unique
-type cross_contended
+type cross_aliased : value mod aliased
+type cross_unique
+type cross_contended : value mod contended
 type cross_shared : value mod shared
-type cross_uncontended : value mod uncontended
+type cross_uncontended
 |}]
 
 let cross_global (x : cross_global @@ local) : _ @@ global = x
@@ -174,56 +174,55 @@ Error: This value is "yielding" but expected to be "unyielding".
 
 let cross_aliased (x : cross_aliased @@ aliased) : _ @@ unique = x
 [%%expect{|
-Line 1, characters 65-66:
-1 | let cross_aliased (x : cross_aliased @@ aliased) : _ @@ unique = x
-                                                                     ^
-Error: This value is "aliased" but expected to be "unique".
+val cross_aliased : cross_aliased -> cross_aliased @ unique = <fun>
 |}]
 
 let cross_unique (x : cross_unique @@ aliased) : _ @@ unique = x
 [%%expect{|
-val cross_unique : cross_unique -> cross_unique @ unique = <fun>
+Line 1, characters 63-64:
+1 | let cross_unique (x : cross_unique @@ aliased) : _ @@ unique = x
+                                                                   ^
+Error: This value is "aliased" but expected to be "unique".
 |}]
 
 let cross_contended1 (x : cross_contended @@ shared) : _ @@ uncontended = x
 [%%expect{|
-Line 1, characters 74-75:
-1 | let cross_contended1 (x : cross_contended @@ shared) : _ @@ uncontended = x
-                                                                              ^
-Error: This value is "shared" but expected to be "uncontended".
+val cross_contended1 : cross_contended @ shared -> cross_contended = <fun>
 |}]
 
 let cross_contended2 (x : cross_contended @@ contended) : _ @@ shared = x
 [%%expect{|
-Line 1, characters 72-73:
-1 | let cross_contended2 (x : cross_contended @@ contended) : _ @@ shared = x
-                                                                            ^
-Error: This value is "contended" but expected to be "shared".
+val cross_contended2 :
+  cross_contended @ contended -> cross_contended @ shared = <fun>
 |}]
 
 let cross_shared1 (x : cross_shared @@ shared) : _ @@ uncontended = x
 [%%expect{|
-Line 1, characters 68-69:
-1 | let cross_shared1 (x : cross_shared @@ shared) : _ @@ uncontended = x
-                                                                        ^
-Error: This value is "shared" but expected to be "uncontended".
+val cross_shared1 : cross_shared @ shared -> cross_shared = <fun>
 |}]
 
 let cross_shared2 (x : cross_shared @@ contended) : _ @@ shared = x
 [%%expect{|
-val cross_shared2 : cross_shared @ contended -> cross_shared @ shared = <fun>
+Line 1, characters 66-67:
+1 | let cross_shared2 (x : cross_shared @@ contended) : _ @@ shared = x
+                                                                      ^
+Error: This value is "contended" but expected to be "shared".
 |}]
 
 let cross_uncontended1 (x : cross_uncontended @@ shared) : _ @@ uncontended = x
 [%%expect{|
-val cross_uncontended1 : cross_uncontended @ shared -> cross_uncontended =
-  <fun>
+Line 1, characters 78-79:
+1 | let cross_uncontended1 (x : cross_uncontended @@ shared) : _ @@ uncontended = x
+                                                                                  ^
+Error: This value is "shared" but expected to be "uncontended".
 |}]
 
 let cross_uncontended2 (x : cross_uncontended @@ contended) : _ @@ shared = x
 [%%expect{|
-val cross_uncontended2 :
-  cross_uncontended @ contended -> cross_uncontended @ shared = <fun>
+Line 1, characters 76-77:
+1 | let cross_uncontended2 (x : cross_uncontended @@ contended) : _ @@ shared = x
+                                                                                ^
+Error: This value is "contended" but expected to be "shared".
 |}]
 
 (* Check that all modalities cross modes -- does not currently work *)
@@ -272,11 +271,23 @@ Error: The kind of type "s" is value
 |}]
 type s : value mod aliased = { v : t @@ aliased } [@@unboxed]
 [%%expect{|
-type s = { v : t @@ aliased; } [@@unboxed]
+Line 1, characters 0-61:
+1 | type s : value mod aliased = { v : t @@ aliased } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "s" is value
+         because of the definition of t at line 1, characters 0-6.
+       But the kind of type "s" must be a subkind of value mod aliased
+         because of the annotation on the declaration of the type s.
 |}]
 type s : value mod contended = { v : t @@ contended } [@@unboxed]
 [%%expect{|
-type s = { v : t @@ contended; } [@@unboxed]
+Line 1, characters 0-65:
+1 | type s : value mod contended = { v : t @@ contended } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "s" is value
+         because of the definition of t at line 1, characters 0-6.
+       But the kind of type "s" must be a subkind of value mod contended
+         because of the annotation on the declaration of the type s.
 |}]
 type s : value mod shared = { v : t @@ shared } [@@unboxed]
 [%%expect{|

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2525,7 +2525,7 @@ let check_and_update_generalized_ty_jkind ?name ~loc env ty =
          might turn out later to be value. This is the conservative choice. *)
       let jkind_of_type = type_jkind_purely_if_principal env in
       let ext = Jkind.get_externality_upper_bound ~jkind_of_type jkind in
-      Jkind.Externality.le ext External64 &&
+      Jkind_axis.Externality.le ext External64 &&
       match Jkind.get_layout jkind with
       | Some (Base Value) | None -> true
       | _ -> false
@@ -6033,7 +6033,7 @@ let rec build_subtype env (visited : transient_expr list)
             let a = mode_cross_right env t1 a in
             build_submode_pos a
           end else begin
-            let a = mode_cross_left_alloc env t1 a in
+            let a = mode_cross_left_alloc env t1 (Alloc.disallow_right a) in
             build_submode_neg a
           end
         end else a, Unchanged
@@ -6263,7 +6263,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
             t2 t1
             cstrs
         in
-        let a2 = mode_cross_left_alloc env t2 a2 in
+        let a2 = mode_cross_left_alloc env t2 (Alloc.disallow_right a2) in
          subtype_alloc_mode env trace a2 a1;
         (* RHS mode of arrow types indicates allocation in the parent region
            and is not subject to mode crossing *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3293,11 +3293,10 @@ and mcomp_unsafe_mode_crossing umc1 umc2 =
   | None, None -> ()
   | Some _, None -> raise Incompatible
   | None, Some _ -> raise Incompatible
-  | Some ({ modal_upper_bounds = mub1 }),
-    Some ({ modal_upper_bounds = mub2 }) ->
-    if (Mode.Alloc.Const.le mub1 mub2 && Mode.Alloc.Const.le mub2 mub1)
-    then ()
-    else raise Incompatible
+  | Some umc1, Some umc2 ->
+      if equal_unsafe_mode_crossing umc1 umc2
+      then ()
+      else raise Incompatible
 
 and mcomp_type_decl type_pairs env p1 p2 tl1 tl2 =
   try
@@ -4870,14 +4869,21 @@ let relevant_pairs pairs v =
 (* This is very similar to Typecore.mode_cross_left_value. Any bugs here
    are likely bugs there, too. *)
 let mode_cross_left_alloc env ty mode =
-  let mode =
-    if not (is_principal ty) then mode else
+  if not (is_principal ty) then mode else begin
     let jkind = type_jkind_purely env ty in
     let jkind_of_type = type_jkind_purely_if_principal env in
     let upper_bounds = Jkind.get_modal_upper_bounds ~jkind_of_type jkind in
-    Alloc.meet_const upper_bounds mode
-  in
-  mode |> Alloc.disallow_right
+    let upper_bounds =
+      Alloc.Const.merge
+        { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
+    in
+    let lower_bounds = Jkind.get_modal_lower_bounds ~jkind_of_type jkind in
+    let lower_bounds =
+      Alloc.Const.merge
+        { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
+    in
+    Alloc.subtract lower_bounds (Alloc.meet_const upper_bounds mode)
+  end
 
 (* This is very similar to Typecore.expect_mode_cross. Any bugs here
    are likely bugs there, too. *)
@@ -4886,7 +4892,16 @@ let mode_cross_right env ty mode =
   let jkind = type_jkind_purely env ty in
   let jkind_of_type = type_jkind_purely_if_principal env in
   let upper_bounds = Jkind.get_modal_upper_bounds ~jkind_of_type jkind in
-  Alloc.imply upper_bounds mode
+  let upper_bounds =
+    Alloc.Const.merge
+      { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
+  in
+  let lower_bounds = Jkind.get_modal_lower_bounds ~jkind_of_type jkind in
+  let lower_bounds =
+    Alloc.Const.merge
+      { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
+  in
+  Alloc.imply upper_bounds (Alloc.join_const lower_bounds mode)
 
 let submode_with_cross env ~is_ret ty l r =
   let r' = mode_cross_right env ty r in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4869,7 +4869,7 @@ let relevant_pairs pairs v =
 (* This is very similar to Typecore.mode_cross_left_value. Any bugs here
    are likely bugs there, too. *)
 let mode_cross_left_alloc env ty mode =
-  if not (is_principal ty) then mode else begin
+  if not (is_principal ty) then Alloc.disallow_right mode else begin
     let jkind = type_jkind_purely env ty in
     let jkind_of_type = type_jkind_purely_if_principal env in
     let upper_bounds = Jkind.get_modal_upper_bounds ~jkind_of_type jkind in
@@ -6033,7 +6033,7 @@ let rec build_subtype env (visited : transient_expr list)
             let a = mode_cross_right env t1 a in
             build_submode_pos a
           end else begin
-            let a = mode_cross_left_alloc env t1 (Alloc.disallow_right a) in
+            let a = mode_cross_left_alloc env t1 a in
             build_submode_neg a
           end
         end else a, Unchanged
@@ -6263,7 +6263,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
             t2 t1
             cstrs
         in
-        let a2 = mode_cross_left_alloc env t2 (Alloc.disallow_right a2) in
+        let a2 = mode_cross_left_alloc env t2 a2 in
          subtype_alloc_mode env trace a2 a1;
         (* RHS mode of arrow types indicates allocation in the parent region
            and is not subject to mode crossing *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -645,7 +645,8 @@ val constrain_type_jkind :
 (* Check whether a type's externality's upper bound is less than some target.
    Potentially cheaper than just calling [type_jkind], because this can stop
    expansion once it succeeds. *)
-val check_type_externality : Env.t -> type_expr -> Jkind.Externality.t -> bool
+val check_type_externality :
+  Env.t -> type_expr -> Jkind_axis.Externality.t -> bool
 
 (* This function should get called after a type is generalized.
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -78,8 +78,18 @@ let right_mode_cross env ty mode =
 let left_mode_cross_jkind env jkind mode =
   let jkind_of_type = Ctype.type_jkind_purely_if_principal env in
   let upper_bounds = Jkind.get_modal_upper_bounds ~jkind_of_type jkind in
+  let upper_bounds =
+    Alloc.Const.merge
+      { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
+  in
   let upper_bounds = Const.alloc_as_value upper_bounds in
-  Value.meet_const upper_bounds mode
+  let lower_bounds = Jkind.get_modal_lower_bounds ~jkind_of_type jkind in
+  let lower_bounds =
+    Alloc.Const.merge
+      { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
+  in
+  let lower_bounds = Const.alloc_as_value lower_bounds in
+  Value.subtract lower_bounds (Value.meet_const upper_bounds mode)
 
 let left_mode_cross env ty mode=
   if not (Ctype.is_principal ty) then mode else

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -57,8 +57,18 @@ type mmodes =
 let right_mode_cross_jkind env jkind mode =
   let jkind_of_type = Ctype.type_jkind_purely_if_principal env in
   let upper_bounds = Jkind.get_modal_upper_bounds ~jkind_of_type jkind in
+  let upper_bounds =
+    Alloc.Const.merge
+      { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
+  in
   let upper_bounds = Const.alloc_as_value upper_bounds in
-  Value.imply upper_bounds mode
+  let lower_bounds = Jkind.get_modal_lower_bounds ~jkind_of_type jkind in
+  let lower_bounds =
+    Alloc.Const.merge
+      { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
+  in
+  let lower_bounds = Const.alloc_as_value lower_bounds in
+  Value.imply upper_bounds (Value.join_const lower_bounds mode)
 
 let right_mode_cross env ty mode =
   if not (Ctype.is_principal ty) then mode else
@@ -688,11 +698,10 @@ let compare_unsafe_mode_crossing umc1 umc2 =
   | None, None -> None
   | Some _, None -> Some (Unsafe_mode_crossing (Mode_crossing_only_on First))
   | None, Some _ -> Some (Unsafe_mode_crossing (Mode_crossing_only_on Second))
-  | Some ({ modal_upper_bounds = mub1 }),
-    Some ({ modal_upper_bounds = mub2 }) ->
-    if (Mode.Alloc.Const.le mub1 mub2 && Mode.Alloc.Const.le mub2 mub1)
-    then None
-    else Some (Unsafe_mode_crossing Mode_crossing_not_equal)
+  | Some umc1, Some umc2 ->
+      if equal_unsafe_mode_crossing umc1 umc2
+      then None
+      else Some (Unsafe_mode_crossing Mode_crossing_not_equal)
 
 module Record_diffing = struct
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -891,11 +891,14 @@ module Const = struct
       { jkind =
           { layout = Base Value;
             mod_bounds =
-              Mod_bounds.simple ~linearity:Linearity.Const.min
-                ~contention:Contention.Const.min
+              Mod_bounds.simple
+                ~locality:Locality.Const.max
+                ~linearity:Linearity.Const.min
                 ~portability:Portability.Const.min
-                ~uniqueness:Uniqueness.Const.max ~locality:Locality.Const.max
-                ~yielding:Yielding.Const.min ~externality:Externality.max
+                ~yielding:Yielding.Const.min
+                ~uniqueness:Uniqueness.Const_op.max
+                ~contention:Contention.Const_op.min
+                ~externality:Externality.max
                 ~nullability:Nullability.Non_null;
             with_bounds = No_with_bounds
           };
@@ -906,11 +909,14 @@ module Const = struct
       { jkind =
           { layout = Base Value;
             mod_bounds =
-              Mod_bounds.simple ~linearity:Linearity.Const.min
-                ~contention:Contention.Const.max
+              Mod_bounds.simple
+                ~locality:Locality.Const.max
+                ~linearity:Linearity.Const.min
                 ~portability:Portability.Const.min
-                ~uniqueness:Uniqueness.Const.max ~locality:Locality.Const.max
-                ~yielding:Yielding.Const.min ~externality:Externality.max
+                ~yielding:Yielding.Const.min
+                ~contention:Contention.Const_op.max
+                ~uniqueness:Uniqueness.Const_op.max
+                ~externality:Externality.max
                 ~nullability:Nullability.Non_null;
             with_bounds = No_with_bounds
           };
@@ -2017,21 +2023,17 @@ let for_arrow =
   |> mark_best
 
 let for_object =
+  (* The crossing of objects are based on the fact that they are
+     produced/defined/allocated at legacy, which applies to only the
+     comonadic axes. *)
   let ({ linearity;
          areality = locality;
          uniqueness;
-         portability;
-         contention;
-         yielding
-       }
-        : Mode.Alloc.Const.t) =
-    (* The crossing of objects are based on the fact that they are
-       produced/defined/allocated at legacy, which applies to only the
-       comonadic axes. *)
-    Alloc.Const.merge
-      { comonadic = Alloc.Comonadic.Const.legacy;
-        monadic = Alloc.Monadic.Const.max
-      }
+         portability; }: Mode.Alloc.Comonadic.Const.t) =
+    Alloc.Comonadic.Const.legacy
+  in
+  let ({ contention; yielding } : Mode.Alloc.Monadic_op.Const.t) =
+    Alloc.Monadic.Const_op.max
   in
   fresh_jkind
     { layout = Sort (Base Value);
@@ -2088,7 +2090,7 @@ let get_layout jk : Layout.Const.t option = Layout.get_const jk.jkind.layout
 let extract_layout jk = jk.jkind.layout
 
 let get_modal_upper_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) :
-    Alloc.Const.t =
+    Alloc.Comonadic.Const.t =
   let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
           Allowance.right_only jkind_desc),
         _ ) =
@@ -2097,11 +2099,19 @@ let get_modal_upper_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) :
   let get axis = Mod_bounds.get mod_bounds ~axis in
   { areality = get (Modal (Comonadic Areality));
     linearity = get (Modal (Comonadic Linearity));
-    uniqueness = get (Modal (Monadic Uniqueness));
     portability = get (Modal (Comonadic Portability));
-    contention = get (Modal (Monadic Contention));
-    yielding = get (Modal (Comonadic Yielding))
-  }
+    yielding = get (Modal (Comonadic Yielding)) }
+
+let get_modal_lower_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) :
+    Alloc.Monadic.Const.t =
+  let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
+          Allowance.right_only jkind_desc),
+        _ ) =
+    Jkind_desc.normalize ~mode:Ignore_best ~jkind_of_type jk.jkind
+  in
+  let get axis = Mod_bounds.get mod_bounds ~axis in
+  { uniqueness = get (Modal (Monadic Uniqueness));
+    contention = get (Modal (Monadic Contention)) }
 
 let get_externality_upper_bound ~jkind_of_type jk =
   let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -476,8 +476,8 @@ module Mod_bounds = struct
 
   let for_arrow =
     simple ~linearity:Linearity.Const.max ~locality:Locality.Const.max
-      ~uniqueness:Uniqueness.Const.min ~portability:Portability.Const.max
-      ~contention:Contention.Const.min ~yielding:Yielding.Const.max
+      ~uniqueness:Uniqueness.Const_op.min ~portability:Portability.Const.max
+      ~contention:Contention.Const_op.min ~yielding:Yielding.Const.max
       ~externality:Externality.max ~nullability:Nullability.Non_null
 end
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -891,14 +891,11 @@ module Const = struct
       { jkind =
           { layout = Base Value;
             mod_bounds =
-              Mod_bounds.simple
-                ~locality:Locality.Const.max
+              Mod_bounds.simple ~locality:Locality.Const.max
                 ~linearity:Linearity.Const.min
-                ~portability:Portability.Const.min
-                ~yielding:Yielding.Const.min
+                ~portability:Portability.Const.min ~yielding:Yielding.Const.min
                 ~uniqueness:Uniqueness.Const_op.max
-                ~contention:Contention.Const_op.min
-                ~externality:Externality.max
+                ~contention:Contention.Const_op.min ~externality:Externality.max
                 ~nullability:Nullability.Non_null;
             with_bounds = No_with_bounds
           };
@@ -909,14 +906,11 @@ module Const = struct
       { jkind =
           { layout = Base Value;
             mod_bounds =
-              Mod_bounds.simple
-                ~locality:Locality.Const.max
+              Mod_bounds.simple ~locality:Locality.Const.max
                 ~linearity:Linearity.Const.min
-                ~portability:Portability.Const.min
-                ~yielding:Yielding.Const.min
+                ~portability:Portability.Const.min ~yielding:Yielding.Const.min
                 ~contention:Contention.Const_op.max
-                ~uniqueness:Uniqueness.Const_op.max
-                ~externality:Externality.max
+                ~uniqueness:Uniqueness.Const_op.max ~externality:Externality.max
                 ~nullability:Nullability.Non_null;
             with_bounds = No_with_bounds
           };
@@ -2026,13 +2020,11 @@ let for_object =
   (* The crossing of objects are based on the fact that they are
      produced/defined/allocated at legacy, which applies to only the
      comonadic axes. *)
-  let ({ linearity;
-         areality = locality;
-         uniqueness;
-         portability; }: Mode.Alloc.Comonadic.Const.t) =
+  let ({ linearity; areality = locality; portability; yielding }
+        : Mode.Alloc.Comonadic.Const.t) =
     Alloc.Comonadic.Const.legacy
   in
-  let ({ contention; yielding } : Mode.Alloc.Monadic_op.Const.t) =
+  let ({ contention; uniqueness } : Mode.Alloc.Monadic.Const_op.t) =
     Alloc.Monadic.Const_op.max
   in
   fresh_jkind
@@ -2100,7 +2092,8 @@ let get_modal_upper_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) :
   { areality = get (Modal (Comonadic Areality));
     linearity = get (Modal (Comonadic Linearity));
     portability = get (Modal (Comonadic Portability));
-    yielding = get (Modal (Comonadic Yielding)) }
+    yielding = get (Modal (Comonadic Yielding))
+  }
 
 let get_modal_lower_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) :
     Alloc.Monadic.Const.t =
@@ -2111,7 +2104,8 @@ let get_modal_lower_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) :
   in
   let get axis = Mod_bounds.get mod_bounds ~axis in
   { uniqueness = get (Modal (Monadic Uniqueness));
-    contention = get (Modal (Monadic Contention)) }
+    contention = get (Modal (Monadic Contention))
+  }
 
 let get_externality_upper_bound ~jkind_of_type jk =
   let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -40,25 +40,6 @@ open Allowance
    This will eventually be incorporated into the mode
    solver, but it is defined here because we do not yet track externalities
    on expressions, just in jkinds. *)
-(* CR externals: Move to mode.ml. But see
-   https://github.com/goldfirere/flambda-backend/commit/d802597fbdaaa850e1ed9209a1305c5dcdf71e17
-   first, which was reisenberg's attempt to do so. *)
-module Externality : sig
-  type t = Jkind_axis.Externality.t =
-    | External (* not managed by the garbage collector *)
-    | External64 (* not managed by the garbage collector on 64-bit systems *)
-    | Internal (* managed by the garbage collector *)
-
-  include module type of Jkind_axis.Externality with type t := t
-end
-
-module Nullability : sig
-  type t = Jkind_axis.Nullability.t =
-    | Non_null (* proven to not have NULL values *)
-    | Maybe_null (* may have NULL values *)
-
-  include module type of Jkind_axis.Nullability with type t := t
-end
 
 module Sort : sig
   include
@@ -530,11 +511,17 @@ val get_layout : 'd Types.jkind -> Layout.Const.t option
 (** Gets the layout of a jkind, without looking through sort variables. *)
 val extract_layout : 'd Types.jkind -> Sort.t Layout.t
 
-(** Gets the maximum modes for types of this jkind. *)
+(** Gets the maximum comonadic modes for types of this jkind. *)
 val get_modal_upper_bounds :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
   'd Types.jkind ->
-  Mode.Alloc.Const.t
+  Mode.Alloc.Comonadic.Const.t
+
+(** Gets the minimum monadic modes for types of this jkind. *)
+val get_modal_upper_bounds :
+  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  'd Types.jkind ->
+  Mode.Alloc.Monadic.Const.t
 
 (** Gets the maximum mode on the externality axis for types of this jkind. *)
 val get_externality_upper_bound :

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -518,7 +518,7 @@ val get_modal_upper_bounds :
   Mode.Alloc.Comonadic.Const.t
 
 (** Gets the minimum monadic modes for types of this jkind. *)
-val get_modal_upper_bounds :
+val get_modal_lower_bounds :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
   'd Types.jkind ->
   Mode.Alloc.Monadic.Const.t
@@ -527,12 +527,12 @@ val get_modal_upper_bounds :
 val get_externality_upper_bound :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
   'd Types.jkind ->
-  Externality.t
+  Jkind_axis.Externality.t
 
 (** Computes a jkind that is the same as the input but with an updated maximum
     mode for the externality axis *)
 val set_externality_upper_bound :
-  Types.jkind_r -> Externality.t -> Types.jkind_r
+  Types.jkind_r -> Jkind_axis.Externality.t -> Types.jkind_r
 
 (** Sets the layout in a jkind. *)
 val set_layout : 'd Types.jkind -> Sort.t Layout.t -> 'd Types.jkind

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1818,8 +1818,8 @@ module Monadic = struct
     let lattice_of_axis (type a) (axis : (t, a) Axis.t) :
         (module Lattice with type t = a) =
       match axis with
-      | Uniqueness -> (module Uniqueness.Const)
-      | Contention -> (module Contention.Const)
+      | Uniqueness -> (module Uniqueness.Const_op)
+      | Contention -> (module Contention.Const_op)
   end
 
   module Const_op = C.Monadic_op

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -352,76 +352,140 @@ module Lattices = struct
     end)
   end
 
-  type monadic = Uniqueness.t * Contention.t
+  type monadic =
+    { uniqueness : Uniqueness.t;
+      contention : Contention.t }
 
   module Monadic = struct
     type t = monadic
 
-    let min = Uniqueness.min, Contention.min
+    let min =
+      let uniqueness = Uniqueness.min in
+      let contention = Contention.min in
+      { uniqueness; contention }
 
-    let max = Uniqueness.max, Contention.max
+    let max =
+      let uniqueness = Uniqueness.max in
+      let contention = Contention.max in
+      { uniqueness; contention }
 
-    let legacy = Uniqueness.legacy, Contention.legacy
+    let legacy =
+      let uniqueness = Uniqueness.legacy in
+      let contention = Contention.legacy in
+      { uniqueness; contention }
 
-    let le (a0, a1) (b0, b1) = Uniqueness.le a0 b0 && Contention.le a1 b1
+    let le m1 m2 =
+      let { uniqueness = uniqueness1;
+            contention = contention1 } = m1 in
+      let { uniqueness = uniqueness2;
+            contention = contention2 } = m2 in
+      Uniqueness.le uniqueness1 uniqueness2
+      && Contention.le contention1 contention2
 
-    let join (a0, a1) (b0, b1) = Uniqueness.join a0 b0, Contention.join a1 b1
+    let join m1 m2 =
+      let uniqueness = Uniqueness.join m1.uniqueness m2.uniqueness in
+      let contention = Contention.join m1.contention m2.contention in
+      { uniqueness; contention }
 
-    let meet (a0, a1) (b0, b1) = Uniqueness.meet a0 b0, Contention.meet a1 b1
+    let meet m1 m2 =
+      let uniqueness = Uniqueness.meet m1.uniqueness m2.uniqueness in
+      let contention = Contention.meet m1.contention m2.contention in
+      { uniqueness; contention }
 
-    let print ppf (a0, a1) =
-      Format.fprintf ppf "%a,%a" Uniqueness.print a0 Contention.print a1
+    let imply m1 m2 =
+      let uniqueness = Uniqueness.imply m1.uniqueness m2.uniqueness in
+      let contention = Contention.imply m1.contention m2.contention in
+      { uniqueness; contention }
 
-    let imply (a0, a1) (b0, b1) = Uniqueness.imply a0 b0, Contention.imply a1 b1
+    let subtract m1 m2 =
+      let uniqueness = Uniqueness.subtract m1.uniqueness m2.uniqueness in
+      let contention = Contention.subtract m1.contention m2.contention in
+      { uniqueness; contention }
 
-    let subtract (a0, a1) (b0, b1) =
-      Uniqueness.subtract a0 b0, Contention.subtract a1 b1
+    let print ppf m =
+      Format.fprintf ppf "%a,%a"
+        Uniqueness.print m.uniqueness
+        Contention.print m.contention
   end
 
   type 'areality comonadic_with =
-    'areality * Linearity.t * Portability.t * Yielding.t
+  { areality : 'areality;
+    linearity : Linearity.t;
+    portability :  Portability.t;
+    yielding : Yielding.t; }
 
   module Comonadic_with (Areality : Areality) = struct
     type t = Areality.t comonadic_with
 
-    let min = Areality.min, Linearity.min, Portability.min, Yielding.min
+    let min =
+      let areality = Areality.min in
+      let linearity = Linearity.min in
+      let portability = Portability.min in
+      let yielding = Yielding.min in
+      { areality; linearity; portability; yielding }
 
-    let max = Areality.max, Linearity.max, Portability.max, Yielding.max
+    let max =
+      let areality = Areality.max in
+      let linearity = Linearity.max in
+      let portability = Portability.max in
+      let yielding = Yielding.max in
+      { areality; linearity; portability; yielding }
 
     let legacy =
-      Areality.legacy, Linearity.legacy, Portability.legacy, Yielding.legacy
+      let areality = Areality.legacy in
+      let linearity = Linearity.legacy in
+      let portability = Portability.legacy in
+      let yielding = Yielding.legacy in
+      { areality; linearity; portability; yielding }
 
-    let le (a0, a1, a2, a3) (b0, b1, b2, b3) =
-      Areality.le a0 b0 && Linearity.le a1 b1 && Portability.le a2 b2
-      && Yielding.le a3 b3
+    let le m1 m2 =
+      let { areality = areality1;
+            linearity = linearity1;
+            portability = portability1;
+            yielding = yielding1 } = m1 in
+      let { areality = areality2;
+            linearity = linearity2;
+            portability = portability2;
+            yielding = yielding2 } = m2 in     
+      Areality.le areality1 areality2
+      && Linearity.le linearity1 linearity2
+      && Portability.le portability1 portability2
+      && Yielding.le yielding1 yielding2
 
-    let join (a0, a1, a2, a3) (b0, b1, b2, b3) =
-      ( Areality.join a0 b0,
-        Linearity.join a1 b1,
-        Portability.join a2 b2,
-        Yielding.join a3 b3 )
+    let join m1 m2 =
+      let areality = Areality.join m1.areality m2.areality in
+      let linearity = Linearity.join m1.linearity m2.linearity in
+      let portability = Portability.join m1.portability m2.portability in
+      let yielding = Yielding.join m1.yielding m2.yielding in
+      { areality; linearity; portability; yielding }
 
-    let meet (a0, a1, a2, a3) (b0, b1, b2, b3) =
-      ( Areality.meet a0 b0,
-        Linearity.meet a1 b1,
-        Portability.meet a2 b2,
-        Yielding.meet a3 b3 )
+    let meet m1 m2 =
+      let areality = Areality.meet m1.areality m2.areality in
+      let linearity = Linearity.meet m1.linearity m2.linearity in
+      let portability = Portability.meet m1.portability m2.portability in
+      let yielding = Yielding.meet m1.yielding m2.yielding in
+      { areality; linearity; portability; yielding }
 
-    let imply (a0, a1, a2, a3) (b0, b1, b2, b3) =
-      ( Areality.imply a0 b0,
-        Linearity.imply a1 b1,
-        Portability.imply a2 b2,
-        Yielding.imply a3 b3 )
+    let imply m1 m2 =
+      let areality = Areality.imply m1.areality m2.areality in
+      let linearity = Linearity.imply m1.linearity m2.linearity in
+      let portability = Portability.imply m1.portability m2.portability in
+      let yielding = Yielding.imply m1.yielding m2.yielding in
+      { areality; linearity; portability; yielding }
 
-    let subtract (a0, a1, a2, a3) (b0, b1, b2, b3) =
-      ( Areality.subtract a0 b0,
-        Linearity.subtract a1 b1,
-        Portability.subtract a2 b2,
-        Yielding.subtract a3 b3 )
+    let subtract m1 m2 =
+      let areality = Areality.subtract m1.areality m2.areality in
+      let linearity = Linearity.subtract m1.linearity m2.linearity in
+      let portability = Portability.subtract m1.portability m2.portability in
+      let yielding = Yielding.subtract m1.yielding m2.yielding in
+      { areality; linearity; portability; yielding }
 
-    let print ppf (a0, a1, a2, a3) =
-      Format.fprintf ppf "%a,%a,%a,%a" Areality.print a0 Linearity.print a1
-        Portability.print a2 Yielding.print a3
+    let print ppf m =
+      Format.fprintf ppf "%a,%a,%a,%a"
+        Areality.print m.areality
+        Linearity.print m.linearity
+        Portability.print m.portability
+        Yielding.print m.yielding
   end
   [@@inline]
 
@@ -630,23 +694,23 @@ module Lattices_mono = struct
 
     let proj : type p r. (p, r) t -> p -> r =
      fun ax t ->
-      match ax, t with
-      | Areality, (a, _, _, _) -> a
-      | Linearity, (_, lin, _, _) -> lin
-      | Portability, (_, _, s, _) -> s
-      | Yielding, (_, _, _, yld) -> yld
-      | Uniqueness, (uni, _) -> uni
-      | Contention, (_, con) -> con
+      match ax with
+      | Areality -> t.areality
+      | Linearity -> t.linearity
+      | Portability -> t.portability
+      | Yielding -> t.yielding
+      | Uniqueness -> t.uniqueness
+      | Contention -> t.contention
 
     let update : type p r. (p, r) t -> r -> p -> p =
      fun ax r t ->
-      match ax, t with
-      | Areality, (_, lin, portable, yld) -> r, lin, portable, yld
-      | Linearity, (area, _, portable, yld) -> area, r, portable, yld
-      | Portability, (area, lin, _, yld) -> area, lin, r, yld
-      | Yielding, (area, lin, portable, _) -> area, lin, portable, r
-      | Uniqueness, (_, con) -> r, con
-      | Contention, (uni, _) -> uni, r
+      match ax with
+      | Areality -> { t with areality = r }
+      | Linearity -> { t with linearity = r }
+      | Portability -> { t with portability = r }
+      | Yielding -> { t with yielding = r }
+      | Uniqueness -> { t with uniqueness = r }
+      | Contention -> { t with contention = r }
   end
 
   type ('a, 'b, 'd) morph =
@@ -799,7 +863,7 @@ module Lattices_mono = struct
   end)
 
   let set_areality : type a0 a1. a1 -> a0 comonadic_with -> a1 comonadic_with =
-   fun r (_, lin, portable, yld) -> r, lin, portable, yld
+   fun r t -> { t with areality = r }
 
   let proj_obj : type t r. (t, r) Axis.t -> t obj -> r obj =
    fun ax obj ->
@@ -984,42 +1048,36 @@ module Lattices_mono = struct
 
   let monadic_to_comonadic_min :
       type a. a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
-   fun obj (uniqueness, contention) ->
-    match obj with
-    | Comonadic_with_locality ->
-      ( Locality.min,
-        unique_to_linear uniqueness,
-        contended_to_portable contention,
-        Yielding.min )
-    | Comonadic_with_regionality ->
-      ( Regionality.min,
-        unique_to_linear uniqueness,
-        contended_to_portable contention,
-        Yielding.min )
+   fun obj m ->
+     let areality : a =
+       match obj with
+       | Comonadic_with_locality -> Locality.min
+       | Comonadic_with_regionality -> Regionality.min
+     in
+     let linearity = unique_to_linear m.uniqueness in
+     let portability = contended_to_portable m.contention in
+     let yielding = Yielding.min in
+     { areality; linearity; portability; yielding }
 
   let comonadic_to_monadic :
       type a. a comonadic_with obj -> a comonadic_with -> Monadic_op.t =
-   fun obj (_, linearity, portability, _) ->
-    match obj with
-    | Comonadic_with_locality ->
-      linear_to_unique linearity, portable_to_contended portability
-    | Comonadic_with_regionality ->
-      linear_to_unique linearity, portable_to_contended portability
+   fun _ m  ->
+     let uniqueness = linear_to_unique m.linearity in
+     let contention = portable_to_contended m.portability in
+     { uniqueness; contention }
 
   let monadic_to_comonadic_max :
       type a. a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
-   fun obj (uniqueness, contention) ->
-    match obj with
-    | Comonadic_with_locality ->
-      ( Locality.max,
-        unique_to_linear uniqueness,
-        contended_to_portable contention,
-        Yielding.max )
-    | Comonadic_with_regionality ->
-      ( Regionality.max,
-        unique_to_linear uniqueness,
-        contended_to_portable contention,
-        Yielding.max )
+   fun obj m ->
+     let areality : a =
+       match obj with
+       | Comonadic_with_locality -> Locality.max
+       | Comonadic_with_regionality -> Regionality.max
+     in
+     let linearity = unique_to_linear m.uniqueness in
+     let portability = contended_to_portable m.contention in
+     let yielding = Yielding.max in
+     { areality; linearity; portability; yielding }
 
   let rec apply : type a b d. b obj -> (a, b, d) morph -> a -> b =
    fun dst f a ->
@@ -1280,9 +1338,15 @@ end
 module C = Lattices_mono
 module S = Solvers_polarized (C)
 
-type monadic = C.monadic
+type monadic = C.monadic =
+  { uniqueness : C.Uniqueness.t;
+    contention : C.Contention.t; }
 
-type 'a comonadic_with = 'a C.comonadic_with
+type 'a comonadic_with = 'a C.comonadic_with =
+  { areality : 'a;
+    linearity : C.Linearity.t;
+    portability : C.Portability.t;
+    yielding : C.Yielding.t; }
 
 module Axis = C.Axis
 
@@ -1605,9 +1669,7 @@ module Comonadic_with (Areality : Areality) = struct
 
   type equate_error = equate_step * error
 
-  open Obj
-
-  let proj_obj ax = C.proj_obj ax obj
+  let proj_obj ax = C.proj_obj ax Obj.obj
 
   module Const = struct
     include C.Comonadic_with (Areality.Const)
@@ -1626,7 +1688,7 @@ module Comonadic_with (Areality : Areality) = struct
       let obj = proj_obj ax in
       C.max obj
 
-    let max_with ax c = Axis.update ax c (C.max obj)
+    let max_with ax c = Axis.update ax c (C.max Obj.obj)
 
     let print_axis ax ppf a =
       let obj = proj_obj ax in
@@ -1641,48 +1703,48 @@ module Comonadic_with (Areality : Areality) = struct
       | Yielding -> (module Yielding.Const)
   end
 
-  let proj ax m = Solver.via_monotone (proj_obj ax) (Proj (Obj.obj, ax)) m
+  let proj ax m = Obj.Solver.via_monotone (proj_obj ax) (Proj (Obj.obj, ax)) m
 
-  let meet_const c m = Solver.via_monotone obj (Meet_with c) m
+  let meet_const c m = Obj.Solver.via_monotone Obj.obj (Meet_with c) m
 
-  let join_const c m = Solver.via_monotone obj (Join_with c) m
+  let join_const c m = Obj.Solver.via_monotone Obj.obj (Join_with c) m
 
   let min_with ax m =
-    Solver.via_monotone Obj.obj (Min_with ax) (Solver.disallow_right m)
+    Obj.Solver.via_monotone Obj.obj (Min_with ax) (Obj.Solver.disallow_right m)
 
   let max_with ax m =
-    Solver.via_monotone Obj.obj (Max_with ax) (Solver.disallow_left m)
+    Obj.Solver.via_monotone Obj.obj (Max_with ax) (Obj.Solver.disallow_left m)
 
   let join_with ax c m = join_const (C.min_with Obj.obj ax c) m
 
   let meet_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
-  let zap_to_legacy m =
+  let zap_to_legacy m : Const.t =
     let areality = proj Areality m |> Areality.zap_to_legacy in
     let linearity = proj Linearity m |> Linearity.zap_to_legacy in
     let portability = proj Portability m |> Portability.zap_to_legacy in
     let yielding = proj Yielding m |> Yielding.zap_to_legacy in
-    areality, linearity, portability, yielding
+    { areality; linearity; portability; yielding }
 
-  let imply c m = Solver.via_monotone obj (Imply c) (Solver.disallow_left m)
+  let imply c m = Obj.Solver.via_monotone Obj.obj (Imply c) (Obj.Solver.disallow_left m)
 
   let legacy = of_const Const.legacy
 
-  let axis_of_error
-      { left = area0, lin0, port0, yld0; right = area1, lin1, port1, yld1 } :
-      error =
-    if Areality.Const.le area0 area1
+  let axis_of_error (err : Obj.const Solver.error) : error =
+    if Areality.Const.le err.left.areality err.right.areality
     then
-      if Linearity.Const.le lin0 lin1
+      if Linearity.Const.le err.left.linearity err.right.linearity
       then
-        if Portability.Const.le port0 port1
+        if Portability.Const.le err.left.portability err.right.portability
         then
-          if Yielding.Const.le yld0 yld1
+          if Yielding.Const.le err.left.yielding err.right.yielding
           then assert false
-          else Error (Yielding, { left = yld0; right = yld1 })
-        else Error (Portability, { left = port0; right = port1 })
-      else Error (Linearity, { left = lin0; right = lin1 })
-    else Error (Areality, { left = area0; right = area1 })
+          else Error (Yielding,
+                      { left = err.left.yielding; right = err.right.yielding })
+        else Error (Portability,
+                    { left = err.left.portability; right = err.right.portability })
+      else Error (Linearity, { left = err.left.linearity; right = err.right.linearity })
+    else Error (Areality, { left = err.left.areality; right = err.right.areality })
 
   (* overriding to report the offending axis *)
   let submode_log m0 m1 ~log : _ result =
@@ -1714,9 +1776,7 @@ module Monadic = struct
 
   type equate_error = equate_step * error
 
-  open Obj
-
-  let proj_obj ax = C.proj_obj ax obj
+  let proj_obj ax = C.proj_obj ax Obj.obj
 
   module Const = struct
     include C.Monadic
@@ -1724,7 +1784,7 @@ module Monadic = struct
     (* CR zqian: The flipping logic leaking to here is bad. Refactoring needed. *)
 
     (* Monadic fragment is flipped, so are the following definitions. *)
-    let min_with ax c = Axis.update ax c (C.max obj)
+    let min_with ax c = Axis.update ax c (C.max Obj.obj)
 
     let min_axis ax =
       let obj = proj_obj ax in
@@ -1745,42 +1805,42 @@ module Monadic = struct
       | Contention -> (module Contention.Const)
   end
 
-  let proj ax m = Solver.via_monotone (proj_obj ax) (Proj (Obj.obj, ax)) m
+  let proj ax m = Obj.Solver.via_monotone (proj_obj ax) (Proj (Obj.obj, ax)) m
 
   (* The monadic fragment is inverted. Most of the inversion logic is taken care
      by [Solver_polarized], but some remain, such as the [Min_with] below which
      is inverted from [Max_with]. *)
 
-  let meet_const c m = Solver.via_monotone obj (Join_with c) m
+  let meet_const c m = Obj.Solver.via_monotone Obj.obj (Join_with c) m
 
-  let join_const c m = Solver.via_monotone obj (Meet_with c) m
+  let join_const c m = Obj.Solver.via_monotone Obj.obj (Meet_with c) m
 
   let max_with ax m =
-    Solver.via_monotone Obj.obj (Min_with ax) (Solver.disallow_left m)
+    Obj.Solver.via_monotone Obj.obj (Min_with ax) (Obj.Solver.disallow_left m)
 
   let min_with ax m =
-    Solver.via_monotone Obj.obj (Max_with ax) (Solver.disallow_right m)
+    Obj.Solver.via_monotone Obj.obj (Max_with ax) (Obj.Solver.disallow_right m)
 
   let join_with ax c m = join_const (C.max_with Obj.obj ax c) m
 
   let meet_with ax c m = meet_const (C.min_with Obj.obj ax c) m
 
-  let imply c m = Solver.via_monotone obj (Subtract c) (Solver.disallow_left m)
+  let imply c m = Obj.Solver.via_monotone Obj.obj (Subtract c) (Obj.Solver.disallow_left m)
 
-  let zap_to_legacy m =
+  let zap_to_legacy m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
     let contention = proj Contention m |> Contention.zap_to_legacy in
-    uniqueness, contention
+    { uniqueness; contention }
 
   let legacy = of_const Const.legacy
 
-  let axis_of_error { left = uni0, con0; right = uni1, con1 } : error =
-    if Uniqueness.Const.le uni0 uni1
+  let axis_of_error (err : Obj.const Solver.error) : error =
+    if Uniqueness.Const.le err.left.uniqueness err.right.uniqueness
     then
-      if Contention.Const.le con0 con1
+      if Contention.Const.le err.left.contention err.right.contention
       then assert false
-      else Error (Contention, { left = con0; right = con1 })
-    else Error (Uniqueness, { left = uni0; right = uni1 })
+      else Error (Contention, { left = err.left.contention; right = err.right.contention })
+    else Error (Uniqueness, { left = err.left.uniqueness; right = err.right.uniqueness })
 
   (* overriding to report the offending axis *)
   let submode_log m0 m1 ~log : _ result =
@@ -1853,15 +1913,19 @@ module Value_with (Areality : Areality) = struct
     }
 
   let split
-      { areality; linearity; portability; uniqueness; contention; yielding } =
-    let monadic = uniqueness, contention in
-    let comonadic = areality, linearity, portability, yielding in
+      { areality; linearity; portability; yielding; uniqueness; contention } =
+    let monadic : Monadic.Const.t = { uniqueness; contention } in
+    let comonadic : Comonadic.Const.t =
+      { areality; linearity; portability; yielding }
+    in
     { comonadic; monadic }
 
   let merge { comonadic; monadic } =
-    let areality, linearity, portability, yielding = comonadic in
-    let uniqueness, contention = monadic in
-    { areality; linearity; portability; uniqueness; contention; yielding }
+    let { areality; linearity; portability; yielding } : Comonadic.Const.t =
+      comonadic
+    in
+    let { uniqueness; contention } : Monadic.Const.t = monadic in
+    { areality; linearity; portability; yielding; uniqueness; contention }
 
   let print ?verbose () ppf { monadic; comonadic } =
     Format.fprintf ppf "%a;%a"

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -354,7 +354,8 @@ module Lattices = struct
 
   type monadic =
     { uniqueness : Uniqueness.t;
-      contention : Contention.t }
+      contention : Contention.t
+    }
 
   module Monadic = struct
     type t = monadic
@@ -375,10 +376,8 @@ module Lattices = struct
       { uniqueness; contention }
 
     let le m1 m2 =
-      let { uniqueness = uniqueness1;
-            contention = contention1 } = m1 in
-      let { uniqueness = uniqueness2;
-            contention = contention2 } = m2 in
+      let { uniqueness = uniqueness1; contention = contention1 } = m1 in
+      let { uniqueness = uniqueness2; contention = contention2 } = m2 in
       Uniqueness.le uniqueness1 uniqueness2
       && Contention.le contention1 contention2
 
@@ -403,16 +402,16 @@ module Lattices = struct
       { uniqueness; contention }
 
     let print ppf m =
-      Format.fprintf ppf "%a,%a"
-        Uniqueness.print m.uniqueness
-        Contention.print m.contention
+      Format.fprintf ppf "%a,%a" Uniqueness.print m.uniqueness Contention.print
+        m.contention
   end
 
   type 'areality comonadic_with =
-  { areality : 'areality;
-    linearity : Linearity.t;
-    portability :  Portability.t;
-    yielding : Yielding.t; }
+    { areality : 'areality;
+      linearity : Linearity.t;
+      portability : Portability.t;
+      yielding : Yielding.t
+    }
 
   module Comonadic_with (Areality : Areality) = struct
     type t = Areality.t comonadic_with
@@ -442,11 +441,17 @@ module Lattices = struct
       let { areality = areality1;
             linearity = linearity1;
             portability = portability1;
-            yielding = yielding1 } = m1 in
+            yielding = yielding1
+          } =
+        m1
+      in
       let { areality = areality2;
             linearity = linearity2;
             portability = portability2;
-            yielding = yielding2 } = m2 in     
+            yielding = yielding2
+          } =
+        m2
+      in
       Areality.le areality1 areality2
       && Linearity.le linearity1 linearity2
       && Portability.le portability1 portability2
@@ -481,11 +486,8 @@ module Lattices = struct
       { areality; linearity; portability; yielding }
 
     let print ppf m =
-      Format.fprintf ppf "%a,%a,%a,%a"
-        Areality.print m.areality
-        Linearity.print m.linearity
-        Portability.print m.portability
-        Yielding.print m.yielding
+      Format.fprintf ppf "%a,%a,%a,%a" Areality.print m.areality Linearity.print
+        m.linearity Portability.print m.portability Yielding.print m.yielding
   end
   [@@inline]
 
@@ -1049,35 +1051,35 @@ module Lattices_mono = struct
   let monadic_to_comonadic_min :
       type a. a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
    fun obj m ->
-     let areality : a =
-       match obj with
-       | Comonadic_with_locality -> Locality.min
-       | Comonadic_with_regionality -> Regionality.min
-     in
-     let linearity = unique_to_linear m.uniqueness in
-     let portability = contended_to_portable m.contention in
-     let yielding = Yielding.min in
-     { areality; linearity; portability; yielding }
+    let areality : a =
+      match obj with
+      | Comonadic_with_locality -> Locality.min
+      | Comonadic_with_regionality -> Regionality.min
+    in
+    let linearity = unique_to_linear m.uniqueness in
+    let portability = contended_to_portable m.contention in
+    let yielding = Yielding.min in
+    { areality; linearity; portability; yielding }
 
   let comonadic_to_monadic :
       type a. a comonadic_with obj -> a comonadic_with -> Monadic_op.t =
-   fun _ m  ->
-     let uniqueness = linear_to_unique m.linearity in
-     let contention = portable_to_contended m.portability in
-     { uniqueness; contention }
+   fun _ m ->
+    let uniqueness = linear_to_unique m.linearity in
+    let contention = portable_to_contended m.portability in
+    { uniqueness; contention }
 
   let monadic_to_comonadic_max :
       type a. a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
    fun obj m ->
-     let areality : a =
-       match obj with
-       | Comonadic_with_locality -> Locality.max
-       | Comonadic_with_regionality -> Regionality.max
-     in
-     let linearity = unique_to_linear m.uniqueness in
-     let portability = contended_to_portable m.contention in
-     let yielding = Yielding.max in
-     { areality; linearity; portability; yielding }
+    let areality : a =
+      match obj with
+      | Comonadic_with_locality -> Locality.max
+      | Comonadic_with_regionality -> Regionality.max
+    in
+    let linearity = unique_to_linear m.uniqueness in
+    let portability = contended_to_portable m.contention in
+    let yielding = Yielding.max in
+    { areality; linearity; portability; yielding }
 
   let rec apply : type a b d. b obj -> (a, b, d) morph -> a -> b =
    fun dst f a ->
@@ -1340,13 +1342,15 @@ module S = Solvers_polarized (C)
 
 type monadic = C.monadic =
   { uniqueness : C.Uniqueness.t;
-    contention : C.Contention.t; }
+    contention : C.Contention.t
+  }
 
 type 'a comonadic_with = 'a C.comonadic_with =
   { areality : 'a;
     linearity : C.Linearity.t;
     portability : C.Portability.t;
-    yielding : C.Yielding.t; }
+    yielding : C.Yielding.t
+  }
 
 module Axis = C.Axis
 
@@ -1579,7 +1583,6 @@ end
 
 module Uniqueness = struct
   module Const = C.Uniqueness
-
   module Const_op = C.Uniqueness_op
 
   module Obj = struct
@@ -1604,7 +1607,6 @@ end
 
 module Contention = struct
   module Const = C.Contention
-
   module Const_op = C.Contention_op
 
   module Obj = struct
@@ -1730,7 +1732,8 @@ module Comonadic_with (Areality : Areality) = struct
     let yielding = proj Yielding m |> Yielding.zap_to_legacy in
     { areality; linearity; portability; yielding }
 
-  let imply c m = Obj.Solver.via_monotone Obj.obj (Imply c) (Obj.Solver.disallow_left m)
+  let imply c m =
+    Obj.Solver.via_monotone Obj.obj (Imply c) (Obj.Solver.disallow_left m)
 
   let subtract c m =
     Obj.Solver.via_monotone Obj.obj (Subtract c) (Obj.Solver.disallow_right m)
@@ -1738,15 +1741,20 @@ module Comonadic_with (Areality : Areality) = struct
   let legacy = of_const Const.legacy
 
   let axis_of_error (err : Obj.const Solver.error) : error =
-    let
-      { left = { areality = areality1;
-                 linearity = linearity1;
-                 portability = portability1;
-                 yielding = yielding1; };
-        right = { areality = areality2;
-                 linearity = linearity2;
-                 portability = portability2;
-                 yielding = yielding2; } } = err
+    let { left =
+            { areality = areality1;
+              linearity = linearity1;
+              portability = portability1;
+              yielding = yielding1
+            };
+          right =
+            { areality = areality2;
+              linearity = linearity2;
+              portability = portability2;
+              yielding = yielding2
+            }
+        } =
+      err
     in
     if Areality.Const.le areality1 areality2
     then
@@ -1756,12 +1764,19 @@ module Comonadic_with (Areality : Areality) = struct
         then
           if Yielding.Const.le yielding1 yielding2
           then assert false
-          else Error (Yielding,
-                      { left = err.left.yielding; right = err.right.yielding })
-        else Error (Portability,
-                    { left = err.left.portability; right = err.right.portability })
-      else Error (Linearity, { left = err.left.linearity; right = err.right.linearity })
-    else Error (Areality, { left = err.left.areality; right = err.right.areality })
+          else
+            Error
+              ( Yielding,
+                { left = err.left.yielding; right = err.right.yielding } )
+        else
+          Error
+            ( Portability,
+              { left = err.left.portability; right = err.right.portability } )
+      else
+        Error
+          (Linearity, { left = err.left.linearity; right = err.right.linearity })
+    else
+      Error (Areality, { left = err.left.areality; right = err.right.areality })
 
   (* overriding to report the offending axis *)
   let submode_log m0 m1 ~log : _ result =
@@ -1844,9 +1859,11 @@ module Monadic = struct
 
   let meet_with ax c m = meet_const (C.min_with Obj.obj ax c) m
 
-  let imply c m = Obj.Solver.via_monotone Obj.obj (Subtract c) (Obj.Solver.disallow_left m)
+  let imply c m =
+    Obj.Solver.via_monotone Obj.obj (Subtract c) (Obj.Solver.disallow_left m)
 
-  let subtract c m = Obj.Solver.via_monotone Obj.obj (Imply c) (Obj.Solver.disallow_right m)
+  let subtract c m =
+    Obj.Solver.via_monotone Obj.obj (Imply c) (Obj.Solver.disallow_right m)
 
   let zap_to_legacy m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
@@ -1856,18 +1873,23 @@ module Monadic = struct
   let legacy = of_const Const.legacy
 
   let axis_of_error (err : Obj.const Solver.error) : error =
-    let
-      { left = { uniqueness = uniqueness1;
-                 contention = contention1; };
-        right = { uniqueness = uniqueness2;
-                 contention = contention2; } } = err
+    let { left = { uniqueness = uniqueness1; contention = contention1 };
+          right = { uniqueness = uniqueness2; contention = contention2 }
+        } =
+      err
     in
     if Uniqueness.Const.le uniqueness1 uniqueness2
     then
       if Contention.Const.le contention1 contention2
       then assert false
-      else Error (Contention, { left = err.left.contention; right = err.right.contention })
-    else Error (Uniqueness, { left = err.left.uniqueness; right = err.right.uniqueness })
+      else
+        Error
+          ( Contention,
+            { left = err.left.contention; right = err.right.contention } )
+    else
+      Error
+        ( Uniqueness,
+          { left = err.left.uniqueness; right = err.right.uniqueness } )
 
   (* overriding to report the offending axis *)
   let submode_log m0 m1 ~log : _ result =
@@ -1948,10 +1970,10 @@ module Value_with (Areality : Areality) = struct
     { comonadic; monadic }
 
   let merge { comonadic; monadic } =
-    let { areality; linearity; portability; yielding } : Comonadic.Const.t =
+    let ({ areality; linearity; portability; yielding } : Comonadic.Const.t) =
       comonadic
     in
-    let { uniqueness; contention } : Monadic.Const.t = monadic in
+    let ({ uniqueness; contention } : Monadic.Const.t) = monadic in
     { areality; linearity; portability; yielding; uniqueness; contention }
 
   let print ?verbose () ppf { monadic; comonadic } =

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -229,6 +229,8 @@ module type S = sig
       include Lattice with type t := t
     end
 
+    module Const_op : Lattice with type t = Const.t
+
     type error = Const.t Solver.error
 
     include
@@ -253,6 +255,8 @@ module type S = sig
 
       include Lattice with type t := t
     end
+
+    module Const_op : Lattice with type t = Const.t
 
     type error = Const.t Solver.error
 
@@ -319,9 +323,11 @@ module type S = sig
         val min_axis : (t, 'a) Axis.t -> 'a
       end
 
+      module Const_op : Lattice with type t = monadic
+
       include Common with module Const := Const
 
-      val imply : Const.t -> ('l * 'r) t -> (disallowed * 'r) t
+      val join_const : Const.t -> ('l * 'r) t -> ('l * 'r) t
     end
 
     module Comonadic : sig
@@ -458,6 +464,10 @@ module type S = sig
     val meet_const : Const.t -> ('l * 'r) t -> ('l * 'r) t
 
     val imply : Const.t -> ('l * 'r) t -> (disallowed * 'r) t
+
+    val join_const : Const.t -> ('l * 'r) t -> ('l * 'r) t
+
+    val subtract : Const.t -> ('l * 'r) t -> ('l * disallowed) t
 
     (* The following two are about the scenario where we partially apply a
        function [A -> B -> C] to [A] and get back [B -> C]. The mode of the

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -364,6 +364,8 @@ module type S = sig
 
     val print_axis : Format.formatter -> ('m, 'a, 'd) axis -> unit
 
+    (** Gets the normal lattice for comonadic axes and the "op"ped lattice for
+        monadic ones. *)
     val lattice_of_axis : ('m, 'a, 'd) axis -> (module Lattice with type t = 'a)
 
     val all_axes : ('l * 'r) axis_packed list

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -281,10 +281,15 @@ module type S = sig
          and type 'd t = (Const.t, 'd) mode_comonadic
   end
 
-  type 'a comonadic_with = private
-    'a * Linearity.Const.t * Portability.Const.t * Yielding.Const.t
+  type 'a comonadic_with =
+    { areality : 'a;
+      linearity : Linearity.Const.t;
+      portability :  Portability.Const.t;
+      yielding :  Yielding.Const.t; }
 
-  type monadic = private Uniqueness.Const.t * Contention.Const.t
+  type monadic =
+    { uniqueness : Uniqueness.Const.t;
+      contention : Contention.Const.t }
 
   module Axis : sig
     (** ('p, 'r) t represents a projection from a product of type ['p] to an

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -288,12 +288,14 @@ module type S = sig
   type 'a comonadic_with =
     { areality : 'a;
       linearity : Linearity.Const.t;
-      portability :  Portability.Const.t;
-      yielding :  Yielding.Const.t; }
+      portability : Portability.Const.t;
+      yielding : Yielding.Const.t
+    }
 
   type monadic =
     { uniqueness : Uniqueness.Const.t;
-      contention : Contention.Const.t }
+      contention : Contention.Const.t
+    }
 
   module Axis : sig
     (** ('p, 'r) t represents a projection from a product of type ['p] to an

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -934,15 +934,25 @@ let has_poly_constraint spat =
 (* This is very similar to Ctype.mode_cross_left_alloc. Any bugs here are likely
    bugs there, too. *)
 let mode_cross_left_value env ty mode =
-  let mode =
-    if not (is_principal ty) then mode else
+  if not (is_principal ty) then
+    Value.disallow_right mode
+  else begin
     let jkind = type_jkind_purely env ty in
     let jkind_of_type = type_jkind_purely_if_principal env in
     let upper_bounds = Jkind.get_modal_upper_bounds ~jkind_of_type jkind in
+    let upper_bounds =
+      Alloc.Const.merge
+        { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
+    in
     let upper_bounds = Const.alloc_as_value upper_bounds in
-    Value.meet_const upper_bounds mode
-  in
-  mode |> Value.disallow_right
+    let lower_bounds = Jkind.get_modal_lower_bounds jkind in
+    let lower_bounds =
+      Alloc.Const.merge
+        { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
+    in
+    let lower_bounds = Const.alloc_as_value lower_bounds in
+    Value.subtract lower_bounds (Value.meet_const upper_bounds mode)
+  end
 
 let actual_mode_cross_left env ty (actual_mode : Env.actual_mode)
   : Env.actual_mode =
@@ -956,11 +966,10 @@ let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
   if not (is_principal ty) then { monadic; comonadic } else
   let jkind = type_jkind_purely env ty in
-  let jkind_of_type = type_jkind_purely_if_principal env in
   let upper_bounds = Jkind.get_modal_upper_bounds ~jkind_of_type jkind in
-  let upper_bounds = Alloc.Const.split upper_bounds in
-  let comonadic = Alloc.Comonadic.meet_const upper_bounds.comonadic comonadic in
-  let monadic = Alloc.Monadic.imply upper_bounds.monadic monadic in
+  let comonadic = Alloc.Comonadic.meet_const upper_bounds comonadic in
+  let lower_bounds = Jkind.get_modal_lower_bounds ~jkind_of_type jkind in
+  let monadic = Alloc.Monadic.join_const lower_bounds monadic in
   { monadic; comonadic }
 
 (** Mode cross a right mode *)
@@ -969,8 +978,22 @@ let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
 let expect_mode_cross_jkind env jkind (expected_mode : expected_mode) =
   let jkind_of_type = type_jkind_purely_if_principal env in
   let upper_bounds = Jkind.get_modal_upper_bounds ~jkind_of_type jkind in
+  let upper_bounds =
+    Alloc.Const.merge
+      { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
+  in
   let upper_bounds = Const.alloc_as_value upper_bounds in
-  mode_morph (Value.imply upper_bounds) expected_mode
+  let lower_bounds = Jkind.get_modal_lower_bounds jkind in
+  let lower_bounds =
+    Alloc.Const.merge
+      { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
+  in
+  let lower_bounds = Const.alloc_as_value lower_bounds in
+  mode_morph
+    (fun m ->
+      Value.imply upper_bounds
+        (Value.join_const lower_bounds m))
+    expected_mode
 
 let expect_mode_cross env ty (expected_mode : expected_mode) =
   if not (is_principal ty) then expected_mode else

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -945,7 +945,7 @@ let mode_cross_left_value env ty mode =
         { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
     in
     let upper_bounds = Const.alloc_as_value upper_bounds in
-    let lower_bounds = Jkind.get_modal_lower_bounds jkind in
+    let lower_bounds = Jkind.get_modal_lower_bounds ~jkind_of_type jkind in
     let lower_bounds =
       Alloc.Const.merge
         { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
@@ -966,6 +966,7 @@ let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
   if not (is_principal ty) then { monadic; comonadic } else
   let jkind = type_jkind_purely env ty in
+  let jkind_of_type = type_jkind_purely_if_principal env in
   let upper_bounds = Jkind.get_modal_upper_bounds ~jkind_of_type jkind in
   let comonadic = Alloc.Comonadic.meet_const upper_bounds comonadic in
   let lower_bounds = Jkind.get_modal_lower_bounds ~jkind_of_type jkind in
@@ -983,7 +984,7 @@ let expect_mode_cross_jkind env jkind (expected_mode : expected_mode) =
       { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
   in
   let upper_bounds = Const.alloc_as_value upper_bounds in
-  let lower_bounds = Jkind.get_modal_lower_bounds jkind in
+  let lower_bounds = Jkind.get_modal_lower_bounds ~jkind_of_type jkind in
   let lower_bounds =
     Alloc.Const.merge
       { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2528,7 +2528,9 @@ let normalize_decl_jkinds env shapes decls =
               in
               let umc =
                 Some { modal_upper_bounds =
-                         Jkind.get_modal_upper_bounds ~jkind_of_type type_jkind }
+                         Jkind.get_modal_upper_bounds ~jkind_of_type type_jkind;
+                       modal_lower_bounds =
+                         Jkind.get_modal_lower_bounds ~jkind_of_type type_jkind }
               in
               let type_kind =
                 match decl.type_kind with

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -88,7 +88,7 @@ let is_base_type env ty base_ty_path =
   | _ -> false
 
 let is_always_gc_ignorable env ty =
-  let ext : Jkind.Externality.t =
+  let ext : Jkind_axis.Externality.t =
     (* We check that we're compiling to (64-bit) native code before counting
        External64 types as gc_ignorable, because bytecode is intended to be
        platform independent. *)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -318,7 +318,8 @@ and type_decl_kind =
   (label_declaration, label_declaration, constructor_declaration) type_kind
 
 and unsafe_mode_crossing =
-  { modal_upper_bounds : Mode.Alloc.Const.t }
+  { modal_upper_bounds : Mode.Alloc.Comonadic.Const.t;
+    modal_lower_bounds : Mode.Alloc.Monadic.Const.t }
 
 and ('lbl, 'lbl_flat, 'cstr) type_kind =
     Type_abstract of type_origin
@@ -869,6 +870,16 @@ let flat_element_to_lowercase_string = function
   | Bits64 -> "bits64"
   | Vec128 -> "vec128"
   | Word -> "word"
+
+let equal_unsafe_mode_crossing umc1 umc2 =
+    let { modal_upper_bounds = mub1;
+          modal_lower_bounds = mlb1 } = umc1 in
+    let { modal_upper_bounds = mub2;
+          modal_lower_bounds = mlb2 } = umc2 in
+    Mode.Alloc.Comonadic.Const.le mub1 mub2
+    && Mode.Alloc.Comonadic.Const.le mub2 mub1
+    && Mode.Alloc.Monadic.Const.le mlb1 mlb2
+    && Mode.Alloc.Monadic.Const.le mlb2 mlb1
 
 (**** Definitions for backtracking ****)
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -640,7 +640,8 @@ type type_declaration =
 and type_decl_kind = (label_declaration, label_declaration, constructor_declaration) type_kind
 
 and unsafe_mode_crossing =
-  { modal_upper_bounds : Mode.Alloc.Const.t }
+  { modal_upper_bounds : Mode.Alloc.Comonadic.Const.t;
+    modal_lower_bounds : Mode.Alloc.Monadic.Const.t }
 
 and ('lbl, 'lbl_flat, 'cstr) type_kind =
     Type_abstract of type_origin
@@ -1058,6 +1059,9 @@ val equal_flat_element : flat_element -> flat_element -> bool
 val compare_flat_element : flat_element -> flat_element -> int
 val flat_element_to_string : flat_element -> string
 val flat_element_to_lowercase_string : flat_element -> string
+
+val equal_unsafe_mode_crossing :
+  unsafe_mode_crossing -> unsafe_mode_crossing -> bool
 
 (**** Utilities for backtracking ****)
 


### PR DESCRIPTION
Currently mode-crossing for monadic modes is an upper bound, however, the correct behaviour for them is to be a lower bound on the expected mode. This PR splits the modal bounds in the kind into a comonadic part and a monadic part and treats the monadic part as a lower bound. The main result of this change is that, something which mode crosses contention should be written `mod contended` instead of `mod uncontended` and something which mode crosses uniqueness should be written `mod aliased` instead of `mod unique`.