### PR TITLE
Rename Lambda.alloc_mode to Lambda.locality_mode (no semantic change)

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -556,7 +556,7 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
         k acc (List.map Named.create_var let_bound_vars))
   in
   let alloc_mode_app =
-    match Lambda.alloc_mode_of_primitive_description prim_desc with
+    match Lambda.locality_mode_of_primitive_description prim_desc with
     | None ->
       (* This happens when stack allocation is disabled. *)
       Alloc_mode.For_applications.heap
@@ -565,7 +565,7 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
         ~current_ghost_region
   in
   let alloc_mode =
-    match Lambda.alloc_mode_of_primitive_description prim_desc with
+    match Lambda.locality_mode_of_primitive_description prim_desc with
     | None ->
       (* This happens when stack allocation is disabled. *)
       Alloc_mode.For_allocations.heap
@@ -2829,7 +2829,7 @@ let close_let_rec acc env ~function_declarations
     (* The closure allocation mode must be the same for all closures in the set
        of closures. *)
     List.fold_left
-      (fun (alloc_mode : Lambda.alloc_mode option) function_decl ->
+      (fun (alloc_mode : Lambda.locality_mode option) function_decl ->
         match alloc_mode, Function_decl.closure_alloc_mode function_decl with
         | None, alloc_mode -> Some alloc_mode
         | Some Alloc_heap, Alloc_heap | Some Alloc_local, Alloc_local ->
@@ -3000,7 +3000,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
     then Lambda.alloc_heap, first_complex_local_param - num_provided
     else Lambda.alloc_local, 0
   in
-  if not (Lambda.sub_mode closure_alloc_mode apply.IR.mode)
+  if not (Lambda.sub_locality_mode closure_alloc_mode apply.IR.mode)
   then
     (* This can happen in a dead GADT match case. *)
     ( acc,
@@ -3048,7 +3048,7 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
   let acc, remaining = find_simples acc env remaining in
   let apply_dbg = Debuginfo.from_location apply.loc in
   let needs_region =
-    match apply.mode, (result_mode : Lambda.alloc_mode) with
+    match apply.mode, (result_mode : Lambda.locality_mode) with
     | Alloc_heap, Alloc_local ->
       let over_app_region = Variable.create "over_app_region" in
       let over_app_ghost_region = Variable.create "over_app_ghost_region" in
@@ -3175,7 +3175,7 @@ type call_args_split =
         provided_arity : [`Complex] Flambda_arity.t;
         remaining : IR.simple list;
         remaining_arity : [`Complex] Flambda_arity.t;
-        result_mode : Lambda.alloc_mode
+        result_mode : Lambda.locality_mode
       }
 
 let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -70,7 +70,7 @@ module IR = struct
       region_close : Lambda.region_close;
       inlined : Lambda.inlined_attribute;
       probe : Lambda.probe;
-      mode : Lambda.alloc_mode;
+      mode : Lambda.locality_mode;
       region : Ident.t;
       ghost_region : Ident.t;
       args_arity : [`Complex] Flambda_arity.t;
@@ -753,7 +753,7 @@ module Function_decls = struct
       { name : Ident.t;
         kind : Flambda_kind.With_subkind.t;
         attributes : Lambda.parameter_attribute;
-        mode : Lambda.alloc_mode
+        mode : Lambda.locality_mode
       }
 
     type unboxing_kind =
@@ -784,9 +784,9 @@ module Function_decls = struct
         attr : Lambda.function_attribute;
         loc : Lambda.scoped_location;
         recursive : Recursive.t;
-        closure_alloc_mode : Lambda.alloc_mode;
+        closure_alloc_mode : Lambda.locality_mode;
         first_complex_local_param : int;
-        result_mode : Lambda.alloc_mode;
+        result_mode : Lambda.locality_mode;
         contains_no_escaping_local_allocs : bool
       }
 
@@ -883,7 +883,7 @@ module Function_decls = struct
   type t =
     { function_decls : Function_decl.t list;
       all_free_idents : Ident.Set.t;
-      alloc_mode : Lambda.alloc_mode
+      alloc_mode : Lambda.locality_mode
     }
 
   let alloc_mode t = t.alloc_mode

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -74,7 +74,7 @@ module IR : sig
       region_close : Lambda.region_close;
       inlined : Lambda.inlined_attribute;
       probe : Lambda.probe;
-      mode : Lambda.alloc_mode;
+      mode : Lambda.locality_mode;
       region : Ident.t;
       ghost_region : Ident.t;
       args_arity : [`Complex] Flambda_arity.t;
@@ -339,7 +339,7 @@ module Function_decls : sig
       { name : Ident.t;
         kind : Flambda_kind.With_subkind.t;
         attributes : Lambda.parameter_attribute;
-        mode : Lambda.alloc_mode
+        mode : Lambda.locality_mode
       }
 
     val create :
@@ -360,9 +360,9 @@ module Function_decls : sig
       loc:Lambda.scoped_location ->
       free_idents_of_body:Ident.Set.t ->
       Recursive.t ->
-      closure_alloc_mode:Lambda.alloc_mode ->
+      closure_alloc_mode:Lambda.locality_mode ->
       first_complex_local_param:int ->
-      result_mode:Lambda.alloc_mode ->
+      result_mode:Lambda.locality_mode ->
       contains_no_escaping_local_allocs:bool ->
       t
 
@@ -410,11 +410,11 @@ module Function_decls : sig
 
     val recursive : t -> Recursive.t
 
-    val closure_alloc_mode : t -> Lambda.alloc_mode
+    val closure_alloc_mode : t -> Lambda.locality_mode
 
     val first_complex_local_param : t -> int
 
-    val result_mode : t -> Lambda.alloc_mode
+    val result_mode : t -> Lambda.locality_mode
 
     val contains_no_escaping_local_allocs : t -> bool
 
@@ -424,9 +424,9 @@ module Function_decls : sig
 
   type t
 
-  val create : Function_decl.t list -> Lambda.alloc_mode -> t
+  val create : Function_decl.t list -> Lambda.locality_mode -> t
 
-  val alloc_mode : t -> Lambda.alloc_mode
+  val alloc_mode : t -> Lambda.locality_mode
 
   val to_list : t -> Function_decl.t list
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -294,8 +294,8 @@ let box_float32 (mode : L.locality_mode) (arg : H.expr_primitive)
           Alloc_mode.For_allocations.from_lambda mode ~current_region ),
       Prim arg )
 
-let box_float (mode : L.locality_mode) (arg : H.expr_primitive)
-    ~current_region : H.expr_primitive =
+let box_float (mode : L.locality_mode) (arg : H.expr_primitive) ~current_region
+    : H.expr_primitive =
   Unary
     ( Box_number
         ( K.Boxable_number.Naked_float,

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -143,7 +143,7 @@ module Array_ref_kind = struct
   type t =
     | Immediates
     | Values
-    | Naked_floats_to_be_boxed of L.alloc_mode
+    | Naked_floats_to_be_boxed of L.locality_mode
     | Naked_floats
     | Naked_float32s
     | Naked_int32s
@@ -153,7 +153,7 @@ end
 
 type converted_array_ref_kind =
   | Array_ref_kind of Array_ref_kind.t
-  | Float_array_opt_dynamic_ref of L.alloc_mode
+  | Float_array_opt_dynamic_ref of L.locality_mode
 
 let convert_array_ref_kind (kind : L.array_ref_kind) : converted_array_ref_kind
     =
@@ -169,7 +169,8 @@ let convert_array_ref_kind (kind : L.array_ref_kind) : converted_array_ref_kind
     Float_array_opt_dynamic_ref mode
   | Paddrarray_ref -> Array_ref_kind Values
   | Pintarray_ref -> Array_ref_kind Immediates
-  | Pfloatarray_ref mode -> Array_ref_kind (Naked_floats_to_be_boxed mode)
+  | Pfloatarray_ref mode ->
+    Array_ref_kind (Naked_floats_to_be_boxed mode)
   | Punboxedfloatarray_ref Pfloat64 -> Array_ref_kind Naked_floats
   | Punboxedfloatarray_ref Pfloat32 -> Array_ref_kind Naked_float32s
   | Punboxedintarray_ref Pint32 -> Array_ref_kind Naked_int32s
@@ -286,7 +287,7 @@ let untag_int (arg : H.simple_or_prim) : H.simple_or_prim =
 let unbox_float32 (arg : H.simple_or_prim) : H.simple_or_prim =
   Prim (Unary (Unbox_number K.Boxable_number.Naked_float32, arg))
 
-let box_float32 (mode : L.alloc_mode) (arg : H.expr_primitive) ~current_region :
+let box_float32 (mode : L.locality_mode) (arg : H.expr_primitive) ~current_region :
     H.expr_primitive =
   Unary
     ( Box_number
@@ -294,7 +295,7 @@ let box_float32 (mode : L.alloc_mode) (arg : H.expr_primitive) ~current_region :
           Alloc_mode.For_allocations.from_lambda mode ~current_region ),
       Prim arg )
 
-let box_float (mode : L.alloc_mode) (arg : H.expr_primitive) ~current_region :
+let box_float (mode : L.locality_mode) (arg : H.expr_primitive) ~current_region :
     H.expr_primitive =
   Unary
     ( Box_number

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -169,8 +169,7 @@ let convert_array_ref_kind (kind : L.array_ref_kind) : converted_array_ref_kind
     Float_array_opt_dynamic_ref mode
   | Paddrarray_ref -> Array_ref_kind Values
   | Pintarray_ref -> Array_ref_kind Immediates
-  | Pfloatarray_ref mode ->
-    Array_ref_kind (Naked_floats_to_be_boxed mode)
+  | Pfloatarray_ref mode -> Array_ref_kind (Naked_floats_to_be_boxed mode)
   | Punboxedfloatarray_ref Pfloat64 -> Array_ref_kind Naked_floats
   | Punboxedfloatarray_ref Pfloat32 -> Array_ref_kind Naked_float32s
   | Punboxedintarray_ref Pint32 -> Array_ref_kind Naked_int32s
@@ -287,16 +286,16 @@ let untag_int (arg : H.simple_or_prim) : H.simple_or_prim =
 let unbox_float32 (arg : H.simple_or_prim) : H.simple_or_prim =
   Prim (Unary (Unbox_number K.Boxable_number.Naked_float32, arg))
 
-let box_float32 (mode : L.locality_mode) (arg : H.expr_primitive) ~current_region :
-    H.expr_primitive =
+let box_float32 (mode : L.locality_mode) (arg : H.expr_primitive)
+    ~current_region : H.expr_primitive =
   Unary
     ( Box_number
         ( K.Boxable_number.Naked_float32,
           Alloc_mode.For_allocations.from_lambda mode ~current_region ),
       Prim arg )
 
-let box_float (mode : L.locality_mode) (arg : H.expr_primitive) ~current_region :
-    H.expr_primitive =
+let box_float (mode : L.locality_mode) (arg : H.expr_primitive)
+    ~current_region : H.expr_primitive =
   Unary
     ( Box_number
         ( K.Boxable_number.Naked_float,

--- a/middle_end/flambda2/term_basics/alloc_mode.ml
+++ b/middle_end/flambda2/term_basics/alloc_mode.ml
@@ -47,7 +47,7 @@ module For_types = struct
     then Heap
     else Heap_or_local
 
-  let from_lambda (mode : Lambda.alloc_mode) =
+  let from_lambda (mode : Lambda.locality_mode) =
     if not (Flambda_features.stack_allocation_enabled ())
     then Heap
     else match mode with Alloc_heap -> Heap | Alloc_local -> Heap_or_local
@@ -95,7 +95,7 @@ module For_applications = struct
   let as_type t : For_types.t =
     match t with Heap -> Heap | Local _ -> Heap_or_local
 
-  let from_lambda (mode : Lambda.alloc_mode) ~current_region
+  let from_lambda (mode : Lambda.locality_mode) ~current_region
       ~current_ghost_region =
     if not (Flambda_features.stack_allocation_enabled ())
     then Heap
@@ -161,7 +161,7 @@ module For_allocations = struct
   let as_type t : For_types.t =
     match t with Heap -> Heap | Local _ -> Heap_or_local
 
-  let from_lambda (mode : Lambda.alloc_mode) ~current_region =
+  let from_lambda (mode : Lambda.locality_mode) ~current_region =
     if not (Flambda_features.stack_allocation_enabled ())
     then Heap
     else

--- a/middle_end/flambda2/term_basics/alloc_mode.mli
+++ b/middle_end/flambda2/term_basics/alloc_mode.mli
@@ -35,10 +35,10 @@ module For_types : sig
 
   (** Maps [Alloc_local] to [Heap_or_local], as all Lambda annotations that we
       transform into constraints have this semantics *)
-  val from_lambda : Lambda.alloc_mode -> t
+  val from_lambda : Lambda.locality_mode -> t
 
   (** Symmetric to [from_lambda], so [Heap_or_local] is mapped to [Alloc_local] *)
-  val to_lambda : t -> Lambda.alloc_mode
+  val to_lambda : t -> Lambda.locality_mode
 end
 
 module For_applications : sig
@@ -62,7 +62,7 @@ module For_applications : sig
   val as_type : t -> For_types.t
 
   val from_lambda :
-    Lambda.alloc_mode ->
+    Lambda.locality_mode ->
     current_region:Variable.t ->
     current_ghost_region:Variable.t ->
     t
@@ -90,7 +90,7 @@ module For_allocations : sig
 
   val as_type : t -> For_types.t
 
-  val from_lambda : Lambda.alloc_mode -> current_region:Variable.t -> t
+  val from_lambda : Lambda.locality_mode -> current_region:Variable.t -> t
 
   include Contains_names.S with type t := t
 

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -25,7 +25,7 @@ type t =
        for instance as a result of a partial application. *)
     result_arity : [`Unarized] Flambda_arity.t;
     result_types : Result_types.t Or_unknown_or_bottom.t;
-    result_mode : Lambda.alloc_mode;
+    result_mode : Lambda.locality_mode;
     contains_no_escaping_local_allocs : bool;
     stub : bool;
     inline : Inline_attribute.t;
@@ -134,7 +134,7 @@ type 'a create_type =
   first_complex_local_param:int ->
   result_arity:[`Unarized] Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
-  result_mode:Lambda.alloc_mode ->
+  result_mode:Lambda.locality_mode ->
   contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->
@@ -550,7 +550,7 @@ let approx_equal
   && List.equal Alloc_mode.For_types.equal param_modes1 param_modes2
   && Int.equal first_complex_local_param1 first_complex_local_param2
   && Flambda_arity.equal_ignoring_subkinds result_arity1 result_arity2
-  && Lambda.equal_alloc_mode result_mode1 result_mode2
+  && Lambda.eq_locality_mode result_mode1 result_mode2
   && Bool.equal contains_no_escaping_local_allocs1
        contains_no_escaping_local_allocs2
   && Bool.equal stub1 stub2

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -44,7 +44,7 @@ module type Code_metadata_accessors_result_type = sig
 
   val result_types : 'a t -> Result_types.t Or_unknown_or_bottom.t
 
-  val result_mode : 'a t -> Lambda.alloc_mode
+  val result_mode : 'a t -> Lambda.locality_mode
 
   val stub : 'a t -> bool
 
@@ -94,7 +94,7 @@ type 'a create_type =
   first_complex_local_param:int ->
   result_arity:[`Unarized] Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
-  result_mode:Lambda.alloc_mode ->
+  result_mode:Lambda.locality_mode ->
   contains_no_escaping_local_allocs:bool ->
   stub:bool ->
   inline:Inline_attribute.t ->

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -49,22 +49,15 @@ include (struct
     | Alloc_heap
     | Alloc_local
 
-  type alloc_mode = locality_mode
-
   type modify_mode =
     | Modify_heap
     | Modify_maybe_stack
 
   let alloc_heap = Alloc_heap
 
-  let alloc_local : alloc_mode =
+  let alloc_local =
     if Config.stack_allocation then Alloc_local
     else Alloc_heap
-
-  let join_mode a b =
-    match a, b with
-    | Alloc_local, _ | _, Alloc_local -> Alloc_local
-    | Alloc_heap, Alloc_heap -> Alloc_heap
 
   let modify_heap = Modify_heap
 
@@ -72,34 +65,28 @@ include (struct
     if Config.stack_allocation then Modify_maybe_stack
     else Modify_heap
 
-  let equal_alloc_mode mode1 mode2 =
-    match mode1, mode2 with
-    | Alloc_local, Alloc_local | Alloc_heap, Alloc_heap -> true
-    | (Alloc_local | Alloc_heap), _ -> false
-
+  let join_locality_mode a b =
+    match a, b with
+    | Alloc_local, _ | _, Alloc_local -> Alloc_local
+    | Alloc_heap, Alloc_heap -> Alloc_heap
 end : sig
 
   type locality_mode = private
     | Alloc_heap
     | Alloc_local
 
-  type alloc_mode = locality_mode
-
   type modify_mode = private
     | Modify_heap
     | Modify_maybe_stack
 
   val alloc_heap : locality_mode
-
   val alloc_local : locality_mode
 
   val modify_heap : modify_mode
 
   val modify_maybe_stack : modify_mode
 
-  val join_mode : alloc_mode -> alloc_mode -> alloc_mode
-
-  val equal_alloc_mode : alloc_mode -> alloc_mode -> bool
+  val join_locality_mode : locality_mode -> locality_mode -> locality_mode
 end)
 
 let is_local_mode = function
@@ -110,13 +97,13 @@ let is_heap_mode = function
   | Alloc_heap -> true
   | Alloc_local -> false
 
-let sub_mode a b =
+let sub_locality_mode a b =
   match a, b with
   | Alloc_heap, _ -> true
   | _, Alloc_local -> true
   | Alloc_local, Alloc_heap -> false
 
-let eq_mode a b =
+let eq_locality_mode a b =
   match a, b with
   | Alloc_heap, Alloc_heap -> true
   | Alloc_local, Alloc_local -> true
@@ -142,15 +129,15 @@ type primitive =
   | Psetglobal of Compilation_unit.t
   | Pgetpredef of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape * alloc_mode
-  | Pmakefloatblock of mutable_flag * alloc_mode
-  | Pmakeufloatblock of mutable_flag * alloc_mode
-  | Pmakemixedblock of int * mutable_flag * mixed_block_shape * alloc_mode
+  | Pmakeblock of int * mutable_flag * block_shape * locality_mode
+  | Pmakefloatblock of mutable_flag * locality_mode
+  | Pmakeufloatblock of mutable_flag * locality_mode
+  | Pmakemixedblock of int * mutable_flag * mixed_block_shape * locality_mode
   | Pfield of int * immediate_or_pointer * field_read_semantics
   | Pfield_computed of field_read_semantics
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
-  | Pfloatfield of int * field_read_semantics * alloc_mode
+  | Pfloatfield of int * field_read_semantics * locality_mode
   | Pufloatfield of int * field_read_semantics
   | Pmixedfield of
       int * mixed_block_read * mixed_block_shape * field_read_semantics
@@ -185,23 +172,23 @@ type primitive =
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)
-  | Pfloatoffloat32 of alloc_mode
-  | Pfloat32offloat of alloc_mode
+  | Pfloatoffloat32 of locality_mode
+  | Pfloat32offloat of locality_mode
   | Pintoffloat of boxed_float
-  | Pfloatofint of boxed_float * alloc_mode
-  | Pnegfloat of boxed_float * alloc_mode
-  | Pabsfloat of boxed_float * alloc_mode
-  | Paddfloat of boxed_float * alloc_mode
-  | Psubfloat of boxed_float * alloc_mode
-  | Pmulfloat of boxed_float * alloc_mode
-  | Pdivfloat of boxed_float * alloc_mode
+  | Pfloatofint of boxed_float * locality_mode
+  | Pnegfloat of boxed_float * locality_mode
+  | Pabsfloat of boxed_float * locality_mode
+  | Paddfloat of boxed_float * locality_mode
+  | Psubfloat of boxed_float * locality_mode
+  | Pmulfloat of boxed_float * locality_mode
+  | Pdivfloat of boxed_float * locality_mode
   | Pfloatcomp of boxed_float * float_comparison
   | Punboxed_float_comp of boxed_float * float_comparison
   (* String operations *)
   | Pstringlength | Pstringrefu  | Pstringrefs
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   (* Array operations *)
-  | Pmakearray of array_kind * mutable_flag * alloc_mode
+  | Pmakearray of array_kind * mutable_flag * locality_mode
   | Pduparray of array_kind * mutable_flag
   | Parraylength of array_kind
   | Parrayrefu of array_ref_kind * array_index_kind
@@ -213,22 +200,22 @@ type primitive =
   (* Test if the (integer) argument is outside an interval *)
   | Pisout
   (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)
-  | Pbintofint of boxed_integer * alloc_mode
+  | Pbintofint of boxed_integer * locality_mode
   | Pintofbint of boxed_integer
   | Pcvtbint of boxed_integer (*source*) * boxed_integer (*destination*)
-                * alloc_mode
-  | Pnegbint of boxed_integer * alloc_mode
-  | Paddbint of boxed_integer * alloc_mode
-  | Psubbint of boxed_integer * alloc_mode
-  | Pmulbint of boxed_integer * alloc_mode
-  | Pdivbint of { size : boxed_integer; is_safe : is_safe; mode: alloc_mode }
-  | Pmodbint of { size : boxed_integer; is_safe : is_safe; mode: alloc_mode }
-  | Pandbint of boxed_integer * alloc_mode
-  | Porbint of boxed_integer * alloc_mode
-  | Pxorbint of boxed_integer * alloc_mode
-  | Plslbint of boxed_integer * alloc_mode
-  | Plsrbint of boxed_integer * alloc_mode
-  | Pasrbint of boxed_integer * alloc_mode
+                * locality_mode
+  | Pnegbint of boxed_integer * locality_mode
+  | Paddbint of boxed_integer * locality_mode
+  | Psubbint of boxed_integer * locality_mode
+  | Pmulbint of boxed_integer * locality_mode
+  | Pdivbint of { size : boxed_integer; is_safe : is_safe; mode: locality_mode }
+  | Pmodbint of { size : boxed_integer; is_safe : is_safe; mode: locality_mode }
+  | Pandbint of boxed_integer * locality_mode
+  | Porbint of boxed_integer * locality_mode
+  | Pxorbint of boxed_integer * locality_mode
+  | Plslbint of boxed_integer * locality_mode
+  | Plsrbint of boxed_integer * locality_mode
+  | Pasrbint of boxed_integer * locality_mode
   | Pbintcomp of boxed_integer * integer_comparison
   | Punboxed_int_comp of unboxed_integer * integer_comparison
   (* Operations on Bigarrays: (unsafe, #dimensions, kind, layout) *)
@@ -239,22 +226,22 @@ type primitive =
   (* load/set 16,32,64,128 bits from a string: (unsafe)*)
   | Pstring_load_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pstring_load_32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pstring_load_f32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pstring_load_128 of
-      { unsafe : bool; index_kind : array_index_kind; mode : alloc_mode }
+      { unsafe : bool; index_kind : array_index_kind; mode : locality_mode }
   | Pbytes_load_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbytes_load_32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbytes_load_f32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbytes_load_64 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbytes_load_128 of
-      { unsafe : bool; index_kind : array_index_kind; mode : alloc_mode }
+      { unsafe : bool; index_kind : array_index_kind; mode : locality_mode }
   | Pbytes_set_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbytes_set_32 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
@@ -268,13 +255,13 @@ type primitive =
      (char, int8_unsigned_elt, c_layout) Bigarray.Array1.t : (unsafe) *)
   | Pbigstring_load_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbigstring_load_32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbigstring_load_f32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbigstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbigstring_load_128 of { aligned : bool; unsafe : bool;
-      index_kind : array_index_kind; mode : alloc_mode; boxed : bool }
+      index_kind : array_index_kind; mode : locality_mode; boxed : bool }
   | Pbigstring_set_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbigstring_set_32 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
@@ -285,14 +272,14 @@ type primitive =
   | Pbigstring_set_128 of { aligned : bool; unsafe : bool;
       index_kind : array_index_kind; boxed : bool }
   (* load/set SIMD vectors in GC-managed arrays *)
-  | Pfloatarray_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Pfloat_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Pint_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Punboxed_float_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Punboxed_float32_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Punboxed_int32_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Punboxed_int64_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Punboxed_nativeint_array_load_128 of { unsafe : bool; mode : alloc_mode }
+  | Pfloatarray_load_128 of { unsafe : bool; mode : locality_mode }
+  | Pfloat_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Pint_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Punboxed_float_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Punboxed_float32_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Punboxed_int32_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Punboxed_int64_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Punboxed_nativeint_array_load_128 of { unsafe : bool; mode : locality_mode }
   | Pfloatarray_set_128 of { unsafe : bool }
   | Pfloat_array_set_128 of { unsafe : bool }
   | Pint_array_set_128 of { unsafe : bool }
@@ -305,9 +292,9 @@ type primitive =
   | Pctconst of compile_time_constant
   (* byte swap *)
   | Pbswap16
-  | Pbbswap of boxed_integer * alloc_mode
+  | Pbbswap of boxed_integer * locality_mode
   (* Integer to external pointer *)
-  | Pint_as_pointer of alloc_mode
+  | Pint_as_pointer of locality_mode
   (* Atomic operations *)
   | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_exchange
@@ -321,15 +308,15 @@ type primitive =
   | Pobj_dup
   | Pobj_magic of layout
   | Punbox_float of boxed_float
-  | Pbox_float of boxed_float * alloc_mode
+  | Pbox_float of boxed_float * locality_mode
   | Punbox_int of boxed_integer
-  | Pbox_int of boxed_integer * alloc_mode
+  | Pbox_int of boxed_integer * locality_mode
   | Preinterpret_unboxed_int64_as_tagged_int63
   | Preinterpret_tagged_int63_as_unboxed_int64
   (* Jane Street extensions *)
   | Parray_to_iarray
   | Parray_of_iarray
-  | Pget_header of alloc_mode
+  | Pget_header of locality_mode
   (* Fetching domain-local state *)
   | Pdls_get
   (* Poll for runtime actions *)
@@ -385,7 +372,7 @@ and flat_element = Types.flat_element =
 
 and flat_element_read =
   | Flat_read of flat_element (* invariant: not [Float] *)
-  | Flat_read_float_boxed of alloc_mode
+  | Flat_read_float_boxed of locality_mode
 and mixed_block_read =
   | Mread_value_prefix of immediate_or_pointer
   | Mread_flat_suffix of flat_element_read
@@ -411,10 +398,10 @@ and array_kind =
   | Punboxedintarray of unboxed_integer
 
 and array_ref_kind =
-  | Pgenarray_ref of alloc_mode
+  | Pgenarray_ref of locality_mode
   | Paddrarray_ref
   | Pintarray_ref
-  | Pfloatarray_ref of alloc_mode
+  | Pfloatarray_ref of locality_mode
   | Punboxedfloatarray_ref of unboxed_float
   | Punboxedintarray_ref of unboxed_integer
 
@@ -727,7 +714,7 @@ type lparam = {
   name : Ident.t;
   layout : layout;
   attributes : parameter_attribute;
-  mode : alloc_mode
+  mode : locality_mode
 }
 
 type pop_region =
@@ -759,7 +746,7 @@ type lambda =
   | Lassign of Ident.t * lambda
   | Lsend of
       meth_kind * lambda * lambda * lambda list
-      * region_close * alloc_mode * scoped_location * layout
+      * region_close * locality_mode * scoped_location * layout
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
   | Lregion of lambda * layout
@@ -777,8 +764,8 @@ and lfunction =
     body: lambda;
     attr: function_attribute; (* specified with [@inline] attribute *)
     loc: scoped_location;
-    mode: alloc_mode;
-    ret_mode: alloc_mode;
+    mode: locality_mode;
+    ret_mode: locality_mode;
     region: bool; }
 
 and lambda_while =
@@ -800,7 +787,7 @@ and lambda_apply =
     ap_args : lambda list;
     ap_result_layout : layout;
     ap_region_close : region_close;
-    ap_mode : alloc_mode;
+    ap_mode : locality_mode;
     ap_loc : scoped_location;
     ap_tailcall : tailcall_attribute;
     ap_inlined : inlined_attribute;
@@ -1307,7 +1294,7 @@ let flat_read_non_float flat_element =
   | Imm | Float64 | Float32 | Bits32 | Bits64 | Word as flat_element ->
       Flat_read flat_element
 
-let flat_read_float_boxed alloc_mode = Flat_read_float_boxed alloc_mode
+let flat_read_float_boxed locality_mode = Flat_read_float_boxed locality_mode
 
 (* Compile a sequence of expressions *)
 
@@ -1686,7 +1673,7 @@ let mod_field ?(read_semantics=Reads_agree) pos =
 let mod_setfield pos =
   Psetfield (pos, Pointer, Root_initialization)
 
-let alloc_mode_of_primitive_description (p : external_call_description) =
+let locality_mode_of_primitive_description (p : external_call_description) =
   if not Config.stack_allocation then
     if p.prim_alloc then Some alloc_heap else None
   else
@@ -1708,7 +1695,7 @@ let alloc_mode_of_primitive_description (p : external_call_description) =
 
 (* Changes to this function may also require changes in Flambda 2 (e.g.
    closure_conversion.ml). *)
-let primitive_may_allocate : primitive -> alloc_mode option = function
+let primitive_may_allocate : primitive -> locality_mode option = function
   | Pbytes_to_string | Pbytes_of_string
   | Parray_to_iarray | Parray_of_iarray
   | Pignore -> None
@@ -1731,7 +1718,7 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Psetmixedfield _ -> None
   | Pduprecord _ -> Some alloc_heap
   | Pmake_unboxed_product _ | Punboxed_product_field _ -> None
-  | Pccall p -> alloc_mode_of_primitive_description p
+  | Pccall p -> locality_mode_of_primitive_description p
   | Praise _ -> None
   | Psequor | Psequand | Pnot
   | Pnegint | Paddint | Psubint | Pmulint
@@ -1798,7 +1785,7 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Punboxed_float32_array_load_128 { mode = m; _ }
   | Punboxed_int32_array_load_128 { mode = m; _ }
   | Punboxed_int64_array_load_128 { mode = m; _ }
-  | Punboxed_nativeint_array_load_128 { mode = m; _ }
+  | Punboxed_nativeint_array_load_128 { mode = m; _ } -> Some m
   | Pget_header m -> Some m
   | Pstring_load_32 { boxed = false; _ }
   | Pstring_load_f32 { boxed = false; _ }
@@ -1899,7 +1886,7 @@ let array_ref_kind_result_layout = function
 let layout_of_mixed_field (kind : mixed_block_read) =
   match kind with
   | Mread_value_prefix _ -> layout_value_field
-  | Mread_flat_suffix (Flat_read_float_boxed (_ : alloc_mode)) ->
+  | Mread_flat_suffix (Flat_read_float_boxed (_ : locality_mode)) ->
       layout_boxed_float Pfloat64
   | Mread_flat_suffix (Flat_read proj) ->
       match proj with
@@ -1983,7 +1970,7 @@ let primitive_result_layout (p : primitive) =
   | Pstring_load_128 _ | Pbytes_load_128 _
   | Pbigstring_load_128 { boxed = true; _ } ->
       layout_boxed_vector (Pvec128 Int8x16)
-  | Pbigstring_load_32 { boxed = false; _ } 
+  | Pbigstring_load_32 { boxed = false; _ }
   | Pstring_load_32 { boxed = false; _ }
   | Pbytes_load_32 { boxed = false; _ } -> layout_unboxed_int Pint32
   | Pbigstring_load_f32 { boxed = false; _ }

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -1785,7 +1785,7 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Punboxed_float32_array_load_128 { mode = m; _ }
   | Punboxed_int32_array_load_128 { mode = m; _ }
   | Punboxed_int64_array_load_128 { mode = m; _ }
-  | Punboxed_nativeint_array_load_128 { mode = m; _ } -> Some m
+  | Punboxed_nativeint_array_load_128 { mode = m; _ }
   | Pget_header m -> Some m
   | Pstring_load_32 { boxed = false; _ }
   | Pstring_load_f32 { boxed = false; _ }

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -41,10 +41,6 @@ type locality_mode = private
   | Alloc_heap
   | Alloc_local
 
-(** For now we don't have strong update, and thus uniqueness is irrelevant in
-    middle and back-end; in the future this will be extended with uniqueness *)
-type alloc_mode = locality_mode
-
 type modify_mode = private
   | Modify_heap
   | Modify_maybe_stack
@@ -57,8 +53,6 @@ val alloc_local : locality_mode
 val modify_heap : modify_mode
 
 val modify_maybe_stack : modify_mode
-
-val equal_alloc_mode : alloc_mode -> alloc_mode -> bool
 
 type initialization_or_assignment =
   (* [Assignment Alloc_local] is a mutation of a block that may be heap or local.
@@ -119,15 +113,15 @@ type primitive =
   | Psetglobal of Compilation_unit.t
   | Pgetpredef of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape * alloc_mode
-  | Pmakefloatblock of mutable_flag * alloc_mode
-  | Pmakeufloatblock of mutable_flag * alloc_mode
-  | Pmakemixedblock of int * mutable_flag * mixed_block_shape * alloc_mode
+  | Pmakeblock of int * mutable_flag * block_shape * locality_mode
+  | Pmakefloatblock of mutable_flag * locality_mode
+  | Pmakeufloatblock of mutable_flag * locality_mode
+  | Pmakemixedblock of int * mutable_flag * mixed_block_shape * locality_mode
   | Pfield of int * immediate_or_pointer * field_read_semantics
   | Pfield_computed of field_read_semantics
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
-  | Pfloatfield of int * field_read_semantics * alloc_mode
+  | Pfloatfield of int * field_read_semantics * locality_mode
   | Pufloatfield of int * field_read_semantics
   | Pmixedfield of
       int * mixed_block_read * mixed_block_shape * field_read_semantics
@@ -167,23 +161,23 @@ type primitive =
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)
-  | Pfloatoffloat32 of alloc_mode
-  | Pfloat32offloat of alloc_mode
+  | Pfloatoffloat32 of locality_mode
+  | Pfloat32offloat of locality_mode
   | Pintoffloat of boxed_float
-  | Pfloatofint of boxed_float * alloc_mode
-  | Pnegfloat of boxed_float * alloc_mode
-  | Pabsfloat of boxed_float * alloc_mode
-  | Paddfloat of boxed_float * alloc_mode
-  | Psubfloat of boxed_float * alloc_mode
-  | Pmulfloat of boxed_float * alloc_mode
-  | Pdivfloat of boxed_float * alloc_mode
+  | Pfloatofint of boxed_float * locality_mode
+  | Pnegfloat of boxed_float * locality_mode
+  | Pabsfloat of boxed_float * locality_mode
+  | Paddfloat of boxed_float * locality_mode
+  | Psubfloat of boxed_float * locality_mode
+  | Pmulfloat of boxed_float * locality_mode
+  | Pdivfloat of boxed_float * locality_mode
   | Pfloatcomp of boxed_float * float_comparison
   | Punboxed_float_comp of boxed_float * float_comparison
   (* String operations *)
   | Pstringlength | Pstringrefu  | Pstringrefs
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   (* Array operations *)
-  | Pmakearray of array_kind * mutable_flag * alloc_mode
+  | Pmakearray of array_kind * mutable_flag * locality_mode
   | Pduparray of array_kind * mutable_flag
   (** For [Pduparray], the argument must be an immutable array.
       The arguments of [Pduparray] give the kind and mutability of the
@@ -198,22 +192,22 @@ type primitive =
   (* Test if the (integer) argument is outside an interval *)
   | Pisout
   (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)
-  | Pbintofint of boxed_integer * alloc_mode
+  | Pbintofint of boxed_integer * locality_mode
   | Pintofbint of boxed_integer
   | Pcvtbint of boxed_integer (*source*) * boxed_integer (*destination*)
-                * alloc_mode
-  | Pnegbint of boxed_integer * alloc_mode
-  | Paddbint of boxed_integer * alloc_mode
-  | Psubbint of boxed_integer * alloc_mode
-  | Pmulbint of boxed_integer * alloc_mode
-  | Pdivbint of { size : boxed_integer; is_safe : is_safe; mode: alloc_mode }
-  | Pmodbint of { size : boxed_integer; is_safe : is_safe; mode: alloc_mode }
-  | Pandbint of boxed_integer * alloc_mode
-  | Porbint of boxed_integer * alloc_mode
-  | Pxorbint of boxed_integer * alloc_mode
-  | Plslbint of boxed_integer * alloc_mode
-  | Plsrbint of boxed_integer * alloc_mode
-  | Pasrbint of boxed_integer * alloc_mode
+                * locality_mode
+  | Pnegbint of boxed_integer * locality_mode
+  | Paddbint of boxed_integer * locality_mode
+  | Psubbint of boxed_integer * locality_mode
+  | Pmulbint of boxed_integer * locality_mode
+  | Pdivbint of { size : boxed_integer; is_safe : is_safe; mode: locality_mode }
+  | Pmodbint of { size : boxed_integer; is_safe : is_safe; mode: locality_mode }
+  | Pandbint of boxed_integer * locality_mode
+  | Porbint of boxed_integer * locality_mode
+  | Pxorbint of boxed_integer * locality_mode
+  | Plslbint of boxed_integer * locality_mode
+  | Plsrbint of boxed_integer * locality_mode
+  | Pasrbint of boxed_integer * locality_mode
   | Pbintcomp of boxed_integer * integer_comparison
   | Punboxed_int_comp of unboxed_integer * integer_comparison
   (* Operations on Bigarrays: (unsafe, #dimensions, kind, layout) *)
@@ -224,22 +218,22 @@ type primitive =
   (* load/set 16,32,64,128 bits from a string: (unsafe)*)
   | Pstring_load_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pstring_load_32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pstring_load_f32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pstring_load_128 of
-      { unsafe : bool; index_kind : array_index_kind; mode : alloc_mode }
+      { unsafe : bool; index_kind : array_index_kind; mode : locality_mode }
   | Pbytes_load_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbytes_load_32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbytes_load_f32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbytes_load_64 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbytes_load_128 of
-      { unsafe : bool; index_kind : array_index_kind; mode : alloc_mode }
+      { unsafe : bool; index_kind : array_index_kind; mode : locality_mode }
   | Pbytes_set_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbytes_set_32 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
@@ -253,13 +247,13 @@ type primitive =
      (char, int8_unsigned_elt, c_layout) Bigarray.Array1.t : (unsafe) *)
   | Pbigstring_load_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbigstring_load_32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbigstring_load_f32 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbigstring_load_64 of { unsafe : bool; index_kind : array_index_kind;
-      mode : alloc_mode; boxed : bool }
+      mode : locality_mode; boxed : bool }
   | Pbigstring_load_128 of { aligned : bool; unsafe : bool;
-      index_kind : array_index_kind; mode : alloc_mode; boxed : bool }
+      index_kind : array_index_kind; mode : locality_mode; boxed : bool }
   | Pbigstring_set_16 of { unsafe : bool; index_kind : array_index_kind }
   | Pbigstring_set_32 of { unsafe : bool; index_kind : array_index_kind;
       boxed : bool }
@@ -270,14 +264,14 @@ type primitive =
   | Pbigstring_set_128 of { aligned : bool; unsafe : bool;
       index_kind : array_index_kind; boxed : bool }
   (* load/set SIMD vectors in GC-managed arrays *)
-  | Pfloatarray_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Pfloat_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Pint_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Punboxed_float_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Punboxed_float32_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Punboxed_int32_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Punboxed_int64_array_load_128 of { unsafe : bool; mode : alloc_mode }
-  | Punboxed_nativeint_array_load_128 of { unsafe : bool; mode : alloc_mode }
+  | Pfloatarray_load_128 of { unsafe : bool; mode : locality_mode }
+  | Pfloat_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Pint_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Punboxed_float_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Punboxed_float32_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Punboxed_int32_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Punboxed_int64_array_load_128 of { unsafe : bool; mode : locality_mode }
+  | Punboxed_nativeint_array_load_128 of { unsafe : bool; mode : locality_mode }
   | Pfloatarray_set_128 of { unsafe : bool }
   | Pfloat_array_set_128 of { unsafe : bool }
   | Pint_array_set_128 of { unsafe : bool }
@@ -290,9 +284,9 @@ type primitive =
   | Pctconst of compile_time_constant
   (* byte swap *)
   | Pbswap16
-  | Pbbswap of boxed_integer * alloc_mode
+  | Pbbswap of boxed_integer * locality_mode
   (* Integer to external pointer *)
-  | Pint_as_pointer of alloc_mode
+  | Pint_as_pointer of locality_mode
   (* Atomic operations *)
   | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_exchange
@@ -306,9 +300,9 @@ type primitive =
   | Pobj_dup
   | Pobj_magic of layout
   | Punbox_float of boxed_float
-  | Pbox_float of boxed_float * alloc_mode
+  | Pbox_float of boxed_float * locality_mode
   | Punbox_int of boxed_integer
-  | Pbox_int of boxed_integer * alloc_mode
+  | Pbox_int of boxed_integer * locality_mode
   | Preinterpret_unboxed_int64_as_tagged_int63
   | Preinterpret_tagged_int63_as_unboxed_int64
     (** At present [Preinterpret_unboxed_int64_as_tagged_int63] and
@@ -325,7 +319,7 @@ type primitive =
                         one; O(1) *)
   | Parray_of_iarray (* Unsafely reinterpret an immutable array as a mutable
                         one; O(1) *)
-  | Pget_header of alloc_mode
+  | Pget_header of locality_mode
   (* Get the header of a block. This primitive is invalid if provided with an
      immediate value.
      Note: The GC color bits in the header are not reliable except for checking
@@ -362,10 +356,10 @@ and array_kind =
 (** When accessing a flat float array, we need to know the mode which we should
     box the resulting float at. *)
 and array_ref_kind =
-  | Pgenarray_ref of alloc_mode (* This might be a flat float array *)
+  | Pgenarray_ref of locality_mode (* This might be a flat float array *)
   | Paddrarray_ref
   | Pintarray_ref
-  | Pfloatarray_ref of alloc_mode
+  | Pfloatarray_ref of locality_mode
   | Punboxedfloatarray_ref of unboxed_float
   | Punboxedintarray_ref of unboxed_integer
 
@@ -423,7 +417,7 @@ and flat_element = Types.flat_element =
 
 and flat_element_read = private
   | Flat_read of flat_element (* invariant: not [Float] *)
-  | Flat_read_float_boxed of alloc_mode
+  | Flat_read_float_boxed of locality_mode
 and mixed_block_read =
   | Mread_value_prefix of immediate_or_pointer
   | Mread_flat_suffix of flat_element_read
@@ -647,7 +641,7 @@ type lparam = {
   name : Ident.t;
   layout : layout;
   attributes : parameter_attribute;
-  mode : alloc_mode
+  mode : locality_mode
 }
 
 type scoped_location = Debuginfo.Scoped_location.t
@@ -696,7 +690,7 @@ type lambda =
   | Lfor of lambda_for
   | Lassign of Ident.t * lambda
   | Lsend of meth_kind * lambda * lambda * lambda list
-             * region_close * alloc_mode * scoped_location * layout
+             * region_close * locality_mode * scoped_location * layout
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
   | Lregion of lambda * layout
@@ -719,8 +713,8 @@ and lfunction = private
     body: lambda;
     attr: function_attribute; (* specified with [@inline] attribute *)
     loc : scoped_location;
-    mode : alloc_mode;     (* alloc mode of the closure itself *)
-    ret_mode: alloc_mode;
+    mode : locality_mode;     (* locality of the closure itself *)
+    ret_mode: locality_mode;
     region : bool;         (* false if this function may locally
                               allocate in the caller's region *)
   }
@@ -744,7 +738,7 @@ and lambda_apply =
     ap_args : lambda list;
     ap_result_layout : layout;
     ap_region_close : region_close;
-    ap_mode : alloc_mode;
+    ap_mode : locality_mode;
     ap_loc : scoped_location;
     ap_tailcall : tailcall_attribute;
     ap_inlined : inlined_attribute; (* [@inlined] attribute in code *)
@@ -853,8 +847,8 @@ val lfunction :
   body:lambda ->
   attr:function_attribute -> (* specified with [@inline] attribute *)
   loc:scoped_location ->
-  mode:alloc_mode ->
-  ret_mode:alloc_mode ->
+  mode:locality_mode ->
+  ret_mode:locality_mode ->
   region:bool ->
   lambda
 
@@ -865,8 +859,8 @@ val lfunction' :
   body:lambda ->
   attr:function_attribute -> (* specified with [@inline] attribute *)
   loc:scoped_location ->
-  mode:alloc_mode ->
-  ret_mode:alloc_mode ->
+  mode:locality_mode ->
+  ret_mode:locality_mode ->
   region:bool ->
   lfunction
 
@@ -910,7 +904,7 @@ val get_mixed_block_element : mixed_block_shape -> int -> mixed_block_element
 
 (** Raises if [flat_element] is [Float_boxed]. *)
 val flat_read_non_float : flat_element -> flat_element_read
-val flat_read_float_boxed : alloc_mode -> flat_element_read
+val flat_read_float_boxed : locality_mode -> flat_element_read
 
 val make_sequence: ('a -> lambda) -> 'a list -> lambda
 
@@ -973,13 +967,13 @@ val max_arity : unit -> int
       This is unlimited ([max_int]) for bytecode, but limited
       (currently to 126) for native code. *)
 
-val join_mode : alloc_mode -> alloc_mode -> alloc_mode
-val sub_mode : alloc_mode -> alloc_mode -> bool
-val eq_mode : alloc_mode -> alloc_mode -> bool
-val is_local_mode : alloc_mode -> bool
-val is_heap_mode : alloc_mode -> bool
+val join_locality_mode : locality_mode -> locality_mode -> locality_mode
+val sub_locality_mode : locality_mode -> locality_mode -> bool
+val eq_locality_mode : locality_mode -> locality_mode -> bool
+val is_local_mode : locality_mode -> bool
+val is_heap_mode : locality_mode -> bool
 
-val primitive_may_allocate : primitive -> alloc_mode option
+val primitive_may_allocate : primitive -> locality_mode option
   (** Whether and where a primitive may allocate.
       [Some Alloc_local] permits both options: that is, primitives that
       may allocate on both the GC heap and locally report this value.
@@ -992,8 +986,8 @@ val primitive_may_allocate : primitive -> alloc_mode option
       revised.
   *)
 
-val alloc_mode_of_primitive_description :
-  external_call_description -> alloc_mode option
+val locality_mode_of_primitive_description :
+  external_call_description -> locality_mode option
   (** Like [primitive_may_allocate], for [external] calls. *)
 
 (***********************)
@@ -1034,7 +1028,7 @@ val array_ref_kind_result_layout: array_ref_kind -> layout
 val compute_expr_layout : (Ident.t -> layout option) -> lambda -> layout
 
 (** The mode will be discarded if unnecessary for the given [array_kind] *)
-val array_ref_kind : alloc_mode -> array_kind -> array_ref_kind
+val array_ref_kind : locality_mode -> array_kind -> array_ref_kind
 
 (** The mode will be discarded if unnecessary for the given [array_kind] *)
 val array_set_kind : modify_mode -> array_kind -> array_set_kind

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -36,7 +36,7 @@ val for_let:
         lambda
 val for_multiple_match:
         scopes:scopes -> return_layout:layout -> Location.t ->
-        (lambda * Jkind.sort * layout) list -> alloc_mode ->
+        (lambda * Jkind.sort * layout) list -> locality_mode ->
         (pattern * lambda) list -> partial ->
         lambda
 

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -116,12 +116,11 @@ let array_set_kind ppf k =
   | Punboxedintarray_set Pint64 -> fprintf ppf "unboxed_int64"
   | Punboxedintarray_set Pnativeint -> fprintf ppf "unboxed_nativeint"
 
-let alloc_mode_if_local = function
+let locality_mode_if_local = function
   | Alloc_heap -> ""
   | Alloc_local -> "local"
 
-let alloc_mode ppf alloc_mode =
-  match alloc_mode with
+let locality_mode ppf = function
   | Alloc_heap -> fprintf ppf "heap"
   | Alloc_local -> fprintf ppf "local"
 
@@ -206,7 +205,7 @@ let rec layout' is_top ppf layout_ =
 let layout ppf layout_ = layout' true ppf layout_
 
 let return_kind ppf (mode, kind) =
-  let smode = alloc_mode_if_local mode in
+  let smode = locality_mode_if_local mode in
   match kind with
   | Pvalue Pgenval when is_heap_mode mode -> ()
   | Pvalue Pgenval -> fprintf ppf ": %s@ " smode
@@ -242,44 +241,44 @@ let field_kind ppf = function
         (tag_and_constructor_shape value_kind'))
       non_consts
 
-let alloc_kind = function
+let locality_kind = function
   | Alloc_heap -> ""
   | Alloc_local -> "[L]"
 
 let print_boxed_integer_conversion ppf bi1 bi2 m =
   fprintf ppf "%s_of_%s%s" (boxed_integer_name bi2) (boxed_integer_name bi1)
-    (alloc_kind m)
+    (locality_kind m)
 
 let boxed_integer_mark name bi m =
   match bi with
-  | Pnativeint -> Printf.sprintf "Nativeint.%s%s" name (alloc_kind m)
-  | Pint32 -> Printf.sprintf "Int32.%s%s" name (alloc_kind m)
-  | Pint64 -> Printf.sprintf "Int64.%s%s" name (alloc_kind m)
+  | Pnativeint -> Printf.sprintf "Nativeint.%s%s" name (locality_kind m)
+  | Pint32 -> Printf.sprintf "Int32.%s%s" name (locality_kind m)
+  | Pint64 -> Printf.sprintf "Int64.%s%s" name (locality_kind m)
 
 let print_boxed_integer name ppf bi m =
   fprintf ppf "%s" (boxed_integer_mark name bi m);;
 
 let unboxed_integer_mark name bi m =
   match bi with
-  | Pnativeint -> Printf.sprintf "Nativeint_u.%s%s" name (alloc_kind m)
-  | Pint32 -> Printf.sprintf "Int32_u.%s%s" name (alloc_kind m)
-  | Pint64 -> Printf.sprintf "Int64_u.%s%s" name (alloc_kind m)
+  | Pnativeint -> Printf.sprintf "Nativeint_u.%s%s" name (locality_kind m)
+  | Pint32 -> Printf.sprintf "Int32_u.%s%s" name (locality_kind m)
+  | Pint64 -> Printf.sprintf "Int64_u.%s%s" name (locality_kind m)
 
 let print_unboxed_integer name ppf bi m =
   fprintf ppf "%s" (unboxed_integer_mark name bi m);;
 
 let boxed_float_mark name bf m =
   match bf with
-  | Pfloat64 -> Printf.sprintf "Float.%s%s" name (alloc_kind m)
-  | Pfloat32 -> Printf.sprintf "Float32.%s%s" name (alloc_kind m)
+  | Pfloat64 -> Printf.sprintf "Float.%s%s" name (locality_kind m)
+  | Pfloat32 -> Printf.sprintf "Float32.%s%s" name (locality_kind m)
 
 let print_boxed_float name ppf bf m =
   fprintf ppf "%s" (boxed_float_mark name bf m);;
 
 let unboxed_float_mark name bf m =
   match bf with
-  | Pfloat64 -> Printf.sprintf "Float_u.%s%s" name (alloc_kind m)
-  | Pfloat32 -> Printf.sprintf "Float32_u.%s%s" name (alloc_kind m)
+  | Pfloat64 -> Printf.sprintf "Float_u.%s%s" name (locality_kind m)
+  | Pfloat32 -> Printf.sprintf "Float32_u.%s%s" name (locality_kind m)
 
 let print_unboxed_float name ppf bf m =
   fprintf ppf "%s" (unboxed_float_mark name bf m);;
@@ -334,7 +333,7 @@ let flat_element ppf : flat_element -> unit = fun x ->
 let flat_element_read ppf : flat_element_read -> unit = function
   | Flat_read flat ->
       pp_print_string ppf (Types.flat_element_to_lowercase_string flat)
-  | Flat_read_float_boxed m -> fprintf ppf "float[%a]" alloc_mode m
+  | Flat_read_float_boxed m -> fprintf ppf "float[%a]" locality_mode m
 
 let mixed_block_read ppf : mixed_block_read -> unit = function
   | Mread_value_prefix Immediate -> pp_print_string ppf "value_int"
@@ -399,40 +398,40 @@ let primitive ppf = function
   | Pgetpredef id -> fprintf ppf "getpredef %a!" Ident.print id
   | Pmakeblock(tag, Immutable, shape, mode) ->
       fprintf ppf "make%sblock %i%a"
-        (alloc_mode_if_local mode) tag block_shape shape
+        (locality_mode_if_local mode) tag block_shape shape
   | Pmakeblock(tag, Immutable_unique, shape, mode) ->
       fprintf ppf "make%sblock_unique %i%a"
-        (alloc_mode_if_local mode) tag block_shape shape
+        (locality_mode_if_local mode) tag block_shape shape
   | Pmakeblock(tag, Mutable, shape, mode) ->
       fprintf ppf "make%smutable %i%a"
-        (alloc_mode_if_local mode) tag block_shape shape
+        (locality_mode_if_local mode) tag block_shape shape
   | Pmakefloatblock (Immutable, mode) ->
       fprintf ppf "make%sfloatblock Immutable"
-        (alloc_mode_if_local mode)
+        (locality_mode_if_local mode)
   | Pmakefloatblock (Immutable_unique, mode) ->
      fprintf ppf "make%sfloatblock Immutable_unique"
-        (alloc_mode_if_local mode)
+        (locality_mode_if_local mode)
   | Pmakefloatblock (Mutable, mode) ->
      fprintf ppf "make%sfloatblock Mutable"
-        (alloc_mode_if_local mode)
+        (locality_mode_if_local mode)
   | Pmakeufloatblock (Immutable, mode) ->
       fprintf ppf "make%sufloatblock Immutable"
-        (alloc_mode_if_local mode)
+        (locality_mode_if_local mode)
   | Pmakeufloatblock (Immutable_unique, mode) ->
      fprintf ppf "make%sufloatblock Immutable_unique"
-        (alloc_mode_if_local mode)
+        (locality_mode_if_local mode)
   | Pmakeufloatblock (Mutable, mode) ->
      fprintf ppf "make%sufloatblock Mutable"
-        (alloc_mode_if_local mode)
+        (locality_mode_if_local mode)
   | Pmakemixedblock (tag, Immutable, abs, mode) ->
       fprintf ppf "make%amixedblock %i Immutable%a"
-        alloc_mode mode tag mixed_block_shape abs
+        locality_mode mode tag mixed_block_shape abs
   | Pmakemixedblock (tag, Immutable_unique, abs, mode) ->
      fprintf ppf "make%amixedblock %i Immutable_unique%a"
-        alloc_mode mode tag mixed_block_shape abs
+        locality_mode mode tag mixed_block_shape abs
   | Pmakemixedblock (tag, Mutable, abs, mode) ->
      fprintf ppf "make%amixedblock %i Mutable%a"
-        alloc_mode mode tag mixed_block_shape abs
+        locality_mode mode tag mixed_block_shape abs
   | Pfield (n, ptr, sem) ->
       let instr =
         match ptr, sem with
@@ -473,7 +472,7 @@ let primitive ppf = function
       fprintf ppf "setfield_%s%s_computed" instr init
   | Pfloatfield (n, sem, mode) ->
       fprintf ppf "floatfield%a%s %i"
-        field_read_semantics sem (alloc_mode_if_local mode) n
+        field_read_semantics sem (locality_mode_if_local mode) n
   | Pufloatfield (n, sem) ->
       fprintf ppf "ufloatfield%a %i"
         field_read_semantics sem n
@@ -550,7 +549,7 @@ let primitive ppf = function
   | Pfloat32offloat m -> print_boxed_float "float32_of_float" ppf Pfloat64 m
   | Pintoffloat bf -> fprintf ppf "int_of_%s" (boxed_float_name bf)
   | Pfloatofint (bf,m) ->
-      fprintf ppf "%s_of_int%s" (boxed_float_name bf) (alloc_kind m)
+      fprintf ppf "%s_of_int%s" (boxed_float_name bf) (locality_kind m)
   | Pabsfloat (bf,m) -> print_boxed_float "abs" ppf bf m
   | Pnegfloat (bf,m) -> print_boxed_float "neg" ppf bf m
   | Paddfloat (bf,m) -> print_boxed_float "add" ppf bf m
@@ -572,11 +571,11 @@ let primitive ppf = function
 
   | Parraylength k -> fprintf ppf "array.length[%s]" (array_kind k)
   | Pmakearray (k, Mutable, mode) ->
-     fprintf ppf "make%sarray[%s]" (alloc_mode_if_local mode) (array_kind k)
+     fprintf ppf "make%sarray[%s]" (locality_mode_if_local mode) (array_kind k)
   | Pmakearray (k, Immutable, mode) ->
-     fprintf ppf "make%sarray_imm[%s]" (alloc_mode_if_local mode) (array_kind k)
+     fprintf ppf "make%sarray_imm[%s]" (locality_mode_if_local mode) (array_kind k)
   | Pmakearray (k, Immutable_unique, mode) ->
-      fprintf ppf "make%sarray_unique[%s]" (alloc_mode_if_local mode)
+      fprintf ppf "make%sarray_unique[%s]" (locality_mode_if_local mode)
         (array_kind k)
   | Pduparray (k, Mutable) -> fprintf ppf "duparray[%s]" (array_kind k)
   | Pduparray (k, Immutable) -> fprintf ppf "duparray_imm[%s]" (array_kind k)
@@ -653,18 +652,18 @@ let primitive ppf = function
   | Pstring_load_32 {unsafe; index_kind; mode; boxed} ->
      fprintf ppf "string.%sget32%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
-       (alloc_kind mode) array_index_kind index_kind
+       (locality_kind mode) array_index_kind index_kind
   | Pstring_load_f32{unsafe; index_kind; mode; boxed} ->
      fprintf ppf "string.%sgetf32%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "")
-       (alloc_kind mode) array_index_kind index_kind
+       (locality_kind mode) array_index_kind index_kind
   | Pstring_load_64{unsafe; index_kind; mode; boxed} ->
      fprintf ppf "string.%sget64%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "")
-       (alloc_kind mode) array_index_kind index_kind
+       (locality_kind mode) array_index_kind index_kind
   | Pstring_load_128 {unsafe; index_kind; mode} ->
      fprintf ppf "string.%sunaligned_get128%s[indexed by %a]"
-       (if unsafe then "unsafe_" else "") (alloc_kind mode) array_index_kind
+       (if unsafe then "unsafe_" else "") (locality_kind mode) array_index_kind
        index_kind
   | Pbytes_load_16 {unsafe; index_kind} ->
      fprintf ppf "bytes.%sget16[indexed by %a]" (if unsafe then "unsafe_" else "")
@@ -672,18 +671,18 @@ let primitive ppf = function
   | Pbytes_load_32 {unsafe; index_kind; mode; boxed} ->
      fprintf ppf "bytes.%sget32%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
-       (alloc_kind mode) array_index_kind index_kind
+       (locality_kind mode) array_index_kind index_kind
   | Pbytes_load_f32{unsafe; index_kind; mode; boxed} ->
      fprintf ppf "bytes.%sgetf32%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "")
-       (alloc_kind mode) array_index_kind index_kind
+       (locality_kind mode) array_index_kind index_kind
   | Pbytes_load_64{unsafe; index_kind; mode; boxed} ->
      fprintf ppf "bytes.%sget64%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "")
-       (alloc_kind mode) array_index_kind index_kind
+       (locality_kind mode) array_index_kind index_kind
   | Pbytes_load_128 {unsafe; index_kind; mode} ->
      fprintf ppf "bytes.%sunaligned_get128%s[indexed by %a]"
-       (if unsafe then "unsafe_" else "") (alloc_kind mode) array_index_kind
+       (if unsafe then "unsafe_" else "") (locality_kind mode) array_index_kind
        index_kind
   | Pbytes_set_16 {unsafe; index_kind} ->
      fprintf ppf "bytes.%sset16[indexed by %a]" (if unsafe then "unsafe_" else "")
@@ -710,20 +709,20 @@ let primitive ppf = function
   | Pbigstring_load_32 { unsafe; mode; boxed; index_kind } ->
      fprintf ppf "bigarray.array1.%sget32%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
-       (alloc_kind mode) array_index_kind index_kind
+       (locality_kind mode) array_index_kind index_kind
   | Pbigstring_load_f32 { unsafe; mode; boxed; index_kind } ->
      fprintf ppf "bigarray.array1.%sgetf32%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
-       (alloc_kind mode) array_index_kind index_kind
+       (locality_kind mode) array_index_kind index_kind
   | Pbigstring_load_64 { unsafe; mode; boxed; index_kind } ->
      fprintf ppf "bigarray.array1.%sget64%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
-       (alloc_kind mode) array_index_kind index_kind
+       (locality_kind mode) array_index_kind index_kind
   | Pbigstring_load_128 { unsafe; aligned; mode; boxed; index_kind } ->
      fprintf ppf "bigarray.array1.%s%sget128%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "")
        (if aligned then "aligned_" else "unaligned_")
-       (if boxed then "" else "#") (alloc_kind mode) array_index_kind index_kind
+       (if boxed then "" else "#") (locality_kind mode) array_index_kind index_kind
   | Pbigstring_set_16 { unsafe; index_kind } ->
      fprintf ppf "bigarray.array1.%sset16[indexed by %a]"
        (if unsafe then "unsafe_" else "") array_index_kind index_kind
@@ -745,29 +744,29 @@ let primitive ppf = function
        (if aligned then "aligned_" else "unaligned_")
        (if boxed then "" else "#") array_index_kind index_kind
   | Pfloatarray_load_128 {unsafe; mode} ->
-     if unsafe then fprintf ppf "floatarray.unsafe_get128%s" (alloc_kind mode)
-     else fprintf ppf "floatarray.get128%s" (alloc_kind mode)
+     if unsafe then fprintf ppf "floatarray.unsafe_get128%s" (locality_kind mode)
+     else fprintf ppf "floatarray.get128%s" (locality_kind mode)
   | Pfloat_array_load_128 {unsafe; mode} ->
-     if unsafe then fprintf ppf "float_array.unsafe_get128%s" (alloc_kind mode)
-     else fprintf ppf "float_array.get128%s" (alloc_kind mode)
+     if unsafe then fprintf ppf "float_array.unsafe_get128%s" (locality_kind mode)
+     else fprintf ppf "float_array.get128%s" (locality_kind mode)
   | Pint_array_load_128 {unsafe; mode} ->
-     if unsafe then fprintf ppf "int_array.unsafe_get128%s" (alloc_kind mode)
-     else fprintf ppf "int_array.get128%s" (alloc_kind mode)
+     if unsafe then fprintf ppf "int_array.unsafe_get128%s" (locality_kind mode)
+     else fprintf ppf "int_array.get128%s" (locality_kind mode)
   | Punboxed_float_array_load_128 {unsafe; mode} ->
-     if unsafe then fprintf ppf "unboxed_float_array.unsafe_get128%s" (alloc_kind mode)
-     else fprintf ppf "unboxed_float_array.get128%s" (alloc_kind mode)
+     if unsafe then fprintf ppf "unboxed_float_array.unsafe_get128%s" (locality_kind mode)
+     else fprintf ppf "unboxed_float_array.get128%s" (locality_kind mode)
   | Punboxed_float32_array_load_128 {unsafe; mode} ->
-     if unsafe then fprintf ppf "unboxed_float32_array.unsafe_get128%s" (alloc_kind mode)
-     else fprintf ppf "unboxed_float32_array.get128%s" (alloc_kind mode)
+     if unsafe then fprintf ppf "unboxed_float32_array.unsafe_get128%s" (locality_kind mode)
+     else fprintf ppf "unboxed_float32_array.get128%s" (locality_kind mode)
   | Punboxed_int32_array_load_128 {unsafe; mode} ->
-     if unsafe then fprintf ppf "unboxed_int32_array.unsafe_get128%s" (alloc_kind mode)
-     else fprintf ppf "unboxed_int32_array.get128%s" (alloc_kind mode)
+     if unsafe then fprintf ppf "unboxed_int32_array.unsafe_get128%s" (locality_kind mode)
+     else fprintf ppf "unboxed_int32_array.get128%s" (locality_kind mode)
   | Punboxed_int64_array_load_128 {unsafe; mode} ->
-     if unsafe then fprintf ppf "unboxed_int64_array.unsafe_get128%s" (alloc_kind mode)
-     else fprintf ppf "unboxed_int64_array.get128%s" (alloc_kind mode)
+     if unsafe then fprintf ppf "unboxed_int64_array.unsafe_get128%s" (locality_kind mode)
+     else fprintf ppf "unboxed_int64_array.get128%s" (locality_kind mode)
   | Punboxed_nativeint_array_load_128 {unsafe; mode} ->
-     if unsafe then fprintf ppf "unboxed_nativeint_array.unsafe_get128%s" (alloc_kind mode)
-     else fprintf ppf "unboxed_nativeint_array.get128%s" (alloc_kind mode)
+     if unsafe then fprintf ppf "unboxed_nativeint_array.unsafe_get128%s" (locality_kind mode)
+     else fprintf ppf "unboxed_nativeint_array.get128%s" (locality_kind mode)
   | Pfloatarray_set_128 {unsafe} ->
      if unsafe then fprintf ppf "floatarray.unsafe_set128"
      else fprintf ppf "floatarray.set128"
@@ -794,7 +793,7 @@ let primitive ppf = function
      else fprintf ppf "unboxed_nativeint_array.set128"
   | Pbswap16 -> fprintf ppf "bswap16"
   | Pbbswap(bi,m) -> print_boxed_integer "bswap" ppf bi m
-  | Pint_as_pointer m -> fprintf ppf "int_as_pointer%s" (alloc_kind m)
+  | Pint_as_pointer m -> fprintf ppf "int_as_pointer%s" (locality_kind m)
   | Patomic_load {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> fprintf ppf "atomic_load_imm"
@@ -810,14 +809,14 @@ let primitive ppf = function
   | Pobj_magic _ -> fprintf ppf "obj_magic"
   | Punbox_float bf -> fprintf ppf "unbox_%s" (boxed_float_name bf)
   | Pbox_float (bf,m) ->
-      fprintf ppf "box_%s%s" (boxed_float_name bf) (alloc_kind m)
+      fprintf ppf "box_%s%s" (boxed_float_name bf) (locality_kind m)
   | Punbox_int bi -> fprintf ppf "unbox_%s" (boxed_integer_name bi)
   | Pbox_int (bi, m) ->
-      fprintf ppf "box_%s%s" (boxed_integer_name bi) (alloc_kind m)
+      fprintf ppf "box_%s%s" (boxed_integer_name bi) (locality_kind m)
 
   | Parray_to_iarray -> fprintf ppf "array_to_iarray"
   | Parray_of_iarray -> fprintf ppf "array_of_iarray"
-  | Pget_header m -> fprintf ppf "get_header%s" (alloc_kind m)
+  | Pget_header m -> fprintf ppf "get_header%s" (locality_kind m)
   | Preinterpret_tagged_int63_as_unboxed_int64 ->
       fprintf ppf "reinterpret_tagged_int63_as_unboxed_int64"
   | Preinterpret_unboxed_int64_as_tagged_int63 ->
@@ -1069,7 +1068,7 @@ let apply_kind name pos mode =
     | Rc_nontail -> name ^ "nontail"
     | Rc_close_at_apply -> name ^ "tail"
   in
-  name ^ alloc_kind mode
+  name ^ locality_kind mode
 
 let rec lam ppf = function
   | Lvar id ->
@@ -1254,7 +1253,7 @@ and lfunction ppf {kind; params; return; body; attr; ret_mode; mode} =
         List.iter (fun (p : Lambda.lparam) ->
             let { unbox_param } = p.attributes in
             fprintf ppf "@ %a%s%a%s"
-              Ident.print p.name (alloc_kind p.mode) layout p.layout
+              Ident.print p.name (locality_kind p.mode) layout p.layout
               (if unbox_param then "[@unboxable]" else "")
           ) params
     | Tupled ->
@@ -1265,14 +1264,14 @@ and lfunction ppf {kind; params; return; body; attr; ret_mode; mode} =
              let { unbox_param } = p.attributes in
              if !first then first := false else fprintf ppf ",@ ";
              Ident.print ppf p.name;
-             Format.fprintf ppf "%s" (alloc_kind p.mode);
+             Format.fprintf ppf "%s" (locality_kind p.mode);
              layout ppf p.layout;
              if unbox_param then Format.fprintf ppf "[@unboxable]"
           )
           params;
         fprintf ppf ")" in
   fprintf ppf "@[<2>(function%s%a@ %a%a%a)@]"
-    (alloc_kind mode) pr_params params
+    (locality_kind mode) pr_params params
     function_attribute attr return_kind (ret_mode, return) lam body
 
 

--- a/ocaml/lambda/printlambda.mli
+++ b/ocaml/lambda/printlambda.mli
@@ -42,7 +42,7 @@ val print_bigarray :
   string -> bool -> Lambda.bigarray_kind -> formatter ->
   Lambda.bigarray_layout -> unit
 val zero_alloc_attribute : formatter -> zero_alloc_attribute -> unit
-val alloc_mode : formatter -> alloc_mode -> unit
+val locality_mode : formatter -> locality_mode -> unit
 val array_kind : array_kind -> string
 
 val tag_and_constructor_shape :

--- a/ocaml/lambda/simplif.mli
+++ b/ocaml/lambda/simplif.mli
@@ -37,7 +37,7 @@ val split_default_wrapper
   -> body:lambda
   -> attr:function_attribute
   -> loc:Lambda.scoped_location
-  -> mode:Lambda.alloc_mode
-  -> ret_mode:Lambda.alloc_mode
+  -> mode:Lambda.locality_mode
+  -> ret_mode:Lambda.locality_mode
   -> region:bool
   -> rec_binding list

--- a/ocaml/lambda/transl_comprehension_utils.mli
+++ b/ocaml/lambda/transl_comprehension_utils.mli
@@ -76,7 +76,7 @@ module Lambda_utils : sig
       other information needed by [Lapply] is set to some default value. *)
   val apply :
     loc:scoped_location ->
-    mode:alloc_mode ->
+    mode:locality_mode ->
     lambda ->
     lambda list ->
     result_layout:layout ->

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1406,7 +1406,7 @@ and transl_apply ~scopes
            Arg (transl_exp ~scopes sort_arg exp, layout_exp sort_arg exp))
       sargs
   in
-  build_apply lam [] loc position (mode : locality_mode) args
+  build_apply lam [] loc position mode args
 
 (* There are two cases in function translation:
     - [Tupled]. It takes a tupled argument, and we can flatten it.

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -186,11 +186,11 @@ let function_attribute_disallowing_arity_fusion =
 *)
 let curried_function_kind
     : (function_curry * Mode.Alloc.l) list
-      -> return_mode:alloc_mode
-      -> alloc_mode:alloc_mode
+      -> return_mode:locality_mode
+      -> mode:locality_mode
       -> curried_function_kind
   =
-  let rec loop params ~return_mode ~alloc_mode ~running_count
+  let rec loop params ~return_mode ~mode ~running_count
       ~found_local_already
     =
     match params with
@@ -199,7 +199,7 @@ let curried_function_kind
         let nlocal =
           if running_count = 0
              && is_alloc_heap return_mode
-             && is_alloc_heap alloc_mode
+             && is_alloc_heap mode
              && is_alloc_heap (transl_alloc_mode_l final_arg_mode)
           then 0
           else running_count + 1
@@ -209,18 +209,18 @@ let curried_function_kind
     | (More_args { partial_mode }, _) :: params ->
         match transl_alloc_mode_l partial_mode with
         | Alloc_heap when not found_local_already ->
-            loop params ~return_mode ~alloc_mode
+            loop params ~return_mode ~mode
               ~running_count:0 ~found_local_already
         | Alloc_local ->
-            loop params ~return_mode ~alloc_mode
+            loop params ~return_mode ~mode
               ~running_count:(running_count + 1) ~found_local_already:true
         | Alloc_heap ->
             Misc.fatal_error
               "A function argument with a Global partial_mode unexpectedly \
               found following a function argument with a Local partial_mode"
   in
-  fun params ~return_mode ~alloc_mode ->
-    loop params ~return_mode ~alloc_mode ~running_count:0
+  fun params ~return_mode ~mode ->
+    loop params ~return_mode ~mode ~running_count:0
       ~found_local_already:false
 
 (* Insertion of debugging events *)
@@ -266,7 +266,7 @@ type fusable_function =
   { params : function_param list
   ; body : function_body
   ; return_sort : Jkind.sort
-  ; return_mode : alloc_mode
+  ; return_mode : locality_mode
   ; region : bool
   }
 
@@ -1134,7 +1134,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           ~kind:(Curried {nlocal=List.length param_idents})
           (* CR layouts: Adjust param layouts when we allow other things in
              probes. *)
-          ~params:(List.map (fun name -> { name; layout = layout_probe_arg; attributes = Lambda.default_param_attribute; mode = alloc_local }) param_idents)
+          ~params:(List.map (fun name -> { name; layout = layout_probe_arg;
+                                           attributes = Lambda.default_param_attribute;
+                                           mode = alloc_local }) param_idents)
           ~return:return_layout
           ~body:body
           ~loc:(of_location ~scopes exp.exp_loc)
@@ -1367,7 +1369,7 @@ and transl_apply ~scopes
           let ret_mode = transl_alloc_mode_l mode_ret in
           let body = build_apply handle [Lvar id_arg] loc Rc_normal ret_mode l in
           let nlocal =
-            match join_mode mode (join_mode arg_mode ret_mode) with
+            match join_locality_mode mode (join_locality_mode arg_mode ret_mode) with
             | Alloc_local -> 1
             | Alloc_heap -> 0
           in
@@ -1404,7 +1406,7 @@ and transl_apply ~scopes
            Arg (transl_exp ~scopes sort_arg exp, layout_exp sort_arg exp))
       sargs
   in
-  build_apply lam [] loc position mode args
+  build_apply lam [] loc position (mode : locality_mode) args
 
 (* There are two cases in function translation:
     - [Tupled]. It takes a tupled argument, and we can flatten it.
@@ -1509,7 +1511,7 @@ and transl_curried_function ~scopes loc repr params body
     let param_curries = List.map (fun fp -> fp.fp_curry, fp.fp_mode) params in
     curried_function_kind
       ~return_mode
-      ~alloc_mode:mode
+      ~mode
       (match body with
        | Tfunction_body _ -> param_curries
        | Tfunction_cases fc -> param_curries @ [ Final_arg, fc.fc_arg_mode ])
@@ -1603,7 +1605,7 @@ and transl_curried_function ~scopes loc repr params body
       type acc =
         { body : lambda; (* The function body of those params *)
           return_layout : layout; (* The layout of [body] *)
-          return_mode : alloc_mode; (* The mode of [body]. *)
+          return_mode : locality_mode; (* The mode of [body]. *)
           region : bool; (* Whether the function has its own region *)
           nlocal : int;
           (* An upper bound on the [nlocal] field for the function. If [nlocal]
@@ -1646,7 +1648,7 @@ and transl_curried_function ~scopes loc repr params body
         (* we return Pgenval (for a function) after the rightmost chunk *)
         { body;
           return_layout = Pvalue Pgenval;
-          return_mode = (if enclosing_region then alloc_heap else alloc_local);
+          return_mode = if enclosing_region then alloc_heap else alloc_local;
           nlocal = enclosing_nlocal;
           region = enclosing_region;
         }

--- a/ocaml/lambda/translcore.mli
+++ b/ocaml/lambda/translcore.mli
@@ -30,7 +30,7 @@ val transl_apply: scopes:scopes
                   -> ?inlined:inlined_attribute
                   -> ?specialised:specialise_attribute
                   -> ?position:region_close
-                  -> ?mode:alloc_mode
+                  -> ?mode:locality_mode
                   -> result_layout:Lambda.layout
                   -> lambda
                   -> (arg_label * apply_arg) list

--- a/ocaml/lambda/translmode.mli
+++ b/ocaml/lambda/translmode.mli
@@ -16,10 +16,10 @@ open Mode
 
 val transl_locality_mode_l : (allowed * 'r) Locality.t -> Lambda.locality_mode
 
-val transl_alloc_mode_l : (allowed * 'r) Alloc.t -> Lambda.alloc_mode
+val transl_alloc_mode_l : (allowed * 'r) Alloc.t -> Lambda.locality_mode
 
-val transl_alloc_mode_r : ('l * allowed) Alloc.t -> Lambda.alloc_mode
+val transl_alloc_mode_r : ('l * allowed) Alloc.t -> Lambda.locality_mode
 
-val transl_alloc_mode : Typedtree.alloc_mode -> Lambda.alloc_mode
+val transl_alloc_mode : Typedtree.alloc_mode -> Lambda.locality_mode
 
 val transl_modify_mode : (allowed * 'r) Locality.t -> Lambda.modify_mode

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -537,9 +537,9 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%nativeint_sub" -> Primitive ((Psubbint (Pnativeint, mode)), 2)
     | "%nativeint_mul" -> Primitive ((Pmulbint (Pnativeint, mode)), 2)
     | "%nativeint_div" ->
-      Primitive ((Pdivbint { size = Pnativeint; is_safe = Safe; mode }), 2);
+      Primitive ((Pdivbint { size = Pnativeint; is_safe = Safe; mode = mode }), 2);
     | "%nativeint_mod" ->
-      Primitive ((Pmodbint { size = Pnativeint; is_safe = Safe; mode }), 2);
+      Primitive ((Pmodbint { size = Pnativeint; is_safe = Safe; mode = mode }), 2);
     | "%nativeint_and" -> Primitive ((Pandbint (Pnativeint, mode)), 2)
     | "%nativeint_or" -> Primitive ( (Porbint (Pnativeint, mode)), 2)
     | "%nativeint_xor" -> Primitive ((Pxorbint (Pnativeint, mode)), 2)
@@ -553,9 +553,9 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%int32_sub" -> Primitive ((Psubbint (Pint32, mode)), 2)
     | "%int32_mul" -> Primitive ((Pmulbint (Pint32, mode)), 2)
     | "%int32_div" ->
-       Primitive ((Pdivbint { size = Pint32; is_safe = Safe; mode }), 2)
+       Primitive ((Pdivbint { size = Pint32; is_safe = Safe; mode = mode }), 2)
     | "%int32_mod" ->
-       Primitive ((Pmodbint { size = Pint32; is_safe = Safe; mode }), 2)
+       Primitive ((Pmodbint { size = Pint32; is_safe = Safe; mode = mode }), 2)
     | "%int32_and" -> Primitive ((Pandbint (Pint32, mode)), 2)
     | "%int32_or" -> Primitive ( (Porbint (Pint32, mode)), 2)
     | "%int32_xor" -> Primitive ((Pxorbint (Pint32, mode)), 2)
@@ -569,9 +569,9 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%int64_sub" -> Primitive ((Psubbint (Pint64, mode)), 2)
     | "%int64_mul" -> Primitive ((Pmulbint (Pint64, mode)), 2)
     | "%int64_div" ->
-       Primitive ((Pdivbint { size = Pint64; is_safe = Safe; mode }), 2)
+       Primitive ((Pdivbint { size = Pint64; is_safe = Safe; mode = mode }), 2)
     | "%int64_mod" ->
-       Primitive ((Pmodbint { size = Pint64; is_safe = Safe; mode }), 2)
+       Primitive ((Pmodbint { size = Pint64; is_safe = Safe; mode = mode }), 2)
     | "%int64_and" -> Primitive ((Pandbint (Pint64, mode)), 2)
     | "%int64_or" -> Primitive ( (Porbint (Pint64, mode)), 2)
     | "%int64_xor" -> Primitive ((Pxorbint (Pint64, mode)), 2)
@@ -1414,7 +1414,6 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
     | None -> prim
     | Some prim -> prim
   in
-  let to_locality = to_locality ~poly:poly_mode in
   let error_loc = to_location loc in
   let rec make_params ty repr_args repr_res =
     match repr_args, repr_res with
@@ -1437,7 +1436,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
           let arg_layout =
             Typeopt.layout env error_loc arg_sort arg_ty
           in
-          let arg_mode = to_locality arg in
+          let arg_mode = to_locality ~poly:poly_mode arg in
           let params, return = make_params ret_ty repr_args repr_res in
           { name = Ident.create_local "prim";
             layout = arg_layout;
@@ -1458,7 +1457,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
          loc
      in
      let body = lambda_of_prim p.prim_name prim loc args None in
-     let alloc_mode = to_locality p.prim_native_repr_res in
+     let locality_mode = to_locality ~poly:poly_mode p.prim_native_repr_res in
      let () =
        (* CR mshinwell: Write a version of [primitive_may_allocate] that
           works on the [prim] type. *)
@@ -1475,7 +1474,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
             (* In this case we add a check to ensure the middle end has
                the correct information as to whether a region was inserted
                at this point. *)
-            match alloc_mode, lambda_alloc_mode with
+            match locality_mode, lambda_alloc_mode with
             | Alloc_heap, Alloc_heap
             | Alloc_local, Alloc_local -> ()
             | Alloc_local, Alloc_heap ->
@@ -1484,16 +1483,16 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
                  deleted by the middle end. *)
               ()
             | Alloc_heap, Alloc_local ->
-              Misc.fatal_errorf "Alloc mode incompatibility for:@ %a@ \
+              Misc.fatal_errorf "Locality mode incompatibility for:@ %a@ \
                   (from to_locality, %a; from primitive_may_allocate, %a)"
                 Printlambda.lambda body
-                Printlambda.alloc_mode alloc_mode
-                Printlambda.alloc_mode lambda_alloc_mode
+                Printlambda.locality_mode locality_mode
+                Printlambda.locality_mode lambda_alloc_mode
          )
        | _ -> ()
      in
      let region =
-       match alloc_mode with
+       match locality_mode with
        | Alloc_heap -> true
        | Alloc_local -> false
      in
@@ -1503,8 +1502,9 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
        | Alloc_heap :: args -> count_nlocal args
        | (Alloc_local :: _) as args -> List.length args
      in
-     let nlocal = count_nlocal (List.map to_locality p.prim_native_repr_args) in
-     lfunction
+     let nlocal = count_nlocal
+                    (List.map (to_locality ~poly:poly_mode) p.prim_native_repr_args)
+     in lfunction
        ~kind:(Curried {nlocal})
        ~params
        ~return
@@ -1512,7 +1512,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
        ~loc
        ~body
        ~mode:alloc_heap
-       ~ret_mode:(to_locality p.prim_native_repr_res)
+       ~ret_mode:(to_locality ~poly:poly_mode p.prim_native_repr_res)
        ~region
 
 let lambda_primitive_needs_event_after = function

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -537,9 +537,9 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%nativeint_sub" -> Primitive ((Psubbint (Pnativeint, mode)), 2)
     | "%nativeint_mul" -> Primitive ((Pmulbint (Pnativeint, mode)), 2)
     | "%nativeint_div" ->
-      Primitive ((Pdivbint { size = Pnativeint; is_safe = Safe; mode = mode }), 2);
+      Primitive ((Pdivbint { size = Pnativeint; is_safe = Safe; mode }), 2);
     | "%nativeint_mod" ->
-      Primitive ((Pmodbint { size = Pnativeint; is_safe = Safe; mode = mode }), 2);
+      Primitive ((Pmodbint { size = Pnativeint; is_safe = Safe; mode }), 2);
     | "%nativeint_and" -> Primitive ((Pandbint (Pnativeint, mode)), 2)
     | "%nativeint_or" -> Primitive ( (Porbint (Pnativeint, mode)), 2)
     | "%nativeint_xor" -> Primitive ((Pxorbint (Pnativeint, mode)), 2)
@@ -553,9 +553,9 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%int32_sub" -> Primitive ((Psubbint (Pint32, mode)), 2)
     | "%int32_mul" -> Primitive ((Pmulbint (Pint32, mode)), 2)
     | "%int32_div" ->
-       Primitive ((Pdivbint { size = Pint32; is_safe = Safe; mode = mode }), 2)
+       Primitive ((Pdivbint { size = Pint32; is_safe = Safe; mode }), 2)
     | "%int32_mod" ->
-       Primitive ((Pmodbint { size = Pint32; is_safe = Safe; mode = mode }), 2)
+       Primitive ((Pmodbint { size = Pint32; is_safe = Safe; mode }), 2)
     | "%int32_and" -> Primitive ((Pandbint (Pint32, mode)), 2)
     | "%int32_or" -> Primitive ( (Porbint (Pint32, mode)), 2)
     | "%int32_xor" -> Primitive ((Pxorbint (Pint32, mode)), 2)
@@ -569,9 +569,9 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%int64_sub" -> Primitive ((Psubbint (Pint64, mode)), 2)
     | "%int64_mul" -> Primitive ((Pmulbint (Pint64, mode)), 2)
     | "%int64_div" ->
-       Primitive ((Pdivbint { size = Pint64; is_safe = Safe; mode = mode }), 2)
+       Primitive ((Pdivbint { size = Pint64; is_safe = Safe; mode }), 2)
     | "%int64_mod" ->
-       Primitive ((Pmodbint { size = Pint64; is_safe = Safe; mode = mode }), 2)
+       Primitive ((Pmodbint { size = Pint64; is_safe = Safe; mode }), 2)
     | "%int64_and" -> Primitive ((Pandbint (Pint64, mode)), 2)
     | "%int64_or" -> Primitive ( (Porbint (Pint64, mode)), 2)
     | "%int64_xor" -> Primitive ((Pxorbint (Pint64, mode)), 2)
@@ -1414,6 +1414,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
     | None -> prim
     | Some prim -> prim
   in
+  let to_locality = to_locality ~poly:poly_mode in
   let error_loc = to_location loc in
   let rec make_params ty repr_args repr_res =
     match repr_args, repr_res with
@@ -1436,7 +1437,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
           let arg_layout =
             Typeopt.layout env error_loc arg_sort arg_ty
           in
-          let arg_mode = to_locality ~poly:poly_mode arg in
+          let arg_mode = to_locality arg in
           let params, return = make_params ret_ty repr_args repr_res in
           { name = Ident.create_local "prim";
             layout = arg_layout;
@@ -1457,7 +1458,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
          loc
      in
      let body = lambda_of_prim p.prim_name prim loc args None in
-     let locality_mode = to_locality ~poly:poly_mode p.prim_native_repr_res in
+     let locality_mode = to_locality p.prim_native_repr_res in
      let () =
        (* CR mshinwell: Write a version of [primitive_may_allocate] that
           works on the [prim] type. *)
@@ -1502,8 +1503,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
        | Alloc_heap :: args -> count_nlocal args
        | (Alloc_local :: _) as args -> List.length args
      in
-     let nlocal = count_nlocal
-                    (List.map (to_locality ~poly:poly_mode) p.prim_native_repr_args)
+     let nlocal = count_nlocal (List.map to_locality p.prim_native_repr_args)
      in lfunction
        ~kind:(Curried {nlocal})
        ~params
@@ -1512,7 +1512,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
        ~loc
        ~body
        ~mode:alloc_heap
-       ~ret_mode:(to_locality ~poly:poly_mode p.prim_native_repr_res)
+       ~ret_mode:(to_locality p.prim_native_repr_res)
        ~region
 
 let lambda_primitive_needs_event_after = function


### PR DESCRIPTION
Following up on #3056 and preparing for adding uniqueness information to `Lambda.alloc_mode`, this PR fully removes all dependency on `Lambda.alloc_mode` and instead prefers `Lambda.locality_mode`. This will make it easy for us to see where uniqueness information is added to the IR once we add a `uniqueness` field to `Lambda.alloc_mode` in a separate PR.

Note that I made this PR against `main` rather than `overwriting`. There are three reasons for this:
 - #3056 was merged into main
 - This change touches many parts of the codebase which might change over time and make our merge of overwriting harder
 - The diff looks much cleaner since this relies on #3056 which is newer than the `overwriting` branch.