### PR TITLE
backport upstream PR #13203

### DIFF
--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -32,6 +32,14 @@ let mark_used t = Attribute_table.remove unused_attrs t
 *)
 let attr_order a1 a2 = Location.compare a1.loc a2.loc
 
+let compiler_stops_before_attributes_consumed () =
+  let stops_before_lambda =
+    match !Clflags.stop_after with
+    | None -> false
+    | Some pass -> Clflags.Compiler_pass.(compare pass Lambda) < 0
+  in
+  stops_before_lambda || !Clflags.print_types
+
 let unchecked_zero_alloc_attributes = Attribute_table.create 1
 let mark_zero_alloc_attribute_checked txt loc =
   Attribute_table.remove unchecked_zero_alloc_attributes { txt; loc }
@@ -49,18 +57,13 @@ let warn_unchecked_zero_alloc_attribute () =
     keys
 
 let warn_unused () =
-  (* When using -i, attributes will not have been translated, so we can't
-     warn about missing ones. *)
-  if !Clflags.print_types then ()
-  else
-  begin
-    let keys = List.of_seq (Attribute_table.to_seq_keys unused_attrs) in
-    Attribute_table.clear unused_attrs;
+  let keys = List.of_seq (Attribute_table.to_seq_keys unused_attrs) in
+  Attribute_table.clear unused_attrs;
+  if not (compiler_stops_before_attributes_consumed ()) then
     let keys = List.sort attr_order keys in
     List.iter (fun sloc ->
       Location.prerr_warning sloc.loc (Warnings.Misplaced_attribute sloc.txt))
       keys
-  end
 
 (* These are the attributes that are tracked in the builtin_attrs table for
    misplaced attribute warnings. *)

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -78,7 +78,8 @@ val register_attr : current_phase -> string Location.loc -> unit
 val mark_payload_attrs_used : Parsetree.payload -> unit
 
 (** Issue misplaced attribute warnings for all attributes created with
-    [mk_internal] but not yet marked used. *)
+    [mk_internal] but not yet marked used. Does nothing if compilation
+    is stopped before lambda due to command-line flags. *)
 val warn_unused : unit -> unit
 
 (** {3 Warning 53 helpers for environment attributes}

--- a/ocaml/testsuite/tests/warnings/w53_flags.ml
+++ b/ocaml/testsuite/tests/warnings/w53_flags.ml
@@ -1,0 +1,39 @@
+(* TEST
+   readonly_files = "w53.ml";
+   setup-ocamlc.byte-build-env;
+   module = "w53.ml";
+
+   (* We don't issue warning 53 when -i is passed *)
+   {
+     flags = "-warn-error +53 -i -w +A-22-27-32-60-67-70-71-72";
+     compile_only = "true";
+     ocamlc_byte_exit_status = "0";
+     ocamlc.byte;
+   }
+
+   (* We don't issue warning 53 when -stop-after parsing or -stop-after typing
+      is passed *)
+   {
+     flags =
+       "-warn-error +53 -stop-after parsing -w +A-22-27-32-60-67-70-71-72";
+     compile_only = "true";
+     ocamlc_byte_exit_status = "0";
+     ocamlc.byte;
+   }
+   {
+     flags =
+       "-warn-error +53 -stop-after typing -w +A-22-27-32-60-67-70-71-72";
+     compile_only = "true";
+     ocamlc_byte_exit_status = "0";
+     ocamlc.byte;
+   }
+
+   (* We do issue warning 53 when -stop-after lambda (or later) is passed *)
+   {
+     flags =
+       "-warn-error +53 -stop-after lambda -w +A-22-27-32-60-67-70-71-72";
+     compile_only = "true";
+     ocamlc_byte_exit_status = "2";
+     ocamlc.byte;
+   }
+*)


### PR DESCRIPTION
The compiler shouldn't issue warning 53 if you pass `-stop-after typing`, `-stop-after parsing`, or `-i` because it needs to get to lambda to see if the attributes are used.  This is already fixed upstream, so I have simply backported that fix.

Review: @rtjoa perhaps you could review this?  It's already reviewed upstream, so that's mainly just checking that I've imported the diff correctly.  Though note there is one change because we had actually already handled the `-i` case and can now remove that special case and replace it with what is done in ocaml/ocaml#13203.