### PR TITLE
Use alloc_mode with uniqueness for block allocations in lambda

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1777,6 +1777,7 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
     List.concat_map
       (fun (({ name; layout; mode; attributes } : L.lparam), kinds) :
            Function_decl.param list ->
+        let mode = L.todo_mode_propagation mode in
         match kinds with
         | [] -> []
         | [kind] -> [{ name; kind; mode; attributes }]
@@ -1821,6 +1822,7 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
     in
     cps_tail acc new_env ccenv body body_cont body_exn_cont
   in
+  let ret_mode = L.todo_mode_propagation ret_mode in
   Function_decl.create ~let_rec_ident:(Some fid) ~function_slot ~kind ~params
     ~params_arity ~removed_params ~return ~calling_convention
     ~return_continuation:body_cont ~exn_continuation ~my_region ~my_ghost_region

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -986,6 +986,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   match prim, args with
   | Pmakeblock (tag, mutability, shape, mode), _ ->
     let args = List.flatten args in
+    let mode = L.todo_mode_propagation mode in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
     let tag = Tag.Scannable.create_exn tag in
     let shape = convert_block_shape shape ~num_fields:(List.length args) in
@@ -1023,6 +1024,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     List.map (fun arg : H.expr_primitive -> Simple arg) projected_args
   | Pmakefloatblock (mutability, mode), _ ->
     let args = List.flatten args in
+    let mode = L.todo_mode_propagation mode in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
     let mutability = Mutability.from_lambda mutability in
     [ Variadic
@@ -1030,6 +1032,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     ]
   | Pmakeufloatblock (mutability, mode), _ ->
     let args = List.flatten args in
+    let mode = L.todo_mode_propagation mode in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
     let mutability = Mutability.from_lambda mutability in
     [Variadic (Make_block (Naked_floats, mutability, mode), args)]
@@ -1045,6 +1048,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
           | Flat_suffix Float_boxed -> unbox_float arg)
         args
     in
+    let mode = L.todo_mode_propagation mode in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
     let mutability = Mutability.from_lambda mutability in
     let tag = Tag.Scannable.create_exn tag in

--- a/ocaml/lambda/matching.ml
+++ b/ocaml/lambda/matching.ml
@@ -3908,7 +3908,7 @@ let failure_handler ~scopes loc ~failer () =
     Lprim
       ( Praise Raise_regular,
         [ Lprim
-            ( Pmakeblock (0, Immutable, None, alloc_heap),
+            ( Pmakeblock (0, Immutable, None, alloc_heap_aliased),
               [ slot;
                 Lconst
                   (Const_block

--- a/ocaml/lambda/matching.mli
+++ b/ocaml/lambda/matching.mli
@@ -36,7 +36,7 @@ val for_let:
         lambda
 val for_multiple_match:
         scopes:scopes -> return_layout:layout -> Location.t ->
-        (lambda * Jkind.sort * layout) list -> locality_mode ->
+        (lambda * Jkind.sort * layout) list -> alloc_mode ->
         (pattern * lambda) list -> partial ->
         lambda
 

--- a/ocaml/lambda/printlambda.mli
+++ b/ocaml/lambda/printlambda.mli
@@ -43,6 +43,7 @@ val print_bigarray :
   Lambda.bigarray_layout -> unit
 val zero_alloc_attribute : formatter -> zero_alloc_attribute -> unit
 val locality_mode : formatter -> locality_mode -> unit
+val alloc_mode : formatter -> alloc_mode -> unit
 val array_kind : array_kind -> string
 
 val tag_and_constructor_shape :

--- a/ocaml/lambda/simplif.mli
+++ b/ocaml/lambda/simplif.mli
@@ -38,6 +38,6 @@ val split_default_wrapper
   -> attr:function_attribute
   -> loc:Lambda.scoped_location
   -> mode:Lambda.locality_mode
-  -> ret_mode:Lambda.locality_mode
+  -> ret_mode:Lambda.alloc_mode
   -> region:bool
   -> rec_binding list

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -63,9 +63,9 @@ let offset_code (Offset t) = t
 
 let add_dst_params ({var; offset} : Ident.t destination) params =
   { name = var ; layout = Lambda.layout_block ;
-    attributes = Lambda.default_param_attribute ; mode = alloc_heap } ::
+    attributes = Lambda.default_param_attribute ; mode = alloc_heap_aliased } ::
   { name = offset ; layout = Lambda.layout_int ;
-    attributes = Lambda.default_param_attribute ; mode = alloc_heap } ::
+    attributes = Lambda.default_param_attribute ; mode = alloc_heap_aliased } ::
   params
 
 let add_dst_args ({var; offset} : offset destination) args =
@@ -124,7 +124,7 @@ end = struct
 
   let apply constr t =
     let block_args = List.append constr.before @@ t :: constr.after in
-    Lprim (Pmakeblock (constr.tag, constr.flag, constr.shape, alloc_heap),
+    Lprim (Pmakeblock (constr.tag, constr.flag, constr.shape, alloc_heap_aliased),
            block_args, constr.loc)
 
   let tmc_placeholder =
@@ -565,10 +565,10 @@ let find_candidate = function
   | Lfunction lfun when lfun.attr.tmc_candidate ->
      (* TMC does not make sense for local-returning functions *)
      begin match lfun.ret_mode with
-     | Alloc_local ->
+     | Alloc_local, _ ->
        raise (Error (Debuginfo.Scoped_location.to_location lfun.loc,
                      Tmc_local_returning))
-     | Alloc_heap -> Some lfun
+     | Alloc_heap, _ -> Some lfun
      end
   | _ -> None
 

--- a/ocaml/lambda/transl_array_comprehension.ml
+++ b/ocaml/lambda/transl_array_comprehension.ml
@@ -218,7 +218,7 @@ end = struct
     Lprim
       ( Praise Raise_regular,
         [ Lprim
-            ( Pmakeblock (0, Immutable, None, alloc_heap),
+            ( Pmakeblock (0, Immutable, None, alloc_heap_aliased),
               [ slot;
                 string ~loc:loc'
                   "integer overflow when precomputing the size of an array \

--- a/ocaml/lambda/transl_list_comprehension.ml
+++ b/ocaml/lambda/transl_list_comprehension.ml
@@ -113,7 +113,7 @@ let ( rev_list_to_list,
     building the intermediate restults of list comprehensions; see the
     documentation for [CamlinternalComprehension.rev_list] for more details. *)
 let rev_list_snoc_local ~loc ~init ~last =
-  Lprim (Pmakeblock (0, Immutable, None, alloc_local), [init; last], loc)
+  Lprim (Pmakeblock (0, Immutable, None, alloc_local_unique), [init; last], loc)
 
 (** The [CamlinternalComprehension.Nil] constructor, for building the
     intermediate restults of list comprehensions; see the documentation for
@@ -244,15 +244,15 @@ let rec translate_bindings ~transl_exp ~scopes ~loc ~inner_body ~accumulator =
               layout = element_kind;
               attributes = Lambda.default_param_attribute;
               (* CR ncourant: check *)
-              mode = alloc_heap
+              mode = alloc_heap_aliased
             };
             { name = inner_acc;
               layout = Pvalue Pgenval;
               attributes = Lambda.default_param_attribute;
-              mode = alloc_local
+              mode = alloc_local_aliased
             } ]
         ~return:(Pvalue Pgenval) ~attr:default_function_attribute ~loc
-        ~mode:alloc_local ~ret_mode:alloc_local ~region:false
+        ~mode:alloc_local ~ret_mode:alloc_local_aliased ~region:false
         ~body:(add_bindings body)
     in
     let result =

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -117,7 +117,7 @@ let rec apply_coercion loc strict restr arg =
             Lprim(mod_field pos,[Lvar id], loc)
         in
         let lam =
-          Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
+          Lprim(Pmakeblock(0, Immutable, None, alloc_heap_aliased),
                 List.map (apply_coercion_field loc get_field) pos_cc_list,
                 loc)
         in
@@ -127,7 +127,7 @@ let rec apply_coercion loc strict restr arg =
       let carg = apply_coercion loc Alias cc_arg (Lvar param) in
       apply_coercion_result loc strict arg
         [{name = param; layout = Lambda.layout_module;
-          attributes = Lambda.default_param_attribute; mode = alloc_heap}]
+          attributes = Lambda.default_param_attribute; mode = alloc_heap_aliased}]
         [carg] cc_res
   | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode; pc_poly_sort } ->
       Translprim.transl_primitive loc pc_desc pc_env pc_type
@@ -151,7 +151,7 @@ and apply_coercion_result loc strict funct params args cc_res =
       ({ name = param;
          layout = Lambda.layout_module;
          attributes = Lambda.default_param_attribute;
-         mode = alloc_heap } :: params)
+         mode = alloc_heap_aliased } :: params)
       (arg :: args) cc_res
   | _ ->
       name_lambda strict funct Lambda.layout_functor
@@ -167,7 +167,7 @@ and apply_coercion_result loc strict funct params args cc_res =
                         may_fuse_arity = true; }
              ~loc
              ~mode:alloc_heap
-             ~ret_mode:alloc_heap
+             ~ret_mode:alloc_heap_aliased
              ~region:true
              ~body:(apply_coercion
                    loc Strict cc_res
@@ -554,7 +554,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
           name = param';
           layout = Lambda.layout_module;
           attributes = Lambda.default_param_attribute;
-          mode = alloc_heap
+          mode = alloc_heap_aliased
         } :: params in
         let body = Llet (Alias, Lambda.layout_module, param, arg, body) in
         params, body)
@@ -581,7 +581,7 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
     }
     ~loc
     ~mode:alloc_heap
-    ~ret_mode:alloc_heap
+    ~ret_mode:alloc_heap_aliased
     ~region:true
     ~body
 
@@ -638,7 +638,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
       let body, size =
         match cc with
           Tcoerce_none ->
-            Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
+            Lprim(Pmakeblock(0, Immutable, None, alloc_heap_aliased),
                   List.map (fun id -> Lvar id) (List.rev fields), loc),
               List.length fields
         | Tcoerce_structure(pos_cc_list, id_pos_list) ->
@@ -654,7 +654,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
             in
             let ids = List.fold_right Ident.Set.add fields Ident.Set.empty in
             let lam =
-              Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
+              Lprim(Pmakeblock(0, Immutable, None, alloc_heap_aliased),
                   List.map
                     (fun (pos, cc) ->
                       match cc with
@@ -862,7 +862,7 @@ and transl_include_functor ~generative modl params scopes loc =
   let modl = transl_module ~scopes Tcoerce_none None modl in
   let params = if generative then [params;[]] else [params] in
   let params = List.map (fun coercion ->
-    Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
+    Lprim(Pmakeblock(0, Immutable, None, alloc_heap_aliased),
           List.map (fun (name, cc) ->
             apply_coercion loc Strict cc (Lvar name))
             coercion,
@@ -1197,7 +1197,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Lambda.layout_module, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
+                             (Lprim(Pmakeblock(0, Immutable, None, alloc_heap_aliased),
                                     List.map (fun id -> Lvar id)
                                       (defined_idents str.str_items), loc)),
                            Lsequence(store_ident loc id,
@@ -1226,7 +1226,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Lambda.layout_module, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
+                             (Lprim(Pmakeblock(0, Immutable, None, alloc_heap_aliased),
                                     List.map field map, loc)),
                            Lsequence(store_ident loc id,
                                      transl_store ~scopes rootpath
@@ -1575,7 +1575,7 @@ let stub_out_runtime_parameters compilation_unit code =
                                        Location.none, None)))
     in
     Lprim (Praise Raise_regular,
-           [Lprim(Pmakeblock(0, Immutable, None, alloc_heap), [ slot; message ], loc)],
+           [Lprim(Pmakeblock(0, Immutable, None, alloc_heap_aliased), [ slot; message ], loc)],
            loc)
 
 let transl_implementation compilation_unit impl ~style =
@@ -1791,7 +1791,7 @@ let transl_package_plain_block component_names coercion =
   in
   size,
   apply_coercion Loc_unknown Strict coercion
-    (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
+    (Lprim(Pmakeblock(0, Immutable, None, alloc_heap_aliased),
            List.map get_component component_names,
            Loc_unknown))
 
@@ -1831,7 +1831,7 @@ let transl_package_set_fields component_names target_name coercion =
          0 component_names)
   | Tcoerce_structure (pos_cc_list, _id_pos_list) ->
       let components =
-        Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
+        Lprim(Pmakeblock(0, Immutable, None, alloc_heap_aliased),
               List.map get_component component_names,
               Loc_unknown)
       in

--- a/ocaml/lambda/translmode.ml
+++ b/ocaml/lambda/translmode.ml
@@ -27,13 +27,25 @@ let transl_locality_mode_r locality =
      to ceil and determined; here we push it again just to get the constant. *)
   Locality.zap_to_ceil locality |> transl_locality_mode
 
+let transl_uniqueness_mode = function
+  | Uniqueness.Const.Unique -> alloc_unique
+  | Uniqueness.Const.Aliased -> alloc_aliased
+
+let transl_uniqueness_mode_l uniqueness =
+  Uniqueness.zap_to_floor uniqueness |> transl_uniqueness_mode
+
+let transl_uniqueness_mode_r uniqueness =
+  Uniqueness.zap_to_ceil uniqueness |> transl_uniqueness_mode
+
 let transl_alloc_mode_l mode =
-  (* we only take the locality axis *)
-  Alloc.proj (Comonadic Areality) mode |> transl_locality_mode_l
+  (* we only take the locality and uniqueness axis *)
+  ( Alloc.proj (Comonadic Areality) mode |> transl_locality_mode_l,
+    Alloc.proj (Monadic Uniqueness) mode |> transl_uniqueness_mode_l )
 
 let transl_alloc_mode_r mode =
-  (* we only take the locality axis *)
-  Alloc.proj (Comonadic Areality) mode |> transl_locality_mode_r
+  (* we only take the locality and uniqueness axis *)
+  ( Alloc.proj (Comonadic Areality) mode |> transl_locality_mode_r,
+    Alloc.proj (Monadic Uniqueness) mode |> transl_uniqueness_mode_r )
 
 let transl_alloc_mode (mode : Typedtree.alloc_mode) =
   transl_alloc_mode_r mode.mode

--- a/ocaml/lambda/translmode.mli
+++ b/ocaml/lambda/translmode.mli
@@ -16,10 +16,10 @@ open Mode
 
 val transl_locality_mode_l : (allowed * 'r) Locality.t -> Lambda.locality_mode
 
-val transl_alloc_mode_l : (allowed * 'r) Alloc.t -> Lambda.locality_mode
+val transl_alloc_mode_l : (allowed * 'r) Alloc.t -> Lambda.alloc_mode
 
-val transl_alloc_mode_r : ('l * allowed) Alloc.t -> Lambda.locality_mode
+val transl_alloc_mode_r : ('l * allowed) Alloc.t -> Lambda.alloc_mode
 
-val transl_alloc_mode : Typedtree.alloc_mode -> Lambda.locality_mode
+val transl_alloc_mode : Typedtree.alloc_mode -> Lambda.alloc_mode
 
 val transl_modify_mode : (allowed * 'r) Locality.t -> Lambda.modify_mode

--- a/ocaml/lambda/translobj.ml
+++ b/ocaml/lambda/translobj.ml
@@ -187,7 +187,7 @@ let oo_wrap_gen env req f x =
            List.fold_left
              (fun lambda id ->
                 let cl =
-                  Lprim(Pmakeblock(0, Mutable, None, alloc_heap),
+                  Lprim(Pmakeblock(0, Mutable, None, alloc_heap_aliased),
                         [lambda_unit; lambda_unit; lambda_unit],
                         Loc_unknown)
                 in

--- a/ocaml/lambda/value_rec_compiler.ml
+++ b/ocaml/lambda/value_rec_compiler.ml
@@ -511,7 +511,7 @@ let rec split_static_function lfun block_var local_idents lam :
         ap_specialised = Default_specialise;
         ap_result_layout = lfun.return;
         ap_region_close = Rc_normal;
-        ap_mode = lfun.ret_mode;
+        ap_mode = fst lfun.ret_mode;
         ap_probe = None;
       }
     in
@@ -529,7 +529,7 @@ let rec split_static_function lfun block_var local_idents lam :
     in
     let lifted = { lfun = wrapper; free_vars_block_size = 1 } in
     Reachable (lifted,
-               Lprim (Pmakeblock (0, lifted_block_mut, None, Lambda.alloc_heap),
+               Lprim (Pmakeblock (0, lifted_block_mut, None, Lambda.alloc_heap_aliased),
                       [Lvar v], no_loc))
   | Lfunction lfun ->
     let free_vars = Lambda.free_variables lfun.body in
@@ -555,7 +555,7 @@ let rec split_static_function lfun block_var local_idents lam :
     in
     let lifted = { lfun = new_fun; free_vars_block_size } in
     let block =
-      Lprim (Pmakeblock (0, lifted_block_mut, None, Lambda.alloc_heap),
+      Lprim (Pmakeblock (0, lifted_block_mut, None, Lambda.alloc_heap_aliased),
              List.rev block_fields_rev,
              no_loc)
     in

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -240,6 +240,10 @@ module type S = sig
     val aliased : lr
 
     val unique : lr
+
+    val zap_to_floor : (allowed * 'r) t -> Const.t
+
+    val zap_to_ceil : ('l * allowed) t -> Const.t
   end
 
   module Contention : sig


### PR DESCRIPTION
This PR tracks adding the `alloc_mode` back to lambda, this time with uniqueness information. I am still unsure about several bits in this PR and am sharing it so that we can discuss (perhaps in person) what is correct and what has to change. In particular:

 - Do we need an `alloc_mode` on `lparam.mode` and `lfunction.ret_mode` in `lambda.mli`?
 - Are all of the `alloc_heap_aliased` and `alloc_local_aliased` bindings below correct?