### PR TITLE
Refactor string of scope

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_abstract_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_abstract_instances.ml
@@ -125,7 +125,8 @@ let decompose_singleton_debuginfo dbg =
           Debuginfo.print_compact_extended dbg
     in
     let demangled_name =
-      Debuginfo.Scoped_location.string_of_scopes ~include_zero_alloc:false dinfo_scopes
+      Debuginfo.Scoped_location.string_of_scopes ~include_zero_alloc:false
+        dinfo_scopes
       |> Misc.remove_double_underscores
     in
     match compilation_unit with

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_abstract_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_abstract_instances.ml
@@ -125,7 +125,7 @@ let decompose_singleton_debuginfo dbg =
           Debuginfo.print_compact_extended dbg
     in
     let demangled_name =
-      Debuginfo.Scoped_location.string_of_scopes dinfo_scopes
+      Debuginfo.Scoped_location.string_of_scopes ~include_zero_alloc:false dinfo_scopes
       |> Misc.remove_double_underscores
     in
     match compilation_unit with

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -28,7 +28,7 @@ let for_fundecl ~get_file_id state (fundecl : L.fundecl) ~fun_end_label
   let linkage_name =
     match Debuginfo.Dbg.to_list (Debuginfo.get_dbg fundecl.fun_dbg) with
     | [item] ->
-      Debuginfo.Scoped_location.string_of_scopes item.dinfo_scopes
+      Debuginfo.Scoped_location.string_of_scopes ~include_zero_alloc:false item.dinfo_scopes
       |> Misc.remove_double_underscores
     (* XXX Not sure what to do in the cases below *)
     | [] | _ :: _ -> fun_name

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -28,7 +28,8 @@ let for_fundecl ~get_file_id state (fundecl : L.fundecl) ~fun_end_label
   let linkage_name =
     match Debuginfo.Dbg.to_list (Debuginfo.get_dbg fundecl.fun_dbg) with
     | [item] ->
-      Debuginfo.Scoped_location.string_of_scopes ~include_zero_alloc:false item.dinfo_scopes
+      Debuginfo.Scoped_location.string_of_scopes ~include_zero_alloc:false
+        item.dinfo_scopes
       |> Misc.remove_double_underscores
     (* XXX Not sure what to do in the cases below *)
     | [] | _ :: _ -> fun_name

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -326,7 +326,10 @@ let emit_frames a =
     a.efa_def_label lbl;
     let rec emit rs d rest =
       let open Debuginfo in
-      let defname = Scoped_location.string_of_scopes d.dinfo_scopes in
+      let defname =
+        Scoped_location.string_of_scopes ~include_zero_alloc:false
+          d.dinfo_scopes
+      in
       let char_end = d.dinfo_char_end + d.dinfo_start_bol - d.dinfo_end_bol in
       let is_fully_packable =
         d.dinfo_line <= 0xFFF

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -1581,7 +1581,9 @@ end = struct
       let scoped_name =
         t.fun_dbg |> Debuginfo.get_dbg |> Debuginfo.Dbg.to_list
         |> List.map (fun dbg ->
-               Debuginfo.(Scoped_location.string_of_scopes dbg.dinfo_scopes))
+               Debuginfo.(
+                 Scoped_location.string_of_scopes ~include_zero_alloc:false
+                   dbg.dinfo_scopes))
         |> String.concat ","
       in
       Format.fprintf ppf

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2929,8 +2929,8 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
          provided_arity = %a@ missing_arity (unarized) = (%a)@ \
          missing_param_modes = (%a)"
         Ident.print apply.func
-        (Debuginfo.Scoped_location.string_of_scoped_location ~include_zero_alloc:false
-           apply.loc)
+        (Debuginfo.Scoped_location.string_of_scoped_location
+           ~include_zero_alloc:false apply.loc)
         Flambda_arity.print provided_arity
         (Format.pp_print_list ~pp_sep:Format.pp_print_space
            Flambda_kind.With_subkind.print)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2929,7 +2929,8 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
          provided_arity = %a@ missing_arity (unarized) = (%a)@ \
          missing_param_modes = (%a)"
         Ident.print apply.func
-        (Debuginfo.Scoped_location.string_of_scoped_location apply.loc)
+        (Debuginfo.Scoped_location.string_of_scoped_location ~include_zero_alloc:false
+           apply.loc)
         Flambda_arity.print provided_arity
         (Format.pp_print_list ~pp_sep:Format.pp_print_space
            Flambda_kind.With_subkind.print)

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -295,7 +295,7 @@ let add_event ev =
       to prevent the debugger to stop at every single allocation. *)
 let add_pseudo_event loc modname c =
   if !Clflags.debug then
-    let ev_defname = string_of_scoped_location loc in
+    let ev_defname = string_of_scoped_location ~include_zero_alloc:false loc in
     let ev =
       { ev_pos = 0;                   (* patched in emitcode *)
         ev_module = Compilation_unit.full_path_as_string modname;
@@ -1129,7 +1129,7 @@ let rec comp_expr stack_info env exp sz cont =
         fatal_error "Bytegen.comp_expr: assign"
       end
   | Levent(lam, lev) ->
-      let ev_defname = string_of_scoped_location lev.lev_loc in
+      let ev_defname = string_of_scoped_location ~include_zero_alloc:false lev.lev_loc in
       let event kind info =
         { ev_pos = 0;                   (* patched in emitcode *)
           ev_module = Compilation_unit.full_path_as_string !compunit_name;

--- a/ocaml/lambda/debuginfo.ml
+++ b/ocaml/lambda/debuginfo.ml
@@ -141,7 +141,7 @@ module Scoped_location = struct
       else
         str
 
-  let string_of_scopes ?(include_zero_alloc=false) =
+  let string_of_scopes ~include_zero_alloc =
     let module StringSet = Set.Make (String) in
     let repr = ref StringSet.empty in
     fun scopes ->
@@ -185,9 +185,9 @@ module Scoped_location = struct
     | Loc_unknown -> Location.none
     | Loc_known { loc; _ } -> loc
 
-  let string_of_scoped_location = function
+  let string_of_scoped_location ~include_zero_alloc = function
     | Loc_unknown -> "??"
-    | Loc_known { loc = _; scopes } -> string_of_scopes scopes
+    | Loc_known { loc = _; scopes } -> string_of_scopes ~include_zero_alloc scopes
 
   let map_scopes f t =
     match t with

--- a/ocaml/lambda/debuginfo.ml
+++ b/ocaml/lambda/debuginfo.ml
@@ -133,16 +133,19 @@ module Scoped_location = struct
     | Empty -> ZA.Assume_info.none
     | Cons { assume_zero_alloc; _ } -> assume_zero_alloc
 
-  let string_of_scopes = function
+  let string_of_scopes ~include_zero_alloc = function
     | Empty -> "<unknown>"
     | Cons {str; assume_zero_alloc; _} ->
-      str^(ZA.Assume_info.to_string assume_zero_alloc)
+      if include_zero_alloc then
+        str^(ZA.Assume_info.to_string assume_zero_alloc)
+      else
+        str
 
-  let string_of_scopes =
+  let string_of_scopes ?(include_zero_alloc=false) =
     let module StringSet = Set.Make (String) in
     let repr = ref StringSet.empty in
     fun scopes ->
-      let res = string_of_scopes scopes in
+      let res = string_of_scopes scopes ~include_zero_alloc in
       match StringSet.find_opt res !repr with
       | Some x -> x
       | None ->

--- a/ocaml/lambda/debuginfo.mli
+++ b/ocaml/lambda/debuginfo.mli
@@ -32,7 +32,7 @@ module Scoped_location : sig
     | Cons of {item: scope_item; str: string; str_fun: string; name : string; prev: scopes;
                assume_zero_alloc: ZA.Assume_info.t}
 
-  val string_of_scopes : scopes -> string
+  val string_of_scopes : ?include_zero_alloc:bool -> scopes -> string
 
   val compilation_unit : scopes -> Compilation_unit.t option
 

--- a/ocaml/lambda/debuginfo.mli
+++ b/ocaml/lambda/debuginfo.mli
@@ -32,7 +32,7 @@ module Scoped_location : sig
     | Cons of {item: scope_item; str: string; str_fun: string; name : string; prev: scopes;
                assume_zero_alloc: ZA.Assume_info.t}
 
-  val string_of_scopes : ?include_zero_alloc:bool -> scopes -> string
+  val string_of_scopes : include_zero_alloc:bool -> scopes -> string
 
   val compilation_unit : scopes -> Compilation_unit.t option
 
@@ -59,7 +59,7 @@ module Scoped_location : sig
 
   val of_location : scopes:scopes -> Location.t -> t
   val to_location : t -> Location.t
-  val string_of_scoped_location : t -> string
+  val string_of_scoped_location : include_zero_alloc:bool -> t -> string
 
   val map_scopes : (scopes:scopes -> scopes) -> t -> t
 end

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -1231,7 +1231,8 @@ let rec lam ppf = function
         fprintf ppf "@[<2>(%s <unknown location>@ %a)@]" kind lam expr
       | Loc_known {scopes; loc} ->
         fprintf ppf "@[<2>(%s %s %s(%i)%s:%i-%i@ %a)@]" kind
-                (Debuginfo.Scoped_location.string_of_scopes scopes)
+                (Debuginfo.Scoped_location.string_of_scopes
+                   ~include_zero_alloc:true scopes)
                 loc.Location.loc_start.Lexing.pos_fname
                 loc.Location.loc_start.Lexing.pos_lnum
                 (if loc.Location.loc_ghost then "<ghost>" else "")

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -1248,7 +1248,8 @@ let lambda_of_loc kind sloc =
     Lconst (Const_immstring loc)
   | Loc_LINE -> Lconst (Const_base (Const_int lnum))
   | Loc_FUNCTION ->
-    let scope_name = Debuginfo.Scoped_location.string_of_scoped_location sloc in
+    let scope_name = Debuginfo.Scoped_location.string_of_scoped_location
+                       ~include_zero_alloc:false sloc in
     Lconst (Const_immstring scope_name)
 
 let caml_restore_raw_backtrace =


### PR DESCRIPTION
We should not print `assume_zero_alloc` field of `Debuginfo.Scoped_location` except for debugging. This PR adds an argument to `Debuginfo.string_of_scopes` and `Debuginfo.string_of_scoped_location`. These functions are used in a few places and it's easy to see that `assume_zero_alloc` field is not relevant to them. Note that currently print the internal representation.

(prereq. for https://github.com/ocaml-flambda/flambda-backend/pull/3104 to show scoped locations in zero_alloc user messages).
