### PR TITLE
Refactor Debuginfo.compare

### DIFF
--- a/ocaml/lambda/debuginfo.ml
+++ b/ocaml/lambda/debuginfo.ml
@@ -211,12 +211,7 @@ let item_with_uid_and_function_symbol item ~dinfo_uid ~dinfo_function_symbol =
 module Dbg = struct
  type t = item list
 
-  (* CR-someday afrisch: FWIW, the current compare function does not seem very
-     good, since it reverses the two lists. I don't know how long the lists are,
-     nor if the specific currently implemented ordering is useful in other
-     contexts, but if one wants to use Map, a more efficient comparison should
-     be considered. *)
-  let compare dbg1 dbg2 =
+  let[@inline always] compare_aux dbg1 dbg2 =
     let rec loop ds1 ds2 =
       match ds1, ds2 with
       | [], [] -> 0
@@ -240,7 +235,17 @@ module Dbg = struct
        if c <> 0 then c else
        loop ds1 ds2
     in
-    loop (List.rev dbg1) (List.rev dbg2)
+    loop dbg1 dbg2
+
+  (* CR-someday afrisch: FWIW, the current compare function does not seem very
+     good, since it reverses the two lists. I don't know how long the lists are,
+     nor if the specific currently implemented ordering is useful in other
+     contexts, but if one wants to use Map, a more efficient comparison should
+     be considered. *)
+  let compare dbg1 dbg2 = compare_aux (List.rev dbg1) (List.rev dbg2)
+
+  (* Outermost inlined location first. *)
+  let compare_outer_first dbg1 dbg2 = compare_aux dbg1 dbg2
 
   let is_none dbg =
     match dbg with

--- a/ocaml/lambda/debuginfo.mli
+++ b/ocaml/lambda/debuginfo.mli
@@ -132,7 +132,14 @@ module Dbg : sig
   (** [compare] and [hash] ignore [dinfo_scopes] field of item *)
 
   val is_none : t -> bool
+
+  (** [compare] Inner-most inlined debug info is used first. Allocates. *)
   val compare : t -> t -> int
+
+  (** [compare_outer_first] Outer-most inlined debug info is used first.
+      Does not allocate. *)
+  val compare_outer_first : t -> t -> int
+
   val hash : t -> int
   val to_list : t -> item list
   val length : t -> int


### PR DESCRIPTION
Two small changes:
- Refactor `Debuginfo.compare`, no change in existing functionality.
-  Add a new version of compare, that sorts in a different order. 

There is already a CR about changing the existing `compare` to use the new order (and avoid allocations) but I am not entirely sure that nothing relies on the existing order, for example in `Dwarf`.

(prereq. for https://github.com/ocaml-flambda/flambda-backend/pull/3104)