### PR TITLE
Refactor uses of `-directory` flag

### DIFF
--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -1183,15 +1183,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
     else l
   | Texp_src_pos ->
       let pos = e.exp_loc.loc_start in
-      let pos =
-        match !Clflags.directory with
-        | None -> pos
-        | Some directory ->
-          let pos_fname = directory ^ "/" ^ pos.pos_fname in
-          { pos with pos_fname }
-      in
+      let pos_fname = Clflags.prepend_directory pos.pos_fname in
       let cl =
-        [ Const_base (Const_string (pos.pos_fname, e.exp_loc, None))
+        [ Const_base (Const_string (pos_fname, e.exp_loc, None))
         ; Const_base (Const_int pos.pos_lnum)
         ; Const_base (Const_int pos.pos_bol)
         ; Const_base (Const_int pos.pos_cnum)

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -683,3 +683,8 @@ let zero_alloc_check = ref Zero_alloc_annotations.Check_default    (* -zero-allo
 let zero_alloc_check_assert_all = ref false (* -zero-alloc-check-assert-all *)
 
 let no_auto_include_otherlibs = ref false      (* -no-auto-include-otherlibs *)
+
+let prepend_directory file_name =
+  match !directory with
+  | Some directory -> Filename.concat directory file_name
+  | None -> file_name

--- a/ocaml/utils/clflags.mli
+++ b/ocaml/utils/clflags.mli
@@ -318,3 +318,5 @@ val zero_alloc_check : Zero_alloc_annotations.t ref
 val zero_alloc_check_assert_all : bool ref
 
 val no_auto_include_otherlibs : bool ref
+
+val prepend_directory : string -> string

--- a/ocaml/utils/profile.ml
+++ b/ocaml/utils/profile.ml
@@ -151,11 +151,7 @@ let record_with_counters ?accumulate ~counter_f pass f x =
 let file_prefix = "file="
 
 let annotate_file_name name =
-  let file_path =
-    match !Clflags.directory with
-    | Some directory -> Filename.concat directory name
-    | None -> name
-  in
+  let file_path = Clflags.prepend_directory name in
   file_prefix ^ file_path
 
 type display = {


### PR DESCRIPTION
Small refactoring and maybe fixing a tiny bug. We should use `Filename.concat` when combining directory with basename. This PR adds a new function `Clflags.prepend_directory` and replaced existing uses of `Clflags.directory` with a call to this function.
