### PR TITLE
Fix #2978 tests typo

### DIFF
--- a/ocaml/testsuite/tests/typing-modes/pr2978.compilers.reference
+++ b/ocaml/testsuite/tests/typing-modes/pr2978.compilers.reference
@@ -1,4 +1,4 @@
-File "pr2979.ml", line 11, characters 23-35:
+File "pr2978.ml", line 11, characters 23-35:
 11 | let[@tail_mod_cons]  f x = (42, 42)
                             ^^^^^^^^^^^^
 Warning 71 [unused-tmc-attribute]: This function is marked @tail_mod_cons

--- a/ocaml/testsuite/tests/typing-modes/pr2978.ml
+++ b/ocaml/testsuite/tests/typing-modes/pr2978.ml
@@ -1,9 +1,9 @@
 (* TEST
- readonly_files = "pr2979.ml pr2979.mli";
+ readonly_files = "pr2978.ml pr2978.mli";
 setup-ocamlc.byte-build-env;
-module = "pr2979.mli";
+module = "pr2978.mli";
 ocamlc.byte;
-module = "pr2979.ml";
+module = "pr2978.ml";
 ocamlc.byte;
 check-ocamlc.byte-output;
 *)


### PR DESCRIPTION
Fix the typo in the test introduced in #2978 