### PR TITLE
Zero alloc: add -zero-alloc-assert flag and [@@@zero_alloc all_opt] attribute

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -135,10 +135,11 @@ let mk_heap_reduction_threshold f =
 ;;
 
 let mk_zero_alloc_check f =
-  let annotations = Zero_alloc_annotations.(List.map to_string all) in
+  let annotations = Zero_alloc_annotations.Check.(List.map to_string all) in
   "-zero-alloc-check", Arg.Symbol (annotations, f),
   " Check that annotated functions do not allocate \
-   and do not have indirect calls. "^Zero_alloc_annotations.doc
+   and do not have indirect calls. "^Zero_alloc_annotations.Check.doc
+
 
 let mk_dzero_alloc f =
   "-dzero-alloc", Arg.Unit f, " (undocumented)"
@@ -1064,7 +1065,7 @@ module Flambda_backend_options_impl = struct
     Flambda_backend_flags.heap_reduction_threshold := x
 
   let zero_alloc_check s =
-    match Zero_alloc_annotations.of_string s with
+    match Zero_alloc_annotations.Check.of_string s with
     | None -> () (* this should not occur as we use Arg.Symbol *)
     | Some a ->
       Clflags.zero_alloc_check := a
@@ -1382,7 +1383,7 @@ module Extra_params = struct
     | "basic-block-sections" -> set' Flambda_backend_flags.basic_block_sections
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
     | "zero-alloc-check" ->
-      (match Zero_alloc_annotations.of_string v with
+      (match Zero_alloc_annotations.Check.of_string v with
        | Some a -> Clflags.zero_alloc_check := a; true
        | None ->
          raise

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -143,7 +143,7 @@ let mk_zero_alloc_check f =
 let mk_zero_alloc_assert f =
   let annotations = Zero_alloc_annotations.Assert.(List.map to_string all) in
   "-zero-alloc-assert", Arg.Symbol (annotations, f),
-  " Add zero_alloc annotations."^Zero_alloc_annotations.Assert.doc
+  " Add zero_alloc annotations to all functions."^Zero_alloc_annotations.Assert.doc
 
 let mk_dzero_alloc f =
   "-dzero-alloc", Arg.Unit f, " (undocumented)"

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -63,6 +63,7 @@ module type Flambda_backend_options = sig
 
   val heap_reduction_threshold : int -> unit
   val zero_alloc_check : string -> unit
+  val zero_alloc_assert : string -> unit
 
   val dzero_alloc : unit -> unit
   val disable_zero_alloc_checker : unit -> unit

--- a/flambda-backend/tests/backend/zero_alloc_checker/dune
+++ b/flambda-backend/tests/backend/zero_alloc_checker/dune
@@ -31,6 +31,18 @@
  (alias  runtest)
  (action (copy test_bounded_join.ml test_bounded_join4.ml )))
 
+(rule
+ (alias  runtest)
+ (action (copy fail27.ml fail27_opt.ml )))
+
+(rule
+ (alias  runtest)
+ (action (copy fail27.ml fail27_default.ml )))
+
+(rule
+ (alias  runtest)
+ (action (copy fail28.ml fail28_opt.ml )))
+
 ;; Tests whose outputs differ depending on stack_allocation configuration flag.
 ;; This condition is not expressible in "enable_if" clause
 ;; because dune does not support %{config:stack_allocation} yet.

--- a/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
+++ b/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
@@ -1136,3 +1136,98 @@
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_remove_inferred_assume_workaround.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail27.output.corrected)
+ (deps (:ml fail27.ml) filter.sh)
+ (action
+   (with-outputs-to fail27.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-assert all -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail27.output fail27.output.corrected)
+ (action (diff fail27.output fail27.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail27_opt.output.corrected)
+ (deps (:ml fail27_opt.ml) filter.sh)
+ (action
+   (with-outputs-to fail27_opt.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-assert all_opt -zero-alloc-check all -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail27_opt.output fail27_opt.output.corrected)
+ (action (diff fail27_opt.output fail27_opt.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail27_default.output.corrected)
+ (deps (:ml fail27_default.ml) filter.sh)
+ (action
+   (with-outputs-to fail27_default.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-assert default -zero-alloc-check all -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail27_default.output fail27_default.output.corrected)
+ (action (diff fail27_default.output fail27_default.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail28.output.corrected)
+ (deps (:ml fail28.ml) filter.sh)
+ (action
+   (with-outputs-to fail28.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail28.output fail28.output.corrected)
+ (action (diff fail28.output fail28.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets fail28_opt.output.corrected)
+ (deps (:ml fail28_opt.ml) filter.sh)
+ (action
+   (with-outputs-to fail28_opt.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check all -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps fail28_opt.output fail28_opt.output.corrected)
+ (action (diff fail28_opt.output fail28_opt.output.corrected)))

--- a/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
+++ b/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
@@ -1138,7 +1138,7 @@
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail27.output.corrected)
  (deps (:ml fail27.ml) filter.sh)
  (action
@@ -1152,12 +1152,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail27.output fail27.output.corrected)
  (action (diff fail27.output fail27.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail27_opt.output.corrected)
  (deps (:ml fail27_opt.ml) filter.sh)
  (action
@@ -1171,12 +1171,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail27_opt.output fail27_opt.output.corrected)
  (action (diff fail27_opt.output fail27_opt.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail27_default.output.corrected)
  (deps (:ml fail27_default.ml) filter.sh)
  (action
@@ -1190,12 +1190,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail27_default.output fail27_default.output.corrected)
  (action (diff fail27_default.output fail27_default.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail28.output.corrected)
  (deps (:ml fail28.ml) filter.sh)
  (action
@@ -1209,12 +1209,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail28.output fail28.output.corrected)
  (action (diff fail28.output fail28.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail28_opt.output.corrected)
  (deps (:ml fail28_opt.ml) filter.sh)
  (action
@@ -1228,6 +1228,6 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail28_opt.output fail28_opt.output.corrected)
  (action (diff fail28_opt.output fail28_opt.output.corrected)))

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail27.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail27.ml
@@ -1,0 +1,17 @@
+let foo x y = (x,y)
+
+let bar x y = [x;y]
+
+let outer x =
+  (** [inner] function should also show in the error message. *)
+  let[@inline never][@local never][@specialize never] inner x =
+    if x > 0 then (x,x)
+    else raise (Failure "boo")
+  in
+  inner (x + 1)
+
+let[@zero_alloc assume] do_not_check_me x =
+  (x,x+1)
+
+let[@zero_alloc opt] only_check_me_in_opt x y =
+  (x,y,x+y)

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail27.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail27.output
@@ -1,0 +1,26 @@
+File "fail27.ml", line 1, characters 8-19:
+Error: Annotation check for zero_alloc failed on function Fail27.foo (camlFail27.foo_HIDE_STAMP)
+
+File "fail27.ml", line 1, characters 14-19:
+Error: allocation of 24 bytes
+
+File "fail27.ml", line 3, characters 8-19:
+Error: Annotation check for zero_alloc failed on function Fail27.bar (camlFail27.bar_HIDE_STAMP)
+
+File "fail27.ml", line 3, characters 14-19:
+Error: allocation of 24 bytes
+
+File "fail27.ml", line 3, characters 17-19:
+Error: allocation of 24 bytes
+
+File "fail27.ml", lines 5-11, characters 10-15:
+Error: Annotation check for zero_alloc failed on function Fail27.outer (camlFail27.outer_HIDE_STAMP)
+
+File "fail27.ml", line 11, characters 2-15:
+Error: called function may allocate (direct tailcall camlFail27.inner_HIDE_STAMP)
+
+File "fail27.ml", lines 7-9, characters 60-30:
+Error: Annotation check for zero_alloc failed on function Fail27.outer.inner (camlFail27.inner_HIDE_STAMP)
+
+File "fail27.ml", line 8, characters 18-23:
+Error: allocation of 24 bytes

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail27_default.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail27_default.output
@@ -1,0 +1,5 @@
+File "fail27_default.ml", line 16, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Fail27_default.only_check_me_in_opt (camlFail27_default.only_check_me_in_opt_HIDE_STAMP)
+
+File "fail27_default.ml", line 17, characters 2-11:
+Error: allocation of 32 bytes

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail27_opt.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail27_opt.output
@@ -1,0 +1,32 @@
+File "fail27_opt.ml", line 1, characters 8-19:
+Error: Annotation check for zero_alloc failed on function Fail27_opt.foo (camlFail27_opt.foo_HIDE_STAMP)
+
+File "fail27_opt.ml", line 1, characters 14-19:
+Error: allocation of 24 bytes
+
+File "fail27_opt.ml", line 3, characters 8-19:
+Error: Annotation check for zero_alloc failed on function Fail27_opt.bar (camlFail27_opt.bar_HIDE_STAMP)
+
+File "fail27_opt.ml", line 3, characters 14-19:
+Error: allocation of 24 bytes
+
+File "fail27_opt.ml", line 3, characters 17-19:
+Error: allocation of 24 bytes
+
+File "fail27_opt.ml", lines 5-11, characters 10-15:
+Error: Annotation check for zero_alloc failed on function Fail27_opt.outer (camlFail27_opt.outer_HIDE_STAMP)
+
+File "fail27_opt.ml", line 11, characters 2-15:
+Error: called function may allocate (direct tailcall camlFail27_opt.inner_HIDE_STAMP)
+
+File "fail27_opt.ml", lines 7-9, characters 60-30:
+Error: Annotation check for zero_alloc failed on function Fail27_opt.outer.inner (camlFail27_opt.inner_HIDE_STAMP)
+
+File "fail27_opt.ml", line 8, characters 18-23:
+Error: allocation of 24 bytes
+
+File "fail27_opt.ml", line 16, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Fail27_opt.only_check_me_in_opt (camlFail27_opt.only_check_me_in_opt_HIDE_STAMP)
+
+File "fail27_opt.ml", line 17, characters 2-11:
+Error: allocation of 32 bytes

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail28.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail28.ml
@@ -1,0 +1,23 @@
+[@@@zero_alloc all_opt]
+
+let foo x y = (x,y)
+
+let bar x y = [x;y]
+
+let outer x =
+  (** [inner] function should also show in the error message. *)
+  let[@inline never][@local never][@specialize never] inner x =
+    if x > 0 then (x,x)
+    else raise (Failure "boo")
+  in
+  inner (x + 1)
+
+let[@zero_alloc assume] do_not_check_me x =
+  (x,x+1)
+
+let[@zero_alloc strict opt] only_check_me_in_opt x y =
+  (x,y,x+y)
+
+let[@zero_alloc strict] check_me_strict x y =
+  if x > 0 then 0
+  else raise (Failure (Printf.sprintf "not positive %d\n" x))

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail28.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail28.output
@@ -1,0 +1,11 @@
+File "fail28.ml", line 21, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Fail28.check_me_strict (camlFail28.check_me_strict_HIDE_STAMP)
+
+File "fail28.ml", line 23, characters 22-60:
+Error: called function may allocate on a path to exceptional return (indirect call)
+
+File "fail28.ml", line 23, characters 13-61:
+Error: allocation of 24 bytes on a path to exceptional return
+
+File "fail28.ml", line 23, characters 22-60:
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP) (fail28.ml:23,22--60;printf.ml:48,18--43;printf.ml:46,2--31)

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail28_opt.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail28_opt.output
@@ -1,0 +1,44 @@
+File "fail28_opt.ml", line 3, characters 8-19:
+Error: Annotation check for zero_alloc failed on function Fail28_opt.foo (camlFail28_opt.foo_HIDE_STAMP)
+
+File "fail28_opt.ml", line 3, characters 14-19:
+Error: allocation of 24 bytes
+
+File "fail28_opt.ml", line 5, characters 8-19:
+Error: Annotation check for zero_alloc failed on function Fail28_opt.bar (camlFail28_opt.bar_HIDE_STAMP)
+
+File "fail28_opt.ml", line 5, characters 14-19:
+Error: allocation of 24 bytes
+
+File "fail28_opt.ml", line 5, characters 17-19:
+Error: allocation of 24 bytes
+
+File "fail28_opt.ml", lines 7-13, characters 10-15:
+Error: Annotation check for zero_alloc failed on function Fail28_opt.outer (camlFail28_opt.outer_HIDE_STAMP)
+
+File "fail28_opt.ml", line 13, characters 2-15:
+Error: called function may allocate (direct tailcall camlFail28_opt.inner_HIDE_STAMP)
+
+File "fail28_opt.ml", lines 9-11, characters 60-30:
+Error: Annotation check for zero_alloc failed on function Fail28_opt.outer.inner (camlFail28_opt.inner_HIDE_STAMP)
+
+File "fail28_opt.ml", line 10, characters 18-23:
+Error: allocation of 24 bytes
+
+File "fail28_opt.ml", line 18, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Fail28_opt.only_check_me_in_opt (camlFail28_opt.only_check_me_in_opt_HIDE_STAMP)
+
+File "fail28_opt.ml", line 19, characters 2-11:
+Error: allocation of 32 bytes
+
+File "fail28_opt.ml", line 21, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Fail28_opt.check_me_strict (camlFail28_opt.check_me_strict_HIDE_STAMP)
+
+File "fail28_opt.ml", line 23, characters 22-60:
+Error: called function may allocate on a path to exceptional return (indirect call)
+
+File "fail28_opt.ml", line 23, characters 13-61:
+Error: allocation of 24 bytes on a path to exceptional return
+
+File "fail28_opt.ml", line 23, characters 22-60:
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP) (fail28_opt.ml:23,22--60;printf.ml:48,18--43;printf.ml:46,2--31)

--- a/flambda-backend/tests/backend/zero_alloc_checker/gen/gen_dune.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/gen/gen_dune.ml
@@ -210,4 +210,9 @@ let () =
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_dep:None ~exit_code:2 "test_remove_inferred_assume";
   print_test "test_remove_inferred_assume_workaround.ml";
+  print_test_expected_output ~extra_flags:"-zero-alloc-assert all" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail27";
+  print_test_expected_output ~extra_flags:"-zero-alloc-assert all_opt -zero-alloc-check all" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail27_opt";
+  print_test_expected_output ~extra_flags:"-zero-alloc-assert default -zero-alloc-check all" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail27_default";
+    print_test_expected_output ~extra_flags:"-zero-alloc-check default" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail28";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check all" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail28_opt";
   ()

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1769,10 +1769,16 @@ and transl_function ~in_new_scope ~scopes e params body
   let zero_alloc : Lambda.zero_alloc_attribute =
     match (zero_alloc : Builtin_attributes.zero_alloc_attribute) with
     | Default_zero_alloc ->
-      if !Clflags.zero_alloc_check_assert_all &&
-         Builtin_attributes.is_zero_alloc_check_enabled ~opt:false
-      then Check { strict = false; loc = e.exp_loc }
-      else Default_zero_alloc
+      (match !Clflags.zero_alloc_assert with
+       | Assert_default -> Default_zero_alloc
+       | Assert_all ->
+         if Builtin_attributes.is_zero_alloc_check_enabled ~opt:false
+         then Check { strict = false; loc = e.exp_loc }
+         else Default_zero_alloc
+       | Assert_all_opt ->
+         if Builtin_attributes.is_zero_alloc_check_enabled ~opt:true
+         then Check { strict = false; loc = e.exp_loc }
+         else Default_zero_alloc)
     | Check { strict; opt; arity = _; loc } ->
       if Builtin_attributes.is_zero_alloc_check_enabled ~opt
       then Check { strict; loc }

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -54,7 +54,10 @@ let prepare_code ~denv acc (code_id : Code_id.t) (code : Code.t) =
   in
   let never_delete =
     match Code.zero_alloc_attribute code with
-    | Default_zero_alloc -> !Clflags.zero_alloc_check_assert_all
+    | Default_zero_alloc ->
+      (* The effect of [Clflags.zero_alloc_assert] has been compiled into
+         [Check] earlier. *)
+      false
     | Assume _ -> false
     | Check _ -> true
   in

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -604,7 +604,7 @@ let zero_alloc_attribute (attr : Parsetree.attribute)  =
       | "all_opt" -> Clflags.zero_alloc_assert := A.Assert.Assert_all_opt
       | _ ->
         warn_payload attr.attr_loc attr.attr_name.txt
-          "Only 'all', 'check', 'check_opt', 'check_all', and 'check_none' are supported")
+          "Only 'all', 'all_opt', 'check', 'check_opt', 'check_all', and 'check_none' are supported")
 
 let attribute_with_ignored_payload name attr =
   when_attribute_is [name; "ocaml." ^ name] attr ~f:(fun () -> ())

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -593,14 +593,15 @@ let parse_attribute_with_ident_payload attr ~name ~f =
     | None -> ())
 
 let zero_alloc_attribute (attr : Parsetree.attribute)  =
+  let module A = Zero_alloc_annotations in
   parse_attribute_with_ident_payload attr
     ~name:"zero_alloc" ~f:(function
-      | "check" -> Clflags.zero_alloc_check := Zero_alloc_annotations.Check_default
-      | "check_opt" -> Clflags.zero_alloc_check := Zero_alloc_annotations.Check_opt_only
-      | "check_all" -> Clflags.zero_alloc_check := Zero_alloc_annotations.Check_all
-      | "check_none" -> Clflags.zero_alloc_check := Zero_alloc_annotations.No_check
       | "all" ->
         Clflags.zero_alloc_check_assert_all := true
+      | "check" -> Clflags.zero_alloc_check := A.Check.Check_default
+      | "check_opt" -> Clflags.zero_alloc_check := A.Check.Check_opt_only
+      | "check_all" -> Clflags.zero_alloc_check := A.Check.Check_all
+      | "check_none" -> Clflags.zero_alloc_check := A.Check.No_check
       | _ ->
         warn_payload attr.attr_loc attr.attr_name.txt
           "Only 'all', 'check', 'check_opt', 'check_all', and 'check_none' are supported")

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -596,12 +596,12 @@ let zero_alloc_attribute (attr : Parsetree.attribute)  =
   let module A = Zero_alloc_annotations in
   parse_attribute_with_ident_payload attr
     ~name:"zero_alloc" ~f:(function
-      | "all" ->
-        Clflags.zero_alloc_check_assert_all := true
       | "check" -> Clflags.zero_alloc_check := A.Check.Check_default
       | "check_opt" -> Clflags.zero_alloc_check := A.Check.Check_opt_only
       | "check_all" -> Clflags.zero_alloc_check := A.Check.Check_all
       | "check_none" -> Clflags.zero_alloc_check := A.Check.No_check
+      | "all" -> Clflags.zero_alloc_assert := A.Assert.Assert_all
+      | "all_opt" -> Clflags.zero_alloc_assert := A.Assert.Assert_all_opt
       | _ ->
         warn_payload attr.attr_loc attr.attr_name.txt
           "Only 'all', 'check', 'check_opt', 'check_all', and 'check_none' are supported")

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -1207,14 +1207,20 @@ let let_bound_idents_with_modes_sorts_and_checks bindings =
                 function - if it remains [Default_zero_alloc], translcore adds
                 the check. *)
              let arity = function_arity fn.params fn.body in
-             if !Clflags.zero_alloc_check_assert_all && arity > 0 then
-               Zero_alloc.create_const
-                 (Check { strict = false;
-                          arity;
-                          loc = Location.none;
-                          opt = false })
-             else
+             if arity <= 0 then
                fn.zero_alloc
+             else
+               let create_const ~opt =
+                 Zero_alloc.create_const
+                   (Check { strict = false;
+                            arity;
+                            loc = Location.none;
+                            opt })
+               in
+               (match !Clflags.zero_alloc_assert with
+                | Assert_default -> fn.zero_alloc
+                | Assert_all -> create_const ~opt:false
+                | Assert_all_opt -> create_const ~opt:true)
            | Ignore_assert_all | Check _ | Assume _ -> fn.zero_alloc
          in
          Ident.Map.add id zero_alloc checks

--- a/utils/.ocamlformat-enable
+++ b/utils/.ocamlformat-enable
@@ -6,5 +6,7 @@ language_extension_kernel.ml
 language_extension_kernel.mli
 zero_alloc_utils.ml
 zero_alloc_utils.mli
+zero_alloc_annotations.ml
+zero_alloc_annotations.mli
 profile_counters_functions.ml
 profile_counters_functions.mli

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -693,8 +693,7 @@ let create_usage_msg program =
 let print_arguments program =
   Arg.usage !arg_spec (create_usage_msg program)
 
-let zero_alloc_check = ref Zero_alloc_annotations.Check_default    (* -zero-alloc-check *)
-let zero_alloc_check_assert_all = ref false (* -zero-alloc-check-assert-all *)
+let zero_alloc_check = ref Zero_alloc_annotations.Check.Check_default  (* -zero-alloc-check *)
 
 let no_auto_include_otherlibs = ref false      (* -no-auto-include-otherlibs *)
 

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -694,6 +694,7 @@ let print_arguments program =
   Arg.usage !arg_spec (create_usage_msg program)
 
 let zero_alloc_check = ref Zero_alloc_annotations.Check.Check_default  (* -zero-alloc-check *)
+let zero_alloc_assert = ref Zero_alloc_annotations.Assert.Assert_default (* -zero-alloc-assert all *)
 
 let no_auto_include_otherlibs = ref false      (* -no-auto-include-otherlibs *)
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -317,6 +317,8 @@ val reset_arguments : unit -> unit
 
 (* [zero_alloc_check] specifies which zero_alloc attributes to check. *)
 val zero_alloc_check : Zero_alloc_annotations.Check.t ref
+(* [zero_alloc_assert] specifies which zero_alloc attributes to add. *)
+val zero_alloc_assert : Zero_alloc_annotations.Assert.t ref
 
 val no_auto_include_otherlibs : bool ref
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -316,8 +316,7 @@ val print_arguments : string -> unit
 val reset_arguments : unit -> unit
 
 (* [zero_alloc_check] specifies which zero_alloc attributes to check. *)
-val zero_alloc_check : Zero_alloc_annotations.t ref
-val zero_alloc_check_assert_all : bool ref
+val zero_alloc_check : Zero_alloc_annotations.Check.t ref
 
 val no_auto_include_otherlibs : bool ref
 

--- a/utils/zero_alloc_annotations.ml
+++ b/utils/zero_alloc_annotations.ml
@@ -61,3 +61,35 @@ module Check = struct
     \      \"all\" covers both \"opt\" and \"default\" and is intended for \
      optimized builds."
 end
+
+module Assert = struct
+  type t =
+    | Assert_default
+    | Assert_all
+    | Assert_all_opt
+
+  let all = [Assert_default; Assert_all; Assert_all_opt]
+
+  let to_string = function
+    | Assert_default -> "default"
+    | Assert_all -> "all"
+    | Assert_all_opt -> "all_opt"
+
+  let equal t1 t2 =
+    match t1, t2 with
+    | Assert_default, Assert_default -> true
+    | Assert_all, Assert_all -> true
+    | Assert_all_opt, Assert_all_opt -> true
+    | (Assert_default | Assert_all | Assert_all_opt), _ -> false
+
+  let of_string v =
+    let f t = if String.equal (to_string t) v then Some t else None in
+    List.find_map f all
+
+  let doc =
+    "\n\
+    \    The argument specifies which annotations to use: \n\
+    \      \"all\" is equivalent to adding [@@@zero_alloc all]\n\
+    \      \"all_opt\" is equiveintended to adding [@@@zero_alloc all_opt]\n\
+    \      \"default\" does not add any attributes."
+end

--- a/utils/zero_alloc_annotations.ml
+++ b/utils/zero_alloc_annotations.ml
@@ -25,32 +25,39 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
-type t = Check_default | Check_all | Check_opt_only | No_check
+module Check = struct
+  type t =
+    | Check_default
+    | Check_all
+    | Check_opt_only
+    | No_check
 
-let all = [ Check_default; Check_all; Check_opt_only; No_check ]
+  let all = [Check_default; Check_all; Check_opt_only; No_check]
 
-let to_string = function
-  | Check_default -> "default"
-  | Check_all -> "all"
-  | Check_opt_only -> "opt"
-  | No_check -> "none"
+  let to_string = function
+    | Check_default -> "default"
+    | Check_all -> "all"
+    | Check_opt_only -> "opt"
+    | No_check -> "none"
 
-let equal t1 t2 =
-  match t1, t2 with
-  | Check_default, Check_default -> true
-  | Check_all, Check_all -> true
-  | No_check, No_check -> true
-  | Check_opt_only, Check_opt_only -> true
-  | (Check_default | Check_all | Check_opt_only | No_check), _ -> false
+  let equal t1 t2 =
+    match t1, t2 with
+    | Check_default, Check_default -> true
+    | Check_all, Check_all -> true
+    | No_check, No_check -> true
+    | Check_opt_only, Check_opt_only -> true
+    | (Check_default | Check_all | Check_opt_only | No_check), _ -> false
 
-let of_string v =
-  let f t =
-    if String.equal (to_string t) v then Some t else None
-  in
-  List.find_map f all
+  let of_string v =
+    let f t = if String.equal (to_string t) v then Some t else None in
+    List.find_map f all
 
-let doc =
-  "\n\    The argument specifies which annotations to check: \n\
-    \      \"opt\" means attributes with \"opt\" payload and is intended for debugging;\n\
+  let doc =
+    "\n\
+    \    The argument specifies which annotations to check: \n\
+    \      \"opt\" means attributes with \"opt\" payload and is intended for \
+     debugging;\n\
     \      \"default\" means attributes without \"opt\" payload; \n\
-    \      \"all\" covers both \"opt\" and \"default\" and is intended for optimized builds."
+    \      \"all\" covers both \"opt\" and \"default\" and is intended for \
+     optimized builds."
+end

--- a/utils/zero_alloc_annotations.ml
+++ b/utils/zero_alloc_annotations.ml
@@ -90,6 +90,6 @@ module Assert = struct
     "\n\
     \    The argument specifies which annotations to use: \n\
     \      \"all\" is equivalent to adding [@@@zero_alloc all]\n\
-    \      \"all_opt\" is equiveintended to adding [@@@zero_alloc all_opt]\n\
+    \      \"all_opt\" is equivalent to adding [@@@zero_alloc all_opt]\n\
     \      \"default\" does not add any attributes."
 end

--- a/utils/zero_alloc_annotations.mli
+++ b/utils/zero_alloc_annotations.mli
@@ -25,9 +25,20 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
-type t = Check_default | Check_all | Check_opt_only | No_check
-val all : t list
-val to_string : t -> string
-val of_string : string -> t option
-val equal : t -> t -> bool
-val doc : string
+module Check : sig
+  type t =
+    | Check_default
+    | Check_all
+    | Check_opt_only
+    | No_check
+
+  val all : t list
+
+  val to_string : t -> string
+
+  val of_string : string -> t option
+
+  val equal : t -> t -> bool
+
+  val doc : string
+end

--- a/utils/zero_alloc_annotations.mli
+++ b/utils/zero_alloc_annotations.mli
@@ -42,3 +42,20 @@ module Check : sig
 
   val doc : string
 end
+
+module Assert : sig
+  type t =
+    | Assert_default
+    | Assert_all
+    | Assert_all_opt
+
+  val all : t list
+
+  val to_string : t -> string
+
+  val of_string : string -> t option
+
+  val equal : t -> t -> bool
+
+  val doc : string
+end


### PR DESCRIPTION
- Parse top-level attribute `[@@@zero_alloc all_opt]` in addition to the existing `[@@@zero_alloc all]`  payload.
- Add `-zero-alloc-assert <arg>` compiler flag with `<arg>` that corresponds to the above payloads.

Both of these were requested by users.

The first commit is just refactoring and formatting, no functionality change. 
