### PR TITLE
Fix `-stop-after lambda`

### DIFF
--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -45,6 +45,7 @@ let compile i typed ~transl_style ~unix ~pipeline =
       |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.program
       |> Compiler_hooks.execute_and_pipe Compiler_hooks.Lambda
       |> (fun program ->
+           if Clflags.(should_stop_after Compiler_pass.Lambda) then () else
            Asmgen.compile_implementation
              unix
              ~pipeline

--- a/ocaml/testsuite/tests/tool-ocamlopt-stop-after/stop_after_lambda_warn_error.compilers.reference
+++ b/ocaml/testsuite/tests/tool-ocamlopt-stop-after/stop_after_lambda_warn_error.compilers.reference
@@ -1,0 +1,4 @@
+File "stop_after_lambda_warn_error.ml", line 12, characters 5-12:
+12 | let[@inlined] f x = x
+          ^^^^^^^
+Error (warning 53 [misplaced-attribute]): the "inlined" attribute cannot appear in this context

--- a/ocaml/testsuite/tests/tool-ocamlopt-stop-after/stop_after_lambda_warn_error.ml
+++ b/ocaml/testsuite/tests/tool-ocamlopt-stop-after/stop_after_lambda_warn_error.ml
@@ -1,0 +1,12 @@
+(* TEST
+ setup-ocamlopt.byte-build-env;
+ flags = "-stop-after lambda -warn-error +53";
+ ocamlopt_byte_exit_status = "0";
+ ocamlopt.byte;
+ check-ocamlopt.byte-output;
+*)
+
+(* Bug: This should have exit code 2, because we've set -warn-error for a
+   warning that is issued.  But it exits with code 0. *)
+
+let[@inlined] f x = x

--- a/ocaml/testsuite/tests/tool-ocamlopt-stop-after/stop_after_lambda_warn_error.ml
+++ b/ocaml/testsuite/tests/tool-ocamlopt-stop-after/stop_after_lambda_warn_error.ml
@@ -1,12 +1,12 @@
 (* TEST
  setup-ocamlopt.byte-build-env;
  flags = "-stop-after lambda -warn-error +53";
- ocamlopt_byte_exit_status = "0";
+ ocamlopt_byte_exit_status = "2";
  ocamlopt.byte;
  check-ocamlopt.byte-output;
 *)
 
-(* Bug: This should have exit code 2, because we've set -warn-error for a
-   warning that is issued.  But it exits with code 0. *)
+(* This should have exit code 2, because we've set -warn-error for a warning
+   that is issued. *)
 
 let[@inlined] f x = x


### PR DESCRIPTION
`-stop-after lambda` is broken in ocamlopt right now - we don't actually stop after lambda.  This fixes it.

This is visible in several ways, but the one that is annoying me at the moment is that we eventually end up reaching [this line](https://github.com/ocaml-flambda/flambda-backend/blob/175c6552ea5641caf961e50eb33e5a38f71c2fb3/backend/asmgen.ml#L683) and terminate with exit code 0 even in some cases where we should have a non-zero exit code.  I've added a test that demonstrates this in the first commit, and then fixed it in the second.