### PR TITLE
Keep unused let-bindings for Simplify

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -1051,7 +1051,12 @@ module Let_with_acc = struct
       | Prim (prim, _) -> Flambda_primitive.at_most_generative_effects prim
       | Simple _ | Static_consts _ | Set_of_closures _ | Rec_info _ -> true
     in
-    if is_unused_singleton && has_no_effects
+    let keep_bindings_for_simplify =
+      (* When using Simplify, we don't delete unused bindings here, to increase
+         the chance that invalid code is actually simplified to [Invalid]. *)
+      not (Flambda_features.classic_mode ())
+    in
+    if is_unused_singleton && has_no_effects && not keep_bindings_for_simplify
     then acc, body
     else
       let cost_metrics_of_defining_expr =


### PR DESCRIPTION
Currently, unused let-bindings that have no effects are deleted during closure conversion.  This inhibits Simplify from being able to turn them into `Invalid`.  For example:

```
external unsafe_get : 'a iarray -> int -> 'a
  = "%array_unsafe_get"

type ('a, 'b) t = Refl : ('a, 'a) t

let magic (type a b) (x : a) : b =
  let arr : (a, b) t iarray = [: :] in
  match unsafe_get arr 0 with
  | Refl -> x
```

This patch prevents this deletion if Simplify is going to be run.  Given that the majority of bindings are used, this should not produce any noticeable compile time changes.

(The above example still does not simplify to `Invalid` even with this patch, there will be a follow-up PR.)