### PR TITLE
Support `@@@zero_alloc all`  and `@@@zero_alloc all_opt` on ".mli" files

### DIFF
--- a/flambda-backend/tests/backend/zero_alloc_checker/dune
+++ b/flambda-backend/tests/backend/zero_alloc_checker/dune
@@ -43,6 +43,14 @@
  (alias  runtest)
  (action (copy fail28.ml fail28_opt.ml )))
 
+(rule
+ (alias  runtest)
+ (action (copy fail29_opt.ml fail29_opt2.ml )))
+
+(rule
+ (alias  runtest)
+ (action (copy fail29_opt.mli fail29_opt2.mli )))
+
 ;; Tests whose outputs differ depending on stack_allocation configuration flag.
 ;; This condition is not expressible in "enable_if" clause
 ;; because dune does not support %{config:stack_allocation} yet.

--- a/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
+++ b/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
@@ -1231,3 +1231,81 @@
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail28_opt.output fail28_opt.output.corrected)
  (action (diff fail28_opt.output fail28_opt.output.corrected)))
+
+(rule
+ (alias runtest)
+ (deps fail29.mli)
+ (target fail29.cmi)
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (action (run %{bin:ocamlopt.opt} fail29.mli -g -c -opaque -stop-after typing -O3 -warn-error +a)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (targets fail29.output.corrected)
+ (deps fail29.cmi (:ml fail29.ml) filter.sh)
+ (action
+   (with-outputs-to fail29.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (deps fail29.output fail29.output.corrected)
+ (action (diff fail29.output fail29.output.corrected)))
+
+(rule
+ (alias runtest)
+ (deps fail29_opt.mli)
+ (target fail29_opt.cmi)
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (action (run %{bin:ocamlopt.opt} fail29_opt.mli -g -c -opaque -stop-after typing -O3 -warn-error +a)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (targets fail29_opt.output.corrected)
+ (deps fail29_opt.cmi (:ml fail29_opt.ml) filter.sh)
+ (action
+   (with-outputs-to fail29_opt.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (deps fail29_opt.output fail29_opt.output.corrected)
+ (action (diff fail29_opt.output fail29_opt.output.corrected)))
+
+(rule
+ (alias runtest)
+ (deps fail29_opt2.mli)
+ (target fail29_opt2.cmi)
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (action (run %{bin:ocamlopt.opt} fail29_opt2.mli -g -c -opaque -stop-after typing -O3 -warn-error +a)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (targets fail29_opt2.output.corrected)
+ (deps fail29_opt2.cmi (:ml fail29_opt2.ml) filter.sh)
+ (action
+   (with-outputs-to fail29_opt2.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check all -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (deps fail29_opt2.output fail29_opt2.output.corrected)
+ (action (diff fail29_opt2.output fail29_opt2.output.corrected)))

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail29.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail29.ml
@@ -1,0 +1,21 @@
+let foo x y = (x,y)
+
+let bar x y = [x;y]
+
+let outer x =
+  (** [inner] function should not show in the error message. *)
+  let[@inline never][@local never][@specialize never] inner x =
+    if x > 0 then (x,x)
+    else raise (Failure "boo")
+  in
+  inner (x + 1)
+
+let do_not_check_me x =
+  (x,x+1)
+
+let only_check_me_in_opt x y =
+  (x,y,x+y)
+
+let[@zero_alloc strict] check_me_strict x =
+  if x > 0 then 0
+  else raise (Failure (Printf.sprintf "not positive %d\n" x))

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail29.mli
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail29.mli
@@ -1,0 +1,13 @@
+[@@@zero_alloc all]
+
+val foo : 'a -> 'b -> 'a*'b
+
+val bar : 'a -> 'a -> 'a list
+
+val outer : int -> int*int
+
+val[@zero_alloc ignore] do_not_check_me : int -> int*int
+
+val[@zero_alloc opt] only_check_me_in_opt : int -> int -> int*int*int
+
+val[@zero_alloc strict] check_me_strict : int -> int

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail29.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail29.output
@@ -1,0 +1,32 @@
+File "fail29.ml", line 1, characters 8-19:
+Error: Annotation check for zero_alloc failed on function Fail29.foo (camlFail29.foo_HIDE_STAMP)
+
+File "fail29.ml", line 1, characters 14-19:
+Error: allocation of 24 bytes
+
+File "fail29.ml", line 3, characters 8-19:
+Error: Annotation check for zero_alloc failed on function Fail29.bar (camlFail29.bar_HIDE_STAMP)
+
+File "fail29.ml", line 3, characters 14-19:
+Error: allocation of 24 bytes
+
+File "fail29.ml", line 3, characters 17-19:
+Error: allocation of 24 bytes
+
+File "fail29.ml", lines 5-11, characters 10-15:
+Error: Annotation check for zero_alloc failed on function Fail29.outer (camlFail29.outer_HIDE_STAMP)
+
+File "fail29.ml", line 11, characters 2-15:
+Error: called function may allocate (direct tailcall camlFail29.inner_HIDE_STAMP)
+
+File "fail29.ml", line 19, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Fail29.check_me_strict (camlFail29.check_me_strict_HIDE_STAMP)
+
+File "fail29.ml", line 21, characters 22-60:
+Error: called function may allocate on a path to exceptional return (indirect call)
+
+File "fail29.ml", line 21, characters 13-61:
+Error: allocation of 24 bytes on a path to exceptional return
+
+File "fail29.ml", line 21, characters 22-60:
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP) (fail29.ml:21,22--60;printf.ml:48,18--43;printf.ml:46,2--31)

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail29_opt.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail29_opt.ml
@@ -1,0 +1,21 @@
+let foo x y = (x,y)
+
+let bar x y = [x;y]
+
+let outer x =
+  (** [inner] function should not show in the error message. *)
+  let[@inline never][@local never][@specialize never] inner x =
+    if x > 0 then (x,x)
+    else raise (Failure "boo")
+  in
+  inner (x + 1)
+
+let do_not_check_me x =
+  (x,x+1)
+
+let only_check_me_in_opt x y =
+  (x,y,x+y)
+
+let[@zero_alloc strict] check_me_strict x =
+  if x > 0 then 0
+  else raise (Failure (Printf.sprintf "not positive %d\n" x))

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail29_opt.mli
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail29_opt.mli
@@ -1,0 +1,13 @@
+[@@@zero_alloc all_opt]
+
+val foo : 'a -> 'b -> 'a*'b
+
+val bar : 'a -> 'a -> 'a list
+
+val outer : int -> int*int
+
+val[@zero_alloc ignore] do_not_check_me : int -> int*int
+
+val[@zero_alloc opt] only_check_me_in_opt : int -> int -> int*int*int
+
+val[@zero_alloc strict] check_me_strict : int -> int

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail29_opt.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail29_opt.output
@@ -1,0 +1,11 @@
+File "fail29_opt.ml", line 19, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Fail29_opt.check_me_strict (camlFail29_opt.check_me_strict_HIDE_STAMP)
+
+File "fail29_opt.ml", line 21, characters 22-60:
+Error: called function may allocate on a path to exceptional return (indirect call)
+
+File "fail29_opt.ml", line 21, characters 13-61:
+Error: allocation of 24 bytes on a path to exceptional return
+
+File "fail29_opt.ml", line 21, characters 22-60:
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP) (fail29_opt.ml:21,22--60;printf.ml:48,18--43;printf.ml:46,2--31)

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail29_opt2.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail29_opt2.output
@@ -1,0 +1,38 @@
+File "fail29_opt2.ml", line 1, characters 8-19:
+Error: Annotation check for zero_alloc failed on function Fail29_opt2.foo (camlFail29_opt2.foo_HIDE_STAMP)
+
+File "fail29_opt2.ml", line 1, characters 14-19:
+Error: allocation of 24 bytes
+
+File "fail29_opt2.ml", line 3, characters 8-19:
+Error: Annotation check for zero_alloc failed on function Fail29_opt2.bar (camlFail29_opt2.bar_HIDE_STAMP)
+
+File "fail29_opt2.ml", line 3, characters 14-19:
+Error: allocation of 24 bytes
+
+File "fail29_opt2.ml", line 3, characters 17-19:
+Error: allocation of 24 bytes
+
+File "fail29_opt2.ml", lines 5-11, characters 10-15:
+Error: Annotation check for zero_alloc failed on function Fail29_opt2.outer (camlFail29_opt2.outer_HIDE_STAMP)
+
+File "fail29_opt2.ml", line 11, characters 2-15:
+Error: called function may allocate (direct tailcall camlFail29_opt2.inner_HIDE_STAMP)
+
+File "fail29_opt2.ml", lines 16-17, characters 25-11:
+Error: Annotation check for zero_alloc failed on function Fail29_opt2.only_check_me_in_opt (camlFail29_opt2.only_check_me_in_opt_HIDE_STAMP)
+
+File "fail29_opt2.ml", line 17, characters 2-11:
+Error: allocation of 32 bytes
+
+File "fail29_opt2.ml", line 19, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Fail29_opt2.check_me_strict (camlFail29_opt2.check_me_strict_HIDE_STAMP)
+
+File "fail29_opt2.ml", line 21, characters 22-60:
+Error: called function may allocate on a path to exceptional return (indirect call)
+
+File "fail29_opt2.ml", line 21, characters 13-61:
+Error: allocation of 24 bytes on a path to exceptional return
+
+File "fail29_opt2.ml", line 21, characters 22-60:
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP) (fail29_opt2.ml:21,22--60;printf.ml:48,18--43;printf.ml:46,2--31)

--- a/flambda-backend/tests/backend/zero_alloc_checker/gen/gen_dune.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/gen/gen_dune.ml
@@ -23,9 +23,11 @@ let () =
     Buffer.output_buffer Out_channel.stdout buf
   in
   let print_cmi_target name =
+    let name_cmi =  (Filename.chop_extension name)^".cmi" in
     let subst = function
       | "enabled_if" -> enabled_if
       | "name" -> name
+      | "name_cmi" -> name_cmi
       | _ -> "assert false"
     in
     Buffer.clear buf;
@@ -33,10 +35,10 @@ let () =
     {|
 (rule
  (alias runtest)
- (deps ${name}.ml)
- (target ${name}.cmi)
+ (deps ${name})
+ (target ${name_cmi})
  ${enabled_if}
- (action (run %{bin:ocamlopt.opt} ${name}.ml -g -c -opaque -stop-after typing -O3 -warn-error +a)))
+ (action (run %{bin:ocamlopt.opt} ${name} -g -c -opaque -stop-after typing -O3 -warn-error +a)))
 |};
     Buffer.output_buffer Out_channel.stdout buf
   in
@@ -165,12 +167,12 @@ let () =
     ~extra_dep:None ~exit_code:2 "test_all_opt3";
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_dep:None ~exit_code:2 "test_arity";
-  print_cmi_target "stop_after_typing";
+  print_cmi_target "stop_after_typing.ml";
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_dep:None ~exit_code:2 "test_signatures_functors";
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_dep:None ~exit_code:2 "test_signatures_first_class_modules";
-  print_cmi_target "test_signatures_separate_a";
+  print_cmi_target "test_signatures_separate_a.ml";
   print_test_expected_output ~cutoff:default_cutoff
     ~output:"test_signatures_separate.output"
     ~extra_dep:(Some "test_signatures_separate_a.cmi")
@@ -215,4 +217,10 @@ let () =
   print_test_expected_output ~extra_flags:"-zero-alloc-assert default -zero-alloc-check all" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail27_default";
     print_test_expected_output ~extra_flags:"-zero-alloc-check default" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail28";
   print_test_expected_output ~extra_flags:"-zero-alloc-check all" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "fail28_opt";
+  print_cmi_target "fail29.mli";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:(Some "fail29.cmi") ~exit_code:2 "fail29";
+  print_cmi_target "fail29_opt.mli";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:(Some "fail29_opt.cmi") ~exit_code:2 "fail29_opt";
+  print_cmi_target "fail29_opt2.mli";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_flags:"-zero-alloc-check all" ~extra_dep:(Some "fail29_opt2.cmi") ~exit_code:2 "fail29_opt2";
   ()

--- a/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -46,16 +46,6 @@ Line 2, characters 2-40:
 Error: zero_alloc "assume" attributes are not supported in signatures
 |}]
 
-module type S_payloads_ignore = sig
-  val[@zero_alloc ignore] f : int -> int
-end
-[%%expect{|
-Line 2, characters 2-40:
-2 |   val[@zero_alloc ignore] f : int -> int
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: zero_alloc "ignore" attributes are not supported in signatures
-|}]
-
 (******************************)
 (* Test 2: allowed inclusions *)
 module type S_good_inc_base = sig

--- a/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -1562,3 +1562,23 @@ module type S_all =
     val f_no_warn_5 : M_aliases.t_two_args [@@zero_alloc arity 45]
   end
 |}]
+
+(* zero_alloc ignore with module inclusion *)
+module type S_all = sig
+  [@@@zero_alloc all]
+
+  val f_warn_one_arg : int -> int
+end
+
+module type S_all_ignored = sig
+  [@@@zero_alloc all]
+
+  val[@zero_alloc ignore] f_warn_one_arg : int -> int
+end
+[%%expect{| |}]
+
+(* This should be rejected *)
+module F (X : S_all_ignored) : S_all = X
+
+(* This should be accepted *)
+module F (X : S_all) : S_all_ignores = X

--- a/typing/zero_alloc.ml
+++ b/typing/zero_alloc.ml
@@ -64,6 +64,7 @@ let set_change_log f = log_change := f
 let create_const x = Const x
 let create_var loc arity = Var { loc; arity; desc = None }
 let default = Const Default_zero_alloc
+let ignore_assert_all = Const Ignore_assert_all
 
 let get (t : t) =
   match t with
@@ -110,9 +111,8 @@ let sub_const_const_exn za1 za2 =
        error. It's essential for the soundness of the way we (will, in the next
        PR) use zero_alloc in signatures that the apparent arity of the type in
        the signature matches the syntactic arity of the function.
-     - [ignore] can not appear in zero_alloc attributes in signatures, and is
-       erased from structure items when computing their signature, so we don't
-       need to consider it here.
+     - [ignore] is erased from structure items when computing their signature,
+       so we don't need to consider it here.
      *)
   let open Builtin_attributes in
   (* abstract domain check *)
@@ -197,9 +197,9 @@ let sub_exn za1 za2 =
     *)
     if not (za1 == za2) then
       Misc.fatal_error "zero_alloc: variable constraint"
-  | _, Const (Ignore_assert_all | Assume _) ->
+  | _, Const (Assume _) ->
     Misc.fatal_error "zero_alloc: invalid constraint"
-  | _, (Const Default_zero_alloc) -> ()
+  | _, (Const (Default_zero_alloc | Ignore_assert_all)) -> ()
   | Var v, Const c -> sub_var_const_exn v c
   | Const c1, Const c2 -> sub_const_const_exn c1 c2
 

--- a/typing/zero_alloc.ml
+++ b/typing/zero_alloc.ml
@@ -111,9 +111,9 @@ let sub_const_const_exn za1 za2 =
        error. It's essential for the soundness of the way we (will, in the next
        PR) use zero_alloc in signatures that the apparent arity of the type in
        the signature matches the syntactic arity of the function.
-     - [ignore] is erased from structure items when computing their signature,
-       so we don't need to consider it here.
-     *)
+     - [ignore] is erased from structure items when computing their signature.
+       On signatures, [ignore] is interpreted as "top" for the inclusion check.
+       This interpretation is the same as erasing [ignore]. *)
   let open Builtin_attributes in
   (* abstract domain check *)
   let abstract_value za =

--- a/typing/zero_alloc.mli
+++ b/typing/zero_alloc.mli
@@ -29,6 +29,10 @@ type t
    done. *)
 val default : t
 
+(* [ignore_assert_all] corresponds to [Ignore_assert_all], meaning no check will be
+   done even if [Clflags.zero_alloc_assert] is set to "all" or "all_opt". *)
+val ignore_assert_all : t
+
 val create_const : const -> t
 
 (* [create_var loc n] creates a variable. [loc] is the location of the function

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -126,6 +126,7 @@ type t =
   | Unerasable_position_argument            (* 188 *)
   | Unnecessarily_partial_tuple_pattern     (* 189 *)
   | Probe_name_too_long of string           (* 190 *)
+  | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)
   | Mod_by_top of string                    (* 211 *)
@@ -215,6 +216,7 @@ let number = function
   | Unerasable_position_argument -> 188
   | Unnecessarily_partial_tuple_pattern -> 189
   | Probe_name_too_long _ -> 190
+  | Zero_alloc_all_hidden_arrow _ -> 198
   | Unchecked_zero_alloc_attribute -> 199
   | Unboxing_impossible -> 210
   | Mod_by_top _ -> 211
@@ -580,6 +582,11 @@ let descriptions = [
   { number = 190;
     names = ["probe-name-too-long"];
     description = "Probe name must be at most 100 characters long.";
+    since = since 4 14 };
+  { number = 198;
+    names = ["zero-alloc-all-hidden-arrow"];
+    description = "A declaration whose type is an alias of a function type \
+                   will be ignored by zero_alloc all or all_opt.";
     since = since 4 14 };
   { number = 199;
     names = ["unchecked-zero-alloc-attribute"];
@@ -1228,6 +1235,14 @@ let message = function
       Printf.sprintf
         "This probe name is too long: `%s'. \
          Probe names must be at most 100 characters long." name
+  | Zero_alloc_all_hidden_arrow s ->
+      Printf.sprintf
+      "The type of this item is an\n\
+       alias of a function type, but the [@@@zero_alloc %s] attribute for\n\
+       this signature does not apply to it because its type is not\n\
+       syntactically a function type. If it should be checked, use an\n\
+       explicit zero_alloc attribute with an arity. If not, use an explicit\n\
+       zero_alloc ignore attribute." s
   | Unchecked_zero_alloc_attribute ->
       Printf.sprintf "the zero_alloc attribute cannot be checked.\n\
       The function it is attached to was optimized away. \n\

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -132,6 +132,7 @@ type t =
   | Unerasable_position_argument            (* 188 *)
   | Unnecessarily_partial_tuple_pattern     (* 189 *)
   | Probe_name_too_long of string           (* 190 *)
+  | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)
   | Mod_by_top of string                    (* 211 *)


### PR DESCRIPTION
On top of https://github.com/ocaml-flambda/flambda-backend/pull/3125.

Support `@@@zero_alloc all`  and `@@@zero_alloc all_opt` on interfaces in the same way as on implementations (just sets  `Clflags.zero_alloc_assert`) including `[@zero_alloc ignore]` on functions.