### PR TITLE
Unboxed vector types should mode cross

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -383,6 +383,78 @@ type t : any mod global unique many uncontended portable external_ = nativeint#
 type t = nativeint#
 |}]
 
+type t : any mod global unique many uncontended portable external_ = int8x16#
+[%%expect{|
+Line 1, characters 0-77:
+1 | type t : any mod global unique many uncontended portable external_ = int8x16#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int8x16#" is vec128
+         because it is the primitive type int8x16#.
+       But the kind of type "int8x16#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-77.
+|}]
+
+type t : any mod global unique many uncontended portable external_ = int16x8#
+[%%expect{|
+Line 1, characters 0-77:
+1 | type t : any mod global unique many uncontended portable external_ = int16x8#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int16x8#" is vec128
+         because it is the primitive type int16x8#.
+       But the kind of type "int16x8#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-77.
+|}]
+
+type t : any mod global unique many uncontended portable external_ = int32x4#
+[%%expect{|
+Line 1, characters 0-77:
+1 | type t : any mod global unique many uncontended portable external_ = int32x4#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int32x4#" is vec128
+         because it is the primitive type int32x4#.
+       But the kind of type "int32x4#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-77.
+|}]
+
+type t : any mod global unique many uncontended portable external_ = int64x2#
+[%%expect{|
+Line 1, characters 0-77:
+1 | type t : any mod global unique many uncontended portable external_ = int64x2#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int64x2#" is vec128
+         because it is the primitive type int64x2#.
+       But the kind of type "int64x2#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-77.
+|}]
+
+type t : any mod global unique many uncontended portable external_ = float32x4#
+[%%expect{|
+Line 1, characters 0-79:
+1 | type t : any mod global unique many uncontended portable external_ = float32x4#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "float32x4#" is vec128
+         because it is the primitive type float32x4#.
+       But the kind of type "float32x4#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-79.
+|}]
+
+type t : any mod global unique many uncontended portable external_ = float64x2#
+[%%expect{|
+Line 1, characters 0-79:
+1 | type t : any mod global unique many uncontended portable external_ = float64x2#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "float64x2#" is vec128
+         because it is the primitive type float64x2#.
+       But the kind of type "float64x2#" must be a subkind of
+         any mod global unique many uncontended portable external_
+         because of the definition of t at line 1, characters 0-79.
+|}]
+
 type indirect_int = int
 type t : any mod global unique many uncontended portable external_ = indirect_int
 [%%expect{|

--- a/ocaml/testsuite/tests/typing-layouts/jkinds.ml
+++ b/ocaml/testsuite/tests/typing-layouts/jkinds.ml
@@ -385,74 +385,32 @@ type t = nativeint#
 
 type t : any mod global unique many uncontended portable external_ = int8x16#
 [%%expect{|
-Line 1, characters 0-77:
-1 | type t : any mod global unique many uncontended portable external_ = int8x16#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int8x16#" is vec128
-         because it is the primitive type int8x16#.
-       But the kind of type "int8x16#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-77.
+type t = int8x16#
 |}]
 
 type t : any mod global unique many uncontended portable external_ = int16x8#
 [%%expect{|
-Line 1, characters 0-77:
-1 | type t : any mod global unique many uncontended portable external_ = int16x8#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int16x8#" is vec128
-         because it is the primitive type int16x8#.
-       But the kind of type "int16x8#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-77.
+type t = int16x8#
 |}]
 
 type t : any mod global unique many uncontended portable external_ = int32x4#
 [%%expect{|
-Line 1, characters 0-77:
-1 | type t : any mod global unique many uncontended portable external_ = int32x4#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int32x4#" is vec128
-         because it is the primitive type int32x4#.
-       But the kind of type "int32x4#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-77.
+type t = int32x4#
 |}]
 
 type t : any mod global unique many uncontended portable external_ = int64x2#
 [%%expect{|
-Line 1, characters 0-77:
-1 | type t : any mod global unique many uncontended portable external_ = int64x2#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int64x2#" is vec128
-         because it is the primitive type int64x2#.
-       But the kind of type "int64x2#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-77.
+type t = int64x2#
 |}]
 
 type t : any mod global unique many uncontended portable external_ = float32x4#
 [%%expect{|
-Line 1, characters 0-79:
-1 | type t : any mod global unique many uncontended portable external_ = float32x4#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "float32x4#" is vec128
-         because it is the primitive type float32x4#.
-       But the kind of type "float32x4#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-79.
+type t = float32x4#
 |}]
 
 type t : any mod global unique many uncontended portable external_ = float64x2#
 [%%expect{|
-Line 1, characters 0-79:
-1 | type t : any mod global unique many uncontended portable external_ = float64x2#
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "float64x2#" is vec128
-         because it is the primitive type float64x2#.
-       But the kind of type "float64x2#" must be a subkind of
-         any mod global unique many uncontended portable external_
-         because of the definition of t at line 1, characters 0-79.
+type t = float64x2#
 |}]
 
 type indirect_int = int

--- a/ocaml/typing/predef.ml
+++ b/ocaml/typing/predef.ml
@@ -540,28 +540,34 @@ let add_simd_stable_extension_types add_type env =
                 Jkind.Const.Builtin.immutable_data.jkind)
       ~jkind_annotation:Jkind.Const.Builtin.immutable_data
   |> add_type ident_unboxed_int8x16
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_int8x16)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_int8x16)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
   |> add_type ident_unboxed_int16x8
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_int16x8)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_int16x8)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
   |> add_type ident_unboxed_int32x4
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_int32x4)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_int32x4)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
   |> add_type ident_unboxed_int64x2
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_int64x2)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_int64x2)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
   |> add_type ident_unboxed_float32x4
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_float32x4)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_float32x4)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
   |> add_type ident_unboxed_float64x2
-      ~jkind:(Jkind.of_const ~why:(Primitive ident_unboxed_float64x2)
-                Jkind.Const.Builtin.vec128.jkind)
+      ~jkind:(Jkind.add_mode_crossing
+                (Jkind.of_const ~why:(Primitive ident_unboxed_float64x2)
+                   Jkind.Const.Builtin.vec128.jkind))
       ~jkind_annotation:Jkind.Const.Builtin.vec128
 
 let add_small_number_extension_types add_type env =


### PR DESCRIPTION
The builtin numeric types of sort `vec128` should mode cross on all axes. I think the fact they don't was just an oversight in the unboxed vector PRs. This PR has two commits - the first adds a test showing they don't currently mode cross, and the second fixes it.

(I noticed this while working on unboxed product arrays.  Unboxed vectors will not be allowed in unboxed product arrays initially, but the fact that they did not mode cross externality prevented me from reaching the type error I added for that.)

Review: @goldfirere 

(cc @TheNumbat )