### PR TITLE
Front-end support for arrays of unboxed products

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -169,6 +169,7 @@ let preserve_tailcall_for_prim = function
   | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
+  | Pmakearray_dynamic _
   | Parrayrefs _ | Parraysets _ | Pisint _ | Pisnull | Pisout | Pbintofint _ | Pintofbint _
   | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _
   | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
@@ -508,43 +509,69 @@ let comp_primitive stack_info p sz args =
      [Parrayset{s,u}]). *)
   | Parrayrefs (Pgenarray_ref _, index_kind, _)
   | Parrayrefs ((Paddrarray_ref | Pintarray_ref | Pfloatarray_ref _
-                | Punboxedfloatarray_ref (Pfloat64 | Pfloat32) | Punboxedintarray_ref _),
-                (Punboxed_int_index _ as index_kind), _) ->
+                | Punboxedfloatarray_ref (Pfloat64 | Pfloat32)
+                | Punboxedintarray_ref _
+                | Pgcscannableproductarray_ref _
+                | Pgcignorableproductarray_ref _),
+                (Punboxed_int_index _ as index_kind),
+                _) ->
       Kccall(indexing_primitive index_kind "caml_array_get", 2)
   | Parrayrefs ((Punboxedfloatarray_ref Pfloat64 | Pfloatarray_ref _), Ptagged_int_index, _) ->
       Kccall("caml_floatarray_get", 2)
   | Parrayrefs ((Punboxedfloatarray_ref Pfloat32 | Punboxedintarray_ref _
-                | Paddrarray_ref | Pintarray_ref), Ptagged_int_index, _) ->
+                | Paddrarray_ref | Pintarray_ref
+                | Pgcscannableproductarray_ref _
+                | Pgcignorableproductarray_ref _),
+                Ptagged_int_index,
+                _) ->
       Kccall("caml_array_get_addr", 2)
   | Parraysets (Pgenarray_set _, index_kind)
   | Parraysets ((Paddrarray_set _ | Pintarray_set | Pfloatarray_set
-                | Punboxedfloatarray_set (Pfloat64 | Pfloat32) | Punboxedintarray_set _),
+                | Punboxedfloatarray_set (Pfloat64 | Pfloat32)
+                | Punboxedintarray_set _
+                | Pgcscannableproductarray_set _
+                | Pgcignorableproductarray_set _),
                 (Punboxed_int_index _ as index_kind)) ->
       Kccall(indexing_primitive index_kind "caml_array_set", 3)
   | Parraysets ((Punboxedfloatarray_set Pfloat64 | Pfloatarray_set),
                 Ptagged_int_index) ->
       Kccall("caml_floatarray_set", 3)
   | Parraysets ((Punboxedfloatarray_set Pfloat32 | Punboxedintarray_set _
-                | Paddrarray_set _ | Pintarray_set), Ptagged_int_index) ->
+                | Paddrarray_set _ | Pintarray_set
+                | Pgcscannableproductarray_set _
+                | Pgcignorableproductarray_set _),
+                Ptagged_int_index) ->
     Kccall("caml_array_set_addr", 3)
   | Parrayrefu (Pgenarray_ref _, index_kind, _)
   | Parrayrefu ((Paddrarray_ref | Pintarray_ref | Pfloatarray_ref _
-                | Punboxedfloatarray_ref (Pfloat64 | Pfloat32) | Punboxedintarray_ref _),
+                | Punboxedfloatarray_ref (Pfloat64 | Pfloat32)
+                | Punboxedintarray_ref _
+                | Pgcscannableproductarray_ref _
+                | Pgcignorableproductarray_ref _),
                 (Punboxed_int_index _ as index_kind), _) ->
       Kccall(indexing_primitive index_kind "caml_array_unsafe_get", 2)
   | Parrayrefu ((Punboxedfloatarray_ref Pfloat64 | Pfloatarray_ref _), Ptagged_int_index, _) ->
     Kccall("caml_floatarray_unsafe_get", 2)
   | Parrayrefu ((Punboxedfloatarray_ref Pfloat32 | Punboxedintarray_ref _
-                | Paddrarray_ref | Pintarray_ref), Ptagged_int_index, _) -> Kgetvectitem
+                | Paddrarray_ref | Pintarray_ref
+                | Pgcscannableproductarray_ref _
+                | Pgcignorableproductarray_ref _),
+                Ptagged_int_index, _) -> Kgetvectitem
   | Parraysetu (Pgenarray_set _, index_kind)
   | Parraysetu ((Paddrarray_set _ | Pintarray_set | Pfloatarray_set
-                | Punboxedfloatarray_set (Pfloat64 | Pfloat32) | Punboxedintarray_set _),
+                | Punboxedfloatarray_set (Pfloat64 | Pfloat32)
+                | Punboxedintarray_set _
+                | Pgcscannableproductarray_set _
+                | Pgcignorableproductarray_set _),
                 (Punboxed_int_index _ as index_kind)) ->
       Kccall(indexing_primitive index_kind "caml_array_unsafe_set", 3)
   | Parraysetu ((Punboxedfloatarray_set Pfloat64 | Pfloatarray_set), Ptagged_int_index) ->
       Kccall("caml_floatarray_unsafe_set", 3)
   | Parraysetu ((Punboxedfloatarray_set Pfloat32 | Punboxedintarray_set _
-                | Paddrarray_set _ | Pintarray_set), Ptagged_int_index) -> Ksetvectitem
+                | Paddrarray_set _ | Pintarray_set
+                | Pgcscannableproductarray_set _
+                | Pgcignorableproductarray_set _),
+                Ptagged_int_index) -> Ksetvectitem
   | Parrayrefs (Punboxedvectorarray_ref _, _, _) | Parraysets (Punboxedvectorarray_set _, _)
   | Parrayrefu (Punboxedvectorarray_ref _, _, _) | Parraysetu (Punboxedvectorarray_set _, _) ->
       fatal_error "SIMD is not supported in bytecode mode."
@@ -656,6 +683,22 @@ let comp_primitive stack_info p sz args =
         "Preinterpret_unboxed_int64_as_tagged_int63 can only be used on 64-bit \
          targets";
     Kccall("caml_reinterpret_unboxed_int64_as_tagged_int63", 1)
+  | Pmakearray_dynamic(kind, locality) ->
+    (* CR layouts v4.0: This is "wrong" for unboxed types. It should construct
+       blocks that can't be marshalled. We've decided to ignore that problem in
+       the short term, as it's unlikely to cause issues - see the internal arrays
+       epic for out plan to deal with it. *)
+    begin match kind with
+    | Punboxedvectorarray _ ->
+      fatal_error "SIMD is not supported in bytecode mode."
+    | Pgenarray | Pintarray | Paddrarray | Punboxedintarray _
+    | Pfloatarray | Punboxedfloatarray _
+    | Pgcscannableproductarray _ | Pgcignorableproductarray _ -> ()
+    end;
+    begin match locality with
+    | Alloc_heap -> Kccall("caml_make_vect", 2)
+    | Alloc_local -> Kccall("caml_make_local_vect", 2)
+    end
   (* The cases below are handled in [comp_expr] before the [comp_primitive] call
      (in the order in which they appear below),
      so they should never be reached in this function. *)
@@ -879,7 +922,8 @@ let rec comp_expr stack_info env exp sz cont =
       (* arrays of unboxed types have the same representation
          as the boxed ones on bytecode *)
       | Pintarray | Paddrarray | Punboxedintarray _
-      | Punboxedfloatarray Pfloat32 ->
+      | Punboxedfloatarray Pfloat32
+      | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
           comp_args stack_info env args sz
             (Kmakeblock(List.length args, 0) :: cont)
       | Pfloatarray | Punboxedfloatarray Pfloat64 ->

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -169,7 +169,7 @@ let preserve_tailcall_for_prim = function
   | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
-  | Pmakearray_dynamic _
+  | Pmakearray_dynamic _ | Parrayblit _
   | Parrayrefs _ | Parraysets _ | Pisint _ | Pisnull | Pisout | Pbintofint _ | Pintofbint _
   | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _
   | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
@@ -699,6 +699,15 @@ let comp_primitive stack_info p sz args =
     | Alloc_heap -> Kccall("caml_make_vect", 2)
     | Alloc_local -> Kccall("caml_make_local_vect", 2)
     end
+  | Parrayblit(kind) ->
+    begin match kind with
+    | Punboxedvectorarray_set _ ->
+      fatal_error "SIMD is not supported in bytecode mode."
+    | Pgenarray_set _ | Pintarray_set | Paddrarray_set _
+    | Punboxedintarray_set _ | Pfloatarray_set | Punboxedfloatarray_set _
+    | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ -> ()
+    end;
+    Kccall("caml_array_blit", 5)
   (* The cases below are handled in [comp_expr] before the [comp_primitive] call
      (in the order in which they appear below),
      so they should never be reached in this function. *)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -582,6 +582,18 @@ let rec compatible_layout x y =
      Punboxed_product _), _ ->
       false
 
+let rec equal_ignorable_product_element_kind k1 k2 =
+  match k1, k2 with
+  | Pint_ignorable, Pint_ignorable -> true
+  | Punboxedfloat_ignorable f1, Punboxedfloat_ignorable f2 ->
+    equal_boxed_float f1 f2
+  | Punboxedint_ignorable i1, Punboxedint_ignorable i2 ->
+    equal_boxed_integer i1 i2
+  | Pproduct_ignorable p1, Pproduct_ignorable p2 ->
+    List.equal equal_ignorable_product_element_kind p1 p2
+  | ( Pint_ignorable | Punboxedfloat_ignorable _
+    | Punboxedint_ignorable _ | Pproduct_ignorable _), _ -> false
+
 let must_be_value layout =
   match layout with
   | Pvalue v -> v

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -191,6 +191,7 @@ type primitive =
   | Pmakearray of array_kind * mutable_flag * locality_mode
   | Pmakearray_dynamic of array_kind * locality_mode
   | Pduparray of array_kind * mutable_flag
+  | Parrayblit of array_set_kind (* Kind of the dest array. *)
   | Parraylength of array_kind
   | Parrayrefu of array_ref_kind * array_index_kind * mutable_flag
   | Parraysetu of array_set_kind * array_index_kind
@@ -1790,6 +1791,7 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Pmakearray_dynamic (_, m) -> Some m
   | Pduparray _ -> Some alloc_heap
   | Parraylength _ -> None
+  | Parrayblit _
   | Parraysetu _ | Parraysets _
   | Parrayrefu ((Paddrarray_ref | Pintarray_ref
       | Punboxedfloatarray_ref _ | Punboxedintarray_ref _
@@ -2004,6 +2006,7 @@ let primitive_result_layout (p : primitive) =
   | Punboxed_float_array_set_128 _ | Punboxed_float32_array_set_128 _
   | Punboxed_int32_array_set_128 _ | Punboxed_int64_array_set_128 _
   | Punboxed_nativeint_array_set_128 _
+  | Parrayblit _
     -> layout_unit
   | Pgetglobal _ | Psetglobal _ | Pgetpredef _ -> layout_module_field
   | Pmakeblock _ | Pmakefloatblock _ | Pmakearray _ | Pmakearray_dynamic _

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -189,6 +189,7 @@ type primitive =
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   (* Array operations *)
   | Pmakearray of array_kind * mutable_flag * locality_mode
+  | Pmakearray_dynamic of array_kind * locality_mode
   | Pduparray of array_kind * mutable_flag
   | Parraylength of array_kind
   | Parrayrefu of array_ref_kind * array_index_kind * mutable_flag
@@ -414,6 +415,8 @@ and array_kind =
   | Punboxedfloatarray of unboxed_float
   | Punboxedintarray of unboxed_integer
   | Punboxedvectorarray of unboxed_vector
+  | Pgcscannableproductarray of scannable_product_element_kind list
+  | Pgcignorableproductarray of ignorable_product_element_kind list
 
 and array_ref_kind =
   | Pgenarray_ref of locality_mode
@@ -423,6 +426,8 @@ and array_ref_kind =
   | Punboxedfloatarray_ref of unboxed_float
   | Punboxedintarray_ref of unboxed_integer
   | Punboxedvectorarray_ref of unboxed_vector
+  | Pgcscannableproductarray_ref of scannable_product_element_kind list
+  | Pgcignorableproductarray_ref of ignorable_product_element_kind list
 
 and array_set_kind =
   | Pgenarray_set of modify_mode
@@ -432,6 +437,20 @@ and array_set_kind =
   | Punboxedfloatarray_set of unboxed_float
   | Punboxedintarray_set of unboxed_integer
   | Punboxedvectorarray_set of unboxed_vector
+  | Pgcscannableproductarray_set of
+      modify_mode * scannable_product_element_kind list
+  | Pgcignorableproductarray_set of ignorable_product_element_kind list
+
+and ignorable_product_element_kind =
+  | Pint_ignorable
+  | Punboxedfloat_ignorable of unboxed_float
+  | Punboxedint_ignorable of unboxed_integer
+  | Pproduct_ignorable of ignorable_product_element_kind list
+
+and scannable_product_element_kind =
+  | Pint_scannable
+  | Paddr_scannable
+  | Pproduct_scannable of scannable_product_element_kind list
 
 and array_index_kind =
   | Ptagged_int_index
@@ -1768,15 +1787,20 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Pstringlength | Pstringrefu  | Pstringrefs
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets -> None
   | Pmakearray (_, _, m) -> Some m
+  | Pmakearray_dynamic (_, m) -> Some m
   | Pduparray _ -> Some alloc_heap
   | Parraylength _ -> None
   | Parraysetu _ | Parraysets _
   | Parrayrefu ((Paddrarray_ref | Pintarray_ref
       | Punboxedfloatarray_ref _ | Punboxedintarray_ref _
-      | Punboxedvectorarray_ref _), _, _)
+      | Punboxedvectorarray_ref _
+      | Pgcscannableproductarray_ref _
+      | Pgcignorableproductarray_ref _), _, _)
   | Parrayrefs ((Paddrarray_ref | Pintarray_ref
       | Punboxedfloatarray_ref _ | Punboxedintarray_ref _
-      | Punboxedvectorarray_ref _), _, _) -> None
+      | Punboxedvectorarray_ref _
+      | Pgcscannableproductarray_ref _
+      | Pgcignorableproductarray_ref _), _, _) -> None
   | Parrayrefu ((Pgenarray_ref m | Pfloatarray_ref m), _, _)
   | Parrayrefs ((Pgenarray_ref m | Pfloatarray_ref m), _, _) -> Some m
   | Pisint _ | Pisnull | Pisout -> None
@@ -1922,15 +1946,32 @@ let layout_of_extern_repr : extern_repr -> _ = function
   | Unboxed_integer bi -> layout_boxedint bi
   | Same_as_ocaml_repr s -> layout_of_const_sort s
 
+let rec layout_of_scannable_kinds kinds =
+  Punboxed_product (List.map layout_of_scannable_kind kinds)
+
+and layout_of_scannable_kind = function
+  | Pint_scannable -> layout_int
+  | Paddr_scannable -> layout_value_field
+  | Pproduct_scannable kinds -> layout_of_scannable_kinds kinds
+
+let rec layout_of_ignorable_kinds kinds =
+  Punboxed_product (List.map layout_of_ignorable_kind kinds)
+
+and layout_of_ignorable_kind = function
+  | Pint_ignorable -> layout_int
+  | Punboxedfloat_ignorable f -> layout_unboxed_float f
+  | Punboxedint_ignorable i -> layout_unboxed_int i
+  | Pproduct_ignorable kinds -> layout_of_ignorable_kinds kinds
+
 let array_ref_kind_result_layout = function
   | Pintarray_ref -> layout_int
   | Pfloatarray_ref _ -> layout_boxed_float Pfloat64
   | Punboxedfloatarray_ref bf -> layout_unboxed_float bf
   | Pgenarray_ref _ | Paddrarray_ref -> layout_value_field
-  | Punboxedintarray_ref Pint32 -> layout_unboxed_int32
-  | Punboxedintarray_ref Pint64 -> layout_unboxed_int64
-  | Punboxedintarray_ref Pnativeint -> layout_unboxed_nativeint
+  | Punboxedintarray_ref i -> layout_unboxed_int i
   | Punboxedvectorarray_ref bv -> layout_unboxed_vector bv
+  | Pgcscannableproductarray_ref kinds -> layout_of_scannable_kinds kinds
+  | Pgcignorableproductarray_ref kinds -> layout_of_ignorable_kinds kinds
 
 let layout_of_mixed_field (kind : mixed_block_read) =
   match kind with
@@ -1965,8 +2006,8 @@ let primitive_result_layout (p : primitive) =
   | Punboxed_nativeint_array_set_128 _
     -> layout_unit
   | Pgetglobal _ | Psetglobal _ | Pgetpredef _ -> layout_module_field
-  | Pmakeblock _ | Pmakefloatblock _ | Pmakearray _ | Pduprecord _
-  | Pmakeufloatblock _ | Pmakemixedblock _
+  | Pmakeblock _ | Pmakefloatblock _ | Pmakearray _ | Pmakearray_dynamic _
+  | Pduprecord _ | Pmakeufloatblock _ | Pmakemixedblock _
   | Pduparray _ | Pbigarraydim _ | Pobj_dup -> layout_block
   | Pfield _ | Pfield_computed _ -> layout_value_field
   | Punboxed_product_field (field, layouts) -> (Array.of_list layouts).(field)
@@ -2139,6 +2180,8 @@ let array_ref_kind mode = function
   | Punboxedintarray int_kind -> Punboxedintarray_ref int_kind
   | Punboxedfloatarray float_kind -> Punboxedfloatarray_ref float_kind
   | Punboxedvectorarray vec_kind -> Punboxedvectorarray_ref vec_kind
+  | Pgcscannableproductarray kinds -> Pgcscannableproductarray_ref kinds
+  | Pgcignorableproductarray kinds -> Pgcignorableproductarray_ref kinds
 
 let array_set_kind mode = function
   | Pgenarray -> Pgenarray_set mode
@@ -2148,6 +2191,8 @@ let array_set_kind mode = function
   | Punboxedintarray int_kind -> Punboxedintarray_set int_kind
   | Punboxedfloatarray float_kind -> Punboxedfloatarray_set float_kind
   | Punboxedvectorarray vec_kind -> Punboxedvectorarray_set vec_kind
+  | Pgcscannableproductarray kinds -> Pgcscannableproductarray_set (mode, kinds)
+  | Pgcignorableproductarray kinds -> Pgcignorableproductarray_set kinds
 
 let may_allocate_in_region lam =
   (* loop_region raises, if the lambda might allocate in parent region *)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -183,6 +183,10 @@ type primitive =
   (** For [Pduparray], the argument must be an immutable array.
       The arguments of [Pduparray] give the kind and mutability of the
       array being *produced* by the duplication. *)
+  | Parrayblit of array_set_kind
+  (** For [Parrayblit], we record the [array_set_kind] of the destination
+      array. We check that the source array has the same shape, but do not
+      need to know anything about its locality. *)
   | Parraylength of array_kind
   | Parrayrefu of array_ref_kind * array_index_kind * mutable_flag
   | Parraysetu of array_set_kind * array_index_kind

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -366,6 +366,7 @@ and array_kind =
   | Punboxedvectorarray of unboxed_vector
   | Pgcscannableproductarray of scannable_product_element_kind list
   | Pgcignorableproductarray of ignorable_product_element_kind list
+  (* Invariant: the product element kind lists have length >= 2 *)
 
 (** When accessing a flat float array, we need to know the mode which we should
     box the resulting float at. *)
@@ -379,6 +380,7 @@ and array_ref_kind =
   | Punboxedvectorarray_ref of unboxed_vector
   | Pgcscannableproductarray_ref of scannable_product_element_kind list
   | Pgcignorableproductarray_ref of ignorable_product_element_kind list
+  (* Invariant: the product element kind lists have length >= 2 *)
 
 (** When updating an array that might contain pointers, we need to know what
     mode they're at; otherwise, access is uniform. *)
@@ -393,17 +395,20 @@ and array_set_kind =
   | Pgcscannableproductarray_set of
       modify_mode * scannable_product_element_kind list
   | Pgcignorableproductarray_set of ignorable_product_element_kind list
+  (* Invariant: the product element kind lists have length >= 2 *)
 
 and ignorable_product_element_kind =
   | Pint_ignorable
   | Punboxedfloat_ignorable of unboxed_float
   | Punboxedint_ignorable of unboxed_integer
   | Pproduct_ignorable of ignorable_product_element_kind list
+  (* Invariant: the product element kind list has length >= 2 *)
 
 and scannable_product_element_kind =
   | Pint_scannable
   | Paddr_scannable
   | Pproduct_scannable of scannable_product_element_kind list
+  (* Invariant: the product element kind list has length >= 2 *)
 
 and array_index_kind =
   | Ptagged_int_index
@@ -535,6 +540,9 @@ val equal_boxed_vector : boxed_vector -> boxed_vector -> bool
 val compare_boxed_vector : boxed_vector -> boxed_vector -> int
 
 val print_boxed_vector : Format.formatter -> boxed_vector -> unit
+
+val equal_ignorable_product_element_kind :
+  ignorable_product_element_kind -> ignorable_product_element_kind -> bool
 
 val must_be_value : layout -> value_kind
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -178,6 +178,7 @@ type primitive =
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   (* Array operations *)
   | Pmakearray of array_kind * mutable_flag * locality_mode
+  | Pmakearray_dynamic of array_kind * locality_mode
   | Pduparray of array_kind * mutable_flag
   (** For [Pduparray], the argument must be an immutable array.
       The arguments of [Pduparray] give the kind and mutability of the
@@ -359,6 +360,8 @@ and array_kind =
   | Punboxedfloatarray of unboxed_float
   | Punboxedintarray of unboxed_integer
   | Punboxedvectorarray of unboxed_vector
+  | Pgcscannableproductarray of scannable_product_element_kind list
+  | Pgcignorableproductarray of ignorable_product_element_kind list
 
 (** When accessing a flat float array, we need to know the mode which we should
     box the resulting float at. *)
@@ -370,6 +373,8 @@ and array_ref_kind =
   | Punboxedfloatarray_ref of unboxed_float
   | Punboxedintarray_ref of unboxed_integer
   | Punboxedvectorarray_ref of unboxed_vector
+  | Pgcscannableproductarray_ref of scannable_product_element_kind list
+  | Pgcignorableproductarray_ref of ignorable_product_element_kind list
 
 (** When updating an array that might contain pointers, we need to know what
     mode they're at; otherwise, access is uniform. *)
@@ -381,6 +386,20 @@ and array_set_kind =
   | Punboxedfloatarray_set of unboxed_float
   | Punboxedintarray_set of unboxed_integer
   | Punboxedvectorarray_set of unboxed_vector
+  | Pgcscannableproductarray_set of
+      modify_mode * scannable_product_element_kind list
+  | Pgcignorableproductarray_set of ignorable_product_element_kind list
+
+and ignorable_product_element_kind =
+  | Pint_ignorable
+  | Punboxedfloat_ignorable of unboxed_float
+  | Punboxedint_ignorable of unboxed_integer
+  | Pproduct_ignorable of ignorable_product_element_kind list
+
+and scannable_product_element_kind =
+  | Pint_scannable
+  | Paddr_scannable
+  | Pproduct_scannable of scannable_product_element_kind list
 
 and array_index_kind =
   | Ptagged_int_index

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -670,6 +670,7 @@ let primitive ppf = function
   | Pduparray (k, Immutable) -> fprintf ppf "duparray_imm[%s]" (array_kind k)
   | Pduparray (k, Immutable_unique) ->
       fprintf ppf "duparray_unique[%s]" (array_kind k)
+  | Parrayblit sk -> fprintf ppf "arrayblit[%a]" array_set_kind sk
   | Parrayrefu (rk, idx, mut) -> fprintf ppf "%s.unsafe_get[%a indexed by %a]"
                                  (array_mut mut)
                                  array_ref_kind rk
@@ -987,6 +988,7 @@ let name_of_primitive = function
   | Pmakearray _ -> "Pmakearray"
   | Pmakearray_dynamic _ -> "Pmakearray_dynamic"
   | Pduparray _ -> "Pduparray"
+  | Parrayblit _ -> "Parrayblit"
   | Parrayrefu _ -> "Parrayrefu"
   | Parraysetu _ -> "Parraysetu"
   | Parrayrefs _ -> "Parrayrefs"

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -67,17 +67,44 @@ and struct_consts ppf (hd, tl) =
   in
   fprintf ppf "%a%a" struct_const hd sconsts tl
 
+let unboxed_float = function
+  | Pfloat64 -> "unboxed_float"
+  | Pfloat32 -> "unboxed_float32"
+
+let unboxed_integer = function
+  | Pint32 -> "unboxed_int32"
+  | Pint64 -> "unboxed_int64"
+  | Pnativeint -> "unboxed_nativeint"
+
+let rec scannable_product_element_kinds kinds =
+  "[" ^ String.concat "; " (List.map scannable_product_element_kind kinds) ^ "]"
+
+and scannable_product_element_kind = function
+  | Pint_scannable -> "int"
+  | Paddr_scannable -> "addr"
+  | Pproduct_scannable kinds -> scannable_product_element_kinds kinds
+
+let rec ignorable_product_element_kinds kinds =
+  "[" ^ String.concat "; " (List.map ignorable_product_element_kind kinds) ^ "]"
+
+and ignorable_product_element_kind = function
+  | Pint_ignorable -> "int"
+  | Punboxedfloat_ignorable f -> unboxed_float f
+  | Punboxedint_ignorable i -> unboxed_integer i
+  | Pproduct_ignorable kinds -> ignorable_product_element_kinds kinds
+
 let array_kind = function
   | Pgenarray -> "gen"
   | Paddrarray -> "addr"
   | Pintarray -> "int"
   | Pfloatarray -> "float"
-  | Punboxedfloatarray Pfloat64 -> "unboxed_float"
-  | Punboxedfloatarray Pfloat32 -> "unboxed_float32"
-  | Punboxedintarray Pint32 -> "unboxed_int32"
-  | Punboxedintarray Pint64 -> "unboxed_int64"
-  | Punboxedintarray Pnativeint -> "unboxed_nativeint"
+  | Punboxedfloatarray f -> unboxed_float f
+  | Punboxedintarray i -> unboxed_integer i
   | Punboxedvectorarray Pvec128 -> "unboxed_vec128"
+  | Pgcscannableproductarray kinds ->
+    "scannableproduct " ^ scannable_product_element_kinds kinds
+  | Pgcignorableproductarray kinds ->
+    "ignorableproduct " ^ ignorable_product_element_kinds kinds
 
 let array_mut = function
   | Mutable -> "array"
@@ -99,6 +126,10 @@ let array_ref_kind ppf k =
   | Punboxedintarray_ref Pint64 -> fprintf ppf "unboxed_int64"
   | Punboxedintarray_ref Pnativeint -> fprintf ppf "unboxed_nativeint"
   | Punboxedvectorarray_ref Pvec128 -> fprintf ppf "unboxed_vec128"
+  | Pgcscannableproductarray_ref kinds ->
+    fprintf ppf "scannableproduct %s" (scannable_product_element_kinds kinds)
+  | Pgcignorableproductarray_ref kinds ->
+    fprintf ppf "ignorableproduct %s" (ignorable_product_element_kinds kinds)
 
 let array_index_kind ppf k =
   match k with
@@ -123,6 +154,11 @@ let array_set_kind ppf k =
   | Punboxedintarray_set Pint64 -> fprintf ppf "unboxed_int64"
   | Punboxedintarray_set Pnativeint -> fprintf ppf "unboxed_nativeint"
   | Punboxedvectorarray_set Pvec128 -> fprintf ppf "unboxed_vec128"
+  | Pgcscannableproductarray_set (mode, kinds) ->
+    fprintf ppf "scannableproduct%a %s" pp_mode mode
+      (scannable_product_element_kinds kinds)
+  | Pgcignorableproductarray_set kinds ->
+    fprintf ppf "ignorableproduct %s" (ignorable_product_element_kinds kinds)
 
 let locality_mode_if_local = function
   | Alloc_heap -> ""
@@ -627,6 +663,9 @@ let primitive ppf = function
   | Pmakearray (k, Immutable_unique, mode) ->
       fprintf ppf "make%sarray_unique[%s]" (locality_mode_if_local mode)
         (array_kind k)
+  | Pmakearray_dynamic (k, mode) ->
+      fprintf ppf "make%sarray_any[%s]" (locality_mode_if_local mode)
+        (array_kind k)
   | Pduparray (k, Mutable) -> fprintf ppf "duparray[%s]" (array_kind k)
   | Pduparray (k, Immutable) -> fprintf ppf "duparray_imm[%s]" (array_kind k)
   | Pduparray (k, Immutable_unique) ->
@@ -946,6 +985,7 @@ let name_of_primitive = function
   | Pbytessets -> "Pbytessets"
   | Parraylength _ -> "Parraylength"
   | Pmakearray _ -> "Pmakearray"
+  | Pmakearray_dynamic _ -> "Pmakearray_dynamic"
   | Pduparray _ -> "Pduparray"
   | Parrayrefu _ -> "Parrayrefu"
   | Parraysetu _ -> "Parraysetu"

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -907,7 +907,7 @@ let rec choice ctx t =
     | Punbox_vector _ | Pbox_vector (_, _)
 
     (* we don't handle array indices as destinations yet *)
-    | (Pmakearray _ | Pduparray _)
+    | (Pmakearray _ | Pduparray _ | Pmakearray_dynamic _)
 
     (* we don't handle { foo with x = ...; y = recursive-call } *)
     | Pduprecord _

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -891,6 +891,7 @@ let rec choice ctx t =
     | Pstringlength | Pstringrefu  | Pstringrefs
     | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
     | Parraylength _ | Parrayrefu _ | Parraysetu _ | Parrayrefs _ | Parraysets _
+    | Parrayblit _
     | Pisint _ | Pisnull | Pisout
     | Pignore
     | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _

--- a/lambda/transl_array_comprehension.ml
+++ b/lambda/transl_array_comprehension.ml
@@ -731,6 +731,9 @@ let initial_array ~loc ~array_kind ~array_size ~array_sizing =
       (* The above cases are not actually allowed/tested yet. *)
       Misc.fatal_error
         "Comprehensions on arrays of unboxed types are not yet supported."
+    | _, (Pgcscannableproductarray _ | Pgcignorableproductarray _) ->
+      Misc.fatal_error
+        "Transl_array_comprehension.initial_array: unboxed product array"
   in
   Let_binding.make array_let_kind layout_any_value "array" array_value
 
@@ -819,6 +822,8 @@ let body ~loc ~array_kind ~array_size ~array_sizing ~array ~index ~body =
     | Punboxedfloatarray (Pfloat64 | Pfloat32)
     | Punboxedintarray _ | Punboxedvectorarray _ ->
       set_element_in_bounds body
+    | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+      Misc.fatal_error "Transl_array_comprehension.body: unboxed product array"
   in
   Lsequence
     (set_element_known_kind_in_bounds, Lassign (index.id, index.var + l1))
@@ -838,7 +843,10 @@ let comprehension ~transl_exp ~scopes ~loc ~(array_kind : Lambda.array_kind)
       Misc.fatal_errorf
         "Array comprehensions for kind %s can only be compiled for 64-bit \
          native targets"
-        (Printlambda.array_kind array_kind));
+        (Printlambda.array_kind array_kind)
+  | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+    Misc.fatal_error
+      "Transl_array_comprehension.comprehension: unboxed product array");
   let { array_sizing_info; array_size; make_comprehension } =
     clauses ~transl_exp ~scopes ~loc comp_clauses
   in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -33,6 +33,8 @@ type error =
   | Illegal_void_record_field
   | Illegal_product_record_field of Jkind.Sort.Const.t
   | Void_sort of type_expr
+  | Unboxed_vector_in_array_comprehension
+  | Unboxed_product_in_array_comprehension
 
 exception Error of Location.t * error
 
@@ -795,7 +797,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                   Lconst(Const_float_array(List.map extract_float cl))
                 | Pgenarray ->
                   raise Not_constant    (* can this really happen? *)
-                | Punboxedfloatarray _ | Punboxedintarray _ | Punboxedvectorarray _ ->
+                | Punboxedfloatarray _ | Punboxedintarray _
+                | Punboxedvectorarray _
+                | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
                   Misc.fatal_error "Use flambda2 for unboxed arrays"
             in
             if Types.is_mutable amut then duparray_to_mutable const else const
@@ -813,6 +817,14 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
          way *)
       let loc = of_location ~scopes e.exp_loc in
       let array_kind = Typeopt.array_kind e elt_sort in
+      begin match array_kind with
+      | Pgenarray | Paddrarray | Pintarray | Pfloatarray
+      | Punboxedfloatarray _ | Punboxedintarray _ -> ()
+      | Punboxedvectorarray _ ->
+        raise (Error(e.exp_loc, Unboxed_vector_in_array_comprehension))
+      | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+        raise (Error(e.exp_loc, Unboxed_product_in_array_comprehension))
+      end;
       Transl_array_comprehension.comprehension
         ~transl_exp ~scopes ~loc ~array_kind comp
   | Texp_ifthenelse(cond, ifso, Some ifnot) ->
@@ -2305,6 +2317,14 @@ let report_error ppf = function
         "Void detected in translation for type %a:@ Please report this error \
          to the Jane Street compilers team."
         Printtyp.type_expr ty
+  | Unboxed_vector_in_array_comprehension ->
+      fprintf ppf
+        "Array comprehensions are not yet supported for arrays of unboxed \
+         vectors."
+  | Unboxed_product_in_array_comprehension ->
+      fprintf ppf
+        "Array comprehensions are not yet supported for arrays of unboxed \
+         products."
 
 let () =
   Location.register_error_of_exn

--- a/lambda/translcore.mli
+++ b/lambda/translcore.mli
@@ -51,6 +51,8 @@ type error =
   | Illegal_void_record_field
   | Illegal_product_record_field of Jkind.Sort.Const.t
   | Void_sort of Types.type_expr
+  | Unboxed_vector_in_array_comprehension
+  | Unboxed_product_in_array_comprehension
 
 exception Error of Location.t * error
 

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -982,8 +982,9 @@ let glb_array_type loc t1 t2 =
   | Pgenarray,
     ((Pgcignorableproductarray _ | Pgcscannableproductarray _) as k) -> k
   | (Pgcignorableproductarray kinds1) as k, Pgcignorableproductarray kinds2 ->
-    if kinds1 = kinds2 then k else
-      Misc.fatal_error "mismatched ignorableproductarray kinds in glb"
+    if List.equal equal_ignorable_product_element_kind kinds1 kinds2
+    then k
+    else Misc.fatal_error "mismatched ignorableproductarray kinds in glb"
   | Pgcscannableproductarray kinds1, Pgcscannableproductarray kinds2 ->
     begin match glb_scannable_kinds kinds1 kinds2 with
     | Some kinds -> Pgcscannableproductarray kinds

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -531,12 +531,10 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
           (gen_array_set_kind (get_first_arg_mode ()), Punboxed_int_index Pnativeint)),
         3)
     | "%makearray_dynamic" ->
-      Jane_syntax_parsing.assert_extension_enabled ~loc Layouts
-        Language_extension.Alpha;
+      Language_extension.assert_enabled ~loc Layouts Language_extension.Alpha;
       Primitive (Pmakearray_dynamic (gen_array_kind, mode), 2)
     | "%arrayblit" ->
-      Jane_syntax_parsing.assert_extension_enabled ~loc Layouts
-        Language_extension.Alpha;
+      Language_extension.assert_enabled ~loc Layouts Language_extension.Alpha;
       Primitive (Parrayblit (gen_array_set_kind (get_third_arg_mode ())), 5)
     | "%obj_size" -> Primitive ((Parraylength Pgenarray), 1)
     | "%obj_field" -> Primitive ((Parrayrefu (Pgenarray_ref mode, Ptagged_int_index, Mutable)), 2)

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -508,6 +508,8 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
         ((Parraysetu
           (gen_array_set_kind (get_first_arg_mode ()), Punboxed_int_index Pnativeint)),
         3)
+    | "%makearray_dynamic" ->
+      Primitive (Pmakearray_dynamic (gen_array_kind, mode), 2)
     | "%obj_size" -> Primitive ((Parraylength Pgenarray), 1)
     | "%obj_field" -> Primitive ((Parrayrefu (Pgenarray_ref mode, Ptagged_int_index, Mutable)), 2)
     | "%obj_set_field" ->
@@ -881,6 +883,23 @@ let simplify_constant_constructor = function
   | Greater_than -> false
   | Compare -> false
 
+(* See [glb_array_type] *)
+let rec glb_scannable_kinds kinds1 kinds2 =
+  if List.length kinds1 = List.length kinds2 then
+    Misc.Stdlib.List.map2_option glb_scannable_kind kinds1 kinds2
+  else
+    None
+
+and glb_scannable_kind kind1 kind2 =
+  match kind1, kind2 with
+  | Pint_scannable, (Paddr_scannable | Pint_scannable)
+  | Paddr_scannable, Pint_scannable -> Some Pint_scannable
+  | Paddr_scannable, Paddr_scannable -> Some Paddr_scannable
+  | Pproduct_scannable kinds1, Pproduct_scannable kinds2 ->
+    Option.map (fun x -> Pproduct_scannable x)
+      (glb_scannable_kinds kinds1 kinds2)
+  | (Pint_scannable | Paddr_scannable | Pproduct_scannable _), _ -> None
+
 (* The following function computes the greatest lower bound of array kinds:
 
         gen      unboxed-float  unboxed-int32  unboxed-int64  unboxed-nativeint
@@ -890,6 +909,9 @@ let simplify_constant_constructor = function
     addr  float
       |
     int
+
+   For product kinds, we take the product of this lattice.
+
    Note that the GLB is not guaranteed to exist.
    In case of array kinds working with layout value, we return
    our first argument instead of raising a fatal error because, although
@@ -928,13 +950,31 @@ let glb_array_type loc t1 t2 =
   | Punboxedvectorarray _, _ | _, Punboxedvectorarray _ ->
     Misc.fatal_error "unexpected array kind in glb"
 
+  (* Unboxed product arrays. Same cheat as above for Pgenarray. *)
+  | Pgenarray,
+    ((Pgcignorableproductarray _ | Pgcscannableproductarray _) as k) -> k
+  | (Pgcignorableproductarray kinds1) as k, Pgcignorableproductarray kinds2 ->
+    if kinds1 = kinds2 then k else
+      Misc.fatal_error "mismatched ignorableproductarray kinds in glb"
+  | Pgcscannableproductarray kinds1, Pgcscannableproductarray kinds2 ->
+    begin match glb_scannable_kinds kinds1 kinds2 with
+    | Some kinds -> Pgcscannableproductarray kinds
+    | None -> Misc.fatal_error "mismatched scannableproductarray kinds in glb"
+    end
+  | Pgcignorableproductarray _, _ | _, Pgcignorableproductarray _ ->
+    Misc.fatal_error "unexpected Pgcignorableproductarray kind in glb"
+  | Pgcscannableproductarray _, _ | _, Pgcscannableproductarray _ ->
+    Misc.fatal_error "unexpected Pgcscannableproductarray kind in glb"
+
   (* No GLB; only used in the [Obj.magic] case *)
   | Pfloatarray, (Paddrarray | Pintarray)
   | (Paddrarray | Pintarray), Pfloatarray -> t1
 
   (* Compute the correct GLB *)
-  | Pgenarray, x | x, Pgenarray -> x
-  | Paddrarray, x | x, Paddrarray -> x
+  | Pgenarray, ((Pgenarray | Paddrarray | Pintarray | Pfloatarray) as x)
+  | ((Paddrarray | Pintarray | Pfloatarray) as x), Pgenarray -> x
+  | Paddrarray, Paddrarray -> Paddrarray
+  | Paddrarray, Pintarray | Pintarray, Paddrarray -> Pintarray
   | Pintarray, Pintarray -> Pintarray
   | Pfloatarray, Pfloatarray -> Pfloatarray
 
@@ -969,6 +1009,25 @@ let glb_array_ref_type loc t1 t2 =
     Punboxedvectorarray_ref Pvec128
   | Punboxedvectorarray_ref _, _ | _, Punboxedvectorarray _ ->
     Misc.fatal_error "unexpected array kind in glb"
+
+  (* Unboxed product arrays. Same cheat as above for Pgenarray. *)
+  | Pgenarray_ref _, Pgcignorableproductarray kinds ->
+    Pgcignorableproductarray_ref kinds
+  | Pgenarray_ref _, Pgcscannableproductarray kinds ->
+    Pgcscannableproductarray_ref kinds
+  | (Pgcignorableproductarray_ref kinds1) as k,
+    Pgcignorableproductarray kinds2 ->
+    if kinds1 = kinds2 then k else
+      Misc.fatal_error "mismatched ignorableproductarray kinds in glb"
+  | Pgcscannableproductarray_ref kinds1, Pgcscannableproductarray kinds2 ->
+    begin match glb_scannable_kinds kinds1 kinds2 with
+    | Some kinds -> Pgcscannableproductarray_ref kinds
+    | None -> Misc.fatal_error "mismatched scannableproductarray kinds in glb"
+    end
+  | Pgcignorableproductarray_ref _, _ | _, Pgcignorableproductarray _ ->
+    Misc.fatal_error "unexpected Pgcignorableproductarray kind in glb"
+  | Pgcscannableproductarray_ref _, _ | _, Pgcscannableproductarray _ ->
+    Misc.fatal_error "unexpected Pgcscannableproductarray kind in glb"
 
   (* No GLB; only used in the [Obj.magic] case *)
   | Pfloatarray_ref _, (Paddrarray | Pintarray)
@@ -1025,6 +1084,26 @@ let glb_array_set_type loc t1 t2 =
     Punboxedvectorarray_set Pvec128
   | Punboxedvectorarray_set _, _ | _, Punboxedvectorarray _ ->
     Misc.fatal_error "unexpected array kind in glb"
+
+  (* Unboxed product arrays. Same cheat as above for Pgenarray. *)
+  | Pgenarray_set _, Pgcignorableproductarray kinds ->
+    Pgcignorableproductarray_set kinds
+  | Pgenarray_set m, Pgcscannableproductarray kinds ->
+    Pgcscannableproductarray_set (m, kinds)
+  | (Pgcignorableproductarray_set kinds1) as k,
+    Pgcignorableproductarray kinds2 ->
+    if kinds1 = kinds2 then k else
+      Misc.fatal_error "mismatched ignorableproductarray kinds in glb"
+  | Pgcscannableproductarray_set (mode, kinds1),
+    Pgcscannableproductarray kinds2 ->
+    begin match glb_scannable_kinds kinds1 kinds2 with
+    | Some kinds -> Pgcscannableproductarray_set (mode, kinds)
+    | None -> Misc.fatal_error "mismatched scannableproductarray kinds in glb"
+    end
+  | Pgcignorableproductarray_set _, _ | _, Pgcignorableproductarray _ ->
+    Misc.fatal_error "unexpected Pgcignorableproductarray_set kind in glb"
+  | Pgcscannableproductarray_set _, _ | _, Pgcscannableproductarray _ ->
+    Misc.fatal_error "unexpected Pgcscannableproductarray_set kind in glb"
 
   (* No GLB; only used in the [Obj.magic] case *)
   | Pfloatarray_set, (Paddrarray | Pintarray)
@@ -1118,6 +1197,16 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       in
       if st = array_set_type then None
       else Some (Primitive (Parraysets (array_set_type, index_kind), arity))
+    end
+  | Primitive (Pmakearray_dynamic (at, mode), arity),
+    _ :: p2 :: _ -> begin
+      let loc = to_location loc in
+      let array_type =
+        glb_array_type loc at
+          (array_kind_of_elt ~elt_sort:None env loc p2)
+      in
+      if at = array_type then None
+      else Some (Primitive (Pmakearray_dynamic (array_type, mode), arity))
     end
   | Primitive (Pbigarrayref(unsafe, n, kind, layout), arity), p1 :: _ -> begin
       let (k, l) = bigarray_specialize_kind_and_layout env ~kind ~layout p1 in
@@ -1604,6 +1693,7 @@ let lambda_primitive_needs_event_after = function
   | Pmulfloat (_, _) | Pdivfloat (_, _)
   | Pstringrefs | Pbytesrefs
   | Pbytessets | Pmakearray (Pgenarray, _, _) | Pduparray _
+  | Pmakearray_dynamic (Pgenarray, _)
   | Parrayrefu ((Pgenarray_ref _ | Pfloatarray_ref _), _, _)
   | Parrayrefs _ | Parraysets _ | Pbintofint _ | Pcvtbint _ | Pnegbint _
   | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _ | Pmodbint _ | Pandbint _
@@ -1648,7 +1738,12 @@ let lambda_primitive_needs_event_after = function
   | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu
   | Pbytessetu
   | Pmakearray ((Pintarray | Paddrarray | Pfloatarray | Punboxedfloatarray _
-      | Punboxedintarray _ | Punboxedvectorarray _), _, _)
+      | Punboxedintarray _ | Punboxedvectorarray _
+      | Pgcscannableproductarray _ | Pgcignorableproductarray _), _, _)
+  | Pmakearray_dynamic
+      ((Pintarray | Paddrarray | Pfloatarray | Punboxedfloatarray _
+       | Punboxedintarray _ | Punboxedvectorarray _
+       | Pgcscannableproductarray _ | Pgcignorableproductarray _), _)
   | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint _ | Pisnull | Pisout
   | Pprobe_is_enabled _
   | Patomic_exchange | Patomic_cas | Patomic_fetch_add | Patomic_load _

--- a/lambda/translprim.mli
+++ b/lambda/translprim.mli
@@ -63,6 +63,7 @@ type error =
   | Unknown_builtin_primitive of string
   | Wrong_arity_builtin_primitive of string
   | Invalid_floatarray_glb
+  | Product_iarrays_unsupported
 
 exception Error of Location.t * error
 

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -255,9 +255,11 @@ let compute_static_size lam =
             Block (Regular_block size)
         | Pfloatarray ->
             Block (Float_record size)
-        | Punboxedfloatarray _ | Punboxedintarray _ | Punboxedvectorarray _ ->
+        | Punboxedfloatarray _ | Punboxedintarray _ | Punboxedvectorarray _
+        | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
             Misc.fatal_error "size_of_primitive"
         end
+    | Pmakearray_dynamic _ -> Misc.fatal_error "size_of_primitive"
     | Pduparray _ ->
         (* The size has to be recovered from the size of the argument *)
         begin match args with

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -260,6 +260,7 @@ let compute_static_size lam =
             Misc.fatal_error "size_of_primitive"
         end
     | Pmakearray_dynamic _ -> Misc.fatal_error "size_of_primitive"
+    | Parrayblit _ -> Constant
     | Pduparray _ ->
         (* The size has to be recovered from the size of the argument *)
         begin match args with

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -922,6 +922,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Pmakearray (array_kind, _, _mode) ->
         let array_kind = Empty_array_kind.of_lambda array_kind in
         register_const0 acc (Static_const.empty_array array_kind) "empty_array"
+      | Pmakearray_dynamic (_array_kind, _mode) ->
+        Misc.fatal_error "Closure_conversion.close_primitive: unimplemented"
       | Pbytes_to_string | Pbytes_of_string | Parray_of_iarray
       | Parray_to_iarray | Pignore | Pgetglobal _ | Psetglobal _ | Pgetpredef _
       | Pfield _ | Pfield_computed _ | Psetfield _ | Psetfield_computed _

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -924,6 +924,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
         register_const0 acc (Static_const.empty_array array_kind) "empty_array"
       | Pmakearray_dynamic (_array_kind, _mode) ->
         Misc.fatal_error "Closure_conversion.close_primitive: unimplemented"
+      | Parrayblit _array_set_kind ->
+        Misc.fatal_error "Closure_conversion.close_primitive: unimplemented"
       | Pbytes_to_string | Pbytes_of_string | Parray_of_iarray
       | Parray_to_iarray | Pignore | Pgetglobal _ | Psetglobal _ | Pgetpredef _
       | Pfield _ | Pfield_computed _ | Psetfield _ | Psetfield_computed _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -708,9 +708,9 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Punboxed_float_comp (_, _)
   | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu | Pbytessetu
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
-  | Pmakearray_dynamic _
-  | Pisint _ | Pisnull | Pisout | Pbintofint _ | Pintofbint _ | Pcvtbint _
-  | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _
+  | Pmakearray_dynamic _ | Pisint _ | Pisnull | Pisout | Pbintofint _
+  | Pintofbint _ | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _
+  | Pmulbint _
   | Pdivbint { is_safe = Unsafe; _ }
   | Pmodbint { is_safe = Unsafe; _ }
   | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _ | Pasrbint _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -680,6 +680,7 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pmodbint { is_safe = Safe; _ }
   | Pbigarrayref (false, _, _, _)
   | Pbigarrayset (false, _, _, _)
+  | Parrayblit _
   (* These bigarray primitives are translated into c-calls which may raise even
      if the unsafe flag is true *)
   | Pbigarrayref (_, _, Pbigarray_unknown, _)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -708,6 +708,7 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Punboxed_float_comp (_, _)
   | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu | Pbytessetu
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
+  | Pmakearray_dynamic _
   | Pisint _ | Pisnull | Pisout | Pbintofint _ | Pintofbint _ | Pcvtbint _
   | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _
   | Pdivbint { is_safe = Unsafe; _ }

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -680,8 +680,7 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pmodbint { is_safe = Safe; _ }
   | Pbigarrayref (false, _, _, _)
   | Pbigarrayset (false, _, _, _)
-  | Parrayblit _
-  | Pmakearray_dynamic _
+  | Parrayblit _ | Pmakearray_dynamic _
   (* These bigarray primitives are translated into c-calls which may raise even
      if the unsafe flag is true *)
   | Pbigarrayref (_, _, Pbigarray_unknown, _)
@@ -710,8 +709,8 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Punboxed_float_comp (_, _)
   | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu | Pbytessetu
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
-  | Pisint _ | Pisout | Pisnull | Pbintofint _ | Pintofbint _
-  | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _
+  | Pisint _ | Pisout | Pisnull | Pbintofint _ | Pintofbint _ | Pcvtbint _
+  | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _
   | Pdivbint { is_safe = Unsafe; _ }
   | Pmodbint { is_safe = Unsafe; _ }
   | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _ | Pasrbint _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -681,6 +681,7 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pbigarrayref (false, _, _, _)
   | Pbigarrayset (false, _, _, _)
   | Parrayblit _
+  | Pmakearray_dynamic _
   (* These bigarray primitives are translated into c-calls which may raise even
      if the unsafe flag is true *)
   | Pbigarrayref (_, _, Pbigarray_unknown, _)
@@ -709,9 +710,8 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Punboxed_float_comp (_, _)
   | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu | Pbytessetu
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
-  | Pmakearray_dynamic _ | Pisint _ | Pisnull | Pisout | Pbintofint _
-  | Pintofbint _ | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _
-  | Pmulbint _
+  | Pisint _ | Pisout | Pisnull | Pbintofint _ | Pintofbint _
+  | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _
   | Pdivbint { is_safe = Unsafe; _ }
   | Pmodbint { is_safe = Unsafe; _ }
   | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _ | Pasrbint _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1184,6 +1184,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
               [K.With_subkind.any_value] ) ]))
   | Pmakearray_dynamic (_lambda_array_kind, _mode), _ ->
     Misc.fatal_error "Lambda_to_flambda_primitives.convert_lprim: unimplemented"
+  | Parrayblit _array_set_kind, _ ->
+    Misc.fatal_error "Lambda_to_flambda_primitives.convert_lprim: unimplemented"
   | Popaque layout, [arg] -> opaque layout arg ~middle_end_only:false
   | Pobj_magic layout, [arg] -> opaque layout arg ~middle_end_only:true
   | Pduprecord (repr, num_fields), [[arg]] ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -336,8 +336,8 @@ let convert_array_kind_to_duplicate_array_kind (kind : L.array_kind) :
     Duplicate_array_kind (Naked_vec128s { length = None })
   | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
     Misc.fatal_error
-      "Lambda_to_flambda_primitives.convert_array_kind_to_duplicate_array_kind\
-       : unimplemented"
+      "Lambda_to_flambda_primitives.convert_array_kind_to_duplicate_array_kind: \
+       unimplemented"
 
 let convert_field_read_semantics (sem : L.field_read_semantics) : Mutability.t =
   match sem with Reads_agree -> Immutable | Reads_vary -> Mutable

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -134,6 +134,9 @@ let convert_array_kind (kind : L.array_kind) : converted_array_kind =
   | Punboxedintarray Pint64 -> Array_kind Naked_int64s
   | Punboxedintarray Pnativeint -> Array_kind Naked_nativeints
   | Punboxedvectorarray Pvec128 -> Array_kind Naked_vec128s
+  | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_kind: unimplemented"
 
 let convert_array_kind_for_length kind : P.Array_kind_for_length.t =
   match convert_array_kind kind with
@@ -189,6 +192,9 @@ let convert_array_ref_kind (kind : L.array_ref_kind) : converted_array_ref_kind
     Array_ref_kind (No_float_array_opt Naked_nativeints)
   | Punboxedvectorarray_ref Pvec128 ->
     Array_ref_kind (No_float_array_opt Naked_vec128s)
+  | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_ref_kind: unimplemented"
 
 let convert_array_ref_kind_to_array_kind (array_ref_kind : Array_ref_kind.t) :
     P.Array_kind.t =
@@ -269,6 +275,9 @@ let convert_array_set_kind (kind : L.array_set_kind) : converted_array_set_kind
     Array_set_kind (No_float_array_opt Naked_nativeints)
   | Punboxedvectorarray_set Pvec128 ->
     Array_set_kind (No_float_array_opt Naked_vec128s)
+  | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_set_kind: unimplemented"
 
 let convert_array_set_kind_to_array_kind (array_set_kind : Array_set_kind.t) :
     P.Array_kind.t =
@@ -325,6 +334,10 @@ let convert_array_kind_to_duplicate_array_kind (kind : L.array_kind) :
     Duplicate_array_kind (Naked_nativeints { length = None })
   | Punboxedvectorarray Pvec128 ->
     Duplicate_array_kind (Naked_vec128s { length = None })
+  | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_array_kind_to_duplicate_array_kind\
+       : unimplemented"
 
 let convert_field_read_semantics (sem : L.field_read_semantics) : Mutability.t =
   match sem with Reads_agree -> Immutable | Reads_vary -> Mutable
@@ -1146,6 +1159,9 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         | Punboxedvectorarray Pvec128 ->
           args
         | Pfloatarray -> List.map unbox_float args
+        | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+          Misc.fatal_error
+            "Lambda_to_flambda_primitives.convert_lprim: unimplemented"
       in
       [Variadic (Make_array (array_kind, mutability, mode), args)]
     | Float_array_opt_dynamic -> (
@@ -1166,6 +1182,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
                   List.map unbox_float args ),
               Variadic (Make_array (Values, mutability, mode), args),
               [K.With_subkind.any_value] ) ]))
+  | Pmakearray_dynamic (_lambda_array_kind, _mode), _ ->
+    Misc.fatal_error "Lambda_to_flambda_primitives.convert_lprim: unimplemented"
   | Popaque layout, [arg] -> opaque layout arg ~middle_end_only:false
   | Pobj_magic layout, [arg] -> opaque layout arg ~middle_end_only:true
   | Pduprecord (repr, num_fields), [[arg]] ->
@@ -2116,13 +2134,15 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       | Parrayrefu
           ( ( Pgenarray_ref _ | Paddrarray_ref | Pintarray_ref
             | Pfloatarray_ref _ | Punboxedfloatarray_ref _
-            | Punboxedintarray_ref _ | Punboxedvectorarray_ref _ ),
+            | Punboxedintarray_ref _ | Punboxedvectorarray_ref _
+            | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ),
             _,
             _ )
       | Parrayrefs
           ( ( Pgenarray_ref _ | Paddrarray_ref | Pintarray_ref
             | Pfloatarray_ref _ | Punboxedfloatarray_ref _
-            | Punboxedintarray_ref _ | Punboxedvectorarray_ref _ ),
+            | Punboxedintarray_ref _ | Punboxedvectorarray_ref _
+            | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ),
             _,
             _ )
       | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _ | Patomic_exchange
@@ -2140,12 +2160,14 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       | Parraysetu
           ( ( Pgenarray_set _ | Paddrarray_set _ | Pintarray_set
             | Pfloatarray_set | Punboxedfloatarray_set _
-            | Punboxedintarray_set _ | Punboxedvectorarray_set _ ),
+            | Punboxedintarray_set _ | Punboxedvectorarray_set _
+            | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ),
             _ )
       | Parraysets
           ( ( Pgenarray_set _ | Paddrarray_set _ | Pintarray_set
             | Pfloatarray_set | Punboxedfloatarray_set _
-            | Punboxedintarray_set _ | Punboxedvectorarray_set _ ),
+            | Punboxedintarray_set _ | Punboxedvectorarray_set _
+            | Pgcscannableproductarray_set _ | Pgcignorableproductarray_set _ ),
             _ )
       | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_f32 _ | Pbytes_set_64 _
       | Pbytes_set_128 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -957,6 +957,8 @@ module With_subkind = struct
       | Parrayval (Punboxedintarray Pint64) -> Unboxed_int64_array
       | Parrayval (Punboxedintarray Pnativeint) -> Unboxed_nativeint_array
       | Parrayval (Punboxedvectorarray Pvec128) -> Unboxed_vec128_array
+      | Parrayval (Pgcscannableproductarray _ | Pgcignorableproductarray _) ->
+        Misc.fatal_errorf "Flambda_kind.from_lambda_value_kind: unimplemented"
     in
     let nullable : Nullable.t =
       match vk.nullable with

--- a/middle_end/flambda2/term_basics/empty_array_kind.ml
+++ b/middle_end/flambda2/term_basics/empty_array_kind.ml
@@ -57,3 +57,5 @@ let of_lambda array_kind =
   | Punboxedintarray Pint64 -> Naked_int64s
   | Punboxedintarray Pnativeint -> Naked_nativeints
   | Punboxedvectorarray Pvec128 -> Naked_vec128s
+  | Pgcscannableproductarray _ | Pgcignorableproductarray _ ->
+    Misc.fatal_errorf "Empty_array_kind.of_lambda: unimplemented"

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -782,13 +782,18 @@ type t3 = #(int * bool) array
 type t4 = #(string * #(float# * bool option)) array
 |}]
 
+(* CR layouts v7.1: The below error is nonsense - an artifact of the fact that
+   we have temporarily gated product arrays to alpha to stage the release. The
+   PR that adds support later in the compiler can allow this test. *)
 let _ = [| #(1,2) |]
 [%%expect{|
 Line 1, characters 8-20:
 1 | let _ = [| #(1,2) |]
             ^^^^^^^^^^^^
-Error: Unboxed products are not yet supported with array primitives.
-       Here, layout value & value was used.
+Error: Non-value layout value & value detected as sort for type #(int * int),
+       but this requires extension layouts_alpha, which is not enabled.
+       If you intended to use this layout, please add this flag to your build file.
+       Otherwise, please report this error to the Jane Street compilers team.
 |}]
 
 let _ = Array.init 3 (fun _ -> #(1,2))
@@ -824,6 +829,10 @@ Lines 1-2, characters 0-18:
 Error: Attribute "[@layout_poly]" can only be used on built-in primitives.
 |}]
 
+(* CR layouts v7.1: The errors in the next two tests are nonsense - an artifact
+   of the fact that we have temporarily gated product arrays to alpha to stage
+   the release. The PR that adds support later in the compiler can allow this
+   test. *)
 external[@layout_poly] array_get : ('a : any) . 'a array -> int -> 'a =
   "%array_safe_get"
 let f x : #(int * int) = array_get x 3
@@ -833,8 +842,10 @@ external array_get : ('a : any). 'a array -> int -> 'a = "%array_safe_get"
 Line 3, characters 25-38:
 3 | let f x : #(int * int) = array_get x 3
                              ^^^^^^^^^^^^^
-Error: Unboxed products are not yet supported with array primitives.
-       Here, layout value & value was used.
+Error: Non-value layout value & value detected as sort for type #(int * int),
+       but this requires extension layouts_alpha, which is not enabled.
+       If you intended to use this layout, please add this flag to your build file.
+       Otherwise, please report this error to the Jane Street compilers team.
 |}]
 
 external[@layout_poly] array_set : ('a : any) . 'a array -> int -> 'a -> unit =
@@ -846,8 +857,10 @@ external array_set : ('a : any). 'a array -> int -> 'a -> unit
 Line 3, characters 10-30:
 3 | let f x = array_set x 3 #(1,2)
               ^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed products are not yet supported with array primitives.
-       Here, layout value & value was used.
+Error: Non-value layout value & value detected as sort for type #(int * int),
+       but this requires extension layouts_alpha, which is not enabled.
+       If you intended to use this layout, please add this flag to your build file.
+       Otherwise, please report this error to the Jane Street compilers team.
 |}]
 
 

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -782,9 +782,8 @@ type t3 = #(int * bool) array
 type t4 = #(string * #(float# * bool option)) array
 |}]
 
-(* CR layouts v7.1: The below error is nonsense - an artifact of the fact that
-   we have temporarily gated product arrays to alpha to stage the release. The
-   PR that adds support later in the compiler can allow this test. *)
+(* CR layouts v7.1: The error below should be improved when we move product
+   arrays to beta. *)
 let _ = [| #(1,2) |]
 [%%expect{|
 Line 1, characters 8-20:
@@ -829,10 +828,8 @@ Lines 1-2, characters 0-18:
 Error: Attribute "[@layout_poly]" can only be used on built-in primitives.
 |}]
 
-(* CR layouts v7.1: The errors in the next two tests are nonsense - an artifact
-   of the fact that we have temporarily gated product arrays to alpha to stage
-   the release. The PR that adds support later in the compiler can allow this
-   test. *)
+(* CR layouts v7.1: The two errors below should be improved when we move product
+   arrays to beta. *)
 external[@layout_poly] array_get : ('a : any) . 'a array -> int -> 'a =
   "%array_safe_get"
 let f x : #(int * int) = array_get x 3

--- a/testsuite/tests/typing-layouts-products/product_array_marshalling.ml
+++ b/testsuite/tests/typing-layouts-products/product_array_marshalling.ml
@@ -1,0 +1,27 @@
+(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ flags = "-extension layouts_alpha";
+ {
+   bytecode;
+ } {
+   ocamlopt_byte_exit_status = "2";
+   setup-ocamlopt.byte-build-env;
+   compiler_reference =
+     "${test_source_directory}/product_array_marshalling.native.reference";
+   ocamlopt.byte;
+   check-ocamlopt.byte-output;
+ }
+*)
+
+(* Here we check that an attempt to marshal an unboxed product array is
+   rejected. *)
+(* CR layouts v7.1: This currently hits a middle end exception in native code.
+   That will be fixed by the follow-on PR that adds tuple array support to the
+   rest of the compiler. This can be moved to beta then. *)
+(* CR layouts v4.0: Except it is is not rejected by bytecode.  See the arrays
+   epic for our plan to fix that. *)
+
+let array = [| #(1, 2); #(3, 4) |]
+
+let _ = Marshal.to_string array []

--- a/testsuite/tests/typing-layouts-products/product_array_marshalling.ml
+++ b/testsuite/tests/typing-layouts-products/product_array_marshalling.ml
@@ -7,10 +7,7 @@
  } {
    ocamlopt_byte_exit_status = "2";
    setup-ocamlopt.byte-build-env;
-   compiler_reference =
-     "${test_source_directory}/product_array_marshalling.native.reference";
    ocamlopt.byte;
-   check-ocamlopt.byte-output;
  }
 *)
 

--- a/testsuite/tests/typing-layouts-products/product_array_marshalling.native.reference
+++ b/testsuite/tests/typing-layouts-products/product_array_marshalling.native.reference
@@ -1,0 +1,37 @@
+>> Fatal error: Flambda_kind.from_lambda_value_kind: unimplemented
+Fatal error: exception Misc.Fatal_error
+Raised at Misc.fatal_errorf.(fun) in file "utils/misc.ml", line 22, characters 14-31
+Called from Flambda2_kinds__Flambda_kind.With_subkind.from_lambda_value_kind in file "middle_end/flambda2/kinds/flambda_kind.ml", line 961, characters 8-78
+Called from Flambda2_from_lambda__Lambda_to_flambda.cps.(fun) in file "middle_end/flambda2/from_lambda/lambda_to_flambda.ml", lines 986-987, characters 20-117
+Called from Flambda2_from_lambda__Closure_conversion_aux.Acc.eval_branch_free_names in file "middle_end/flambda2/from_lambda/closure_conversion_aux.ml", line 667, characters 17-65
+Called from Flambda2_from_lambda__Closure_conversion_aux.Let_cont_with_acc.build_non_recursive in file "middle_end/flambda2/from_lambda/closure_conversion_aux.ml", line 1180, characters 6-44
+Called from Flambda2_from_lambda__Closure_conversion.close_program in file "middle_end/flambda2/from_lambda/closure_conversion.ml", lines 3458-3459, characters 4-124
+Called from Misc.try_finally in file "utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 45, characters 10-56
+Called from Flambda2.lambda_to_cmm.run in file "middle_end/flambda2/flambda2.ml", lines 167-170, characters 6-238
+Called from Misc.try_finally in file "utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 45, characters 10-56
+Called from Asmgen.compile_implementation.(fun) in file "asmcomp/asmgen.ml", line 731, characters 26-69
+Called from Asmgen.compile_unit.(fun) in file "asmcomp/asmgen.ml", line 655, characters 10-16
+Called from Misc.try_finally in file "utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 45, characters 10-56
+Called from Asmgen.compile_unit.(fun) in file "asmcomp/asmgen.ml", lines 653-661, characters 6-382
+Called from Misc.try_finally in file "utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 45, characters 10-56
+Called from Optcompile.compile.(fun) in file "driver/optcompile.ml", lines 44-55, characters 6-523
+Called from Misc.try_finally in file "utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 45, characters 10-56
+Called from Compile_common.implementation.(fun) in file "driver/compile_common.ml", lines 159-161, characters 71-114
+Called from Misc.try_finally in file "utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 45, characters 10-56
+Called from Misc.try_finally in file "utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 45, characters 10-56
+Called from Misc.try_finally in file "utils/misc.ml", line 31, characters 8-15
+Re-raised at Misc.try_finally in file "utils/misc.ml", line 45, characters 10-56
+Called from Compenv.process_action.impl in file "driver/compenv.ml", lines 648-649, characters 4-95
+Called from Stdlib__List.iter in file "list.ml", line 117, characters 12-15
+Called from Compenv.process_deferred_actions in file "driver/compenv.ml", lines 746-747, characters 2-85
+Called from Optmaindriver.main in file "driver/optmaindriver.ml", lines 68-73, characters 6-169
+Re-raised at Location.report_exception.loop in file "parsing/location.ml", line 1085, characters 14-25
+Called from Optmaindriver.main in file "driver/optmaindriver.ml", line 154, characters 4-35
+Called from Flambda_backend_main in file "driver/flambda_backend_main.ml", lines 5-7, characters 7-140

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -1,0 +1,1808 @@
+(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ flags = "-extension layouts_alpha";
+ {
+   expect;
+ }
+*)
+
+(* Basic typing tests. Mainly we are checking that all array primitives reject
+   illegally mixed tuples. *)
+
+(* CR layouts v7.1: The PR with middle-end support for product arrays can move
+   this test to beta. *)
+
+(* CR layouts v7.1: Everywhere this file says "any_non_null" it should instead
+   say any. This is caused by [any] meaning different things alpha and beta - we
+   can fix it when we move this test to beta. *)
+
+(*******************************************************)
+(* Test 1: Some allowed scannable product array types. *)
+type t1 = #(int * bool option) array
+type t2 = #(int * string) array
+type t3 = #(string * int * int option) array
+
+type t4 : immediate & value
+type t4a = t4 array
+type t5 : value & immediate
+type t5a = t5 array
+type t6 : value & immediate & value & immediate
+type t6a = t6 array
+[%%expect{|
+type t1 = #(int * bool option) array
+type t2 = #(int * string) array
+type t3 = #(string * int * int option) array
+type t4 : immediate & value
+type t4a = t4 array
+type t5 : value & immediate
+type t5a = t5 array
+type t6 : value & immediate & value & immediate
+type t6a = t6 array
+|}]
+
+(*******************************************************)
+(* Test 2: Some allowed ignorable product array types. *)
+type t1 = #(int * int) array
+type t2 = #(int * float#) array
+type t3 = #(float# * int * int64# * bool) array
+
+type t4 : immediate & immediate
+type t4a = t4 array
+type t5 : immediate & float64
+type t5a = t5 array
+type t6 : bits64 & immediate & float64 & immediate
+type t6a = t6 array
+[%%expect{|
+type t1 = #(int * int) array
+type t2 = #(int * float#) array
+type t3 = #(float# * int * int64# * bool) array
+type t4 : immediate & immediate
+type t4a = t4 array
+type t5 : immediate & float64
+type t5a = t5 array
+type t6 : bits64 & immediate & float64 & immediate
+type t6a = t6 array
+|}]
+
+(******************************************************************************)
+(* Test 3: Some array types that are allowed even though you can't make them. *)
+type t1 = #(float# * string) array
+type t2 = #(string * int64#) array
+type t3 = #(string * int64# * int) array
+type t4 = #(int * int64# * string) array
+
+type t5 : value & float64
+type t5a = t5 array
+type t6 : bits64 & value
+type t6a = t6 array
+type t7 : value & bits64 & immediate
+type t7a = t7 array
+type t8 : immediate & bits64 & value
+type t8a = t8 array
+
+[%%expect{|
+type t1 = #(float# * string) array
+type t2 = #(string * int64#) array
+type t3 = #(string * int64# * int) array
+type t4 = #(int * int64# * string) array
+type t5 : value & float64
+type t5a = t5 array
+type t6 : bits64 & value
+type t6a = t6 array
+type t7 : value & bits64 & immediate
+type t7a = t7 array
+type t8 : immediate & bits64 & value
+type t8a = t8 array
+|}]
+
+(*****************************)
+(* Test 4: makearray_dynamic *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] make_vect : ('a : any_non_null) . int -> 'a -> 'a array =
+  "%makearray_dynamic"
+
+let f_scannable (x : #(int * float * string) array) = make_vect 42 x
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) = make_vect 42 x
+[%%expect{|
+external make_vect : ('a : any_non_null). int -> 'a -> 'a array
+  = "%makearray_dynamic" [@@layout_poly]
+val f_scannable :
+  #(int * float * string) array -> #(int * float * string) array array =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array ->
+  #(float# * int * int64# * bool) array array = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = make_vect 42 x
+[%%expect{|
+Line 1, characters 10-40:
+1 | let f_bad (x : #(string * float#) array) = make_vect 42 x
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external make_scannable :
+  int -> #(int * float * string) -> #(int * float * string) array =
+  "%makearray_dynamic"
+let make_scannable_app x = make_scannable x
+
+external make_ignorable :
+  int -> #(float# * int * int64# * bool)
+  -> #(float# * int * int64# * bool) array =
+  "%makearray_dynamic"
+let make_ignorable_app x = make_ignorable x
+[%%expect{|
+external make_scannable :
+  int -> #(int * float * string) -> #(int * float * string) array
+  = "%makearray_dynamic"
+val make_scannable_app :
+  int -> #(int * float * string) -> #(int * float * string) array = <fun>
+external make_ignorable :
+  int ->
+  #(float# * int * int64# * bool) -> #(float# * int * int64# * bool) array
+  = "%makearray_dynamic"
+val make_ignorable_app :
+  int ->
+  #(float# * int * int64# * bool) -> #(float# * int * int64# * bool) array =
+  <fun>
+|}]
+
+external make_bad : int -> #(string * float#) -> #(string * float#) array =
+  "%makearray_dynamic"
+let make_bad_app x = make_bad x
+[%%expect{|
+external make_bad : int -> #(string * float#) -> #(string * float#) array
+  = "%makearray_dynamic"
+Line 3, characters 21-29:
+3 | let make_bad_app x = make_bad x
+                         ^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = make_vect 42 x
+[%%expect{|
+Line 1, characters 10-39:
+1 | let f_bad (x : #(int * int32x4#) array) = make_vect 42 x
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external make_ignorable_with_vec :
+  int -> #(int * int32x4#) -> #(int * int32x4#) array = "%makearray_dynamic"
+let make_ignorable_with_vec_app x = make_ignorable_with_vec x
+[%%expect{|
+external make_ignorable_with_vec :
+  int -> #(int * int32x4#) -> #(int * int32x4#) array = "%makearray_dynamic"
+Line 3, characters 36-59:
+3 | let make_ignorable_with_vec_app x = make_ignorable_with_vec x
+                                        ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(************************)
+(* Test 5: array length *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] len : ('a : any_non_null) . 'a array -> int =
+  "%array_length"
+
+let f_scannable (x : #(int * float * string) array) = len x
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) = len x
+[%%expect{|
+external len : ('a : any_non_null). 'a array -> int = "%array_length"
+  [@@layout_poly]
+val f_scannable : #(int * float * string) array -> int = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> int = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = len x
+[%%expect{|
+Line 1, characters 43-48:
+1 | let f_bad (x : #(string * float#) array) = len x
+                                               ^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external len_scannable : #(int * float * string) array -> int = "%array_length"
+let len_scannable_app x = len_scannable x
+
+external len_ignorable : #(float# * int * int64# * bool) array -> int =
+  "%array_length"
+let len_ignorable_app x = len_ignorable x
+[%%expect{|
+external len_scannable : #(int * float * string) array -> int
+  = "%array_length"
+val len_scannable_app : #(int * float * string) array -> int = <fun>
+external len_ignorable : #(float# * int * int64# * bool) array -> int
+  = "%array_length"
+val len_ignorable_app : #(float# * int * int64# * bool) array -> int = <fun>
+|}]
+
+external len_bad : #(string * float#) array -> int = "%array_length"
+let len_bad_app x = len_bad x
+[%%expect{|
+external len_bad : #(string * float#) array -> int = "%array_length"
+Line 2, characters 20-29:
+2 | let len_bad_app x = len_bad x
+                        ^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = len x
+[%%expect{|
+Line 1, characters 42-47:
+1 | let f_bad (x : #(int * int32x4#) array) = len x
+                                              ^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external len_ignorable_with_vec :
+  #(int * int32x4#) array -> int = "%array_length"
+let len_ignorable_with_vec_app x = len_ignorable_with_vec x
+[%%expect{|
+external len_ignorable_with_vec : #(int * int32x4#) array -> int
+  = "%array_length"
+Line 3, characters 35-59:
+3 | let len_ignorable_with_vec_app x = len_ignorable_with_vec x
+                                       ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(********************)
+(* Test 6: safe get *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int -> 'a =
+  "%array_safe_get"
+
+let f_scannable (x : #(int * float * string) array) = get x 42
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x 42
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int -> 'a = "%array_safe_get"
+  [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x 42
+[%%expect{|
+Line 1, characters 43-51:
+1 | let f_bad (x : #(string * float#) array) = get x 42
+                                               ^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) =
+  "%array_safe_get"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int
+  -> #(float# * int * int64# * bool) =
+  "%array_safe_get"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int -> #(int * float * string)
+  = "%array_safe_get"
+val get_scannable_app :
+  #(int * float * string) array -> int -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) = "%array_safe_get"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int -> #(string * float#) =
+  "%array_safe_get"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int -> #(string * float#)
+  = "%array_safe_get"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x 42
+[%%expect{|
+Line 1, characters 42-50:
+1 | let f_bad (x : #(int * int32x4#) array) = get x 42
+                                              ^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) = "%array_safe_get"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) = "%array_safe_get"
+Line 3, characters 37-63:
+3 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(********************)
+(* Test 7: safe set *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> int -> 'a -> unit = "%array_safe_set"
+
+let f_scannable (x : #(int * float * string) array) = set x 42 #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x 42 #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int -> 'a -> unit
+  = "%array_safe_set" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-64:
+1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit =
+  "%array_safe_set"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_safe_set"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit
+  = "%array_safe_set"
+val set_scannable_app :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) -> unit = "%array_safe_set"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int -> #(string * float#) -> unit =
+  "%array_safe_set"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> int -> #(string * float#) -> unit
+  = "%array_safe_set"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
+[%%expect{|
+Line 1, characters 44-60:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
+                                                ^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) -> unit =
+  "%array_safe_set"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) -> unit
+  = "%array_safe_set"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(**********************)
+(* Test 8: unsafe get *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int -> 'a =
+  "%array_unsafe_get"
+
+let f_scannable (x : #(int * float * string) array) = get x 42
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x 42
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int -> 'a
+  = "%array_unsafe_get" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x 42
+[%%expect{|
+Line 1, characters 43-51:
+1 | let f_bad (x : #(string * float#) array) = get x 42
+                                               ^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) =
+  "%array_unsafe_get"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int
+  -> #(float# * int * int64# * bool) =
+  "%array_unsafe_get"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int -> #(int * float * string)
+  = "%array_unsafe_get"
+val get_scannable_app :
+  #(int * float * string) array -> int -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) = "%array_unsafe_get"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int -> #(string * float#) =
+  "%array_unsafe_get"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int -> #(string * float#)
+  = "%array_unsafe_get"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x 42
+[%%expect{|
+Line 1, characters 42-50:
+1 | let f_bad (x : #(int * int32x4#) array) = get x 42
+                                              ^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) =
+  "%array_unsafe_get"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) = "%array_unsafe_get"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(**********************)
+(* Test 9: unsafe set *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+
+let f_scannable (x : #(int * float * string) array) = set x 42 #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x 42 #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int -> 'a -> unit
+  = "%array_unsafe_set" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-64:
+1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit =
+  "%array_unsafe_set"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_unsafe_set"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit
+  = "%array_unsafe_set"
+val set_scannable_app :
+  #(int * float * string) array -> int -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) -> unit = "%array_unsafe_set"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int -> #(string * float#) -> unit =
+  "%array_unsafe_set"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> int -> #(string * float#) -> unit
+  = "%array_unsafe_set"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
+[%%expect{|
+Line 1, characters 44-60:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
+                                                ^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) -> unit =
+  "%array_unsafe_set"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int -> #(int * int32x4#) -> unit
+  = "%array_unsafe_set"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(***************************************)
+(* Test 10: safe get indexed by int64# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int64# -> 'a =
+  "%array_safe_get_indexed_by_int64#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42L
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42L
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int64# -> 'a
+  = "%array_safe_get_indexed_by_int64#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42L
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42L
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) =
+  "%array_safe_get_indexed_by_int64#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int64#
+  -> #(float# * int * int64# * bool) =
+  "%array_safe_get_indexed_by_int64#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string)
+  = "%array_safe_get_indexed_by_int64#"
+val get_scannable_app :
+  #(int * float * string) array -> int64# -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool)
+  = "%array_safe_get_indexed_by_int64#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int64# -> #(string * float#) =
+  "%array_safe_get_indexed_by_int64#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int64# -> #(string * float#)
+  = "%array_safe_get_indexed_by_int64#"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42L
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42L
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) =
+  "%array_safe_get_indexed_by_int64#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#)
+  = "%array_safe_get_indexed_by_int64#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(***************************************)
+(* Test 11: safe set indexed by int64# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> int64# -> 'a -> unit =
+  "%array_safe_set_indexed_by_int64#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42L #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42L #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int64# -> 'a -> unit
+  = "%array_safe_set_indexed_by_int64#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int64#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit
+  = "%array_safe_set_indexed_by_int64#"
+val set_scannable_app :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) -> unit
+  = "%array_safe_set_indexed_by_int64#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int64# -> #(string * float#) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> int64# -> #(string * float#) -> unit
+  = "%array_safe_set_indexed_by_int64#"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) -> unit
+  = "%array_safe_set_indexed_by_int64#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*****************************************)
+(* Test 12: unsafe get indexed by int64# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int64# -> 'a =
+  "%array_unsafe_get_indexed_by_int64#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42L
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42L
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int64# -> 'a
+  = "%array_unsafe_get_indexed_by_int64#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42L
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42L
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) =
+  "%array_unsafe_get_indexed_by_int64#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int64#
+  -> #(float# * int * int64# * bool) =
+  "%array_unsafe_get_indexed_by_int64#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string)
+  = "%array_unsafe_get_indexed_by_int64#"
+val get_scannable_app :
+  #(int * float * string) array -> int64# -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool)
+  = "%array_unsafe_get_indexed_by_int64#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int64# -> #(string * float#) =
+  "%array_unsafe_get_indexed_by_int64#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int64# -> #(string * float#)
+  = "%array_unsafe_get_indexed_by_int64#"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42L
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42L
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) =
+  "%array_unsafe_get_indexed_by_int64#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#)
+  = "%array_unsafe_get_indexed_by_int64#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*****************************************)
+(* Test 13: unsafe set indexed by int64# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set : ('a : any_non_null) . 'a array -> int64# -> 'a -> unit =
+  "%array_unsafe_set_indexed_by_int64#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42L #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42L #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int64# -> 'a -> unit
+  = "%array_unsafe_set_indexed_by_int64#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit =
+  "%array_unsafe_set_indexed_by_int64#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int64#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_unsafe_set_indexed_by_int64#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit
+  = "%array_unsafe_set_indexed_by_int64#"
+val set_scannable_app :
+  #(int * float * string) array -> int64# -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) -> unit
+  = "%array_unsafe_set_indexed_by_int64#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int64# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int64# -> #(string * float#) -> unit =
+  "%array_unsafe_set_indexed_by_int64#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> int64# -> #(string * float#) -> unit
+  = "%array_unsafe_set_indexed_by_int64#"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) -> unit =
+  "%array_unsafe_set_indexed_by_int64#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int64# -> #(int * int32x4#) -> unit
+  = "%array_unsafe_set_indexed_by_int64#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(***************************************)
+(* Test 14: safe get indexed by int32# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int32# -> 'a =
+  "%array_safe_get_indexed_by_int32#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42l
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42l
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int32# -> 'a
+  = "%array_safe_get_indexed_by_int32#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42l
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42l
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) =
+  "%array_safe_get_indexed_by_int32#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int32#
+  -> #(float# * int * int64# * bool) =
+  "%array_safe_get_indexed_by_int32#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string)
+  = "%array_safe_get_indexed_by_int32#"
+val get_scannable_app :
+  #(int * float * string) array -> int32# -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool)
+  = "%array_safe_get_indexed_by_int32#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int32# -> #(string * float#) =
+  "%array_safe_get_indexed_by_int32#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int32# -> #(string * float#)
+  = "%array_safe_get_indexed_by_int32#"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42l
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42l
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) =
+  "%array_safe_get_indexed_by_int32#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#)
+  = "%array_safe_get_indexed_by_int32#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(***************************************)
+(* Test 15: safe set indexed by int32# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> int32# -> 'a -> unit =
+  "%array_safe_set_indexed_by_int32#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42l #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42l #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int32# -> 'a -> unit
+  = "%array_safe_set_indexed_by_int32#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit =
+  "%array_safe_set_indexed_by_int32#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int32#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_safe_set_indexed_by_int32#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit
+  = "%array_safe_set_indexed_by_int32#"
+val set_scannable_app :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) -> unit
+  = "%array_safe_set_indexed_by_int32#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int32# -> #(string * float#) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+Line 2, characters 2-66:
+2 |   #(string * float#) array -> int32# -> #(string * float#) -> unit =
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [%array_safe_set_indexed_by_int64#] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) -> unit =
+  "%array_safe_set_indexed_by_int32#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) -> unit
+  = "%array_safe_set_indexed_by_int32#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*****************************************)
+(* Test 16: unsafe get indexed by int32# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get : ('a : any_non_null) . 'a array -> int32# -> 'a =
+  "%array_unsafe_get_indexed_by_int32#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42l
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42l
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> int32# -> 'a
+  = "%array_unsafe_get_indexed_by_int32#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42l
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42l
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) =
+  "%array_unsafe_get_indexed_by_int32#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> int32#
+  -> #(float# * int * int64# * bool) =
+  "%array_unsafe_get_indexed_by_int32#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string)
+  = "%array_unsafe_get_indexed_by_int32#"
+val get_scannable_app :
+  #(int * float * string) array -> int32# -> #(int * float * string) = <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool)
+  = "%array_unsafe_get_indexed_by_int32#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad : #(string * float#) array -> int32# -> #(string * float#) =
+  "%array_unsafe_get_indexed_by_int32#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad : #(string * float#) array -> int32# -> #(string * float#)
+  = "%array_unsafe_get_indexed_by_int32#"
+Line 3, characters 22-33:
+3 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42l
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42l
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) =
+  "%array_unsafe_get_indexed_by_int32#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#)
+  = "%array_unsafe_get_indexed_by_int32#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*****************************************)
+(* Test 17: unsafe set indexed by int32# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> int32# -> 'a -> unit =
+  "%array_unsafe_set_indexed_by_int32#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42l #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42l #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> int32# -> 'a -> unit
+  = "%array_unsafe_set_indexed_by_int32#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit =
+  "%array_unsafe_set_indexed_by_int32#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> int32#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_unsafe_set_indexed_by_int32#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit
+  = "%array_unsafe_set_indexed_by_int32#"
+val set_scannable_app :
+  #(int * float * string) array -> int32# -> #(int * float * string) -> unit =
+  <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) -> unit
+  = "%array_unsafe_set_indexed_by_int32#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  int32# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> int32# -> #(string * float#) -> unit =
+  "%array_unsafe_set_indexed_by_int32#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> int32# -> #(string * float#) -> unit
+  = "%array_unsafe_set_indexed_by_int32#"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) -> unit =
+  "%array_unsafe_set_indexed_by_int32#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> int32# -> #(int * int32x4#) -> unit
+  = "%array_unsafe_set_indexed_by_int32#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*******************************************)
+(* Test 18: safe get indexed by nativeint# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get :
+  ('a : any_non_null) . 'a array -> nativeint# -> 'a =
+  "%array_safe_get_indexed_by_nativeint#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42n
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42n
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> nativeint# -> 'a
+  = "%array_safe_get_indexed_by_nativeint#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42n
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42n
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string) =
+  "%array_safe_get_indexed_by_nativeint#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> nativeint#
+  -> #(float# * int * int64# * bool) =
+  "%array_safe_get_indexed_by_nativeint#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string)
+  = "%array_safe_get_indexed_by_nativeint#"
+val get_scannable_app :
+  #(int * float * string) array -> nativeint# -> #(int * float * string) =
+  <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool)
+  = "%array_safe_get_indexed_by_nativeint#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#) =
+  "%array_safe_get_indexed_by_nativeint#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#)
+  = "%array_safe_get_indexed_by_nativeint#"
+Line 4, characters 22-33:
+4 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42n
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42n
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) =
+  "%array_safe_get_indexed_by_nativeint#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#)
+  = "%array_safe_get_indexed_by_nativeint#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*******************************************)
+(* Test 19: safe set indexed by nativeint# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> nativeint# -> 'a -> unit =
+  "%array_safe_set_indexed_by_nativeint#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42n #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42n #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> nativeint# -> 'a -> unit
+  = "%array_safe_set_indexed_by_nativeint#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string)
+  -> unit =
+  "%array_safe_set_indexed_by_nativeint#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> nativeint#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_safe_set_indexed_by_nativeint#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array ->
+  nativeint# -> #(int * float * string) -> unit
+  = "%array_safe_set_indexed_by_nativeint#"
+val set_scannable_app :
+  #(int * float * string) array ->
+  nativeint# -> #(int * float * string) -> unit = <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) -> unit
+  = "%array_safe_set_indexed_by_nativeint#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#) -> unit =
+  "%array_safe_set_indexed_by_int64#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+Line 2, characters 2-70:
+2 |   #(string * float#) array -> nativeint# -> #(string * float#) -> unit =
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The primitive [%array_safe_set_indexed_by_int64#] is used in an invalid declaration.
+       The declaration contains argument/return types with the wrong layout.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) -> unit =
+  "%array_safe_set_indexed_by_nativeint#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) -> unit
+  = "%array_safe_set_indexed_by_nativeint#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*********************************************)
+(* Test 20: unsafe get indexed by nativeint# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] get :
+  ('a : any_non_null) . 'a array -> nativeint# -> 'a =
+  "%array_unsafe_get_indexed_by_nativeint#"
+
+let f_scannable (x : #(int * float * string) array) = get x #42n
+let f_ignorable (x : #(float# * int * int64# * bool) array) = get x #42n
+[%%expect{|
+external get : ('a : any_non_null). 'a array -> nativeint# -> 'a
+  = "%array_unsafe_get_indexed_by_nativeint#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> #(int * float * string) =
+  <fun>
+val f_ignorable :
+  #(float# * int * int64# * bool) array -> #(float# * int * int64# * bool) =
+  <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = get x #42n
+[%%expect{|
+Line 1, characters 43-53:
+1 | let f_bad (x : #(string * float#) array) = get x #42n
+                                               ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external get_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string) =
+  "%array_unsafe_get_indexed_by_nativeint#"
+let get_scannable_app a i = get_scannable a i
+
+external get_ignorable :
+  #(float# * int * int64# * bool) array -> nativeint#
+  -> #(float# * int * int64# * bool) =
+  "%array_unsafe_get_indexed_by_nativeint#"
+let get_ignorable_app a i = get_ignorable a i
+[%%expect{|
+external get_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string)
+  = "%array_unsafe_get_indexed_by_nativeint#"
+val get_scannable_app :
+  #(int * float * string) array -> nativeint# -> #(int * float * string) =
+  <fun>
+external get_ignorable :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool)
+  = "%array_unsafe_get_indexed_by_nativeint#"
+val get_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) = <fun>
+|}]
+
+external get_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#) =
+  "%array_unsafe_get_indexed_by_nativeint#"
+let get_bad_app a i = get_bad a i
+[%%expect{|
+external get_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#)
+  = "%array_unsafe_get_indexed_by_nativeint#"
+Line 4, characters 22-33:
+4 | let get_bad_app a i = get_bad a i
+                          ^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) = get x #42n
+[%%expect{|
+Line 1, characters 42-52:
+1 | let f_bad (x : #(int * int32x4#) array) = get x #42n
+                                              ^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) =
+  "%array_unsafe_get_indexed_by_nativeint#"
+let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+[%%expect{|
+external get_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#)
+  = "%array_unsafe_get_indexed_by_nativeint#"
+Line 4, characters 37-63:
+4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+(*********************************************)
+(* Test 21: unsafe set indexed by nativeint# *)
+
+(* An array poly version works at valid product layouts. *)
+external[@layout_poly] set :
+  ('a : any_non_null) . 'a array -> nativeint# -> 'a -> unit =
+  "%array_unsafe_set_indexed_by_nativeint#"
+
+let f_scannable (x : #(int * float * string) array) = set x #42n #(1, 2.0, "3")
+
+let f_ignorable (x : #(float# * int * int64# * bool) array) =
+  set x #42n #(#1.0, 2, #3L, true)
+[%%expect{|
+external set : ('a : any_non_null). 'a array -> nativeint# -> 'a -> unit
+  = "%array_unsafe_set_indexed_by_nativeint#" [@@layout_poly]
+val f_scannable : #(int * float * string) array -> unit = <fun>
+val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
+|}]
+
+(* But not on the bad ones. *)
+let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
+[%%expect{|
+Line 1, characters 43-66:
+1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
+                                               ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* And similarly if we specialize it at declaration time. *)
+external set_scannable :
+  #(int * float * string) array -> nativeint# -> #(int * float * string)
+  -> unit =
+  "%array_unsafe_set_indexed_by_nativeint#"
+let set_scannable_app a i x = set_scannable a i x
+
+external set_ignorable :
+  #(float# * int * int64# * bool) array -> nativeint#
+  -> #(float# * int * int64# * bool) -> unit =
+  "%array_unsafe_set_indexed_by_nativeint#"
+let set_ignorable_app a i x = set_ignorable a i x
+[%%expect{|
+external set_scannable :
+  #(int * float * string) array ->
+  nativeint# -> #(int * float * string) -> unit
+  = "%array_unsafe_set_indexed_by_nativeint#"
+val set_scannable_app :
+  #(int * float * string) array ->
+  nativeint# -> #(int * float * string) -> unit = <fun>
+external set_ignorable :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) -> unit
+  = "%array_unsafe_set_indexed_by_nativeint#"
+val set_ignorable_app :
+  #(float# * int * int64# * bool) array ->
+  nativeint# -> #(float# * int * int64# * bool) -> unit = <fun>
+|}]
+
+external set_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#) -> unit =
+  "%array_unsafe_set_indexed_by_nativeint#"
+let set_bad_app a i x = set_bad a i x
+[%%expect{|
+external set_bad :
+  #(string * float#) array -> nativeint# -> #(string * float#) -> unit
+  = "%array_unsafe_set_indexed_by_nativeint#"
+Line 4, characters 24-37:
+4 | let set_bad_app a i x = set_bad a i x
+                            ^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* Unboxed vectors are also rejected. *)
+let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
+[%%expect{|
+Line 1, characters 44-62:
+1 | let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
+                                                ^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]
+
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) -> unit =
+  "%array_unsafe_set_indexed_by_nativeint#"
+let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+[%%expect{|
+external set_ignorable_with_vec :
+  #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) -> unit
+  = "%array_unsafe_set_indexed_by_nativeint#"
+Line 4, characters 39-73:
+4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unboxed vector types are not yet supported in arrays of unboxed
+       products.
+|}]

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -2028,6 +2028,9 @@ Error: This expression has type "#(string * a * bool option) array"
 (****************************************************)
 (* Test 25: literal expressions have the same rules *)
 
+(* CR layouts v7.1: Make sure literals are also adequately tested by the middle-
+   and back-ends when that support arrives. *)
+
 let f_scannable_literal (type a : value mod external_)
       (x : int) (y : a) (z : bool option) = [| #(x, y, z) |]
 let f_scannable_empty_literal (type a : value mod external_)

--- a/testsuite/tests/typing-layouts-products/product_iarrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_iarrays.ml
@@ -1,0 +1,446 @@
+(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ flags = "-extension layouts_alpha";
+ {
+   expect;
+ }
+*)
+
+(* This test checks that you get an error if you attempts to manipulate iarrays
+   of unboxed products are rejected. *)
+(* CR layouts v7.1: Support iarrays of unboxed products. *)
+
+
+(* makearray_dynamic *)
+external[@layout_poly] make_vect : ('a : any_non_null) . int -> 'a -> 'a iarray
+  = "%makearray_dynamic"
+
+let make_scannable (x : #(int * string)) = make_vect 42 x
+[%%expect{|
+external make_vect : ('a : any_non_null). int -> 'a -> 'a iarray
+  = "%makearray_dynamic" [@@layout_poly]
+Line 4, characters 43-57:
+4 | let make_scannable (x : #(int * string)) = make_vect 42 x
+                                               ^^^^^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let make_ignorable (x : #(int * float#)) = make_vect 42 x
+[%%expect{|
+Line 1, characters 43-57:
+1 | let make_ignorable (x : #(int * float#)) = make_vect 42 x
+                                               ^^^^^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let make_bad (x : #(string * float#)) = make_vect 42 x
+
+[%%expect{|
+Line 1, characters 40-54:
+1 | let make_bad (x : #(string * float#)) = make_vect 42 x
+                                            ^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* array length *)
+external[@layout_poly] len : ('a : any_non_null) . 'a iarray -> int =
+  "%array_length"
+
+let length_scannable (x : #(int * string) iarray) = len x
+[%%expect{|
+external len : ('a : any_non_null). 'a iarray -> int = "%array_length"
+  [@@layout_poly]
+Line 4, characters 52-57:
+4 | let length_scannable (x : #(int * string) iarray) = len x
+                                                        ^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let length_ignorable (x : #(int * float#) iarray) = len x
+[%%expect{|
+Line 1, characters 52-57:
+1 | let length_ignorable (x : #(int * float#) iarray) = len x
+                                                        ^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let length_bad (x : #(string * float#) iarray) = len x
+[%%expect{|
+Line 1, characters 49-54:
+1 | let length_bad (x : #(string * float#) iarray) = len x
+                                                     ^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* safe get *)
+external[@layout_poly] get : ('a : any_non_null) . 'a iarray -> int -> 'a =
+  "%array_safe_get"
+
+let get_scannable (x : #(int * string) iarray) = get x 42
+[%%expect{|
+external get : ('a : any_non_null). 'a iarray -> int -> 'a
+  = "%array_safe_get" [@@layout_poly]
+Line 4, characters 49-57:
+4 | let get_scannable (x : #(int * string) iarray) = get x 42
+                                                     ^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_ignorable (x : #(int * float#) iarray) = get x 42
+[%%expect{|
+Line 1, characters 49-57:
+1 | let get_ignorable (x : #(int * float#) iarray) = get x 42
+                                                     ^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_bad (x : #(string * float#) iarray) = get x 42
+[%%expect{|
+Line 1, characters 46-54:
+1 | let get_bad (x : #(string * float#) iarray) = get x 42
+                                                  ^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* unsafe get *)
+external[@layout_poly] get : ('a : any_non_null) . 'a iarray -> int -> 'a =
+  "%array_unsafe_get"
+
+let get_scannable (x : #(int * string) iarray) = get x 42
+[%%expect{|
+external get : ('a : any_non_null). 'a iarray -> int -> 'a
+  = "%array_unsafe_get" [@@layout_poly]
+Line 4, characters 49-57:
+4 | let get_scannable (x : #(int * string) iarray) = get x 42
+                                                     ^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_ignorable (x : #(int * float#) iarray) = get x 42
+[%%expect{|
+Line 1, characters 49-57:
+1 | let get_ignorable (x : #(int * float#) iarray) = get x 42
+                                                     ^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_bad (x : #(string * float#) iarray) = get x 42
+[%%expect{|
+Line 1, characters 46-54:
+1 | let get_bad (x : #(string * float#) iarray) = get x 42
+                                                  ^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* safe get indexed by int64# *)
+external[@layout_poly] get : ('a : any_non_null) . 'a iarray -> int64# -> 'a =
+  "%array_safe_get_indexed_by_int64#"
+
+let get_scannable (x : #(int * string) iarray) = get x #42L
+[%%expect{|
+external get : ('a : any_non_null). 'a iarray -> int64# -> 'a
+  = "%array_safe_get_indexed_by_int64#" [@@layout_poly]
+Line 4, characters 49-59:
+4 | let get_scannable (x : #(int * string) iarray) = get x #42L
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_ignorable (x : #(int * float#) iarray) = get x #42L
+[%%expect{|
+Line 1, characters 49-59:
+1 | let get_ignorable (x : #(int * float#) iarray) = get x #42L
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_bad (x : #(string * float#) iarray) = get x #42L
+[%%expect{|
+Line 1, characters 46-56:
+1 | let get_bad (x : #(string * float#) iarray) = get x #42L
+                                                  ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* unsafe get indexed by int64# *)
+external[@layout_poly] get : ('a : any_non_null) . 'a iarray -> int64# -> 'a =
+  "%array_unsafe_get_indexed_by_int64#"
+
+let get_scannable (x : #(int * string) iarray) = get x #42L
+[%%expect{|
+external get : ('a : any_non_null). 'a iarray -> int64# -> 'a
+  = "%array_unsafe_get_indexed_by_int64#" [@@layout_poly]
+Line 4, characters 49-59:
+4 | let get_scannable (x : #(int * string) iarray) = get x #42L
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_ignorable (x : #(int * float#) iarray) = get x #42L
+[%%expect{|
+Line 1, characters 49-59:
+1 | let get_ignorable (x : #(int * float#) iarray) = get x #42L
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_bad (x : #(string * float#) iarray) = get x #42L
+[%%expect{|
+Line 1, characters 46-56:
+1 | let get_bad (x : #(string * float#) iarray) = get x #42L
+                                                  ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* safe get indexed by int32# *)
+external[@layout_poly] get : ('a : any_non_null) . 'a iarray -> int32# -> 'a =
+  "%array_safe_get_indexed_by_int32#"
+
+let get_scannable (x : #(int * string) iarray) = get x #42l
+[%%expect{|
+external get : ('a : any_non_null). 'a iarray -> int32# -> 'a
+  = "%array_safe_get_indexed_by_int32#" [@@layout_poly]
+Line 4, characters 49-59:
+4 | let get_scannable (x : #(int * string) iarray) = get x #42l
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_ignorable (x : #(int * float#) iarray) = get x #42l
+[%%expect{|
+Line 1, characters 49-59:
+1 | let get_ignorable (x : #(int * float#) iarray) = get x #42l
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_bad (x : #(string * float#) iarray) = get x #42l
+[%%expect{|
+Line 1, characters 46-56:
+1 | let get_bad (x : #(string * float#) iarray) = get x #42l
+                                                  ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* unsafe get indexed by int32# *)
+external[@layout_poly] get : ('a : any_non_null) . 'a iarray -> int32# -> 'a =
+  "%array_unsafe_get_indexed_by_int32#"
+
+let get_scannable (x : #(int * string) iarray) = get x #42l
+[%%expect{|
+external get : ('a : any_non_null). 'a iarray -> int32# -> 'a
+  = "%array_unsafe_get_indexed_by_int32#" [@@layout_poly]
+Line 4, characters 49-59:
+4 | let get_scannable (x : #(int * string) iarray) = get x #42l
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_ignorable (x : #(int * float#) iarray) = get x #42l
+[%%expect{|
+Line 1, characters 49-59:
+1 | let get_ignorable (x : #(int * float#) iarray) = get x #42l
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_bad (x : #(string * float#) iarray) = get x #42l
+[%%expect{|
+Line 1, characters 46-56:
+1 | let get_bad (x : #(string * float#) iarray) = get x #42l
+                                                  ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* safe get indexed by nativeint# *)
+external[@layout_poly] get :
+  ('a : any_non_null) . 'a iarray -> nativeint# -> 'a =
+  "%array_safe_get_indexed_by_nativeint#"
+
+let get_scannable (x : #(int * string) iarray) = get x #42n
+[%%expect{|
+external get : ('a : any_non_null). 'a iarray -> nativeint# -> 'a
+  = "%array_safe_get_indexed_by_nativeint#" [@@layout_poly]
+Line 5, characters 49-59:
+5 | let get_scannable (x : #(int * string) iarray) = get x #42n
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_ignorable (x : #(int * float#) iarray) = get x #42n
+[%%expect{|
+Line 1, characters 49-59:
+1 | let get_ignorable (x : #(int * float#) iarray) = get x #42n
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_bad (x : #(string * float#) iarray) = get x #42n
+[%%expect{|
+Line 1, characters 46-56:
+1 | let get_bad (x : #(string * float#) iarray) = get x #42n
+                                                  ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* unsafe get indexed by nativeint# *)
+external[@layout_poly] get :
+  ('a : any_non_null) . 'a iarray -> nativeint# -> 'a =
+  "%array_unsafe_get_indexed_by_nativeint#"
+
+let get_scannable (x : #(int * string) iarray) = get x #42n
+[%%expect{|
+external get : ('a : any_non_null). 'a iarray -> nativeint# -> 'a
+  = "%array_unsafe_get_indexed_by_nativeint#" [@@layout_poly]
+Line 5, characters 49-59:
+5 | let get_scannable (x : #(int * string) iarray) = get x #42n
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_ignorable (x : #(int * float#) iarray) = get x #42n
+[%%expect{|
+Line 1, characters 49-59:
+1 | let get_ignorable (x : #(int * float#) iarray) = get x #42n
+                                                     ^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let get_bad (x : #(string * float#) iarray) = get x #42n
+[%%expect{|
+Line 1, characters 46-56:
+1 | let get_bad (x : #(string * float#) iarray) = get x #42n
+                                                  ^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* expression literals *)
+let f_scannable_literal (type a : value mod external_)
+      (x : int) (y : a) (z : bool option) = [: #(x, y, z) :]
+[%%expect{|
+Line 2, characters 44-60:
+2 |       (x : int) (y : a) (z : bool option) = [: #(x, y, z) :]
+                                                ^^^^^^^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let f_scannable_empty_literal (type a : value mod external_)
+  : #(int * a * bool option) iarray = [: :]
+[%%expect{|
+Lines 1-2, characters 30-43:
+1 | ..............................(type a : value mod external_)
+2 |   : #(int * a * bool option) iarray = [: :]
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let f_ignorable_literal (type a : value mod external_)
+      (x : int) (y : a) (z : #(int64# * float#)) = [: #(x, y, z) :]
+[%%expect{|
+Line 2, characters 51-67:
+2 |       (x : int) (y : a) (z : #(int64# * float#)) = [: #(x, y, z) :]
+                                                       ^^^^^^^^^^^^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let f_ignorable_empty_literal (type a : value mod external_)
+  : #(int * a * #(int64# * float#)) iarray = [: :]
+[%%expect{|
+Lines 1-2, characters 30-50:
+1 | ..............................(type a : value mod external_)
+2 |   : #(int * a * #(int64# * float#)) iarray = [: :]
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let f_illegal_literal (type a : value mod external_)
+      (x : float#) (y : a) (z : bool option) = [: #(x, y, z) :]
+[%%expect{|
+Line 2, characters 47-63:
+2 |       (x : float#) (y : a) (z : bool option) = [: #(x, y, z) :]
+                                                   ^^^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+let f_illegal_empty_literal (type a : value mod external_)
+  : #(float# * a * bool option) iarray = [: :]
+[%%expect{|
+Lines 1-2, characters 28-46:
+1 | ............................(type a : value mod external_)
+2 |   : #(float# * a * bool option) iarray = [: :]
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+(* pattern literals *)
+let f_scannable_literal arr : #(bool option * string * int) =
+  match arr with
+  | [: :] -> #(None, "hi", 42)
+  | [: #(x, y, z) :] -> #(z, y, x)
+  | _ -> assert false
+[%%expect{|
+Line 3, characters 4-9:
+3 |   | [: :] -> #(None, "hi", 42)
+        ^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let f_ignorable_literal arr : #(#(int64# * float#) * int32# * int) =
+  match arr with
+  | [: :] -> #(#(#42L, #3.14), #10l, 43)
+  | [: #(x, y, #(z, q)) :] -> #(#(q, z), y, x)
+  | _ -> assert false
+[%%expect{|
+Line 3, characters 4-9:
+3 |   | [: :] -> #(#(#42L, #3.14), #10l, 43)
+        ^^^^^
+Error: Immutable arrays of unboxed products are not yet supported.
+|}]
+
+let f_illegal_literal : #(float# * bool option * int) iarray -> int =
+  function
+  | [: #(a,b,c) :] -> 1
+  | _ -> 0
+[%%expect{|
+Line 3, characters 4-18:
+3 |   | [: #(a,b,c) :] -> 1
+        ^^^^^^^^^^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]
+
+let f_illegal_empty_literal : #(float# * bool option * int) iarray -> int =
+  function
+  | [: :] -> 0
+  | _ -> 1
+[%%expect{|
+Line 3, characters 4-9:
+3 |   | [: :] -> 0
+        ^^^^^
+Error: Unboxed product array elements must be external or contain all gc
+       scannable types. The product type this function is applied at is
+       not external but contains an element of sort float64.
+|}]

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -714,3 +714,26 @@ Error: "[@layout_poly]" on this external declaration has no
        effect. Consider removing it or adding a type
        variable for it to operate on.
 |}]
+
+(***********************************************)
+(* New untested array prims are gated to alpha *)
+
+external[@layout_poly] makearray_dynamic : ('a : any). int -> 'a -> 'a array =
+  "%makearray_dynamic"
+[%%expect{|
+Lines 1-2, characters 0-22:
+1 | external[@layout_poly] makearray_dynamic : ('a : any). int -> 'a -> 'a array =
+2 |   "%makearray_dynamic"
+Error: This construct requires the alpha version of the extension "layouts", which is disabled and cannot be used
+|}]
+
+external[@layout_poly] arrayblit :
+  ('a : any). 'a array -> int -> 'a array -> int -> int -> unit =
+  "%arrayblit"
+[%%expect{|
+Lines 1-3, characters 0-14:
+1 | external[@layout_poly] arrayblit :
+2 |   ('a : any). 'a array -> int -> 'a array -> int -> int -> unit =
+3 |   "%arrayblit"
+Error: This construct requires the alpha version of the extension "layouts", which is disabled and cannot be used
+|}]

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -648,7 +648,7 @@ let prim_has_valid_reprs ~loc prim =
         is (Same_as_ocaml_repr C.word);
         any;
         is (Same_as_ocaml_repr C.value)]
-    | "%make_unboxed_tuple_vect" ->
+    | "%makearray_dynamic" ->
       check [
         is (Same_as_ocaml_repr C.value);
         any;

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -759,6 +759,7 @@ let prim_has_valid_reprs ~loc prim =
 let prim_can_contain_layout_any prim =
   match prim.prim_name with
   | "%array_length"
+  | "%array_blit"
   | "%array_safe_get"
   | "%array_safe_set"
   | "%array_unsafe_get"

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -31,7 +31,8 @@ type error =
   | Not_a_sort of type_expr * Jkind.Violation.t
   | Unsupported_sort of Jkind.Sort.Const.t
   | Unsupported_product_in_lazy of Jkind.Sort.Const.t
-  | Unsupported_product_in_array of Jkind.Sort.Const.t
+  | Unsupported_vector_in_product_array
+  | Mixed_product_array of Jkind.Sort.Const.t
 
 exception Error of Location.t * error
 
@@ -114,23 +115,25 @@ let type_legacy_sort ~why env loc ty =
   | Ok sort -> sort
   | Error err -> raise (Error (loc, Not_a_sort (ty, err)))
 
-type classification =
+(* [classification]s are used for two things: things in arrays, and things in
+   lazys. In the former case, we need detailed information about unboxed
+   products and in the latter it would be wasteful to compute that information,
+   so this type is polymorphic in what it remembers about products. *)
+type 'a classification =
   | Int   (* any immediate type *)
   | Float
   | Unboxed_float of unboxed_float
   | Unboxed_int of unboxed_integer
   | Unboxed_vector of unboxed_vector
   | Lazy
-  | Addr  (* anything except a float or a lazy *)
+  | Addr  (* any value except a float or a lazy *)
   | Any
-  | Product of Jkind.Sort.Const.t list
-  (* CR layouts v7.1: This [Product] case is always an error for now, but soon
-     we will support unboxed products in arrays and it will only sometimes be an
-     error. *)
+  | Product of 'a
 
-(* Classify a ty into a [classification]. Looks through synonyms, using [scrape_ty].
-   Returning [Any] is safe, though may skip some optimizations. *)
-let classify env loc ty sort : classification =
+(* Classify a ty into a [classification]. Looks through synonyms, using
+   [scrape_ty].  Returning [Any] is safe, though may skip some optimizations.
+   See comment on [classification] above to understand [classify_product]. *)
+let classify ~classify_product env loc ty sort : _ classification =
   let ty = scrape_ty env ty in
   match Jkind.(Sort.default_to_value_and_get sort) with
   | Base Value -> begin
@@ -181,30 +184,70 @@ let classify env loc ty sort : classification =
   | Base Word -> Unboxed_int Pnativeint
   | Base Void as c ->
     raise (Error (loc, Unsupported_sort c))
-  | Product c -> Product c
+  | Product c -> Product (classify_product ty c)
+
+let rec scannable_product_array_kind loc sorts =
+  List.map (sort_to_scannable_product_element_kind loc) sorts
+
+and sort_to_scannable_product_element_kind loc (s : Jkind.Sort.Const.t) =
+  (* Unfortunate: this never returns `Pint_scannable`.  Doing so would require
+     this to traverse the type, rather than just the kind, or to add product
+     kinds. *)
+  match s with
+  | Base Value -> Paddr_scannable
+  | Base (Float64 | Float32 | Bits32 | Bits64 | Word | Vec128) as c ->
+    raise (Error (loc, Mixed_product_array c))
+  | Base Void as c ->
+    raise (Error (loc, Unsupported_sort c))
+  | Product sorts -> Pproduct_scannable (scannable_product_array_kind loc sorts)
+
+let rec ignorable_product_array_kind loc sorts =
+  List.map (sort_to_ignorable_product_element_kind loc) sorts
+
+and sort_to_ignorable_product_element_kind loc (s : Jkind.Sort.Const.t) =
+  match s with
+  | Base Value -> Pint_ignorable
+  | Base Float64 -> Punboxedfloat_ignorable Pfloat64
+  | Base Float32 -> Punboxedfloat_ignorable Pfloat32
+  | Base Bits32 -> Punboxedint_ignorable Pint32
+  | Base Bits64 -> Punboxedint_ignorable Pint64
+  | Base Word -> Punboxedint_ignorable Pnativeint
+  | Base Vec128 -> raise (Error (loc, Unsupported_vector_in_product_array))
+  | Base Void as c -> raise (Error (loc, Unsupported_sort c))
+  | Product sorts -> Pproduct_ignorable (ignorable_product_array_kind loc sorts)
+
+let array_kind_of_elt ~elt_sort env loc ty =
+  let elt_sort =
+    match elt_sort with
+    | Some s -> s
+    | None ->
+      type_legacy_sort ~why:Array_element env loc ty
+  in
+  let classify_product ty sorts =
+    if Language_extension.(is_at_least Layouts Alpha) then
+      if is_always_gc_ignorable env ty then
+        Pgcignorableproductarray (ignorable_product_array_kind loc sorts)
+      else
+        Pgcscannableproductarray (scannable_product_array_kind loc sorts)
+    else
+      let sort = Jkind.Sort.of_const (Jkind.Sort.Const.Product sorts) in
+      raise (Error (loc, Sort_without_extension (sort, Alpha, Some ty)))
+  in
+  match classify ~classify_product env loc ty elt_sort with
+  | Any -> if Config.flat_float_array then Pgenarray else Paddrarray
+  | Float -> if Config.flat_float_array then Pfloatarray else Paddrarray
+  | Addr | Lazy -> Paddrarray
+  | Int -> Pintarray
+  | Unboxed_float f -> Punboxedfloatarray f
+  | Unboxed_int i -> Punboxedintarray i
+  | Unboxed_vector v -> Punboxedvectorarray v
+  | Product c -> c
 
 let array_type_kind ~elt_sort env loc ty =
   match scrape_poly env ty with
   | Tconstr(p, [elt_ty], _)
     when Path.same p Predef.path_array || Path.same p Predef.path_iarray ->
-      let elt_sort =
-        match elt_sort with
-        | Some s -> s
-        | None ->
-          type_legacy_sort ~why:Array_element env loc elt_ty
-      in
-      begin match classify env loc elt_ty elt_sort with
-      | Any -> if Config.flat_float_array then Pgenarray else Paddrarray
-      | Float -> if Config.flat_float_array then Pfloatarray else Paddrarray
-      | Addr | Lazy -> Paddrarray
-      | Int -> Pintarray
-      | Unboxed_float f -> Punboxedfloatarray f
-      | Unboxed_int i -> Punboxedintarray i
-      | Unboxed_vector v -> Punboxedvectorarray v
-      | Product cs ->
-        let kind = Jkind.Sort.Const.Product cs in
-        raise (Error (loc, Unsupported_product_in_array kind))
-      end
+      array_kind_of_elt ~elt_sort env loc elt_ty
   | Tconstr(p, [], _) when Path.same p Predef.path_floatarray ->
       Pfloatarray
   | _ ->
@@ -822,7 +865,11 @@ let function_arg_layout env loc sort ty =
     if the value can be represented as a float/forward/lazy *)
 let lazy_val_requires_forward env loc ty =
   let sort = Jkind.Sort.for_lazy_body in
-  match classify env loc ty sort with
+  let classify_product _ sorts =
+    let kind = Jkind.Sort.Const.Product sorts in
+    raise (Error (loc, Unsupported_product_in_lazy kind))
+  in
+  match classify ~classify_product env loc ty sort with
   | Any | Lazy -> true
   (* CR layouts: Fix this when supporting lazy unboxed values.
      Blocks with forward_tag can get scanned by the gc thus can't
@@ -832,9 +879,7 @@ let lazy_val_requires_forward env loc ty =
     Misc.fatal_error "Unboxed value encountered inside lazy expression"
   | Float -> Config.flat_float_array
   | Addr | Int -> false
-  | Product cs ->
-    let kind = Jkind.Sort.Const.Product cs in
-    raise (Error (loc, Unsupported_product_in_lazy kind))
+  | Product _ -> assert false (* because [classify_product] raises *)
 
 (** The compilation of the expression [lazy e] depends on the form of e:
     constants, floats and identifiers are optimized.  The optimization must be
@@ -979,11 +1024,16 @@ let report_error ppf = function
         "Product layout %a detected in [lazy] in [Typeopt.Layout]@ \
          Please report this error to the Jane Street compilers team."
         Jkind.Sort.Const.format const
-  | Unsupported_product_in_array const ->
-    fprintf ppf
-      "Unboxed products are not yet supported with array primitives.@ \
-       Here, layout %a was used."
-      Jkind.Sort.Const.format const
+  | Unsupported_vector_in_product_array ->
+      fprintf ppf
+        "Unboxed vector types are not yet supported in arrays of unboxed@ \
+         products."
+  | Mixed_product_array const ->
+      fprintf ppf
+        "Unboxed product array elements must be external or contain all gc@ \
+         scannable types. The product type this function is applied at is@ \
+         not external but contains an element of sort %a."
+        Jkind.Sort.Const.format const
 
 let () =
   Location.register_error_of_exn

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -29,6 +29,9 @@ val array_type_kind :
   elt_sort:(Jkind.Sort.t option)
   -> Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
 val array_type_mut : Env.t -> Types.type_expr -> Lambda.mutable_flag
+val array_kind_of_elt :
+  elt_sort:(Jkind.Sort.t option)
+  -> Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
 val array_kind :
   Typedtree.expression -> Jkind.Sort.t -> Lambda.array_kind
 val array_pattern_kind :

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -605,7 +605,8 @@ let array_mode exp elt_sort = match Typeopt.array_kind exp elt_sort with
     (* non-generic, non-float arrays act as constructors *)
     Guard
   | Lambda.Punboxedfloatarray _ | Lambda.Punboxedintarray _
-  | Lambda.Punboxedvectorarray _ ->
+  | Lambda.Punboxedvectorarray _
+  | Lambda.Pgcscannableproductarray _ | Lambda.Pgcignorableproductarray _ ->
     Dereference
 
 (* Expression judgment:

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -185,6 +185,19 @@ module Stdlib = struct
       in
       aux l []
 
+    let map2_option f l1 l2 =
+      let rec aux l1 l2 acc =
+        match l1, l2 with
+        | [], [] -> Some (List.rev acc)
+        | x :: xs, y :: ys ->
+          begin match f x y with
+          | None -> None
+          | Some z -> aux xs ys (z :: acc)
+          end
+        | _, _ -> invalid_arg "map2_option"
+      in
+      aux l1 l2 []
+
     let split_at n l =
       let rec aux n acc l =
         if n = 0

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -133,6 +133,8 @@ module Stdlib : sig
     (** [map_option f l] is [some_if_all_elements_are_some (map f l)], but with
         short circuiting. *)
 
+    val map2_option : ('a -> 'b -> 'c option) -> 'a t -> 'b t -> 'c t option
+
     val map2_prefix : ('a -> 'b -> 'c) -> 'a t -> 'b t -> ('c t * 'b t)
     (** [let r1, r2 = map2_prefix f l1 l2]
         If [l1] is of length n and [l2 = h2 @ t2] with h2 of length n,


### PR DESCRIPTION
This adds the front-end bits of support for arrays of unboxed products. In particular:
- It adds two new array kinds - one for arrays of products where everything is GC scannable, and another for arrays of products where everything is GC ignorable.
- It adds a new primitive (which has no native code implementation yet) for creating arrays, `"%makearray_dynamic"`, so named because it is like `makearray` but the size is not statically known.

This is all limited to alpha because there is no middle- or back-end support for these things yet. There are typing tests showing that all the array primitives work on product arrays but reject products that aren't all GC scannable or all GC ignorable.  It doesn't yet add the planned "re-interpret" primitives or "size of". Those will come soon, but there is still discussion about the exact design.

Note that the new array creation primitive isn't specific to products - it can be used to create arrays containing data of any representable layout. Our plan is to eventually replace the per-layout C functions with this primitive.

There are no dynamic tests here. Tests will come in the follow-up PR that adds middle- and back-end support, which will also move these to beta. I actually think the bytecode implementation here works, and have started testing it over in [this branch](https://github.com/ccasin/flambda-backend/tree/tuple-arrays-frontend-test). But I can't easily include those tests here because the fact that "any" is interpreted differently in alpha makes it impossible to use our generic unboxed array testing framework while these arrays are in alpha.

**Review:** @goldfirere.
- Note there are three commits.  The first two are just #3138, so only the last needs review here.
- The odd looking diff in `typing/primitive.ml` is a result of me accidentally including the typing rule for the new primitive prematurely in #3092, but with the name we planned when we thought it would only work with product arrays.