### PR TITLE
Zero alloc: new payload "assume_unless_opt"

### DIFF
--- a/flambda-backend/tests/backend/zero_alloc_checker/dune
+++ b/flambda-backend/tests/backend/zero_alloc_checker/dune
@@ -51,6 +51,14 @@
  (alias  runtest)
  (action (copy fail29_opt.mli fail29_opt2.mli )))
 
+(rule
+ (alias  runtest)
+ (action (copy test_assume_unless_opt_sig.ml test_assume_unless_opt_sig2.ml  )))
+
+(rule
+ (alias  runtest)
+ (action (copy test_assume_unless_opt_on_call.ml test_assume_unless_opt_on_call2.ml  )))
+
 ;; Tests whose outputs differ depending on stack_allocation configuration flag.
 ;; This condition is not expressible in "enable_if" clause
 ;; because dune does not support %{config:stack_allocation} yet.

--- a/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
+++ b/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
@@ -1311,7 +1311,7 @@
  (action (diff fail29_opt2.output fail29_opt2.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_assume_unless_opt.output.corrected)
  (deps (:ml test_assume_unless_opt.ml) filter.sh)
  (action
@@ -1325,18 +1325,18 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_unless_opt.output test_assume_unless_opt.output.corrected)
  (action (diff test_assume_unless_opt.output test_assume_unless_opt.output.corrected)))
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_unless_opt.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_assume_unless_opt_sig.output.corrected)
  (deps (:ml test_assume_unless_opt_sig.ml) filter.sh)
  (action
@@ -1350,12 +1350,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_unless_opt_sig.output test_assume_unless_opt_sig.output.corrected)
  (action (diff test_assume_unless_opt_sig.output test_assume_unless_opt_sig.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_assume_unless_opt_sig2.output.corrected)
  (deps (:ml test_assume_unless_opt_sig2.ml) filter.sh)
  (action
@@ -1369,12 +1369,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_unless_opt_sig2.output test_assume_unless_opt_sig2.output.corrected)
  (action (diff test_assume_unless_opt_sig2.output test_assume_unless_opt_sig2.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_assume_unless_opt_on_call.output.corrected)
  (deps (:ml test_assume_unless_opt_on_call.ml) filter.sh)
  (action
@@ -1388,12 +1388,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_unless_opt_on_call.output test_assume_unless_opt_on_call.output.corrected)
  (action (diff test_assume_unless_opt_on_call.output test_assume_unless_opt_on_call.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_assume_unless_opt_on_call2.output.corrected)
  (deps (:ml test_assume_unless_opt_on_call2.ml) filter.sh)
  (action
@@ -1407,6 +1407,6 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_unless_opt_on_call2.output test_assume_unless_opt_on_call2.output.corrected)
  (action (diff test_assume_unless_opt_on_call2.output test_assume_unless_opt_on_call2.output.corrected)))

--- a/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
+++ b/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
@@ -1309,3 +1309,104 @@
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail29_opt2.output fail29_opt2.output.corrected)
  (action (diff fail29_opt2.output fail29_opt2.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_assume_unless_opt.output.corrected)
+ (deps (:ml test_assume_unless_opt.ml) filter.sh)
+ (action
+   (with-outputs-to test_assume_unless_opt.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check all -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_unless_opt.output test_assume_unless_opt.output.corrected)
+ (action (diff test_assume_unless_opt.output test_assume_unless_opt.output.corrected)))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_unless_opt.ml)
+ (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_assume_unless_opt_sig.output.corrected)
+ (deps (:ml test_assume_unless_opt_sig.ml) filter.sh)
+ (action
+   (with-outputs-to test_assume_unless_opt_sig.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 0
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_unless_opt_sig.output test_assume_unless_opt_sig.output.corrected)
+ (action (diff test_assume_unless_opt_sig.output test_assume_unless_opt_sig.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_assume_unless_opt_sig2.output.corrected)
+ (deps (:ml test_assume_unless_opt_sig2.ml) filter.sh)
+ (action
+   (with-outputs-to test_assume_unless_opt_sig2.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check all -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_unless_opt_sig2.output test_assume_unless_opt_sig2.output.corrected)
+ (action (diff test_assume_unless_opt_sig2.output test_assume_unless_opt_sig2.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_assume_unless_opt_on_call.output.corrected)
+ (deps (:ml test_assume_unless_opt_on_call.ml) filter.sh)
+ (action
+   (with-outputs-to test_assume_unless_opt_on_call.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check default -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_unless_opt_on_call.output test_assume_unless_opt_on_call.output.corrected)
+ (action (diff test_assume_unless_opt_on_call.output test_assume_unless_opt_on_call.output.corrected)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (targets test_assume_unless_opt_on_call2.output.corrected)
+ (deps (:ml test_assume_unless_opt_on_call2.ml) filter.sh)
+ (action
+   (with-outputs-to test_assume_unless_opt_on_call2.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-check all -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (deps test_assume_unless_opt_on_call2.output test_assume_unless_opt_on_call2.output.corrected)
+ (action (diff test_assume_unless_opt_on_call2.output test_assume_unless_opt_on_call2.output.corrected)))

--- a/flambda-backend/tests/backend/zero_alloc_checker/gen/gen_dune.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/gen/gen_dune.ml
@@ -223,4 +223,10 @@ let () =
   print_test_expected_output ~cutoff:default_cutoff ~extra_dep:(Some "fail29_opt.cmi") ~exit_code:2 "fail29_opt";
   print_cmi_target "fail29_opt2.mli";
   print_test_expected_output ~cutoff:default_cutoff ~extra_flags:"-zero-alloc-check all" ~extra_dep:(Some "fail29_opt2.cmi") ~exit_code:2 "fail29_opt2";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check all" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_assume_unless_opt";
+  print_test "test_assume_unless_opt.ml";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check default" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:0 "test_assume_unless_opt_sig";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check all" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_assume_unless_opt_sig2";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check default" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_assume_unless_opt_on_call";
+  print_test_expected_output ~extra_flags:"-zero-alloc-check all" ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2 "test_assume_unless_opt_on_call2";
   ()

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_assume_on_call.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_assume_on_call.output
@@ -1,6 +1,6 @@
 File "test_assume_on_call.ml", line 4, characters 8-18:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-Only the following combinations are supported in this context: 'zero_alloc assume', `zero_alloc assume strict`, `zero_alloc assume error`,`zero_alloc assume never_returns_normally`,`zero_alloc assume never_returns_normally strict`.
+Only the following combinations are supported in this context: 'zero_alloc assume', 'zero_alloc assume_unless_opt', `zero_alloc assume strict`, `zero_alloc assume error`,`zero_alloc assume never_returns_normally`,`zero_alloc assume never_returns_normally strict`.
 
 File "test_assume_on_call.ml", line 3, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test1 (camlTest_assume_on_call.test1_HIDE_STAMP)

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt.ml
@@ -1,0 +1,20 @@
+let[@local never][@inline never] bar y = Some y
+
+let[@local never][@inline never][@zero_alloc assume_unless_opt] foo x =
+  match bar x with
+  | Some y -> y
+  | None -> x
+
+module Pass_check = struct
+
+  let[@inline] bar y = Some y
+
+  let[@zero_alloc assume_unless_opt] foo x =
+    match (bar[@inlined]) x with
+    | Some y -> y
+    | None -> x
+
+  let[@zero_alloc] test x = foo x
+
+end
+

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt.output
@@ -1,0 +1,5 @@
+File "test_assume_unless_opt.ml", line 3, characters 34-44:
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt.foo (camlTest_assume_unless_opt.foo_HIDE_STAMP)
+
+File "test_assume_unless_opt.ml", line 4, characters 8-13:
+Error: called function may allocate (direct call camlTest_assume_unless_opt.bar_HIDE_STAMP)

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call.ml
@@ -1,0 +1,6 @@
+let foo x = (x,x)
+
+let[@zero_alloc] bar x = (foo[@zero_alloc assume_unless_opt]) x
+
+let[@zero_alloc] test_warning x =
+  (foo[@zero_alloc assume_unless_opt never_returns_normally]) x

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call.output
@@ -1,0 +1,9 @@
+File "test_assume_unless_opt_on_call.ml", line 6, characters 8-18:
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore' or empty
+
+File "test_assume_unless_opt_on_call.ml", line 5, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call.test_warning (camlTest_assume_unless_opt_on_call.test_warning_HIDE_STAMP)
+
+File "test_assume_unless_opt_on_call.ml", line 6, characters 2-63:
+Error: allocation of 24 bytes (test_assume_unless_opt_on_call.ml:6,2--63;test_assume_unless_opt_on_call.ml:1,12--17)

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call2.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call2.output
@@ -1,0 +1,15 @@
+File "test_assume_unless_opt_on_call2.ml", line 6, characters 8-18:
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore' or empty
+
+File "test_assume_unless_opt_on_call2.ml", line 3, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call2.bar (camlTest_assume_unless_opt_on_call2.bar_HIDE_STAMP)
+
+File "test_assume_unless_opt_on_call2.ml", line 3, characters 25-63:
+Error: allocation of 24 bytes (test_assume_unless_opt_on_call2.ml:3,25--63;test_assume_unless_opt_on_call2.ml:1,12--17)
+
+File "test_assume_unless_opt_on_call2.ml", line 5, characters 5-15:
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call2.test_warning (camlTest_assume_unless_opt_on_call2.test_warning_HIDE_STAMP)
+
+File "test_assume_unless_opt_on_call2.ml", line 6, characters 2-63:
+Error: allocation of 24 bytes (test_assume_unless_opt_on_call2.ml:6,2--63;test_assume_unless_opt_on_call2.ml:1,12--17)

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig.ml
@@ -1,0 +1,26 @@
+module Test_fail_in_opt_only : sig
+  val foo : 'a -> 'a * 'a [@@zero_alloc]
+end = struct
+  let[@inline never][@zero_alloc assume_unless_opt] foo x = (x,x)
+end
+
+module Test_pass : sig
+  val foo : 'a -> 'a [@@zero_alloc]
+end = struct
+  let[@inline never][@zero_alloc assume_unless_opt] foo x = x
+end
+
+module Test_error : sig
+  (* The payload "assume_zero_alloc" is not allowed on signatures, just like "assume".
+     We get a warning, then the check of the implementation fails in "opt" mode,
+     because the unsupported payload is removed from the attribute,
+     and the signature annotation becomes [@@zero_alloc],
+     and the check of the caller passes. *)
+  val foo : 'a -> 'a * 'a [@@zero_alloc assume_unless_opt]
+end = struct
+  let[@inline never][@zero_alloc assume_unless_opt] foo x = (x,x)
+end
+
+let[@zero_alloc] test1_pass x = Test_fail_in_opt_only.foo x
+let[@zero_alloc] test2_pass x = Test_pass.foo x
+let[@zero_alloc] test3_pass x = Test_error.foo x

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig.output
@@ -1,0 +1,3 @@
+File "test_assume_unless_opt_sig.ml", line 19, characters 29-39:
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+The payload "assume_unless_opt" is not supported in signatures.

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig2.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig2.output
@@ -1,0 +1,15 @@
+File "test_assume_unless_opt_sig2.ml", line 19, characters 29-39:
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+The payload "assume_unless_opt" is not supported in signatures.
+
+File "test_assume_unless_opt_sig2.ml", line 4, characters 22-32:
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_sig2.Test_fail_in_opt_only.foo (camlTest_assume_unless_opt_sig2.foo_HIDE_STAMP)
+
+File "test_assume_unless_opt_sig2.ml", line 4, characters 60-65:
+Error: allocation of 24 bytes
+
+File "test_assume_unless_opt_sig2.ml", line 21, characters 22-32:
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_sig2.Test_error.foo (camlTest_assume_unless_opt_sig2.foo_HIDE_STAMP)
+
+File "test_assume_unless_opt_sig2.ml", line 21, characters 60-65:
+Error: allocation of 24 bytes

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_attribute_error_duplicate.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_attribute_error_duplicate.output
@@ -6,15 +6,15 @@ Warning 54 [duplicated-attribute]: the "zero_alloc" attribute is used more than 
 
 File "test_attribute_error_duplicate.ml", line 3, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore' or empty
+It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore' or empty
 
 File "test_attribute_error_duplicate.ml", line 4, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore' or empty
+It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore' or empty
 
 File "test_attribute_error_duplicate.ml", line 5, characters 5-15:
 Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
-It must be either 'assume', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore' or empty
+It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore' or empty
 
 File "test_attribute_error_duplicate.ml", line 1, characters 5-15:
 Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate.test1_HIDE_STAMP)

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -965,7 +965,7 @@ let parse_zero_alloc_attribute ~in_signature ~on_application ~default_arity attr
           let no_other_payload = List.compare_length_with rest 0 = 0 in
           if is_zero_alloc_check_enabled ~opt:true && no_other_payload then
             (if on_application then
-               (* Treat is if there is no attribute.
+               (* Treat as if there is no attribute.
                   Check is not allowed on applications. *)
                Default_zero_alloc
              else

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -963,21 +963,26 @@ let parse_zero_alloc_attribute ~in_signature ~on_application ~default_arity attr
            parse rest)
         else
           let no_other_payload = List.compare_length_with rest 0 = 0 in
-          if is_zero_alloc_check_enabled ~opt:true && no_other_payload then
-            (if on_application then
-               (* Treat as if there is no attribute.
-                  Check is not allowed on applications. *)
-               Default_zero_alloc
-             else
-               (* Treat [@zero_alloc assume_unless_opt] as [@zero_alloc],
-                  forcing the function to be checked.
-                  Setting [opt = false] to satisfy [@zero_alloc]
-                  and not only [@zero_alloc opt] on the corresponding signatures. *)
-               empty arity)
-          else
-            (* Treat "assume_unless_opt" as "assume".
-               Reuse standard parsing for better error messages. *)
-            parse payload
+          if no_other_payload then (
+            if is_zero_alloc_check_enabled ~opt:true then
+              (if on_application then
+                 (* Treat as if there is no attribute.
+                    Check is not allowed on applications. *)
+                 Default_zero_alloc
+               else
+                 (* Treat [@zero_alloc assume_unless_opt] as [@zero_alloc],
+                    forcing the function to be checked.
+                    Setting [opt = false] to satisfy [@zero_alloc]
+                    and not only [@zero_alloc opt] on the corresponding signatures. *)
+                 empty arity)
+            else
+              (* Treat "assume_unless_opt" as "assume".
+                 Reuse standard parsing for better error messages. *)
+              parse payload)
+          else (
+            (* No support for other payloads with "assume_unless_opt". *)
+            warn ();
+            Default_zero_alloc)
 
 
 let get_zero_alloc_attribute ~in_signature ~on_application ~default_arity l =

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -309,7 +309,7 @@ val is_zero_alloc_check_enabled : opt:bool -> bool
    "arity n" field is allowed, and whether we track this attribute for
    warning 199. *)
 val get_zero_alloc_attribute :
-  in_signature:bool -> default_arity:int -> Parsetree.attributes ->
+  in_signature:bool -> on_application:bool-> default_arity:int -> Parsetree.attributes ->
   zero_alloc_attribute
 
 (* This returns the [zero_alloc_assume] if the input is an assume.  Otherwise,

--- a/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -47,6 +47,20 @@ Line 2, characters 2-40:
 Error: zero_alloc "assume" attributes are not supported in signatures
 |}]
 
+module type S_payloads_assume_unless_opt = sig
+  val[@zero_alloc assume_unless_opt] f : int -> int
+end
+[%%expect{|
+Line 2, characters 7-17:
+2 |   val[@zero_alloc assume_unless_opt] f : int -> int
+           ^^^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'zero_alloc'.
+The payload "assume_unless_opt" is not supported in signatures.
+
+module type S_payloads_assume_unless_opt =
+  sig val f : int -> int [@@zero_alloc] end
+|}]
+
 (******************************)
 (* Test 2: allowed inclusions *)
 module type S_good_inc_base = sig

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5290,6 +5290,7 @@ let add_zero_alloc_attribute expr attributes =
     let default_arity = function_arity fn.params fn.body in
     let za =
       get_zero_alloc_attribute ~in_signature:false ~default_arity attributes
+        ~on_application:false
     in
     begin match za with
     | Default_zero_alloc -> expr
@@ -5880,6 +5881,7 @@ and type_expect_
       in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
+          ~on_application:true
           ~default_arity:(List.length args) sfunct.pexp_attributes
         |> Builtin_attributes.zero_alloc_attribute_only_assume_allowed
       in
@@ -9549,6 +9551,7 @@ and type_n_ary_function
     end;
     let zero_alloc =
       Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
+        ~on_application:false
         ~default_arity:syntactic_arity attributes
     in
     let zero_alloc =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3268,6 +3268,7 @@ let transl_value_decl env loc ~sig_modalities valdecl =
       in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:true
+          ~on_application:false
           ~default_arity valdecl.pval_attributes
       in
       let zero_alloc =


### PR DESCRIPTION
On top of https://github.com/ocaml-flambda/flambda-backend/pull/3134.

The meaning of the new payload depends on the value of `-zero-alloc-check` flag (or the corresponding top-level `[@@@zero_alloc check]` attribute). 

- If checking of `opt` annotations is disabled, then `[@zero_alloc assume_unless_opt]` is treated as "[@zero_alloc assume]". 
- If checking `opt` annotations is enabled, then `[@zero_alloc assume_unless_opt]` is treated as `[@zero_alloc]` on function definitions. On applications, `[@zero_alloc assume_unless_opt]` is ignored, which corresponds to checking the callee as usual.
- The new payload is not allowed on signatures.

The intended use of this annotation is on function definitions that can only be shown as zero_alloc in an optimized build. As such, it is not intended to be inferred from the signatures.

Additional payloads (such as `strict` and `never_returns_normally`) are not supported.

The implementation is entirely during parsing, the new payload is interpreted as one of the the existing `zero_alloc` constructors.
