### PR TITLE
Squelch quotes with -error-style short

### DIFF
--- a/ocaml/testsuite/tests/misc/short_errors.ml
+++ b/ocaml/testsuite/tests/misc/short_errors.ml
@@ -1,0 +1,12 @@
+(* TEST
+   flags = "-error-style short";
+   expect;
+*)
+
+let _ = 1 + true
+
+[%%expect{|
+Line 1, characters 12-16:
+Error: This expression has type bool but an expression was expected of type
+         int
+|}]

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -443,7 +443,18 @@ let error_style = ref None (* -error-style *)
 let error_style_reader = {
   parse = (function
     | "contextual" -> Some Misc.Error_style.Contextual
-    | "short" -> Some Misc.Error_style.Short
+    | "short" ->
+      (* Jane Street specific: This little bit of code suppresses the ["]
+         marks in error messages. Remove this after we can get formatted
+         output in our editors. *)
+      let styles = Misc.Style.get_styles () in
+      let styles =
+        { styles with inline_code =
+          { styles.inline_code with text_open = ""; text_close = "" } }
+      in
+      Misc.Style.set_styles styles;
+      (* End Jane Street specific code *)
+      Some Misc.Error_style.Short
     | _ -> None);
   print = (function
     | Misc.Error_style.Contextual -> "contextual"

--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -444,7 +444,7 @@ let error_style_reader = {
   parse = (function
     | "contextual" -> Some Misc.Error_style.Contextual
     | "short" ->
-      (* Jane Street specific: This little bit of code suppresses the ["]
+      (* Jane Street specific: This little bit of code suppresses the quote
          marks in error messages. Remove this after we can get formatted
          output in our editors. *)
       let styles = Misc.Style.get_styles () in


### PR DESCRIPTION
As tin.

This is pretty gross. But it works.