### PR TITLE
Revert "Reorder fields in block header (#3042)"

### DIFF
--- a/ocaml/asmcomp/cmm_helpers.ml
+++ b/ocaml/asmcomp/cmm_helpers.ml
@@ -735,7 +735,6 @@ let get_header ptr dbg =
     [Cop(Cadda, [ptr; Cconst_int(-size_int, dbg)], dbg)], dbg)
 
 let get_header_masked ptr dbg =
-  if true then failwith "this code has not been updated for runtime changes, but isn't used";
   if Config.reserved_header_bits > 0 then
     let header_mask = (1 lsl (64 - Config.reserved_header_bits)) - 1
     in Cop(Cand, [get_header ptr dbg; Cconst_int (header_mask, dbg)], dbg)

--- a/ocaml/asmcomp/cmm_helpers.mli
+++ b/ocaml/asmcomp/cmm_helpers.mli
@@ -227,6 +227,9 @@ val set_field :
 (** Load a block's header *)
 val get_header : expression -> Debuginfo.t -> expression
 
+(** Same as [get_header], but also clear all reserved bits of the result *)
+val get_header_masked : expression -> Debuginfo.t -> expression
+
 (** Load a block's tag *)
 val get_tag : expression -> Debuginfo.t -> expression
 

--- a/ocaml/debugger/debugcom.ml
+++ b/ocaml/debugger/debugcom.ml
@@ -299,8 +299,8 @@ module Remote_value =
         flush !conn.io_out;
         let header = input_binary_int !conn.io_in in
         if header land 0xFF = Obj.double_array_tag && Sys.word_size = 32
-        then header lsr (11 + Config.reserved_header_bits)
-        else header lsr (10 + Config.reserved_header_bits)
+        then header lsr 11
+        else header lsr 10
 
     let field v n =
       match v with

--- a/ocaml/debugger4/debugcom.ml
+++ b/ocaml/debugger4/debugcom.ml
@@ -357,8 +357,8 @@ module Remote_value =
         flush !conn.io_out;
         let header = input_binary_int !conn.io_in in
         if header land 0xFF = Obj.double_array_tag && Sys.word_size = 32
-        then header lsr (11 + Config.reserved_header_bits)
-        else header lsr (10 + Config.reserved_header_bits)
+        then header lsr 11
+        else header lsr 10
 
     let field v n =
       match v with

--- a/ocaml/runtime/alloc.c
+++ b/ocaml/runtime/alloc.c
@@ -31,10 +31,6 @@
 #include "caml/fiber.h"
 #include "caml/domain.h"
 
-/* When you update this macro, be sure to also update the exported value. */
-Assert_mixed_block_layout_v2;
-value caml_mixed_block_layout_version = 2;
-
 CAMLexport value caml_alloc_with_reserved (mlsize_t wosize, tag_t tag,
                                            reserved_t reserved)
 {

--- a/ocaml/runtime/caml/mlvalues.h
+++ b/ocaml/runtime/caml/mlvalues.h
@@ -101,10 +101,10 @@ bits  31    10 9     8 7   0
 
 For 64-bit architectures:
 
-     +--------+----------+-------+-----+
-     | wosize | reserved | color | tag |
-     +--------+----------+-------+-----+
-bits  63       R+10    10 9     8 7   0
+     +----------+--------+-------+-----+
+     | reserved | wosize | color | tag |
+     +----------+--------+-------+-----+
+bits  63    64-R 63-R  10 9     8 7   0
 
 where 0 <= R <= 31 is HEADER_RESERVED_BITS. R is always
 set to 8 for the flambda-backend compiler in order to support
@@ -123,21 +123,16 @@ mixed blocks. In the upstream compiler, R is set with the
 #define HEADER_COLOR_MASK (((1ull << HEADER_COLOR_BITS) - 1ull) \
                             << HEADER_COLOR_SHIFT)
 
-// HEADER_RESERVED_BITS is defined by configuration
-#define HEADER_RESERVED_SHIFT (HEADER_COLOR_SHIFT + HEADER_COLOR_BITS)
-
 #define HEADER_WOSIZE_BITS (HEADER_BITS - HEADER_TAG_BITS \
                             - HEADER_COLOR_BITS - HEADER_RESERVED_BITS)
-#define HEADER_WOSIZE_SHIFT (HEADER_RESERVED_BITS + HEADER_RESERVED_SHIFT)
+#define HEADER_WOSIZE_SHIFT (HEADER_COLOR_SHIFT  + HEADER_COLOR_BITS)
 #define HEADER_WOSIZE_MASK (((1ull << HEADER_WOSIZE_BITS) - 1ull) \
                              << HEADER_WOSIZE_SHIFT)
 
 #define Tag_hd(hd) ((tag_t) ((hd) & HEADER_TAG_MASK))
 #define Hd_with_tag(hd, tag) (((hd) &~ HEADER_TAG_MASK) | (tag))
-
-/* By construction, there's nothing above wosize in header, so we don't need to
-   mask, only shift. */
-#define Allocated_wosize_hd(hd) ((mlsize_t) ((hd) >> HEADER_WOSIZE_SHIFT))
+#define Allocated_wosize_hd(hd) ((mlsize_t) (((hd) & HEADER_WOSIZE_MASK) \
+                                     >> HEADER_WOSIZE_SHIFT))
 
 /* A "clean" header, without reserved or color bits. */
 #define Cleanhd_hd(hd) (((header_t)(hd)) & \
@@ -145,12 +140,8 @@ mixed blocks. In the upstream compiler, R is set with the
 
 #if HEADER_RESERVED_BITS > 0
 
-#define HEADER_RESERVED_MASK  (((1ull << HEADER_RESERVED_BITS) - 1ull) \
-                             << HEADER_RESERVED_SHIFT)
-
-#define Reserved_hd(hd)   ((((header_t) (hd)) & HEADER_RESERVED_MASK) \
-                             >> HEADER_RESERVED_SHIFT)
-
+#define HEADER_RESERVED_SHIFT (HEADER_BITS - HEADER_RESERVED_BITS)
+#define Reserved_hd(hd)   (((header_t) (hd)) >> HEADER_RESERVED_SHIFT)
 #define Hd_reserved(res)  ((header_t)(res) << HEADER_RESERVED_SHIFT)
 
 #else /* HEADER_RESERVED_BITS is 0 */
@@ -592,14 +583,13 @@ CAMLextern value caml_set_oo_id(value obj);
 
    Users can write:
 
-   Assert_mixed_block_layout_v2;
+   Assert_mixed_block_layout_v1;
 
    (Hack: we define using _Static_assert rather than just an empty
    definition so that users can write a semicolon, which is treated
    better by C formatters.)
  */
-#define Assert_mixed_block_layout_v2 _Static_assert(1, "")
-CAMLextern value mixed_block_layout_version;
+#define Assert_mixed_block_layout_v1 _Static_assert(1, "")
 
 /* Header for out-of-heap blocks. */
 

--- a/ocaml/runtime/extern.c
+++ b/ocaml/runtime/extern.c
@@ -627,17 +627,7 @@ Caml_inline void extern_header(struct caml_extern_state* s,
   if (tag < 16 && sz < 8) {
     writebyte(s, PREFIX_SMALL_BLOCK + tag + (sz << 4));
   } else {
-    /* This is the equivalent of [Make_header] before our changes to reorder
-       mixed-block related fields.
-
-       Is marshalling guaranteed to be stable? I'm uncertain if there's a rule
-       about this or a guarantee made by Ocaml. But, as a matter of practice,
-       one can't build the compiler without crossming marshal/unmarshal
-       boundaries where one end is from system ocamlc and one end is from the
-       built one. As such, it is in practice unsafe to use our new headers in
-       marshalling.
-    */
-    header_t hd = (sz << 10) + tag;
+    header_t hd = Make_header(sz, tag, NOT_MARKABLE);
 #ifdef ARCH_SIXTYFOUR
     if (sz > 0x3FFFFF && (s->extern_flags & COMPAT_32))
       extern_failwith(s, "output_value: array cannot be read back on "

--- a/ocaml/runtime/hash.c
+++ b/ocaml/runtime/hash.c
@@ -180,12 +180,6 @@ CAMLexport uint32_t caml_hash_mix_string(uint32_t h, value s)
 /* Maximal number of Forward_tag links followed in one step */
 #define MAX_FORWARD_DEREFERENCE 1000
 
-/* A version of Cleanhd_hd that's compatible with what upstream does.
-   This allows us to avoid changing the output of polymorphic hash,
-   at a performance cost to users of polymorphic hash.
- */
-#define Stable_cleanhd_hd(hd) ((Wosize_hd(hd) << 10) | Tag_hd(hd))
-
 /* The generic hash function */
 
 /* Internally to Jane Street, we have renamed [caml_hash] to [caml_hash_exn]
@@ -273,7 +267,7 @@ CAMLprim value caml_hash_exn(value count, value limit, value seed, value obj)
         startenv = Start_env_closinfo(Closinfo_val(v));
         CAMLassert (startenv <= len);
         /* Mix in the tag and size, but do not count this towards [num] */
-        h = caml_hash_mix_uint32(h, Stable_cleanhd_hd(Hd_val(v)));
+        h = caml_hash_mix_uint32(h, Cleanhd_hd(Hd_val(v)));
         /* Mix the code pointers, closure info fields, and infix headers */
         for (i = 0; i < startenv; i++) {
           h = caml_hash_mix_intnat(h, Field(v, i));
@@ -297,7 +291,7 @@ CAMLprim value caml_hash_exn(value count, value limit, value seed, value obj)
 	  caml_invalid_argument("hash: mixed block value");
 	}
         /* Mix in the tag and size, but do not count this towards [num] */
-        h = caml_hash_mix_uint32(h, Stable_cleanhd_hd(Hd_val(v)));
+        h = caml_hash_mix_uint32(h, Cleanhd_hd(Hd_val(v)));
         /* Copy fields into queue, not exceeding the total size [sz] */
         for (i = 0, len = Wosize_val(v); i < len; i++) {
           if (wr >= sz) break;

--- a/ocaml/runtime/intern.c
+++ b/ocaml/runtime/intern.c
@@ -591,15 +591,13 @@ static void intern_rec(struct caml_intern_state* s,
       case CODE_BLOCK32:
         header = (header_t) read32u(s);
         tag = Tag_hd(header);
-        /* See comment in extern.c extern_header() */
-        size = header >> 10;
+        size = Wosize_hd(header);
         goto read_block;
 #ifdef ARCH_SIXTYFOUR
       case CODE_BLOCK64:
         header = (header_t) read64u(s);
         tag = Tag_hd(header);
-        /* See comment in extern.c extern_header() */
-        size = header >> 10;
+        size = Wosize_hd(header);
         goto read_block;
 #endif
       case CODE_STRING8:

--- a/ocaml/runtime4/alloc.c
+++ b/ocaml/runtime4/alloc.c
@@ -32,10 +32,6 @@
 #define Setup_for_gc
 #define Restore_after_gc
 
-/* When you update this macro, be sure to also update the exported value. */
-Assert_mixed_block_layout_v2;
-value caml_mixed_block_layout_version = 2;
-
 CAMLexport value caml_alloc_with_reserved (mlsize_t wosize, tag_t tag,
                                            reserved_t reserved)
 {

--- a/ocaml/runtime4/caml/gc.h
+++ b/ocaml/runtime4/caml/gc.h
@@ -41,7 +41,7 @@
 /* This depends on the layout of the header.  See [mlvalues.h]. */
 #define Make_header(wosize, tag, color)                                       \
       (/*CAMLassert ((wosize) <= Max_wosize),*/                               \
-       ((header_t) (((header_t) (wosize) << (10+PROFINFO_WIDTH))              \
+       ((header_t) (((header_t) (wosize) << 10)                               \
                     + (color)                                                 \
                     + (tag_t) (tag)))                                         \
       )

--- a/ocaml/runtime4/caml/mlvalues.h
+++ b/ocaml/runtime4/caml/mlvalues.h
@@ -110,10 +110,10 @@ bits  63    10 9     8 7   0
 
 For 64-bit architectures with mixed block support enabled:
   P = PROFINFO_WIDTH (as set by "configure", currently 8 bits)
-     +----- --+------------------------+-------------+
-     | wosize | scannable size         | color | tag |
-     +--------+------------------------+-------------+
-bits  63      (P+10)                 10 9     8 7   0
+     +----------------+----------------+-------------+
+     | scannable size | wosize         | color | tag |
+     +----------------+----------------+-------------+
+bits  63        (64-P) (63-P)        10 9     8 7   0
 
 Mixed block support uses the PROFINFO_WIDTH functionality
 originally built for Spacetime profiling, hence the odd name.
@@ -121,7 +121,7 @@ originally built for Spacetime profiling, hence the odd name.
 
 #define Tag_hd(hd) ((tag_t) ((hd) & 0xFF))
 
-#define Gen_profinfo_shift(width) (10)
+#define Gen_profinfo_shift(width) (64 - (width))
 #define Gen_profinfo_mask(width) ((1ull << (width)) - 1ull)
 #define Gen_profinfo_hd(width, hd) \
   (((mlsize_t) ((hd) >> (Gen_profinfo_shift(width)))) \
@@ -131,9 +131,8 @@ originally built for Spacetime profiling, hence the odd name.
 #define PROFINFO_SHIFT (Gen_profinfo_shift(PROFINFO_WIDTH))
 #define PROFINFO_MASK (Gen_profinfo_mask(PROFINFO_WIDTH))
 #define NO_PROFINFO 0
-
-#define HD_WOSIZE_SHIFT (PROFINFO_SHIFT + PROFINFO_WIDTH)
-#define Allocated_wosize_hd(hd) ((mlsize_t) ((hd) >> HD_WOSIZE_SHIFT))
+#define Hd_no_profinfo(hd) ((hd) & ~(PROFINFO_MASK << PROFINFO_SHIFT))
+#define Allocated_wosize_hd(hd) ((mlsize_t) ((Hd_no_profinfo(hd)) >> 10))
 #define Profinfo_hd(hd) (Gen_profinfo_hd(PROFINFO_WIDTH, hd))
 #else
 #define NO_PROFINFO 0
@@ -557,14 +556,13 @@ CAMLextern value caml_set_oo_id(value obj);
 
    Users can write:
 
-   Assert_mixed_block_layout_v2;
+   Assert_mixed_block_layout_v1;
 
    (Hack: we define using _Static_assert rather than just an empty
    definition so that users can write a semicolon, which is treated
    better by C formatters.)
  */
-#define Assert_mixed_block_layout_v2 _Static_assert(1, "")
-CAMLextern value mixed_block_layout_version; /* To help us in coredumps. */
+#define Assert_mixed_block_layout_v1 _Static_assert(1, "")
 
 /* Header for out-of-heap blocks. */
 

--- a/ocaml/runtime4/extern.c
+++ b/ocaml/runtime4/extern.c
@@ -549,17 +549,7 @@ Caml_inline void extern_header(mlsize_t sz, tag_t tag)
   if (tag < 16 && sz < 8) {
     write(PREFIX_SMALL_BLOCK + tag + (sz << 4));
   } else {
-    /* This is the equivalent of [Make_header] before our changes to reorder
-       mixed-block related fields.
-
-       Is marshalling guaranteed to be stable? I'm uncertain if there's a rule
-       about this or a guarantee made by Ocaml. But, as a matter of practice,
-       one can't build the compiler without crossming marshal/unmarshal
-       boundaries where one end is from system ocamlc and one end is from the
-       built one. As such, it is in practice unsafe to use our new headers in
-       marshalling.
-    */
-    header_t hd = (sz << 10) + tag;
+    header_t hd = Make_header(sz, tag, Caml_white);
 #ifdef ARCH_SIXTYFOUR
     if (sz > 0x3FFFFF && (extern_flags & COMPAT_32))
       extern_failwith("output_value: array cannot be read back on "

--- a/ocaml/runtime4/hash.c
+++ b/ocaml/runtime4/hash.c
@@ -175,12 +175,6 @@ CAMLexport uint32_t caml_hash_mix_string(uint32_t h, value s)
   return h;
 }
 
-/* A version of Whitehd_hd that's compatible with what upstream does.
-   This allows us to avoid changing the output of polymorphic hash,
-   at a performance cost to users of polymorphic hash.
- */
-#define Stable_whitehd_hd(hd) ((Wosize_hd(hd) << 10) | Tag_hd(hd))
-
 /* Maximal size of the queue used for breadth-first traversal.  */
 #define HASH_QUEUE_SIZE 256
 /* Maximal number of Forward_tag links followed in one step */
@@ -280,7 +274,7 @@ CAMLprim value caml_hash_exn(value count, value limit, value seed, value obj)
         startenv = Start_env_closinfo(Closinfo_val(v));
         CAMLassert (startenv <= len);
         /* Mix in the tag and size, but do not count this towards [num] */
-        h = caml_hash_mix_uint32(h, Stable_whitehd_hd(Hd_val(v)));
+        h = caml_hash_mix_uint32(h, Whitehd_hd(Hd_val(v)));
         /* Mix the code pointers, closure info fields, and infix headers */
         for (i = 0; i < startenv; i++) {
           h = caml_hash_mix_intnat(h, Field(v, i));
@@ -300,7 +294,7 @@ CAMLprim value caml_hash_exn(value count, value limit, value seed, value obj)
 	  caml_invalid_argument("hash: mixed block value");
 	}
         /* Mix in the tag and size, but do not count this towards [num] */
-        h = caml_hash_mix_uint32(h, Stable_whitehd_hd(Hd_val(v)));
+        h = caml_hash_mix_uint32(h, Whitehd_hd(Hd_val(v)));
         /* Copy fields into queue, not exceeding the total size [sz] */
         for (i = 0, len = Wosize_val(v); i < len; i++) {
           if (wr >= sz) break;

--- a/ocaml/runtime4/intern.c
+++ b/ocaml/runtime4/intern.c
@@ -459,15 +459,13 @@ static void intern_rec(value *dest)
       case CODE_BLOCK32:
         header = (header_t) read32u();
         tag = Tag_hd(header);
-        /* See comment in extern.c extern_header() */
-        size = header >> 10;
+        size = Wosize_hd(header);
         goto read_block;
 #ifdef ARCH_SIXTYFOUR
       case CODE_BLOCK64:
         header = (header_t) read64u();
         tag = Tag_hd(header);
-        /* See comment in extern.c extern_header() */
-        size = header >> 10;
+        size = Wosize_hd(header);
         goto read_block;
 #endif
       case CODE_STRING8:

--- a/ocaml/testsuite/tests/lib-obj/get_header.ml
+++ b/ocaml/testsuite/tests/lib-obj/get_header.ml
@@ -31,14 +31,11 @@ type header = {
   tag : int
 }
 
-(* for mixed block size *)
-let reserved_bits = 8
-
 let parse_header : nativeint -> header =
   fun header ->
     let wosize =
       Nativeint.to_int
-        (Nativeint.shift_right_logical header (10 + reserved_bits))
+        (Nativeint.shift_right_logical header 10)
     in
 
     let color =


### PR DESCRIPTION
Revert #3042. This requires more work internally.