### PR TITLE
Rename fields in `typedtree.signature` from `sig_` to `sg_`

### DIFF
--- a/ocaml/driver/compile_common.ml
+++ b/ocaml/driver/compile_common.ml
@@ -70,7 +70,7 @@ let typecheck_intf info ast =
     |> print_if info.ppf_dump Clflags.dump_typedtree Printtyped.interface
   in
   let alerts = Builtin_attributes.alerts_of_sig ~mark:true ast in
-  let sg = tsg.Typedtree.sig_type in
+  let sg = tsg.Typedtree.sg_type in
   if !Clflags.print_types then
     Printtyp.wrap_printing_env ~error:false info.env (fun () ->
         Format.(fprintf std_formatter) "%a@."
@@ -96,7 +96,7 @@ let emit_signature info alerts tsg =
         Normal { cmi_impl = info.module_name; cmi_arg_for }
       end
     in
-    Env.save_signature ~alerts tsg.Typedtree.sig_type
+    Env.save_signature ~alerts tsg.Typedtree.sg_type
       (Compilation_unit.name info.module_name) kind
       (Unit_info.cmi info.target)
   in

--- a/ocaml/ocamldoc/odoc_analyse.ml
+++ b/ocaml/ocamldoc/odoc_analyse.ml
@@ -198,7 +198,7 @@ let process_file sourcefile =
        try
          let (ast, signat, input_file) = process_interface_file file in
          let file_module = Sig_analyser.analyse_signature file
-             input_file ast signat.sig_type
+             input_file ast signat.sg_type
          in
 
          file_module.Odoc_module.m_top_deps <- Odoc_dep.intf_dependencies ast ;

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -907,7 +907,7 @@ and module_type i ppf x =
     module_type i ppf mt;
     line i ppf "%a\n" fmt_path li;
 
-and signature i ppf x = list i signature_item ppf x.sig_items
+and signature i ppf x = list i signature_item ppf x.sg_items
 
 and signature_item i ppf x =
   line i ppf "signature_item %a\n" fmt_location x.sig_loc;
@@ -1210,7 +1210,7 @@ and label_x_bool_x_core_type_list i ppf x =
       line i ppf "Tinherit\n";
       core_type (i+1) ppf ct
 
-let interface ppf x = list 0 signature_item ppf x.sig_items
+let interface ppf x = list 0 signature_item ppf x.sg_items
 
 let implementation ppf x = list 0 structure_item ppf x.str_items
 

--- a/ocaml/typing/signature_group.mli
+++ b/ocaml/typing/signature_group.mli
@@ -44,7 +44,7 @@ type core_rec_group =
   | Not_rec of sig_item
   | Rec_group of sig_item list
 
-(** [rec_items group] is the list of sig_items in the group *)
+(** [rec_items group] is the list of sg_items in the group *)
 val rec_items: core_rec_group -> sig_item list
 
 (** Private #row types are manifested as a sequence of definitions

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -438,9 +438,9 @@ let binding_op sub {bop_loc; bop_op_name; bop_exp; _} =
   iter_loc sub bop_op_name;
   sub.expr sub bop_exp
 
-let signature sub {sig_items; sig_final_env; _} =
-  sub.env sub sig_final_env;
-  List.iter (sub.signature_item sub) sig_items
+let signature sub {sg_items; sg_final_env; _} =
+  sub.env sub sg_final_env;
+  List.iter (sub.signature_item sub) sg_items
 
 let sig_include_infos sub {incl_loc; incl_mod; incl_attributes; incl_kind; _} =
   sub.location sub incl_loc;

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -617,9 +617,9 @@ let binding_op sub x =
   { x with bop_loc; bop_op_name; bop_exp = sub.expr sub x.bop_exp }
 
 let signature sub x =
-  let sig_final_env = sub.env sub x.sig_final_env in
-  let sig_items = List.map (sub.signature_item sub) x.sig_items in
-  {x with sig_items; sig_final_env}
+  let sg_final_env = sub.env sub x.sg_final_env in
+  let sg_items = List.map (sub.signature_item sub) x.sg_items in
+  {x with sg_items; sg_final_env}
 
 let sig_include_infos sub x =
   let incl_loc = sub.location sub x.incl_loc in

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -508,9 +508,9 @@ and primitive_coercion =
   }
 
 and signature = {
-  sig_items : signature_item list;
-  sig_type : Types.signature;
-  sig_final_env : Env.t;
+  sg_items : signature_item list;
+  sg_type : Types.signature;
+  sg_final_env : Env.t;
 }
 
 and signature_item =

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -781,9 +781,9 @@ and primitive_coercion =
   }
 
 and signature = {
-  sig_items : signature_item list;
-  sig_type : Types.signature;
-  sig_final_env : Env.t;
+  sg_items : signature_item list;
+  sg_type : Types.signature;
+  sg_final_env : Env.t;
 }
 
 and signature_item =

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -1594,7 +1594,7 @@ let mksig desc env loc =
   Cmt_format.add_saved_type (Cmt_format.Partial_signature_item sg);
   sg
 
-(* let signature sg = List.map (fun item -> item.sig_type) sg *)
+(* let signature sg = List.map (fun item -> item.sg_type) sg *)
 
 let rec transl_modtype env smty =
   Builtin_attributes.warning_scope smty.pmty_attributes
@@ -1620,7 +1620,7 @@ and transl_modtype_aux env smty =
         smty.pmty_attributes
   | Pmty_signature ssg ->
       let sg = transl_signature env ssg in
-      mkmty (Tmty_signature sg) (Mty_signature sg.sig_type) env loc
+      mkmty (Tmty_signature sg) (Mty_signature sg.sg_type) env loc
         smty.pmty_attributes
   | Pmty_functor(sarg_opt, sres) ->
       let t_arg, ty_arg, newenv =
@@ -1793,12 +1793,12 @@ and transl_signature env sg =
         List.iter (fun td ->
           Signature_names.check_type names td.typ_loc td.typ_id;
         ) decls;
-        let sig_items =
+        let sg_items =
           map_rec_type_with_row_types ~rec_flag
             (fun rs td -> Sig_type(td.typ_id, td.typ_type, rs, Exported))
             decls
         in
-        mksig (Tsig_type (rec_flag, decls)) env loc, sig_items, newenv
+        mksig (Tsig_type (rec_flag, decls)) env loc, sg_items, newenv
     | Psig_typesubst sdecls ->
         let (decls, newenv, _shapes) =
           Typedecl.transl_type_decl env Nonrecursive sdecls
@@ -1940,7 +1940,7 @@ and transl_signature env sg =
         List.iter (fun (id, md, _uid) ->
           Signature_names.check_module names md.md_loc id;
         ) decls;
-        let sig_items =
+        let sg_items =
           map_rec (fun rs (id, md, uid) ->
             let d = {Types.md_type = md.md_type.mty_type;
                      md_attributes = md.md_attributes;
@@ -1951,7 +1951,7 @@ and transl_signature env sg =
             decls []
         in
         mksig (Tsig_recmodule (List.map (fun (md, _, _) -> md) tdecls)) env loc,
-        sig_items,
+        sg_items,
         newenv
     | Psig_modtype pmtd ->
         let newenv, mtd, decl = transl_modtype_decl env pmtd in
@@ -2036,13 +2036,13 @@ and transl_signature env sg =
     | Psig_extension (ext, _attrs) ->
         raise (Error_forward (Builtin_attributes.error_of_extension ext))
   in
-  let rec transl_sig env sig_items sig_type = function
-    | [] -> List.rev sig_items, List.rev sig_type, env
+  let rec transl_sig env sg_items sg_type = function
+    | [] -> List.rev sg_items, List.rev sg_type, env
     | item :: srem ->
-      let new_item , new_types , env = transl_sig_item env sig_type item in
+      let new_item , new_types , env = transl_sig_item env sg_type item in
       transl_sig env
-        (new_item :: sig_items)
-        (List.rev_append new_types sig_type)
+        (new_item :: sg_items)
+        (List.rev_append new_types sg_type)
         srem
   in
   let previous_saved_types = Cmt_format.get_saved_types () in
@@ -2053,7 +2053,7 @@ and transl_signature env sg =
        in
        let rem = Signature_names.simplify final_env names rem in
        let sg =
-         { sig_items = trem; sig_type = rem; sig_final_env = final_env }
+         { sg_items = trem; sg_type = rem; sg_final_env = final_env }
        in
        Cmt_format.set_saved_types
          ((Cmt_format.Partial_signature sg) :: previous_saved_types);
@@ -3872,7 +3872,7 @@ let type_interface ~sourcefile modulename env ast =
     !Clflags.as_argument_for
     |> Option.map (fun name -> Global_module.Name.create_no_args name)
   in
-  ignore (check_argument_type_if_given env sourcefile sg.sig_type arg_type
+  ignore (check_argument_type_if_given env sourcefile sg.sg_type arg_type
           : Typedtree.argument_interface option);
   sg
 

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -784,7 +784,7 @@ let module_type_declaration sub mtd =
     (map_loc sub mtd.mtd_name)
 
 let signature sub sg =
-  List.map (sub.signature_item sub) sg.sig_items
+  List.map (sub.signature_item sub) sg.sg_items
 
 let signature_item sub item =
   let loc = sub.location sub item.sig_loc in


### PR DESCRIPTION
EDIT: Changed approach. See comments below.

This PR renames `sig_` to `sigi_` for `typedtree.signature_item`; similar for `structure_item`.

# Motivation

Very soon we will have a field `psig_loc` in `parsetree.signature`, but there is already a field of this name in `parsetree.signature_item`. To avoid clashes, we will rename the second one to `psigi_loc` where `i` stands for "item". Then, for naming consistency between `parsetree` and `typedtree`, we should rename the `sig_*` fields in `typedtree.signature_item` as well. 

# Review

Please only review `typedtree.mli`. The rest is mechanical and boring.