### PR TITLE
Fix problems with allocation of stacks

### DIFF
--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -292,13 +292,9 @@ CAMLnoret CAMLextern void caml_raise_unhandled_effect (value effect);
 value caml_make_unhandled_effect_exn (value effect);
 
 #if defined(NATIVE_CODE) && !defined(STACK_CHECKS_ENABLED)
-// mmap does not seem to guarantee it will always return a page-aligned
-// address as per some man pages from a few years ago (more recent man
-// pages seem to indicate the alignment is guaranteed), hence the last
-// part of the expression below to add an offset guaranteeing alignment
+// We can assume that mmap returns page-aligned addresses.
 #define Protected_stack_page(block, page_size) \
-  (((char*) (block)) + (page_size) + (page_size) - \
-   ((uintnat) ((char*) (block)) % (page_size)))
+  (((char*) (block)) + (page_size))
 #endif
 
 #endif /* CAML_INTERNALS */


### PR DESCRIPTION
The existing code to allocate stacks, when stack checks are off, erroneously asks for memory not backed by huge pages on Linux.  In addition it can inhibit the transparent huge page coalescing algorithm (or split existing huge pages), because the guard page that gets `mprotect`ed might be in the middle of a proposed (or existing) huge page partially occupied by something else at an address just below the stack.  (We only consider 2Mb huge pages as this seems like the common case.)

This PR aims to fix these problems.  It also removes the use of `MAP_STACK`, as it seems that certain versions of the kernel might interpret this as a request to disable huge pages.