### PR TITLE
Improved error messages from Emit

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1875,6 +1875,14 @@ let emit_instr ~first ~fallthrough i =
   | Lstackcheck { max_frame_size_bytes; } ->
     emit_stack_check ~size_in_bytes:max_frame_size_bytes ~save_registers:(not first)
 
+let emit_instr ~first ~fallthrough i =
+  try emit_instr ~first ~fallthrough i
+  with exn -> (
+    Format.eprintf "Exception whilst emitting instruction:@ %a\n"
+      Printlinear.instr i;
+    raise exn
+  )
+
 let rec emit_all ~first ~fallthrough i =
   match i.desc with
   | Lend -> ()

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -1238,6 +1238,14 @@ let emit_instr i =
         sc_max_frame_size_in_bytes = max_frame_size_bytes;
       }
 
+let emit_instr i =
+  try emit_instr i
+  with exn -> (
+    Format.eprintf "Exception whilst emitting instruction:@ %a\n"
+      Printlinear.instr i;
+    raise exn
+  )
+
 (* Emission of an instruction sequence *)
 
 let rec emit_all i =


### PR DESCRIPTION
Error messages from `Emit` during emission of instructions can be very unhelpful at the moment.  This PR improves them to print the offending instruction, e.g.:
```
Exception whilst emitting instruction:
signed int32[a:V/61[%rax] + i:I/62[%rbx] * 2 + 6] := new_value:X/93[%xmm0] (assign) {tests/simd/arrays_internal.ml:1281,16-55}
Fatal error: exception File "backend/amd64/emit.mlp", line 329, characters 9-15: Assertion failed
```
Previously you would just get the "Assertion failed" line.