### PR TITLE
Add converters to the capsule API

### DIFF
--- a/testsuite/tests/capsule-api/poisoning.ml
+++ b/testsuite/tests/capsule-api/poisoning.ml
@@ -68,10 +68,10 @@ let () =
   assert (!x = 2)
 ;;
 
-(* Destroying the mutex leaks the password. *)
+(* Destroying the mutex leaks a converter. *)
 let () =
   let (P m) = m in
-  let _k : _ Capsule.Password.t = Capsule.Mutex.destroy m in
+  let _k : _ Capsule.Access.t = Capsule.Mutex.destroy m in
   ()
 ;;
 


### PR DESCRIPTION
This PR extends the capsule API with a new `Converter.t` type that doesn't cross contention and, when `uncontended`, can freely wrap and unwrap `Data.t` values. They are made available by a `Capsule.access` function, which many of the `Capsule.Data` functions could be implemented in terms of. They should make some patterns slightly easier to write.

Converters replace the `expose` function and the use of global `Password.t`s for converting values, which allows us to safely mark `Password.t`s as crossing contention which makes it easier to nest their usage. Separating these two roles also helps to clarify the relationship between capsules and threads.