### PR TITLE
Add caml_no_bytecode_impl

### DIFF
--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -53,6 +53,7 @@
      runtime_events.c sync.c
    dynlink.c backtrace_byt.c backtrace.c afl.c bigarray.c prng.c float32.c
    blake2.c
+   misc.c
    build_config.h sync_posix.h caml/jumptbl.h)
  (action
    (progn

--- a/ocaml/runtime/misc.c
+++ b/ocaml/runtime/misc.c
@@ -328,3 +328,8 @@ const char * __tsan_default_suppressions(void) {
          "deadlock:pthread_mutex_lock\n"; /* idem */
 }
 #endif /* WITH_THREAD_SANITIZER */
+
+CAMLprim value caml_no_bytecode_impl(void)
+{
+  caml_failwith("No bytecode implementation provided for this external");
+}

--- a/ocaml/runtime4/misc.c
+++ b/ocaml/runtime4/misc.c
@@ -306,3 +306,8 @@ CAMLprim value caml_domain_dls_compare_and_set(void)
 {
   caml_fatal_error("Domains not implemented in runtime4");
 }
+
+CAMLprim value caml_no_bytecode_impl(void)
+{
+  caml_failwith("No bytecode implementation provided for this external");
+}

--- a/ocaml/testsuite/tests/external/no_bytecode_impl.ml
+++ b/ocaml/testsuite/tests/external/no_bytecode_impl.ml
@@ -1,0 +1,11 @@
+(* TEST *)
+
+external foo : unit -> unit = "caml_no_bytecode_impl"
+
+(* All we really want to check is that this links without a missing primitive
+   error on bytecode *)
+let () =
+  try
+    foo ();
+    assert false
+  with (Failure _) -> ()


### PR DESCRIPTION
This adds a primitive C function (i.e. one recognised by the bytecode runtime for use in `external`) which just fails with a message saying that the external isn't available on bytecode.  The aim is to standardise on this for native-only externals.  We did discuss having an attribute instead, but this is much easier and seems just as clear.