### PR TITLE
Linscan (CFG): use `DLL.t` instead of `List.t` for ranges

### DIFF
--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -51,9 +51,9 @@ let build_intervals : State.t -> Cfg_with_infos.t -> unit =
     match Reg.Tbl.find_opt past_ranges reg with
     | None ->
       Reg.Tbl.replace past_ranges reg
-        { Interval.reg; begin_; end_; ranges = [range] }
+        { Interval.reg; begin_; end_; ranges = DLL.make_single range }
     | Some (interval : Interval.t) ->
-      interval.ranges <- range :: interval.ranges;
+      DLL.add_end interval.ranges range;
       interval.end_ <- end_
   in
   let update_range (reg : Reg.t) ~(begin_ : int) ~(end_ : int) : unit =
@@ -104,10 +104,6 @@ let build_intervals : State.t -> Cfg_with_infos.t -> unit =
          present at the end of every "block". *)
       incr pos);
   Reg.Tbl.iter (fun reg (range : Range.t) -> add_range reg range) current_ranges;
-  Reg.Tbl.iter
-    (fun _reg (interval : Interval.t) ->
-      interval.ranges <- List.rev interval.ranges)
-    past_ranges;
   if ls_debug && Lazy.force ls_verbose
   then
     iter_cfg_dfs (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun block ->

--- a/backend/regalloc/regalloc_ls_state.ml
+++ b/backend/regalloc/regalloc_ls_state.ml
@@ -65,25 +65,27 @@ let[@inline] get_and_incr_instruction_id state =
   state.next_instruction_id <- succ res;
   res
 
-let rec check_ranges (prev : Range.t) (l : Range.t list) : int =
+let rec check_ranges (prev : Range.t) (cell : Range.t DLL.cell option) : int =
   if prev.begin_ > prev.end_
   then fatal "Regalloc_ls_state.check_ranges: prev.begin_ > prev.end_";
-  match l with
-  | [] -> prev.end_
-  | hd :: tl ->
-    if prev.end_ >= hd.begin_
+  match cell with
+  | None -> prev.end_
+  | Some cell ->
+    let value = DLL.value cell in
+    if prev.end_ >= value.begin_
     then fatal "Regalloc_ls_state.check_ranges: prev.end_ >= hd.begin_";
-    check_ranges hd tl
+    check_ranges value (DLL.next cell)
 
 let rec check_intervals (prev : Interval.t) (l : Interval.t list) : unit =
   if prev.begin_ > prev.end_
   then fatal "Regalloc_ls_state.check_intervals: prev.begin_ > prev.end_";
-  (match prev.ranges with
-  | [] -> fatal "Regalloc_ls_state.check_intervals: no ranges"
-  | hd :: tl ->
-    if hd.begin_ <> prev.begin_
+  (match DLL.hd_cell prev.ranges with
+  | None -> fatal "Regalloc_ls_state.check_intervals: no ranges"
+  | Some cell ->
+    let value = DLL.value cell in
+    if value.begin_ <> prev.begin_
     then fatal "Regalloc_ls_state.check_intervals: hd.begin_ <> prev.begin_";
-    let end_ = check_ranges hd tl in
+    let end_ = check_ranges value (DLL.next cell) in
     if end_ <> prev.end_
     then fatal "Regalloc_ls_state.check_intervals: end_ <> prev.end_");
   match l with
@@ -93,11 +95,13 @@ let rec check_intervals (prev : Interval.t) (l : Interval.t list) : unit =
     then fatal "Regalloc_ls_state.check_intervals: prev.begin_ > hd.begin_";
     check_intervals hd tl
 
-let rec is_in_a_range ls_order (l : Range.t list) : bool =
-  match l with
-  | [] -> false
-  | hd :: tl ->
-    (ls_order >= hd.begin_ && ls_order <= hd.end_) || is_in_a_range ls_order tl
+let rec is_in_a_range ls_order (cell : Range.t DLL.cell option) : bool =
+  match cell with
+  | None -> false
+  | Some cell ->
+    let value = DLL.value cell in
+    (ls_order >= value.begin_ && ls_order <= value.end_)
+    || is_in_a_range ls_order (DLL.next cell)
 
 let[@inline] invariant_intervals state cfg_with_infos =
   if ls_debug && Lazy.force ls_invariants
@@ -136,7 +140,7 @@ let[@inline] invariant_intervals state cfg_with_infos =
               fatal
                 "Regalloc_ls_state.invariant_intervals: instr.ls_order > \
                  interval.end_";
-            if not (is_in_a_range instr.ls_order interval.ranges)
+            if not (is_in_a_range instr.ls_order (DLL.hd_cell interval.ranges))
             then
               fatal
                 "Regalloc_ls_state.invariant_intervals: not (is_in_a_range \

--- a/backend/regalloc/regalloc_ls_utils.mli
+++ b/backend/regalloc/regalloc_ls_utils.mli
@@ -1,6 +1,7 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
 open Regalloc_utils
+module DLL = Flambda_backend_utils.Doubly_linked_list
 
 val ls_debug : bool
 
@@ -42,11 +43,11 @@ module Range : sig
 
   val print : Format.formatter -> t -> unit
 
-  val overlap : t list -> t list -> bool
+  val overlap : t DLL.t -> t DLL.t -> bool
 
-  val is_live : t list -> pos:int -> bool
+  val is_live : t DLL.t -> pos:int -> bool
 
-  val remove_expired : t list -> pos:int -> t list
+  val remove_expired : t DLL.t -> pos:int -> unit
 end
 
 module Interval : sig
@@ -55,7 +56,7 @@ module Interval : sig
     { reg : Reg.t;
       mutable begin_ : int;
       mutable end_ : int;
-      mutable ranges : Range.t list
+      ranges : Range.t DLL.t
     }
 
   val copy : t -> t

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -362,3 +362,8 @@ let transfer ~to_ ~from () =
     from.first <- Empty;
     from.last <- Empty;
     from.length <- 0
+
+let map t ~f =
+  let res = make_empty () in
+  iter t ~f:(fun x -> add_end res (f x));
+  res

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -82,3 +82,5 @@ val to_list : 'a t -> 'a list
 
 (* Adds all of the elements of `from` to `to_`, and clears `from`. *)
 val transfer : to_:'a t -> from:'a t -> unit -> unit
+
+val map : 'a t -> f:('a -> 'b) -> 'b t


### PR DESCRIPTION
As per title. I will do some benchmarking,
but the impact of this change alone is
probably rather modest.