### PR TITLE
Module parameter names should have its own type

### DIFF
--- a/ocaml/file_formats/cmi_format.ml
+++ b/ocaml/file_formats/cmi_format.ml
@@ -23,7 +23,7 @@ type pers_flags =
 type kind =
   | Normal of {
       cmi_impl : Compilation_unit.t;
-      cmi_arg_for : Global_module.Name.t option;
+      cmi_arg_for : Global_module.Parameter.t option;
     }
   | Parameter
 
@@ -73,7 +73,7 @@ type 'sg cmi_infos_generic = {
     cmi_kind : kind;
     cmi_globals : Global_module.t array;
     cmi_sign : 'sg;
-    cmi_params : Global_module.t list;
+    cmi_params : Global_module.Parameter.t list;
     cmi_crcs : crcs;
     cmi_flags : flags;
 }

--- a/ocaml/file_formats/cmi_format.mli
+++ b/ocaml/file_formats/cmi_format.mli
@@ -25,16 +25,16 @@ type kind =
       cmi_impl : Compilation_unit.t;
         (* If this module takes parameters, [cmi_impl] will be the functor that
            generates instances *)
-      cmi_arg_for : Global_module.Name.t option;
+      cmi_arg_for : Global_module.Parameter.t option;
+      cmi_globals : Global_module.t array;
+      cmi_params : Global_module.Parameter.t list;
     }
   | Parameter
 
 type 'sg cmi_infos_generic = {
     cmi_name : Compilation_unit.Name.t;
     cmi_kind : kind;
-    cmi_globals : Global_module.t array;
     cmi_sign : 'sg;
-    cmi_params : Global_module.t list; (* CR lmaurer: Should be [Parameter_name.t list] *)
     cmi_crcs : Import_info.t array;
     cmi_flags : pers_flags list;
 }

--- a/ocaml/typing/.ocamlformat-enable
+++ b/ocaml/typing/.ocamlformat-enable
@@ -17,3 +17,7 @@ jkind_axis.mli
 jkind_axis.ml
 allowance.mli
 allowance.ml
+global_module.ml
+global_module.mli
+signature_with_global_bindings.ml
+signature_with_global_bindings.mli

--- a/ocaml/typing/signature_with_global_bindings.ml
+++ b/ocaml/typing/signature_with_global_bindings.ml
@@ -5,11 +5,11 @@ type t = {
   bound_globals : Global_module.t array;
 }
 
-let read_from_cmi (cmi : Cmi_format.cmi_infos_lazy) =
+let read_from_cmi cmi_sign cmi_globals =
   let sign =
     (* Freshen identifiers bound by signature *)
-    Subst.Lazy.signature Make_local Subst.identity cmi.cmi_sign in
-  let bound_globals = cmi.cmi_globals in
+    Subst.Lazy.signature Make_local Subst.identity cmi_sign in
+  let bound_globals = cmi_globals in
   { sign; bound_globals }
 
 let array_fold_left_filter_map f init array =
@@ -20,18 +20,18 @@ let array_fold_left_filter_map f init array =
   in
   ans, new_array
 
-let subst t (args : (Global_module.Name.t * Global_module.t) list) =
+let subst t (args : (Global_module.Parameter.t * Global_module.t) list) =
   let { sign; bound_globals } = t in
   match args with
   | [] -> t
   | _ ->
       (* The global-level substitution *)
-      let arg_subst = Global_module.Name.Map.of_list args in
+      let arg_subst = Global_module.Parameter.Map.of_list args in
       (* Take a bound global, substitute arguments into it, then return the
          updated global while also adding it to the term-level substitution *)
       let add_and_update_binding subst bound_global =
         let name = Global_module.to_name bound_global in
-        if Global_module.Name.Map.mem name arg_subst then
+        if Global_module.Parameter.Map.mem name arg_subst then
           (* This shouldn't happen: only globals with hidden arguments should be
              in [bound_globals], and parameters shouldn't have arguments.
              Previous code that was meant to handle parameterised parameters

--- a/ocaml/typing/signature_with_global_bindings.mli
+++ b/ocaml/typing/signature_with_global_bindings.mli
@@ -17,7 +17,7 @@ type t = private {
   bound_globals : Global_module.t array;
 }
 
-val read_from_cmi : Cmi_format.cmi_infos_lazy -> t
+val read_from_cmi : Subst.Lazy.signature -> Global_module.t array -> t
 
 (** To see how substitution will work on [t], suppose we have something like
       {v let X = X in
@@ -51,4 +51,4 @@ val read_from_cmi : Cmi_format.cmi_infos_lazy -> t
     Note that the argument values themselves won't be returned in the new list
     of bound globals, since it's assumed that they are already accounted for in
     the environment. *)
-val subst : t -> (Global_module.Name.t * Global_module.t) list -> t
+val subst : t -> (Global_module.Parameter.t * Global_module.t) list -> t

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -161,7 +161,7 @@ type error =
       old_arg_type: Global_module.Name.t option;
       old_source_file: Misc.filepath;
     }
-  | Duplicate_parameter_name of Global_module.Name.t
+  | Duplicate_parameter_name of Global_module.Parameter.t
   | Submode_failed of Mode.Value.error
 
 exception Error of Location.t * Env.t * error

--- a/ocaml/utils/compilation_unit.ml
+++ b/ocaml/utils/compilation_unit.ml
@@ -44,7 +44,7 @@ module Name : sig
 
   val of_head_of_global_name : Global_module.Name.t -> t
 
-  val of_global_name_no_args_exn : Global_module.Name.t -> t
+  val of_parameter : Global_module.Parameter.t -> t
 
   val to_global_name : t -> Global_module.Name.t
 
@@ -80,17 +80,8 @@ end = struct
 
   let of_head_of_global_name (name : Global_module.Name.t) = of_string name.head
 
-  let of_global_name_no_args_exn (name : Global_module.Name.t) =
-    match name.args with
-    | [] -> of_head_of_global_name name
-    | _ ->
-      (* This is a wart. We should have a separate type
-         [Global_module.Parameter_name.t] that is known not to have arguments,
-         and then we can convert without runtime checks here. Note that we can't
-         actually be specific in this message about why the thing isn't supposed
-         to have arguments. *)
-      Misc.fatal_errorf "Arguments not allowed in name:@ %a"
-        Global_module.Name.print name
+  let of_parameter (name : Global_module.Parameter.t) =
+    of_string (Global_module.Parameter.to_string name)
 
   let to_global_name t = Global_module.Name.create_no_args t
 

--- a/ocaml/utils/compilation_unit.mli
+++ b/ocaml/utils/compilation_unit.mli
@@ -47,7 +47,7 @@ module Name : sig
 
   val of_head_of_global_name : Global_module.Name.t -> t
 
-  val of_global_name_no_args_exn : Global_module.Name.t -> t
+  val of_parameter : Global_module.Parameter.t -> t
 
   val to_global_name : t -> Global_module.Name.t
 

--- a/tests/typing/global_module_test.ml
+++ b/tests/typing/global_module_test.ml
@@ -9,16 +9,18 @@ module Test_data = struct
 
     let g ?(vis = []) ?(hid = []) head =
       create_exn head (args_of_pairs vis) ~hidden_args:(args_of_pairs hid)
+
+    let p s = Parameter.create s
   end
 
   let [@ocamlformat "disable"] () =
     (* This [let] is only here so that ocamlformat lets us add line breaks in
        the following. Note that, despite being disabled, ocamlformat insists on
        adding whitespace errors by indenting empty lines. *)
-  
+
     (* Here we imagine the following modules and parameters, with their
        parameters given in square brackets:
-  
+
        {v
          - X (parameter)
          - Y[X] (parameter)
@@ -33,7 +35,7 @@ module Test_data = struct
          - Opaque[I] : Conv[I][O:String]
          - Print[I][Conv[I][O:String]] (regular module)
        v}
-  
+
        Each [*_p] is an [I.param] and an untagged identifier is an [I.t].
        *)
     ()
@@ -41,6 +43,8 @@ module Test_data = struct
   let x = n "X"
 
   let x_g = g "X"
+
+  let x_p = p "X"
 
   let y = n "Y"
 
@@ -54,11 +58,11 @@ module Test_data = struct
 
   let i = n "I"
 
-  let i_g = g "I"
+  let i_g = p "I"
 
   let o = n "O"
 
-  let o_g = g "O"
+  let o_g = p "O"
 
   let conv = n "Conv"
 


### PR DESCRIPTION
Based on #1726 

Uses the fact that parameters can't be parameterized, and encode that info in the types. This can help remove some `assert false` in the code.

This will be picked up by @lukemaurer when he has time.