### PR TITLE
Temporary fix for compaction / hugepage interaction - don't free pools

### DIFF
--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -52,6 +52,7 @@ extern uintnat caml_custom_minor_max_bsz; /* see custom.c */
 extern uintnat caml_minor_heap_max_wsz;   /* see domain.c */
 extern uintnat caml_custom_work_max_multiplier; /* see major_gc.c */
 extern uintnat caml_prelinking_in_use;    /* see startup_nat.c */
+extern uintnat caml_compact_unmap;        /* see shared_heap.c */
 
 CAMLprim value caml_gc_quick_stat(value v)
 {
@@ -428,7 +429,8 @@ struct gc_tweak {
 };
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
-  { "prelinking_in_use", &caml_prelinking_in_use, 0 }
+  { "prelinking_in_use", &caml_prelinking_in_use, 0 },
+  { "compact_unmap", &caml_compact_unmap, 0 },
 };
 enum {N_GC_TWEAKS = sizeof(gc_tweaks)/sizeof(gc_tweaks[0])};
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -845,6 +845,9 @@ void caml_verify_heap_from_stw(caml_domain_state *domain) {
 
 /* Compaction starts here. See [caml_compact_heap] for entry. */
 
+/* Whether compaction should actually unmap memory. */
+uintnat caml_compact_unmap = 0;
+
 /* Given a single value `v`, found at `p`, check if it points to an
    evacuated block, and if so update it using the forwarding pointer
    created by the compactor. */
@@ -1291,31 +1294,53 @@ void caml_compact_heap(caml_domain_state* domain_state,
       Note that we may have no "available" pools left, if all
       remaining pools have been filled up by evacuated blocks. */
 
-  pool* cur_pool = evacuated_pools;
-  uintnat freed_pools = 0;
-  while (cur_pool) {
-    pool* next_pool = cur_pool->next;
+  if (caml_compact_unmap) {
+    pool* cur_pool = evacuated_pools;
+    uintnat freed_pools = 0;
+    while (cur_pool) {
+      pool* next_pool = cur_pool->next;
 
-    #ifdef DEBUG
-    for (header_t *p = POOL_FIRST_BLOCK(cur_pool, cur_pool->sz);
-         p < POOL_END(cur_pool); p++) {
-      *p = Debug_free_major;
+      #ifdef DEBUG
+      for (header_t *p = POOL_FIRST_BLOCK(cur_pool, cur_pool->sz);
+           p < POOL_END(cur_pool); p++) {
+        *p = Debug_free_major;
+      }
+      #endif
+
+      pool_free(heap, cur_pool, cur_pool->sz);
+      cur_pool = next_pool;
+      freed_pools++;
     }
-    #endif
+    caml_plat_lock_blocking(&pool_freelist.lock);
+    pool_freelist.active_pools -= freed_pools;
+    caml_plat_unlock(&pool_freelist.lock);
+  } else {
+    pool* cur_pool = evacuated_pools;
+    pool* last = NULL;
+    uintnat freed_pools = 0;
+    while (cur_pool) {
+      sizeclass sz = cur_pool->sz;
+      heap->stats.pool_words -= POOL_WSIZE;
+      heap->stats.pool_frag_words -= POOL_HEADER_WSIZE + wastage_sizeclass[sz];
+      last = cur_pool;
+      cur_pool = cur_pool->next;
+      freed_pools++;
+    }
 
-    pool_free(heap, cur_pool, cur_pool->sz);
-    cur_pool = next_pool;
-    freed_pools++;
+    if (evacuated_pools) {
+      caml_plat_lock_blocking(&pool_freelist.lock);
+      last->next = pool_freelist.free;
+      pool_freelist.free = evacuated_pools;
+      pool_freelist.active_pools -= freed_pools;
+      caml_plat_unlock(&pool_freelist.lock);
+    }
   }
-  caml_plat_lock_blocking(&pool_freelist.lock);
-  pool_freelist.active_pools -= freed_pools;
-  caml_plat_unlock(&pool_freelist.lock);
 
   CAML_EV_END(EV_COMPACT_RELEASE);
   caml_global_barrier(participating_count);
 
   /* Fourth phase: one domain also needs to release the free list */
-  if( participants[0] == Caml_state ) {
+  if( participants[0] == Caml_state && caml_compact_unmap ) {
     pool* cur_pool;
     pool* next_pool;
 
@@ -1332,7 +1357,9 @@ void caml_compact_heap(caml_domain_state* domain_state,
     pool_freelist.free = NULL;
 
     caml_plat_unlock(&pool_freelist.lock);
+  }
 
+  if (participants[0] == Caml_state) {
     /* We are done, increment our compaction count */
     atomic_fetch_add(&caml_compactions_count, 1);
   }


### PR DESCRIPTION
Currently, the compactor frees an arbitrary subset of 32 kB pools from the shared heap when it runs. Unfortunately, performance of many programs depends on getting most of the heap backed by 2MB hugepages rather than 4kB pages, and freeing a 32 kB chunk from the middle of a hugepage causes the kernel to dissolve the hugepages into 4kB pages.

There's a proper fix for this being worked on in #2488 . This is a temporary fix: with this patch, compaction no longer actually frees memory. (This means you get the cache-locality benefits of compaction, but not the memory reduction).

For programs that really do want to free the pools, the old behaviour is available as a gc tweak with `Xcompact_unmap=1` in `OCAMLRUNPARAM`.

**Reviewer note**: Use `Diff view -> Hide whitespace` to read this - a block of code moved inside an if and got indented, making the patch look bigger than it is.

### Testing

I tested with this program, which allocates a bunch of memory, frees it, then allocates a bunch more:
<details>
<summary>Source</summary>

```ocaml
let mem () =
  Printf.printf "% 10d %!" ((Gc.quick_stat ()).heap_words * 8 / 1024);
  ignore (Unix.system (Printf.sprintf "grep VmRSS /proc/%d/status" (Unix.getpid ())))

let make _ = Array.make 23 'x'

let () =
  mem ();
  let a = Array.init (1000 * 1024) make in
  mem ();
  Gc.compact ();
  mem ();
  Gc.compact ();
  mem ();
  for i = 0 to (Array.length a - 1) / 2 do
    a.(i * 2) <- [| |]
  done;
  Gc.compact ();
  mem ();
  for i = 0 to (Array.length a - 1) / 2 do
    a.(i * 2) <- make ()
  done;
  mem ();
  Gc.compact ();
  mem ();
  ignore (Sys.opaque_identity a)
```

</details>

With `Xcompact_unmap=1` we see the old behaviour, where the heap size (as reported by `Gc.quick_stat`) and memory usage (as reported by `/proc`) grow and shrink:
```
         0 VmRSS:	    3464 kB
    201248 VmRSS:	  213216 kB
    209312 VmRSS:	  221280 kB
    209312 VmRSS:	  221280 kB
    108800 VmRSS:	  120816 kB
    203136 VmRSS:	  215152 kB
    209312 VmRSS:	  221328 kB
```

With the new behaviour, the RSS does not shrink. However, the freed pools are available for later allocation, so it doesn't grow either when more allocation occurs:
```
         0 VmRSS:	    3400 kB
    201248 VmRSS:	  213152 kB
    209312 VmRSS:	  221216 kB
    209312 VmRSS:	  221216 kB
    108800 VmRSS:	  221264 kB
    203136 VmRSS:	  221264 kB
    209312 VmRSS:	  221264 kB
```

(I'm not planning to check this program in as a test: it's nonportable and its output is unstable)

### Alternatives

I experimented with using `madvise` with any of `MADV_DONTNEED`, `MADV_FREE` and `MADV_COLD` to tell the kernel that some memory was free and available for other programs should there be memory pressure. Sadly, all of these madvise options cause Linux to immediately dissolve the surrounding hugepage (even if, in the case of `MADV_FREE` at least, it does not actually free the memory promptly). This has the same disadvantage of ruining the performance of adjacent pools, so isn't workable.