### PR TITLE
Fix test for float32_cvt_i32

### DIFF
--- a/flambda-backend/tests/simd/dune
+++ b/flambda-backend/tests/simd/dune
@@ -11,7 +11,7 @@
  (archive_name stubs)
  (language c)
  (names stubs)
- (flags -msse4.2)
+ (flags (:standard -msse4.2))
  (include_dirs "../../../%{env:RUNTIME_DIR=runtime-dir-env-var-not-set}"))
 
 ; Tests with external assembler

--- a/flambda-backend/tests/simd/ops.ml
+++ b/flambda-backend/tests/simd/ops.ml
@@ -356,8 +356,6 @@ module Float32 = struct
     external sqrt : (t [@unboxed]) -> (t [@unboxed]) = "caml_vec128_unreachable" "float32_sqrt" [@@noalloc]
     external rsqrt : (t [@unboxed]) -> (t [@unboxed]) = "caml_vec128_unreachable" "float32_rsqrt" [@@noalloc]
 
-    let is_nan (f:t) = neq f f
-
     let check_floats f =
         Random.set_state (Random.State.make [|1234567890|]);
         f zero zero;
@@ -386,9 +384,6 @@ module Float32 = struct
         for _ = 0 to 100_000 do
             let f0 = Random.int32 Int32.max_int in
             let f1 = Random.int32 Int32.max_int in
-            if (is_nan(f0) || is_nan(f1))
-            then (* operations on nans behave differently *) ()
-            else
             f (if Random.bool () then f0 else Int32.neg f0)
               (if Random.bool () then f1 else Int32.neg f1)
         done
@@ -430,15 +425,9 @@ module Float64 = struct
         f max_float max_float;
         f min_float min_float;
         f max_float min_float;
-        let is_nan x =
-          Int64.float_of_bits x |> Float.is_nan
-        in
         for _ = 0 to 100_000 do
             let f0 = Random.int64 Int64.max_int in
             let f1 = Random.int64 Int64.max_int in
-            if (is_nan(f0) || is_nan(f1))
-            then (* operations on nans behave differently *) ()
-            else
             f (if Random.bool () then Int64.float_of_bits f0 else Int64.(neg f0 |> float_of_bits))
               (if Random.bool () then Int64.float_of_bits f1 else Int64.(neg f1 |> float_of_bits))
         done

--- a/flambda-backend/tests/simd/ops.ml
+++ b/flambda-backend/tests/simd/ops.ml
@@ -66,6 +66,26 @@ external float64x2_of_int64s : int64 -> int64 -> float64x2 = "caml_vec128_unreac
 external float64x2_low_int64 : float64x2 -> int64 = "caml_vec128_unreachable" "vec128_low_int64" [@@noalloc] [@@unboxed]
 external float64x2_high_int64 : float64x2 -> int64 = "caml_vec128_unreachable" "vec128_high_int64" [@@noalloc] [@@unboxed]
 
+external float32x4_extract : (float32x4[@unboxed]) -> (int[@untagged]) -> (int32[@unboxed]) = "caml_vec128_unreachable" "test_simd_vec128_extract_ps" [@@noalloc]
+
+let eq_float32x4 ~result ~expect =
+  for i = 0 to 3 do
+    let r = float32x4_extract result i |> Int32.float_of_bits in
+    let e = float32x4_extract expect i |> Int32.float_of_bits in
+    eqf' r e
+  done
+;;
+
+let eq_float64x2 ~result ~expect =
+  let lv = float64x2_low_int64 result |> Int64.float_of_bits in
+  let hv = float64x2_high_int64 result |> Int64.float_of_bits in
+  let l = float64x2_low_int64 expect |> Int64.float_of_bits in
+  let h = float64x2_high_int64 expect |> Int64.float_of_bits in
+  eqf' lv l;
+  eqf' hv h;
+  ()
+;;
+
 let () =
     failmsg := (fun () -> Printf.printf "basic_checks!");
     let a : int8x16 = int8x16_of_int64s 1L 2L in
@@ -782,8 +802,7 @@ module Float32x4 = struct
         let v2 = Float32.to_float32x4 f1 f0 f1 f0 in
         let result = vector v1 v2 in
         failmsg := (fun () -> Printf.printf "check_binop32 %s %lx %lx\n%!" msg f0 f1);
-        eq (float32x4_low_int64 result) (float32x4_high_int64 result)
-           (float32x4_low_int64 expect) (float32x4_high_int64 expect)
+        eq_float32x4 ~result ~expect
     ;;
     let () =
         Float32.check_floats (check_binop "add" Float32.add add);
@@ -807,8 +826,7 @@ module Float32x4 = struct
         let expect = Float32.to_float32x4 r r r r in
         let v = Float32.to_float32x4 f f f f in
         let result = vector v in
-        eq (float32x4_low_int64 result) (float32x4_high_int64 result)
-           (float32x4_low_int64 expect) (float32x4_high_int64 expect)
+        eq_float32x4 ~result ~expect
     ;;
     let () =
         Float32.check_floats (fun f _ -> check_unop "rcp" Float32.rcp rcp f);
@@ -841,9 +859,8 @@ module Float32x4 = struct
             let iv = float64x2_of_int64s i0 i1 in
             let fv = Float32.to_float32x4 f0 f1 0l 0l in
             let res = cvt_float64x2 fv in
-            eq (float64x2_low_int64 res) (float64x2_high_int64 res)
-               (float64x2_low_int64 iv) (float64x2_high_int64 iv)
-        )
+            eq_float64x2 ~result:res ~expect:iv
+          )
     ;;
 
     external addsub : t -> t -> t = "caml_vec128_unreachable" "caml_sse3_float32x4_addsub"
@@ -861,8 +878,7 @@ module Float32x4 = struct
             let fv1 = Float32.to_float32x4 f1 f1 f0 f0 in
             let result = addsub fv0 fv1 in
             let expect = Float32.to_float32x4 (Float32.sub f0 f1) (Float32.add f0 f1) (Float32.sub f1 f0) (Float32.add f1 f0) in
-            eq (float32x4_low_int64 result) (float32x4_high_int64 result)
-               (float32x4_low_int64 expect) (float32x4_high_int64 expect)
+            eq_float32x4 ~result ~expect
         );
         Float32.check_floats (fun f0 f1 ->
             failmsg := (fun () -> Printf.printf "%f | %f\n%!" (Int32.float_of_bits f0) (Int32.float_of_bits f1));
@@ -870,8 +886,7 @@ module Float32x4 = struct
             let fv1 = Float32.to_float32x4 f1 f1 f0 f0 in
             let result = hadd fv0 fv1 in
             let expect = Float32.to_float32x4 (Float32.add f0 f0) (Float32.add f1 f1) (Float32.add f1 f1) (Float32.add f0 f0) in
-            eq (float32x4_low_int64 result) (float32x4_high_int64 result)
-               (float32x4_low_int64 expect) (float32x4_high_int64 expect)
+            eq_float32x4 ~result ~expect
         );
         Float32.check_floats (fun f0 f1 ->
             failmsg := (fun () -> Printf.printf "%f | %f\n%!" (Int32.float_of_bits f0) (Int32.float_of_bits f1));
@@ -879,9 +894,8 @@ module Float32x4 = struct
             let fv1 = Float32.to_float32x4 f1 f0 f1 f0 in
             let result = hsub fv0 fv1 in
             let expect = Float32.to_float32x4 (Float32.sub f0 f1) (Float32.sub f0 f1) (Float32.sub f1 f0) (Float32.sub f1 f0) in
-            eq (float32x4_low_int64 result) (float32x4_high_int64 result)
-               (float32x4_low_int64 expect) (float32x4_high_int64 expect)
-        );
+            eq_float32x4  ~result ~expect
+          );
       )
     ;;
 
@@ -900,16 +914,14 @@ module Float32x4 = struct
             (* When both are NaN, AMD returns the first argument and Intel returns the second argument.
                Hence we do not test this case. *)
             if f0 |> Int32.float_of_bits |> Float.is_nan && f1 |> Int32.float_of_bits |> Float.is_nan then () else
-            eq (float32x4_low_int64 result) (float32x4_high_int64 result)
-            (float32x4_low_int64 expect) (float32x4_high_int64 expect)
+            eq_float32x4  ~result ~expect
         );
         Float32.check_floats (fun f0 f1 ->
             failmsg := (fun () -> Printf.printf "roundf32 %f %f\n%!" (Int32.float_of_bits f0) (Int32.float_of_bits f1));
             let fv = Float32.to_float32x4 f0 f1 f0 f1 in
             let result = round 0x8 fv in
             let expect = Float32.to_float32x4 (Float32.round f0) (Float32.round f1) (Float32.round f0) (Float32.round f1) in
-            eq (float32x4_low_int64 result) (float32x4_high_int64 result)
-            (float32x4_low_int64 expect) (float32x4_high_int64 expect)
+            eq_float32x4  ~result ~expect
         )
     ;;
 end
@@ -1000,8 +1012,7 @@ module Float64x2 = struct
         let v1 = to_float64x2 f0 f1 in
         let v2 = to_float64x2 f1 f0 in
         let result = vector v1 v2 in
-        eq (float64x2_low_int64 result) (float64x2_high_int64 result)
-           (float64x2_low_int64 expect) (float64x2_high_int64 expect)
+        eq_float64x2 ~result ~expect
     ;;
     let () =
         let preserve_nan p l r = if Float.is_nan r then r else if Float.is_nan l then r else p l r in
@@ -1046,8 +1057,7 @@ module Float64x2 = struct
             let iv = float32x4_of_int64s ii 0L in
             let fv = to_float64x2 f0 f1 in
             let res = cvt_float32x4 fv in
-            eq (float32x4_low_int64 res) (float32x4_high_int64 res)
-               (float32x4_low_int64 iv) (float32x4_high_int64 iv)
+            eq_float32x4  ~result:res ~expect:iv
         )
     ;;
 
@@ -1066,8 +1076,7 @@ module Float64x2 = struct
             let fv1 = to_float64x2 f1 f1 in
             let result = addsub fv0 fv1 in
             let expect = to_float64x2 (f0 -. f1) (f0 +. f1) in
-            eq (float64x2_low_int64 result) (float64x2_high_int64 result)
-               (float64x2_low_int64 expect) (float64x2_high_int64 expect)
+            eq_float64x2 ~result ~expect
         );
         Float64.check_floats (fun f0 f1 ->
             failmsg := (fun () -> Printf.printf "%f | %f\n%!" f0 f1);
@@ -1075,8 +1084,7 @@ module Float64x2 = struct
             let fv1 = to_float64x2 f1 f1 in
             let result = hadd fv0 fv1 in
             let expect = to_float64x2 (f0 +. f0) (f1 +. f1) in
-            eq (float64x2_low_int64 result) (float64x2_high_int64 result)
-               (float64x2_low_int64 expect) (float64x2_high_int64 expect)
+            eq_float64x2 ~result ~expect
         );
         Float64.check_floats (fun f0 f1 ->
             failmsg := (fun () -> Printf.printf "%f | %f\n%!" f0 f1);
@@ -1084,8 +1092,7 @@ module Float64x2 = struct
             let fv1 = to_float64x2 f1 f0 in
             let result = hsub fv0 fv1 in
             let expect = to_float64x2 (f0 -. f1) (f1 -. f0) in
-            eq (float64x2_low_int64 result) (float64x2_high_int64 result)
-               (float64x2_low_int64 expect) (float64x2_high_int64 expect)
+            eq_float64x2  ~result ~expect
         );
       )
     ;;
@@ -1102,16 +1109,14 @@ module Float64x2 = struct
             let fv1 = to_float64x2 f1 f0 in
             let result = dp 0b0011_0001 fv0 fv1 in
             let expect = to_float64x2 (f0 *. f1 +. f1 *. f0) 0.0 in
-            eq (float64x2_low_int64 result) (float64x2_high_int64 result)
-            (float64x2_low_int64 expect) (float64x2_high_int64 expect)
+            eq_float64x2  ~result ~expect
         );
         Float64.check_floats (fun f0 f1 ->
             failmsg := (fun () -> Printf.printf "roundf64 %f %f\n%!" f0 f1);
             let fv = to_float64x2 f0 f1 in
             let result = round 0x8 fv in
             let expect = to_float64x2 (Float64.c_round f0) (Float64.c_round f1) in
-            eq (float64x2_low_int64 result) (float64x2_high_int64 result)
-            (float64x2_low_int64 expect) (float64x2_high_int64 expect)
+            eq_float64x2  ~result ~expect
         )
     ;;
 end

--- a/flambda-backend/tests/simd/ops.ml
+++ b/flambda-backend/tests/simd/ops.ml
@@ -356,6 +356,8 @@ module Float32 = struct
     external sqrt : (t [@unboxed]) -> (t [@unboxed]) = "caml_vec128_unreachable" "float32_sqrt" [@@noalloc]
     external rsqrt : (t [@unboxed]) -> (t [@unboxed]) = "caml_vec128_unreachable" "float32_rsqrt" [@@noalloc]
 
+    let is_nan (f:t) = neq f f
+
     let check_floats f =
         Random.set_state (Random.State.make [|1234567890|]);
         f zero zero;
@@ -384,6 +386,9 @@ module Float32 = struct
         for _ = 0 to 100_000 do
             let f0 = Random.int32 Int32.max_int in
             let f1 = Random.int32 Int32.max_int in
+            if (is_nan(f0) || is_nan(f1))
+            then (* operations on nans behave differently *) ()
+            else
             f (if Random.bool () then f0 else Int32.neg f0)
               (if Random.bool () then f1 else Int32.neg f1)
         done
@@ -425,9 +430,15 @@ module Float64 = struct
         f max_float max_float;
         f min_float min_float;
         f max_float min_float;
+        let is_nan x =
+          Int64.float_of_bits x |> Float.is_nan
+        in
         for _ = 0 to 100_000 do
             let f0 = Random.int64 Int64.max_int in
             let f1 = Random.int64 Int64.max_int in
+            if (is_nan(f0) || is_nan(f1))
+            then (* operations on nans behave differently *) ()
+            else
             f (if Random.bool () then Int64.float_of_bits f0 else Int64.(neg f0 |> float_of_bits))
               (if Random.bool () then Int64.float_of_bits f1 else Int64.(neg f1 |> float_of_bits))
         done

--- a/flambda-backend/tests/simd/ops_u.ml
+++ b/flambda-backend/tests/simd/ops_u.ml
@@ -746,7 +746,8 @@ module Float32x4 = struct
     external movemask_32 : (int32x4 [@unboxed]) -> (int [@untagged]) = "caml_vec128_unreachable" "caml_sse_vec128_movemask_32"
         [@@noalloc] [@@builtin]
 
-    let check_cmp scalar vector f0 f1 =
+    let check_cmp msg scalar vector f0 f1 =
+      failmsg := (fun () -> Printf.printf "check_cmp32 %s %lx %lx!\n" msg f0 f1);
         let r0, m0 = if scalar f0 f1 then 0xffffffffl, 1 else 0l, 0 in
         let r1, m1 = if scalar f1 f0 then 0xffffffffl, 1 else 0l, 0 in
         let expect = Float32.to_float32x4 r0 r1 r0 r1 |> Vector_casts.int32x4_of_float32x4 in
@@ -760,14 +761,14 @@ module Float32x4 = struct
            (int32x4_low_int64 expect) (int32x4_high_int64 expect)
     ;;
     let () =
-        Float32.check_floats (check_cmp Float32.eq (fun l r -> cmp 0 l r));
-        Float32.check_floats (check_cmp Float32.lt (fun l r -> cmp 1 l r));
-        Float32.check_floats (check_cmp Float32.le (fun l r -> cmp 2 l r));
-        Float32.check_floats (check_cmp Float32.uord (fun l r -> cmp 3 l r));
-        Float32.check_floats (check_cmp Float32.neq (fun l r -> cmp 4 l r));
-        Float32.check_floats (check_cmp Float32.nlt (fun l r -> cmp 5 l r));
-        Float32.check_floats (check_cmp Float32.nle (fun l r -> cmp 6 l r));
-        Float32.check_floats (check_cmp Float32.ord (fun l r -> cmp 7 l r))
+        Float32.check_floats (check_cmp "0" Float32.eq (fun l r -> cmp 0 l r));
+        Float32.check_floats (check_cmp "1" Float32.lt (fun l r -> cmp 1 l r));
+        Float32.check_floats (check_cmp "2" Float32.le (fun l r -> cmp 2 l r));
+        Float32.check_floats (check_cmp "3" Float32.uord (fun l r -> cmp 3 l r));
+        Float32.check_floats (check_cmp "4" Float32.neq (fun l r -> cmp 4 l r));
+        Float32.check_floats (check_cmp "5" Float32.nlt (fun l r -> cmp 5 l r));
+        Float32.check_floats (check_cmp "6" Float32.nle (fun l r -> cmp 6 l r));
+        Float32.check_floats (check_cmp "7" Float32.ord (fun l r -> cmp 7 l r))
     ;;
 
     external add : t -> t -> t = "caml_vec128_unreachable" "caml_sse_float32x4_add"

--- a/flambda-backend/tests/simd/ops_u.ml
+++ b/flambda-backend/tests/simd/ops_u.ml
@@ -368,6 +368,8 @@ module Float32 = struct
     external sqrt : (t [@unboxed]) -> (t [@unboxed]) = "caml_vec128_unreachable" "float32_sqrt" [@@noalloc]
     external rsqrt : (t [@unboxed]) -> (t [@unboxed]) = "caml_vec128_unreachable" "float32_rsqrt" [@@noalloc]
 
+    let is_nan (f:t) = neq f f
+
     let check_floats f =
         Random.set_state (Random.State.make [|1234567890|]);
         f zero zero;
@@ -396,6 +398,9 @@ module Float32 = struct
         for _ = 0 to 100_000 do
             let f0 = Random.int32 Int32.max_int in
             let f1 = Random.int32 Int32.max_int in
+            if (is_nan(f0) || is_nan(f1))
+            then (* operations on nans behave differently *) ()
+            else
             f (if Random.bool () then f0 else Int32.neg f0)
               (if Random.bool () then f1 else Int32.neg f1)
         done
@@ -437,9 +442,15 @@ module Float64 = struct
         f max_float max_float;
         f min_float min_float;
         f max_float min_float;
+        let is_nan x =
+          Int64.float_of_bits x |> Float.is_nan
+        in
         for _ = 0 to 100_000 do
             let f0 = Random.int64 Int64.max_int in
             let f1 = Random.int64 Int64.max_int in
+            if (is_nan(f0) || is_nan(f1))
+            then (* operations on nans behave differently *) ()
+            else
             f (if Random.bool () then Int64.float_of_bits f0 else Int64.(neg f0 |> float_of_bits))
               (if Random.bool () then Int64.float_of_bits f1 else Int64.(neg f1 |> float_of_bits))
         done

--- a/flambda-backend/tests/simd/ops_u.ml
+++ b/flambda-backend/tests/simd/ops_u.ml
@@ -368,8 +368,6 @@ module Float32 = struct
     external sqrt : (t [@unboxed]) -> (t [@unboxed]) = "caml_vec128_unreachable" "float32_sqrt" [@@noalloc]
     external rsqrt : (t [@unboxed]) -> (t [@unboxed]) = "caml_vec128_unreachable" "float32_rsqrt" [@@noalloc]
 
-    let is_nan (f:t) = neq f f
-
     let check_floats f =
         Random.set_state (Random.State.make [|1234567890|]);
         f zero zero;
@@ -398,9 +396,6 @@ module Float32 = struct
         for _ = 0 to 100_000 do
             let f0 = Random.int32 Int32.max_int in
             let f1 = Random.int32 Int32.max_int in
-            if (is_nan(f0) || is_nan(f1))
-            then (* operations on nans behave differently *) ()
-            else
             f (if Random.bool () then f0 else Int32.neg f0)
               (if Random.bool () then f1 else Int32.neg f1)
         done
@@ -442,15 +437,9 @@ module Float64 = struct
         f max_float max_float;
         f min_float min_float;
         f max_float min_float;
-        let is_nan x =
-          Int64.float_of_bits x |> Float.is_nan
-        in
         for _ = 0 to 100_000 do
             let f0 = Random.int64 Int64.max_int in
             let f1 = Random.int64 Int64.max_int in
-            if (is_nan(f0) || is_nan(f1))
-            then (* operations on nans behave differently *) ()
-            else
             f (if Random.bool () then Int64.float_of_bits f0 else Int64.(neg f0 |> float_of_bits))
               (if Random.bool () then Int64.float_of_bits f1 else Int64.(neg f1 |> float_of_bits))
         done

--- a/flambda-backend/tests/simd/stubs.c
+++ b/flambda-backend/tests/simd/stubs.c
@@ -675,6 +675,12 @@ value float32_uord(int32_t l, int32_t r) { return Val_bool(isnan(float_of_int32(
     return _mm_extract_ps(intrin(v), 0);       \
   }
 
+#define FLOAT32_UNOP_INT(name, intrin)         \
+  int32_t float32_##name(int32_t f) {          \
+    __m128 v = _mm_set1_ps(float_of_int32(f)); \
+    return _mm_extract_epi32(intrin(v), 0);    \
+  }
+
 FLOAT32_BINOP(add, _mm_add_ps);
 FLOAT32_BINOP(sub, _mm_sub_ps);
 FLOAT32_BINOP(mul, _mm_mul_ps);
@@ -685,7 +691,7 @@ FLOAT32_BINOP(max, _mm_max_ps);
 FLOAT32_UNOP(sqrt, _mm_sqrt_ps);
 FLOAT32_UNOP(rcp, _mm_rcp_ps);
 FLOAT32_UNOP(rsqrt, _mm_rsqrt_ps);
-FLOAT32_UNOP(cvt_i32, _mm_cvtps_epi32);
+FLOAT32_UNOP_INT(cvt_i32, _mm_cvtps_epi32);
 
 int32_t float32_round(int32_t f) {
   __m128 v = _mm_set1_ps(float_of_int32(f));

--- a/flambda-backend/tests/simd/stubs.c
+++ b/flambda-backend/tests/simd/stubs.c
@@ -644,6 +644,17 @@ float float_of_int32(int32_t i) {
   return *(float*)&i;
 }
 
+int32_t test_simd_vec128_extract_ps(__m128 a, intnat i) {
+  int32_t bits;
+  switch (i % 4) {
+    case 0: return (_mm_extract_ps(a, 0));
+    case 1: return (_mm_extract_ps(a, 1));
+    case 2: return (_mm_extract_ps(a, 2));
+    case 3: return (_mm_extract_ps(a, 3));
+    default: assert(0);
+  }
+}
+
 int32_t float32_zero(value unit) { return int32_of_float(0.0f); }
 int32_t float32_neg_zero(value unit) { return int32_of_float(-0.0f); }
 int32_t float32_one(value unit) { return int32_of_float(1.0f); }


### PR DESCRIPTION
One of the C stubs in `flambda-backend/tests/simd/` uses incompatible types. There is a macro that calls  `_mm_extract_ps` which expects `__m128` argument, but one of the uses of the macro is with the result of  `_mm_cvtps_epi32` which is of type `__m128i`.  This issue was originally reported by @bclement-ocp.  

This PR attempts to fix it:
- Add another macro that uses  `_mm_extract_epi32` instead of `_mm_extract_ps` for `_mm_cvtps_epi32`.
- Add `standard` to `c_flags` in this test directory, to get the warning about "incompatible type" in the CI.