### PR TITLE
Documentation for Uniqueness

### DIFF
--- a/jane/doc/extensions/uniqueness/intro.md
+++ b/jane/doc/extensions/uniqueness/intro.md
@@ -103,9 +103,10 @@ let bad t =
     free t
 ```
 
-In the `bad` function above, the `free t` assumes that it gets all of `t`
-uniquely, but this is not true if `field` has already been freed. However, we
-can use parts of `t` twice if these uses happen in different branches:
+In the `bad` function above, `free_field` assumes that it gets the only
+reference to `field`. But `field` can still be referenced from `t`, which is
+itself passed to `free`. However, we are allowed to use parts of `t` twice if
+these uses happen in different branches:
 
 ```ocaml
 let okay t =

--- a/jane/doc/extensions/uniqueness/intro.md
+++ b/jane/doc/extensions/uniqueness/intro.md
@@ -1,0 +1,111 @@
+# Introduction to Uniqueness
+
+See also the full feature [reference](reference.md) and [common pitfalls](pitfalls.md).
+
+The `unique` mode designates values that have only a single reference pointing
+to them. For example, an externally allocated data structure might support a
+`free` operation:
+
+```ocaml
+val free : t @ unique -> unit
+```
+
+The compiler guarantees that this operation will be sound: as the argument is
+`unique`, there can be no further references to it that could lead to a
+use-after-free. The compiler tracks the uniqueness of values and marks values
+which have more than one reference pointing to them with the `aliased` mode:
+
+```ocaml
+let duplicate : t -> t * t @ aliased = fun t -> t, t
+```
+
+When a `unique` value is captured in a closure, this closure can be invoked at
+most once: if the closure was invoked more often, it could not use the value
+uniquely each time. Values that contain closures that can be invoked at most
+once are at mode `once`, while values with closures that can be invoked
+arbitrarily often are at mode `many`:
+
+```ocaml
+let delay_free : t @ unique -> (unit -> unit) @ once = fun t -> fun () -> free t
+```
+
+## Modalities and Mode Crossing
+
+These modes form two mode axis: the _uniqueness_ of a value is either `unique`
+or `aliased`, while the _affinity_ of a value is `once` or `many`. Similar to
+[locality](../local/intro.md), uniqueness and affinity are deep properties. If a
+value is at mode `unique` then all of its children are also `unique`.
+
+We make an exception to this rule for record fields that are annotated with a
+_modality_. Analogous to global fields, a record field that is annotated as `@@
+aliased`, can contain `aliased` values even if the record itself is `unique`.
+However, a read from such a field always returns an `aliased` value. If a record
+field is annotated by `@@ many`, then it can only store `many` values even if
+the record itself is `once`. In return, a read of that field always yields a
+`many` value.
+
+Analogous to the `globalize` function, it is possible to cast between the modes:
+
+```ocaml
+val alias : 'a @ unique -> 'a @ aliased
+val linearize : 'a @ many -> 'a @ once
+```
+
+However, the other directions are disallowed in general: if a value is `aliased`
+there is no way to get it back to mode `unique`; similarly a `once` value can
+not be made `many`.
+
+We make an exception to this rule for values of special types to which these
+modes do not apply. For example, `int`s and other immediates can be used as
+`unique` and `many`, no matter their mode. Similarly, most values that don't
+contain functions can be used as `many`. For example, an `int list @ once
+aliased` can be used as `many` but not as `unique`.
+
+## Checking for Uniqueness
+
+The compiler performs a sophisticated analysis to determine which values are
+aliased and which ones are unique. For example, it is fine to match on a value
+and then use it:
+
+```ocaml
+let okay t =
+  match t with
+  | Con { field } -> free t
+```
+
+But it would not be fine to use (parts of) `t` twice:
+
+```ocaml
+let bad t =
+  match t with
+  | Con { field } ->
+    free_field field;
+    free t
+```
+
+In the `bad` function above, the `free t` assumes that it gets all of `t`
+uniquely, but this is not true if the `field` as been freed previously. However,
+we can use parts of `t` twice if these uses happen in different branches:
+
+```ocaml
+let okay t =
+  match t with
+  | Con { field } ->
+    if flip_coin ()
+    then free_field field
+    else free t
+```
+
+or if the uses both accept `aliased` arguments:
+
+```ocaml
+val store : t @ aliased -> unit
+
+let okay t =
+  match t with
+  | Con { field } ->
+    store_field field;
+    store t
+```
+
+For more details, read [the reference](./reference.md).

--- a/jane/doc/extensions/uniqueness/intro.md
+++ b/jane/doc/extensions/uniqueness/intro.md
@@ -1,8 +1,7 @@
 # Introduction to Uniqueness
 
 See also the full feature [reference](reference.md) and [common pitfalls](pitfalls.md).
-In this document, we use the new [syntax for modes](../modes/syntax.md),
-which we expect to be stable soonish.
+In this document, we use the new [syntax for modes](../modes/syntax.md).
 
 The `unique` mode designates values that have only a single reference pointing
 to them. If an operation takes a `unique` argument, it will consume the only

--- a/jane/doc/extensions/uniqueness/intro.md
+++ b/jane/doc/extensions/uniqueness/intro.md
@@ -117,7 +117,8 @@ let okay t =
     else free t
 ```
 
-or if the uses both accept `aliased` arguments:
+or if the uses both accept `aliased` arguments (eg. by calling a function that
+only stores its argument somewhere):
 
 ```ocaml
 val store : t @ aliased -> unit

--- a/jane/doc/extensions/uniqueness/intro.md
+++ b/jane/doc/extensions/uniqueness/intro.md
@@ -130,14 +130,4 @@ let okay t =
     store t
 ```
 
-## Current syntax
-
-Until the new [syntax for modes](../modes/syntax.md) is stable, our syntax for
-uniqueness will be slightly different from the description above. Currently, you
-would mark an argument or return value in a type signature as unique by
-prepending it with `unique_` and as once by prepending it with `once_`. You can
-not mark arguments or return values as aliased or many. To mark a record field
-as `@@ aliased`, you would prepend `aliased_` and to mark it as `@@ many`, you
-would prepend `many_`.
-
 For more details, read [the reference](./reference.md).

--- a/jane/doc/extensions/uniqueness/intro.md
+++ b/jane/doc/extensions/uniqueness/intro.md
@@ -55,6 +55,8 @@ to make them unique, we wrap them in a record with the `aliased` modality:
 
 ```ocaml
 type 'a aliased = { a : 'a @@ aliased } [[@@unboxed]]
+
+val cons : 'a @ aliased -> 'a aliased list @ unique -> 'a aliased list @ unique
 ```
 
 ## Mode Crossing

--- a/jane/doc/extensions/uniqueness/intro.md
+++ b/jane/doc/extensions/uniqueness/intro.md
@@ -1,6 +1,8 @@
 # Introduction to Uniqueness
 
 See also the full feature [reference](reference.md) and [common pitfalls](pitfalls.md).
+In this document, we use the new [syntax for modes](../modes/syntax.md),
+which we expect to be stable soonish.
 
 The `unique` mode designates values that have only a single reference pointing
 to them. For example, an externally allocated data structure might support a
@@ -107,5 +109,15 @@ let okay t =
     store_field field;
     store t
 ```
+
+## Current syntax
+
+Until the new [syntax for modes](../modes/syntax.md) is stable, our syntax for
+uniqueness will be slightly different from the description above. Currently, you
+would mark an argument or return value in a type signature as unique by
+prepending it with `unique_` and as once by prepending it with `once_`. You can
+not mark arguments or return values as aliased or many. To mark a record field
+as `@@ aliased`, you would prepend `aliased_` and to mark it as `@@ many`, you
+would prepend `many_`.
 
 For more details, read [the reference](./reference.md).

--- a/jane/doc/extensions/uniqueness/intro.md
+++ b/jane/doc/extensions/uniqueness/intro.md
@@ -54,7 +54,7 @@ elements will always be unique. Rather than copying the elements upon insertion
 to make them unique, we wrap them in a record with the `aliased` modality:
 
 ```ocaml
-type 'a aliased = { a : 'a @@ aliased } [[@@unboxed]]
+type 'a aliased = { a : 'a @@ aliased } [@@unboxed]
 
 val cons : 'a @ aliased -> 'a aliased list @ unique -> 'a aliased list @ unique
 ```

--- a/jane/doc/extensions/uniqueness/intro.md
+++ b/jane/doc/extensions/uniqueness/intro.md
@@ -33,7 +33,7 @@ let delay_free : t @ unique -> (unit -> unit) @ once = fun t -> fun () -> free t
 
 ## Modalities
 
-These modes form two mode axis: the _uniqueness_ of a value is either `unique`
+These modes form two mode axes: the _uniqueness_ of a value is either `unique`
 or `aliased`, while the _affinity_ of a value is `once` or `many`. Similar to
 [locality](../local/intro.md), uniqueness and affinity are deep properties. If a
 value is at mode `unique` then all of its children are also `unique`. If a value
@@ -64,8 +64,8 @@ be used as `many` but not as `unique`.
 ## Checking for Uniqueness
 
 The compiler performs a sophisticated analysis to determine which values are
-aliased and which ones are unique. For example, it is fine to match on a value
-and then use it:
+aliased and which ones are unique. For example, it is fine to match on a unique
+value and then use it:
 
 ```ocaml
 let okay t =
@@ -84,8 +84,8 @@ let bad t =
 ```
 
 In the `bad` function above, the `free t` assumes that it gets all of `t`
-uniquely, but this is not true if the `field` has been freed previously. However,
-we can use parts of `t` twice if these uses happen in different branches:
+uniquely, but this is not true if `field` has already been freed. However, we
+can use parts of `t` twice if these uses happen in different branches:
 
 ```ocaml
 let okay t =

--- a/jane/doc/extensions/uniqueness/pitfalls.md
+++ b/jane/doc/extensions/uniqueness/pitfalls.md
@@ -10,16 +10,16 @@ If you want an introduction to uniqueness, see the [introduction](intro.md).
 ## Annotating unique return values
 
 When the compiler infers uniqueness, it will only mark values as `unique` if
-they are actually used as `unique`. For example, if create a smart constructor:
+they are actually used as `unique`. For example, given a smart constructor:
 
 ```ocaml
 let mk () = { x = 1 }
 ```
 
-This value is not unique by default. This helps the compiler identify static
+The result is not unique by default. This helps the compiler identify static
 allocations: as long as `mk ()` returns an `aliased` value, the compiler can
 lift out the allocation so that `mk ()` returns the same pointer on each
-invokation. However, you might want to annotate this allocation as `unique`:
+invocation. However, you might want to annotate this allocation as `unique`:
 
 ```ocaml
 let mk () = unique_ { x = 1 }
@@ -42,7 +42,7 @@ the return mode `unique` if there is any unique use of the result of `mk ()`:
 let use () = free (mk ())
 ```
 
-This code checks even if `mk` is not annotated, because, now that the need as
+This code typechecks even if `mk` is not annotated, because, now that a need has
 arisen, the compiler has inferred the return mode of `mk` to be `unique`.
 However, this analysis happens on a per module basis. If we abstract `mk` into
 its own module we will get a mode error:

--- a/jane/doc/extensions/uniqueness/pitfalls.md
+++ b/jane/doc/extensions/uniqueness/pitfalls.md
@@ -1,0 +1,115 @@
+# Some Pitfalls of Uniqueness
+
+This document outlines some common pitfalls that may come up when trying out
+uniqueness, as well as some suggested workarounds. Over time, this list may grow
+(as experience discovers new things that go wrong) or shrink (as we deploy new
+compiler versions that ameliorate some issues).
+
+If you want an introduction to uniqueness, see the [introduction](intro.md).
+
+## Annotating unique return values
+
+When the compiler infers uniqueness, it will only mark values as `unique` if
+they are actually used as `unique`. For example, if create a smart constructor:
+
+```ocaml
+let mk () = { x = 1 }
+```
+
+This value is not unique by default. This helps the compiler identify static
+allocations: as long as `mk ()` returns an `aliased` value, the compiler can
+lift out the allocation so that `mk ()` returns the same pointer on each
+invokation. However, you might want to annotate this allocation as `unique`:
+
+```ocaml
+let mk () = unique_ { x = 1 }
+```
+
+Unfortunately, this will not work: while the allocation is now indeed `unique`,
+the compiler immediately casts it to `aliased` so that `mk` still returns an
+`aliased` value. The only way to reliably change the return mode of `mk` to be
+`unique` is through a type signature:
+
+```ocaml
+let mk : unit -> t @ unique = fun () -> { x = 1 }
+```
+
+Most times, it will not be necessary to manually annotate a return value as
+`unique`. While the compiler defaults the return mode to `aliased`, it will make
+the return mode `unique` if there is any unique use of the result of `mk ()`:
+
+```ocaml
+let use () = free (mk ())
+```
+
+This code checks even if `mk` is not annotated, because, now that the need as
+arisen, the compiler has inferred the return mode of `mk` to be `unique`.
+However, this analysis happens on a per module basis. If we abstract `mk` into
+its own module we will get a mode error:
+
+```ocaml
+module Mk = struct
+  let mk () = { x = 1 }
+end
+
+let use () = free (Mk.mk ())
+                  ^^^^^^^^^^
+Error: This value is "aliased" but expected to be "unique".
+```
+
+When abstracting functions that return unique values into a module, we need to
+provide an explicit mode annotation in the signature.
+
+## Threading unique values
+
+While unique values allow safe mutation, they require a coding style that is
+much closer to purely functional code than mutating code. For example, you might
+imagine a function to set values in unique arrays:
+
+```ocaml
+val set : 'a array @ unique -> int -> 'a -> unit
+```
+
+which you would use like this:
+
+```ocaml
+let set_all_zero arr =
+  for i = 0 to Unique_array.size arr do
+    Unique_array.set arr i 0
+  done
+```
+
+But this does not work! Similar to how closures closing over unique values can
+only be invoked once, a for-loop may not close over unique values at all:
+
+```ocaml
+3 |     Unique_array.set arr i 0
+                         ^^^
+Error: This value is "aliased" but expected to be "unique".
+  Hint: This identifier cannot be used uniquely,
+  because it was defined outside of the for-loop.
+```
+
+Indeed, we can not use the same array `arr` more than once uniquely. Instead,
+the `set` function needs to return the new array:
+
+```ocaml
+val set : 'a array @ unique -> int -> 'a -> 'a array @ unique
+```
+
+This is a crucial change: since `set` consumes a `unique` argument, this removes
+the only reference we have to the old array. To be able to use the `array`
+afterwards, you need `set` to return another reference. Then we can write:
+
+```ocaml
+let set_all_zero arr =
+  let rec loop idx arr =
+    if idx == 0 then arr
+    else loop (idx - 1) (Unique_array.set arr idx 0)
+  in
+  let size, arr = Unique_array.size arr in
+  loop size arr
+```
+
+We are planning a new feature called _exclusive mutable_ that will allow you to
+use unique values in a more imperative code style similar to the first example.

--- a/jane/doc/extensions/uniqueness/reference.md
+++ b/jane/doc/extensions/uniqueness/reference.md
@@ -1,0 +1,103 @@
+# Uniqueness Reference
+
+The goal of this document is to be a reasonably complete reference to the
+uniqueness mode. For a gentler introduction, see [the introduction](intro.md).
+It will grow over time as we add more features such as overwriting and
+borrowing.
+
+## More details on uniqueness checking
+
+### Mixing unique and aliased uses
+
+Continuing the example from [the introduction](intro.md), we can have both a
+unique and an aliased access to a value, as long as those occur in separate
+branches:
+
+```ocaml
+val free : t @ unique -> unit
+val store : t @ aliased -> unit
+
+let okay t =
+  if flip_coin ()
+  then free t
+  else store t; store t
+```
+
+This might be surprising coming from a language that uses ownership like Rust.
+In Rust, each value needs to have exactly one owner which is responsible for its
+deallocation. But in OCaml, we can rely on the GC for deallocation which makes
+it possible to give up ownership of the value in the second branch.
+
+### Unique uses of different fields
+
+The uniqueness analysis makes it possible to consume some fields of an
+allocation without losing access to the allocation or its other fields. For
+example, you might write:
+
+```ocaml
+let okay r =
+  free r.field1;
+  match r with
+  | { field2 } -> free field2
+```
+
+This is fine: we free the first field of `r`, then pattern match on `r` itself
+(which was not affected by the free of its child) and then free the second
+child. However, it would not be okay to free the first field and then free `r`
+itself (which has now partially been consumed):
+
+```ocaml
+let bad r =
+  free r.field1;
+  match r with
+  | { field2 } -> free r
+```
+
+The uniqueness analysis carefully tracks which children of an allocation have
+already been consumed. This tracking also works with obvious aliases, such as
+simple renamings:
+
+```ocaml
+let okay r =
+  let x = r in
+  free x.field1;
+  match r with
+  | { field2 } -> free field2
+```
+
+However, which children have been consumed is not tracked through more
+complicated aliases, such as function calls:
+
+```ocaml
+let bad r =
+  let x = Fun.id r in
+  free x.field1;
+  match r with
+  | { field2 } -> free field2
+```
+
+## Matching on tuples
+
+In OCaml, it is possible to simultaneously match on multiple values:
+
+```ocaml
+match x, y, z with
+| p, q, r -> ...
+```
+
+There is in fact no special syntax for this: as parentheses are optional in
+tuples, the above is actually a match on a single value, the tuple `(x, y, z)`,
+against a single pattern, the pattern `(p, q, r)`. Normally, this would mean
+that `x`, `y` and `z` need to have the same mode. However, just as for locals,
+we check this code as if it was special syntax and the modes of `x`, `y`, `z`
+may be unrelated.
+
+However, this changes when the tuple is explicitly named:
+
+```ocaml
+match x, y, z with
+| p, q, r as t -> ...
+```
+
+In this case, the OCaml compiler may actually allocate a tuple `(x, y, z)`at
+runtime and all of `x`, `y`, `z` need to have the same mode.

--- a/jane/doc/extensions/uniqueness/reference.md
+++ b/jane/doc/extensions/uniqueness/reference.md
@@ -20,7 +20,7 @@ val store : t @ aliased -> unit
 let okay t =
   if flip_coin ()
   then free t
-  else store t; store t
+  else (store t; store t)
 ```
 
 This might be surprising coming from a language that uses ownership like Rust.

--- a/jane/doc/extensions/uniqueness/reference.md
+++ b/jane/doc/extensions/uniqueness/reference.md
@@ -38,7 +38,7 @@ example, you might write:
 let okay r =
   free r.field1;
   match r with
-  | { field2 } -> free field2
+  | { field2; _ } -> free field2
 ```
 
 This is fine: we free the first field of `r`, then pattern match on `r` itself
@@ -50,7 +50,7 @@ itself (which has now partially been consumed):
 let bad r =
   free r.field1;
   match r with
-  | { field2 } -> free r
+  | { field2; _ } -> free r
 ```
 
 The uniqueness analysis carefully tracks which children of an allocation have
@@ -62,7 +62,7 @@ let okay r =
   let x = r in
   free x.field1;
   match r with
-  | { field2 } -> free field2
+  | { field2; _ } -> free field2
 ```
 
 However, which children have been consumed is not tracked through more
@@ -73,7 +73,7 @@ let bad r =
   let x = Fun.id r in
   free x.field1;
   match r with
-  | { field2 } -> free field2
+  | { field2; _ } -> free field2
 ```
 
 ## Matching on tuples

--- a/jane/doc/extensions/uniqueness/reference.md
+++ b/jane/doc/extensions/uniqueness/reference.md
@@ -28,6 +28,11 @@ In Rust, each value needs to have exactly one owner which is responsible for its
 deallocation. But in OCaml, we can rely on the GC for deallocation which makes
 it possible to give up ownership of the value in the second branch.
 
+In particular, this enables a programming pattern to create data structures in
+two phases: In the first phase, the data structure is unique and we can mutate
+it safely and efficiently. In the second phase, we relinquish the uniqueness and
+the data structure becomes an ordinary OCaml value which can be shared freely.
+
 ### Unique uses of different fields
 
 The uniqueness analysis makes it possible to consume some fields of an
@@ -43,8 +48,10 @@ let okay r =
 
 This is fine: we free the first field of `r`, then pattern match on `r` itself
 (which was not affected by the free of its child) and then free the second
-child. However, it would not be okay to free the first field and then free `r`
-itself (which has now partially been consumed):
+child. While `r` technically still keeps a reference to `r.field1`, it is never
+dereferenced after the free.
+
+However, it would not be fine to free the first field and then free `r` itself:
 
 ```ocaml
 let bad r =
@@ -53,6 +60,8 @@ let bad r =
   | { field2; _ } -> free r
 ```
 
+The problem here is that the compiler can not determine whether `free r` might
+dereference `r.field1` again. As such, it would be unsafe to free `r.field1`.
 The uniqueness analysis carefully tracks which children of an allocation have
 already been consumed. This tracking also works with obvious aliases, such as
 simple renamings:
@@ -76,6 +85,16 @@ let bad r =
   | { field2; _ } -> free field2
 ```
 
+or new allocations:
+
+```ocaml
+let bad r =
+  let x = { field1 = r.field1; field2 = r.field2 } in
+  free x.field1;
+  match r with
+  | { field2; _ } -> free field2
+```
+
 ## Matching on tuples
 
 In OCaml, it is possible to simultaneously match on multiple values:
@@ -88,16 +107,28 @@ match x, y, z with
 There is in fact no special syntax for this: as parentheses are optional in
 tuples, the above is actually a match on a single value, the tuple `(x, y, z)`,
 against a single pattern, the pattern `(p, q, r)`. Normally, this would mean
-that `x`, `y` and `z` need to have the same mode. However, just as for locals,
-we check this code as if it was special syntax and the modes of `x`, `y`, `z`
-may be unrelated.
+that `x`, `y` and `z` have the same mode. However, just as for other modes, we
+check this code as if it was special syntax and the modes of `x`, `y`, `z` may
+be unrelated.
 
-However, this changes when the tuple is explicitly named:
+Furthermore, we track aliasing through tuples that are immediately matched on:
 
 ```ocaml
-match x, y, z with
-| p, q, r as t -> ...
+let okay x y z =
+  match x, y, z with
+  | p, q, r -> free x.field1; free p.field2
 ```
 
-In this case, the OCaml compiler may actually allocate a tuple `(x, y, z)`at
-runtime and all of `x`, `y`, `z` need to have the same mode.
+Here we free both the first and the second field of `x`. However, this changes
+when the tuple is explicitly named:
+
+```ocaml
+let bad x y z =
+  match x, y, z with
+  | p, q, r as t -> free x.field1; free p.field2
+```
+
+In this case, the OCaml compiler may actually allocate a tuple `(x, y, z)` at
+runtime and we now consider the value `x` to be consumed by the tuple. That
+makes it impossible to free its first field, which can now be referenced through
+the new allocation `t`.

--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -1,6 +1,5 @@
 (* TEST
- flags += "-extension unique ";
- flags += "-extension-universe alpha";
+ flags += "-extension unique";
  expect;
 *)
 
@@ -20,7 +19,7 @@ Line 1, characters 21-22:
 (* unique value can be used more than once *)
 let dup (unique_ x) = (x, x)
 [%%expect{|
-val dup : ('a : value_or_null). unique_ 'a -> 'a * 'a @@ global many = <fun>
+val dup : unique_ 'a -> 'a * 'a = <fun>
 |}]
 
 (* once value can be used only once*)
@@ -78,7 +77,7 @@ Line 1, characters 23-34:
   but manually relax it to once *)
 let dup x = once_ (x, x)
 [%%expect{|
-val dup : ('a : value_or_null). 'a -> once_ 'a * 'a @@ global many = <fun>
+val dup : 'a -> once_ 'a * 'a = <fun>
 |}]
 
 (* closing over unique values gives once closure  *)
@@ -104,7 +103,7 @@ let f () =
   let g () = k ^ k in
   g () ^ g ()
 [%%expect{|
-val f : unit -> string @@ global many = <fun>
+val f : unit -> string = <fun>
 |}]
 
 (* variables inside loops will be made both aliased and many *)
@@ -115,7 +114,7 @@ let f () =
     ignore k
   done
 [%%expect{|
-val f : unit -> unit @@ global many = <fun>
+val f : unit -> unit = <fun>
 |}]
 
 
@@ -171,7 +170,7 @@ let f =
   done;
   ()
 [%%expect{|
-val f : unit @@ global many = ()
+val f : unit = ()
 |}]
 
 (* the following is howerver fine, because g doesn't use the uniqueness of k;
@@ -183,7 +182,7 @@ let f () =
   (* k is unique, and thus g is once *)
   g () ^ g ()
 [%%expect{|
-val f : unit -> string @@ global many = <fun>
+val f : unit -> string = <fun>
 |}]
 
 (* closing over once values gives once closure *)
@@ -207,7 +206,7 @@ Line 4, characters 3-4:
 
 let x = "foo"
 [%%expect{|
-val x : string @@ global many = "foo"
+val x : string = "foo"
 |}]
 
 (* Top-level must be many *)
@@ -222,13 +221,13 @@ Error: This value is "once" but expected to be "many".
 (* the following is fine - we relax many to once *)
 let foo y = once_ x
 [%%expect{|
-val foo : ('a : value_or_null). 'a -> once_ string @@ global many = <fun>
+val foo : 'a -> once_ string = <fun>
 |}]
 
 (* top-level must be aliased; the following unique is weakened to aliased *)
 let unique_ foo = "foo"
 [%%expect{|
-val foo : string @@ global many = "foo"
+val foo : string = "foo"
 |}]
 
 
@@ -250,7 +249,7 @@ type 'a glob = { glob : 'a @@ many aliased; } [@@unboxed]
 |}]
 let dup (glob : 'a) : 'a glob * 'a glob = unique_ ({glob}, {glob})
 [%%expect{|
-val dup : 'a -> 'a glob * 'a glob @@ global many = <fun>
+val dup : 'a -> 'a glob * 'a glob = <fun>
 |}]
 
 (* For strict type/mode match we need module *)
@@ -267,40 +266,35 @@ module M : sig val drop : unique_ 'a -> unique_ unit end
 (* printed modes are imprecise *)
 let unique_id : 'a. unique_ 'a -> unique_ 'a = fun x -> x
 [%%expect{|
-val unique_id : unique_ 'a -> unique_ 'a @@ global many = <fun>
+val unique_id : unique_ 'a -> unique_ 'a = <fun>
 |}]
 
 let aliased_id : 'a -> 'a = fun x -> x
 [%%expect{|
-val aliased_id : ('a : value_or_null). 'a -> 'a @@ global many = <fun>
+val aliased_id : 'a -> 'a = <fun>
 |}]
 
 let tail_unique _x =
   let unique_ y = "foo" in unique_id y
 [%%expect{|
-val tail_unique : ('a : value_or_null). 'a -> string @@ global many = <fun>
+val tail_unique : 'a -> string = <fun>
 |}]
 
 let tail_unique : unique_ 'a list -> unique_ 'a list = function
   | [] -> []
   | _ :: xx -> xx
 [%%expect{|
-val tail_unique : unique_ 'a list -> unique_ 'a list @@ global many = <fun>
+val tail_unique : unique_ 'a list -> unique_ 'a list = <fun>
 |}]
 
 let higher_order (f : unique_ 'a -> unique_ 'b) (unique_ x : 'a) = unique_ f x
 [%%expect{|
-val higher_order :
-  ('a : value_or_null) ('b : value_or_null).
-    (unique_ 'a -> unique_ 'b) -> unique_ 'a -> 'b
-  @@ global many = <fun>
+val higher_order : (unique_ 'a -> unique_ 'b) -> unique_ 'a -> 'b = <fun>
 |}]
 
 let higher_order2 (f : 'a -> unique_ 'b) (x : 'a) = unique_ f x
 [%%expect{|
-val higher_order2 :
-  ('a : value_or_null) ('b : value_or_null). ('a -> unique_ 'b) -> 'a -> 'b
-  @@ global many = <fun>
+val higher_order2 : ('a -> unique_ 'b) -> 'a -> 'b = <fun>
 |}]
 
 let higher_order3 (f : 'a -> 'b) (unique_ x : 'a) = unique_ f x
@@ -321,8 +315,7 @@ Error: This value is "aliased" but expected to be "unique".
 
 let higher_order5 (unique_ x) = let f (unique_ x) = unique_ x in higher_order f x
 [%%expect{|
-val higher_order5 : ('a : value_or_null). unique_ 'a -> 'a @@ global many =
-  <fun>
+val higher_order5 : unique_ 'a -> 'a = <fun>
 |}]
 
 let higher_order6 (unique_ x) = let f (unique_ x) = unique_ x in higher_order2 f x
@@ -349,12 +342,12 @@ Error: Unbound value "update"
 
 let inf1 (unique_ x : float) = unique_ let y = x in y
 [%%expect{|
-val inf1 : unique_ float -> float @@ global many = <fun>
+val inf1 : unique_ float -> float = <fun>
 |}]
 
 let inf2 (b : bool) (unique_ x : float) = unique_ let y = if b then x else 1.0 in y
 [%%expect{|
-val inf2 : bool -> unique_ float -> float @@ global many = <fun>
+val inf2 : bool -> unique_ float -> float = <fun>
 |}]
 
 let inf3 : bool -> float -> unique_ float -> float = fun b y x ->
@@ -383,33 +376,29 @@ Line 2, characters 21-22:
 let inf5 (b : bool) (y : float) (unique_ x : float) =
   let z = if b then x else y in unique_ z
 [%%expect{|
-val inf5 : bool -> unique_ float -> unique_ float -> float @@ global many =
-  <fun>
+val inf5 : bool -> unique_ float -> unique_ float -> float = <fun>
 |}]
 
 let inf6 (unique_ x) = let f x = x in higher_order f x
 [%%expect{|
-val inf6 : ('a : value_or_null). unique_ 'a -> 'a @@ global many = <fun>
+val inf6 : unique_ 'a -> 'a = <fun>
 |}]
 
 let unique_default_args ?(unique_ x = 1.0) () = x
 [%%expect{|
-val unique_default_args : ?x:unique_ float -> unit -> float @@ global many =
-  <fun>
+val unique_default_args : ?x:unique_ float -> unit -> float = <fun>
 |}]
 
 (* Unique Local *)
 
 let ul (unique_ local_ x) = x
 [%%expect{|
-val ul : ('a : value_or_null). local_ unique_ 'a -> local_ 'a @@ global many =
-  <fun>
+val ul : local_ unique_ 'a -> local_ 'a = <fun>
 |}]
 
 let ul_ret x = exclave_ unique_ x
 [%%expect{|
-val ul_ret : ('a : value_or_null). unique_ 'a -> local_ 'a @@ global many =
-  <fun>
+val ul_ret : unique_ 'a -> local_ 'a = <fun>
 |}]
 
 type point = { x : float; y : float }
@@ -420,14 +409,14 @@ type point = { x : float; y : float; }
 let overwrite_point t =
   unique_ ({t with y = 0.5}, {t with x = 0.5})
 [%%expect{|
-val overwrite_point : unique_ point -> point * point @@ global many = <fun>
+val overwrite_point : unique_ point -> point * point = <fun>
 |}]
 
 let gc_soundness_nobug (local_ unique_ p) (local_ f) =
   exclave_ { p with x = f }
 [%%expect{|
-val gc_soundness_nobug : local_ unique_ point -> local_ float -> local_ point
-  @@ global many = <fun>
+val gc_soundness_nobug : local_ unique_ point -> local_ float -> local_ point =
+  <fun>
 |}]
 
 let rec foo =
@@ -436,7 +425,7 @@ let rec foo =
   | Some () -> foo None
   | None -> ()
 [%%expect{|
-val foo : local_ unique_ unit option -> unit @@ global many = <fun>
+val foo : local_ unique_ unit option -> unit = <fun>
 |}]
 
 let rec bar =
@@ -445,17 +434,17 @@ let rec bar =
   | Some () -> ()
   | None -> bar (local_ Some ()) [@nontail]
 [%%expect{|
-val bar : local_ unique_ unit option -> unit @@ global many = <fun>
+val bar : local_ unique_ unit option -> unit = <fun>
 |}]
 
 let foo : local_ unique_ string -> unit = fun (local_ s) -> ()
 [%%expect{|
-val foo : local_ unique_ string -> unit @@ global many = <fun>
+val foo : local_ unique_ string -> unit = <fun>
 |}]
 
 let bar : local_ unique_ string -> unit = fun (unique_ s) -> ()
 [%%expect{|
-val bar : local_ unique_ string -> unit @@ global many = <fun>
+val bar : local_ unique_ string -> unit = <fun>
 |}]
 
 (* Currying *)
@@ -464,8 +453,8 @@ let curry =
   let foo ~a ~b ~c ~d = (a, b, c, (unique_ d)) in
   foo ~a:3 ~c:4
 [%%expect{|
-val curry : b:'_weak1 -> d:unique_ '_weak2 -> int * '_weak1 * int * '_weak2
-  @@ global many = <fun>
+val curry : b:'_weak1 -> d:unique_ '_weak2 -> int * '_weak1 * int * '_weak2 =
+  <fun>
 |}]
 
 (* the following two failed because top-level must be many *)
@@ -495,8 +484,8 @@ let curry =
   foo ~a:3 ~c:4
 [%%expect{|
 val curry :
-  b:unique_ '_weak3 -> d:unique_ '_weak4 -> int * '_weak3 * int * '_weak4 @@
-  global many = <fun>
+  b:unique_ '_weak3 -> d:unique_ '_weak4 -> int * '_weak3 * int * '_weak4 =
+  <fun>
 |}]
 
 let curry =
@@ -554,12 +543,12 @@ type box = { x : int; }
 
 let curry (unique_ b1 : box) (unique_ b2 : box) = ()
 [%%expect{|
-val curry : unique_ box -> unique_ box -> unit @@ global many = <fun>
+val curry : unique_ box -> unique_ box -> unit = <fun>
 |}]
 
 let curry : unique_ box -> unique_ box -> unit = fun b1 b2 -> ()
 [%%expect{|
-val curry : unique_ box -> unique_ box -> unit @@ global many = <fun>
+val curry : unique_ box -> unique_ box -> unit = <fun>
 |}]
 
 let curry : unique_ box -> (unique_ box -> unit) = fun b1 b2 -> ()
@@ -583,7 +572,7 @@ Error: This function when partially applied returns a value which is "once",
 (* For nested functions, inner functions are not constrained *)
 let no_curry : unique_ box -> (unique_ box -> unit) = fun b1 -> fun b2 -> ()
 [%%expect{|
-val no_curry : unique_ box -> (unique_ box -> unit) @@ global many = <fun>
+val no_curry : unique_ box -> (unique_ box -> unit) = <fun>
 |}]
 
 (* If both type and mode are wrong, complain about type *)
@@ -602,10 +591,8 @@ Error: This expression has type "int" but an expression was expected of type
 let return_local : local_ 'a -> local_ 'a = fun x -> x
 let return_global : local_ 'a -> int = fun x -> 0
 [%%expect{|
-val return_local : ('a : value_or_null). local_ 'a -> local_ 'a @@ global
-  many = <fun>
-val return_global : ('a : value_or_null). local_ 'a -> int @@ global many =
-  <fun>
+val return_local : local_ 'a -> local_ 'a = <fun>
+val return_global : local_ 'a -> int = <fun>
 |}]
 
 
@@ -636,8 +623,8 @@ let f ~(call_pos : [%call_pos]) () =
   (x, x)
 ;;
 [%%expect{|
-val f : call_pos:[%call_pos] -> unit -> lexing_position * lexing_position @@
-  global many = <fun>
+val f : call_pos:[%call_pos] -> unit -> lexing_position * lexing_position =
+  <fun>
 |}]
 
 let f ~(call_pos : [%call_pos]) () =
@@ -651,207 +638,5 @@ Error: This value is used here, but it has already been used as unique:
 Line 2, characters 11-19:
 2 |   unique_ (call_pos, call_pos)
                ^^^^^^^^
-
-|}]
-
-(*******************************)
-(* Examples from documentation *)
-
-type t = Con of { field : int }
-
-let free : t @ unique -> unit = fun t -> ()
-let free_field (unique_ i) = ()
-let store : t @ aliased -> unit = fun t -> ()
-let store_field i = ()
-let flip_coin () = true
-[%%expect{|
-type t = Con of { field : int; }
-val free : unique_ t -> unit @@ global many = <fun>
-val free_field : ('a : value_or_null). unique_ 'a -> unit @@ global many =
-  <fun>
-val store : t -> unit @@ global many = <fun>
-val store_field : ('a : value_or_null). 'a -> unit @@ global many = <fun>
-val flip_coin : unit -> bool @@ global many = <fun>
-|}]
-
-let test () =
-  let dup : t -> t * t @ aliased = function t -> t, t in
-  let delay_free : t @ unique -> (unit -> unit) @ once = function t -> fun () -> free t in
-  let alias : 'a @ unique -> 'a @ aliased = fun x -> x in
-  let linearize : 'a @ many -> 'a @ once = fun x -> x in
-  ()
-[%%expect{|
-Line 2, characters 6-9:
-2 |   let dup : t -> t * t @ aliased = function t -> t, t in
-          ^^^
-Warning 26 [unused-var]: unused variable dup.
-
-Line 3, characters 6-16:
-3 |   let delay_free : t @ unique -> (unit -> unit) @ once = function t -> fun () -> free t in
-          ^^^^^^^^^^
-Warning 26 [unused-var]: unused variable delay_free.
-
-Line 4, characters 6-11:
-4 |   let alias : 'a @ unique -> 'a @ aliased = fun x -> x in
-          ^^^^^
-Warning 26 [unused-var]: unused variable alias.
-
-Line 5, characters 6-15:
-5 |   let linearize : 'a @ many -> 'a @ once = fun x -> x in
-          ^^^^^^^^^
-Warning 26 [unused-var]: unused variable linearize.
-
-val test : unit -> unit @@ global many = <fun>
-|}]
-
-let okay t =
-  match t with
-  | Con { field } -> free t
-[%%expect{|
-val okay : unique_ t -> unit @@ global many = <fun>
-|}]
-
-let bad t =
-  match t with
-  | Con { field } ->
-    free_field field;
-    free t
-[%%expect{|
-Line 5, characters 9-10:
-5 |     free t
-             ^
-Error: This value is used here,
-       but part of it has already been used as unique:
-Line 4, characters 15-20:
-4 |     free_field field;
-                   ^^^^^
-
-|}]
-
-let okay t =
-  match t with
-  | Con { field } ->
-    if flip_coin ()
-    then free_field field
-    else free t
-[%%expect{|
-val okay : unique_ t -> unit @@ global many = <fun>
-|}]
-
-let okay t =
-  match t with
-  | Con { field } ->
-    store_field field;
-    store t
-[%%expect{|
-val okay : t -> unit @@ global many = <fun>
-|}]
-
-let module_ret_unique =
-  let mk () = Con { field = 1 } in
-  let use () = free (mk ()) in
-  ()
-[%%expect{|
-Line 3, characters 6-9:
-3 |   let use () = free (mk ()) in
-          ^^^
-Warning 26 [unused-var]: unused variable use.
-
-val module_ret_unique : unit @@ global many = ()
-|}]
-
-module Mk = struct
-  let mk () = Con { field = 1 }
-end
-
-let module_ret_unique =
-  let use () = free (Mk.mk ()) in
-  ()
-[%%expect{|
-module Mk : sig val mk : unit -> t @@ global many portable end
-Line 6, characters 20-30:
-6 |   let use () = free (Mk.mk ()) in
-                        ^^^^^^^^^^
-Error: This value is "aliased" but expected to be "unique".
-|}]
-
-module Unique_array = struct
-  let set : 'a @ unique -> int -> 'b -> 'a @ unique = fun arr -> fun i -> fun x -> arr
-  let size arr = 10
-end
-[%%expect{|
-module Unique_array :
-  sig
-    val set :
-      ('a : value_or_null) ('b : value_or_null).
-        unique_ 'a -> int -> 'b -> unique_ 'a
-      @@ global many portable
-    val size : ('a : value_or_null). 'a -> int @@ global many portable
-  end
-|}]
-
-let set_all_zero arr =
-  for i = 0 to Unique_array.size arr do
-    Unique_array.set arr i 0
-  done
-[%%expect{|
-Line 3, characters 21-24:
-3 |     Unique_array.set arr i 0
-                         ^^^
-Error: This value is "aliased" but expected to be "unique".
-  Hint: This identifier cannot be used uniquely,
-  because it was defined outside of the for-loop.
-|}]
-
-let set_all_zero arr =
-  let set = Unique_array.set arr in
-  for i = 0 to Unique_array.size arr do
-    set i 0
-  done
-[%%expect{|
-Line 4, characters 4-7:
-4 |     set i 0
-        ^^^
-Error: The value "set" is once, so cannot be used inside a for loop
-|}]
-
-let set_all_zero arr =
-  let size (unique_ arr) = 10, arr in
-  let rec loop idx arr =
-    if idx == 0 then arr
-    else loop (idx - 1) (Unique_array.set arr idx 0)
-  in
-  let size, arr = size arr in
-  loop size arr
-[%%expect{|
-val set_all_zero : ('a : value_or_null). unique_ 'a -> 'a @@ global many =
-  <fun>
-|}]
-
-let check_tuple x y z =
-  let m =
-    match x, y, z with
-    | p, q, r -> free x
-  in m, y
-[%%expect{|
-val check_tuple :
-  ('a : value_or_null) ('b : value_or_null).
-    unique_ t -> 'a -> 'b -> unit * 'a
-  @@ global many = <fun>
-|}]
-
-let check_tuple x y z =
-  let m =
-    match x, y, z with
-    | p, q, r as t -> free x
-  in m, y
-[%%expect{|
-Line 4, characters 27-28:
-4 |     | p, q, r as t -> free x
-                               ^
-Error: This value is used here as unique, but it has already been used:
-Line 3, characters 10-11:
-3 |     match x, y, z with
-              ^
 
 |}]

--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -1,5 +1,6 @@
 (* TEST
- flags += "-extension unique";
+ flags += "-extension unique ";
+ flags += "-extension-universe alpha";
  expect;
 *)
 
@@ -19,7 +20,7 @@ Line 1, characters 21-22:
 (* unique value can be used more than once *)
 let dup (unique_ x) = (x, x)
 [%%expect{|
-val dup : unique_ 'a -> 'a * 'a = <fun>
+val dup : ('a : value_or_null). unique_ 'a -> 'a * 'a @@ global many = <fun>
 |}]
 
 (* once value can be used only once*)
@@ -77,7 +78,7 @@ Line 1, characters 23-34:
   but manually relax it to once *)
 let dup x = once_ (x, x)
 [%%expect{|
-val dup : 'a -> once_ 'a * 'a = <fun>
+val dup : ('a : value_or_null). 'a -> once_ 'a * 'a @@ global many = <fun>
 |}]
 
 (* closing over unique values gives once closure  *)
@@ -103,7 +104,7 @@ let f () =
   let g () = k ^ k in
   g () ^ g ()
 [%%expect{|
-val f : unit -> string = <fun>
+val f : unit -> string @@ global many = <fun>
 |}]
 
 (* variables inside loops will be made both aliased and many *)
@@ -114,7 +115,7 @@ let f () =
     ignore k
   done
 [%%expect{|
-val f : unit -> unit = <fun>
+val f : unit -> unit @@ global many = <fun>
 |}]
 
 
@@ -170,7 +171,7 @@ let f =
   done;
   ()
 [%%expect{|
-val f : unit = ()
+val f : unit @@ global many = ()
 |}]
 
 (* the following is howerver fine, because g doesn't use the uniqueness of k;
@@ -182,7 +183,7 @@ let f () =
   (* k is unique, and thus g is once *)
   g () ^ g ()
 [%%expect{|
-val f : unit -> string = <fun>
+val f : unit -> string @@ global many = <fun>
 |}]
 
 (* closing over once values gives once closure *)
@@ -206,7 +207,7 @@ Line 4, characters 3-4:
 
 let x = "foo"
 [%%expect{|
-val x : string = "foo"
+val x : string @@ global many = "foo"
 |}]
 
 (* Top-level must be many *)
@@ -221,13 +222,13 @@ Error: This value is "once" but expected to be "many".
 (* the following is fine - we relax many to once *)
 let foo y = once_ x
 [%%expect{|
-val foo : 'a -> once_ string = <fun>
+val foo : ('a : value_or_null). 'a -> once_ string @@ global many = <fun>
 |}]
 
 (* top-level must be aliased; the following unique is weakened to aliased *)
 let unique_ foo = "foo"
 [%%expect{|
-val foo : string = "foo"
+val foo : string @@ global many = "foo"
 |}]
 
 
@@ -249,7 +250,7 @@ type 'a glob = { glob : 'a @@ many aliased; } [@@unboxed]
 |}]
 let dup (glob : 'a) : 'a glob * 'a glob = unique_ ({glob}, {glob})
 [%%expect{|
-val dup : 'a -> 'a glob * 'a glob = <fun>
+val dup : 'a -> 'a glob * 'a glob @@ global many = <fun>
 |}]
 
 (* For strict type/mode match we need module *)
@@ -266,35 +267,40 @@ module M : sig val drop : unique_ 'a -> unique_ unit end
 (* printed modes are imprecise *)
 let unique_id : 'a. unique_ 'a -> unique_ 'a = fun x -> x
 [%%expect{|
-val unique_id : unique_ 'a -> unique_ 'a = <fun>
+val unique_id : unique_ 'a -> unique_ 'a @@ global many = <fun>
 |}]
 
 let aliased_id : 'a -> 'a = fun x -> x
 [%%expect{|
-val aliased_id : 'a -> 'a = <fun>
+val aliased_id : ('a : value_or_null). 'a -> 'a @@ global many = <fun>
 |}]
 
 let tail_unique _x =
   let unique_ y = "foo" in unique_id y
 [%%expect{|
-val tail_unique : 'a -> string = <fun>
+val tail_unique : ('a : value_or_null). 'a -> string @@ global many = <fun>
 |}]
 
 let tail_unique : unique_ 'a list -> unique_ 'a list = function
   | [] -> []
   | _ :: xx -> xx
 [%%expect{|
-val tail_unique : unique_ 'a list -> unique_ 'a list = <fun>
+val tail_unique : unique_ 'a list -> unique_ 'a list @@ global many = <fun>
 |}]
 
 let higher_order (f : unique_ 'a -> unique_ 'b) (unique_ x : 'a) = unique_ f x
 [%%expect{|
-val higher_order : (unique_ 'a -> unique_ 'b) -> unique_ 'a -> 'b = <fun>
+val higher_order :
+  ('a : value_or_null) ('b : value_or_null).
+    (unique_ 'a -> unique_ 'b) -> unique_ 'a -> 'b
+  @@ global many = <fun>
 |}]
 
 let higher_order2 (f : 'a -> unique_ 'b) (x : 'a) = unique_ f x
 [%%expect{|
-val higher_order2 : ('a -> unique_ 'b) -> 'a -> 'b = <fun>
+val higher_order2 :
+  ('a : value_or_null) ('b : value_or_null). ('a -> unique_ 'b) -> 'a -> 'b
+  @@ global many = <fun>
 |}]
 
 let higher_order3 (f : 'a -> 'b) (unique_ x : 'a) = unique_ f x
@@ -315,7 +321,8 @@ Error: This value is "aliased" but expected to be "unique".
 
 let higher_order5 (unique_ x) = let f (unique_ x) = unique_ x in higher_order f x
 [%%expect{|
-val higher_order5 : unique_ 'a -> 'a = <fun>
+val higher_order5 : ('a : value_or_null). unique_ 'a -> 'a @@ global many =
+  <fun>
 |}]
 
 let higher_order6 (unique_ x) = let f (unique_ x) = unique_ x in higher_order2 f x
@@ -342,12 +349,12 @@ Error: Unbound value "update"
 
 let inf1 (unique_ x : float) = unique_ let y = x in y
 [%%expect{|
-val inf1 : unique_ float -> float = <fun>
+val inf1 : unique_ float -> float @@ global many = <fun>
 |}]
 
 let inf2 (b : bool) (unique_ x : float) = unique_ let y = if b then x else 1.0 in y
 [%%expect{|
-val inf2 : bool -> unique_ float -> float = <fun>
+val inf2 : bool -> unique_ float -> float @@ global many = <fun>
 |}]
 
 let inf3 : bool -> float -> unique_ float -> float = fun b y x ->
@@ -376,29 +383,33 @@ Line 2, characters 21-22:
 let inf5 (b : bool) (y : float) (unique_ x : float) =
   let z = if b then x else y in unique_ z
 [%%expect{|
-val inf5 : bool -> unique_ float -> unique_ float -> float = <fun>
+val inf5 : bool -> unique_ float -> unique_ float -> float @@ global many =
+  <fun>
 |}]
 
 let inf6 (unique_ x) = let f x = x in higher_order f x
 [%%expect{|
-val inf6 : unique_ 'a -> 'a = <fun>
+val inf6 : ('a : value_or_null). unique_ 'a -> 'a @@ global many = <fun>
 |}]
 
 let unique_default_args ?(unique_ x = 1.0) () = x
 [%%expect{|
-val unique_default_args : ?x:unique_ float -> unit -> float = <fun>
+val unique_default_args : ?x:unique_ float -> unit -> float @@ global many =
+  <fun>
 |}]
 
 (* Unique Local *)
 
 let ul (unique_ local_ x) = x
 [%%expect{|
-val ul : local_ unique_ 'a -> local_ 'a = <fun>
+val ul : ('a : value_or_null). local_ unique_ 'a -> local_ 'a @@ global many =
+  <fun>
 |}]
 
 let ul_ret x = exclave_ unique_ x
 [%%expect{|
-val ul_ret : unique_ 'a -> local_ 'a = <fun>
+val ul_ret : ('a : value_or_null). unique_ 'a -> local_ 'a @@ global many =
+  <fun>
 |}]
 
 type point = { x : float; y : float }
@@ -409,14 +420,14 @@ type point = { x : float; y : float; }
 let overwrite_point t =
   unique_ ({t with y = 0.5}, {t with x = 0.5})
 [%%expect{|
-val overwrite_point : unique_ point -> point * point = <fun>
+val overwrite_point : unique_ point -> point * point @@ global many = <fun>
 |}]
 
 let gc_soundness_nobug (local_ unique_ p) (local_ f) =
   exclave_ { p with x = f }
 [%%expect{|
-val gc_soundness_nobug : local_ unique_ point -> local_ float -> local_ point =
-  <fun>
+val gc_soundness_nobug : local_ unique_ point -> local_ float -> local_ point
+  @@ global many = <fun>
 |}]
 
 let rec foo =
@@ -425,7 +436,7 @@ let rec foo =
   | Some () -> foo None
   | None -> ()
 [%%expect{|
-val foo : local_ unique_ unit option -> unit = <fun>
+val foo : local_ unique_ unit option -> unit @@ global many = <fun>
 |}]
 
 let rec bar =
@@ -434,17 +445,17 @@ let rec bar =
   | Some () -> ()
   | None -> bar (local_ Some ()) [@nontail]
 [%%expect{|
-val bar : local_ unique_ unit option -> unit = <fun>
+val bar : local_ unique_ unit option -> unit @@ global many = <fun>
 |}]
 
 let foo : local_ unique_ string -> unit = fun (local_ s) -> ()
 [%%expect{|
-val foo : local_ unique_ string -> unit = <fun>
+val foo : local_ unique_ string -> unit @@ global many = <fun>
 |}]
 
 let bar : local_ unique_ string -> unit = fun (unique_ s) -> ()
 [%%expect{|
-val bar : local_ unique_ string -> unit = <fun>
+val bar : local_ unique_ string -> unit @@ global many = <fun>
 |}]
 
 (* Currying *)
@@ -453,8 +464,8 @@ let curry =
   let foo ~a ~b ~c ~d = (a, b, c, (unique_ d)) in
   foo ~a:3 ~c:4
 [%%expect{|
-val curry : b:'_weak1 -> d:unique_ '_weak2 -> int * '_weak1 * int * '_weak2 =
-  <fun>
+val curry : b:'_weak1 -> d:unique_ '_weak2 -> int * '_weak1 * int * '_weak2
+  @@ global many = <fun>
 |}]
 
 (* the following two failed because top-level must be many *)
@@ -484,8 +495,8 @@ let curry =
   foo ~a:3 ~c:4
 [%%expect{|
 val curry :
-  b:unique_ '_weak3 -> d:unique_ '_weak4 -> int * '_weak3 * int * '_weak4 =
-  <fun>
+  b:unique_ '_weak3 -> d:unique_ '_weak4 -> int * '_weak3 * int * '_weak4 @@
+  global many = <fun>
 |}]
 
 let curry =
@@ -543,12 +554,12 @@ type box = { x : int; }
 
 let curry (unique_ b1 : box) (unique_ b2 : box) = ()
 [%%expect{|
-val curry : unique_ box -> unique_ box -> unit = <fun>
+val curry : unique_ box -> unique_ box -> unit @@ global many = <fun>
 |}]
 
 let curry : unique_ box -> unique_ box -> unit = fun b1 b2 -> ()
 [%%expect{|
-val curry : unique_ box -> unique_ box -> unit = <fun>
+val curry : unique_ box -> unique_ box -> unit @@ global many = <fun>
 |}]
 
 let curry : unique_ box -> (unique_ box -> unit) = fun b1 b2 -> ()
@@ -572,7 +583,7 @@ Error: This function when partially applied returns a value which is "once",
 (* For nested functions, inner functions are not constrained *)
 let no_curry : unique_ box -> (unique_ box -> unit) = fun b1 -> fun b2 -> ()
 [%%expect{|
-val no_curry : unique_ box -> (unique_ box -> unit) = <fun>
+val no_curry : unique_ box -> (unique_ box -> unit) @@ global many = <fun>
 |}]
 
 (* If both type and mode are wrong, complain about type *)
@@ -591,8 +602,10 @@ Error: This expression has type "int" but an expression was expected of type
 let return_local : local_ 'a -> local_ 'a = fun x -> x
 let return_global : local_ 'a -> int = fun x -> 0
 [%%expect{|
-val return_local : local_ 'a -> local_ 'a = <fun>
-val return_global : local_ 'a -> int = <fun>
+val return_local : ('a : value_or_null). local_ 'a -> local_ 'a @@ global
+  many = <fun>
+val return_global : ('a : value_or_null). local_ 'a -> int @@ global many =
+  <fun>
 |}]
 
 
@@ -623,8 +636,8 @@ let f ~(call_pos : [%call_pos]) () =
   (x, x)
 ;;
 [%%expect{|
-val f : call_pos:[%call_pos] -> unit -> lexing_position * lexing_position =
-  <fun>
+val f : call_pos:[%call_pos] -> unit -> lexing_position * lexing_position @@
+  global many = <fun>
 |}]
 
 let f ~(call_pos : [%call_pos]) () =
@@ -638,5 +651,207 @@ Error: This value is used here, but it has already been used as unique:
 Line 2, characters 11-19:
 2 |   unique_ (call_pos, call_pos)
                ^^^^^^^^
+
+|}]
+
+(*******************************)
+(* Examples from documentation *)
+
+type t = Con of { field : int }
+
+let free : t @ unique -> unit = fun t -> ()
+let free_field (unique_ i) = ()
+let store : t @ aliased -> unit = fun t -> ()
+let store_field i = ()
+let flip_coin () = true
+[%%expect{|
+type t = Con of { field : int; }
+val free : unique_ t -> unit @@ global many = <fun>
+val free_field : ('a : value_or_null). unique_ 'a -> unit @@ global many =
+  <fun>
+val store : t -> unit @@ global many = <fun>
+val store_field : ('a : value_or_null). 'a -> unit @@ global many = <fun>
+val flip_coin : unit -> bool @@ global many = <fun>
+|}]
+
+let test () =
+  let dup : t -> t * t @ aliased = function t -> t, t in
+  let delay_free : t @ unique -> (unit -> unit) @ once = function t -> fun () -> free t in
+  let alias : 'a @ unique -> 'a @ aliased = fun x -> x in
+  let linearize : 'a @ many -> 'a @ once = fun x -> x in
+  ()
+[%%expect{|
+Line 2, characters 6-9:
+2 |   let dup : t -> t * t @ aliased = function t -> t, t in
+          ^^^
+Warning 26 [unused-var]: unused variable dup.
+
+Line 3, characters 6-16:
+3 |   let delay_free : t @ unique -> (unit -> unit) @ once = function t -> fun () -> free t in
+          ^^^^^^^^^^
+Warning 26 [unused-var]: unused variable delay_free.
+
+Line 4, characters 6-11:
+4 |   let alias : 'a @ unique -> 'a @ aliased = fun x -> x in
+          ^^^^^
+Warning 26 [unused-var]: unused variable alias.
+
+Line 5, characters 6-15:
+5 |   let linearize : 'a @ many -> 'a @ once = fun x -> x in
+          ^^^^^^^^^
+Warning 26 [unused-var]: unused variable linearize.
+
+val test : unit -> unit @@ global many = <fun>
+|}]
+
+let okay t =
+  match t with
+  | Con { field } -> free t
+[%%expect{|
+val okay : unique_ t -> unit @@ global many = <fun>
+|}]
+
+let bad t =
+  match t with
+  | Con { field } ->
+    free_field field;
+    free t
+[%%expect{|
+Line 5, characters 9-10:
+5 |     free t
+             ^
+Error: This value is used here,
+       but part of it has already been used as unique:
+Line 4, characters 15-20:
+4 |     free_field field;
+                   ^^^^^
+
+|}]
+
+let okay t =
+  match t with
+  | Con { field } ->
+    if flip_coin ()
+    then free_field field
+    else free t
+[%%expect{|
+val okay : unique_ t -> unit @@ global many = <fun>
+|}]
+
+let okay t =
+  match t with
+  | Con { field } ->
+    store_field field;
+    store t
+[%%expect{|
+val okay : t -> unit @@ global many = <fun>
+|}]
+
+let module_ret_unique =
+  let mk () = Con { field = 1 } in
+  let use () = free (mk ()) in
+  ()
+[%%expect{|
+Line 3, characters 6-9:
+3 |   let use () = free (mk ()) in
+          ^^^
+Warning 26 [unused-var]: unused variable use.
+
+val module_ret_unique : unit @@ global many = ()
+|}]
+
+module Mk = struct
+  let mk () = Con { field = 1 }
+end
+
+let module_ret_unique =
+  let use () = free (Mk.mk ()) in
+  ()
+[%%expect{|
+module Mk : sig val mk : unit -> t @@ global many portable end
+Line 6, characters 20-30:
+6 |   let use () = free (Mk.mk ()) in
+                        ^^^^^^^^^^
+Error: This value is "aliased" but expected to be "unique".
+|}]
+
+module Unique_array = struct
+  let set : 'a @ unique -> int -> 'b -> 'a @ unique = fun arr -> fun i -> fun x -> arr
+  let size arr = 10
+end
+[%%expect{|
+module Unique_array :
+  sig
+    val set :
+      ('a : value_or_null) ('b : value_or_null).
+        unique_ 'a -> int -> 'b -> unique_ 'a
+      @@ global many portable
+    val size : ('a : value_or_null). 'a -> int @@ global many portable
+  end
+|}]
+
+let set_all_zero arr =
+  for i = 0 to Unique_array.size arr do
+    Unique_array.set arr i 0
+  done
+[%%expect{|
+Line 3, characters 21-24:
+3 |     Unique_array.set arr i 0
+                         ^^^
+Error: This value is "aliased" but expected to be "unique".
+  Hint: This identifier cannot be used uniquely,
+  because it was defined outside of the for-loop.
+|}]
+
+let set_all_zero arr =
+  let set = Unique_array.set arr in
+  for i = 0 to Unique_array.size arr do
+    set i 0
+  done
+[%%expect{|
+Line 4, characters 4-7:
+4 |     set i 0
+        ^^^
+Error: The value "set" is once, so cannot be used inside a for loop
+|}]
+
+let set_all_zero arr =
+  let size (unique_ arr) = 10, arr in
+  let rec loop idx arr =
+    if idx == 0 then arr
+    else loop (idx - 1) (Unique_array.set arr idx 0)
+  in
+  let size, arr = size arr in
+  loop size arr
+[%%expect{|
+val set_all_zero : ('a : value_or_null). unique_ 'a -> 'a @@ global many =
+  <fun>
+|}]
+
+let check_tuple x y z =
+  let m =
+    match x, y, z with
+    | p, q, r -> free x
+  in m, y
+[%%expect{|
+val check_tuple :
+  ('a : value_or_null) ('b : value_or_null).
+    unique_ t -> 'a -> 'b -> unit * 'a
+  @@ global many = <fun>
+|}]
+
+let check_tuple x y z =
+  let m =
+    match x, y, z with
+    | p, q, r as t -> free x
+  in m, y
+[%%expect{|
+Line 4, characters 27-28:
+4 |     | p, q, r as t -> free x
+                               ^
+Error: This value is used here as unique, but it has already been used:
+Line 3, characters 10-11:
+3 |     match x, y, z with
+              ^
 
 |}]

--- a/testsuite/tests/typing-unique/unique_documentation.ml
+++ b/testsuite/tests/typing-unique/unique_documentation.ml
@@ -1,0 +1,207 @@
+(* TEST
+   flags += "-extension unique ";
+   flags += "-extension-universe alpha";
+   expect;
+*)
+
+(*******************************)
+(* Examples from documentation *)
+
+type t = Con of { field : int }
+
+let free : t @ unique -> unit = fun t -> ()
+let free_field (unique_ i) = ()
+let store : t @ aliased -> unit = fun t -> ()
+let store_field i = ()
+let flip_coin () = true
+[%%expect{|
+type t = Con of { field : int; }
+val free : unique_ t -> unit @@ global many = <fun>
+val free_field : ('a : value_or_null). unique_ 'a -> unit @@ global many =
+  <fun>
+val store : t -> unit @@ global many = <fun>
+val store_field : ('a : value_or_null). 'a -> unit @@ global many = <fun>
+val flip_coin : unit -> bool @@ global many = <fun>
+|}]
+
+let test () =
+  let dup : t -> t * t @ aliased = function t -> t, t in
+  let delay_free : t @ unique -> (unit -> unit) @ once = function t -> fun () -> free t in
+  let alias : 'a @ unique -> 'a @ aliased = fun x -> x in
+  let linearize : 'a @ many -> 'a @ once = fun x -> x in
+  ()
+[%%expect{|
+Line 2, characters 6-9:
+2 |   let dup : t -> t * t @ aliased = function t -> t, t in
+          ^^^
+Warning 26 [unused-var]: unused variable dup.
+
+Line 3, characters 6-16:
+3 |   let delay_free : t @ unique -> (unit -> unit) @ once = function t -> fun () -> free t in
+          ^^^^^^^^^^
+Warning 26 [unused-var]: unused variable delay_free.
+
+Line 4, characters 6-11:
+4 |   let alias : 'a @ unique -> 'a @ aliased = fun x -> x in
+          ^^^^^
+Warning 26 [unused-var]: unused variable alias.
+
+Line 5, characters 6-15:
+5 |   let linearize : 'a @ many -> 'a @ once = fun x -> x in
+          ^^^^^^^^^
+Warning 26 [unused-var]: unused variable linearize.
+
+val test : unit -> unit @@ global many = <fun>
+|}]
+
+let okay t =
+  match t with
+  | Con { field } -> free t
+[%%expect{|
+val okay : unique_ t -> unit @@ global many = <fun>
+|}]
+
+let bad t =
+  match t with
+  | Con { field } ->
+    free_field field;
+    free t
+[%%expect{|
+Line 5, characters 9-10:
+5 |     free t
+             ^
+Error: This value is used here,
+       but part of it has already been used as unique:
+Line 4, characters 15-20:
+4 |     free_field field;
+                   ^^^^^
+
+|}]
+
+let okay t =
+  match t with
+  | Con { field } ->
+    if flip_coin ()
+    then free_field field
+    else free t
+[%%expect{|
+val okay : unique_ t -> unit @@ global many = <fun>
+|}]
+
+let okay t =
+  match t with
+  | Con { field } ->
+    store_field field;
+    store t
+[%%expect{|
+val okay : t -> unit @@ global many = <fun>
+|}]
+
+let module_ret_unique =
+  let mk () = Con { field = 1 } in
+  let use () = free (mk ()) in
+  ()
+[%%expect{|
+Line 3, characters 6-9:
+3 |   let use () = free (mk ()) in
+          ^^^
+Warning 26 [unused-var]: unused variable use.
+
+val module_ret_unique : unit @@ global many = ()
+|}]
+
+module Mk = struct
+  let mk () = Con { field = 1 }
+end
+
+let module_ret_unique =
+  let use () = free (Mk.mk ()) in
+  ()
+[%%expect{|
+module Mk : sig val mk : unit -> t @@ global many portable end
+Line 6, characters 20-30:
+6 |   let use () = free (Mk.mk ()) in
+                        ^^^^^^^^^^
+Error: This value is "aliased" but expected to be "unique".
+|}]
+
+module Unique_array = struct
+  let set : 'a @ unique -> int -> 'b -> 'a @ unique = fun arr -> fun i -> fun x -> arr
+  let size arr = 10
+end
+[%%expect{|
+module Unique_array :
+  sig
+    val set :
+      ('a : value_or_null) ('b : value_or_null).
+        unique_ 'a -> int -> 'b -> unique_ 'a
+      @@ global many portable
+    val size : ('a : value_or_null). 'a -> int @@ global many portable
+  end
+|}]
+
+let set_all_zero arr =
+  for i = 0 to Unique_array.size arr do
+    Unique_array.set arr i 0
+  done
+[%%expect{|
+Line 3, characters 21-24:
+3 |     Unique_array.set arr i 0
+                         ^^^
+Error: This value is "aliased" but expected to be "unique".
+  Hint: This identifier cannot be used uniquely,
+  because it was defined outside of the for-loop.
+|}]
+
+let set_all_zero arr =
+  let set = Unique_array.set arr in
+  for i = 0 to Unique_array.size arr do
+    set i 0
+  done
+[%%expect{|
+Line 4, characters 4-7:
+4 |     set i 0
+        ^^^
+Error: The value "set" is once, so cannot be used inside a for loop
+|}]
+
+let set_all_zero arr =
+  let size (unique_ arr) = 10, arr in
+  let rec loop idx arr =
+    if idx == 0 then arr
+    else loop (idx - 1) (Unique_array.set arr idx 0)
+  in
+  let size, arr = size arr in
+  loop size arr
+[%%expect{|
+val set_all_zero : ('a : value_or_null). unique_ 'a -> 'a @@ global many =
+  <fun>
+|}]
+
+let check_tuple x y z =
+  let m =
+    match x, y, z with
+    | p, q, r -> free x
+  in m, y
+[%%expect{|
+val check_tuple :
+  ('a : value_or_null) ('b : value_or_null).
+    unique_ t -> 'a -> 'b -> unit * 'a
+  @@ global many = <fun>
+|}]
+
+let check_tuple x y z =
+  let m =
+    match x, y, z with
+    | p, q, r as t -> free x
+  in m, y
+[%%expect{|
+Line 4, characters 27-28:
+4 |     | p, q, r as t -> free x
+                               ^
+Error: This value is used here as unique, but it has already been used:
+Line 3, characters 10-11:
+3 |     match x, y, z with
+              ^
+
+|}]

--- a/testsuite/tests/typing-unique/unique_documentation.ml
+++ b/testsuite/tests/typing-unique/unique_documentation.ml
@@ -1,6 +1,5 @@
 (* TEST
-   flags += "-extension unique ";
-   flags += "-extension-universe alpha";
+   flags += "-extension unique";
    expect;
 *)
 
@@ -19,12 +18,11 @@ let store_field i = ()
 let flip_coin () = true
 [%%expect{|
 type t = Con of { field : int list; }
-val free : unique_ t -> unit @@ global many = <fun>
-val free_field : ('a : value_or_null). unique_ 'a -> unit @@ global many =
-  <fun>
-val store : t -> unit @@ global many = <fun>
-val store_field : ('a : value_or_null). 'a -> unit @@ global many = <fun>
-val flip_coin : unit -> bool @@ global many = <fun>
+val free : unique_ t -> unit = <fun>
+val free_field : unique_ 'a -> unit = <fun>
+val store : t -> unit = <fun>
+val store_field : 'a -> unit = <fun>
+val flip_coin : unit -> bool = <fun>
 |}]
 
 let test () =
@@ -54,7 +52,7 @@ Line 5, characters 6-15:
           ^^^^^^^^^
 Warning 26 [unused-var]: unused variable linearize.
 
-val test : unit -> unit @@ global many = <fun>
+val test : unit -> unit = <fun>
 |}]
 
 type 'a aliased = { a : 'a @@ aliased } [@@unboxed]
@@ -63,8 +61,7 @@ let cons : 'a @ aliased -> 'a aliased list @ unique -> 'a aliased list @ unique 
   fun x xs -> { a = x } :: xs
 [%%expect{|
 type 'a aliased = { a : 'a @@ aliased; } [@@unboxed]
-val cons : 'a -> unique_ 'a aliased list -> unique_ 'a aliased list @@ global
-  many = <fun>
+val cons : 'a -> unique_ 'a aliased list -> unique_ 'a aliased list = <fun>
 |}]
 
 type delayed_free = { id : int; callback : unit -> unit }
@@ -72,7 +69,7 @@ type delayed_free = { id : int; callback : unit -> unit }
 let get_id : delayed_free @ once -> int @ many = fun d -> d.id
 [%%expect{|
 type delayed_free = { id : int; callback : unit -> unit; }
-val get_id : once_ delayed_free -> int @@ global many = <fun>
+val get_id : once_ delayed_free -> int = <fun>
 |}]
 
 type delayed_free = { ids : int list; callback : unit -> unit }
@@ -92,7 +89,7 @@ let okay t =
   match t with
   | Con { field } -> free t
 [%%expect{|
-val okay : unique_ t -> unit @@ global many = <fun>
+val okay : unique_ t -> unit = <fun>
 |}]
 
 let bad t =
@@ -119,7 +116,7 @@ let okay t =
     then free_field field
     else free t
 [%%expect{|
-val okay : unique_ t -> unit @@ global many = <fun>
+val okay : unique_ t -> unit = <fun>
 |}]
 
 let okay t =
@@ -128,7 +125,7 @@ let okay t =
     store_field field;
     store t
 [%%expect{|
-val okay : t -> unit @@ global many = <fun>
+val okay : t -> unit = <fun>
 |}]
 
 (****************)
@@ -144,7 +141,7 @@ Line 3, characters 6-9:
           ^^^
 Warning 26 [unused-var]: unused variable use.
 
-val module_ret_unique : unit @@ global many = ()
+val module_ret_unique : unit = ()
 |}]
 
 module Mk = struct
@@ -155,7 +152,7 @@ let module_ret_unique =
   let use () = free (Mk.mk ()) in
   ()
 [%%expect{|
-module Mk : sig val mk : unit -> t @@ global many portable end
+module Mk : sig val mk : unit -> t end
 Line 6, characters 20-30:
 6 |   let use () = free (Mk.mk ()) in
                         ^^^^^^^^^^
@@ -169,11 +166,8 @@ end
 [%%expect{|
 module Unique_array :
   sig
-    val set :
-      ('a : value_or_null) ('b : value_or_null).
-        unique_ 'a -> int -> 'b -> unique_ 'a
-      @@ global many portable
-    val size : ('a : value_or_null). 'a -> int @@ global many portable
+    val set : unique_ 'a -> int -> 'b -> unique_ 'a
+    val size : 'a -> int
   end
 |}]
 
@@ -211,8 +205,7 @@ let set_all_zero arr =
   let size, arr = size arr in
   loop size arr
 [%%expect{|
-val set_all_zero : ('a : value_or_null). unique_ 'a -> 'a @@ global many =
-  <fun>
+val set_all_zero : unique_ 'a -> 'a = <fun>
 |}]
 
 (****************)
@@ -227,12 +220,11 @@ let store_field i = ()
 let flip_coin () = true
 [%%expect{|
 type t = { field1 : t; field2 : t; }
-val free : unique_ t -> unit @@ global many = <fun>
-val free_field : ('a : value_or_null). unique_ 'a -> unit @@ global many =
-  <fun>
-val store : t -> unit @@ global many = <fun>
-val store_field : ('a : value_or_null). 'a -> unit @@ global many = <fun>
-val flip_coin : unit -> bool @@ global many = <fun>
+val free : unique_ t -> unit = <fun>
+val free_field : unique_ 'a -> unit = <fun>
+val store : t -> unit = <fun>
+val store_field : 'a -> unit = <fun>
+val flip_coin : unit -> bool = <fun>
 |}]
 
 let okay t =
@@ -240,7 +232,7 @@ let okay t =
   then free t
   else (store t; store t)
 [%%expect{|
-val okay : unique_ t -> unit @@ global many = <fun>
+val okay : unique_ t -> unit = <fun>
 |}]
 
 let okay r =
@@ -248,7 +240,7 @@ let okay r =
   match r with
   | { field2; _ } -> free field2
 [%%expect{|
-val okay : unique_ t -> unit @@ global many = <fun>
+val okay : unique_ t -> unit = <fun>
 |}]
 
 let bad r =
@@ -273,13 +265,12 @@ let okay r =
   match r with
   | { field2; _ } -> free field2
 [%%expect{|
-val okay : unique_ t -> unit @@ global many = <fun>
+val okay : unique_ t -> unit = <fun>
 |}]
 
 let id : 'a @ unique -> 'a @ unique = fun t -> t
 [%%expect{|
-val id : ('a : value_or_null). unique_ 'a -> unique_ 'a @@ global many =
-  <fun>
+val id : unique_ 'a -> unique_ 'a = <fun>
 |}]
 
 let bad r =
@@ -320,19 +311,14 @@ let check_tuple x y z =
     | p, q, r -> free p
   in m, y, y
 [%%expect{|
-val check_tuple :
-  ('a : value_or_null) ('b : value_or_null).
-    unique_ t -> 'a -> 'b -> unit * 'a * 'a
-  @@ global many = <fun>
+val check_tuple : unique_ t -> 'a -> 'b -> unit * 'a * 'a = <fun>
 |}]
 
 let okay x y z =
   match x, y, z with
   | p, q, r -> free x.field1; free p.field2
 [%%expect{|
-val okay :
-  ('a : value_or_null) ('b : value_or_null). unique_ t -> 'a -> 'b -> unit @@
-  global many = <fun>
+val okay : unique_ t -> 'a -> 'b -> unit = <fun>
 |}]
 
 let bad x y z =

--- a/testsuite/tests/typing-unique/unique_documentation.ml
+++ b/testsuite/tests/typing-unique/unique_documentation.ml
@@ -215,7 +215,7 @@ val okay : unique_ t -> unit @@ global many = <fun>
 let okay r =
   free r.field1;
   match r with
-  | { field2 } -> free field2
+  | { field2; _ } -> free field2
 [%%expect{|
 val okay : unique_ t -> unit @@ global many = <fun>
 |}]
@@ -223,11 +223,11 @@ val okay : unique_ t -> unit @@ global many = <fun>
 let bad r =
   free r.field1;
   match r with
-  | { field2 } -> free r
+  | { field2; _ } -> free r
 [%%expect{|
-Line 4, characters 23-24:
-4 |   | { field2 } -> free r
-                           ^
+Line 4, characters 26-27:
+4 |   | { field2; _ } -> free r
+                              ^
 Error: This value is used here,
        but part of it has already been used as unique:
 Line 2, characters 7-15:
@@ -240,7 +240,7 @@ let okay r =
   let x = r in
   free x.field1;
   match r with
-  | { field2 } -> free field2
+  | { field2; _ } -> free field2
 [%%expect{|
 val okay : unique_ t -> unit @@ global many = <fun>
 |}]
@@ -249,7 +249,7 @@ let bad r =
   let x = Fun.id r in
   free x.field1;
   match r with
-  | { field2 } -> free field2
+  | { field2; _ } -> free field2
 [%%expect{|
 Line 3, characters 7-15:
 3 |   free x.field1;


### PR DESCRIPTION
This PR adds some documentation for the uniqueness mode. This unblocks #3065.

I have followed the structure of the `local/` documentation. This is arguably too heavy weight for the current amount of content, but I would expect that we will add descriptions of borrowing and in-place overwrite to these files once those features are ready.

I have used the new syntax for modes throughout. I believe that this makes the documentation more clear and I would expect that most users only start to use uniqueness later on when the new syntax is stable. I have added a short description of the current syntax for users who read this earlier.

~~I have marked this PR as a draft because it should be merged simultanously with #3065.~~ Edit: @riaqn remarks below that this can be merged before #3065.