### PR TITLE
Bump magic numbers for 5.2.0minus-2

### DIFF
--- a/build-aux/ocaml_version.m4
+++ b/build-aux/ocaml_version.m4
@@ -97,7 +97,7 @@ m4_define([OCAML__RELEASE_EXTRA],
 # - A 3-bytes version number
 
 m4_define([MAGIC_NUMBER__PREFIX], [Caml1999])
-m4_define([MAGIC_NUMBER__VERSION], [551])
+m4_define([MAGIC_NUMBER__VERSION], [552])
 
 # The following macro is used to define all our magic numbers
 # Its first argument is the name of the file type described by that


### PR DESCRIPTION
I believe that, post pivot-root, only this one-line change is needed to bump the magic numbers (since we are still not committing the configure script).