### PR TITLE
Make objects crosses modes

### DIFF
--- a/testsuite/tests/typing-layouts/jkinds.ml
+++ b/testsuite/tests/typing-layouts/jkinds.ml
@@ -1426,13 +1426,7 @@ type t = <  >
 
 type t : value mod global = < >
 [%%expect {|
-Line 1, characters 0-31:
-1 | type t : value mod global = < >
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "<  >" is value
-         because it's the type of an object.
-       But the kind of type "<  >" must be a subkind of value mod global
-         because of the definition of t at line 1, characters 0-31.
+type t = <  >
 |}]
 
 let x : (_ as (_ : value)) = object end
@@ -1442,28 +1436,12 @@ val x : <  > = <obj>
 
 let x : (_ as (_ : value mod global)) = object end
 [%%expect {|
-Line 1, characters 40-50:
-1 | let x : (_ as (_ : value mod global)) = object end
-                                            ^^^^^^^^^^
-Error: This expression has type "<  >" but an expression was expected of type
-         "('a : value mod global)"
-       The kind of <  > is value
-         because it's the type of an object.
-       But the kind of <  > must be a subkind of value mod global
-         because of the annotation on the wildcard _ at line 1, characters 19-35.
+val x : <  > = <obj>
 |}]
 
 let x : (_ as (_ : value mod many)) = object end
 [%%expect {|
-Line 1, characters 38-48:
-1 | let x : (_ as (_ : value mod many)) = object end
-                                          ^^^^^^^^^^
-Error: This expression has type "<  >" but an expression was expected of type
-         "('a : value mod many)"
-       The kind of <  > is value
-         because it's the type of an object.
-       But the kind of <  > must be a subkind of value mod many
-         because of the annotation on the wildcard _ at line 1, characters 19-33.
+val x : <  > = <obj>
 |}]
 
 let x : (_ as (_ : value mod unique)) = object end
@@ -1473,7 +1451,7 @@ Line 1, characters 40-50:
                                             ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod unique)"
-       The kind of <  > is value
+       The kind of <  > is value mod global many
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod unique
          because of the annotation on the wildcard _ at line 1, characters 19-35.
@@ -1486,7 +1464,7 @@ Line 1, characters 42-52:
                                               ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod portable)"
-       The kind of <  > is value
+       The kind of <  > is value mod global many
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod portable
          because of the annotation on the wildcard _ at line 1, characters 19-37.
@@ -1499,7 +1477,7 @@ Line 1, characters 45-55:
                                                  ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod uncontended)"
-       The kind of <  > is value
+       The kind of <  > is value mod global many
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod uncontended
          because of the annotation on the wildcard _ at line 1, characters 19-40.
@@ -1512,7 +1490,7 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod external_)"
-       The kind of <  > is value
+       The kind of <  > is value mod global many
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod external_
          because of the annotation on the wildcard _ at line 1, characters 19-38.

--- a/testsuite/tests/typing-local/alloc.heap.reference
+++ b/testsuite/tests/typing-local/alloc.heap.reference
@@ -34,3 +34,4 @@
        manylong: Allocation
     optionalarg: Allocation
     optionaleta: Allocation
+         object: Allocation

--- a/testsuite/tests/typing-local/alloc.heap.reference
+++ b/testsuite/tests/typing-local/alloc.heap.reference
@@ -35,3 +35,4 @@
     optionalarg: Allocation
     optionaleta: Allocation
          object: Allocation
+  object_direct: Allocation

--- a/testsuite/tests/typing-local/alloc.ml
+++ b/testsuite/tests/typing-local/alloc.ml
@@ -460,10 +460,15 @@ class cla = object
     val x = 42
 end
 
-let[@inline never] obj () =
+let obj () =
   ignore_local (new cla);
   ()
 
+let obj_direct () =
+  ignore_local (object
+    val x = 42
+  end);
+  ()
 
 let run name f x =
   let prebefore = Gc.allocated_bytes () in
@@ -519,7 +524,8 @@ let () =
   run "manylong" makemanylong 100;
   run "optionalarg" optionalarg (fun_with_optional_arg, 10);
   run "optionaleta" optionaleta ();
-  run "object" obj ()
+  run "object" obj ();
+  run "object_direct" obj_direct ()
 
   (* The following test commented out as it require more memory than the CI has
      *)

--- a/testsuite/tests/typing-local/alloc.ml
+++ b/testsuite/tests/typing-local/alloc.ml
@@ -456,6 +456,15 @@ let[@inline never] huge () =
   bytes_set b pos 'h';
   assert (bytes_get b pos = 'h')
 
+class cla = object
+    val x = 42
+end
+
+let[@inline never] obj () =
+  ignore_local (new cla);
+  ()
+
+
 let run name f x =
   let prebefore = Gc.allocated_bytes () in
   let before = Gc.allocated_bytes () in
@@ -509,7 +518,8 @@ let () =
   run "verylong" makeverylong 42;
   run "manylong" makemanylong 100;
   run "optionalarg" optionalarg (fun_with_optional_arg, 10);
-  run "optionaleta" optionaleta ()
+  run "optionaleta" optionaleta ();
+  run "object" obj ()
 
   (* The following test commented out as it require more memory than the CI has
      *)

--- a/testsuite/tests/typing-local/alloc.stack.reference
+++ b/testsuite/tests/typing-local/alloc.stack.reference
@@ -35,3 +35,4 @@
     optionalarg: No Allocation
     optionaleta: No Allocation
          object: Allocation
+  object_direct: Allocation

--- a/testsuite/tests/typing-local/alloc.stack.reference
+++ b/testsuite/tests/typing-local/alloc.stack.reference
@@ -34,3 +34,4 @@
        manylong: No Allocation
     optionalarg: No Allocation
     optionaleta: No Allocation
+         object: Allocation

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2149,7 +2149,7 @@ let rec estimate_type_jkind ~expand_component env ty =
       with
         Not_found -> Jkind.Builtin.any ~why:(Missing_cmi p)
     end
-  | Tobject _ -> Jkind.Builtin.value ~why:Object
+  | Tobject _ -> Jkind.for_object
   | Tfield _ -> Jkind.Builtin.value ~why:Tfield
   | Tnil -> Jkind.Builtin.value ~why:Tnil
   | Tlink _ | Tsubst _ -> assert false

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1252,6 +1252,22 @@ let for_arrow =
     }
     ~why:(Value_creation Arrow)
 
+let for_object =
+  fresh_jkind
+    { layout = Sort (Base Value);
+      modes_upper_bounds =
+        (* The crossing of objects are based on the fact that they are
+           produced/defined/allocated at legacy, which applies to only the
+           comonadic axes. *)
+        Alloc.Const.merge
+          { comonadic = Alloc.Comonadic.Const.legacy;
+            monadic = Alloc.Monadic.Const.max
+          };
+      externality_upper_bound = Externality.max;
+      nullability_upper_bound = Non_null
+    }
+    ~why:(Value_creation Object)
+
 (******************************)
 (* elimination and defaulting *)
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -376,6 +376,9 @@ val for_boxed_variant : all_voids:bool -> jkind_l
 (** The jkind of an arrow type. *)
 val for_arrow : jkind_l
 
+(** The jkind of an object type.  *)
+val for_object : jkind_l
+
 (******************************)
 (* elimination and defaulting *)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -891,12 +891,15 @@ let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
 (** Mode cross a right mode *)
 (* This is very similar to Ctype.mode_cross_right. Any bugs here are likely bugs
    there, too. *)
-let expect_mode_cross env ty (expected_mode : expected_mode) =
-  if not (is_principal ty) then expected_mode else
-  let jkind = type_jkind_purely env ty in
+let expect_mode_cross_jkind jkind (expected_mode : expected_mode) =
   let upper_bounds = Jkind.get_modal_upper_bounds jkind in
   let upper_bounds = Const.alloc_as_value upper_bounds in
   mode_morph (Value.imply upper_bounds) expected_mode
+
+let expect_mode_cross env ty (expected_mode : expected_mode) =
+  if not (is_principal ty) then expected_mode else
+  let jkind = type_jkind_purely env ty in
+  expect_mode_cross_jkind jkind expected_mode
 
 let mode_annots_from_pat pat =
   let modes =
@@ -9362,7 +9365,8 @@ and type_immutable_array
 
 (* Typing of method call *)
 and type_send env loc explanation e met =
-  let obj = type_exp env mode_legacy e in
+  let expected_mode = expect_mode_cross_jkind Jkind.for_object mode_legacy in
+  let obj = type_exp env expected_mode e in
   let (meth, typ) =
     match obj.exp_desc with
     | Texp_ident(_, _, {val_kind = Val_self(sign, meths, _, _)}, _, _) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -901,6 +901,9 @@ let expect_mode_cross env ty (expected_mode : expected_mode) =
   let jkind = type_jkind_purely env ty in
   expect_mode_cross_jkind jkind expected_mode
 
+(** The expected mode for objects *)
+let mode_object = expect_mode_cross_jkind Jkind.for_object mode_legacy
+
 let mode_annots_from_pat pat =
   let modes =
     match pat.ppat_desc with
@@ -9365,8 +9368,7 @@ and type_immutable_array
 
 (* Typing of method call *)
 and type_send env loc explanation e met =
-  let expected_mode = expect_mode_cross_jkind Jkind.for_object mode_legacy in
-  let obj = type_exp env expected_mode e in
+  let obj = type_exp env mode_object e in
   let (meth, typ) =
     match obj.exp_desc with
     | Texp_ident(_, _, {val_kind = Val_self(sign, meths, _, _)}, _, _) ->


### PR DESCRIPTION
Objects are currently defined/produced/allocated at `legacy`, this allows an "actual"/left object to cross to `global` and `many` as needed.

Note that objects are also defined at `uncontended`, but that doesn't mean objects can cross to `uncontended`. For example:
```
let obj = new cla in
let (foo @ portable) () = .. obj#method ..
```
This shouldn't type check because (among other reasons) `obj` is used inside the closure as `uncontended`, which forces the closure to be `nonportable`.

In general, objects cannot cross monadic axes, because the mode crossing of objects are solely based on how they are defined at a fixed mode, which only affects comonadic axes.