### PR TITLE
Add an alert to `Domain.spawn`

### DIFF
--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -32,6 +32,9 @@ type !'a t
     result of type 'a, or an exception *)
 
 val spawn : (unit -> 'a) -> 'a t
+[@@alert unsafe_parallelism
+           "This function is unsafe and should not be used in production \
+            code.\nA safe interface for parallelism is forthcoming."]
 (** [spawn f] creates a new domain that runs in parallel with the
     current domain.
 

--- a/testsuite/tests/gc-roots/globroots_parallel.ml
+++ b/testsuite/tests/gc-roots/globroots_parallel.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags += " -w a ";
+ flags += " -w a -alert -unsafe_parallelism ";
  modules = "globrootsprim.c globroots.ml";
  runtime5;
  { bytecode; }

--- a/testsuite/tests/gc-roots/globroots_parallel_spawn_burn.ml
+++ b/testsuite/tests/gc-roots/globroots_parallel_spawn_burn.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags += " -w a ";
+ flags += " -w a -alert -unsafe_parallelism ";
  modules = "globrootsprim.c globroots.ml";
  runtime5;
  { bytecode; }

--- a/testsuite/tests/lazy/lazy2.ml
+++ b/testsuite/tests/lazy/lazy2.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  ocamlopt_flags += " -O3 ";
  runtime5;
  { bytecode; }

--- a/testsuite/tests/lazy/lazy3.ml
+++ b/testsuite/tests/lazy/lazy3.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  ocamlopt_flags += " -O3 ";
  runtime5;
  { bytecode; }

--- a/testsuite/tests/lazy/lazy5.ml
+++ b/testsuite/tests/lazy/lazy5.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  ocamlopt_flags += " -O3 ";
  runtime5;
  { bytecode; }

--- a/testsuite/tests/lazy/lazy6.ml
+++ b/testsuite/tests/lazy/lazy6.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  ocamlopt_flags += " -O3 ";
  runtime5;
  { bytecode; }

--- a/testsuite/tests/lazy/lazy7.ml
+++ b/testsuite/tests/lazy/lazy7.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  ocamlopt_flags += " -O3 ";
  runtime5;
  { bytecode; }

--- a/testsuite/tests/lazy/lazy8.ml
+++ b/testsuite/tests/lazy/lazy8.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  ocamlopt_flags += " -O3 ";
  runtime5;
  { bytecode; }

--- a/testsuite/tests/lf_skiplist/test_parallel.ml
+++ b/testsuite/tests/lf_skiplist/test_parallel.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags = "-alert -unsafe_parallelism";
  modules = "stubs.c";
  no-tsan;
  runtime5;

--- a/testsuite/tests/lib-channels/refcounting.ml
+++ b/testsuite/tests/lib-channels/refcounting.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  expect;
 *)

--- a/testsuite/tests/lib-format/domains.ml
+++ b/testsuite/tests/lib-format/domains.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/lib-format/mc_pr586_par.ml
+++ b/testsuite/tests/lib-format/mc_pr586_par.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/lib-format/mc_pr586_par2.ml
+++ b/testsuite/tests/lib-format/mc_pr586_par2.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/lib-marshal/intext_par.ml
+++ b/testsuite/tests/lib-marshal/intext_par.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  modules = "intextaux_par.c";
  no-tsan;
  runtime5;

--- a/testsuite/tests/lib-random/parallel.ml
+++ b/testsuite/tests/lib-random/parallel.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  include unix;
  runtime5;
  libunix;

--- a/testsuite/tests/lib-str/parallel.ml
+++ b/testsuite/tests/lib-str/parallel.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  include str;
  hasstr;

--- a/testsuite/tests/lib-sync/prodcons.ml
+++ b/testsuite/tests/lib-sync/prodcons.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/lib-systhreads/multicore_lifecycle.ml
+++ b/testsuite/tests/lib-systhreads/multicore_lifecycle.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  include systhreads;
  hassysthreads;
  runtime5;

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  include unix;
  hasunix;

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  include unix;
  hasunix;

--- a/testsuite/tests/memory-model/forbidden.ml
+++ b/testsuite/tests/memory-model/forbidden.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  modules = "opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml";
  not-bsd;
  no-tsan; (* tsan detects the intentional data races and fails *)

--- a/testsuite/tests/memory-model/publish.ml
+++ b/testsuite/tests/memory-model/publish.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  modules = "opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml";
  not-bsd;
  no-tsan; (* tsan detects data races and fails *)

--- a/testsuite/tests/parallel/atomics.ml
+++ b/testsuite/tests/parallel/atomics.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/backup_thread.ml
+++ b/testsuite/tests/parallel/backup_thread.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  include unix;
  hasunix;

--- a/testsuite/tests/parallel/backup_thread_pipe.ml
+++ b/testsuite/tests/parallel/backup_thread_pipe.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  include unix;
  hasunix;

--- a/testsuite/tests/parallel/catch_break.ml
+++ b/testsuite/tests/parallel/catch_break.ml
@@ -1,4 +1,5 @@
 (* TEST
+flags += "-alert -unsafe_parallelism";
 hassysthreads;
 include systhreads;
 not-windows;

--- a/testsuite/tests/parallel/churn.ml
+++ b/testsuite/tests/parallel/churn.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/constpromote.ml
+++ b/testsuite/tests/parallel/constpromote.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/domain_dls.ml
+++ b/testsuite/tests/parallel/domain_dls.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/domain_dls2.ml
+++ b/testsuite/tests/parallel/domain_dls2.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/domain_id.ml
+++ b/testsuite/tests/parallel/domain_id.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/domain_parallel_spawn_burn_gc_set.ml
+++ b/testsuite/tests/parallel/domain_parallel_spawn_burn_gc_set.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/domain_serial_spawn_burn.ml
+++ b/testsuite/tests/parallel/domain_serial_spawn_burn.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  include unix;
  hasunix;

--- a/testsuite/tests/parallel/fib_threads.ml
+++ b/testsuite/tests/parallel/fib_threads.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  include systhreads;
  hassysthreads;

--- a/testsuite/tests/parallel/join.ml
+++ b/testsuite/tests/parallel/join.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/major_gc_wait_backup.ml
+++ b/testsuite/tests/parallel/major_gc_wait_backup.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  include unix;
  hasunix;

--- a/testsuite/tests/parallel/multicore_systhreads.ml
+++ b/testsuite/tests/parallel/multicore_systhreads.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  include systhreads;
  hassysthreads;

--- a/testsuite/tests/parallel/pingpong.ml
+++ b/testsuite/tests/parallel/pingpong.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  no-tsan; (* TSan detects the intentional data race *)
  runtime5;
  { bytecode; }

--- a/testsuite/tests/parallel/poll.ml
+++ b/testsuite/tests/parallel/poll.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  poll-insertion;
  include unix;
  hasunix;

--- a/testsuite/tests/parallel/prodcons_domains.ml
+++ b/testsuite/tests/parallel/prodcons_domains.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/tak.ml
+++ b/testsuite/tests/parallel/tak.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/parallel/test_c_thread_register.ml
+++ b/testsuite/tests/parallel/test_c_thread_register.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  modules = "test_c_thread_register_cstubs.c";
  runtime5;
  include systhreads;

--- a/testsuite/tests/parallel/unsafe_alert.compilers.reference
+++ b/testsuite/tests/parallel/unsafe_alert.compilers.reference
@@ -1,0 +1,6 @@
+File "unsafe_alert.ml", line 7, characters 8-20:
+7 | let _ = Domain.spawn (fun () -> ())
+            ^^^^^^^^^^^^
+Alert unsafe_parallelism: Stdlib.Domain.spawn
+This function is unsafe and should not be used in production code.
+A safe interface for parallelism is forthcoming.

--- a/testsuite/tests/parallel/unsafe_alert.ml
+++ b/testsuite/tests/parallel/unsafe_alert.ml
@@ -1,0 +1,7 @@
+(* TEST
+ runtime5;
+ { bytecode; }
+ { native; }
+*)
+
+let _ = Domain.spawn (fun () -> ())

--- a/testsuite/tests/weak-ephe-final/ephetest_par.ml
+++ b/testsuite/tests/weak-ephe-final/ephetest_par.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/weak-ephe-final/finaliser2.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser2.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/weak-ephe-final/finaliser_handover.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser_handover.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }

--- a/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
+++ b/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags += "-alert -unsafe_parallelism";
  runtime5;
  { bytecode; }
  { native; }


### PR DESCRIPTION
Soon we will have more users on runtime5, and, as of #3029, `Domain.spawn` doesn't immediately fail.  This PR adds an alert to it, to make it clear users that parallelism is not ready for prime time.  This is compatible with our long term plan to add alerts more thorougly within `Domain` and `Effect` (though we'll probably want to slightly update the exact text once we are ready for people to start using the DRF free stuff).  It's fine to wait on that full plan - this is the only function people are likely to try experimenting with.

The changes are:
* add an alert
* add a test that exercises it
* suppress the alert in all other multicore tests

Review: @ncik-roberts 