### PR TITLE
Add amd64 instrinsic for `CLDEMOTE`

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -41,6 +41,7 @@ method! class_of_operation op =
       | Pure -> Op_pure
       end
     | Ipause
+    | Icldemote _
     | Iprefetch _ -> Op_other
     end
   | Imove | Ispill | Ireload
@@ -84,6 +85,7 @@ class cfg_cse = object
       | Pure -> Op_pure
       end
     | Ipause
+    | Icldemote _
     | Iprefetch _ -> Op_other
       end
   | Move | Spill | Reload

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -86,6 +86,7 @@ type specific_operation =
   | Imfence                            (* memory fence *)
   | Ipause                             (* hint for spin-wait loops *)
   | Isimd of Simd.operation            (* SIMD instruction set operations *)
+  | Icldemote of addressing_mode       (* hint to demote a cacheline to L3 *)
   | Iprefetch of                       (* memory prefetching hint *)
       { is_write: bool;
         locality: prefetch_temporal_locality_hint;

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -99,7 +99,7 @@ let pseudoregs_for_operation op arg res =
       | Istore_int (_, _, _)
       | Ipause | Ilfence | Isfence | Imfence
       | Ioffset_loc (_, _)
-      | Irdtsc | Iprefetch _ )
+      | Irdtsc | Icldemote _ | Iprefetch _ )
   | Move | Spill | Reload | Reinterpret_cast _ | Static_cast _ | Const_int _
   | Const_float32 _ | Const_float _ | Const_vec128 _ | Const_symbol _
   | Stackoffset _ | Load _

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1725,6 +1725,8 @@ let emit_instr ~first ~fallthrough i =
     emit_reinterpret_cast cast i
   | Lop (Ispecific Ipause) ->
     I.pause ()
+  | Lop (Ispecific (Icldemote addr)) ->
+    I.cldemote (addressing addr QWORD i 0)
   | Lop (Ispecific (Iprefetch { is_write; locality; addr; })) ->
     let locality =
       match locality with

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -440,7 +440,7 @@ let destroyed_at_oper = function
   | Iop(Ispecific(Isimd op)) -> destroyed_by_simd_op op
   | Iop(Ispecific(Isextend32 | Izextend32 | Ilea _
                  | Istore_int (_, _, _) | Ioffset_loc (_, _)
-                 | Ipause | Iprefetch _
+                 | Ipause | Icldemote _ | Iprefetch _
                  | Ifloatarithmem (_, _, _) | Ibswap _))
   | Iop(Iintop(Iadd | Isub | Imul | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr
               | Ipopcnt | Iclz _ | Ictz _ ))
@@ -515,7 +515,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        | End_region
        | Specific (Ilea _ | Istore_int _ | Ioffset_loc _
                   | Ifloatarithmem _ | Ibswap _
-                  | Isextend32 | Izextend32 | Ipause
+                  | Isextend32 | Izextend32 | Ipause | Icldemote _
                   | Iprefetch _ | Ilfence | Isfence | Imfence)
        | Name_for_debugger _ | Dls_get)
   | Poptrap | Prologue ->
@@ -544,7 +544,7 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
                        | Ifloatarithmem _ | Irdtsc | Irdpmc | Ipause
                        | Isimd _ | Ilfence | Isfence | Imfence
                        | Istore_int (_, _, _) | Ioffset_loc (_, _)
-                       | Iprefetch _); _ } ->
+                       | Icldemote _ | Iprefetch _); _ } ->
     Misc.fatal_error "no instructions specific for this architecture can raise"
 
 (* CR-soon xclerc for xclerc: consider having more destruction points.
@@ -574,7 +574,7 @@ let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_int
                        | Ifloatarithmem _ | Irdtsc | Irdpmc | Ipause
                        | Isimd _ | Ilfence | Isfence | Imfence
                        | Istore_int (_, _, _) | Ioffset_loc (_, _)
-                       | Iprefetch _); _ } ->
+                       | Icldemote _ | Iprefetch _); _ } ->
     Misc.fatal_error "no instructions specific for this architecture can raise"
 
 (* Maximal register pressure *)
@@ -647,7 +647,7 @@ let max_register_pressure =
   | Iconst_symbol _ | Iconst_vec128 _
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Istackoffset _ | Iload _
-  | Ispecific(Ilea _ | Isextend32 | Izextend32 | Iprefetch _ | Ipause
+  | Ispecific(Ilea _ | Isextend32 | Izextend32 | Icldemote _ | Iprefetch _ | Ipause
              | Irdtsc | Irdpmc | Istore_int (_, _, _)
              | Ilfence | Isfence | Imfence
              | Ioffset_loc (_, _) | Ifloatarithmem (_, _, _)

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -236,6 +236,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
                  | Istore_int (_, _, _)
                  | Ioffset_loc (_, _) | Ifloatarithmem (_, _, _)
                  | Ipause
+                 | Icldemote _
                  | Iprefetch _
                  | Ibswap _))
   | Reloadretaddr

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -191,7 +191,7 @@ method! reload_operation op arg res =
                | Ioffset_loc (_, _) | Ifloatarithmem (_, _, _)
                | Ipause
                | Ilfence | Isfence | Imfence
-               | Iprefetch _ | Ibswap _)
+               | Icldemote _ | Iprefetch _ | Ibswap _)
   | Imove|Ispill|Ireload|Iconst_float _|Iconst_float32 _|Iconst_vec128 _
   | Icall_ind|Icall_imm _|Ifloatop (_,(Icompf _|Inegf|Iabsf))
   | Itailcall_ind|Itailcall_imm _|Iextcall _|Istackoffset _|Iload _

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -95,7 +95,7 @@ let pseudoregs_for_operation op arg res =
       | Istore_int (_, _, _)
       | Ipause | Ilfence | Isfence | Imfence
       | Ioffset_loc (_, _)
-      | Irdtsc | Iprefetch _ )
+      | Irdtsc | Icldemote _ | Iprefetch _ )
   | Imove | Ispill | Ireload | Ireinterpret_cast _ | Istatic_cast _
   | Iconst_int _ | Iconst_float32 _ | Iconst_float _ | Iconst_vec128 _
   | Iconst_symbol _ | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
@@ -211,6 +211,11 @@ class selector =
         | "caml_load_fence" -> Ispecific Ilfence, args
         | "caml_store_fence" -> Ispecific Isfence, args
         | "caml_memory_fence" -> Ispecific Imfence, args
+        | "caml_cldemote" ->
+          let addr, eloc =
+            self#select_addressing Word_int (one_arg "cldemote" args)
+          in
+          Ispecific (Icldemote addr), [eloc]
         | _ -> (
           match Simd_selection.select_operation func args with
           | Some (op, args) -> op, args

--- a/backend/x86_ast.mli
+++ b/backend/x86_ast.mli
@@ -305,6 +305,7 @@ type instruction =
   | BSWAP of arg
   | CALL of arg
   | CDQ
+  | CLDEMOTE of arg
   | CMOV of condition * arg * arg
   | CMP of arg * arg
   | CMPSD of float_condition * arg * arg

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1726,6 +1726,8 @@ let rd_of_prefetch_hint = function
   | T1 -> 2
   | T2 -> 3
 
+let emit_cldemote b rm = emit_mod_rm_reg b no_rex [ 0x0F; 0x1C ] rm 0
+
 let emit_prefetch b ~is_write ~hint rm =
   match (is_write, hint, rm) with
   | (false, _, (Mem _ | Mem64_RIP _)) ->
@@ -1870,6 +1872,7 @@ let assemble_instr b loc = function
   | BSR (src, dst) -> emit_bsr b ~dst ~src
   | BSWAP arg -> emit_BSWAP b arg
   | CALL dst -> emit_call b dst
+  | CLDEMOTE rm -> emit_cldemote b rm
   | CVTSI2SS (src, dst) -> emit_CVTSI2SS b dst src
   | CVTSI2SD (src, dst) -> emit_CVTSI2SD b dst src
   | CVTSD2SI (src, dst) -> emit_CVTSD2SI b dst src

--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -120,6 +120,7 @@ module I = struct
   let bswap x = emit (BSWAP x)
   let call x = emit (CALL x)
   let cdq () = emit CDQ
+  let cldemote x = emit (CLDEMOTE x)
   let cmov cond x y = emit (CMOV (cond, x, y))
   let cmp x y = emit (CMP (x, y))
   let cmpsd cond x y = emit (CMPSD (cond, x, y))

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -124,6 +124,7 @@ module I : sig
   val bswap: arg -> unit
   val call: arg -> unit
   val cdq: unit -> unit
+  val cldemote : arg -> unit
   val cmov : condition -> arg -> arg -> unit
   val cmp: arg -> arg -> unit
   val cmpsd : float_condition -> arg -> arg -> unit

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -130,6 +130,7 @@ let print_instr b = function
   | BSWAP arg -> i1 b "bswap" arg
   | CALL arg  -> i1_call_jmp b "call" arg
   | CDQ -> i0 b "cltd"
+  | CLDEMOTE arg -> i1 b "cldemote" arg
   | CMOV (c, arg1, arg2) -> i2 b ("cmov" ^ string_of_condition c) arg1 arg2
   | CMP (arg1, arg2) -> i2_s b "cmp" arg1 arg2
   | CMPSD (c, arg1, arg2) ->

--- a/backend/x86_masm.ml
+++ b/backend/x86_masm.ml
@@ -129,6 +129,7 @@ let print_instr b = function
   | BSWAP arg -> i1 b "bswap" arg
   | CALL arg  -> i1_call_jmp b "call" arg
   | CDQ -> i0 b "cdq"
+  | CLDEMOTE arg -> i1 b "cldemote" arg
   | CMOV (c, arg1, arg2) -> i2 b ("cmov" ^ string_of_condition c) arg1 arg2
   | CMP (arg1, arg2) -> i2 b "cmp" arg1 arg2
   | CMPSD (c, arg1, arg2) ->


### PR DESCRIPTION
`CLDEMOTE` is a hint to hardware that a cacheline should be demoted from L1/L2 to L3 (as opposed to `CLFLUSH(OPT)`, which demotes to RAM).

This can improve the performance of producer-consumer systems.

The instruction decodes as a no-op on hardware that does not support it.

Testing:

```
$ cat cldemote.ml
external cldemote : 'a -> unit = "caml_cldemote_ignore" "caml_cldemote" [@@noalloc] [@@builtin]
let () = cldemote "Hello, World!"

$ cat cldemote_stubs.c
CAMLprim value caml_cldemote_ignore(value v) { return Val_unit; }
CAMLprim value caml_cldemote(value v) { return Val_unit; }

$ ocamlopt.opt -c cldemote_stubs.c
$ ocamlopt.opt -c cldemote.ml
$ ocamlopt.opt -o cldemote cldemote_stubs.o cldemote.cmx

$ ./cldemote
; No SIGILL, even on machines that are too old to have `CLDEMOTE`.

$ objdump -d cldemote | grep '<camlCldemote__entry>:' -A4
000000000041e7a0 <camlCldemote__entry>:
  41e7a0:       48 8d 05 d9 0b 04 00    lea    0x40bd9(%rip),%rax        # 45f380 <camlCldemote+0x8>
  41e7a7:       0f 1c 00                cldemote (%rax)
  41e7aa:       b8 01 00 00 00          mov    $0x1,%eax
  41e7af:       c3                      retq
```