### PR TITLE
chamelon: QoL improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ci-coverage: boot-runtest coverage
 # 	RUNTIME_DIR=$(RUNTIME_DIR) $(dune) build $(ws_main) @chamelon/all
 
 .PHONY: minimizer
-minimizer: _build/_bootinstall
+minimizer: runtime-stdlib
 	cp chamelon/dune.jst chamelon/dune
 	RUNTIME_DIR=$(RUNTIME_DIR) $(dune) build $(ws_main) @chamelon/all
 

--- a/chamelon/README.md
+++ b/chamelon/README.md
@@ -17,3 +17,6 @@ The following options are also available:
   version of OCaml chamelon is compiled with.
 - `-m [minimizers]`: this runs the minimizers from the comma-separated list of minimizers given
   as arguments instead of the default iteration order.
+- `-x [minimizers]`: do not run the minimizers from the comma-separated list of
+  minimizers given as arguments
+- `-l`: lists all available minimizers and exit

--- a/chamelon/chamelon.ml
+++ b/chamelon/chamelon.ml
@@ -7,27 +7,33 @@ open Cmt_format
 
 (* ______ COMMAND SETUP ______ *)
 let usage_msg =
-  "minimize <file1> [<file2>] ... -c \"<command>\" [-m <minimizers>] [-e \
-   <error>] [-t <typing command>] [-o <output>]"
+  Format.asprintf
+    "usage: %s <file1> [<file2>] ... -c \"<command>\" [-m <minimizers>] [-x \
+     <minimizers>] [-e <error>] [-t <typing command>] [-o <output>]"
+    (Filename.basename Sys.executable_name)
 
 let input_files = ref []
 let arg_minimizers = ref ""
+let exclude_minimizers = ref ""
 let command = ref ""
 let typing_command = ref ""
 let output_file = ref ""
 let test = ref false
 let anon_fun filename = input_files := filename :: !input_files
+let list_minimizers = ref false
 
 let spec_list =
   [
     ("-c", Arg.Set_string command, "Set command");
     ("-m", Arg.Set_string arg_minimizers, "Set minimizers");
+    ("-x", Arg.Set_string exclude_minimizers, "Exclude minimizers");
     ("-e", Arg.Set_string Utils.error_str, "Set error to preserve");
     ( "-t",
       Arg.Set_string typing_command,
       "Set command to use to generate cmt file" );
     ("-o", Arg.Set_string output_file, "Set output file/folder");
     ("--test", Arg.Set test, "Run only first iteration of minimizer");
+    ("-l", Arg.Set list_minimizers, "List available minimizers");
   ]
 
 let () = Arg.parse spec_list anon_fun usage_msg
@@ -85,14 +91,22 @@ let default_iteration =
   ]
 
 let minimizers_to_run =
-  List.map
+  let minimizer_names =
+    if !arg_minimizers = "" then default_iteration
+    else String.split_on_char ',' !arg_minimizers
+  in
+  let to_exclude =
+    if !exclude_minimizers = "" then []
+    else String.split_on_char ',' !exclude_minimizers
+  in
+  List.filter_map
     (fun name ->
-      try Smap.find name all_minimizers
-      with Not_found ->
-        Format.eprintf "Minimizer %S not found@." name;
-        exit 1)
-    (if !arg_minimizers = "" then default_iteration
-    else String.split_on_char ',' !arg_minimizers)
+      match Smap.find name all_minimizers with
+      | minimizer -> if List.mem name to_exclude then None else Some minimizer
+      | exception Not_found ->
+          Format.eprintf "Minimizer %S not found@." name;
+          exit 1)
+    minimizer_names
 
 (* ______ ONE FILE MINIMIZATION ______ *)
 
@@ -114,7 +128,18 @@ let one_file_minimize c (map : structure Smap.t) file : structure Smap.t * bool
       (map, false) minimizers_to_run)
 
 let main () =
+  (* LIST MINIMIZERS *)
+  if !list_minimizers then (
+    Format.printf "@[<v 2>Available minimizers:@ @[<v>%a@]@]@."
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space (fun ppf (name, _) ->
+           Format.pp_print_string ppf name))
+      (Smap.bindings all_minimizers);
+    exit 0);
   (* PARSING COMMAND AND READING FILES*)
+  if !command = "" then (
+    Format.eprintf "No command provided (hint: `-c` argument is mandatory).@.";
+    Arg.usage spec_list usage_msg;
+    exit 2);
   let file_names = List.rev !input_files in
   let cmt_command =
     if !typing_command = "" then !command else !typing_command


### PR DESCRIPTION
Add some small quality-of-life improvements to the Chamelon minimizer:

 - A new `-l` flag to list the available minimizers;
 - A new `-x` flag to exclude some minimizers (useful as a quick fix when a minimizer is broken or too slow on the current input file);
 - A less confusing error message (that does not mention "-bin-annot: command not found") when no command is provided with `-c`

Also fix the dependency in the Makefile to `runtime-stdlib`; Chamelon is built with `$(ws_main)` since c87dab6d483.

@Ekdohibs 