### PR TITLE
Comprehensions layouts bug

### DIFF
--- a/testsuite/tests/typing-layouts/comprehensions.ml
+++ b/testsuite/tests/typing-layouts/comprehensions.ml
@@ -1,0 +1,67 @@
+(* TEST
+ include stdlib_upstream_compatible;
+ {
+   flags = "-extension comprehensions";
+   expect;
+ }
+*)
+
+open Stdlib_upstream_compatible
+
+(* Unboxed types are banned in comprehensions: The output array must contain
+   things of layout value, as must any arrays you iterate over. *)
+
+let unbox_array x = [| Float_u.of_float a for a in x |]
+[%%expect{|
+Line 6, characters 23-41:
+6 | let unbox_array x = [| Float_u.of_float a for a in x |]
+                           ^^^^^^^^^^^^^^^^^^
+Error: This expression has type "Stdlib_upstream_compatible.Float_u.t" = "float#"
+       but an expression was expected of type "('a : value)"
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because it's the element type of array comprehension.
+|}]
+
+(* The below error demonstrates a missing check in the type system and will be
+   fixed in the next commit. *)
+let box_array x = [| Float_u.to_float a for a in x |]
+[%%expect{|
+Line 1, characters 44-45:
+1 | let box_array x = [| Float_u.to_float a for a in x |]
+                                                ^
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because it has to be value for the V1 safety check.
+|}]
+
+(* List cases are less interesting because we don't allow unboxed types in lists
+   at all.  These tests are here just so we remember to think about
+   comprehensions when that changes. *)
+let unbox_list x = [ Float_u.of_float a for a in x ]
+[%%expect{|
+Line 1, characters 21-39:
+1 | let unbox_list x = [ Float_u.of_float a for a in x ]
+                         ^^^^^^^^^^^^^^^^^^
+Error: This expression has type "Stdlib_upstream_compatible.Float_u.t" = "float#"
+       but an expression was expected of type "('a : value_or_null)"
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because the type argument of list has layout value_or_null.
+|}]
+
+(* The below error demonstrates a missing check in the type system and will be
+   fixed in the next commit. *)
+let box_list x = [ Float_u.to_float a for a in x ]
+[%%expect{|
+Line 1, characters 42-43:
+1 | let box_list x = [ Float_u.to_float a for a in x ]
+                                              ^
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of Stdlib_upstream_compatible.Float_u.t is float64.
+       But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
+         because it has to be value for the V1 safety check.
+|}]

--- a/testsuite/tests/typing-layouts/comprehensions.ml
+++ b/testsuite/tests/typing-layouts/comprehensions.ml
@@ -23,18 +23,17 @@ Error: This expression has type "Stdlib_upstream_compatible.Float_u.t" = "float#
          because it's the element type of array comprehension.
 |}]
 
-(* The below error demonstrates a missing check in the type system and will be
-   fixed in the next commit. *)
 let box_array x = [| Float_u.to_float a for a in x |]
 [%%expect{|
-Line 1, characters 44-45:
+Line 1, characters 38-39:
 1 | let box_array x = [| Float_u.to_float a for a in x |]
-                                                ^
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
+                                          ^
+Error: This expression has type "('a : value)"
+       but an expression was expected of type
+         "Stdlib_upstream_compatible.Float_u.t" = "float#"
        The layout of Stdlib_upstream_compatible.Float_u.t is float64.
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
-         because it has to be value for the V1 safety check.
+         because it's the element type of an array that is iterated over in a comprehension.
 |}]
 
 (* List cases are less interesting because we don't allow unboxed types in lists
@@ -52,16 +51,15 @@ Error: This expression has type "Stdlib_upstream_compatible.Float_u.t" = "float#
          because the type argument of list has layout value_or_null.
 |}]
 
-(* The below error demonstrates a missing check in the type system and will be
-   fixed in the next commit. *)
 let box_list x = [ Float_u.to_float a for a in x ]
 [%%expect{|
-Line 1, characters 42-43:
+Line 1, characters 36-37:
 1 | let box_list x = [ Float_u.to_float a for a in x ]
-                                              ^
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
+                                        ^
+Error: This expression has type "('a : value)"
+       but an expression was expected of type
+         "Stdlib_upstream_compatible.Float_u.t" = "float#"
        The layout of Stdlib_upstream_compatible.Float_u.t is float64.
        But the layout of Stdlib_upstream_compatible.Float_u.t must be a sublayout of value
-         because it has to be value for the V1 safety check.
+         because it's the element type of a list that is iterated over in a comprehension.
 |}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2569,6 +2569,14 @@ module Format_history = struct
       fprintf ppf "it's an unannotated existential type variable"
     | Array_comprehension_element ->
       fprintf ppf "it's the element type of array comprehension"
+    | List_comprehension_iterator_element ->
+      fprintf ppf
+        "it's the element type of a list that is iterated over in a \
+         comprehension"
+    | Array_comprehension_iterator_element ->
+      fprintf ppf
+        "it's the element type of an array that is iterated over in a \
+         comprehension"
     | Lazy_expression -> fprintf ppf "it's the type of a lazy expression"
     | Class_type_argument ->
       fprintf ppf "it's a type argument to a class constructor"
@@ -3282,6 +3290,10 @@ module Debug_printers = struct
     | Default_type_jkind -> fprintf ppf "Default_type_jkind"
     | Existential_type_variable -> fprintf ppf "Existential_type_variable"
     | Array_comprehension_element -> fprintf ppf "Array_comprehension_element"
+    | List_comprehension_iterator_element ->
+      fprintf ppf "List_comprehension_iterator_element"
+    | Array_comprehension_iterator_element ->
+      fprintf ppf "Array_comprehension_iterator_element"
     | Lazy_expression -> fprintf ppf "Lazy_expression"
     | Class_type_argument -> fprintf ppf "Class_type_argument"
     | Class_term_argument -> fprintf ppf "Class_term_argument"

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -290,6 +290,8 @@ module History = struct
     | Default_type_jkind
     | Existential_type_variable
     | Array_comprehension_element
+    | List_comprehension_iterator_element
+    | Array_comprehension_iterator_element
     | Lazy_expression
     | Class_type_argument
     | Class_term_argument

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -9827,7 +9827,14 @@ and type_comprehension_iterator
       in
       Texp_comp_range { ident; pattern; start; stop; direction }
   | Pcomp_in seq ->
-      let item_ty = newvar (Jkind.Builtin.any ~why:Dummy_jkind) in
+      let value_reason =
+        match (comprehension_type : comprehension_type) with
+        | Array_comprehension _ ->
+          Jkind.History.Array_comprehension_iterator_element
+        | List_comprehension ->
+          Jkind.History.List_comprehension_iterator_element
+      in
+      let item_ty = newvar (Jkind.Builtin.value ~why:value_reason) in
       let seq_ty = container_type item_ty in
       let sequence =
         (* To understand why we can currently only iterate over [mode_global]


### PR DESCRIPTION
(**Note**: This PR is based on the "delete jane syntax" branch to avoid conflicts and should be merged after that one.)

Right now the front-end prevents you from constructing an array/list of unboxed things with a comprehension, but not from iterating over one.  But `transl` assumes that the front-end does prevent this, making it possible to hit the scary "contact us" sanity check error in `value_kind`.

There are two commits here: the first demonstrates the bug with a test (as far as I can tell, there weren't any tests at all for unboxed things in comprehensions).  The second fixes it.

I have fixed this by adding the appropriate front-end check. It's quite possible this would just work if we instead threaded through the appropriate sort, but that should come with extensive tests that I don't think it is worth doing right now.

I noticed this because of a request to add a comprehensions test to #3139 

Review: @goldfirere 

