### PR TITLE
Add simd.c to gen_primitives

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -52,6 +52,7 @@
    finalise.c domain.c platform.c fiber.c memory.c startup_aux.c
      runtime_events.c sync.c
    dynlink.c backtrace_byt.c backtrace.c afl.c bigarray.c prng.c float32.c
+   simd.c
    blake2.c
    misc.c
    build_config.h sync_posix.h caml/jumptbl.h)

--- a/runtime4/dune
+++ b/runtime4/dune
@@ -51,6 +51,7 @@
   misc.c
   domain.c
   float32.c
+  simd.c
   blake2.c)
  (action
   (with-stdout-to

--- a/runtime4/gen_primitives.sh
+++ b/runtime4/gen_primitives.sh
@@ -25,7 +25,7 @@ export LC_ALL=C
       alloc array compare extern floats gc_ctrl hash intern interp ints io \
       lexing md5 meta memprof obj parsing signals str sys callback weak \
       finalise stacks dynlink backtrace_byt backtrace afl \
-      bigarray eventlog misc domain prng float32 blake2
+      bigarray eventlog misc domain prng float32 simd blake2
   do
       sed -n -e 's/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p' "$prim.c"
   done


### PR DESCRIPTION
The `gen_primitives.sh` script needs to be aware that `simd.c` contains `CAMLprim` functions.
Otherwise, the linker will eliminate these symbols from executables that do not declare externals using them.
This results in a failure to dynamically link in a shared object that uses the symbols.