### PR TITLE
Minor refactoring of `Cfg_selectgen`

### DIFF
--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -130,13 +130,17 @@ let next_instr_id () : int =
   incr next_instr_id;
   res
 
-(* A "sub" CFG is the counterpart of an instruction list in the original
+(* A "sub" CFG is the counterpart of an instruction list in the original Mach
    selection pass.
 
    It is essentially a collection of blocks (stored as a layout, i.e. as a
-   list), with two designated block: - an entry block; - an exit block.
+   list), with two designated blocks:
 
-   The exit block is where mere instructions are being added, which means that
+   - an entry block;
+
+   - an exit block.
+
+   The exit block is where more instructions are being added, which means that
    the terminator of an in-construction "sub" CFG is `Never`, and will be
    changed only when no additional instructions will be inserted to the
    block. *)

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -130,6 +130,16 @@ let next_instr_id () : int =
   incr next_instr_id;
   res
 
+(* A "sub" CFG is the counterpart of an instruction list in the original
+   selection pass.
+
+   It is essentially a collection of blocks (stored as a layout, i.e. as a
+   list), with two designated block: - an entry block; - an exit block.
+
+   The exit block is where mere instructions are being added, which means that
+   the terminator of an in-construction "sub" CFG is `Never`, and will be
+   changed only when no additional instructions will be inserted to the
+   block. *)
 module Sub_cfg : sig
   type t =
     { entry : Cfg.basic_block;
@@ -142,6 +152,8 @@ module Sub_cfg : sig
 
   val make_empty_block :
     ?label:Label.t -> Cfg.terminator Cfg.instruction -> Cfg.basic_block
+
+  val make_never_block : ?label:Label.t -> unit -> Cfg.basic_block
 
   val make_empty : unit -> t
 
@@ -194,10 +206,11 @@ end = struct
       cold = false
     }
 
+  let make_never_block ?label () : Cfg.basic_block =
+    make_empty_block ?label (make_instr Cfg.Never [||] [||] Debuginfo.none)
+
   let make_empty () =
-    let exit =
-      make_empty_block (make_instr Cfg.Never [||] [||] Debuginfo.none)
-    in
+    let exit = make_never_block () in
     let entry =
       make_empty_block
         (make_instr (Cfg.Always exit.start) [||] [||] Debuginfo.none)
@@ -536,10 +549,7 @@ class virtual selector_generic =
               self#insert_debug' env term dbg
                 (Array.append [| r1.(0) |] loc_arg)
                 loc_res;
-              let next_block =
-                Sub_cfg.make_empty_block ~label:label_after
-                  (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-              in
+              let next_block = Sub_cfg.make_never_block ~label:label_after () in
               DLL.add_end sub_cfg.Sub_cfg.layout next_block;
               sub_cfg <- { sub_cfg with Sub_cfg.exit = next_block };
               (* The destination registers (as per the procedure calling
@@ -561,10 +571,7 @@ class virtual selector_generic =
               self#insert_move_args env r1 loc_arg stack_ofs;
               self#insert_debug' env term dbg loc_arg loc_res;
               add_naming_op_for_bound_name loc_res;
-              let next_block =
-                Sub_cfg.make_empty_block ~label:label_after
-                  (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-              in
+              let next_block = Sub_cfg.make_never_block ~label:label_after () in
               DLL.add_end sub_cfg.Sub_cfg.layout next_block;
               sub_cfg <- { sub_cfg with Sub_cfg.exit = next_block };
               self#insert_move_results env loc_res rd stack_ofs;
@@ -583,10 +590,7 @@ class virtual selector_generic =
                 self#insert_op_debug' env term dbg loc_arg
                   (Proc.loc_external_results (Reg.typv rd))
               in
-              let next_block =
-                Sub_cfg.make_empty_block ~label:label_after
-                  (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-              in
+              let next_block = Sub_cfg.make_never_block ~label:label_after () in
               DLL.add_end sub_cfg.Sub_cfg.layout next_block;
               sub_cfg <- { sub_cfg with Sub_cfg.exit = next_block };
               add_naming_op_for_bound_name loc_res;
@@ -598,14 +602,14 @@ class virtual selector_generic =
               let rd = self#regs_for ty in
               let rd = self#insert_op_debug' env term dbg r1 rd in
               Select_utils.set_traps_for_raise env;
-              let next_block =
-                Sub_cfg.make_empty_block ~label:label_after
-                  (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-              in
+              let next_block = Sub_cfg.make_never_block ~label:label_after () in
               DLL.add_end sub_cfg.Sub_cfg.layout next_block;
               sub_cfg <- { sub_cfg with Sub_cfg.exit = next_block };
               ret rd
-            | _ -> assert false)
+            | _ ->
+              Misc.fatal_errorf "unexpected terminator (%a)"
+                (Cfg.dump_terminator ~sep:"")
+                term)
           | Terminator (Call_no_return ({ func_symbol; ty_args; _ } as r)) ->
             let loc_arg, stack_ofs =
               self#emit_extcall_args env ty_args new_args
@@ -625,17 +629,14 @@ class virtual selector_generic =
               then Cfg.Prim { op = Cfg.External r; label_after = label }
               else Cfg.Call_no_return r
             in
-            let _ =
+            let (_ : Reg.t array) =
               self#insert_op_debug' env term dbg loc_arg
                 (Proc.loc_external_results (Reg.typv rd))
             in
             Select_utils.set_traps_for_raise env;
             if returns
             then (
-              let dummy_block =
-                Sub_cfg.make_empty_block ~label
-                  (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-              in
+              let dummy_block = Sub_cfg.make_never_block ~label () in
               DLL.add_end sub_cfg.Sub_cfg.layout dummy_block;
               sub_cfg <- { sub_cfg with Sub_cfg.exit = dummy_block };
               ret rd)
@@ -661,8 +662,12 @@ class virtual selector_generic =
             let rd = self#regs_for ty in
             add_naming_op_for_bound_name rd;
             ret (self#insert_op_debug env op dbg r1 rd)
-          | Basic _ -> assert false
-          | Terminator _ -> assert false)
+          | Basic basic ->
+            Misc.fatal_errorf "unexpected basic (%a)" Cfg.dump_basic basic
+          | Terminator term ->
+            Misc.fatal_errorf "unexpected terminator (%a)"
+              (Cfg.dump_terminator ~sep:"")
+              term)
 
     method emit_expr_aux_ifthenelse
         : environment ->
@@ -675,7 +680,8 @@ class virtual selector_generic =
           Debuginfo.t ->
           Cmm.kind_for_unboxing ->
           Reg.t array option =
-      fun env bound_name econd _ifso_dbg eif _ifnotdbg eelse _XXXdbg _value_kind ->
+      fun env bound_name econd _ifso_dbg eif _ifnotdbg eelse _dbg _value_kind ->
+        (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
         let cond, earg = self#select_condition econd in
         match self#emit_expr env earg ~bound_name:None with
         | None -> None
@@ -701,10 +707,7 @@ class virtual selector_generic =
                };
           DLL.transfer ~from:sub_if.Sub_cfg.layout ~to_:sub_cfg.layout ();
           DLL.transfer ~from:sub_else.Sub_cfg.layout ~to_:sub_cfg.layout ();
-          let join_block =
-            Sub_cfg.make_empty_block
-              (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-          in
+          let join_block = Sub_cfg.make_never_block () in
           Sub_cfg.link_if_needed ~from:sub_if.Sub_cfg.exit ~to_:join_block ();
           Sub_cfg.link_if_needed ~from:sub_else.Sub_cfg.exit ~to_:join_block ();
           DLL.add_end sub_cfg.Sub_cfg.layout join_block;
@@ -720,7 +723,8 @@ class virtual selector_generic =
           Debuginfo.t ->
           Cmm.kind_for_unboxing ->
           Reg.t array option =
-      fun env bound_name esel index ecases _XXXdbg _value_kind ->
+      fun env bound_name esel index ecases _dbg _value_kind ->
+        (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
         match self#emit_expr env esel ~bound_name:None with
         | None -> None
         | Some rsel ->
@@ -746,10 +750,7 @@ class virtual selector_generic =
             (fun sub_case ->
               DLL.transfer ~from:sub_case.Sub_cfg.layout ~to_:sub_cfg.layout ())
             subs;
-          let join_block =
-            Sub_cfg.make_empty_block
-              (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-          in
+          let join_block = Sub_cfg.make_never_block () in
           Array.iter
             (fun sub_case ->
               Sub_cfg.link_if_needed ~from:sub_case.Sub_cfg.exit ~to_:join_block
@@ -772,7 +773,7 @@ class virtual selector_generic =
           Cmm.expression ->
           Cmm.kind_for_unboxing ->
           Reg.t array option =
-      fun env bound_name _XXXrec_flag handlers body _value_kind ->
+      fun env bound_name _rec_flag handlers body _value_kind ->
         let handlers =
           List.map
             (fun (nfail, ids, e2, dbg, is_cold) ->
@@ -885,10 +886,7 @@ class virtual selector_generic =
                id = next_instr_id ()
              };
         DLL.transfer ~from:s_body.Sub_cfg.layout ~to_:sub_cfg.layout ();
-        let join_block =
-          Sub_cfg.make_empty_block
-            (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-        in
+        let join_block = Sub_cfg.make_never_block () in
         Sub_cfg.link_if_needed ~from:s_body.Sub_cfg.exit ~to_:join_block ();
         List.iter
           (fun sub_handler ->
@@ -972,7 +970,8 @@ class virtual selector_generic =
           Debuginfo.t ->
           Cmm.kind_for_unboxing ->
           Reg.t array option =
-      fun env bound_name e1 exn_cont v e2 _XXXdbg _value_kind ->
+      fun env bound_name e1 exn_cont v e2 _dbg _value_kind ->
+        (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
         assert (sub_cfg.exit.terminator.desc = Cfg.Never);
         let exn_label = Cmm.new_label () in
         let env_body = Select_utils.env_enter_trywith env exn_cont exn_label in
@@ -1014,10 +1013,7 @@ class virtual selector_generic =
                };
           DLL.transfer ~from:s1.Sub_cfg.layout ~to_:sub_cfg.layout ();
           DLL.transfer ~from:s2.Sub_cfg.layout ~to_:sub_cfg.layout ();
-          let join_block =
-            Sub_cfg.make_empty_block
-              (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-          in
+          let join_block = Sub_cfg.make_never_block () in
           DLL.add_end sub_cfg.Sub_cfg.layout join_block;
           Sub_cfg.link_if_needed ~from:s1.exit ~to_:join_block ();
           Sub_cfg.link_if_needed ~from:s2.exit ~to_:join_block ();
@@ -1071,7 +1067,8 @@ class virtual selector_generic =
             (fun trap ->
               let instr_desc =
                 match trap with
-                | Cmm.Push _ -> assert false
+                | Cmm.Push _ ->
+                  Misc.fatal_error "unexpected push on trap actions"
                 | Cmm.Pop _ -> Cfg.Poptrap
               in
               DLL.add_end sub_cfg.exit.body
@@ -1128,10 +1125,7 @@ class virtual selector_generic =
               self#insert_debug' env new_op dbg
                 (Array.append [| r1.(0) |] loc_arg)
                 loc_res;
-              let new_exit =
-                Sub_cfg.make_empty_block ~label:label_after
-                  (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-              in
+              let new_exit = Sub_cfg.make_never_block ~label:label_after () in
               DLL.add_end sub_cfg.Sub_cfg.layout new_exit;
               sub_cfg <- { sub_cfg with exit = new_exit };
               Select_utils.set_traps_for_raise env;
@@ -1159,10 +1153,7 @@ class virtual selector_generic =
             else (
               self#insert_move_args env r1 loc_arg stack_ofs;
               self#insert_debug' env new_op dbg loc_arg loc_res;
-              let new_exit =
-                Sub_cfg.make_empty_block ~label:label_after
-                  (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-              in
+              let new_exit = Sub_cfg.make_never_block ~label:label_after () in
               DLL.add_end sub_cfg.Sub_cfg.layout new_exit;
               sub_cfg <- { sub_cfg with exit = new_exit };
               Select_utils.set_traps_for_raise env;
@@ -1180,7 +1171,8 @@ class virtual selector_generic =
           Debuginfo.t ->
           Cmm.kind_for_unboxing ->
           unit =
-      fun env econd _ifso_dbg eif _ifnot_dbg eelse _XXXdbg _kind ->
+      fun env econd _ifso_dbg eif _ifnot_dbg eelse _dbg _kind ->
+        (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
         let cond, earg = self#select_condition econd in
         match self#emit_expr env earg ~bound_name:None with
         | None -> ()
@@ -1201,10 +1193,7 @@ class virtual selector_generic =
                };
           DLL.transfer ~from:sub_if.Sub_cfg.layout ~to_:sub_cfg.layout ();
           DLL.transfer ~from:sub_else.Sub_cfg.layout ~to_:sub_cfg.layout ();
-          let dummy_block =
-            Sub_cfg.make_empty_block
-              (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-          in
+          let dummy_block = Sub_cfg.make_never_block () in
           DLL.add_end sub_cfg.Sub_cfg.layout dummy_block;
           sub_cfg <- { sub_cfg with Sub_cfg.exit = dummy_block }
 
@@ -1216,7 +1205,8 @@ class virtual selector_generic =
           Debuginfo.t ->
           Cmm.kind_for_unboxing ->
           unit =
-      fun env esel index ecases _XXXdbg _king ->
+      fun env esel index ecases _dbg _king ->
+        (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
         match self#emit_expr env esel ~bound_name:None with
         | None -> ()
         | Some rsel ->
@@ -1240,10 +1230,7 @@ class virtual selector_generic =
             (fun sub_case ->
               DLL.transfer ~from:sub_case.Sub_cfg.layout ~to_:sub_cfg.layout ())
             sub_cases;
-          let dummy_block =
-            Sub_cfg.make_empty_block
-              (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-          in
+          let dummy_block = Sub_cfg.make_never_block () in
           DLL.add_end sub_cfg.Sub_cfg.layout dummy_block;
           sub_cfg <- { sub_cfg with Sub_cfg.exit = dummy_block }
 
@@ -1259,7 +1246,7 @@ class virtual selector_generic =
           Cmm.expression ->
           Cmm.kind_for_unboxing ->
           unit =
-      fun env _XXXrec_flag handlers e1 _value_kind ->
+      fun env _rec_flag handlers e1 _value_kind ->
         let handlers =
           List.map
             (fun (nfail, ids, e2, dbg, is_cold) ->
@@ -1374,7 +1361,8 @@ class virtual selector_generic =
           Debuginfo.t ->
           Cmm.kind_for_unboxing ->
           unit =
-      fun env e1 exn_cont v e2 _XXXdbg _value_kind ->
+      fun env e1 exn_cont v e2 _dbg _value_kind ->
+        (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
         assert (sub_cfg.exit.terminator.desc = Cfg.Never);
         let exn_label = Cmm.new_label () in
         let env_body = Select_utils.env_enter_trywith env exn_cont exn_label in
@@ -1413,10 +1401,7 @@ class virtual selector_generic =
                };
           DLL.transfer ~from:s1.Sub_cfg.layout ~to_:sub_cfg.layout ();
           DLL.transfer ~from:s2.Sub_cfg.layout ~to_:sub_cfg.layout ();
-          let dummy_block =
-            Sub_cfg.make_empty_block
-              (Sub_cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
-          in
+          let dummy_block = Sub_cfg.make_never_block () in
           DLL.add_end sub_cfg.Sub_cfg.layout dummy_block;
           sub_cfg <- { sub_cfg with Sub_cfg.exit = dummy_block }
         in


### PR DESCRIPTION
Follow-up to https://github.com/ocaml-flambda/flambda-backend/pull/3073.

This pull requests:

- adds a short description of the `Sub_cfg` module;
- changes `assert false` to more useful errors;
- removes the `XXX` "marker" from parameter names (leaving a CR instead);
- factors out the construction of blocks with a `Never` terminator.
