### PR TITLE
Enforce arity check on return continuation in to_cmm

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -72,7 +72,7 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
      return the unit value). *)
   let env =
     Env.create offsets all_code ~return_continuation:dummy_k
-      ~trans_prim:To_cmm_primitive.trans_prim
+      ~return_continuation_arity:[] ~trans_prim:To_cmm_primitive.trans_prim
       ~exn_continuation:(Flambda_unit.exn_continuation flambda_unit)
   in
   let _env, return_cont_params =

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -81,6 +81,7 @@ val create :
   Exported_code.t ->
   trans_prim:t trans_prim ->
   return_continuation:Continuation.t ->
+  return_continuation_arity:Cmm.machtype list ->
   exn_continuation:Continuation.t ->
   t
 
@@ -90,6 +91,7 @@ val create :
 val enter_function_body :
   t ->
   return_continuation:Continuation.t ->
+  return_continuation_arity:Cmm.machtype list ->
   exn_continuation:Continuation.t ->
   t
 
@@ -109,9 +111,6 @@ val set_inlined_debuginfo : t -> Inlined_debuginfo.t -> t
 val currently_in_inlined_body : t -> bool
 
 (** {2 Continuations} *)
-
-(** Returns the return continuation of the environment. *)
-val return_continuation : t -> Continuation.t
 
 (** Returns the exception continuation of the environment. *)
 val exn_continuation : t -> Continuation.t
@@ -300,6 +299,7 @@ type 'a param_type =
     translated as a static jump to a Cmm continuation (represented as a Cmm
     label), or inlined at any unique use site. *)
 type cont = private
+  | Return of { param_types : Cmm.machtype list }
   | Jump of
       { cont : Lambda.static_label;
         param_types : Cmm.machtype param_type list

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -466,24 +466,32 @@ let translate_jump_to_continuation ~dbg_with_inlined:dbg env res apply types
 (* A call to the return continuation of the current block simply is the return
    value for the current block being translated. *)
 let translate_jump_to_return_continuation ~dbg_with_inlined:dbg env res apply
-    return_cont args =
-  let return_values, free_vars, env, res, _ = C.simple_list ~dbg env res args in
-  let return_value = C.make_tuple return_values in
-  let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-  match Apply_cont.trap_action apply with
-  | None ->
-    let cmm, free_vars = wrap return_value free_vars in
-    cmm, free_vars, res
-  | Some (Pop { exn_handler; _ }) ->
-    let cont = Env.get_cmm_continuation env exn_handler in
-    let cmm, free_vars =
-      wrap (C.trap_return return_value [Cmm.Pop cont]) free_vars
+    return_cont types args =
+  if List.compare_lengths types args = 0
+  then
+    let return_values, free_vars, env, res, _ =
+      C.simple_list ~dbg env res args
     in
-    cmm, free_vars, res
-  | Some (Push _) ->
-    Misc.fatal_errorf
-      "Return continuation %a should not be applied with a Push trap action"
-      Continuation.print return_cont
+    let return_value = C.make_tuple return_values in
+    let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
+    match Apply_cont.trap_action apply with
+    | None ->
+      let cmm, free_vars = wrap return_value free_vars in
+      cmm, free_vars, res
+    | Some (Pop { exn_handler; _ }) ->
+      let cont = Env.get_cmm_continuation env exn_handler in
+      let cmm, free_vars =
+        wrap (C.trap_return return_value [Cmm.Pop cont]) free_vars
+      in
+      cmm, free_vars, res
+    | Some (Push _) ->
+      Misc.fatal_errorf
+        "Return continuation %a should not be applied with a Push trap action"
+        Continuation.print return_cont
+  else
+    Misc.fatal_errorf "Types (%a) do not match arguments of@ %a"
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space Printcmm.machtype)
+      types Apply_cont.print apply
 
 (* Invalid expressions *)
 let invalid env res ~message =
@@ -873,13 +881,15 @@ and apply_expr env res apply =
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     let cmm, free_vars = wrap call free_vars in
     cmm, free_vars, res
-  | Return k when Continuation.equal (Env.return_continuation env) k ->
-    (* Case 1 *)
-    let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    let cmm, free_vars = wrap call free_vars in
-    cmm, free_vars, res
   | Return k -> (
     match Env.get_continuation env k with
+    | Return { param_types = _ } ->
+      (* Case 1 *)
+      (* CR gbury: is it worth it to check that the return arity of the function
+         being called matches that of the current return continuation ? *)
+      let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
+      let cmm, free_vars = wrap call free_vars in
+      cmm, free_vars, res
     | Jump { param_types = _; cont } ->
       (* Case 2 *)
       let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
@@ -952,12 +962,11 @@ and apply_cont env res apply_cont =
   let args = Apply_cont.args apply_cont in
   if Env.is_exn_handler env k
   then translate_raise ~dbg_with_inlined env res apply_cont k args
-  else if Continuation.equal (Env.return_continuation env) k
-  then
-    translate_jump_to_return_continuation ~dbg_with_inlined env res apply_cont k
-      args
   else
     match Env.get_continuation env k with
+    | Return { param_types } ->
+      translate_jump_to_return_continuation ~dbg_with_inlined env res apply_cont
+        k param_types args
     | Jump { param_types; cont } ->
       translate_jump_to_continuation ~dbg_with_inlined env res apply_cont
         param_types cont args

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -427,10 +427,10 @@ let transl_check_attrib : Zero_alloc_attribute.t -> Cmm.codegen_option list =
 
 (* Translation of the bodies of functions. *)
 
-let params_and_body0 env res code_id ~fun_dbg ~zero_alloc_attribute
-    ~return_continuation ~exn_continuation params ~body ~my_closure
-    ~(is_my_closure_used : _ Or_unknown.t) ~my_region ~my_ghost_region
-    ~translate_expr =
+let params_and_body0 env res code_id ~result_arity ~fun_dbg
+    ~zero_alloc_attribute ~return_continuation ~exn_continuation params ~body
+    ~my_closure ~(is_my_closure_used : _ Or_unknown.t) ~my_region
+    ~my_ghost_region ~translate_expr =
   let params =
     let is_my_closure_used =
       match is_my_closure_used with
@@ -448,8 +448,13 @@ let params_and_body0 env res code_id ~fun_dbg ~zero_alloc_attribute
   in
   (* Init the env and create a jump id for the return continuation in case a
      trap action is attached to one of its calls *)
+  let return_continuation_arity =
+    List.map To_cmm_shared.machtype_of_kind
+      (Flambda_arity.unarized_components result_arity)
+  in
   let env =
-    Env.enter_function_body env ~return_continuation ~exn_continuation
+    Env.enter_function_body env ~return_continuation ~return_continuation_arity
+      ~exn_continuation
   in
   (* [my_region] can be referenced in [Begin_try_region] primitives so must be
      in the environment; however it should never end up in actual generated
@@ -496,8 +501,8 @@ let params_and_body0 env res code_id ~fun_dbg ~zero_alloc_attribute
   in
   C.fundecl fun_sym fun_params fun_body fun_flags fun_dbg fun_poll, res
 
-let params_and_body env res code_id p ~fun_dbg ~zero_alloc_attribute
-    ~translate_expr =
+let params_and_body env res code_id p ~result_arity ~fun_dbg
+    ~zero_alloc_attribute ~translate_expr =
   Function_params_and_body.pattern_match p
     ~f:(fun
          ~return_continuation
@@ -512,9 +517,10 @@ let params_and_body env res code_id p ~fun_dbg ~zero_alloc_attribute
          ~free_names_of_body:_
        ->
       try
-        params_and_body0 env res code_id ~fun_dbg ~zero_alloc_attribute
-          ~return_continuation ~exn_continuation params ~body ~my_closure
-          ~is_my_closure_used ~my_region ~my_ghost_region ~translate_expr
+        params_and_body0 env res code_id ~result_arity ~fun_dbg
+          ~zero_alloc_attribute ~return_continuation ~exn_continuation params
+          ~body ~my_closure ~is_my_closure_used ~my_region ~my_ghost_region
+          ~translate_expr
       with Misc.Fatal_error as e ->
         let bt = Printexc.get_raw_backtrace () in
         Format.eprintf

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -48,6 +48,7 @@ val params_and_body :
   To_cmm_result.t ->
   Code_id.t ->
   Function_params_and_body.t ->
+  result_arity:[`Unarized] Flambda_arity.t ->
   fun_dbg:Debuginfo.t ->
   zero_alloc_attribute:Zero_alloc_attribute.t ->
   translate_expr:translate_expr ->

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -104,17 +104,18 @@ let static_boxed_number ~kind ~env ~symbol ~default ~emit ~transl ~structured v
   in
   R.update_data res (or_variable aux default v), env, updates
 
-let add_function env res ~params_and_body code_id p ~fun_dbg
+let add_function env res ~params_and_body code_id p ~result_arity ~fun_dbg
     ~zero_alloc_attribute =
   let fundecl, res =
-    params_and_body env res code_id p ~fun_dbg ~zero_alloc_attribute
+    params_and_body env res code_id p ~result_arity ~fun_dbg
+      ~zero_alloc_attribute
   in
   R.add_function res fundecl
 
 let add_functions env ~params_and_body res (code : Code.t) =
   add_function env res ~params_and_body (Code.code_id code)
     (Code.params_and_body code)
-    ~fun_dbg:(Code.dbg code)
+    ~result_arity:(Code.result_arity code) ~fun_dbg:(Code.dbg code)
     ~zero_alloc_attribute:(Code.zero_alloc_attribute code)
 
 let preallocate_set_of_closures (res, updates, env) ~closure_symbols

--- a/middle_end/flambda2/to_cmm/to_cmm_static.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.mli
@@ -24,6 +24,7 @@ val static_consts :
     To_cmm_result.t ->
     Code_id.t ->
     Function_params_and_body.t ->
+    result_arity:[`Unarized] Flambda_arity.t ->
     fun_dbg:Debuginfo.t ->
     zero_alloc_attribute:Zero_alloc_attribute.t ->
     Cmm.fundecl * To_cmm_result.t) ->


### PR DESCRIPTION
As description said. This check is already done for other continuations, i.e.  `to_cmm` checks that at least the number of argument matches the arity of the continuation.