### PR TITLE
Map unique_barrier information to Reads_vary (cherry-picked from #3066)

### DIFF
--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -279,6 +279,18 @@ let view_texp (e : expression_desc) =
   | Texp_match (e, sort, cases, partial) -> Texp_match (e, cases, partial, sort)
   | _ -> O e
 
+let mkpattern_data ~pat_desc ~pat_loc ~pat_extra ~pat_type ~pat_env
+    ~pat_attributes =
+  {
+    pat_desc;
+    pat_loc;
+    pat_extra;
+    pat_type;
+    pat_env;
+    pat_attributes;
+    pat_unique_barrier = Unique_barrier.not_computed ();
+  }
+
 type tpat_var_identifier = Value.l
 
 let mkTpat_var ?id:(mode = dummy_value_mode) (ident, name) =

--- a/chamelon/compat.mli
+++ b/chamelon/compat.mli
@@ -103,6 +103,15 @@ type matched_expression_desc =
 
 val view_texp : expression_desc -> matched_expression_desc
 
+val mkpattern_data :
+  pat_desc:'a ->
+  pat_loc:Location.t ->
+  pat_extra:(pat_extra * Location.t * attribute list) list ->
+  pat_type:type_expr ->
+  pat_env:Env.t ->
+  pat_attributes:attribute list ->
+  'a pattern_data
+
 type tpat_var_identifier
 type tpat_alias_identifier
 type tpat_array_identifier

--- a/chamelon/compat.upstream.ml
+++ b/chamelon/compat.upstream.ml
@@ -165,6 +165,10 @@ let rec view_texp (e : expression_desc) =
   | Texp_match (e, cases, partial) -> Texp_match (e, cases, partial, ())
   | _ -> O e
 
+let mkpattern_data ~pat_desc ~pat_loc ~pat_extra ~pat_type ~pat_env
+    ~pat_attributes =
+  { pat_desc; pat_loc; pat_extra; pat_type; pat_env; pat_attributes }
+
 type tpat_var_identifier = unit
 
 let mkTpat_var ?id:(() = ()) (ident, name) = Tpat_var (ident, name)

--- a/chamelon/minimizer/dummy.ml
+++ b/chamelon/minimizer/dummy.ml
@@ -101,14 +101,8 @@ let false_expr =
     ({ txt = Lident "false"; loc = Location.none }, false_description, [])
 
 let any_pat =
-  {
-    pat_desc = Tpat_any;
-    pat_loc = Location.none;
-    pat_extra = [];
-    pat_type = dummy_type_expr;
-    pat_env = Env.empty;
-    pat_attributes = [];
-  }
+  mkpattern_data ~pat_desc:Tpat_any ~pat_loc:Location.none ~pat_extra:[]
+    ~pat_type:dummy_type_expr ~pat_env:Env.empty ~pat_attributes:[]
 
 let dummy1_str_it_desc =
   Tstr_value
@@ -116,17 +110,13 @@ let dummy1_str_it_desc =
       [
         mk_value_binding
           ~vb_pat:
-            {
-              pat_desc =
-                mkTpat_var
-                  ( create_scoped ~scope:0 "__dummy1__",
-                    { txt = "__dummy1__"; loc = Location.none } );
-              pat_loc = Location.none;
-              pat_extra = [];
-              pat_type = dummy_type_expr;
-              pat_env = Env.empty;
-              pat_attributes = [];
-            }
+            (mkpattern_data
+               ~pat_desc:
+                 (mkTpat_var
+                    ( create_scoped ~scope:0 "__dummy1__",
+                      { txt = "__dummy1__"; loc = Location.none } ))
+               ~pat_loc:Location.none ~pat_extra:[] ~pat_type:dummy_type_expr
+               ~pat_env:Env.empty ~pat_attributes:[])
           ~vb_expr:
             (exp_desc_to_exp
                (mkTexp_function
@@ -252,14 +242,8 @@ let ignore = exp_desc_to_exp ignore_desc
 let empty_value_case =
   {
     c_lhs =
-      {
-        pat_desc = Tpat_any;
-        pat_loc = Location.none;
-        pat_extra = [];
-        pat_type = dummy_type_expr;
-        pat_env = Env.empty;
-        pat_attributes = [];
-      };
+      mkpattern_data ~pat_desc:Tpat_any ~pat_loc:Location.none ~pat_extra:[]
+        ~pat_type:dummy_type_expr ~pat_env:Env.empty ~pat_attributes:[];
     c_guard = None;
     c_rhs =
       {
@@ -276,14 +260,8 @@ let empty_computation_case =
   {
     c_lhs =
       as_computation_pattern
-        {
-          pat_desc = Tpat_any;
-          pat_loc = Location.none;
-          pat_extra = [];
-          pat_type = dummy_type_expr;
-          pat_env = Env.empty;
-          pat_attributes = [];
-        };
+        (mkpattern_data ~pat_desc:Tpat_any ~pat_loc:Location.none ~pat_extra:[]
+           ~pat_type:dummy_type_expr ~pat_env:Env.empty ~pat_attributes:[]);
     c_guard = None;
     c_rhs =
       {

--- a/chamelon/minimizer/removeunusedargs.ml
+++ b/chamelon/minimizer/removeunusedargs.ml
@@ -48,20 +48,16 @@ let rec fun_wrapper arg_list acc_id depth path_fun n =
              [
                {
                  c_lhs =
-                   {
-                     pat_desc =
-                       mkTpat_var
-                         ( id_arg,
-                           {
-                             txt = "arg" ^ string_of_int n;
-                             loc = Location.none;
-                           } );
-                     pat_loc = Location.none;
-                     pat_extra = [];
-                     pat_env = Env.empty;
-                     pat_attributes = [];
-                     pat_type = dummy_type_expr;
-                   };
+                   mkpattern_data
+                     ~pat_desc:
+                       (mkTpat_var
+                          ( id_arg,
+                            {
+                              txt = "arg" ^ string_of_int n;
+                              loc = Location.none;
+                            } ))
+                     ~pat_loc:Location.none ~pat_extra:[] ~pat_env:Env.empty
+                     ~pat_attributes:[] ~pat_type:dummy_type_expr;
                  c_guard = None;
                  c_rhs =
                    exp_desc_to_exp

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -185,7 +185,7 @@ let iter_on_occurrences
           f ~namespace:Value exp_env path lid
       | Texp_construct (lid, constr_desc, _, _) ->
           add_constructor_description exp_env lid constr_desc
-      | Texp_field (_, lid, label_desc, _)
+      | Texp_field (_, lid, label_desc, _, _)
       | Texp_setfield (_, _, lid, label_desc, _) ->
           add_label exp_env lid label_desc
       | Texp_new (path, lid, _, _) ->

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -648,6 +648,21 @@ type function_kind = Curried of curried_function_kind | Tupled
 
 type let_kind = Strict | Alias | StrictOpt
 
+type unique_barrier =
+  | May_be_pushed_down
+  | Must_stay_here
+
+let add_barrier_to_read ubr sem =
+  match ubr with
+  | May_be_pushed_down -> sem
+  | Must_stay_here -> Reads_vary
+
+let add_barrier_to_let_kind ubr str =
+  match ubr, str with
+  | May_be_pushed_down, str -> str
+  | Must_stay_here, Strict -> Strict
+  | Must_stay_here, (Alias|StrictOpt) -> StrictOpt
+
 type meth_kind = Self | Public | Cached
 
 let equal_meth_kind x y =

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -603,6 +603,14 @@ type let_kind = Strict | Alias | StrictOpt
       we can discard e if x does not appear in e'
  *)
 
+type unique_barrier =
+  | May_be_pushed_down
+  | Must_stay_here
+
+val add_barrier_to_read : unique_barrier -> field_read_semantics -> field_read_semantics
+
+val add_barrier_to_let_kind : unique_barrier -> let_kind -> let_kind
+
 type meth_kind = Self | Public | Cached
 
 val equal_meth_kind : meth_kind -> meth_kind -> bool

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1899,10 +1899,12 @@ let get_expr_args_constr ~scopes head (arg, _mut, sort, layout) rem =
   Array.iter (fun jkind ->
       jkind_layout_default_to_value_and_check_not_void head.pat_loc jkind)
     cstr.cstr_arg_jkinds;
+  let ubr = Translmode.transl_unique_barrier (head.pat_unique_barrier) in
+  let sem = add_barrier_to_read ubr Reads_agree in
   let make_field_access binding_kind ~field ~pos =
     let prim =
       match cstr.cstr_shape with
-      | Constructor_uniform_value -> Pfield (pos, Pointer, Reads_agree)
+      | Constructor_uniform_value -> Pfield (pos, Pointer, sem)
       | Constructor_mixed shape ->
           let read =
             match Types.get_mixed_product_element shape field with
@@ -1919,25 +1921,26 @@ let get_expr_args_constr ~scopes head (arg, _mut, sort, layout) rem =
                 Mread_flat_suffix flat_read
           in
           let shape = Lambda.transl_mixed_product_shape shape in
-          Pmixedfield (pos, read, shape, Reads_agree)
+          Pmixedfield (pos, read, shape, sem)
     in
     let jkind = cstr.cstr_arg_jkinds.(field) in
     let sort = Jkind.sort_of_jkind jkind in
     let layout = Typeopt.layout_of_sort head.pat_loc sort in
     (Lprim (prim, [ arg ], loc), binding_kind, sort, layout)
   in
+  let str = add_barrier_to_let_kind ubr Alias in
   if cstr.cstr_inlined <> None then
-    (arg, Alias, sort, layout) :: rem
+    (arg, str, sort, layout) :: rem
   else
     match cstr.cstr_repr with
     | Variant_boxed _ ->
         List.init cstr.cstr_arity
-          (fun i -> make_field_access Alias ~field:i ~pos:i)
+          (fun i -> make_field_access str ~field:i ~pos:i)
         @ rem
-    | Variant_unboxed -> (arg, Alias, sort, layout) :: rem
+    | Variant_unboxed -> (arg, str, sort, layout) :: rem
     | Variant_extensible ->
         List.init cstr.cstr_arity
-          (fun i -> make_field_access Alias ~field:i ~pos:(i+1))
+          (fun i -> make_field_access str ~field:i ~pos:(i+1))
         @ rem
 
 let divide_constructor ~scopes ctx pm =
@@ -1952,14 +1955,17 @@ let divide_constructor ~scopes ctx pm =
 
 let get_expr_args_variant_constant = drop_expr_arg
 
-let nonconstant_variant_field index =
-  Lambda.Pfield(index, Pointer, Reads_agree)
+let nonconstant_variant_field ubr index =
+  let sem = add_barrier_to_read ubr Reads_agree in
+  Lambda.Pfield(index, Pointer, sem)
 
 let get_expr_args_variant_nonconst ~scopes head (arg, _mut, _sort, _layout)
       rem =
   let loc = head_loc ~scopes head in
-   let field_prim = nonconstant_variant_field 1 in
-  (Lprim (field_prim, [ arg ], loc), Alias, Jkind.Sort.for_variant_arg,
+  let ubr = Translmode.transl_unique_barrier (head.pat_unique_barrier) in
+  let field_prim = nonconstant_variant_field ubr 1 in
+  let str = add_barrier_to_let_kind ubr Alias in
+  (Lprim (field_prim, [ arg ], loc), str, Jkind.Sort.for_variant_arg,
    layout_variant_arg)
   :: rem
 
@@ -2202,11 +2208,14 @@ let get_pat_args_unboxed_tuple arity p rem =
 let get_expr_args_tuple ~scopes head (arg, _mut, _sort, _layout) rem =
   let loc = head_loc ~scopes head in
   let arity = Patterns.Head.arity head in
+  let ubr = Translmode.transl_unique_barrier (head.pat_unique_barrier) in
+  let sem = add_barrier_to_read ubr Reads_agree in
+  let str = add_barrier_to_let_kind ubr Alias in
   let rec make_args pos =
     if pos >= arity then
       rem
     else
-      (Lprim (Pfield (pos, Pointer, Reads_agree), [ arg ], loc), Alias,
+      (Lprim (Pfield (pos, Pointer, sem), [ arg ], loc), str,
        Jkind.Sort.for_tuple_element, layout_tuple_element)
         :: make_args (pos + 1)
   in
@@ -2286,6 +2295,8 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
       let sem =
         if Types.is_mutable lbl.lbl_mut then Reads_vary else Reads_agree
       in
+      let ubr = Translmode.transl_unique_barrier head.pat_unique_barrier in
+      let sem = add_barrier_to_read ubr sem in
       let access, sort, layout =
         match lbl.lbl_repres with
         | Record_boxed _
@@ -2335,6 +2346,7 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
             lbl_sort, lbl_layout
       in
       let str = if Types.is_mutable lbl.lbl_mut then StrictOpt else Alias in
+      let str = add_barrier_to_let_kind ubr str in
       (access, str, sort, layout) :: make_args (pos + 1)
   in
   make_args 0
@@ -3171,8 +3183,11 @@ let combine_constructor value_kind loc arg pat_env cstr partial ctx def
                       (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem, value_kind))
                   nonconsts default
               in
-              Llet (Alias, Lambda.layout_block, tag,
-                    Lprim (Pfield (0, Pointer, Reads_agree), [ arg ], loc),
+              (* Since the tag is used directly in the tests, it would be sound
+                 to mark it Alias+Reads_agree but this would not change performance.
+                 We keep it this way to guarantee soundness of in-place overwriting. *)
+              Llet (StrictOpt, Lambda.layout_block, tag,
+                    Lprim (Pfield (0, Pointer, Reads_vary), [ arg ], loc),
                     tests)
         in
         List.fold_right
@@ -3299,11 +3314,14 @@ let call_switcher_variant_constant kind loc fail arg int_lambda_list =
 
 let call_switcher_variant_constr value_kind loc fail arg int_lambda_list =
   let v = Ident.create_local "variant" in
+  (* Since v is used directly in the tests, it would be sound
+     to mark it Alias+May_be_pushed_down but this would not change performance.
+     We keep it this way to guarantee soundness of in-place overwriting. *)
   Llet
-    ( Alias,
+    ( StrictOpt,
       Lambda.layout_int,
       v,
-      Lprim (nonconstant_variant_field 0, [ arg ], loc),
+      Lprim (nonconstant_variant_field Must_stay_here 0, [ arg ], loc),
       call_switcher value_kind loc fail (Lvar v) min_int max_int int_lambda_list )
 
 let combine_variant value_kind loc row arg partial ctx def
@@ -4353,7 +4371,9 @@ let for_optional_arg_default
       ~if_some:
         (Lprim
            (* CR ncik-roberts: Check whether we need something better here. *)
-           (Pfield (0, Pointer, Reads_agree),
+           (* Since overwriting this option is not possible, it would be sound to
+              use Reads_agree here, but we want to be conservative. *)
+           (Pfield (0, Pointer, Reads_vary),
             [ Lvar param ],
             Loc_unknown))
   in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -629,11 +629,12 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       transl_record ~scopes e.exp_loc e.exp_env
         (Option.map transl_alloc_mode alloc_mode)
         fields representation extended_expression
-  | Texp_field(arg, id, lbl, float) ->
+  | Texp_field(arg, id, lbl, float, ubr) ->
       let targ = transl_exp ~scopes Jkind.Sort.for_record arg in
       let sem =
         if Types.is_mutable lbl.lbl_mut then Reads_vary else Reads_agree
       in
+      let sem = add_barrier_to_read (transl_unique_barrier ubr) sem in
       let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
       check_record_field_sort id.loc lbl_sort;
       begin match lbl.lbl_repres with
@@ -1804,16 +1805,79 @@ and transl_setinstvar ~scopes loc self var expr =
 
 (* CR layouts v5: Invariant - this is only called on values.  Relax that. *)
 and transl_record ~scopes loc env mode fields repres opt_init_expr =
-  let size = Array.length fields in
   (* Determine if there are "enough" fields (only relevant if this is a
      functional-style record update *)
-  let no_init = match opt_init_expr with None -> true | _ -> false in
+  let size = Array.length fields in
   let on_heap = match mode with
     | None -> false (* unboxed is not on heap *)
     | Some m -> is_heap_mode m
   in
-  if no_init || size < Config.max_young_wosize || not on_heap
-  then begin
+  match opt_init_expr with
+  | Some (init_expr, _) when on_heap && size >= Config.max_young_wosize ->
+    (* Take a shallow copy of the init record, then mutate the fields
+       of the copy *)
+    let copy_id = Ident.create_local "newrecord" in
+    let update_field cont (lbl, definition) =
+      (* CR layouts v5: allow more unboxed types here. *)
+      let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
+      check_record_field_sort lbl.lbl_loc lbl_sort;
+      match definition with
+      | Kept _ -> cont
+      | Overridden (_lid, expr) ->
+          let upd =
+            match repres with
+              Record_boxed _
+            | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
+                let ptr = maybe_pointer expr in
+                Psetfield(lbl.lbl_pos, ptr, Assignment modify_heap)
+            | Record_unboxed | Record_inlined (_, _, Variant_unboxed) ->
+                assert false
+            | Record_float ->
+                Psetfloatfield (lbl.lbl_pos, Assignment modify_heap)
+            | Record_ufloat ->
+                Psetufloatfield (lbl.lbl_pos, Assignment modify_heap)
+            | Record_inlined (_, Constructor_uniform_value, Variant_extensible) ->
+                let pos = lbl.lbl_pos + 1 in
+                let ptr = maybe_pointer expr in
+                Psetfield(pos, ptr, Assignment modify_heap)
+            | Record_inlined (_, Constructor_mixed _, Variant_extensible) ->
+                (* CR layouts v5.9: support this *)
+                fatal_error
+                  "Mixed inlined records not supported for extensible variants"
+            | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+            | Record_mixed shape -> begin
+                let { value_prefix_len; flat_suffix } : mixed_product_shape =
+                  shape
+                in
+                let write =
+                  if lbl.lbl_num < value_prefix_len then
+                    let ptr = maybe_pointer expr in
+                    Mwrite_value_prefix ptr
+                  else
+                    let flat_element =
+                      flat_suffix.(lbl.lbl_num - value_prefix_len)
+                    in
+                    Mwrite_flat_suffix flat_element
+                in
+                let shape : Lambda.mixed_block_shape =
+                  { value_prefix_len; flat_suffix }
+                in
+                Psetmixedfield
+                  (lbl.lbl_pos, write, shape, Assignment modify_heap)
+              end
+          in
+          Lsequence(Lprim(upd, [Lvar copy_id;
+                                transl_exp ~scopes lbl_sort expr],
+                          of_location ~scopes loc),
+                    cont)
+    in
+    assert (is_heap_mode (Option.get mode)); (* Pduprecord must be Alloc_heap and not unboxed *)
+    Llet(Strict, Lambda.layout_block, copy_id,
+         Lprim(Pduprecord (repres, size),
+               [transl_exp ~scopes Jkind.Sort.for_record init_expr],
+               of_location ~scopes loc),
+         Array.fold_left update_field (Lvar copy_id) fields)
+  | Some _ | None ->
     (* Allocate new record with given fields (and remaining fields
        taken from init_expr if any *)
     (* CR layouts v5: allow non-value fields beyond just float# *)
@@ -1832,6 +1896,11 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                let sem =
                  if Types.is_mutable mut then Reads_vary else Reads_agree
                in
+               let unique_barrier = match opt_init_expr with
+                 | Some (_, ubr) -> Translmode.transl_unique_barrier ubr
+                 | None -> assert false (* Kept fields only exist on extended records *)
+               in
+               let sem = add_barrier_to_read unique_barrier sem in
                let access =
                  match repres with
                    Record_boxed _
@@ -1961,78 +2030,9 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     in
     begin match opt_init_expr with
       None -> lam
-    | Some init_expr -> Llet(Strict, Lambda.layout_block, init_id,
+    | Some (init_expr, _) -> Llet(Strict, Lambda.layout_block, init_id,
                              transl_exp ~scopes Jkind.Sort.for_record init_expr, lam)
     end
-  end else begin
-    (* Take a shallow copy of the init record, then mutate the fields
-       of the copy *)
-    let copy_id = Ident.create_local "newrecord" in
-    let update_field cont (lbl, definition) =
-      (* CR layouts v5: allow more unboxed types here. *)
-      let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
-      check_record_field_sort lbl.lbl_loc lbl_sort;
-      match definition with
-      | Kept _ -> cont
-      | Overridden (_lid, expr) ->
-          let upd =
-            match repres with
-              Record_boxed _
-            | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
-                let ptr = maybe_pointer expr in
-                Psetfield(lbl.lbl_pos, ptr, Assignment modify_heap)
-            | Record_unboxed | Record_inlined (_, _, Variant_unboxed) ->
-                assert false
-            | Record_float ->
-                Psetfloatfield (lbl.lbl_pos, Assignment modify_heap)
-            | Record_ufloat ->
-                Psetufloatfield (lbl.lbl_pos, Assignment modify_heap)
-            | Record_inlined (_, Constructor_uniform_value, Variant_extensible) ->
-                let pos = lbl.lbl_pos + 1 in
-                let ptr = maybe_pointer expr in
-                Psetfield(pos, ptr, Assignment modify_heap)
-            | Record_inlined (_, Constructor_mixed _, Variant_extensible) ->
-                (* CR layouts v5.9: support this *)
-                fatal_error
-                  "Mixed inlined records not supported for extensible variants"
-            | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
-            | Record_mixed shape -> begin
-                let { value_prefix_len; flat_suffix } : mixed_product_shape =
-                  shape
-                in
-                let write =
-                  if lbl.lbl_num < value_prefix_len then
-                    let ptr = maybe_pointer expr in
-                    Mwrite_value_prefix ptr
-                  else
-                    let flat_element =
-                      flat_suffix.(lbl.lbl_num - value_prefix_len)
-                    in
-                    Mwrite_flat_suffix flat_element
-                in
-                let shape : Lambda.mixed_block_shape =
-                  { value_prefix_len; flat_suffix }
-                in
-                Psetmixedfield
-                  (lbl.lbl_pos, write, shape, Assignment modify_heap)
-              end
-          in
-          Lsequence(Lprim(upd, [Lvar copy_id;
-                                transl_exp ~scopes lbl_sort expr],
-                          of_location ~scopes loc),
-                    cont)
-    in
-    begin match opt_init_expr with
-      None -> assert false
-    | Some init_expr ->
-        assert (is_heap_mode (Option.get mode)); (* Pduprecord must be Alloc_heap and not unboxed *)
-        Llet(Strict, Lambda.layout_block, copy_id,
-             Lprim(Pduprecord (repres, size),
-                   [transl_exp ~scopes Jkind.Sort.for_record init_expr],
-                   of_location ~scopes loc),
-             Array.fold_left update_field (Lvar copy_id) fields)
-    end
-  end
 
 and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
   let return_layout = layout_exp return_sort e in

--- a/lambda/translmode.ml
+++ b/lambda/translmode.ml
@@ -42,3 +42,8 @@ let transl_modify_mode locality =
   match Locality.zap_to_floor locality with
   | Global -> modify_heap
   | Local -> modify_maybe_stack
+
+let transl_unique_barrier barrier =
+  match Typedtree.Unique_barrier.resolve barrier with
+  | Uniqueness.Const.Aliased -> May_be_pushed_down
+  | Uniqueness.Const.Unique -> Must_stay_here

--- a/lambda/translmode.mli
+++ b/lambda/translmode.mli
@@ -23,3 +23,5 @@ val transl_alloc_mode_r : ('l * allowed) Alloc.t -> Lambda.locality_mode
 val transl_alloc_mode : Typedtree.alloc_mode -> Lambda.locality_mode
 
 val transl_modify_mode : (allowed * 'r) Locality.t -> Lambda.modify_mode
+
+val transl_unique_barrier : Typedtree.Unique_barrier.t -> Lambda.unique_barrier

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -85,8 +85,10 @@ let f = function
              (exit 8))
           with (8)
            (if (field_imm 1 param/32)
-             (if (== (field_imm 0 *match*/33) B/28) 2
-               (if (== (field_imm 0 *match*/33) C/29) 3 4))
+             (let (tag/41 =o (field_mut 0 *match*/33))
+               (if (== tag/41 B/28) 2
+                 (let (tag/46 =o (field_mut 0 *match*/33))
+                   (if (== tag/46 C/29) 3 4))))
              (if (field_imm 2 param/32) 12 11))))))
   (apply (field_imm 1 (global Toploop!)) "f" f/30))
 val f : t * bool * bool -> int = <fun>

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -1,0 +1,339 @@
+(* TEST
+   flags += "-extension unique ";
+   flags += "-dlambda";
+   expect;
+*)
+
+(* This file tests the lambda code that is generated for projections out of unique values.
+   We need to ensure that if an allocation is used uniquely, all projections out of
+   this allocation happen before the unique use and are not pushed down beyond that point.
+*)
+
+type record = { x : string; y : string @@ many aliased }
+[%%expect{|
+0
+type record = { x : string; y : string @@ many aliased; }
+|}]
+
+let aliased_use x = x
+[%%expect{|
+(let (aliased_use/280 = (function {nlocal = 0} x/282 x/282))
+  (apply (field_imm 1 (global Toploop!)) "aliased_use" aliased_use/280))
+val aliased_use : 'a -> 'a = <fun>
+|}]
+
+let unique_use (unique_ x) = x
+[%%expect{|
+(let (unique_use/283 = (function {nlocal = 0} x/285 x/285))
+  (apply (field_imm 1 (global Toploop!)) "unique_use" unique_use/283))
+val unique_use : unique_ 'a -> 'a = <fun>
+|}]
+
+(* This output is fine with overwriting: The [r.y] is not pushed down. *)
+let proj_aliased r =
+  let y = r.y in
+  let r = aliased_use r in
+  (r, y)
+[%%expect{|
+(let
+  (aliased_use/280 = (apply (field_imm 0 (global Toploop!)) "aliased_use")
+   proj_aliased/286 =
+     (function {nlocal = 0} r/288[(consts ()) (non_consts ([0: *, *]))]
+       [(consts ())
+        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+       (let
+         (y/289 = (field_imm 1 r/288)
+          r/290 =[(consts ()) (non_consts ([0: *, *]))]
+            (apply aliased_use/280 r/288))
+         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/290 y/289))))
+  (apply (field_imm 1 (global Toploop!)) "proj_aliased" proj_aliased/286))
+val proj_aliased : record -> record * string = <fun>
+|}]
+
+let proj_unique r =
+  let y = r.y in
+  let r = unique_use r in
+  (r, y)
+[%%expect{|
+(let
+  (unique_use/283 = (apply (field_imm 0 (global Toploop!)) "unique_use")
+   proj_unique/291 =
+     (function {nlocal = 0} r/293[(consts ()) (non_consts ([0: *, *]))]
+       [(consts ())
+        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+       (let
+         (y/294 = (field_mut 1 r/293)
+          r/295 =[(consts ()) (non_consts ([0: *, *]))]
+            (apply unique_use/283 r/293))
+         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/295 y/294))))
+  (apply (field_imm 1 (global Toploop!)) "proj_unique" proj_unique/291))
+val proj_unique : unique_ record -> record * string = <fun>
+|}]
+
+(* This output would be unsound if [aliased_use] was able to overwrite [r]
+   because the [field_imm 1 r] read happens after calling [aliased_use]. *)
+let match_aliased r =
+  match r with
+  | { y } ->
+    let r = aliased_use r in
+    (r, y)
+[%%expect{|
+(let
+  (aliased_use/280 = (apply (field_imm 0 (global Toploop!)) "aliased_use")
+   match_aliased/296 =
+     (function {nlocal = 0} r/298[(consts ()) (non_consts ([0: *, *]))]
+       [(consts ())
+        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+       (let
+         (r/300 =[(consts ()) (non_consts ([0: *, *]))]
+            (apply aliased_use/280 r/298))
+         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/300
+           (field_imm 1 r/298)))))
+  (apply (field_imm 1 (global Toploop!)) "match_aliased" match_aliased/296))
+val match_aliased : record -> record * string = <fun>
+|}]
+
+(* This is sound since we bind [y] before the [unique_use] *)
+let match_unique r =
+  match r with
+  | { y } ->
+    let r = unique_use r in
+    (r, y)
+[%%expect{|
+(let
+  (unique_use/283 = (apply (field_imm 0 (global Toploop!)) "unique_use")
+   match_unique/302 =
+     (function {nlocal = 0} r/304[(consts ()) (non_consts ([0: *, *]))]
+       [(consts ())
+        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+       (let
+         (y/305 =o (field_mut 1 r/304)
+          r/306 =[(consts ()) (non_consts ([0: *, *]))]
+            (apply unique_use/283 r/304))
+         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/306 y/305))))
+  (apply (field_imm 1 (global Toploop!)) "match_unique" match_unique/302))
+val match_unique : unique_ record -> record * string = <fun>
+|}]
+
+(* Similarly, this would be unsound since Lambda performs a mini ANF pass. *)
+let match_mini_anf_aliased r =
+  let y, _ =
+    match r with
+    | { y } -> (y, 1)
+  in
+  let r = aliased_use r in
+  (r, y)
+[%%expect{|
+(let
+  (aliased_use/280 = (apply (field_imm 0 (global Toploop!)) "aliased_use")
+   match_mini_anf_aliased/308 =
+     (function {nlocal = 0} r/310[(consts ()) (non_consts ([0: *, *]))]
+       [(consts ())
+        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+       (let
+         (*match*/316 =[int] 1
+          r/313 =[(consts ()) (non_consts ([0: *, *]))]
+            (apply aliased_use/280 r/310))
+         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/313
+           (field_imm 1 r/310)))))
+  (apply (field_imm 1 (global Toploop!)) "match_mini_anf_aliased"
+    match_mini_anf_aliased/308))
+val match_mini_anf_aliased : record -> record * string = <fun>
+|}]
+
+(* This is sound since we bind [y] before the [unique_use] *)
+let match_mini_anf_unique r =
+  let y, _ =
+    match r with
+    | { y } -> (y, 1)
+  in
+  let r = unique_use r in
+  (r, y)
+[%%expect{|
+(let
+  (unique_use/283 = (apply (field_imm 0 (global Toploop!)) "unique_use")
+   match_mini_anf_unique/318 =
+     (function {nlocal = 0} r/320[(consts ()) (non_consts ([0: *, *]))]
+       [(consts ())
+        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+       (let
+         (y/322 =o (field_mut 1 r/320)
+          *match*/326 =[int] 1
+          r/323 =[(consts ()) (non_consts ([0: *, *]))]
+            (apply unique_use/283 r/320))
+         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/323 y/322))))
+  (apply (field_imm 1 (global Toploop!)) "match_mini_anf_unique"
+    match_mini_anf_unique/318))
+val match_mini_anf_unique : unique_ record -> record * string = <fun>
+|}]
+
+let match_anf_aliased r =
+  let y, _ =
+    match r with
+    | { y } when y == "" -> (y, 0)
+    | { y } -> (y, 1)
+  in
+  let r = aliased_use r in
+  (r, y)
+[%%expect{|
+(let
+  (aliased_use/280 = (apply (field_imm 0 (global Toploop!)) "aliased_use")
+   match_anf_aliased/328 =
+     (function {nlocal = 0} r/330[(consts ()) (non_consts ([0: *, *]))]
+       [(consts ())
+        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+       (catch
+         (let (y/332 =a (field_imm 1 r/330))
+           (if (== y/332 "") (let (*match*/339 =[int] 0) (exit 8 y/332))
+             (let (*match*/337 =[int] 1) (exit 8 (field_imm 1 r/330)))))
+        with (8 y/331)
+         (let
+           (r/334 =[(consts ()) (non_consts ([0: *, *]))]
+              (apply aliased_use/280 r/330))
+           (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/334
+             y/331)))))
+  (apply (field_imm 1 (global Toploop!)) "match_anf_aliased"
+    match_anf_aliased/328))
+val match_anf_aliased : record -> record * string = <fun>
+|}]
+
+(* This is sound since we bind [y] using [field_mut] *)
+let match_anf_unique r =
+  let y, _ =
+    match r with
+    | { y } when y == "" -> (y, 0)
+    | { y } -> (y, 1)
+  in
+  let r = unique_use r in
+  (r, y)
+[%%expect{|
+(let
+  (unique_use/283 = (apply (field_imm 0 (global Toploop!)) "unique_use")
+   match_anf_unique/340 =
+     (function {nlocal = 0} r/342[(consts ()) (non_consts ([0: *, *]))]
+       [(consts ())
+        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+       (catch
+         (let (y/344 =o (field_mut 1 r/342))
+           (if (== y/344 "") (let (*match*/351 =[int] 0) (exit 14 y/344))
+             (let (y/345 =o (field_mut 1 r/342) *match*/349 =[int] 1)
+               (exit 14 y/345))))
+        with (14 y/343)
+         (let
+           (r/346 =[(consts ()) (non_consts ([0: *, *]))]
+              (apply unique_use/283 r/342))
+           (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/346
+             y/343)))))
+  (apply (field_imm 1 (global Toploop!)) "match_anf_unique"
+    match_anf_unique/340))
+val match_anf_unique : unique_ record -> record * string = <fun>
+|}]
+
+type tree =
+  | Leaf
+  | Node of { l : tree; x : int; r : tree }
+[%%expect{|
+0
+type tree = Leaf | Node of { l : tree; x : int; r : tree; }
+|}]
+
+(* This output would be unsound with overwriting:
+   If we naively replaced makeblock with reuseblock,
+   then we would first overwrite r to have left child lr.
+   But then, the overwrite of l still has to read the left child of r
+   (as field_imm 0 *match*/329). But this value has been overwritten and so in fact,
+   this code drops the rl and sets lr to be the inner child of both l and r.
+*)
+let swap_inner (t : tree) =
+  match t with
+  | Node ({ l = Node ({ r = lr } as l); r = Node ({ l = rl } as r) } as t) ->
+    Node { t with l = Node { l with r = rl; }; r = Node { r with l = lr; }}
+  | _ -> t
+[%%expect{|
+(let
+  (swap_inner/358 =
+     (function {nlocal = 0}
+       t/360[(consts (0))
+             (non_consts ([0: [(consts (0)) (non_consts ([0: *, [int], *]))],
+                           [int],
+                           [(consts (0)) (non_consts ([0: *, [int], *]))]]))]
+       [(consts (0))
+        (non_consts ([0: [(consts (0)) (non_consts ([0: *, [int], *]))],
+                      [int], [(consts (0)) (non_consts ([0: *, [int], *]))]]))]
+       (catch
+         (if t/360
+           (let (*match*/369 =a (field_imm 0 t/360))
+             (if *match*/369
+               (let (*match*/373 =a (field_imm 2 t/360))
+                 (if *match*/373
+                   (makeblock 0 ([(consts (0))
+                                  (non_consts ([0:
+                                                [(consts (0))
+                                                 (non_consts ([0: *, [int],
+                                                               *]))], [int],
+                                                [(consts (0))
+                                                 (non_consts ([0: *, [int],
+                                                               *]))]]))],int,
+                     [(consts (0))
+                      (non_consts ([0:
+                                    [(consts (0))
+                                     (non_consts ([0: *, [int], *]))], [int],
+                                    [(consts (0))
+                                     (non_consts ([0: *, [int], *]))]]))])
+                     (makeblock 0 ([(consts (0))
+                                    (non_consts ([0:
+                                                  [(consts (0))
+                                                   (non_consts ([0: *, [int],
+                                                                 *]))],
+                                                  [int],
+                                                  [(consts (0))
+                                                   (non_consts ([0: *, [int],
+                                                                 *]))]]))],int,
+                       [(consts (0))
+                        (non_consts ([0:
+                                      [(consts (0))
+                                       (non_consts ([0: *, [int], *]))],
+                                      [int],
+                                      [(consts (0))
+                                       (non_consts ([0: *, [int], *]))]]))])
+                       (field_imm 0 *match*/369) (field_int 1 *match*/369)
+                       (field_imm 0 *match*/373))
+                     (field_int 1 t/360)
+                     (makeblock 0 ([(consts (0))
+                                    (non_consts ([0:
+                                                  [(consts (0))
+                                                   (non_consts ([0: *, [int],
+                                                                 *]))],
+                                                  [int],
+                                                  [(consts (0))
+                                                   (non_consts ([0: *, [int],
+                                                                 *]))]]))],int,
+                       [(consts (0))
+                        (non_consts ([0:
+                                      [(consts (0))
+                                       (non_consts ([0: *, [int], *]))],
+                                      [int],
+                                      [(consts (0))
+                                       (non_consts ([0: *, [int], *]))]]))])
+                       (field_imm 2 *match*/369) (field_int 1 *match*/373)
+                       (field_imm 2 *match*/373)))
+                   (exit 19)))
+               (exit 19)))
+           (exit 19))
+        with (19) t/360)))
+  (apply (field_imm 1 (global Toploop!)) "swap_inner" swap_inner/358))
+val swap_inner : tree -> tree = <fun>
+|}]
+
+(* TODO: Update this test once overwriting is fully implemented.
+let swap_inner (t : tree) =
+  match t with
+  | Node { l = Node { r = lr } as l; r = Node { l = rl } as r } as t ->
+      overwrite_ t with
+        Node { l = overwrite_ l with Node { r = rl; };
+               r = overwrite_ r with Node { l = lr; }}
+  | _ -> t
+[%%expect{|
+
+|}]
+*)

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -355,7 +355,8 @@ let name_expression ~loc ~attrs sort exp =
       pat_extra = [];
       pat_type = exp.exp_type;
       pat_env = exp.exp_env;
-      pat_attributes = []; }
+      pat_attributes = [];
+      pat_unique_barrier = Unique_barrier.not_computed () }
   in
   let vb =
     { vb_pat = pat;

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -240,6 +240,8 @@ module type S = sig
     val aliased : lr
 
     val unique : lr
+
+    val zap_to_ceil : ('l * allowed) t -> Const.t
   end
 
   module Contention : sig

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -52,6 +52,7 @@ let make_pat desc ty tenv =
   {pat_desc = desc; pat_loc = Location.none; pat_extra = [];
    pat_type = ty ; pat_env = tenv;
    pat_attributes = [];
+   pat_unique_barrier = Unique_barrier.not_computed ();
   }
 
 let omega = Patterns.omega

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -27,6 +27,7 @@ let omega = {
   pat_type = Ctype.none;
   pat_env = Env.empty;
   pat_attributes = [];
+  pat_unique_barrier = Unique_barrier.not_computed ();
 }
 
 let rec omegas i =

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -513,7 +513,7 @@ and expression i ppf x =
   | Texp_variant (l, eo) ->
       line i ppf "Texp_variant \"%s\"\n" l;
       option i expression_alloc_mode ppf eo;
-  | Texp_record { fields; representation; extended_expression; alloc_mode = am} ->
+  | Texp_record { fields; representation; extended_expression; alloc_mode = am } ->
       line i ppf "Texp_record\n";
       let i = i+1 in
       alloc_mode_option i ppf am;
@@ -522,8 +522,8 @@ and expression i ppf x =
       line i ppf "representation =\n";
       record_representation (i+1) ppf representation;
       line i ppf "extended_expression =\n";
-      option (i+1) expression ppf extended_expression;
-  | Texp_field (e, li, _, _) ->
+      option (i+1) expression ppf (Option.map fst extended_expression);
+  | Texp_field (e, li, _, _, _) ->
       line i ppf "Texp_field\n";
       expression i ppf e;
       longident i ppf li;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -351,8 +351,8 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
         | _, Kept _ -> ()
         | _, Overridden (lid, exp) -> iter_loc sub lid; sub.expr sub exp)
         fields;
-      Option.iter (sub.expr sub) extended_expression;
-  | Texp_field (exp, lid, _, _) ->
+      Option.iter (fun (exp, _) -> sub.expr sub exp) extended_expression;
+  | Texp_field (exp, lid, _, _, _) ->
       iter_loc sub lid;
       sub.expr sub exp
   | Texp_setfield (exp1, _, lid, _, exp2) ->

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -485,11 +485,12 @@ let expr sub x =
         in
         Texp_record {
           fields; representation;
-          extended_expression = Option.map (sub.expr sub) extended_expression;
+          extended_expression =
+            Option.map (fun (exp, ubr) -> (sub.expr sub exp, ubr)) extended_expression;
           alloc_mode
         }
-    | Texp_field (exp, lid, ld, float) ->
-        Texp_field (sub.expr sub exp, map_loc sub lid, ld, float)
+    | Texp_field (exp, lid, ld, float, ubr) ->
+        Texp_field (sub.expr sub exp, map_loc sub lid, ld, float, ubr)
     | Texp_setfield (exp1, am, lid, ld, exp2) ->
         Texp_setfield (
           sub.expr sub exp1,

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1789,7 +1789,7 @@ let build_or_pat env loc lid =
             let f = rf_either [ty] ~no_arg:false ~matched:true in
             (l, Some {pat_desc=Tpat_any; pat_loc=Location.none; pat_env=env;
                       pat_type=ty; pat_extra=[];
-                      pat_attributes=[]})
+                      pat_attributes=[];pat_unique_barrier=Unique_barrier.not_computed () })
             :: pats,
             (l, f) :: fields
         | _ -> pats, fields)
@@ -1809,7 +1809,8 @@ let build_or_pat env loc lid =
       (fun (l,p) ->
         {pat_desc=Tpat_variant(l,p,row'); pat_loc=gloc;
          pat_env=env; pat_type=ty;
-         pat_extra=[]; pat_attributes=[]})
+         pat_extra=[]; pat_attributes=[];
+         pat_unique_barrier=Unique_barrier.not_computed () })
       pats
   in
   match pats with
@@ -1823,7 +1824,7 @@ let build_or_pat env loc lid =
           (fun pat pat0 ->
             {pat_desc=Tpat_or(pat0,pat,Some row0); pat_extra=[];
              pat_loc=gloc; pat_env=env; pat_type=ty;
-             pat_attributes=[]})
+             pat_attributes=[]; pat_unique_barrier=Unique_barrier.not_computed () })
           pat pats in
       (path, rp { r with pat_loc = loc })
 
@@ -2529,7 +2530,8 @@ and type_pat_aux
       pat_loc = loc; pat_extra=[];
       pat_type = instance expected_ty;
       pat_attributes;
-      pat_env = !!penv }
+      pat_env = !!penv;
+      pat_unique_barrier = Unique_barrier.not_computed () }
   in
   let type_tuple_pat spl closed =
     (* CR layouts v5: consider sharing code with [type_unboxed_tuple_pat] below
@@ -2565,7 +2567,8 @@ and type_pat_aux
       pat_loc = loc; pat_extra=[];
       pat_type = newty (Ttuple (List.map (fun (lbl, p) -> lbl, p.pat_type) pl));
       pat_attributes = sp.ppat_attributes;
-      pat_env = !!penv }
+      pat_env = !!penv;
+      pat_unique_barrier = Unique_barrier.not_computed () }
   in
   let type_unboxed_tuple_pat spl closed =
     Jane_syntax_parsing.assert_extension_enabled ~loc Layouts
@@ -2605,7 +2608,8 @@ and type_pat_aux
       pat_loc = loc; pat_extra=[];
       pat_type = ty;
       pat_attributes = sp.ppat_attributes;
-      pat_env = !!penv }
+      pat_env = !!penv;
+      pat_unique_barrier = Unique_barrier.not_computed () }
   in
   match Jane_syntax.Pattern.of_ast sp with
   | Some (jpat, attrs) -> begin
@@ -2625,7 +2629,8 @@ and type_pat_aux
         pat_loc = loc; pat_extra=[];
         pat_type = instance expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !!penv }
+        pat_env = !!penv;
+        pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_var name ->
       let ty = instance expected_ty in
       let alloc_mode =
@@ -2639,7 +2644,8 @@ and type_pat_aux
         pat_loc = loc; pat_extra=[];
         pat_type = ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !!penv }
+        pat_env = !!penv;
+        pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_unpack name ->
       let t = instance expected_ty in
       begin match name.txt with
@@ -2650,7 +2656,8 @@ and type_pat_aux
             pat_extra=[Tpat_unpack, name.loc, sp.ppat_attributes];
             pat_type = t;
             pat_attributes = [];
-            pat_env = !!penv }
+            pat_env = !!penv;
+            pat_unique_barrier = Unique_barrier.not_computed () }
       | Some s ->
           let v = { name with txt = s } in
           (* We're able to pass ~is_module:true here without an error because
@@ -2664,7 +2671,8 @@ and type_pat_aux
             pat_extra=[Tpat_unpack, loc, sp.ppat_attributes];
             pat_type = t;
             pat_attributes = [];
-            pat_env = !!penv }
+            pat_env = !!penv;
+            pat_unique_barrier = Unique_barrier.not_computed () }
       end
   | Ppat_alias(sq, name) ->
       let q = type_pat tps Value sq expected_ty in
@@ -2678,7 +2686,8 @@ and type_pat_aux
             pat_loc = loc; pat_extra=[];
             pat_type = q.pat_type;
             pat_attributes = sp.ppat_attributes;
-            pat_env = !!penv }
+            pat_env = !!penv;
+            pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_constant cst ->
       let cst = constant_or_raise !!penv loc cst in
       rvp @@ solve_expected {
@@ -2686,7 +2695,8 @@ and type_pat_aux
         pat_loc = loc; pat_extra=[];
         pat_type = type_constant cst;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !!penv }
+        pat_env = !!penv;
+        pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_interval (Pconst_char c1, Pconst_char c2) ->
       let open Ast_helper.Pat in
       let gloc = Location.ghostify loc in
@@ -2811,7 +2821,8 @@ and type_pat_aux
             pat_loc = loc; pat_extra=[];
             pat_type = instance expected_ty;
             pat_attributes = sp.ppat_attributes;
-            pat_env = !!penv }
+            pat_env = !!penv;
+            pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_variant(tag, sarg) ->
       assert (tag <> Parmatch.some_private_tag);
       let constant = (sarg = None) in
@@ -2828,7 +2839,8 @@ and type_pat_aux
         pat_loc = loc; pat_extra = [];
         pat_type = pat_type;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !!penv }
+        pat_env = !!penv;
+        pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_record(lid_sp_list, closed) ->
       assert (lid_sp_list <> []);
       let expected_type, record_ty =
@@ -2861,6 +2873,7 @@ and type_pat_aux
           pat_type = instance record_ty;
           pat_attributes = sp.ppat_attributes;
           pat_env = !!penv;
+          pat_unique_barrier = Unique_barrier.not_computed ();
         }
       in
       let lbl_a_list =
@@ -2927,7 +2940,8 @@ and type_pat_aux
            pat_loc = loc; pat_extra = [];
            pat_type = instance expected_ty;
            pat_attributes = sp.ppat_attributes;
-           pat_env = !!penv }
+           pat_env = !!penv;
+           pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_lazy sp1 ->
       submode ~loc ~env:!!penv alloc_mode.mode mode_force_lazy;
       let nv = solve_Ppat_lazy ~refine:false loc penv expected_ty in
@@ -2938,7 +2952,8 @@ and type_pat_aux
         pat_loc = loc; pat_extra=[];
         pat_type = instance expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !!penv }
+        pat_env = !!penv;
+        pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_constraint(sp_constrained, sty, ms) ->
       (* Pretend separate = true *)
       begin match sty with
@@ -2980,6 +2995,7 @@ and type_pat_aux
         pat_type = expected_ty;
         pat_env = !!penv;
         pat_attributes = sp.ppat_attributes;
+        pat_unique_barrier = Unique_barrier.not_computed ();
       }
   | Ppat_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
@@ -3312,7 +3328,8 @@ let rec check_counter_example_pat
   (* "make pattern" and "make pattern then continue" *)
   let mp ?(pat_type = expected_ty) desc =
     { pat_desc = desc; pat_loc = loc; pat_extra=[];
-      pat_type = instance pat_type; pat_attributes = []; pat_env = !!penv } in
+      pat_type = instance pat_type; pat_attributes = []; pat_env = !!penv;
+      pat_unique_barrier = Unique_barrier.not_computed () } in
   let mkp k ?pat_type desc = k (mp ?pat_type desc) in
   let must_backtrack_on_gadt =
     match info.splitting_mode with
@@ -3966,8 +3983,8 @@ let rec is_nonexpansive exp =
                lbl.lbl_mut = Immutable && is_nonexpansive exp
            | Kept _ -> true)
         fields
-      && is_nonexpansive_opt extended_expression
-  | Texp_field(exp, _, _, _) -> is_nonexpansive exp
+      && is_nonexpansive_opt (Option.map fst extended_expression)
+  | Texp_field(exp, _, _, _, _) -> is_nonexpansive exp
   | Texp_ifthenelse(_cond, ifso, ifnot) ->
       is_nonexpansive ifso && is_nonexpansive_opt ifnot
   | Texp_sequence (_e1, _jkind, e2) -> is_nonexpansive e2  (* PR#4354 *)
@@ -5732,7 +5749,8 @@ and type_expect_
                 end
             in
             let label_definitions = Array.map unify_kept lbl.lbl_all in
-            Some {exp with exp_type = ty_exp}, label_definitions
+            let ubr = Unique_barrier.not_computed () in
+            Some ({exp with exp_type = ty_exp}, ubr), label_definitions
       in
       let num_fields =
         match lbl_exp_list with [] -> assert false
@@ -5751,7 +5769,7 @@ and type_expect_
         exp_desc = Texp_record {
             fields; representation;
             extended_expression = opt_exp;
-            alloc_mode
+            alloc_mode;
           };
         exp_loc = loc; exp_extra = [];
         exp_type = instance ty_expected;
@@ -5801,7 +5819,7 @@ and type_expect_
           Non_boxing uu
       in
       rue {
-        exp_desc = Texp_field(record, lid, label, boxing);
+        exp_desc = Texp_field(record, lid, label, boxing, Unique_barrier.not_computed ());
         exp_loc = loc; exp_extra = [];
         exp_type = ty_arg;
         exp_attributes = sexp.pexp_attributes;
@@ -6487,7 +6505,7 @@ and type_expect_
       | Texp_variant (_, Some (_, alloc_mode))
       | Texp_record {alloc_mode = Some alloc_mode; _}
       | Texp_array (_, _, _, alloc_mode)
-      | Texp_field (_, _, _, Boxing (alloc_mode, _)) ->
+      | Texp_field (_, _, _, Boxing (alloc_mode, _), _) ->
         begin match Locality.submode Locality.local
           (Alloc.proj (Comonadic Areality) alloc_mode.mode) with
         | Ok () -> ()
@@ -7520,7 +7538,8 @@ and type_argument ?explanation ?recarg env (mode : expected_mode) sarg
          pat_type = ty;
          pat_extra=[];
          pat_attributes = [];
-         pat_loc = Location.none; pat_env = env},
+         pat_loc = Location.none; pat_env = env;
+         pat_unique_barrier = Unique_barrier.not_computed () },
         {exp_type = ty; exp_loc = Location.none; exp_env = exp_env;
          exp_extra = []; exp_attributes = [];
          exp_desc =

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -50,7 +50,44 @@ type _ pattern_category =
 | Value : value pattern_category
 | Computation : computation pattern_category
 
-type unique_barrier = Mode.Uniqueness.r
+module Unique_barrier = struct
+  (* For added safety, we record the states in the life of a barrier:
+     - Barriers start out as Not_computed
+     - They are enabled by the uniqueness analysis
+     - They are resolved in translcore
+    This allows us to error if the barrier is not enabled or resolved. *)
+  type barrier =
+    | Enabled of Mode.Uniqueness.lr
+    | Resolved of Mode.Uniqueness.Const.t
+    | Not_computed
+
+  type t = barrier ref
+
+  let not_computed () = ref Not_computed
+
+  let enable barrier = match !barrier with
+    | Not_computed ->
+      barrier := Enabled (Uniqueness.newvar ())
+    | _ -> Misc.fatal_error "Unique barrier was enabled twice"
+
+  (* Due to or-patterns a barrier may have several upper bounds. *)
+  let add_upper_bound uniq barrier =
+    match !barrier with
+    | Enabled barrier -> Uniqueness.submode_exn barrier uniq
+    | _ -> Misc.fatal_error "Unique barrier got an upper bound in the wrong state"
+
+  let resolve barrier =
+    match !barrier with
+    | Enabled uniq ->
+      let zapped = Uniqueness.zap_to_ceil uniq in
+      barrier := Resolved zapped;
+      zapped
+    | Resolved barrier -> barrier
+    | Not_computed ->
+      if Language_extension.is_enabled Unique then
+        Misc.fatal_error "A unique barrier was not enabled by the analysis"
+      else Uniqueness.Const.Aliased
+end
 
 type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
@@ -77,6 +114,7 @@ and 'a pattern_data =
     pat_type: type_expr;
     pat_env: Env.t;
     pat_attributes: attribute list;
+    pat_unique_barrier : Unique_barrier.t;
    }
 
 and pat_extra =
@@ -168,11 +206,12 @@ and expression_desc =
   | Texp_record of {
       fields : ( Types.label_description * record_label_definition ) array;
       representation : Types.record_representation;
-      extended_expression : expression option;
+      extended_expression : (expression * Unique_barrier.t) option;
       alloc_mode : alloc_mode option
     }
   | Texp_field of
-      expression * Longident.t loc * label_description * texp_field_boxing
+      expression * Longident.t loc * label_description * texp_field_boxing *
+        Unique_barrier.t
   | Texp_setfield of
       expression * Mode.Locality.l * Longident.t loc * label_description * expression
   | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode
@@ -854,6 +893,7 @@ let as_computation_pattern (p : pattern) : computation general_pattern =
     pat_type = p.pat_type;
     pat_env = p.pat_env;
     pat_attributes = [];
+    pat_unique_barrier = p.pat_unique_barrier;
   }
 
 let function_arity params body =
@@ -1192,7 +1232,7 @@ let rec exp_is_nominal exp =
   | Texp_variant (_, None)
   | Texp_construct (_, _, [], _) ->
       true
-  | Texp_field (parent, _, _, _) | Texp_send (parent, _, _) ->
+  | Texp_field (parent, _, _, _, _) | Texp_send (parent, _, _) ->
       exp_is_nominal parent
   | _ -> false
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -62,12 +62,25 @@ type _ pattern_category =
 | Value : value pattern_category
 | Computation : computation pattern_category
 
-(* CR zqian: use this field when overwriting is supported. *)
-(** Access mode for a field projection, represented by the usage of the record
-  immediately following the projection. If the following usage is unique, the
-  projection must be borrowed and cannot be moved. If the following usage is
-  aliased, the projection can be aliased and moved. *)
-type unique_barrier = Mode.Uniqueness.r
+(** A unique barrier annotates field accesses (eg. Texp_field and patterns)
+    with the uniqueness mode of the allocation that is projected out of.
+    Projections out of unique allocations may not be pushed down in later
+    stages of the compiler, because the unique allocation may be overwritten. *)
+module Unique_barrier : sig
+  type t
+
+  (* Barriers start out as not computed. *)
+  val not_computed : unit -> t
+
+  (* The uniqueness analysis enables all barriers. *)
+  val enable : t -> unit
+
+  (* Record an upper bound on the uniqueness of the record. *)
+  val add_upper_bound : Mode.Uniqueness.r -> t -> unit
+
+  (* Resolve the unique barrier once type-checking is complete. *)
+  val resolve : t -> Mode.Uniqueness.Const.t
+end
 
 type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
@@ -96,6 +109,9 @@ and 'a pattern_data =
     pat_type: Types.type_expr;
     pat_env: Env.t;
     pat_attributes: attributes;
+    pat_unique_barrier : Unique_barrier.t;
+    (** This tracks whether the scrutinee of the pattern is used uniquely
+        within the body of the pattern match. *)
    }
 
 and pat_extra =
@@ -359,7 +375,7 @@ and expression_desc =
   | Texp_record of {
       fields : ( Types.label_description * record_label_definition ) array;
       representation : Types.record_representation;
-      extended_expression : expression option;
+      extended_expression : (expression * Unique_barrier.t) option;
       alloc_mode : alloc_mode option
     }
         (** { l1=P1; ...; ln=Pn }           (extended_expression = None)
@@ -377,7 +393,7 @@ and expression_desc =
             in which case it does not need allocation.
           *)
   | Texp_field of expression * Longident.t loc * Types.label_description *
-      texp_field_boxing
+      texp_field_boxing * Unique_barrier.t
     (** [texp_field_boxing] provides extra information depending on if the
         projection requires boxing. *)
   | Texp_setfield of

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -605,8 +605,9 @@ let expression sub exp =
             | _, Overridden (lid, exp) -> (lid, sub.expr sub exp) :: l)
             [] fields
         in
-        Pexp_record (list, Option.map (sub.expr sub) extended_expression)
-    | Texp_field (exp, lid, _label, _) ->
+        Pexp_record (list, Option.map (fun (exp, _) -> sub.expr sub exp)
+                             extended_expression)
+    | Texp_field (exp, lid, _label, _, _) ->
         Pexp_field (sub.expr sub exp, map_loc sub lid)
     | Texp_setfield (exp1, _, lid, _label, exp2) ->
         Pexp_setfield (sub.expr sub exp1, map_loc sub lid,

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -766,7 +766,7 @@ let rec expression : Typedtree.expression -> term_judg =
         in
         join [
           array field es;
-          option expression eo << Dereference
+          option expression (Option.map fst eo) << Dereference
         ]
     | Texp_ifthenelse (cond, ifso, ifnot) ->
       (*
@@ -832,7 +832,7 @@ let rec expression : Typedtree.expression -> term_judg =
       join [
         expression e1 << Dereference
       ]
-    | Texp_field (e, _, _, _) ->
+    | Texp_field (e, _, _, _, _) ->
       (*
         G |- e: m[Dereference]
         -----------------------


### PR DESCRIPTION
@goldfirere and I discussed today that we would like to have the full unique barrier information on `main` before we make uniqueness stable. While it is unlikely that users could actually exploit the bad behaviour around pushing down projections with just uniqueness (and not overwriting), it might be possible and we would like to be on the safe side.

This PR cherry-picks the merge commit of #3066, which was fully reviewed by @goldfirere.