### PR TITLE
Rebase "Support for or_null in Flambda2"

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1579,7 +1579,7 @@ module Extended_machtype = struct
     | Punboxed_int _ ->
       (* Only 64-bit architectures, so this is always [typ_int] *)
       typ_any_int
-    | Pvalue Pintval -> typ_tagged_int
+    | Pvalue { raw_kind = Pintval; _ } -> typ_tagged_int
     | Pvalue _ -> typ_val
     | Punboxed_product fields -> Array.concat (List.map of_layout fields)
 end
@@ -4098,10 +4098,10 @@ let cmm_arith_size (e : Cmm.expression) =
 
 let kind_of_layout (layout : Lambda.layout) =
   match layout with
-  | Pvalue (Pboxedfloatval bf) -> Boxed_float bf
-  | Pvalue (Pboxedintval bi) -> Boxed_integer bi
-  | Pvalue (Pboxedvectorval vi) -> Boxed_vector vi
-  | Pvalue (Pgenval | Pintval | Pvariant _ | Parrayval _)
+  | Pvalue { raw_kind = Pboxedfloatval bf; _ } -> Boxed_float bf
+  | Pvalue { raw_kind = Pboxedintval bi; _ } -> Boxed_integer bi
+  | Pvalue { raw_kind = Pboxedvectorval vi; _ } -> Boxed_vector vi
+  | Pvalue { raw_kind = (Pgenval | Pintval | Pvariant _ | Parrayval _); _ }
   | Ptop | Pbottom | Punboxed_float _ | Punboxed_int _ | Punboxed_vector _
   | Punboxed_product _ ->
     Any

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4101,7 +4101,7 @@ let kind_of_layout (layout : Lambda.layout) =
   | Pvalue { raw_kind = Pboxedfloatval bf; _ } -> Boxed_float bf
   | Pvalue { raw_kind = Pboxedintval bi; _ } -> Boxed_integer bi
   | Pvalue { raw_kind = Pboxedvectorval vi; _ } -> Boxed_vector vi
-  | Pvalue { raw_kind = (Pgenval | Pintval | Pvariant _ | Parrayval _); _ }
+  | Pvalue { raw_kind = Pgenval | Pintval | Pvariant _ | Parrayval _; _ }
   | Ptop | Pbottom | Punboxed_float _ | Punboxed_int _ | Punboxed_vector _
   | Punboxed_product _ ->
     Any

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -384,7 +384,19 @@ and array_index_kind =
   | Ptagged_int_index
   | Punboxed_int_index of unboxed_integer
 
+(** [Nullable] value kinds allow the special Null value in addition to the
+    values of its underlying type. [Non_nullable] only allows values of the
+    underlying type. *)
+and nullable =
+  | Nullable
+  | Non_nullable
+
 and value_kind =
+  { raw_kind : value_kind_non_null;
+    nullable : nullable;
+  }
+
+and value_kind_non_null =
   | Pgenval
   | Pintval
   | Pboxedfloatval of boxed_float
@@ -500,6 +512,8 @@ val compare_boxed_vector : boxed_vector -> boxed_vector -> int
 val print_boxed_vector : Format.formatter -> boxed_vector -> unit
 
 val must_be_value : layout -> value_kind
+
+val generic_value : value_kind
 
 (* This is the layout of ocaml values used as arguments to or returned from
    primitives for this [extern_repr].  So the legacy [Unboxed_float] - which is

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -171,37 +171,59 @@ let tag_and_constructor_shape print_value_kind ppf (tag, shape) =
     (constructor_shape print_value_kind)
     shape
 
-let variant_kind print_value_kind ppf ~consts ~non_consts =
-  fprintf ppf "@[<hov 1>[(consts (%a))@ (non_consts (%a))]@]"
+let variant_kind or_null_suffix print_value_kind ppf ~consts ~non_consts =
+  fprintf ppf "@[<hov 1>[(consts (%a))@ (non_consts (%a))%s]@]"
     (Format.pp_print_list ~pp_sep:Format.pp_print_space Format.pp_print_int)
     consts
     (Format.pp_print_list ~pp_sep:Format.pp_print_space
       (tag_and_constructor_shape print_value_kind))
     non_consts
+    or_null_suffix
 
-let rec value_kind ppf = function
+let value_kind print_value_kind_non_null ppf vk =
+  let or_null_suffix =
+    match vk.nullable with
+    | Non_nullable -> ""
+    | Nullable -> " or_null"
+  in
+  print_value_kind_non_null or_null_suffix ppf vk.raw_kind
+
+let rec value_kind_non_null or_null_suffix ppf = function
   | Pgenval -> ()
-  | Pintval -> fprintf ppf "[int]"
-  | Pboxedfloatval bf -> fprintf ppf "[%s]" (boxed_float_name bf)
-  | Parrayval elt_kind -> fprintf ppf "[%sarray]" (array_kind elt_kind)
-  | Pboxedintval bi -> fprintf ppf "[%s]" (boxed_integer_name bi)
-  | Pboxedvectorval bv -> fprintf ppf "[%s]" (boxed_vector_name bv)
+  | Pintval -> fprintf ppf "[int%s]" or_null_suffix
+  | Pboxedfloatval bf ->
+    fprintf ppf "[%s%s]" (boxed_float_name bf) or_null_suffix
+  | Parrayval elt_kind ->
+    fprintf ppf "[%sarray%s]" (array_kind elt_kind) or_null_suffix
+  | Pboxedintval bi ->
+    fprintf ppf "[%s%s]" (boxed_integer_name bi) or_null_suffix
+  | Pboxedvectorval bv ->
+    fprintf ppf "[%s%s]" (boxed_vector_name bv) or_null_suffix
   | Pvariant { consts; non_consts; } ->
-    variant_kind value_kind' ppf ~consts ~non_consts
+    variant_kind or_null_suffix (value_kind value_kind_non_null')
+      ppf ~consts ~non_consts
 
-and value_kind' ppf = function
+and value_kind_non_null' or_null_suffix ppf = function
   | Pgenval -> fprintf ppf "*"
-  | Pintval -> fprintf ppf "[int]"
-  | Pboxedfloatval bf -> fprintf ppf "[%s]" (boxed_float_name bf)
-  | Parrayval elt_kind -> fprintf ppf "[%sarray]" (array_kind elt_kind)
-  | Pboxedintval bi -> fprintf ppf "[%s]" (boxed_integer_name bi)
-  | Pboxedvectorval bv -> fprintf ppf "[%s]" (boxed_vector_name bv)
+  | Pintval -> fprintf ppf "[int%s]" or_null_suffix
+  | Pboxedfloatval bf ->
+    fprintf ppf "[%s%s]" (boxed_float_name bf) or_null_suffix
+  | Parrayval elt_kind ->
+    fprintf ppf "[%sarray%s]" (array_kind elt_kind) or_null_suffix
+  | Pboxedintval bi ->
+    fprintf ppf "[%s%s]" (boxed_integer_name bi) or_null_suffix
+  | Pboxedvectorval bv ->
+    fprintf ppf "[%s%s]" (boxed_vector_name bv) or_null_suffix
   | Pvariant { consts; non_consts; } ->
-    variant_kind value_kind' ppf ~consts ~non_consts
+    variant_kind or_null_suffix (value_kind value_kind_non_null')
+      ppf ~consts ~non_consts
 
 let rec layout' is_top ppf layout_ =
   match layout_ with
-  | Pvalue k -> (if is_top then value_kind else value_kind') ppf k
+  | Pvalue k ->
+    (if is_top then value_kind value_kind_non_null
+     else value_kind value_kind_non_null')
+      ppf k
   | Ptop -> fprintf ppf "[top]"
   | Pbottom -> fprintf ppf "[bottom]"
   | Punboxed_float bf -> fprintf ppf "[unboxed_%s]" (boxed_float_name bf)
@@ -217,17 +239,28 @@ let layout ppf layout_ = layout' true ppf layout_
 let return_kind ppf (mode, kind) =
   let smode = locality_mode_if_local mode in
   match kind with
-  | Pvalue Pgenval when is_heap_mode mode -> ()
-  | Pvalue Pgenval -> fprintf ppf ": %s@ " smode
-  | Pvalue Pintval -> fprintf ppf ": int@ "
-  | Pvalue (Pboxedfloatval bf) ->
-     fprintf ppf ": %s%s@ " smode (boxed_float_name bf)
-  | Pvalue (Parrayval elt_kind) ->
-     fprintf ppf ": %s%sarray@ " smode (array_kind elt_kind)
-  | Pvalue (Pboxedintval bi) -> fprintf ppf ": %s%s@ " smode (boxed_integer_name bi)
-  | Pvalue (Pboxedvectorval bv) -> fprintf ppf ": %s%s@ " smode (boxed_vector_name bv)
-  | Pvalue (Pvariant { consts; non_consts; }) ->
-    variant_kind value_kind' ppf ~consts ~non_consts
+  | Pvalue { raw_kind; nullable } -> begin
+    let or_null_suffix =
+      match nullable with
+      | Non_nullable -> ""
+      | Nullable -> " or_null"
+    in
+    match raw_kind with
+    | Pgenval when is_heap_mode mode -> ()
+    | Pgenval -> fprintf ppf ": %s@ " smode
+    | Pintval -> fprintf ppf ": int@ "
+    | Pboxedfloatval bf ->
+      fprintf ppf ": %s%s%s@ " smode (boxed_float_name bf) or_null_suffix
+    | Parrayval elt_kind ->
+      fprintf ppf ": %s%sarray%s@ " smode (array_kind elt_kind) or_null_suffix
+    | Pboxedintval bi ->
+      fprintf ppf ": %s%s%s@ " smode (boxed_integer_name bi) or_null_suffix
+    | Pboxedvectorval bv ->
+      fprintf ppf ": %s%s%s@ " smode (boxed_vector_name bv) or_null_suffix
+    | Pvariant { consts; non_consts; } ->
+      variant_kind or_null_suffix (value_kind value_kind_non_null')
+        ppf ~consts ~non_consts
+  end
   | Punboxed_float bf -> fprintf ppf ": unboxed_%s@ " (boxed_float_name bf)
   | Punboxed_int bi -> fprintf ppf ": unboxed_%s@ " (boxed_integer_name bi)
   | Punboxed_vector bv -> fprintf ppf ": unboxed_%s@ " (boxed_vector_name bv)
@@ -235,20 +268,27 @@ let return_kind ppf (mode, kind) =
   | Ptop -> fprintf ppf ": top@ "
   | Pbottom -> fprintf ppf ": bottom@ "
 
-let field_kind ppf = function
+let field_kind_non_null or_null_suffix ppf = function
   | Pgenval -> pp_print_string ppf "*"
-  | Pintval -> pp_print_string ppf "int"
-  | Pboxedfloatval bf -> pp_print_string ppf (boxed_float_name bf)
-  | Parrayval elt_kind -> fprintf ppf "%s-array" (array_kind elt_kind)
-  | Pboxedintval bi -> pp_print_string ppf (boxed_integer_name bi)
-  | Pboxedvectorval bv -> pp_print_string ppf (boxed_vector_name bv)
+  | Pintval -> fprintf ppf "int%s" or_null_suffix
+  | Pboxedfloatval bf ->
+    fprintf ppf "%s%s" (boxed_float_name bf) or_null_suffix
+  | Parrayval elt_kind ->
+    fprintf ppf "%s-array%s" (array_kind elt_kind) or_null_suffix
+  | Pboxedintval bi ->
+    fprintf ppf "%s%s" (boxed_integer_name bi) or_null_suffix
+  | Pboxedvectorval bv ->
+    fprintf ppf "%s%s" (boxed_vector_name bv) or_null_suffix
   | Pvariant { consts; non_consts; } ->
-    fprintf ppf "@[<hov 1>[(consts (%a))@ (non_consts (%a))]@]"
+    fprintf ppf "@[<hov 1>[(consts (%a))@ (non_consts (%a))%s]@]"
       (Format.pp_print_list ~pp_sep:Format.pp_print_space Format.pp_print_int)
       consts
       (Format.pp_print_list ~pp_sep:Format.pp_print_space
-        (tag_and_constructor_shape value_kind'))
+        (tag_and_constructor_shape (value_kind value_kind_non_null')))
       non_consts
+      or_null_suffix
+
+let field_kind = value_kind field_kind_non_null
 
 let locality_kind = function
   | Alloc_heap -> ""
@@ -326,7 +366,7 @@ let record_rep ppf r = match r with
 
 let block_shape ppf shape = match shape with
   | None | Some [] -> ()
-  | Some l when List.for_all ((=) Pgenval) l -> ()
+  | Some l when List.for_all ((=) Lambda.generic_value) l -> ()
   | Some [elt] ->
       Format.fprintf ppf " (%a)" field_kind elt
   | Some (h :: t) ->
@@ -1296,3 +1336,9 @@ let structured_constant = struct_const
 let lambda = lam
 
 let program ppf { code } = lambda ppf code
+
+let value_kind' = value_kind value_kind_non_null'
+
+let value_kind = value_kind value_kind_non_null
+
+let variant_kind = variant_kind ""

--- a/lambda/transl_array_comprehension.ml
+++ b/lambda/transl_array_comprehension.ml
@@ -241,10 +241,7 @@ end = struct
        don't have to bind them first to avoid extra computation. *)
     Let_binding.let_one product
       (Lifthenelse
-         ( product.var / y = x,
-           product.var,
-           raise_overflow_exn ~loc,
-           layout_int ))
+         (product.var / y = x, product.var, raise_overflow_exn ~loc, layout_int))
 
   (** [safe_product_pos_vals ~loc xs] generates the lambda expression that
       computes the product of all the lambda values in [xs] assuming they are
@@ -556,7 +553,7 @@ let clause ~transl_exp ~scopes ~loc = function
         ( transl_exp ~scopes Jkind.Sort.for_predef_value cond,
           body,
           lambda_unit,
-          layout_unit)
+          layout_unit )
 
 (** The [array_sizing] type describes whether an array comprehension has been
     translated using the fixed-size array optimization ([Fixed_size]), or it has
@@ -796,7 +793,7 @@ let body ~loc ~array_kind ~array_size ~array_sizing ~array ~index ~body =
               Lsequence
                 ( Lassign (array_size.id, i 2 * array_size.var),
                   Lassign (array.id, Resizable_array.double ~loc array.var) ),
-              layout_unit),
+              layout_unit ),
           (* ...and then set the element now that the array is big enough *)
           set_element_raw elt )
   in

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -34,7 +34,7 @@ let layout_t = layout_any_value
 let layout_obj = layout_array Pgenarray
 let layout_table = layout_block
 let layout_meth = layout_any_value
-let layout_tables = Lambda.Pvalue Pgenval
+let layout_tables = layout_any_value
 
 
 let lfunction ?(kind=Curried {nlocal=0}) ?(region=true) ?(ret_mode=alloc_heap) return_layout params body =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -595,7 +595,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                         Lambda.must_be_value (layout_exp sort e))
                       args_with_sorts
                   in
-                  Pmakeblock(0, Immutable, Some (Pgenval :: shape),
+                  Pmakeblock(0, Immutable, Some (Lambda.generic_value :: shape),
                             alloc_mode)
               | Constructor_mixed shape ->
                   let shape = Lambda.transl_mixed_product_shape shape in
@@ -1467,8 +1467,10 @@ and transl_tupled_function
             cases in
         let kinds =
           match arg_layout with
-          | Pvalue (Pvariant { consts = [];
-                               non_consts = [0, Constructor_uniform kinds] }) ->
+          | Pvalue {
+              nullable = Non_nullable;
+              raw_kind = Pvariant { consts = [];
+                               non_consts = [0, Constructor_uniform kinds] }} ->
               (* CR layouts v5: to change when we have non-value tuple
                  elements. *)
               List.map (fun vk -> Pvalue vk) kinds
@@ -1640,7 +1642,7 @@ and transl_curried_function ~scopes loc repr params body
         in
         (* we return Pgenval (for a function) after the rightmost chunk *)
         { body;
-          return_layout = Pvalue Pgenval;
+          return_layout = Lambda.layout_function;
           return_mode = if enclosing_region then alloc_heap else alloc_local;
           nlocal = enclosing_nlocal;
           region = enclosing_region;
@@ -1945,7 +1947,10 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                           Constructor_uniform_value, Variant_extensible) ->
             let shape = List.map must_be_value shape in
             let slot = transl_extension_path loc env path in
-            Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape), Option.get mode),
+            Lprim(Pmakeblock(0,
+                             mut,
+                             Some (Lambda.generic_value :: shape),
+                             Option.get mode),
                   slot :: ll, loc)
         | Record_inlined (Extension _, _, (Variant_unboxed | Variant_boxed _))
         | Record_inlined (Ordinary _, _, Variant_extensible) ->

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1136,7 +1136,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
                                   Jkind.Sort.for_block_element typ))
           fields
       in
-      let useful = List.exists (fun knd -> knd <> Pgenval) shape in
+      let useful = List.exists (fun knd -> knd <> Lambda.generic_value) shape in
       if useful then
         Some (Primitive (Pmakeblock(tag, mut, Some shape, mode),arity))
       else None

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -717,7 +717,7 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
       call args prim_native_repr_args []
   in
   let wrap_c_call acc ~handler_param ~code_after_call c_call =
-    let return_kind = Flambda_kind.With_subkind.create return_kind Anything in
+    let return_kind = Flambda_kind.With_subkind.create return_kind Anything Nullable in
     let params =
       [BP.create handler_param return_kind] |> Bound_parameters.create
     in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -717,9 +717,7 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
       call args prim_native_repr_args []
   in
   let wrap_c_call acc ~handler_param ~code_after_call c_call =
-    let return_kind =
-      Flambda_kind.With_subkind.create return_kind Anything Nullable
-    in
+    let return_kind = Flambda_kind.With_subkind.anything return_kind in
     let params =
       [BP.create handler_param return_kind] |> Bound_parameters.create
     in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -717,7 +717,9 @@ let close_c_call acc env ~loc ~let_bound_ids_with_kinds
       call args prim_native_repr_args []
   in
   let wrap_c_call acc ~handler_param ~code_after_call c_call =
-    let return_kind = Flambda_kind.With_subkind.create return_kind Anything Nullable in
+    let return_kind =
+      Flambda_kind.With_subkind.create return_kind Anything Nullable
+    in
     let params =
       [BP.create handler_param return_kind] |> Bound_parameters.create
     in

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1640,17 +1640,26 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
   let unboxing_kind (layout : Lambda.layout) :
       Function_decl.unboxing_kind option =
     match[@warning "-fragile-match"] layout with
-    | Pvalue { nullable = Non_nullable; raw_kind =
-        (Pvariant
-          { consts = []; non_consts = [(0, Constructor_uniform field_kinds)] })}
-      ->
+    | Pvalue
+        { nullable = Non_nullable;
+          raw_kind =
+            Pvariant
+              { consts = [];
+                non_consts = [(0, Constructor_uniform field_kinds)]
+              }
+        } ->
       Some
         (Fields_of_block_with_tag_zero
            (List.map Flambda_kind.With_subkind.from_lambda_value_kind
               field_kinds))
-    | Pvalue { nullable = Non_nullable; raw_kind =
-        (Pvariant
-          { consts = []; non_consts = [(tag, Constructor_uniform field_kinds)] })}
+    | Pvalue
+        { nullable = Non_nullable;
+          raw_kind =
+            Pvariant
+              { consts = [];
+                non_consts = [(tag, Constructor_uniform field_kinds)]
+              }
+        }
       when tag = Obj.double_array_tag ->
       assert (
         List.for_all
@@ -1663,8 +1672,10 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
               false)
           field_kinds);
       Some (Unboxed_float_record (List.length field_kinds))
-    | Pvalue { nullable = Non_nullable; raw_kind = Pboxedfloatval Pfloat64 } -> Some (Unboxed_number Naked_float)
-    | Pvalue { nullable = Non_nullable; raw_kind = Pboxedfloatval Pfloat32 } -> Some (Unboxed_number Naked_float32)
+    | Pvalue { nullable = Non_nullable; raw_kind = Pboxedfloatval Pfloat64 } ->
+      Some (Unboxed_number Naked_float)
+    | Pvalue { nullable = Non_nullable; raw_kind = Pboxedfloatval Pfloat32 } ->
+      Some (Unboxed_number Naked_float32)
     | Pvalue { nullable = Non_nullable; raw_kind = Pboxedintval bi } ->
       let bn : Flambda_kind.Boxable_number.t =
         match bi with
@@ -1678,7 +1689,10 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
         match bv with Pvec128 -> Naked_vec128
       in
       Some (Unboxed_number bn)
-    | Pvalue { nullable = Non_nullable; raw_kind = (Pgenval | Pintval | Pvariant _ | Parrayval _) }
+    | Pvalue
+        { nullable = Non_nullable;
+          raw_kind = Pgenval | Pintval | Pvariant _ | Parrayval _
+        }
     | Pvalue { nullable = Nullable; raw_kind = _ }
     | Ptop | Pbottom | Punboxed_float _ | Punboxed_int _ | Punboxed_vector _
     | Punboxed_product _ ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1640,22 +1640,22 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
   let unboxing_kind (layout : Lambda.layout) :
       Function_decl.unboxing_kind option =
     match[@warning "-fragile-match"] layout with
-    | Pvalue
+    | Pvalue { nullable = Non_nullable; raw_kind =
         (Pvariant
-          { consts = []; non_consts = [(0, Constructor_uniform field_kinds)] })
+          { consts = []; non_consts = [(0, Constructor_uniform field_kinds)] })}
       ->
       Some
         (Fields_of_block_with_tag_zero
            (List.map Flambda_kind.With_subkind.from_lambda_value_kind
               field_kinds))
-    | Pvalue
+    | Pvalue { nullable = Non_nullable; raw_kind =
         (Pvariant
-          { consts = []; non_consts = [(tag, Constructor_uniform field_kinds)] })
+          { consts = []; non_consts = [(tag, Constructor_uniform field_kinds)] })}
       when tag = Obj.double_array_tag ->
       assert (
         List.for_all
           (fun (kind : Lambda.value_kind) ->
-            match kind with
+            match kind.raw_kind with
             | Pboxedfloatval Pfloat64 -> true
             | Pboxedfloatval Pfloat32
             | Pgenval | Pintval | Pboxedintval _ | Pvariant _ | Parrayval _
@@ -1663,9 +1663,9 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
               false)
           field_kinds);
       Some (Unboxed_float_record (List.length field_kinds))
-    | Pvalue (Pboxedfloatval Pfloat64) -> Some (Unboxed_number Naked_float)
-    | Pvalue (Pboxedfloatval Pfloat32) -> Some (Unboxed_number Naked_float32)
-    | Pvalue (Pboxedintval bi) ->
+    | Pvalue { nullable = Non_nullable; raw_kind = Pboxedfloatval Pfloat64 } -> Some (Unboxed_number Naked_float)
+    | Pvalue { nullable = Non_nullable; raw_kind = Pboxedfloatval Pfloat32 } -> Some (Unboxed_number Naked_float32)
+    | Pvalue { nullable = Non_nullable; raw_kind = Pboxedintval bi } ->
       let bn : Flambda_kind.Boxable_number.t =
         match bi with
         | Pint32 -> Naked_int32
@@ -1673,12 +1673,13 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
         | Pnativeint -> Naked_nativeint
       in
       Some (Unboxed_number bn)
-    | Pvalue (Pboxedvectorval bv) ->
+    | Pvalue { nullable = Non_nullable; raw_kind = Pboxedvectorval bv } ->
       let bn : Flambda_kind.Boxable_number.t =
         match bv with Pvec128 -> Naked_vec128
       in
       Some (Unboxed_number bn)
-    | Pvalue (Pgenval | Pintval | Pvariant _ | Parrayval _)
+    | Pvalue { nullable = Non_nullable; raw_kind = (Pgenval | Pintval | Pvariant _ | Parrayval _) }
+    | Pvalue { nullable = Nullable; raw_kind = _ }
     | Ptop | Pbottom | Punboxed_float _ | Punboxed_int _ | Punboxed_vector _
     | Punboxed_product _ ->
       Location.prerr_warning

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -1040,10 +1040,10 @@ module With_subkind = struct
 
   let equal_ignoring_subkind t1 t2 = equal (erase_subkind t1) (erase_subkind t2)
 
-  let must_be_gc_scannable t =
+  let must_be_gc_scannable (t : t) =
     match kind t with
     | Value -> (
-      match subkind t with
+      match t.value_subkind with
       | Tagged_immediate -> false
       | Anything | Boxed_float | Boxed_float32 | Boxed_int32 | Boxed_int64
       | Boxed_nativeint | Boxed_vec128 | Variant _ | Float_block _ | Float_array

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -81,7 +81,7 @@ let rec_info = Rec_info
 
 let to_lambda (t : t) : Lambda.layout =
   match t with
-  | Value -> Pvalue Pgenval
+  | Value -> Lambda.layout_any_value
   | Naked_number Naked_immediate ->
     Misc.fatal_error "Can't convert kind [Naked_immediate] to lambda layout"
   | Naked_number Naked_float -> Punboxed_float Pfloat64
@@ -537,7 +537,34 @@ module Boxable_number = struct
 end
 
 module With_subkind = struct
-  module Subkind = struct
+  module Nullable = struct
+    type t =
+      | Nullable
+      | Non_nullable
+
+    include Container_types.Make (struct
+      type nonrec t = t
+
+      let print ppf t =
+      match t with
+      | Nullable -> Format.fprintf ppf "|Null"
+      | Non_nullable -> ()
+
+      let compare t1 t2 =
+        match t1, t2 with
+        | Nullable, Nullable
+        | Non_nullable, Non_nullable ->
+          0
+        | Nullable, Non_nullable -> -1
+        | Non_nullable, Nullable -> 1
+
+      let equal t1 t2 = compare t1 t2 = 0
+
+      let hash = Hashtbl.hash
+    end)
+  end
+
+  module Non_null_value_subkind = struct
     type t =
       | Anything
       | Boxed_float32
@@ -550,7 +577,7 @@ module With_subkind = struct
       | Variant of
           { consts : Targetint_31_63.Set.t;
             non_consts :
-              (Block_shape.t * kind_and_subkind list) Tag.Scannable.Map.t
+              (Block_shape.t * full_kind list) Tag.Scannable.Map.t
           }
       | Float_block of { num_fields : int }
       | Float_array
@@ -563,9 +590,10 @@ module With_subkind = struct
       | Unboxed_nativeint_array
       | Unboxed_vec128_array
 
-    and kind_and_subkind =
+    and full_kind =
       { kind : kind;
-        subkind : t
+        value_subkind : t;
+        nullable : Nullable.t;
       }
 
     let rec compatible (t : t) ~(when_used_at : t) =
@@ -609,8 +637,8 @@ module With_subkind = struct
                 then false
                 else
                   List.for_all2
-                    (fun { kind = _; subkind = d }
-                         { kind = _; subkind = when_used_at } ->
+                    (fun { kind = _; value_subkind = d; nullable = _ }
+                         { kind = _; value_subkind = when_used_at; nullable = _ } ->
                       compatible d ~when_used_at)
                     fields1 fields2)
               field_lists1 field_lists2
@@ -669,7 +697,8 @@ module With_subkind = struct
           Format.fprintf ppf "%t=boxed_@<1>\u{2115}@<1>\u{1d54d}128%t" colour
             Flambda_colours.pop
         | Variant { consts; non_consts } ->
-          let print_field ppf { kind = _; subkind } = print ppf subkind in
+          (* CR vlaviron: print nullability *)
+          let print_field ppf { kind = _; value_subkind; nullable = _ } = print ppf value_subkind in
           Format.fprintf ppf "%t=Variant((consts (%a))@ (non_consts (%a)))%t"
             colour Targetint_31_63.Set.print consts
             (Tag.Scannable.Map.print (fun ppf (_shape, fields) ->
@@ -713,86 +742,86 @@ module With_subkind = struct
     end)
   end
 
-  type with_subkind = Subkind.kind_and_subkind
+  type full_kind = Non_null_value_subkind.full_kind
 
-  type t = with_subkind
+  type t = full_kind
 
-  let create (kind : kind) (subkind : Subkind.t) : t =
+  let create (kind : kind) (value_subkind : Non_null_value_subkind.t) (nullable : Nullable.t) : t =
     (match kind with
     | Value -> ()
     | Naked_number _ | Region | Rec_info -> (
-      match subkind with
-      | Anything -> ()
-      | Boxed_float | Boxed_float32 | Boxed_int32 | Boxed_int64
+      match value_subkind, nullable with
+      | Anything, Non_nullable -> ()
+      | (Boxed_float | Boxed_float32 | Boxed_int32 | Boxed_int64
       | Boxed_nativeint | Boxed_vec128 | Tagged_immediate | Variant _
       | Float_block _ | Float_array | Immediate_array | Value_array
       | Generic_array | Unboxed_float32_array | Unboxed_int32_array
-      | Unboxed_int64_array | Unboxed_nativeint_array | Unboxed_vec128_array ->
-        Misc.fatal_errorf "Subkind %a is not valid for kind %a" Subkind.print
-          subkind print kind));
-    { kind; subkind }
+      | Unboxed_int64_array | Unboxed_nativeint_array | Unboxed_vec128_array), _ ->
+        Misc.fatal_errorf "Subkind %a is not valid for kind %a" Non_null_value_subkind.print
+          value_subkind print kind
+      | _, Nullable ->
+        Misc.fatal_errorf "Kind %a cannot be Nullable" print kind));
+    { kind; value_subkind; nullable }
 
-  let anything kind = create kind Anything
+  let anything kind =
+    match kind with
+    | Value -> create kind Anything Nullable
+    | Naked_number _ | Region | Rec_info ->
+      create kind Anything Non_nullable
 
   let compatible (t : t) ~(when_used_at : t) =
     equal t.kind when_used_at.kind
-    && Subkind.compatible t.subkind ~when_used_at:when_used_at.subkind
+    && Non_null_value_subkind.compatible t.value_subkind ~when_used_at:when_used_at.value_subkind
 
   let kind (t : t) = t.kind
 
-  let subkind (t : t) = t.subkind
+  let non_null_value_subkind (t : t) = t.value_subkind
 
-  let any_value = create value Anything
+  let nullable (t : t) = t.nullable
 
-  let naked_immediate = create naked_immediate Anything
+  let any_value = create value Anything Nullable
 
-  let naked_float32 = create naked_float32 Anything
+  let naked_immediate = create naked_immediate Anything Non_nullable
 
-  let naked_float = create naked_float Anything
+  let naked_float32 = create naked_float32 Anything Non_nullable
 
-  let naked_int32 = create naked_int32 Anything
+  let naked_float = create naked_float Anything Non_nullable
 
-  let naked_int64 = create naked_int64 Anything
+  let naked_int32 = create naked_int32 Anything Non_nullable
 
-  let naked_nativeint = create naked_nativeint Anything
+  let naked_int64 = create naked_int64 Anything Non_nullable
 
-  let naked_vec128 = create naked_vec128 Anything
+  let naked_nativeint = create naked_nativeint Anything Non_nullable
 
-  let region = create region Anything
+  let naked_vec128 = create naked_vec128 Anything Non_nullable
 
-  let boxed_float32 = create value Boxed_float32
+  let region = create region Anything Non_nullable
 
-  let boxed_float = create value Boxed_float
+  let boxed_float32 = create value Boxed_float32 Non_nullable
 
-  let boxed_int32 = create value Boxed_int32
+  let boxed_float = create value Boxed_float Non_nullable
 
-  let boxed_int64 = create value Boxed_int64
+  let boxed_int32 = create value Boxed_int32 Non_nullable
 
-  let boxed_nativeint = create value Boxed_nativeint
+  let boxed_int64 = create value Boxed_int64 Non_nullable
 
-  let boxed_vec128 = create value Boxed_vec128
+  let boxed_nativeint = create value Boxed_nativeint Non_nullable
 
-  let tagged_immediate = create value Tagged_immediate
+  let boxed_vec128 = create value Boxed_vec128 Non_nullable
 
-  let rec_info = create rec_info Anything
+  let tagged_immediate = create value Tagged_immediate Non_nullable
 
-  let float_array = create value Float_array
+  let rec_info = create rec_info Anything Non_nullable
 
-  let immediate_array = create value Immediate_array
+  let float_array = create value Float_array Non_nullable
 
-  let value_array = create value Value_array
+  let immediate_array = create value Immediate_array Non_nullable
 
-  let generic_array = create value Generic_array
+  let value_array = create value Value_array Non_nullable
 
-  let unboxed_float32_array = create value Unboxed_float32_array
+  let generic_array = create value Generic_array Non_nullable
 
-  let unboxed_int32_array = create value Unboxed_int32_array
-
-  let unboxed_int64_array = create value Unboxed_int64_array
-
-  let unboxed_nativeint_array = create value Unboxed_nativeint_array
-
-  let unboxed_vec128_array = create value Unboxed_vec128_array
+  let unboxed_vec128_array = create value Unboxed_vec128_array Non_nullable
 
   let block tag fields =
     if List.exists (fun (t : t) -> not (equal t.kind Value)) fields
@@ -809,9 +838,10 @@ module With_subkind = struct
                Tag.Scannable.Map.singleton tag
                  (Block_shape.Scannable Value_only, fields)
            })
+        Non_nullable
     | None -> Misc.fatal_errorf "Tag %a is not scannable" Tag.print tag
 
-  let float_block ~num_fields = create value (Float_block { num_fields })
+  let float_block ~num_fields = create value (Float_block { num_fields }) Non_nullable
 
   let of_naked_number_kind (naked_number_kind : Naked_number_kind.t) =
     match naked_number_kind with
@@ -842,79 +872,89 @@ module With_subkind = struct
     | Naked_vec128 -> boxed_vec128
 
   let of_flat_suffix_element elt =
-    create (Flat_suffix_element0.kind elt) Anything
+    (* CR vlaviron: tagged immediates can be nullable and can appear in the flat suffix;
+       we need to properly propagate that *)
+    create (Flat_suffix_element0.kind elt) Anything Non_nullable
 
   let of_lambda_flat_element_kind elt =
     Flat_suffix_element0.from_lambda elt |> of_flat_suffix_element
 
   let rec from_lambda_value_kind (vk : Lambda.value_kind) =
-    match vk with
-    | Pgenval -> any_value
-    | Pboxedfloatval Pfloat64 -> boxed_float
-    | Pboxedfloatval Pfloat32 -> boxed_float32
-    | Pboxedintval Pint32 -> boxed_int32
-    | Pboxedintval Pint64 -> boxed_int64
-    | Pboxedintval Pnativeint -> boxed_nativeint
-    | Pboxedvectorval Pvec128 -> boxed_vec128
-    | Pintval -> tagged_immediate
-    | Pvariant { consts; non_consts } -> (
-      match consts, non_consts with
-      | [], [] -> Misc.fatal_error "[Pvariant] with no constructors at all"
-      | [], [(tag, shape)] when tag = Obj.double_array_tag ->
-        (* If we have [Obj.double_array_tag] here, this is always an all-float
-           block, not an array. *)
-        (* CR vlaviron: change the Lambda type *)
-        let num_fields =
-          match shape with
-          | Constructor_uniform fields -> List.length fields
-          | Constructor_mixed _ -> assert false
-        in
-        float_block ~num_fields
-      | [], _ :: _ | _ :: _, [] | _ :: _, _ :: _ ->
-        let consts =
-          Targetint_31_63.Set.of_list
-            (List.map (fun const -> Targetint_31_63.of_int const) consts)
-        in
-        let non_consts =
-          List.fold_left
-            (fun non_consts (tag, shape) ->
-              match Tag.Scannable.create tag with
-              | Some tag ->
-                let shape_and_fields : Block_shape.t * _ =
-                  (* CR mshinwell/vlaviron: In both of these cases it would be
-                     nice to propagate immediacy information. *)
-                  match (shape : Lambda.constructor_shape) with
-                  | Constructor_uniform fields ->
-                    Scannable Value_only, List.map from_lambda_value_kind fields
-                  | Constructor_mixed { value_prefix; flat_suffix } ->
-                    let mixed_block_shape =
-                      Mixed_block_shape.from_lambda
-                        { value_prefix_len = List.length value_prefix;
-                          flat_suffix = Array.of_list flat_suffix
-                        }
-                    in
-                    let fields =
-                      List.map from_lambda_value_kind value_prefix
-                      @ List.map of_lambda_flat_element_kind flat_suffix
-                    in
-                    Scannable (Mixed_record mixed_block_shape), fields
-                in
-                Tag.Scannable.Map.add tag shape_and_fields non_consts
-              | None ->
-                Misc.fatal_errorf "Non-scannable tag %d in [Pvariant]" tag)
-            Tag.Scannable.Map.empty non_consts
-        in
-        create value (Variant { consts; non_consts }))
-    | Parrayval Pfloatarray -> float_array
-    | Parrayval Pintarray -> immediate_array
-    | Parrayval Paddrarray -> value_array
-    | Parrayval Pgenarray -> generic_array
-    | Parrayval (Punboxedfloatarray Pfloat64) -> float_array
-    | Parrayval (Punboxedfloatarray Pfloat32) -> unboxed_float32_array
-    | Parrayval (Punboxedintarray Pint32) -> unboxed_int32_array
-    | Parrayval (Punboxedintarray Pint64) -> unboxed_int64_array
-    | Parrayval (Punboxedintarray Pnativeint) -> unboxed_nativeint_array
-    | Parrayval (Punboxedvectorarray Pvec128) -> unboxed_vec128_array
+    let value_subkind : Non_null_value_subkind.t =
+      match vk.raw_kind with
+      | Pgenval -> Anything
+      | Pboxedfloatval Pfloat64 -> Boxed_float
+      | Pboxedfloatval Pfloat32 -> Boxed_float32
+      | Pboxedintval Pint32 -> Boxed_int32
+      | Pboxedintval Pint64 -> Boxed_int64
+      | Pboxedintval Pnativeint -> Boxed_nativeint
+      | Pboxedvectorval Pvec128 -> Boxed_vec128
+      | Pintval -> Tagged_immediate
+      | Pvariant { consts; non_consts } -> (
+          match consts, non_consts with
+          | [], [] -> Misc.fatal_error "[Pvariant] with no constructors at all"
+          | [], [(tag, shape)] when tag = Obj.double_array_tag ->
+            (* If we have [Obj.double_array_tag] here, this is always an all-float
+               block, not an array. *)
+            (* CR vlaviron: change the Lambda type *)
+            let num_fields =
+              match shape with
+              | Constructor_uniform fields -> List.length fields
+              | Constructor_mixed _ -> assert false
+            in
+            Float_block { num_fields }
+          | [], _ :: _ | _ :: _, [] | _ :: _, _ :: _ ->
+            let consts =
+              Targetint_31_63.Set.of_list
+                (List.map (fun const -> Targetint_31_63.of_int const) consts)
+            in
+            let non_consts =
+              List.fold_left
+                (fun non_consts (tag, shape) ->
+                   match Tag.Scannable.create tag with
+                   | Some tag ->
+                     let shape_and_fields : Block_shape.t * t list =
+                       (* CR mshinwell/vlaviron: In both of these cases it would be
+                          nice to propagate immediacy information. *)
+                       match (shape : Lambda.constructor_shape) with
+                       | Constructor_uniform fields ->
+                         Scannable Value_only, List.map from_lambda_value_kind fields
+                       | Constructor_mixed { value_prefix; flat_suffix } ->
+                         let mixed_block_shape =
+                           Mixed_block_shape.from_lambda
+                             { value_prefix_len = List.length value_prefix;
+                               flat_suffix = Array.of_list flat_suffix
+                             }
+                         in
+                         let fields =
+                           List.map from_lambda_value_kind value_prefix
+                           @ List.map of_lambda_flat_element_kind flat_suffix
+                         in
+                         Scannable (Mixed_record mixed_block_shape), fields
+                     in
+                     Tag.Scannable.Map.add tag shape_and_fields non_consts
+                   | None ->
+                     Misc.fatal_errorf "Non-scannable tag %d in [Pvariant]" tag)
+                Tag.Scannable.Map.empty non_consts
+            in
+            Variant { consts; non_consts })
+      | Parrayval Pfloatarray -> Float_array
+      | Parrayval Pintarray -> Immediate_array
+      | Parrayval Paddrarray -> Value_array
+      | Parrayval Pgenarray -> Generic_array
+      | Parrayval (Punboxedfloatarray Pfloat64) -> Float_array
+      | Parrayval (Punboxedfloatarray Pfloat32) -> Unboxed_float32_array
+      | Parrayval (Punboxedintarray Pint32) -> Unboxed_int32_array
+      | Parrayval (Punboxedintarray Pint64) -> Unboxed_int64_array
+      | Parrayval (Punboxedintarray Pnativeint) -> Unboxed_nativeint_array
+      | Parrayval (Punboxedvectorarray Pvec128) -> Unboxed_vec128_array
+    in
+    let nullable : Nullable.t =
+      match vk.nullable with
+      | Nullable -> Nullable
+      | Non_nullable -> Non_nullable
+    in
+    create value value_subkind nullable
 
   let from_lambda_values_and_unboxed_numbers_only (layout : Lambda.layout) =
     match layout with
@@ -934,43 +974,59 @@ module With_subkind = struct
   include Container_types.Make (struct
     type nonrec t = t
 
-    let print ppf ({ kind; subkind } : t) =
-      match kind, subkind with
-      | _, Anything -> print ppf kind
-      | Value, subkind ->
-        Format.fprintf ppf "@[%a%a@]" print kind Subkind.print subkind
+    let print ppf ({ kind; value_subkind; nullable } : t) =
+      match kind, value_subkind, nullable with
+      | _, Anything, Non_nullable -> print ppf kind
+      | Value, value_subkind, nullable ->
+        Format.fprintf ppf "@[%a%a%a@]" print kind Non_null_value_subkind.print value_subkind
+          Nullable.print nullable
       | ( (Naked_number _ | Region | Rec_info),
           ( Boxed_float | Boxed_float32 | Boxed_int32 | Boxed_int64
           | Boxed_nativeint | Boxed_vec128 | Tagged_immediate | Variant _
           | Float_block _ | Float_array | Immediate_array | Value_array
           | Generic_array | Unboxed_float32_array | Unboxed_int32_array
-          | Unboxed_int64_array | Unboxed_nativeint_array | Unboxed_vec128_array
-            ) ) ->
+          | Unboxed_int64_array | Unboxed_nativeint_array | Unboxed_vec128_array ),
+          Non_nullable )
+      | (Naked_number _ | Region | Rec_info), _, Nullable ->
         assert false
     (* see [create] *)
 
-    let compare ({ kind = kind1; subkind = subkind1 } : t)
-        ({ kind = kind2; subkind = subkind2 } : t) =
+    let compare ({ kind = kind1; value_subkind = value_subkind1; nullable = nullable1 } : t)
+        ({ kind = kind2; value_subkind = value_subkind2; nullable = nullable2 } : t) =
       let c = compare kind1 kind2 in
-      if c <> 0 then c else Subkind.compare subkind1 subkind2
+      if c <> 0 then c
+      else
+        let c = Non_null_value_subkind.compare value_subkind1 value_subkind2 in
+        if c <> 0 then c
+          else Nullable.compare nullable1 nullable2
 
     let equal t1 t2 = compare t1 t2 = 0
 
-    let hash ({ kind; subkind } : t) =
-      Hashtbl.hash (hash kind, Subkind.hash subkind)
+    let hash ({ kind; value_subkind; nullable } : t) =
+      Hashtbl.hash (hash kind, Non_null_value_subkind.hash value_subkind, Nullable.hash nullable)
   end)
 
   let has_useful_subkind_info (t : t) =
-    match t.subkind with
-    | Anything -> false
+    match t.kind with
+    | Value -> (
+    match t.value_subkind with
+    | Anything -> (
+        match t.nullable with
+        | Nullable -> false
+        | Non_nullable -> true)
     | Boxed_float | Boxed_float32 | Boxed_int32 | Boxed_int64 | Boxed_nativeint
     | Boxed_vec128 | Tagged_immediate | Variant _ | Float_block _ | Float_array
     | Immediate_array | Value_array | Generic_array | Unboxed_float32_array
     | Unboxed_int32_array | Unboxed_int64_array | Unboxed_nativeint_array
     | Unboxed_vec128_array ->
-      true
+      true)
+    | Naked_number _ | Rec_info | Region -> false
 
-  let erase_subkind (t : t) : t = { t with subkind = Anything }
+  let erase_subkind (t : t) : t =
+    match t.kind with
+    | Value ->
+      { t with value_subkind = Anything; nullable = Nullable }
+    | Naked_number _ | Rec_info | Region -> t
 
   let equal_ignoring_subkind t1 t2 = equal (erase_subkind t1) (erase_subkind t2)
 

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -197,7 +197,6 @@ module Boxable_number : sig
   include Container_types.S with type t := t
 end
 
-
 module With_subkind : sig
   type full_kind
 

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -197,10 +197,17 @@ module Boxable_number : sig
   include Container_types.S with type t := t
 end
 
-module With_subkind : sig
-  type with_subkind
 
-  module Subkind : sig
+module With_subkind : sig
+  type full_kind
+
+  module Nullable : sig
+    type t =
+      | Nullable
+      | Non_nullable
+  end
+
+  module Non_null_value_subkind : sig
     type t =
       | Anything
       | Boxed_float32
@@ -212,7 +219,7 @@ module With_subkind : sig
       | Tagged_immediate
       | Variant of
           { consts : Targetint_31_63.Set.t;
-            non_consts : (Block_shape.t * with_subkind list) Tag.Scannable.Map.t
+            non_consts : (Block_shape.t * full_kind list) Tag.Scannable.Map.t
           }
       | Float_block of { num_fields : int }
       | Float_array
@@ -228,18 +235,23 @@ module With_subkind : sig
     include Container_types.S with type t := t
   end
 
-  type t = with_subkind
+  type t = full_kind
 
-  val create : kind -> Subkind.t -> t
+  val create : kind -> Non_null_value_subkind.t -> Nullable.t -> t
 
   val anything : kind -> t
 
   val kind : t -> kind
 
-  val subkind : t -> Subkind.t
+  val non_null_value_subkind : t -> Non_null_value_subkind.t
+
+  val nullable : t -> Nullable.t
 
   val has_useful_subkind_info : t -> bool
 
+  (* Note: all constructors below assume non-nullability, except when noted *)
+
+  (* [any_value] is nullable *)
   val any_value : t
 
   val naked_immediate : t
@@ -280,6 +292,8 @@ module With_subkind : sig
 
   val generic_array : t
 
+  val unboxed_vec128_array : t
+
   val block : Tag.t -> t list -> t
 
   val float_block : num_fields:int -> t
@@ -290,8 +304,10 @@ module With_subkind : sig
 
   val boxed_of_boxable_number : Boxable_number.t -> t
 
+  (* Nullability is taken from the Lambda value kind *)
   val from_lambda_value_kind : Lambda.value_kind -> t
 
+  (* Nullability is taken from the Lambda value kind *)
   val from_lambda_values_and_unboxed_numbers_only : Lambda.layout -> t
 
   val compatible : t -> when_used_at:t -> bool

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -256,7 +256,7 @@ let float32 f = f |> Numeric_types.Float32_by_bit_pattern.create
 
 let float f = f |> Numeric_types.Float_by_bit_pattern.create
 
-let rec subkind : Fexpr.subkind -> Flambda_kind.With_subkind.Subkind.t =
+let rec subkind : Fexpr.subkind -> Flambda_kind.With_subkind.Non_null_value_subkind.t =
   function
   | Anything -> Anything
   | Boxed_float32 -> Boxed_float32
@@ -288,7 +288,7 @@ let rec subkind : Fexpr.subkind -> Flambda_kind.With_subkind.Subkind.t =
 and value_kind_with_subkind :
     Fexpr.kind_with_subkind -> Flambda_kind.With_subkind.t = function
   | Value sk ->
-    Flambda_kind.With_subkind.create Flambda_kind.value (sk |> subkind)
+    Flambda_kind.With_subkind.create Flambda_kind.value (sk |> subkind) Nullable
   | Naked_number nnk -> Flambda_kind.With_subkind.of_naked_number_kind nnk
   | Region -> Flambda_kind.With_subkind.region
   | Rec_info -> Flambda_kind.With_subkind.rec_info

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -256,7 +256,8 @@ let float32 f = f |> Numeric_types.Float32_by_bit_pattern.create
 
 let float f = f |> Numeric_types.Float_by_bit_pattern.create
 
-let rec subkind : Fexpr.subkind -> Flambda_kind.With_subkind.Non_null_value_subkind.t =
+let rec subkind :
+    Fexpr.subkind -> Flambda_kind.With_subkind.Non_null_value_subkind.t =
   function
   | Anything -> Anything
   | Boxed_float32 -> Boxed_float32

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -421,7 +421,8 @@ let is_default_kind_with_subkind (k : Flambda_kind.With_subkind.t) =
   Flambda_kind.is_value (Flambda_kind.With_subkind.kind k)
   && not (Flambda_kind.With_subkind.has_useful_subkind_info k)
 
-let rec subkind (k : Flambda_kind.With_subkind.Non_null_value_subkind.t) : Fexpr.subkind =
+let rec subkind (k : Flambda_kind.With_subkind.Non_null_value_subkind.t) :
+    Fexpr.subkind =
   match k with
   | Anything -> Anything
   | Boxed_float32 -> Boxed_float32
@@ -457,7 +458,8 @@ and variant_subkind consts non_consts : Fexpr.subkind =
 and kind_with_subkind (k : Flambda_kind.With_subkind.t) :
     Fexpr.kind_with_subkind =
   match Flambda_kind.With_subkind.kind k with
-  | Value -> Value (subkind (Flambda_kind.With_subkind.non_null_value_subkind k))
+  | Value ->
+    Value (subkind (Flambda_kind.With_subkind.non_null_value_subkind k))
   | Naked_number nnk -> Naked_number nnk
   | Region -> Region
   | Rec_info -> Rec_info

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -421,7 +421,7 @@ let is_default_kind_with_subkind (k : Flambda_kind.With_subkind.t) =
   Flambda_kind.is_value (Flambda_kind.With_subkind.kind k)
   && not (Flambda_kind.With_subkind.has_useful_subkind_info k)
 
-let rec subkind (k : Flambda_kind.With_subkind.Subkind.t) : Fexpr.subkind =
+let rec subkind (k : Flambda_kind.With_subkind.Non_null_value_subkind.t) : Fexpr.subkind =
   match k with
   | Anything -> Anything
   | Boxed_float32 -> Boxed_float32
@@ -457,7 +457,7 @@ and variant_subkind consts non_consts : Fexpr.subkind =
 and kind_with_subkind (k : Flambda_kind.With_subkind.t) :
     Fexpr.kind_with_subkind =
   match Flambda_kind.With_subkind.kind k with
-  | Value -> Value (subkind (Flambda_kind.With_subkind.subkind k))
+  | Value -> Value (subkind (Flambda_kind.With_subkind.non_null_value_subkind k))
   | Naked_number nnk -> Naked_number nnk
   | Region -> Region
   | Rec_info -> Rec_info

--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -243,7 +243,7 @@ let join_one_cse_equation ~cse_at_each_use prim bound_to_map
       let prim_result_kind = P.result_kind' (EP.to_primitive prim) in
       let var = Variable.create "cse_param" in
       let extra_param =
-        BP.create var (K.With_subkind.create prim_result_kind Anything)
+        BP.create var (K.With_subkind.create prim_result_kind Anything Nullable)
       in
       let bound_to = RI.Map.map Rhs_kind.bound_to bound_to_map in
       let cse = EP.Map.add prim (Simple.var var) cse in

--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -243,7 +243,7 @@ let join_one_cse_equation ~cse_at_each_use prim bound_to_map
       let prim_result_kind = P.result_kind' (EP.to_primitive prim) in
       let var = Variable.create "cse_param" in
       let extra_param =
-        BP.create var (K.With_subkind.create prim_result_kind Anything Nullable)
+        BP.create var (K.With_subkind.anything prim_result_kind)
       in
       let bound_to = RI.Map.map Rhs_kind.bound_to bound_to_map in
       let cse = EP.Map.add prim (Simple.var var) cse in

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -127,7 +127,10 @@ let define_variable t var kind =
         let kind = Flambda_kind.With_subkind.create kind Anything in
         let variables_defined_in_current_continuation =
           Lifted_cont_params.new_param variables_defined_in_current_continuation
-            (Bound_parameter.create (Bound_var.var var) kind)
+            (Bound_parameter.create (Bound_var.var var)
+               (kind Non_nullable)
+               (* CR layouts v3: this likely should be [Nullable], but Stdlib
+                  fails to compile if set so. *))
         in
         variables_defined_in_current_continuation :: r
   in

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -132,7 +132,10 @@ let simplify_caml_make_vect dacc ~len_ty ~init_value_ty : t =
     (* We can't deduce subkind information, e.g. an array is all-immediates
        rather than arbitrary values, but we can deduce kind information. *)
     if not (Flambda_features.flat_float_array ())
-    then Ok (Flambda_kind.With_subkind.create (T.kind init_value_ty) Anything Nullable)
+    then
+      Ok
+        (Flambda_kind.With_subkind.create (T.kind init_value_ty) Anything
+           Nullable)
     else
       match T.prove_is_or_is_not_a_boxed_float typing_env init_value_ty with
       | Proved true ->

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -132,7 +132,7 @@ let simplify_caml_make_vect dacc ~len_ty ~init_value_ty : t =
     (* We can't deduce subkind information, e.g. an array is all-immediates
        rather than arbitrary values, but we can deduce kind information. *)
     if not (Flambda_features.flat_float_array ())
-    then Ok (Flambda_kind.With_subkind.create (T.kind init_value_ty) Anything)
+    then Ok (Flambda_kind.With_subkind.create (T.kind init_value_ty) Anything Nullable)
     else
       match T.prove_is_or_is_not_a_boxed_float typing_env init_value_ty with
       | Proved true ->

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -132,10 +132,7 @@ let simplify_caml_make_vect dacc ~len_ty ~init_value_ty : t =
     (* We can't deduce subkind information, e.g. an array is all-immediates
        rather than arbitrary values, but we can deduce kind information. *)
     if not (Flambda_features.flat_float_array ())
-    then
-      Ok
-        (Flambda_kind.With_subkind.create (T.kind init_value_ty) Anything
-           Nullable)
+    then Ok (Flambda_kind.With_subkind.anything (T.kind init_value_ty))
     else
       match T.prove_is_or_is_not_a_boxed_float typing_env init_value_ty with
       | Proved true ->

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -259,8 +259,7 @@ let extra_params_for_continuation_param_aliases cont uacc rewrite_ids =
       let var_kind =
         Flambda_kind.With_subkind.create
           (Variable.Map.find var aliases_kind)
-          Anything
-          Nullable
+          Anything Nullable
       in
       EPA.add
         ~extra_param:(Bound_parameter.create var var_kind)

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -257,9 +257,7 @@ let extra_params_for_continuation_param_aliases cont uacc rewrite_ids =
           rewrite_ids
       in
       let var_kind =
-        Flambda_kind.With_subkind.create
-          (Variable.Map.find var aliases_kind)
-          Anything Nullable
+        Flambda_kind.With_subkind.anything (Variable.Map.find var aliases_kind)
       in
       EPA.add
         ~extra_param:(Bound_parameter.create var var_kind)

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -260,6 +260,7 @@ let extra_params_for_continuation_param_aliases cont uacc rewrite_ids =
         Flambda_kind.With_subkind.create
           (Variable.Map.find var aliases_kind)
           Anything
+          Nullable
       in
       EPA.add
         ~extra_param:(Bound_parameter.create var var_kind)

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -205,7 +205,8 @@ and make_optimistic_vars_within_closure ~depth ~recursive tenv closures_entry =
       let kind =
         K.With_subkind.create
           (Flambda2_types.kind var_type)
-          K.With_subkind.Subkind.Anything
+          Anything
+          Nullable
       in
       { epa; decision; kind })
     map

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -203,10 +203,7 @@ and make_optimistic_vars_within_closure ~depth ~recursive tenv closures_entry =
           ~param_type:var_type
       in
       let kind =
-        K.With_subkind.create
-          (Flambda2_types.kind var_type)
-          Anything
-          Nullable
+        K.With_subkind.create (Flambda2_types.kind var_type) Anything Nullable
       in
       { epa; decision; kind })
     map

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -202,8 +202,6 @@ and make_optimistic_vars_within_closure ~depth ~recursive tenv closures_entry =
         make_optimistic_decision ~depth:(depth + 1) ~recursive tenv
           ~param_type:var_type
       in
-      let kind =
-        K.With_subkind.create (Flambda2_types.kind var_type) Anything Nullable
-      in
+      let kind = K.With_subkind.anything (Flambda2_types.kind var_type) in
       { epa; decision; kind })
     map

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -896,7 +896,7 @@ end = struct
           | Naked_number Naked_vec128 -> 2, true
           | Value -> (
             match[@ocaml.warning "-4"]
-              Flambda_kind.With_subkind.subkind kind
+              Flambda_kind.With_subkind.non_null_value_subkind kind
             with
             | Tagged_immediate -> 1, true
             | _ -> 1, false)

--- a/middle_end/flambda2/terms/exn_continuation.ml
+++ b/middle_end/flambda2/terms/exn_continuation.ml
@@ -106,7 +106,7 @@ let apply_renaming ({ exn_handler; extra_args } as t) renaming =
 let arity t =
   let extra_args = List.map (fun (_simple, kind) -> kind) t.extra_args in
   let exn_bucket_kind =
-    Flambda_kind.With_subkind.create Flambda_kind.value Anything
+    Flambda_kind.With_subkind.create Flambda_kind.value Anything Non_nullable
   in
   Flambda_arity.create_singletons (exn_bucket_kind :: extra_args)
 

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -580,7 +580,8 @@ and print_function_params_and_body ppf t =
       ~is_my_closure_used:_ ~my_region ~my_ghost_region ~my_depth
       ~free_names_of_body:_ =
     let my_closure =
-      Bound_parameter.create my_closure (K.With_subkind.create K.value Anything)
+      Bound_parameter.create my_closure
+        (K.With_subkind.create K.value Anything Non_nullable)
     in
     fprintf ppf
       "@[<hov 1>(%t@<1>\u{03bb}%t@[<hov \

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -181,7 +181,9 @@ end = struct
               let module UK = C.Update_kind in
               match KS.kind kind with
               | Value ->
-                if KS.Non_null_value_subkind.equal (KS.non_null_value_subkind kind) Tagged_immediate
+                if KS.Non_null_value_subkind.equal
+                     (KS.non_null_value_subkind kind)
+                     Tagged_immediate
                 then UK.tagged_immediates
                 else UK.pointers
               | Naked_number Naked_immediate

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -181,7 +181,7 @@ end = struct
               let module UK = C.Update_kind in
               match KS.kind kind with
               | Value ->
-                if KS.Subkind.equal (KS.subkind kind) Tagged_immediate
+                if KS.Non_null_value_subkind.equal (KS.non_null_value_subkind kind) Tagged_immediate
                 then UK.tagged_immediates
                 else UK.pointers
               | Naked_number Naked_immediate

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -61,7 +61,7 @@ let exttype_of_kind (k : Flambda_kind.t) : Cmm.exttype =
 let machtype_of_kind (kind : Flambda_kind.With_subkind.t) =
   match Flambda_kind.With_subkind.kind kind with
   | Value -> (
-    match Flambda_kind.With_subkind.subkind kind with
+    match Flambda_kind.With_subkind.non_null_value_subkind kind with
     | Tagged_immediate -> Cmm.typ_int
     | Anything | Boxed_float32 | Boxed_float | Boxed_int32 | Boxed_int64
     | Boxed_nativeint | Boxed_vec128 | Variant _ | Float_block _ | Float_array
@@ -81,7 +81,7 @@ let machtype_of_kind (kind : Flambda_kind.With_subkind.t) =
 let extended_machtype_of_kind (kind : Flambda_kind.With_subkind.t) =
   match Flambda_kind.With_subkind.kind kind with
   | Value -> (
-    match Flambda_kind.With_subkind.subkind kind with
+    match Flambda_kind.With_subkind.non_null_value_subkind kind with
     | Tagged_immediate -> Extended_machtype.typ_tagged_int
     | Anything | Boxed_float | Boxed_float32 | Boxed_int32 | Boxed_int64
     | Boxed_nativeint | Boxed_vec128 | Variant _ | Float_block _ | Float_array
@@ -102,7 +102,7 @@ let memory_chunk_of_kind (kind : Flambda_kind.With_subkind.t) : Cmm.memory_chunk
     =
   match Flambda_kind.With_subkind.kind kind with
   | Value -> (
-    match Flambda_kind.With_subkind.subkind kind with
+    match Flambda_kind.With_subkind.non_null_value_subkind kind with
     | Tagged_immediate -> Word_int
     | Anything | Boxed_float | Boxed_float32 | Boxed_int32 | Boxed_int64
     | Boxed_nativeint | Boxed_vec128 | Variant _ | Float_block _ | Float_array

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1427,7 +1427,9 @@ end = struct
             ~const:(fun const -> VA.Value_const const)
             ~var:(fun _ ~coercion:_ -> VA.Value_unknown)
             ~symbol:(fun symbol ~coercion:_ -> VA.Value_symbol symbol)
-        | Ok (No_alias head) -> (
+        | Ok (No_alias { is_null = Unknown | Known true; _ }) ->
+          VA.Value_unknown
+        | Ok (No_alias { is_null = Known false; non_null = head }) -> (
           match head with
           | Mutable_block _ | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _
           | Boxed_int64 _ | Boxed_vec128 _ | Boxed_nativeint _ | String _

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -52,6 +52,11 @@ type t =
   | Region of head_of_kind_region TD.t
 
 and head_of_kind_value =
+  { non_null : head_of_kind_value_non_null;
+    is_null : bool Or_unknown.t (* CR vlaviron: define a dedicated type *)
+  }
+
+and head_of_kind_value_non_null =
   | Variant of
       { immediates : t Or_unknown.t;
         blocks : row_like_for_blocks Or_unknown.t;
@@ -256,7 +261,11 @@ let rec free_names0 ~follow_value_slots t =
   | Region ty ->
     type_descr_free_names ~free_names_head:free_names_head_of_kind_region ty
 
-and free_names_head_of_kind_value0 ~follow_value_slots head =
+and free_names_head_of_kind_value0 ~follow_value_slots { non_null; is_null = _ }
+    =
+  free_names_head_of_kind_value_non_null ~follow_value_slots non_null
+
+and free_names_head_of_kind_value_non_null ~follow_value_slots head =
   match head with
   | Variant { blocks; immediates; is_unique = _ } ->
     Name_occurrences.union
@@ -532,6 +541,15 @@ let rec apply_renaming t renaming =
       if ty == ty' then t else Region ty'
 
 and apply_renaming_head_of_kind_value head renaming =
+  let { non_null; is_null = _ } = head in
+  let non_null' =
+    apply_renaming_head_of_kind_value_non_null non_null renaming
+  in
+  if non_null == non_null'
+  then head
+  else { non_null = non_null'; is_null = head.is_null }
+
+and apply_renaming_head_of_kind_value_non_null head renaming =
   match head with
   | Variant { blocks; immediates; is_unique } ->
     let immediates' =
@@ -811,7 +829,15 @@ let rec print ppf t =
       (TD.print ~print_head:print_head_of_kind_region)
       ty
 
-and print_head_of_kind_value ppf head =
+and print_head_of_kind_value ppf { non_null; is_null } =
+  match is_null with
+  | Known true -> Format.fprintf ppf "Null"
+  | Known false -> print_head_of_kind_value_non_null ppf non_null
+  | Unknown ->
+    Format.fprintf ppf "@[<hov 1>(Null@ |@ %a)@]"
+      print_head_of_kind_value_non_null non_null
+
+and print_head_of_kind_value_non_null ppf head =
   match head with
   | Variant { blocks; immediates; is_unique } ->
     (* CR-someday mshinwell: Improve so that we elide blocks and/or immediates
@@ -1061,7 +1087,10 @@ let rec ids_for_export t =
   | Region ty ->
     TD.ids_for_export ~ids_for_export_head:ids_for_export_head_of_kind_region ty
 
-and ids_for_export_head_of_kind_value head =
+and ids_for_export_head_of_kind_value { non_null; is_null = _ } =
+  ids_for_export_head_of_kind_value_non_null non_null
+
+and ids_for_export_head_of_kind_value_non_null head =
   match head with
   | Variant { blocks; immediates; is_unique = _ } ->
     Ids_for_export.union
@@ -1299,7 +1328,13 @@ let rec apply_coercion t coercion : t Or_bottom.t =
       in
       if ty == ty' then t else Region ty'
 
-and apply_coercion_head_of_kind_value head coercion : _ Or_bottom.t =
+and apply_coercion_head_of_kind_value { non_null; is_null } coercion =
+  let<+ non_null =
+    apply_coercion_head_of_kind_value_non_null non_null coercion
+  in
+  { non_null; is_null }
+
+and apply_coercion_head_of_kind_value_non_null head coercion : _ Or_bottom.t =
   match head with
   | Closures { by_function_slot; alloc_mode } ->
     let<+ by_function_slot' =
@@ -1645,6 +1680,17 @@ let rec remove_unused_value_slots_and_shortcut_aliases t ~used_value_slots
 
 and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value head
     ~used_value_slots ~canonicalise =
+  let { non_null; is_null = _ } = head in
+  let non_null' =
+    remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value_non_null
+      non_null ~used_value_slots ~canonicalise
+  in
+  if non_null == non_null'
+  then head
+  else { non_null = non_null'; is_null = head.is_null }
+
+and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value_non_null
+    head ~used_value_slots ~canonicalise =
   match head with
   | Variant { blocks; immediates; is_unique } ->
     let immediates' =
@@ -2197,6 +2243,15 @@ let rec project_variables_out ~to_project ~expand t =
     if ty == ty' then t else Region ty'
 
 and project_head_of_kind_value ~to_project ~expand head =
+  let { non_null; is_null = _ } = head in
+  let non_null' =
+    project_head_of_kind_value_non_null ~to_project ~expand non_null
+  in
+  if non_null == non_null'
+  then head
+  else { non_null = non_null'; is_null = head.is_null }
+
+and project_head_of_kind_value_non_null ~to_project ~expand head =
   match head with
   | Variant { blocks; immediates; is_unique } ->
     let immediates' =
@@ -2470,6 +2525,9 @@ let kind t =
   | Rec_info _ -> K.rec_info
   | Region _ -> K.region
 
+let non_null_value non_null =
+  Value (TD.create { non_null; is_null = Known false })
+
 let create_variant ~is_unique ~(immediates : _ Or_unknown.t) ~blocks =
   (match immediates with
   | Unknown -> ()
@@ -2480,12 +2538,12 @@ let create_variant ~is_unique ~(immediates : _ Or_unknown.t) ~blocks =
         "Cannot create [immediates] with type that is not of kind \
          [Naked_immediate]:@ %a"
         print immediates);
-  Value (TD.create (Variant { immediates; blocks; is_unique }))
+  non_null_value (Variant { immediates; blocks; is_unique })
 
-let mutable_block alloc_mode = Value (TD.create (Mutable_block { alloc_mode }))
+let mutable_block alloc_mode = non_null_value (Mutable_block { alloc_mode })
 
 let create_closures alloc_mode by_function_slot =
-  Value (TD.create (Closures { by_function_slot; alloc_mode }))
+  non_null_value (Closures { by_function_slot; alloc_mode })
 
 module Function_type = struct
   type t = function_type
@@ -3070,14 +3128,14 @@ let these_naked_vec128s vs =
 
 let box_float32 (t : t) alloc_mode : t =
   match t with
-  | Naked_float32 _ -> Value (TD.create (Boxed_float32 (t, alloc_mode)))
+  | Naked_float32 _ -> non_null_value (Boxed_float32 (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_int32 _ | Naked_float _ | Naked_int64 _
   | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _ ->
     Misc.fatal_errorf "Type of wrong kind for [box_float32]: %a" print t
 
 let box_float (t : t) alloc_mode : t =
   match t with
-  | Naked_float _ -> Value (TD.create (Boxed_float (t, alloc_mode)))
+  | Naked_float _ -> non_null_value (Boxed_float (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_int32 _ | Naked_float32 _
   | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _
     ->
@@ -3085,7 +3143,7 @@ let box_float (t : t) alloc_mode : t =
 
 let box_int32 (t : t) alloc_mode : t =
   match t with
-  | Naked_int32 _ -> Value (TD.create (Boxed_int32 (t, alloc_mode)))
+  | Naked_int32 _ -> non_null_value (Boxed_int32 (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_float32 _
   | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _
     ->
@@ -3093,7 +3151,7 @@ let box_int32 (t : t) alloc_mode : t =
 
 let box_int64 (t : t) alloc_mode : t =
   match t with
-  | Naked_int64 _ -> Value (TD.create (Boxed_int64 (t, alloc_mode)))
+  | Naked_int64 _ -> non_null_value (Boxed_int64 (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_float32 _
   | Naked_int32 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _
     ->
@@ -3101,14 +3159,14 @@ let box_int64 (t : t) alloc_mode : t =
 
 let box_nativeint (t : t) alloc_mode : t =
   match t with
-  | Naked_nativeint _ -> Value (TD.create (Boxed_nativeint (t, alloc_mode)))
+  | Naked_nativeint _ -> non_null_value (Boxed_nativeint (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_float32 _
   | Naked_int32 _ | Naked_int64 _ | Naked_vec128 _ | Rec_info _ | Region _ ->
     Misc.fatal_errorf "Type of wrong kind for [box_nativeint]: %a" print t
 
 let box_vec128 (t : t) alloc_mode : t =
   match t with
-  | Naked_vec128 _ -> Value (TD.create (Boxed_vec128 (t, alloc_mode)))
+  | Naked_vec128 _ -> non_null_value (Boxed_vec128 (t, alloc_mode))
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_float32 _
   | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _ | Rec_info _ | Region _ ->
     Misc.fatal_errorf "Type of wrong kind for [box_vec128]: %a" print t
@@ -3119,13 +3177,12 @@ let this_tagged_immediate imm : t =
 let tag_immediate t : t =
   match t with
   | Naked_immediate _ ->
-    Value
-      (TD.create
-         (Variant
-            { is_unique = false;
-              immediates = Known t;
-              blocks = Known Row_like_for_blocks.bottom
-            }))
+    non_null_value
+      (Variant
+         { is_unique = false;
+           immediates = Known t;
+           blocks = Known Row_like_for_blocks.bottom
+         })
   | Value _ | Naked_float _ | Naked_float32 _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Naked_vec128 _ | Rec_info _ | Region _ ->
     Misc.fatal_errorf "Type of wrong kind for [tag_immediate]: %a" print t
@@ -3165,7 +3222,7 @@ let this_immutable_string str =
     String_info.Set.singleton
       (String_info.create ~contents:(Contents str) ~size)
   in
-  Value (TD.create (String string_info))
+  non_null_value (String string_info)
 
 let mutable_string ~size =
   let size = Targetint_31_63.of_int size in
@@ -3173,28 +3230,25 @@ let mutable_string ~size =
     String_info.Set.singleton
       (String_info.create ~contents:Unknown_or_mutable ~size)
   in
-  Value (TD.create (String string_info))
+  non_null_value (String string_info)
 
 let array_of_length ~element_kind ~length alloc_mode =
-  Value
-    (TD.create (Array { element_kind; length; contents = Unknown; alloc_mode }))
+  non_null_value
+    (Array { element_kind; length; contents = Unknown; alloc_mode })
 
 let mutable_array ~element_kind ~length alloc_mode =
-  Value
-    (TD.create
-       (Array { element_kind; length; contents = Known Mutable; alloc_mode }))
+  non_null_value
+    (Array { element_kind; length; contents = Known Mutable; alloc_mode })
 
 let immutable_array ~element_kind ~fields alloc_mode =
-  Value
-    (TD.create
-       (Array
-          { element_kind;
-            length =
-              this_tagged_immediate
-                (Targetint_31_63.of_int (List.length fields));
-            contents = Known (Immutable { fields = Array.of_list fields });
-            alloc_mode
-          }))
+  non_null_value
+    (Array
+       { element_kind;
+         length =
+           this_tagged_immediate (Targetint_31_63.of_int (List.length fields));
+         contents = Known (Immutable { fields = Array.of_list fields });
+         alloc_mode
+       })
 
 let this_rec_info (rec_info_expr : Rec_info_expr.t) =
   match rec_info_expr with
@@ -3254,6 +3308,52 @@ let create_from_head_region head = Region (TD.create head)
 
 module Head_of_kind_value = struct
   type t = head_of_kind_value
+
+  let mk_non_null non_null = { non_null; is_null = Known false }
+
+  let create_variant ~is_unique ~blocks ~immediates =
+    mk_non_null (Variant { is_unique; blocks; immediates })
+
+  let create_mutable_block alloc_mode =
+    mk_non_null (Mutable_block { alloc_mode })
+
+  let create_boxed_float32 ty alloc_mode =
+    mk_non_null (Boxed_float32 (ty, alloc_mode))
+
+  let create_boxed_float ty alloc_mode =
+    mk_non_null (Boxed_float (ty, alloc_mode))
+
+  let create_boxed_int32 ty alloc_mode =
+    mk_non_null (Boxed_int32 (ty, alloc_mode))
+
+  let create_boxed_int64 ty alloc_mode =
+    mk_non_null (Boxed_int64 (ty, alloc_mode))
+
+  let create_boxed_nativeint ty alloc_mode =
+    mk_non_null (Boxed_nativeint (ty, alloc_mode))
+
+  let create_boxed_vec128 ty alloc_mode =
+    mk_non_null (Boxed_vec128 (ty, alloc_mode))
+
+  let create_tagged_immediate imm : t =
+    mk_non_null
+      (Variant
+         { is_unique = false;
+           immediates = Known (this_naked_immediate imm);
+           blocks = Known Row_like_for_blocks.bottom
+         })
+
+  let create_closures by_function_slot alloc_mode =
+    mk_non_null (Closures { by_function_slot; alloc_mode })
+
+  let create_string info = mk_non_null (String info)
+
+  let create_array_with_contents ~element_kind ~length contents alloc_mode =
+    mk_non_null (Array { element_kind; length; contents; alloc_mode })
+end
+
+module Head_of_kind_value_non_null = struct
+  type t = head_of_kind_value_non_null
 
   let create_variant ~is_unique ~blocks ~immediates =
     Variant { is_unique; blocks; immediates }
@@ -3368,13 +3468,22 @@ let rec recover_some_aliases t =
     match TD.descr ty with
     | Unknown | Bottom
     | Ok (Equals _)
+    | Ok (No_alias { is_null = Unknown | Known true; _ })
+    (* CR vlaviron: Known true should be an alias *)
     | Ok
         (No_alias
-          ( Mutable_block _ | Boxed_float _ | Boxed_float32 _ | Boxed_int32 _
-          | Boxed_int64 _ | Boxed_vec128 _ | Boxed_nativeint _ | String _
-          | Closures _ | Array _ )) ->
+          { is_null = Known false;
+            non_null =
+              ( Mutable_block _ | Boxed_float _ | Boxed_float32 _
+              | Boxed_int32 _ | Boxed_int64 _ | Boxed_vec128 _
+              | Boxed_nativeint _ | String _ | Closures _ | Array _ )
+          }) ->
       t
-    | Ok (No_alias (Variant { immediates; blocks; is_unique = _ })) -> (
+    | Ok
+        (No_alias
+          { is_null = Known false;
+            non_null = Variant { immediates; blocks; is_unique = _ }
+          }) -> (
       match blocks with
       | Unknown -> t
       | Known blocks -> (

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -41,7 +41,12 @@ type t = private
   | Rec_info of head_of_kind_rec_info Type_descr.t
   | Region of head_of_kind_region Type_descr.t
 
-and head_of_kind_value = private
+and head_of_kind_value =
+  { non_null : head_of_kind_value_non_null;
+    is_null : bool Or_unknown.t (* CR vlaviron: define a dedicated type *)
+  }
+
+and head_of_kind_value_non_null = private
   | Variant of
       { immediates : t Or_unknown.t;
         blocks : row_like_for_blocks Or_unknown.t;
@@ -628,6 +633,45 @@ val apply_coercion_head_of_kind_region :
 
 module Head_of_kind_value : sig
   type t = head_of_kind_value
+
+  val create_variant :
+    is_unique:bool ->
+    blocks:Row_like_for_blocks.t Or_unknown.t ->
+    immediates:flambda_type Or_unknown.t ->
+    t
+
+  val create_mutable_block : Alloc_mode.For_types.t -> t
+
+  (* CR-someday mshinwell: these alloc mode params should probably be
+     labelled *)
+  val create_boxed_float32 : flambda_type -> Alloc_mode.For_types.t -> t
+
+  val create_boxed_float : flambda_type -> Alloc_mode.For_types.t -> t
+
+  val create_boxed_int32 : flambda_type -> Alloc_mode.For_types.t -> t
+
+  val create_boxed_int64 : flambda_type -> Alloc_mode.For_types.t -> t
+
+  val create_boxed_nativeint : flambda_type -> Alloc_mode.For_types.t -> t
+
+  val create_boxed_vec128 : flambda_type -> Alloc_mode.For_types.t -> t
+
+  val create_tagged_immediate : Targetint_31_63.t -> t
+
+  val create_closures : Row_like_for_closures.t -> Alloc_mode.For_types.t -> t
+
+  val create_string : String_info.Set.t -> t
+
+  val create_array_with_contents :
+    element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
+    length:flambda_type ->
+    array_contents Or_unknown.t ->
+    Alloc_mode.For_types.t ->
+    t
+end
+
+module Head_of_kind_value_non_null : sig
+  type t = head_of_kind_value_non_null
 
   val create_variant :
     is_unique:bool ->

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -565,6 +565,25 @@ and meet_expanded_head0 env (descr1 : ET.descr) (descr2 : ET.descr) :
 
 and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
     (head2 : TG.head_of_kind_value) : TG.head_of_kind_value meet_result =
+  let meet_is_null env (is_null1 : bool Or_unknown.t)
+      (is_null2 : bool Or_unknown.t) : _ meet_result =
+    match is_null1, is_null2 with
+    | Unknown, Unknown | Known true, Known true | Known false, Known false ->
+      Ok (Both_inputs, env)
+    | Unknown, Known _ -> Ok (Right_input, env)
+    | Known _, Unknown -> Ok (Left_input, env)
+    | Known true, Known false | Known false, Known true -> Bottom
+  in
+  combine_results2 env ~meet_a:meet_head_of_kind_value_non_null
+    ~meet_b:meet_is_null ~left_a:head1.non_null ~right_a:head2.non_null
+    ~left_b:head1.is_null ~right_b:head2.is_null
+    ~rebuild:(fun non_null is_null : TG.head_of_kind_value ->
+      { non_null; is_null })
+
+and meet_head_of_kind_value_non_null env
+    (head1 : TG.head_of_kind_value_non_null)
+    (head2 : TG.head_of_kind_value_non_null) :
+    TG.head_of_kind_value_non_null meet_result =
   match head1, head2 with
   | ( Variant { blocks = blocks1; immediates = imms1; is_unique = is_unique1 },
       Variant { blocks = blocks2; immediates = imms2; is_unique = is_unique2 } )
@@ -574,13 +593,14 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
     let is_unique = is_unique1 || is_unique2 in
     map_result
       ~f:(fun (blocks, immediates) ->
-        TG.Head_of_kind_value.create_variant ~is_unique ~blocks ~immediates)
+        TG.Head_of_kind_value_non_null.create_variant ~is_unique ~blocks
+          ~immediates)
       (meet_variant env ~blocks1 ~imms1 ~blocks2 ~imms2)
   | ( Mutable_block { alloc_mode = alloc_mode1 },
       Mutable_block { alloc_mode = alloc_mode2 } ) ->
     map_result
       ~f:(fun alloc_mode ->
-        TG.Head_of_kind_value.create_mutable_block alloc_mode)
+        TG.Head_of_kind_value_non_null.create_mutable_block alloc_mode)
       (meet_alloc_mode env alloc_mode1 alloc_mode2)
   | Variant { blocks; _ }, Mutable_block { alloc_mode = alloc_mode_right } -> (
     match blocks with
@@ -615,11 +635,13 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
       | Ok (Left_input, env) ->
         Ok
           ( New_result
-              (TG.Head_of_kind_value.create_mutable_block alloc_mode_left),
+              (TG.Head_of_kind_value_non_null.create_mutable_block
+                 alloc_mode_left),
             env )
       | Ok (New_result alloc_mode, env) ->
         Ok
-          ( New_result (TG.Head_of_kind_value.create_mutable_block alloc_mode),
+          ( New_result
+              (TG.Head_of_kind_value_non_null.create_mutable_block alloc_mode),
             env )))
   | Mutable_block { alloc_mode = alloc_mode_left }, Variant { blocks; _ } -> (
     match blocks with
@@ -632,45 +654,53 @@ and meet_head_of_kind_value env (head1 : TG.head_of_kind_value)
       | Ok (Right_input, env) ->
         Ok
           ( New_result
-              (TG.Head_of_kind_value.create_mutable_block alloc_mode_right),
+              (TG.Head_of_kind_value_non_null.create_mutable_block
+                 alloc_mode_right),
             env )
       | Ok (New_result alloc_mode, env) ->
         Ok
-          ( New_result (TG.Head_of_kind_value.create_mutable_block alloc_mode),
+          ( New_result
+              (TG.Head_of_kind_value_non_null.create_mutable_block alloc_mode),
             env )))
   | Boxed_float32 (n1, alloc_mode1), Boxed_float32 (n2, alloc_mode2) ->
-    combine_results2 env ~rebuild:TG.Head_of_kind_value.create_boxed_float32
-      ~meet_a:meet ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2
-      ~left_b:alloc_mode1 ~right_b:alloc_mode2
+    combine_results2 env
+      ~rebuild:TG.Head_of_kind_value_non_null.create_boxed_float32 ~meet_a:meet
+      ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2 ~left_b:alloc_mode1
+      ~right_b:alloc_mode2
   | Boxed_float (n1, alloc_mode1), Boxed_float (n2, alloc_mode2) ->
-    combine_results2 env ~rebuild:TG.Head_of_kind_value.create_boxed_float
-      ~meet_a:meet ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2
-      ~left_b:alloc_mode1 ~right_b:alloc_mode2
+    combine_results2 env
+      ~rebuild:TG.Head_of_kind_value_non_null.create_boxed_float ~meet_a:meet
+      ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2 ~left_b:alloc_mode1
+      ~right_b:alloc_mode2
   | Boxed_int32 (n1, alloc_mode1), Boxed_int32 (n2, alloc_mode2) ->
-    combine_results2 env ~rebuild:TG.Head_of_kind_value.create_boxed_int32
-      ~meet_a:meet ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2
-      ~left_b:alloc_mode1 ~right_b:alloc_mode2
+    combine_results2 env
+      ~rebuild:TG.Head_of_kind_value_non_null.create_boxed_int32 ~meet_a:meet
+      ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2 ~left_b:alloc_mode1
+      ~right_b:alloc_mode2
   | Boxed_int64 (n1, alloc_mode1), Boxed_int64 (n2, alloc_mode2) ->
-    combine_results2 env ~rebuild:TG.Head_of_kind_value.create_boxed_int64
-      ~meet_a:meet ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2
-      ~left_b:alloc_mode1 ~right_b:alloc_mode2
+    combine_results2 env
+      ~rebuild:TG.Head_of_kind_value_non_null.create_boxed_int64 ~meet_a:meet
+      ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2 ~left_b:alloc_mode1
+      ~right_b:alloc_mode2
   | Boxed_nativeint (n1, alloc_mode1), Boxed_nativeint (n2, alloc_mode2) ->
-    combine_results2 env ~rebuild:TG.Head_of_kind_value.create_boxed_nativeint
+    combine_results2 env
+      ~rebuild:TG.Head_of_kind_value_non_null.create_boxed_nativeint
       ~meet_a:meet ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2
       ~left_b:alloc_mode1 ~right_b:alloc_mode2
   | Boxed_vec128 (n1, alloc_mode1), Boxed_vec128 (n2, alloc_mode2) ->
-    combine_results2 env ~rebuild:TG.Head_of_kind_value.create_boxed_vec128
-      ~meet_a:meet ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2
-      ~left_b:alloc_mode1 ~right_b:alloc_mode2
+    combine_results2 env
+      ~rebuild:TG.Head_of_kind_value_non_null.create_boxed_vec128 ~meet_a:meet
+      ~meet_b:meet_alloc_mode ~left_a:n1 ~right_a:n2 ~left_b:alloc_mode1
+      ~right_b:alloc_mode2
   | ( Closures { by_function_slot = by_function_slot1; alloc_mode = alloc_mode1 },
       Closures
         { by_function_slot = by_function_slot2; alloc_mode = alloc_mode2 } ) ->
-    combine_results2 env ~rebuild:TG.Head_of_kind_value.create_closures
+    combine_results2 env ~rebuild:TG.Head_of_kind_value_non_null.create_closures
       ~meet_a:meet_row_like_for_closures ~meet_b:meet_alloc_mode
       ~left_a:by_function_slot1 ~right_a:by_function_slot2 ~left_b:alloc_mode1
       ~right_b:alloc_mode2
   | String strs1, String strs2 ->
-    map_result ~f:TG.Head_of_kind_value.create_string
+    map_result ~f:TG.Head_of_kind_value_non_null.create_string
       (set_meet (module String_info.Set) env strs1 strs2 ~of_set:Fun.id)
   | ( Array
         { element_kind = element_kind1;
@@ -700,8 +730,8 @@ and meet_array_type env (element_kind1, length1, contents1, alloc_mode1)
   let element_kind = meet_array_element_kinds element_kind1 element_kind2 in
   combine_results env
     ~rebuild:(fun (length, (contents, (alloc_mode, ()))) ->
-      TG.Head_of_kind_value.create_array_with_contents ~element_kind ~length
-        contents alloc_mode)
+      TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
+        ~length contents alloc_mode)
     ~meet_ops:
       [ meet;
         meet_array_contents ~meet_element_kind:element_kind;
@@ -1506,6 +1536,20 @@ and join_expanded_head env kind (expanded1 : ET.t) (expanded2 : ET.t) : ET.t =
 
 and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
     (head2 : TG.head_of_kind_value) : TG.head_of_kind_value Or_unknown.t =
+  match join_head_of_kind_value_non_null env head1.non_null head2.non_null with
+  | Unknown -> Unknown
+  | Known non_null ->
+    let is_null : _ Or_unknown.t =
+      match head1.is_null, head2.is_null with
+      | Unknown, _ | _, Unknown -> Unknown
+      | Known b1, Known b2 -> if Bool.equal b1 b2 then Known b1 else Unknown
+    in
+    Known { non_null; is_null }
+
+and join_head_of_kind_value_non_null env
+    (head1 : TG.head_of_kind_value_non_null)
+    (head2 : TG.head_of_kind_value_non_null) :
+    TG.head_of_kind_value_non_null Or_unknown.t =
   match head1, head2 with
   | ( Variant { blocks = blocks1; immediates = imms1; is_unique = is_unique1 },
       Variant { blocks = blocks2; immediates = imms2; is_unique = is_unique2 } )
@@ -1516,35 +1560,35 @@ and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
     (* Uniqueness tracks whether duplication/lifting is allowed. It must always
        be propagated, both for meet and join. *)
     let is_unique = is_unique1 || is_unique2 in
-    TG.Head_of_kind_value.create_variant ~is_unique ~blocks ~immediates
+    TG.Head_of_kind_value_non_null.create_variant ~is_unique ~blocks ~immediates
   | ( Mutable_block { alloc_mode = alloc_mode1 },
       Mutable_block { alloc_mode = alloc_mode2 } ) ->
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    Known (TG.Head_of_kind_value.create_mutable_block alloc_mode)
+    Known (TG.Head_of_kind_value_non_null.create_mutable_block alloc_mode)
   | Boxed_float32 (n1, alloc_mode1), Boxed_float32 (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_float32 n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_float32 n alloc_mode
   | Boxed_float (n1, alloc_mode1), Boxed_float (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_float n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_float n alloc_mode
   | Boxed_int32 (n1, alloc_mode1), Boxed_int32 (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_int32 n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_int32 n alloc_mode
   | Boxed_int64 (n1, alloc_mode1), Boxed_int64 (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_int64 n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_int64 n alloc_mode
   | Boxed_nativeint (n1, alloc_mode1), Boxed_nativeint (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_nativeint n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_nativeint n alloc_mode
   | Boxed_vec128 (n1, alloc_mode1), Boxed_vec128 (n2, alloc_mode2) ->
     let>+ n = join env n1 n2 in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    TG.Head_of_kind_value.create_boxed_vec128 n alloc_mode
+    TG.Head_of_kind_value_non_null.create_boxed_vec128 n alloc_mode
   | ( Closures { by_function_slot = by_function_slot1; alloc_mode = alloc_mode1 },
       Closures
         { by_function_slot = by_function_slot2; alloc_mode = alloc_mode2 } ) ->
@@ -1552,10 +1596,12 @@ and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
       join_row_like_for_closures env by_function_slot1 by_function_slot2
     in
     let alloc_mode = join_alloc_mode alloc_mode1 alloc_mode2 in
-    Known (TG.Head_of_kind_value.create_closures by_function_slot alloc_mode)
+    Known
+      (TG.Head_of_kind_value_non_null.create_closures by_function_slot
+         alloc_mode)
   | String strs1, String strs2 ->
     let strs = String_info.Set.union strs1 strs2 in
-    Known (TG.Head_of_kind_value.create_string strs)
+    Known (TG.Head_of_kind_value_non_null.create_string strs)
   | ( Array
         { element_kind = element_kind1;
           length = length1;
@@ -1575,8 +1621,8 @@ and join_head_of_kind_value env (head1 : TG.head_of_kind_value)
         ~joined_element_kind:element_kind
     in
     let>+ length = join env length1 length2 in
-    TG.Head_of_kind_value.create_array_with_contents ~element_kind ~length
-      contents alloc_mode
+    TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
+      ~length contents alloc_mode
   | ( ( Variant _ | Mutable_block _ | Boxed_float _ | Boxed_float32 _
       | Boxed_int32 _ | Boxed_vec128 _ | Boxed_int64 _ | Boxed_nativeint _
       | Closures _ | String _ | Array _ ),

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -697,7 +697,7 @@ let prove_is_immediates_array env t : unit proof_of_property =
         { is_null = Known false;
           non_null = Array { element_kind = Ok element_kind; _ }
         }) -> (
-    match K.With_subkind.subkind element_kind with
+    match K.With_subkind.non_null_value_subkind element_kind with
     | Tagged_immediate -> Proved ()
     | Anything | Boxed_float | Boxed_float32 | Boxed_int32 | Boxed_int64
     | Boxed_nativeint | Boxed_vec128 | Variant _ | Float_block _ | Float_array
@@ -766,7 +766,7 @@ let prove_is_immutable_array_generic env t : _ generic_proof =
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
-  | Value (Ok { is_null = Unknown; non_null = _ }) -> Need_meet
+  | Value (Ok { is_null = Unknown; non_null = _ }) -> Unknown
   | Value (Ok { is_null = Known true; non_null = _ }) -> Invalid
   | Value
       (Ok


### PR DESCRIPTION
Rebase #3112 onto main, temporary PR for posting other drafts.

Of interest is the change in `middle_end/flambda2/simplify/env/downwards_env.ml`. Intuitively, this should be `Nullable`, but Stdlib only compiles if the kind is set to `Non_nullable`. I haven't investigated this in detail.