### PR TITLE
Add partial rebuilding option to ART + some associated refactoring

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2102,7 +2102,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
       Inlining_report.record_decision_at_function_definition ~absolute_history
         ~code_metadata:(Code_or_metadata.code_metadata meta)
         ~pass:After_closure_conversion
-        ~are_rebuilding_terms:(Are_rebuilding_terms.rebuild_everything)
+        ~are_rebuilding_terms:Are_rebuilding_terms.rebuild_everything
         inlining_decision;
       if Function_decl_inlining_decision_type.must_be_inlined inlining_decision
       then code
@@ -2499,7 +2499,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
       Inlining_report.record_decision_at_function_definition ~absolute_history
         ~code_metadata:(Code_or_metadata.code_metadata meta)
         ~pass:After_closure_conversion
-        ~are_rebuilding_terms:(Are_rebuilding_terms.rebuild_everything)
+        ~are_rebuilding_terms:Are_rebuilding_terms.rebuild_everything
         inlining_decision;
       if Function_decl_inlining_decision_type.must_be_inlined inlining_decision
       then code

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -318,7 +318,7 @@ module Inlining = struct
   (* CR keryan: we need to emit warnings *)
   let inlinable env apply callee_approx =
     let tracker = Env.inlining_history_tracker env in
-    let are_rebuilding_terms = Are_rebuilding_terms.of_bool true in
+    let are_rebuilding_terms = Are_rebuilding_terms.rebuild_everything in
     let compilation_unit =
       Env.inlining_history_tracker env
       |> Inlining_history.Tracker.absolute
@@ -2102,7 +2102,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
       Inlining_report.record_decision_at_function_definition ~absolute_history
         ~code_metadata:(Code_or_metadata.code_metadata meta)
         ~pass:After_closure_conversion
-        ~are_rebuilding_terms:(Are_rebuilding_terms.of_bool true)
+        ~are_rebuilding_terms:(Are_rebuilding_terms.rebuild_everything)
         inlining_decision;
       if Function_decl_inlining_decision_type.must_be_inlined inlining_decision
       then code
@@ -2499,7 +2499,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
       Inlining_report.record_decision_at_function_definition ~absolute_history
         ~code_metadata:(Code_or_metadata.code_metadata meta)
         ~pass:After_closure_conversion
-        ~are_rebuilding_terms:(Are_rebuilding_terms.of_bool true)
+        ~are_rebuilding_terms:(Are_rebuilding_terms.rebuild_everything)
         inlining_decision;
       if Function_decl_inlining_decision_type.must_be_inlined inlining_decision
       then code

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -574,7 +574,7 @@ let generate_phantom_lets t =
   && Flambda_features.Expert.phantom_lets ()
   (* It would be a waste of time generating phantom lets when not rebuilding
      terms, since they have no effect on cost metrics. *)
-  && Are_rebuilding_terms.are_rebuilding (are_rebuilding_terms t)
+  && not (Are_rebuilding_terms.not_rebuilding_terms (are_rebuilding_terms t))
 
 let loopify_state t = t.loopify_state
 

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -483,13 +483,18 @@ let find_comparison_result t var =
 let with_cse t cse = { t with cse }
 
 let set_do_not_rebuild_terms_and_disable_inlining t =
-  { t with are_rebuilding_terms = Are_rebuilding_terms.rebuild_nothing; can_inline = false }
+  { t with
+    are_rebuilding_terms = Are_rebuilding_terms.rebuild_nothing;
+    can_inline = false
+  }
 
 let disable_inlining t = { t with can_inline = false }
 
-let set_rebuild_terms t = { t with are_rebuilding_terms = Are_rebuilding_terms.rebuild_everything }
+let set_rebuild_terms t =
+  { t with are_rebuilding_terms = Are_rebuilding_terms.rebuild_everything }
 
-let set_rebuild_partially t = { t with are_rebuilding_terms = Are_rebuilding_terms.partial_rebuilding }
+let set_rebuild_partially t =
+  { t with are_rebuilding_terms = Are_rebuilding_terms.partial_rebuilding }
 
 let are_rebuilding_terms t = t.are_rebuilding_terms
 

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -181,6 +181,8 @@ val disable_inlining : t -> t
 
 val set_rebuild_terms : t -> t
 
+val set_rebuild_partially : t -> t
+
 val are_rebuilding_terms : t -> Are_rebuilding_terms.t
 
 val enter_closure :

--- a/middle_end/flambda2/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/upwards_acc.ml
@@ -103,7 +103,7 @@ let map_uenv t ~f = { t with uenv = f t.uenv }
 let with_uenv t uenv = { t with uenv }
 
 let remember_code_for_cmx t code =
-  if ART.do_not_rebuild_terms (are_rebuilding_terms t)
+  if ART.are_not_rebuilding (are_rebuilding_terms t)
   then t
   else
     let keep_code code_id =

--- a/middle_end/flambda2/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/upwards_acc.ml
@@ -103,7 +103,7 @@ let map_uenv t ~f = { t with uenv = f t.uenv }
 let with_uenv t uenv = { t with uenv }
 
 let remember_code_for_cmx t code =
-  if ART.are_not_rebuilding (are_rebuilding_terms t)
+  if ART.not_rebuilding_terms (are_rebuilding_terms t)
   then t
   else
     let keep_code code_id =

--- a/middle_end/flambda2/simplify/env/upwards_env.ml
+++ b/middle_end/flambda2/simplify/env/upwards_env.ml
@@ -18,6 +18,7 @@ type t =
   { continuations : Continuation_in_env.t Continuation.Map.t;
     continuation_aliases : Continuation.t Continuation.Map.t;
     apply_cont_rewrites : Apply_cont_rewrite.t Continuation.Map.t;
+    (* this [are_rebuilding_terms] is **only** used for printing *)
     are_rebuilding_terms : Are_rebuilding_terms.t
   }
 

--- a/middle_end/flambda2/simplify/env/upwards_env.mli
+++ b/middle_end/flambda2/simplify/env/upwards_env.mli
@@ -18,6 +18,9 @@
 
 type t
 
+(** Create an upwards environment.
+
+    The [are_rebuilding_terms] provided is only used for printing. *)
 val create : Are_rebuilding_terms.t -> t
 
 val print : Format.formatter -> t -> unit

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -220,8 +220,7 @@ let create_let uacc (bound_vars : Bound_pattern.t) (defining_expr : Named.t)
         free_names_of_let
     in
     let uacc =
-      if Are_rebuilding_terms.are_not_rebuilding
-           (UA.are_rebuilding_terms uacc)
+      if Are_rebuilding_terms.are_not_rebuilding (UA.are_rebuilding_terms uacc)
       then uacc
       else add_set_of_closures_offsets ~is_phantom defining_expr uacc
     in

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -220,7 +220,7 @@ let create_let uacc (bound_vars : Bound_pattern.t) (defining_expr : Named.t)
         free_names_of_let
     in
     let uacc =
-      if Are_rebuilding_terms.do_not_rebuild_terms
+      if Are_rebuilding_terms.are_not_rebuilding
            (UA.are_rebuilding_terms uacc)
       then uacc
       else add_set_of_closures_offsets ~is_phantom defining_expr uacc
@@ -375,7 +375,7 @@ let create_raw_let_symbol uacc bound_static static_consts ~body =
               (* Static consts always have zero cost metrics at present. *)
             ~cost_metrics_of_defining_expr:Cost_metrics.zero)
   in
-  if Are_rebuilding_terms.do_not_rebuild_terms (UA.are_rebuilding_terms uacc)
+  if Are_rebuilding_terms.are_not_rebuilding (UA.are_rebuilding_terms uacc)
   then RE.term_not_rebuilt, uacc
   else
     let defining_expr = Rebuilt_static_const.Group.to_named static_consts in

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -220,7 +220,8 @@ let create_let uacc (bound_vars : Bound_pattern.t) (defining_expr : Named.t)
         free_names_of_let
     in
     let uacc =
-      if Are_rebuilding_terms.are_not_rebuilding (UA.are_rebuilding_terms uacc)
+      if Are_rebuilding_terms.not_rebuilding_terms
+           (UA.are_rebuilding_terms uacc)
       then uacc
       else add_set_of_closures_offsets ~is_phantom defining_expr uacc
     in
@@ -374,7 +375,7 @@ let create_raw_let_symbol uacc bound_static static_consts ~body =
               (* Static consts always have zero cost metrics at present. *)
             ~cost_metrics_of_defining_expr:Cost_metrics.zero)
   in
-  if Are_rebuilding_terms.are_not_rebuilding (UA.are_rebuilding_terms uacc)
+  if Are_rebuilding_terms.not_rebuilding_terms (UA.are_rebuilding_terms uacc)
   then RE.term_not_rebuilt, uacc
   else
     let defining_expr = Rebuilt_static_const.Group.to_named static_consts in

--- a/middle_end/flambda2/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda2/simplify/rebuilt_expr.ml
@@ -20,7 +20,7 @@ type t = Expr.t
 type rebuilt_expr = t
 
 let to_expr t are_rebuilding =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then
     Misc.fatal_error
       "Cannot ask [Rebuilt_expr] for the built expression when \
@@ -33,7 +33,7 @@ let to_apply_cont t =
   | Let _ | Let_cont _ | Apply _ | Switch _ | Invalid _ -> None
 
 let can_be_removed_as_invalid t are_rebuilding =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then false
   else
     match Expr.descr t with
@@ -42,7 +42,7 @@ let can_be_removed_as_invalid t are_rebuilding =
     | Let _ | Let_cont _ | Apply _ | Apply_cont _ | Switch _ -> false
 
 let [@ocamlformat "disable"] print are_rebuilding ppf t =
-  if ART.do_not_rebuild_terms are_rebuilding then
+  if ART.are_not_rebuilding are_rebuilding then
     Format.fprintf ppf "<unavailable, terms not being rebuilt>"
   else
     Expr.print ppf t
@@ -51,7 +51,7 @@ let term_not_rebuilt = Expr.create_invalid Code_not_rebuilt
 
 let create_let are_rebuilding bound_vars defining_expr ~body ~free_names_of_body
     =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then term_not_rebuilt
   else
     Let.create bound_vars defining_expr ~body
@@ -59,7 +59,7 @@ let create_let are_rebuilding bound_vars defining_expr ~body ~free_names_of_body
     |> Expr.create_let
 
 let create_apply are_rebuilding apply =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then term_not_rebuilt
   else Expr.create_apply apply
 
@@ -75,7 +75,7 @@ module Function_params_and_body = struct
       ~my_region ~my_ghost_region ~my_depth
 
   let to_function_params_and_body t are_rebuilding =
-    if ART.do_not_rebuild_terms are_rebuilding
+    if ART.are_not_rebuilding are_rebuilding
     then
       Misc.fatal_error
         "Cannot ask for function params and body when not rebuilding terms"
@@ -96,7 +96,7 @@ module Continuation_handler = struct
 
   let create are_rebuilding params ~handler ~free_names_of_handler
       ~is_exn_handler ~is_cold =
-    if ART.do_not_rebuild_terms are_rebuilding
+    if ART.are_not_rebuilding are_rebuilding
     then dummy
     else
       Continuation_handler.create params ~handler
@@ -104,7 +104,7 @@ module Continuation_handler = struct
         ~is_cold
 
   let create' are_rebuilding params ~handler ~is_exn_handler ~is_cold =
-    if ART.do_not_rebuild_terms are_rebuilding
+    if ART.are_not_rebuilding are_rebuilding
     then dummy
     else
       Continuation_handler.create params ~handler ~free_names_of_handler:Unknown
@@ -113,7 +113,7 @@ end
 
 let create_non_recursive_let_cont are_rebuilding cont handler ~body
     ~free_names_of_body =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then term_not_rebuilt
   else
     Let_cont.create_non_recursive cont handler ~body
@@ -121,7 +121,7 @@ let create_non_recursive_let_cont are_rebuilding cont handler ~body
 
 let create_non_recursive_let_cont' are_rebuilding cont handler ~body
     ~num_free_occurrences_of_cont_in_body ~is_applied_with_traps =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then term_not_rebuilt
   else
     Let_cont.create_non_recursive' ~cont handler ~body
@@ -130,18 +130,18 @@ let create_non_recursive_let_cont' are_rebuilding cont handler ~body
 
 let create_non_recursive_let_cont_without_free_names are_rebuilding cont handler
     ~body =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then term_not_rebuilt
   else
     Let_cont.create_non_recursive cont handler ~body ~free_names_of_body:Unknown
 
 let create_recursive_let_cont are_rebuilding ~invariant_params handlers ~body =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then term_not_rebuilt
   else Let_cont.create_recursive ~invariant_params handlers ~body
 
 let create_switch are_rebuilding switch =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then term_not_rebuilt
   else Expr.create_switch switch
 

--- a/middle_end/flambda2/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda2/simplify/rebuilt_expr.ml
@@ -20,11 +20,11 @@ type t = Expr.t
 type rebuilt_expr = t
 
 let to_expr t are_rebuilding =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then
     Misc.fatal_error
       "Cannot ask [Rebuilt_expr] for the built expression when \
-       [UA.do_not_rebuild_terms] is set"
+       [UA.are_rebuilding_terms] is set to not rebuild terms"
   else t
 
 let to_apply_cont t =
@@ -33,7 +33,7 @@ let to_apply_cont t =
   | Let _ | Let_cont _ | Apply _ | Switch _ | Invalid _ -> None
 
 let can_be_removed_as_invalid t are_rebuilding =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then false
   else
     match Expr.descr t with
@@ -42,7 +42,7 @@ let can_be_removed_as_invalid t are_rebuilding =
     | Let _ | Let_cont _ | Apply _ | Apply_cont _ | Switch _ -> false
 
 let [@ocamlformat "disable"] print are_rebuilding ppf t =
-  if ART.are_not_rebuilding are_rebuilding then
+  if ART.not_rebuilding_terms are_rebuilding then
     Format.fprintf ppf "<unavailable, terms not being rebuilt>"
   else
     Expr.print ppf t
@@ -51,7 +51,7 @@ let term_not_rebuilt = Expr.create_invalid Code_not_rebuilt
 
 let create_let are_rebuilding bound_vars defining_expr ~body ~free_names_of_body
     =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then term_not_rebuilt
   else
     Let.create bound_vars defining_expr ~body
@@ -59,7 +59,7 @@ let create_let are_rebuilding bound_vars defining_expr ~body ~free_names_of_body
     |> Expr.create_let
 
 let create_apply are_rebuilding apply =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then term_not_rebuilt
   else Expr.create_apply apply
 
@@ -75,7 +75,7 @@ module Function_params_and_body = struct
       ~my_region ~my_ghost_region ~my_depth
 
   let to_function_params_and_body t are_rebuilding =
-    if ART.are_not_rebuilding are_rebuilding
+    if ART.not_rebuilding_terms are_rebuilding
     then
       Misc.fatal_error
         "Cannot ask for function params and body when not rebuilding terms"
@@ -96,7 +96,7 @@ module Continuation_handler = struct
 
   let create are_rebuilding params ~handler ~free_names_of_handler
       ~is_exn_handler ~is_cold =
-    if ART.are_not_rebuilding are_rebuilding
+    if ART.not_rebuilding_terms are_rebuilding
     then dummy
     else
       Continuation_handler.create params ~handler
@@ -104,7 +104,7 @@ module Continuation_handler = struct
         ~is_cold
 
   let create' are_rebuilding params ~handler ~is_exn_handler ~is_cold =
-    if ART.are_not_rebuilding are_rebuilding
+    if ART.not_rebuilding_terms are_rebuilding
     then dummy
     else
       Continuation_handler.create params ~handler ~free_names_of_handler:Unknown
@@ -113,7 +113,7 @@ end
 
 let create_non_recursive_let_cont are_rebuilding cont handler ~body
     ~free_names_of_body =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then term_not_rebuilt
   else
     Let_cont.create_non_recursive cont handler ~body
@@ -121,7 +121,7 @@ let create_non_recursive_let_cont are_rebuilding cont handler ~body
 
 let create_non_recursive_let_cont' are_rebuilding cont handler ~body
     ~num_free_occurrences_of_cont_in_body ~is_applied_with_traps =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then term_not_rebuilt
   else
     Let_cont.create_non_recursive' ~cont handler ~body
@@ -130,18 +130,18 @@ let create_non_recursive_let_cont' are_rebuilding cont handler ~body
 
 let create_non_recursive_let_cont_without_free_names are_rebuilding cont handler
     ~body =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then term_not_rebuilt
   else
     Let_cont.create_non_recursive cont handler ~body ~free_names_of_body:Unknown
 
 let create_recursive_let_cont are_rebuilding ~invariant_params handlers ~body =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then term_not_rebuilt
   else Let_cont.create_recursive ~invariant_params handlers ~body
 
 let create_switch are_rebuilding switch =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then term_not_rebuilt
   else Expr.create_switch switch
 

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -54,7 +54,7 @@ let create_normal_non_code const =
     }
 
 let create_code are_rebuilding ~params_and_body ~free_names_of_params_and_body =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then
     Code_metadata.createk (fun code_metadata ->
         ( Code_not_rebuilt
@@ -94,7 +94,7 @@ let create_set_of_closures are_rebuilding set =
       (Set_of_closures.function_decls set)
   in
   let free_names = Set_of_closures.free_names set in
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then Set_of_closures_not_rebuilt { free_names }
   else
     Normal
@@ -109,44 +109,44 @@ let free_names_of_fields fields =
       Name_occurrences.union free_names (Simple.With_debuginfo.free_names field))
 
 let create_block are_rebuilding tag is_mutable shape ~fields =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then
     let free_names = free_names_of_fields fields in
     Block_not_rebuilt { free_names }
   else create_normal_non_code (SC.block tag is_mutable shape fields)
 
 let create_boxed_float32 are_rebuilding or_var =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_float32 or_var)
 
 let create_boxed_float are_rebuilding or_var =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_float or_var)
 
 let create_boxed_int32 are_rebuilding or_var =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_int32 or_var)
 
 let create_boxed_int64 are_rebuilding or_var =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_int64 or_var)
 
 let create_boxed_nativeint are_rebuilding or_var =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_nativeint or_var)
 
 let create_boxed_vec128 are_rebuilding or_var =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_vec128 or_var)
 
 let create_immutable_float_block are_rebuilding fields =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then
     let free_names =
       ListLabels.fold_left fields ~init:Name_occurrences.empty
@@ -157,7 +157,7 @@ let create_immutable_float_block are_rebuilding fields =
   else create_normal_non_code (SC.immutable_float_block fields)
 
 let create_immutable_naked_number_array builder are_rebuilding fields =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then
     let free_names =
       ListLabels.fold_left fields ~init:Name_occurrences.empty
@@ -186,24 +186,24 @@ let create_immutable_vec128_array =
   create_immutable_naked_number_array SC.immutable_vec128_array
 
 let create_immutable_value_array are_rebuilding fields =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then
     let free_names = free_names_of_fields fields in
     Block_not_rebuilt { free_names }
   else create_normal_non_code (SC.immutable_value_array fields)
 
 let create_empty_array are_rebuilding array_kind =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then Block_not_rebuilt { free_names = Name_occurrences.empty }
   else create_normal_non_code (SC.empty_array array_kind)
 
 let create_mutable_string are_rebuilding ~initial_value =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then Block_not_rebuilt { free_names = Name_occurrences.empty }
   else create_normal_non_code (SC.mutable_string ~initial_value)
 
 let create_immutable_string are_rebuilding str =
-  if ART.are_not_rebuilding are_rebuilding
+  if ART.not_rebuilding_terms are_rebuilding
   then Block_not_rebuilt { free_names = Name_occurrences.empty }
   else create_normal_non_code (SC.immutable_string str)
 

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -54,7 +54,7 @@ let create_normal_non_code const =
     }
 
 let create_code are_rebuilding ~params_and_body ~free_names_of_params_and_body =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then
     Code_metadata.createk (fun code_metadata ->
         ( Code_not_rebuilt
@@ -94,7 +94,7 @@ let create_set_of_closures are_rebuilding set =
       (Set_of_closures.function_decls set)
   in
   let free_names = Set_of_closures.free_names set in
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then Set_of_closures_not_rebuilt { free_names }
   else
     Normal
@@ -109,44 +109,44 @@ let free_names_of_fields fields =
       Name_occurrences.union free_names (Simple.With_debuginfo.free_names field))
 
 let create_block are_rebuilding tag is_mutable shape ~fields =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then
     let free_names = free_names_of_fields fields in
     Block_not_rebuilt { free_names }
   else create_normal_non_code (SC.block tag is_mutable shape fields)
 
 let create_boxed_float32 are_rebuilding or_var =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_float32 or_var)
 
 let create_boxed_float are_rebuilding or_var =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_float or_var)
 
 let create_boxed_int32 are_rebuilding or_var =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_int32 or_var)
 
 let create_boxed_int64 are_rebuilding or_var =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_int64 or_var)
 
 let create_boxed_nativeint are_rebuilding or_var =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_nativeint or_var)
 
 let create_boxed_vec128 are_rebuilding or_var =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then Block_not_rebuilt { free_names = Or_variable.free_names or_var }
   else create_normal_non_code (SC.boxed_vec128 or_var)
 
 let create_immutable_float_block are_rebuilding fields =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then
     let free_names =
       ListLabels.fold_left fields ~init:Name_occurrences.empty
@@ -157,7 +157,7 @@ let create_immutable_float_block are_rebuilding fields =
   else create_normal_non_code (SC.immutable_float_block fields)
 
 let create_immutable_naked_number_array builder are_rebuilding fields =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then
     let free_names =
       ListLabels.fold_left fields ~init:Name_occurrences.empty
@@ -186,24 +186,24 @@ let create_immutable_vec128_array =
   create_immutable_naked_number_array SC.immutable_vec128_array
 
 let create_immutable_value_array are_rebuilding fields =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then
     let free_names = free_names_of_fields fields in
     Block_not_rebuilt { free_names }
   else create_normal_non_code (SC.immutable_value_array fields)
 
 let create_empty_array are_rebuilding array_kind =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then Block_not_rebuilt { free_names = Name_occurrences.empty }
   else create_normal_non_code (SC.empty_array array_kind)
 
 let create_mutable_string are_rebuilding ~initial_value =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then Block_not_rebuilt { free_names = Name_occurrences.empty }
   else create_normal_non_code (SC.mutable_string ~initial_value)
 
 let create_immutable_string are_rebuilding str =
-  if ART.do_not_rebuild_terms are_rebuilding
+  if ART.are_not_rebuilding are_rebuilding
   then Block_not_rebuilt { free_names = Name_occurrences.empty }
   else create_normal_non_code (SC.immutable_string str)
 

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -207,8 +207,9 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
         Simplify_rec_info_expr.known_remaining_unrolling_depth dacc
           (Call_site_inlining_decision.get_rec_info dacc ~function_type)
       in
-      if Are_rebuilding_terms.are_rebuilding
-           (DE.are_rebuilding_terms (DA.denv dacc))
+      if not
+           (Are_rebuilding_terms.not_rebuilding_terms
+              (DE.are_rebuilding_terms (DA.denv dacc)))
       then
         Inlining_report.record_decision_at_call_site_for_known_function
           ~pass:Inlining_report.Pass.Before_simplify ~unrolling_depth
@@ -881,7 +882,9 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
     (call : Call_kind.Function_call.t) ~apply_alloc_mode ~down_to_up =
   fail_if_probe apply;
   let denv = DA.denv dacc in
-  if Are_rebuilding_terms.are_rebuilding (DE.are_rebuilding_terms denv)
+  if not
+       (Are_rebuilding_terms.not_rebuilding_terms
+          (DE.are_rebuilding_terms denv))
   then
     Inlining_report.record_decision_at_call_site_for_unknown_function
       ~pass:Inlining_report.Pass.Before_simplify

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -478,10 +478,10 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
     let are_rebuilding = DA.are_rebuilding_terms dacc_after_body in
     match new_code with
     | None ->
-      assert (not (Are_rebuilding_terms.are_rebuilding are_rebuilding));
+      assert (Are_rebuilding_terms.not_rebuilding_terms are_rebuilding);
       Not_rebuilding
     | Some new_code ->
-      assert (Are_rebuilding_terms.are_rebuilding are_rebuilding);
+      assert (not (Are_rebuilding_terms.not_rebuilding_terms are_rebuilding));
       Rebuilding new_code
   in
   { code_id; code = Some (code, code_const); outer_dacc; should_resimplify }

--- a/middle_end/flambda2/simplify_shared/are_rebuilding_terms.ml
+++ b/middle_end/flambda2/simplify_shared/are_rebuilding_terms.ml
@@ -24,11 +24,9 @@ let [@ocamlformat "disable"] print ppf = function
   | Rebuilding_partially -> Format.fprintf ppf "partial"
   | Rebuilding_everything -> Format.fprintf ppf "%b" true
 
-let are_rebuilding = function
-  | Not_rebuilding -> false
-  | Rebuilding_partially | Rebuilding_everything -> true
-
-let are_not_rebuilding t = not (are_rebuilding t)
+let not_rebuilding_terms = function
+  | Not_rebuilding -> true
+  | Rebuilding_partially | Rebuilding_everything -> false
 
 let are_rebuilding_partially = function
   | Not_rebuilding | Rebuilding_everything -> false

--- a/middle_end/flambda2/simplify_shared/are_rebuilding_terms.ml
+++ b/middle_end/flambda2/simplify_shared/are_rebuilding_terms.ml
@@ -26,8 +26,7 @@ let [@ocamlformat "disable"] print ppf = function
 
 let are_rebuilding = function
   | Not_rebuilding -> false
-  | Rebuilding_partially
-  | Rebuilding_everything -> true
+  | Rebuilding_partially | Rebuilding_everything -> true
 
 let are_not_rebuilding t = not (are_rebuilding t)
 
@@ -36,5 +35,7 @@ let are_rebuilding_partially = function
   | Rebuilding_partially -> true
 
 let rebuild_nothing = Not_rebuilding
+
 let rebuild_everything = Rebuilding_everything
+
 let partial_rebuilding = Rebuilding_partially

--- a/middle_end/flambda2/simplify_shared/are_rebuilding_terms.ml
+++ b/middle_end/flambda2/simplify_shared/are_rebuilding_terms.ml
@@ -14,15 +14,27 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t = bool
+type t =
+  | Not_rebuilding
+  | Rebuilding_partially
+  | Rebuilding_everything
 
-let of_bool t = t
+let [@ocamlformat "disable"] print ppf = function
+  | Not_rebuilding -> Format.fprintf ppf "%b" false
+  | Rebuilding_partially -> Format.fprintf ppf "partial"
+  | Rebuilding_everything -> Format.fprintf ppf "%b" true
 
-let to_bool t = t
+let are_rebuilding = function
+  | Not_rebuilding -> false
+  | Rebuilding_partially
+  | Rebuilding_everything -> true
 
-let do_not_rebuild_terms t = not (to_bool t)
+let are_not_rebuilding t = not (are_rebuilding t)
 
-let [@ocamlformat "disable"] print ppf t =
-  Format.fprintf ppf "%b" (to_bool t)
+let are_rebuilding_partially = function
+  | Not_rebuilding | Rebuilding_everything -> false
+  | Rebuilding_partially -> true
 
-let are_rebuilding t = t
+let rebuild_nothing = Not_rebuilding
+let rebuild_everything = Rebuilding_everything
+let partial_rebuilding = Rebuilding_partially

--- a/middle_end/flambda2/simplify_shared/are_rebuilding_terms.mli
+++ b/middle_end/flambda2/simplify_shared/are_rebuilding_terms.mli
@@ -14,21 +14,29 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Flag indicating whether terms are being rebuilt during simplification. This
-    is not just [bool] to enforce that the setting in [DE] is used everywhere. *)
-
+(** Store information about whether terms are rebuilt during simplification,
+    and if so, whether the full expression is being rebuilt (as is the case most
+    of the time), or wheterh only part of the expressions if being rebuilt (as is
+    the case for continuation specialization where a single handler is rebuilt). *)
 type t
 
+(** Print *)
 val print : Format.formatter -> t -> unit
 
-val are_rebuilding : t -> bool
+(** This function returns [true] iff we are **not** rebuilding terms during the
+    upwards pass. *)
+val not_rebuilding_terms : t -> bool
 
-val are_not_rebuilding : t -> bool
-
+(** This function returns [true] iff we are rebuilding terms **and** we do so
+    partially (i.e. in the context of continuation specialization). *)
 val are_rebuilding_partially : t -> bool
 
+(** The value for when we do **not** rebuild terms. *)
 val rebuild_nothing : t
 
+(** The value for when we rebuild everything (i.e. most of the time) *)
 val rebuild_everything : t
 
+(** The value for when we rebuild terms, but only partially, i.e. in the
+    context of continuation specialization where only one handler is rebuilt. *)
 val partial_rebuilding : t

--- a/middle_end/flambda2/simplify_shared/are_rebuilding_terms.mli
+++ b/middle_end/flambda2/simplify_shared/are_rebuilding_terms.mli
@@ -22,10 +22,13 @@ type t
 val print : Format.formatter -> t -> unit
 
 val are_rebuilding : t -> bool
+
 val are_not_rebuilding : t -> bool
+
 val are_rebuilding_partially : t -> bool
 
 val rebuild_nothing : t
-val rebuild_everything : t
-val partial_rebuilding : t
 
+val rebuild_everything : t
+
+val partial_rebuilding : t

--- a/middle_end/flambda2/simplify_shared/are_rebuilding_terms.mli
+++ b/middle_end/flambda2/simplify_shared/are_rebuilding_terms.mli
@@ -19,10 +19,13 @@
 
 type t
 
-val of_bool : bool -> t
-
-val do_not_rebuild_terms : t -> bool
+val print : Format.formatter -> t -> unit
 
 val are_rebuilding : t -> bool
+val are_not_rebuilding : t -> bool
+val are_rebuilding_partially : t -> bool
 
-val print : Format.formatter -> t -> unit
+val rebuild_nothing : t
+val rebuild_everything : t
+val partial_rebuilding : t
+


### PR DESCRIPTION
(this is a pre-requisite for the "match-in-match" optimisation)

Instead of encoding a simple boolean, the [Are_rebuilding_terms.t], now also encodes whether we are rebuilding everything (as is almost always the case), or whether we are only rebuilding a small part of the unit (as will be the case for match-in-match/continuation specialization).

With this changes comes a small refactoring, removing the boolean conversions to/from [Are_rebuilding_terms] which would be misleading with the thirs option present, and renaming some functions for better clarity and consistency.

Finally, the [ART] in [uenv] is only there for printing, could we find a way to not need it ?