### PR TITLE
Fix reification of mixed blocks and float blocks

### DIFF
--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -67,15 +67,7 @@ let try_to_reify_fields env ~var_allowed alloc_mode
             ~var:(fun var ~coercion:_ ->
               if var_allowed alloc_mode var then Some simple else None)
             ~symbol:(fun _sym ~coercion:_ -> Some simple)
-            ~const:(fun const ->
-              match Reg_width_const.descr const with
-              | Tagged_immediate _imm -> Some simple
-              | Naked_immediate _ | Naked_float _ | Naked_float32 _
-              | Naked_int32 _ | Naked_vec128 _ | Naked_int64 _
-              | Naked_nativeint _ ->
-                (* This should never happen, as we should have got a kind error
-                   instead *)
-                None)
+            ~const:(fun _const -> Some simple)
         | Unknown -> None)
       field_types_and_expected_kinds
   in

--- a/testsuite/tests/mixed-blocks/reified_constants.ml
+++ b/testsuite/tests/mixed-blocks/reified_constants.ml
@@ -1,0 +1,24 @@
+(* TEST
+   flambda2;
+   flags="-extension layouts_beta";
+   native;
+*)
+
+(* Classic mode doesn't perform any lifting after inlining *)
+[@@@ocaml.flambda_o3]
+
+type t = { x : int option; y : int64#; }
+
+let[@inline] f x y = { x; y }
+
+let[@opaque] test () =
+  let a = f (Some 1) #2L in
+  a
+
+let () =
+  let bytes_start0 = Gc.allocated_bytes () in
+  let bytes_start1 = Gc.allocated_bytes () in
+  ignore (test ());
+  let bytes_end = Gc.allocated_bytes () in
+  assert (bytes_start0 +. bytes_end = 2. *. bytes_start1);
+  ()


### PR DESCRIPTION
See added example for a case where lifting fails.

The code used to only work for blocks full of values, when we added support for mixed blocks we failed to update the support for constants.