### PR TITLE
`Unique_barrier.Not_computed` defaults to `legacy`

### DIFF
--- a/testsuite/tests/typing-unique/unique_mod_class.ml
+++ b/testsuite/tests/typing-unique/unique_mod_class.ml
@@ -151,3 +151,15 @@ Line 7, characters 12-17:
                 ^^^^^
 Error: This value is "aliased" but expected to be "unique".
 |}]
+
+
+let foo (local_ x : string ref) =
+  let module M = struct
+    class c =
+      let y = !x in
+      fun () ->
+      object method m = y end
+  end in new M.c
+[%%expect{|
+val foo : local_ string ref -> (unit -> < m : string >) = <fun>
+|}]

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -84,9 +84,9 @@ module Unique_barrier = struct
       zapped
     | Resolved barrier -> barrier
     | Not_computed ->
-      if Language_extension.is_enabled Unique then
-        Misc.fatal_error "A unique barrier was not enabled by the analysis"
-      else Uniqueness.Const.Aliased
+      (* Uniqueness analysis does not go into legacy language constructs such as
+      objects; for those, we default to legacy *)
+      Uniqueness.Const.legacy
 end
 
 type unique_use = Mode.Uniqueness.r * Mode.Linearity.l

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -84,8 +84,13 @@ module Unique_barrier = struct
       zapped
     | Resolved barrier -> barrier
     | Not_computed ->
-      (* Uniqueness analysis does not go into legacy language constructs such as
-      objects; for those, we default to legacy *)
+      (* CR uniqueness: The uniqueness analysis does not go into legacy
+         language constructs such as objects; for those, we default to legacy.
+         We should change the uniqueness analysis to also traverse these
+         constructs. Then this case will be impossible to reach and we can fail
+         here. Failing here will protect us when future language extensions are
+         not traversing the uniqueness analysis. This ensures that the
+         unique barriers will stay sound for future extensions. *)
       Uniqueness.Const.legacy
 end
 


### PR DESCRIPTION
Uniqueness analysis does not go into legacy language constructs such as objects; for those, we default to legacy, instead of raising.