### PR TITLE
Eliminate deadcode potentially created by terminator simplification

### DIFF
--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1590,7 +1590,7 @@ class virtual selector_generic =
         (* CR xclerc for xclerc: Regalloc_irc_utils.log_cfg_with_infos ~indent:1
            (Cfg_with_infos.make cfg_with_layout); *)
         Merge_straightline_blocks.run cfg_with_layout;
-        Eliminate_dead_code.run_dead_block cfg_with_layout;
         Simplify_terminator.run cfg;
+        Eliminate_dead_code.run_dead_block cfg_with_layout;
         cfg_with_layout
   end

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2827,8 +2827,8 @@ let update_caml_flambda_invalid_cfg cfg_with_layout =
         (fun () ->
           Eliminate_fallthrough_blocks.run cfg_with_layout;
           Merge_straightline_blocks.run cfg_with_layout;
-          Eliminate_dead_code.run_dead_block cfg_with_layout;
-          Simplify_terminator.run cfg)
+          Simplify_terminator.run cfg;
+          Eliminate_dead_code.run_dead_block cfg_with_layout)
         ())
 
 let fundecl ppf_dump ~future_funcnames fd =


### PR DESCRIPTION
Terminator simplification can result in dead
code, which is then making later passes fail.
This pull request thus ensures that all calls to
`Simplify_terminator.run` are followed by calls
to `Eliminate_dead_code.run_dead_block` (like
in `Cfgize`).