### PR TITLE
Add `-no-mach-ir` command-line switch

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -1348,12 +1348,7 @@ module Extra_params = struct
     match name with
     | "internal-assembler" -> set' Flambda_backend_flags.internal_assembler
     | "dgc-timings" -> set' Flambda_backend_flags.gc_timings
-    | "no-mach-ir" ->
-      Flambda_backend_flags.cfg_selection := true;
-      Flambda_backend_flags.cfg_cse_optimize := true;
-      Flambda_backend_flags.cfg_zero_alloc_checker := true;
-      Flambda_backend_flags.regalloc := "cfg";
-      true
+    | "no-mach-ir" -> Flambda_backend_options_impl.no_mach_ir (); true
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
     | "cfg-invariants" -> set' Flambda_backend_flags.cfg_invariants
     | "cfg-equivalence-check" -> set' Flambda_backend_flags.cfg_equivalence_check

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -22,6 +22,9 @@ let mk_flambda2_debug f =
 let mk_no_flambda2_debug f =
   "-no-flambda2-debug", Arg.Unit f, " Disable debug output for the Flambda2 pass"
 
+let mk_no_mach_ir f =
+  "-no-mach-ir", Arg.Unit f, " Avoid using the Mach IR"
+
 let mk_ocamlcfg f =
   "-ocamlcfg", Arg.Unit f, " Use ocamlcfg"
 
@@ -755,6 +758,8 @@ module type Flambda_backend_options = sig
 
   val gc_timings : unit -> unit
 
+  val no_mach_ir : unit -> unit
+
   val flambda2_debug : unit -> unit
   val no_flambda2_debug : unit -> unit
   val flambda2_join_points : unit -> unit
@@ -891,6 +896,8 @@ struct
     mk_internal_assembler F.internal_assembler;
 
     mk_gc_timings F.gc_timings;
+
+    mk_no_mach_ir F.no_mach_ir;
 
     mk_flambda2_debug F.flambda2_debug;
     mk_no_flambda2_debug F.no_flambda2_debug;
@@ -1094,6 +1101,12 @@ module Flambda_backend_options_impl = struct
   let internal_assembler = set' Flambda_backend_flags.internal_assembler
 
   let gc_timings = set' Flambda_backend_flags.gc_timings
+
+  let no_mach_ir () =
+    Flambda_backend_flags.cfg_selection := true;
+    Flambda_backend_flags.cfg_cse_optimize := true;
+    Flambda_backend_flags.cfg_zero_alloc_checker := true;
+    Flambda_backend_flags.regalloc := "cfg"
 
   let flambda2_debug = set' Flambda_backend_flags.Flambda2.debug
   let no_flambda2_debug = clear' Flambda_backend_flags.Flambda2.debug
@@ -1335,6 +1348,12 @@ module Extra_params = struct
     match name with
     | "internal-assembler" -> set' Flambda_backend_flags.internal_assembler
     | "dgc-timings" -> set' Flambda_backend_flags.gc_timings
+    | "no-mach-ir" ->
+      Flambda_backend_flags.cfg_selection := true;
+      Flambda_backend_flags.cfg_cse_optimize := true;
+      Flambda_backend_flags.cfg_zero_alloc_checker := true;
+      Flambda_backend_flags.regalloc := "cfg";
+      true
     | "ocamlcfg" -> set' Flambda_backend_flags.use_ocamlcfg
     | "cfg-invariants" -> set' Flambda_backend_flags.cfg_invariants
     | "cfg-equivalence-check" -> set' Flambda_backend_flags.cfg_equivalence_check

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -85,6 +85,8 @@ module type Flambda_backend_options = sig
 
   val gc_timings : unit -> unit
 
+  val no_mach_ir : unit -> unit
+
   val flambda2_debug : unit -> unit
   val no_flambda2_debug : unit -> unit
   val flambda2_join_points : unit -> unit


### PR DESCRIPTION
This pull request is arguably a bit gimmicky, but
slightly simplifies testing by providing a single
command-line switch (namely `-no-mach-ir`) to
switch all passes to their CFG implementations
(so that the Mach IR is not used).

At the time of writing, it is equivalent to passing:

- `-cfg-selection`;
- `-cfg-cse-optimize`;
- `-cfg-zero-alloc-checker`;
- `-regalloc cfg`.