### PR TITLE
Ensure consistent variable binding times

### DIFF
--- a/middle_end/flambda2/types/env/typing_env_level.ml
+++ b/middle_end/flambda2/types/env/typing_env_level.ml
@@ -69,11 +69,11 @@ let [@ocamlformat "disable"] print ppf
 
 let fold_on_defined_vars f t init =
   Binding_time.Map.fold
-    (fun _bt vars acc ->
+    (fun bt vars acc ->
       Variable.Set.fold
         (fun var acc ->
           let kind = Variable.Map.find var t.defined_vars in
-          f var kind acc)
+          f ~binding_time:bt var kind acc)
         vars acc)
     t.binding_times init
 
@@ -113,7 +113,8 @@ let add_symbol_projection t var proj =
   { t with symbol_projections }
 
 let add_definition t var kind binding_time =
-  if Flambda_features.check_invariants () && Variable.Map.mem var t.defined_vars
+  if Flambda_features.check_light_invariants ()
+     && Variable.Map.mem var t.defined_vars
   then
     Misc.fatal_errorf "Environment extension already binds variable %a:@ %a"
       Variable.print var print t;

--- a/middle_end/flambda2/types/env/typing_env_level.mli
+++ b/middle_end/flambda2/types/env/typing_env_level.mli
@@ -58,6 +58,9 @@ val variables_by_binding_time : t -> Variable.Set.t Binding_time.Map.t
 val variable_is_defined : t -> Variable.t -> bool
 
 val fold_on_defined_vars :
-  (Variable.t -> Flambda_kind.t -> 'a -> 'a) -> t -> 'a -> 'a
+  (binding_time:Binding_time.t -> Variable.t -> Flambda_kind.t -> 'a -> 'a) ->
+  t ->
+  'a ->
+  'a
 
 val as_extension_without_bindings : t -> Type_grammar.Env_extension.t


### PR DESCRIPTION
When joining environments, we exclude variables that are no longer useful in the joined environment. This causes the remaining variables to have new (lower) binding times.

If we later join the resulting environment again with another environment that still has those variables, we end up having the same variable with different binding times in the joined level, and we define the variable twice in the resulting environment.

This can allow breaking the order between two variable's binding times, which means that different canonical elements can be chosen in different environments for the same pair of variables.

This patch fixes the issue by keeping track of `next_binding_time` *globally* across all related environments and keeping the binding time during join, ensuring that the binding time of a variable is globally unique and preventing any such re-orderings.

Longer explanation
------------------

Consider 4 environments that define variables `a`, `b`, `c`, and `d`.

```
      _________________________________
     /            |            |       \
  Env 1         Env 2        Env 3    Env 4
   /              |            |         \
define a       define a     define a  define a
   |              |            |         |
define b       define b     define b  define b
   |              |            |         |
define c       define c     define c  define c
   |              |            |         |
define d       define d     define d  define d

```

Suppose that we first join environments 3 and 4 (filtering out `a` and `b`) and environments 1 and 2 (filtering out `d`):

```
      ____________
     /            \
  Env 1 \/ 2      Env 3 \/ 4
   /                \
define a         define c
   |                |
define b         define d
   |
define c
```

Once we join the two resulting environments, if we filter out `a` and `b` but keep `c` and `d`, the current implementation creates a level which defines `c`, then `d`, then `c` again. Since we keep the last definition, we end up with the environment:

```
define d
   |
define c
```

We have now swapped the binding times of `c` and `d` which, if they were in the same alias set, can introduce subtle bugs.