### PR TITLE
Fix bug in dataflow with [Invalid] extra_args

### DIFF
--- a/middle_end/flambda2/simplify/flow/flow_acc.ml
+++ b/middle_end/flambda2/simplify/flow/flow_acc.ml
@@ -445,6 +445,12 @@ let extend_args_with_extra_args (t : T.Acc.t) =
                   rewrite_ids)
             elt.apply_cont_args
         in
+        let apply_cont_args =
+          Continuation.Map.filter
+            (fun _ rewrite_ids ->
+              not (Apply_cont_rewrite_id.Map.is_empty rewrite_ids))
+            apply_cont_args
+        in
         { elt with apply_cont_args })
       t.map
   in

--- a/middle_end/flambda2/simplify/flow/flow_acc.ml
+++ b/middle_end/flambda2/simplify/flow/flow_acc.ml
@@ -445,7 +445,7 @@ let extend_args_with_extra_args (t : T.Acc.t) =
                     (add_extra_args_to_call ~extra_args)
                     rewrite_ids
               in
-              (* We must leave an empty [Apply_cont_rewrite_id] map here.
+              (* We must not leave an empty [Apply_cont_rewrite_id] map here.
                  Indeed, not having any actual continuation arguments will let
                  flow analysis find a dominator for parameters of [cont] that we
                  do not have access to. Since we then only look at which

--- a/middle_end/flambda2/simplify/flow/flow_acc.ml
+++ b/middle_end/flambda2/simplify/flow/flow_acc.ml
@@ -434,22 +434,30 @@ let extend_args_with_extra_args (t : T.Acc.t) =
     Continuation.Map.map
       (fun (elt : T.Continuation_info.t) ->
         let apply_cont_args =
-          Continuation.Map.mapi
+          Continuation.Map.filter_map
             (fun cont rewrite_ids ->
-              match Continuation.Map.find cont t.extra with
-              | exception Not_found -> rewrite_ids
-              | epa ->
-                let extra_args = EPA.extra_args epa in
-                Apply_cont_rewrite_id.Map.filter_map
-                  (add_extra_args_to_call ~extra_args)
-                  rewrite_ids)
+              let rewrite_ids =
+                match Continuation.Map.find cont t.extra with
+                | exception Not_found -> rewrite_ids
+                | epa ->
+                  let extra_args = EPA.extra_args epa in
+                  Apply_cont_rewrite_id.Map.filter_map
+                    (add_extra_args_to_call ~extra_args)
+                    rewrite_ids
+              in
+              (* We must leave an empty [Apply_cont_rewrite_id] map here.
+                 Indeed, not having any actual continuation arguments will let
+                 flow analysis find a dominator for parameters of [cont] that we
+                 do not have access to. Since we then only look at which
+                 continuation can call which to know which arguments to add,
+                 this causes the ‌adding of the extra parameters to assume we
+                 need access to that dominator since it looks like we can call
+                 [cont], but since neither we nor any of our callers have access
+                 to it, trying to add the dominator crashes the compiler. *)
+              if Apply_cont_rewrite_id.Map.is_empty rewrite_ids
+              then None
+              else Some rewrite_ids)
             elt.apply_cont_args
-        in
-        let apply_cont_args =
-          Continuation.Map.filter
-            (fun _ rewrite_ids ->
-              not (Apply_cont_rewrite_id.Map.is_empty rewrite_ids))
-            apply_cont_args
         in
         { elt with apply_cont_args })
       t.map

--- a/testsuite/tests/flambda/invalid_apply_cont_in_flow_analysis.ml
+++ b/testsuite/tests/flambda/invalid_apply_cont_in_flow_analysis.ml
@@ -1,0 +1,31 @@
+(* TEST
+ flambda2;
+ native;
+*)
+
+[@@@ocaml.flambda_o3]
+
+external magic : 'a -> 'b = "%identity"
+
+type _ tag =
+  | A : int list tag
+  | B : (int * int list option) tag
+
+type mut = E : { mutable tag : 'a tag; v : 'a } -> mut
+
+let go input =
+  let (x, y) : int * int list option =
+    match input with
+    | E { tag = A; v = a } -> 0, Some a
+    | E { tag = B; v = b } -> let (b0, b1) = b in (b0, b1)
+  in
+  x, y
+;;
+
+let make i =
+  let list = [ i; 123 ] in
+  if true then
+    go (magic (A, list))
+  else
+    go (E { tag = A; v = list})
+;;


### PR DESCRIPTION
This fixes a fatal error on main with this input:
```ocaml
let go input =
  let x, y =
    match input with
    | `A a -> 0, Some a
    | `B b -> b
  in
  x, y
;;

let make i =
  let list = [ i; 123 ] in
  go (`A list)
;;
```

What happened was that there was a continuation with two calling sites, one being the one taken at runtime, the other being invalid. However, this invalid was only seen due to (normal) unboxing, and thus ended in the extra args.
We thus had a continuation `k1` being called from two different continuations, `k2` and `k3`, with the calling site from `k3` being invalid.

Since we compute dataflow after normalisation and removing the invalid call site, we saw that a variable defined inside `k2` was the dominator of an argument to `k1`, and passed as an alias. However, `k3` was not in scope of this variable, but we tried to add it as we thought `k3` was calling `k1`, due to the `k1` being in the `apply_cont_args` map of `k3`, even though the list of call sites was empty! Since neither `k3` nor any continuation calling it in scope of the variable, the extra argument was added all the way up until the dummy toplevel continuation, crashing the compiler.