### PR TITLE
Ensure predecessor sets are correct after teminator simplification

### DIFF
--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -199,4 +199,11 @@ let run cfg =
         let shortcircuit = block cfg b in
         registration_needed || shortcircuit)
   in
-  if registration_needed then Cfg.register_predecessors_for_all_blocks cfg
+  if registration_needed
+  then (
+    (* We may need to remove predecessors, and
+       `register_predecessors_for_all_blocks` is only adding predecessors, so we
+       first set all to empty. *)
+    C.iter_blocks cfg ~f:(fun _label block ->
+        block.predecessors <- Label.Set.empty);
+    Cfg.register_predecessors_for_all_blocks cfg)


### PR DESCRIPTION
This pull request fixes a bug in terminator
simplification. At the end of the pass, the
`register_predecessors_for_all_blocks` was
called, but this function can only add
missing predecessors, not remove ones.

This means that if predecessors would need
to be deleted, we would end up with an
invalid CFG. Interestingly enough, last
week's fix ensuring the deletion of dead
code was partially masking this issue.
In practice, when a predecessor needs to
be removed, it is often the case that the
portion of the CFG that would be invalid
is in fact dead code.