### PR TITLE
Zero alloc: better error messages for allocations

### DIFF
--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -45,7 +45,7 @@ type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
 type specific_operation =
   | Ifar_poll of { return_label: cmm_label option }
-  | Ifar_alloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo }
+  | Ifar_alloc of { bytes : int; dbginfo : Cmm.alloc_dbginfo }
   | Ishiftarith of arith_operation * int
   | Imuladd       (* multiply and add *)
   | Imulsub       (* multiply and subtract *)

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -43,7 +43,7 @@ type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
 type specific_operation =
   | Ifar_poll of { return_label: cmm_label option }
-  | Ifar_alloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo }
+  | Ifar_alloc of { bytes : int; dbginfo : Cmm.alloc_dbginfo }
   | Ishiftarith of arith_operation * int
   | Imuladd       (* multiply and add *)
   | Imulsub       (* multiply and subtract *)

--- a/backend/branch_relaxation_intf.mli
+++ b/backend/branch_relaxation_intf.mli
@@ -61,7 +61,7 @@ module type S = sig
      the size of out-of-line code (cf. branch_relaxation.mli). *)
   val relax_allocation
      : num_bytes:int
-    -> dbginfo:Debuginfo.alloc_dbginfo
+    -> dbginfo:Cmm.alloc_dbginfo
     -> Linear.instruction_desc
 
   val relax_poll

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -9,7 +9,7 @@ type cell = Cfg.basic Cfg.instruction DLL.cell
    cell so that the instruction can be modified. *)
 type allocation =
   { bytes : int;
-    dbginfo : Debuginfo.alloc_dbginfo;
+    dbginfo : Cmm.alloc_dbginfo;
     mode : Cmm.Alloc_mode.t;
     cell : cell
   }

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -223,7 +223,7 @@ class virtual selector_generic =
         | _ -> basic_op (Store (chunk, addr, is_assign)), [arg2; eloc]
         (* Inversion addr/datum in Istore *))
       | Cdls_get -> basic_op Dls_get, args
-      | Calloc (mode, alloc_block_kind), _ ->
+      | Calloc (mode, alloc_block_kind) ->
         let placeholder_for_alloc_block_kind =
           { alloc_words = 0; alloc_block_kind; alloc_dbg = Debuginfo.none }
         in
@@ -500,14 +500,14 @@ class virtual selector_generic =
             sub_cfg <- Sub_cfg.add_never_block sub_cfg ~label;
             ret rd)
           else None
-        | Basic (Op (Alloc { bytes = _; mode })) ->
+        | Basic (Op (Alloc { bytes = _; mode; dbginfo = [placeholder] })) ->
           let rd = self#regs_for typ_val in
           let bytes = Select_utils.size_expr env (Ctuple new_args) in
           let alloc_words = (bytes + Arch.size_addr - 1) / Arch.size_addr in
           let op =
             Operation.Alloc
               { bytes = alloc_words * Arch.size_addr;
-                dbginfo = [{ alloc_words; alloc_dbg = dbg }];
+                dbginfo = [{ placeholder with alloc_words; alloc_dbg = dbg }];
                 mode
               }
           in

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -223,7 +223,14 @@ class virtual selector_generic =
         | _ -> basic_op (Store (chunk, addr, is_assign)), [arg2; eloc]
         (* Inversion addr/datum in Istore *))
       | Cdls_get -> basic_op Dls_get, args
-      | Calloc mode -> basic_op (Alloc { bytes = 0; dbginfo = []; mode }), args
+      | Calloc (mode, alloc_block_kind), _ ->
+        let placeholder_for_alloc_block_kind =
+          { alloc_words = 0; alloc_block_kind; alloc_dbg = Debuginfo.none }
+        in
+        ( basic_op
+            (Alloc
+               { bytes = 0; dbginfo = [placeholder_for_alloc_block_kind]; mode }),
+          args )
       | Cpoll -> basic_op Poll, args
       | Caddi -> self#select_arith_comm Simple_operation.Iadd args
       | Csubi -> self#select_arith Simple_operation.Isub args

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -516,6 +516,10 @@ class virtual selector_generic =
           self#emit_stores env dbg new_args rd;
           Select_utils.set_traps_for_raise env;
           ret rd
+        | Basic (Op (Alloc { bytes = _; mode = _; dbginfo })) ->
+          Misc.fatal_errorf
+            "Selection Alloc: expected a single placehold in dbginfo, found %d"
+            (List.length dbginfo)
         | Basic (Op op) ->
           let r1 = self#emit_tuple env new_args in
           let rd = self#regs_for ty in

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -262,8 +262,22 @@ module Alloc_mode = struct
     | Local -> false
 end
 
+type alloc_block_kind =
+  | Alloc_block_kind_other
+  | Alloc_block_kind_closure
+  | Alloc_block_kind_float
+  | Alloc_block_kind_float32
+  | Alloc_block_kind_vec128
+  | Alloc_block_kind_boxed_int of Primitive.boxed_integer
+  | Alloc_block_kind_float_array
+  | Alloc_block_kind_float32_u_array
+  | Alloc_block_kind_int32_u_array
+  | Alloc_block_kind_int64_u_array
+  | Alloc_block_kind_vec128_u_array
+
 type alloc_dbginfo_item =
   { alloc_words : int;
+    alloc_block_kind : alloc_block_kind;
     alloc_dbg : Debuginfo.t }
 type alloc_dbginfo = alloc_dbginfo_item list
 
@@ -284,7 +298,7 @@ type operation =
         mutability: Asttypes.mutable_flag;
         is_atomic: bool;
       }
-  | Calloc of Alloc_mode.t
+  | Calloc of Alloc_mode.t * alloc_block_kind
   | Cstore of memory_chunk * initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool } | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -262,6 +262,11 @@ module Alloc_mode = struct
     | Local -> false
 end
 
+type alloc_dbginfo_item =
+  { alloc_words : int;
+    alloc_dbg : Debuginfo.t }
+type alloc_dbginfo = alloc_dbginfo_item list
+
 type operation =
     Capply of machtype * Lambda.region_close
   | Cextcall of

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -229,8 +229,22 @@ module Alloc_mode : sig
   val is_heap  : t -> bool
 end
 
+type alloc_block_kind =
+  | Alloc_block_kind_other
+  | Alloc_block_kind_closure
+  | Alloc_block_kind_float
+  | Alloc_block_kind_float32
+  | Alloc_block_kind_vec128
+  | Alloc_block_kind_boxed_int of Primitive.boxed_integer
+  | Alloc_block_kind_float_array
+  | Alloc_block_kind_float32_u_array
+  | Alloc_block_kind_int32_u_array
+  | Alloc_block_kind_int64_u_array
+  | Alloc_block_kind_vec128_u_array
+
 type alloc_dbginfo_item =
   { alloc_words : int;
+    alloc_block_kind : alloc_block_kind;
     alloc_dbg : Debuginfo.t }
 (** Due to Comballoc, a single Ialloc instruction may combine several
     unrelated allocations. Their Debuginfo.t (which may differ) are stored
@@ -261,7 +275,7 @@ type operation =
         mutability: Asttypes.mutable_flag;
         is_atomic: bool;
       }
-  | Calloc of Alloc_mode.t
+  | Calloc of Alloc_mode.t * alloc_block_kind
   | Cstore of memory_chunk * initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi of { signed: bool }  | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -229,6 +229,17 @@ module Alloc_mode : sig
   val is_heap  : t -> bool
 end
 
+type alloc_dbginfo_item =
+  { alloc_words : int;
+    alloc_dbg : Debuginfo.t }
+(** Due to Comballoc, a single Ialloc instruction may combine several
+    unrelated allocations. Their Debuginfo.t (which may differ) are stored
+    as a list of alloc_dbginfo. This list is in order of increasing memory
+    address, which is the reverse of the original allocation order. Later
+    allocations are consed to the front of this list by Comballoc. *)
+
+type alloc_dbginfo = alloc_dbginfo_item list
+
 type operation =
     Capply of machtype * Lambda.region_close
   | Cextcall of

--- a/backend/comballoc.ml
+++ b/backend/comballoc.ml
@@ -20,7 +20,7 @@ open Mach
 
 type pending_alloc =
   { reg: Reg.t;         (* register holding the result of the last allocation *)
-    dbginfos: Debuginfo.alloc_dbginfo;   (* debug info for each pending alloc *)
+    dbginfos: Cmm.alloc_dbginfo;   (* debug info for each pending alloc *)
     totalsz: int;                     (* amount to be allocated in this block *)
     mode: Cmm.Alloc_mode.t }                      (* heap or stack allocation *)
 

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -111,7 +111,7 @@ let emit_float32_directive directive x = emit_printf "\t%s\t0x%lx\n" directive x
 (* Record live pointers at call points *)
 
 type frame_debuginfo =
-  | Dbg_alloc of Debuginfo.alloc_dbginfo
+  | Dbg_alloc of Cmm.alloc_dbginfo
   | Dbg_raise of Debuginfo.t
   | Dbg_other of Debuginfo.t
 
@@ -132,7 +132,7 @@ let get_flags debuginfo =
   | Dbg_other d | Dbg_raise d -> if is_none_dbg d then 0 else 1
   | Dbg_alloc dbgs ->
     if !Clflags.debug
-       && List.exists (fun d -> not (is_none_dbg d.Debuginfo.alloc_dbg)) dbgs
+       && List.exists (fun d -> not (is_none_dbg d.Cmm.alloc_dbg)) dbgs
     then 3
     else 2
 
@@ -243,7 +243,7 @@ let emit_frames a =
       assert (List.length dbg < 256);
       a.efa_8 (List.length dbg);
       List.iter
-        (fun Debuginfo.{ alloc_words; _ } ->
+        (fun Cmm.{ alloc_words; _ } ->
           (* Possible allocations range between 2 and 257 *)
           assert (
             2 <= alloc_words
@@ -255,7 +255,7 @@ let emit_frames a =
       then (
         a.efa_align 4;
         List.iter
-          (fun Debuginfo.{ alloc_dbg; _ } ->
+          (fun Cmm.{ alloc_dbg; _ } ->
             if is_none_dbg alloc_dbg
             then a.efa_32 Int32.zero
             else a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero)

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -61,7 +61,7 @@ val get_file_num :
   file_emitter:(file_num:int -> file_name:string -> unit) -> string -> int
 
 type frame_debuginfo =
-  | Dbg_alloc of Debuginfo.alloc_dbginfo
+  | Dbg_alloc of Cmm.alloc_dbginfo
   | Dbg_raise of Debuginfo.t
   | Dbg_other of Debuginfo.t
 

--- a/backend/mach.ml
+++ b/backend/mach.ml
@@ -40,7 +40,7 @@ type operation =
                mutability : Asttypes.mutable_flag;
                is_atomic : bool }
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
-  | Ialloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo;
+  | Ialloc of { bytes : int; dbginfo : Cmm.alloc_dbginfo;
                 mode : Cmm.Alloc_mode.t }
   | Iintop of integer_operation
   | Iintop_imm of integer_operation * int

--- a/backend/mach.mli
+++ b/backend/mach.mli
@@ -41,7 +41,7 @@ type operation =
                is_atomic : bool }
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
                                  (* false = initialization, true = assignment *)
-  | Ialloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo;
+  | Ialloc of { bytes : int; dbginfo : Cmm.alloc_dbginfo;
                 mode: Cmm.Alloc_mode.t }
   | Iintop of integer_operation
   | Iintop_imm of integer_operation * int

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -70,7 +70,7 @@ type t =
   | Poll
   | Alloc of
       { bytes : int;
-        dbginfo : Debuginfo.alloc_dbginfo;
+        dbginfo : Cmm.alloc_dbginfo;
         mode : Cmm.Alloc_mode.t
       }
 

--- a/backend/operation.mli
+++ b/backend/operation.mli
@@ -74,7 +74,7 @@ type t =
   | Poll
   | Alloc of
       { bytes : int;
-        dbginfo : Debuginfo.alloc_dbginfo;
+        dbginfo : Cmm.alloc_dbginfo;
         mode : Cmm.Alloc_mode.t
       }
 

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -222,8 +222,8 @@ let operation d = function
       match mutability with
       | Asttypes.Immutable -> Printf.sprintf "load %s" (chunk memory_chunk)
       | Asttypes.Mutable   -> Printf.sprintf "load_mut %s" (chunk memory_chunk))
-  | Calloc Alloc_mode.Heap -> "alloc" ^ location d
-  | Calloc Alloc_mode.Local -> "alloc_local" ^ location d
+  | Calloc (Alloc_mode.Heap,_) -> "alloc" ^ location d
+  | Calloc (Alloc_mode.Local,_) -> "alloc_local" ^ location d
   | Cstore (c, init) ->
     let init =
       match init with

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -488,8 +488,8 @@ class virtual ['env, 'op, 'instr] common_selector =
           | Cextcall { effects = e; coeffects = ce } ->
             EC.create (select_effects e) (select_coeffects ce)
           | Capply _ | Cprobe _ | Copaque | Cpoll -> EC.arbitrary
-          | Calloc Heap -> EC.none
-          | Calloc Local -> EC.coeffect_only Coeffect.Arbitrary
+          | Calloc (Heap, _) -> EC.none
+          | Calloc (Local, _) -> EC.coeffect_only Coeffect.Arbitrary
           | Cstore _ -> EC.effect_only Effect.Arbitrary
           | Cbeginregion | Cendregion -> EC.arbitrary
           | Cprefetch _ -> EC.arbitrary

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -439,6 +439,10 @@ class virtual selector_generic =
           self#emit_stores env dbg new_args rd;
           Select_utils.set_traps_for_raise env;
           ret rd
+        | Ialloc { bytes = _; mode = _; dbginfo } ->
+          Misc.fatal_errorf
+            "Selection Ialloc: expected a single placehold in dbginfo, found %d"
+            (List.length dbginfo)
         | Iprobe _ ->
           let r1 = self#emit_tuple env new_args in
           let rd = self#regs_for ty in

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -33,7 +33,7 @@ module Witness = struct
   type kind =
     | Alloc of
         { bytes : int;
-          dbginfo : Debuginfo.alloc_dbginfo
+          dbginfo : Cmm.alloc_dbginfo
         }
     | Indirect_call
     | Indirect_tailcall
@@ -1626,7 +1626,7 @@ end = struct
         in
         let details =
           List.map
-            (fun (item : Debuginfo.alloc_dbginfo_item) ->
+            (fun (item : Cmm.alloc_dbginfo_item) ->
               let pp_alloc ppf =
                 Format.fprintf ppf "allocate %d words%a" item.alloc_words
                   pp_inlined_dbg item.alloc_dbg

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -1623,9 +1623,9 @@ end = struct
       | Alloc_block_kind_boxed_int bi ->
         pp
           (match bi with
-          | Pnativeint -> "boxed_nativeint"
-          | Pint32 -> "boxed_int32"
-          | Pint64 -> "boxed_int64")
+          | Boxed_nativeint -> "boxed_nativeint"
+          | Boxed_int32 -> "boxed_int32"
+          | Boxed_int64 -> "boxed_int64")
       | Alloc_block_kind_float_array -> pp "unboxed_float64_array"
       | Alloc_block_kind_float32_u_array -> pp "unboxed_float32_array"
       | Alloc_block_kind_int32_u_array -> pp "unboxed_int32_array"

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -1612,9 +1612,40 @@ end = struct
       if Debuginfo.Dbg.length (Debuginfo.get_dbg dbg) > 1
       then Format.fprintf ppf " (%a)" Debuginfo.print_compact dbg
     in
+    let pp_alloc_block_kind ppf k =
+      let pp s = Format.fprintf ppf " for %s" s in
+      match (k : Cmm.alloc_block_kind) with
+      | Alloc_block_kind_other -> ()
+      | Alloc_block_kind_closure -> pp "closure"
+      | Alloc_block_kind_float -> pp "float"
+      | Alloc_block_kind_float32 -> pp "float32"
+      | Alloc_block_kind_vec128 -> pp "vec128"
+      | Alloc_block_kind_boxed_int bi ->
+        pp
+          (match bi with
+          | Pnativeint -> "boxed_nativeint"
+          | Pint32 -> "boxed_int32"
+          | Pint64 -> "boxed_int64")
+      | Alloc_block_kind_float_array -> pp "unboxed_float64_array"
+      | Alloc_block_kind_float32_u_array -> pp "unboxed_float32_array"
+      | Alloc_block_kind_int32_u_array -> pp "unboxed_int32_array"
+      | Alloc_block_kind_int64_u_array -> pp "unboxed_int64_array"
+      | Alloc_block_kind_vec128_u_array -> pp "unboxed_vec128_array"
+    in
+    let pp_alloc_dbginfo_item (item : Cmm.alloc_dbginfo_item) =
+      let pp_alloc ppf =
+        Format.fprintf ppf "allocate %d words%a%a" item.alloc_words
+          pp_alloc_block_kind item.alloc_block_kind pp_inlined_dbg
+          item.alloc_dbg
+      in
+      let aloc = Debuginfo.to_location item.alloc_dbg in
+      Location.mkloc pp_alloc aloc
+    in
     let print_comballoc dbg =
       match dbg with
-      | [] | [_] -> "", []
+      | [] -> "", []
+      | [item] ->
+        Format.asprintf "%a" pp_alloc_block_kind item.Cmm.alloc_block_kind, []
       | alloc_dbginfo ->
         (* If one Ialloc is a result of combining multiple allocations, print
            details of each location. Currently, this cannot happen because
@@ -1624,17 +1655,7 @@ end = struct
           Printf.sprintf " combining %d allocations below"
             (List.length alloc_dbginfo)
         in
-        let details =
-          List.map
-            (fun (item : Cmm.alloc_dbginfo_item) ->
-              let pp_alloc ppf =
-                Format.fprintf ppf "allocate %d words%a" item.alloc_words
-                  pp_inlined_dbg item.alloc_dbg
-              in
-              let aloc = Debuginfo.to_location item.alloc_dbg in
-              Location.mkloc pp_alloc aloc)
-            alloc_dbginfo
-        in
+        let details = List.map pp_alloc_dbginfo_item alloc_dbginfo in
         msg, details
     in
     let print_witness (w : Witness.t) ~component =

--- a/backend/zero_alloc_checker.mli
+++ b/backend/zero_alloc_checker.mli
@@ -55,7 +55,7 @@ module Witness : sig
   type kind =
     | Alloc of
         { bytes : int;
-          dbginfo : Debuginfo.alloc_dbginfo
+          dbginfo : Cmm.alloc_dbginfo
         }
     | Indirect_call
     | Indirect_tailcall

--- a/flambda-backend/tests/backend/zero_alloc_checker/fail24.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/fail24.output
@@ -5,4 +5,4 @@ File "fail24.ml", line 6, characters 4-54:
 Error: called function may allocate (external call to caml_ba_set_1)
 
 File "fail24.ml", line 6, characters 38-54:
-Error: allocation of 24 bytes
+Error: allocation of 24 bytes for boxed_int64

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_bounded_join3.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_bounded_join3.output
@@ -2,7 +2,7 @@ File "test_bounded_join3.ml", line 8, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_bounded_join3.foo (camlTest_bounded_join3.foo_HIDE_STAMP)
 
 File "test_bounded_join3.ml", lines 10-11, characters 43-61:
-Error: allocation of 200 bytes
+Error: allocation of 200 bytes for closure
 
 File "test_bounded_join3.ml", line 24, characters 11-19:
 Error: called function may allocate (direct tailcall camlTest_bounded_join3.do_a_HIDE_STAMP)

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_bounded_join4.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_bounded_join4.output
@@ -2,7 +2,7 @@ File "test_bounded_join4.ml", line 8, characters 5-15:
 Error: Annotation check for zero_alloc failed on function Test_bounded_join4.foo (camlTest_bounded_join4.foo_HIDE_STAMP)
 
 File "test_bounded_join4.ml", lines 10-11, characters 43-61:
-Error: allocation of 200 bytes
+Error: allocation of 200 bytes for closure
 
 File "test_bounded_join4.ml", line 24, characters 11-19:
 Error: called function may allocate (direct tailcall camlTest_bounded_join4.do_a_HIDE_STAMP)

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_inference.opt.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_inference.opt.output
@@ -14,7 +14,7 @@ File "test_inference.ml", line 27, characters 16-34:
 Error: Annotation check for zero_alloc failed on function Test_inference.f_arity_one (camlTest_inference.f_arity_one_HIDE_STAMP)
 
 File "test_inference.ml", line 27, characters 20-34:
-Error: allocation of 32 bytes
+Error: allocation of 32 bytes for closure
 
 File "test_inference.ml", line 41, characters 19-29:
 Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc (camlTest_inference.f_shadow_alloc_HIDE_STAMP)

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_inference.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_inference.output
@@ -14,7 +14,7 @@ File "test_inference.ml", line 27, characters 16-34:
 Error: Annotation check for zero_alloc failed on function Test_inference.f_arity_one (camlTest_inference.f_arity_one_HIDE_STAMP)
 
 File "test_inference.ml", line 27, characters 20-34:
-Error: allocation of 32 bytes
+Error: allocation of 32 bytes for closure
 
 File "test_inference.ml", line 41, characters 19-29:
 Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc (camlTest_inference.f_shadow_alloc_HIDE_STAMP)

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_remove_inferred_assume.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_remove_inferred_assume.output
@@ -2,4 +2,4 @@ File "test_remove_inferred_assume.ml", line 80, characters 15-25:
 Error: Annotation check for zero_alloc failed on function Test_remove_inferred_assume.read_exn (camlTest_remove_inferred_assume.read_exn_HIDE_STAMP)
 
 File "test_remove_inferred_assume.ml", line 81, characters 2-22:
-Error: allocation of 24 bytes (test_remove_inferred_assume.ml:81,2--22;test_remove_inferred_assume.ml:75,12--32;test_remove_inferred_assume.ml:70,26--46;test_remove_inferred_assume.ml:60,70--82)
+Error: allocation of 24 bytes for boxed_int64 (test_remove_inferred_assume.ml:81,2--22;test_remove_inferred_assume.ml:75,12--32;test_remove_inferred_assume.ml:70,26--46;test_remove_inferred_assume.ml:60,70--82)

--- a/flambda-backend/testsuite/tools/parsecmm.mly
+++ b/flambda-backend/testsuite/tools/parsecmm.mly
@@ -233,7 +233,9 @@ expr:
                               coeffects=Has_coeffects;
                               ty_args=[];},
                      List.rev $4, debuginfo ())}
-  | LPAREN ALLOC exprlist RPAREN { Cop(Calloc Cmm.Alloc_mode.Heap, List.rev $3, debuginfo ()) }
+  | LPAREN ALLOC exprlist RPAREN { Cop(Calloc (Cmm.Alloc_mode.Heap,
+                                               Cmm.Alloc_block_kind_other),
+                                       List.rev $3, debuginfo ()) }
   | LPAREN SUBF expr RPAREN { Cop(Cnegf Float64, [$3], debuginfo ()) }
   | LPAREN SUBF expr expr RPAREN { Cop(Csubf Float64, [$3; $4], debuginfo ()) }
   | LPAREN unaryop expr RPAREN { Cop($2, [$3], debuginfo ()) }

--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -279,11 +279,6 @@ end
 
 type t = { dbg : Dbg.t; assume_zero_alloc : ZA.Assume_info.t }
 
-type alloc_dbginfo_item =
-  { alloc_words : int;
-    alloc_dbg : t }
-type alloc_dbginfo = alloc_dbginfo_item list
-
 let none = { dbg = []; assume_zero_alloc = ZA.Assume_info.none }
 
 let of_items items = { dbg = items; assume_zero_alloc = ZA.Assume_info.none }

--- a/lambda/debuginfo.mli
+++ b/lambda/debuginfo.mli
@@ -86,17 +86,6 @@ val item_with_uid_and_function_symbol : item -> dinfo_uid:string option
 
 type t
 
-type alloc_dbginfo_item =
-  { alloc_words : int;
-    alloc_dbg : t }
-(** Due to Comballoc, a single Ialloc instruction may combine several
-    unrelated allocations. Their Debuginfo.t (which may differ) are stored
-    as a list of alloc_dbginfo. This list is in order of increasing memory
-    address, which is the reverse of the original allocation order. Later
-    allocations are consed to the front of this list by Comballoc. *)
-
-type alloc_dbginfo = alloc_dbginfo_item list
-
 val none : t
 
 val is_none : t -> bool

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -221,7 +221,8 @@ expr:
                       $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
                {Cop(Cextcall($3, $5, [], false), List.rev $4, debuginfo ())}
-  | LPAREN ALLOC exprlist RPAREN { Cop(Calloc Lambda.alloc_heap, List.rev $3, debuginfo ()) }
+  | LPAREN ALLOC exprlist RPAREN { Cop(Calloc (Lambda.alloc_heap,Cmm.Alloc_block_kind_other),
+                                       List.rev $3, debuginfo ()) }
   | LPAREN SUBF expr RPAREN { Cop(Cnegf, [$3], debuginfo ()) }
   | LPAREN SUBF expr expr RPAREN { Cop(Csubf, [$3; $4], debuginfo ()) }
   | LPAREN unaryop expr RPAREN { Cop($2, [$3], debuginfo ()) }


### PR DESCRIPTION
As part of debuginfo for an allocation track what kind of block was allocated to give better error messages for `zero_alloc` check failures for example due to an allocation of a closure.
This PR starts with a bit of refactoring and will be easier to review by commit.
