### PR TITLE
Reads of tags of unique allocations have to be Reads_agree

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3183,11 +3183,12 @@ let combine_constructor value_kind loc arg pat_env cstr partial ctx def
                       (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem, value_kind))
                   nonconsts default
               in
-              (* Since the tag is used directly in the tests, it would be sound
-                 to mark it Alias+Reads_agree but this would not change performance.
-                 We keep it this way to guarantee soundness of in-place overwriting. *)
+              (* CR uniqueness: This read might be on a unique allocation that could
+                 be overwritten. We should ensure that it is never pushed down.
+                 However, we can not use [Reads_vary] here, since this breaks
+                 flambda2. *)
               Llet (StrictOpt, Lambda.layout_block, tag,
-                    Lprim (Pfield (0, Pointer, Reads_vary), [ arg ], loc),
+                    Lprim (Pfield (0, Pointer, Reads_agree), [ arg ], loc),
                     tests)
         in
         List.fold_right
@@ -3314,14 +3315,15 @@ let call_switcher_variant_constant kind loc fail arg int_lambda_list =
 
 let call_switcher_variant_constr value_kind loc fail arg int_lambda_list =
   let v = Ident.create_local "variant" in
-  (* Since v is used directly in the tests, it would be sound
-     to mark it Alias+May_be_pushed_down but this would not change performance.
-     We keep it this way to guarantee soundness of in-place overwriting. *)
+  (* CR uniqueness: This read might be on a unique allocation that could
+     be overwritten. We should ensure that it is never pushed down.
+     However, we can not use [Must_stay_here] here, since this breaks
+     flambda2. *)
   Llet
     ( StrictOpt,
       Lambda.layout_int,
       v,
-      Lprim (nonconstant_variant_field Must_stay_here 0, [ arg ], loc),
+      Lprim (nonconstant_variant_field May_be_pushed_down 0, [ arg ], loc),
       call_switcher value_kind loc fail (Lvar v) min_int max_int int_lambda_list )
 
 let combine_variant value_kind loc row arg partial ctx def
@@ -4371,9 +4373,11 @@ let for_optional_arg_default
       ~if_some:
         (Lprim
            (* CR ncik-roberts: Check whether we need something better here. *)
-           (* Since overwriting this option is not possible, it would be sound to
-              use Reads_agree here, but we want to be conservative. *)
-           (Pfield (0, Pointer, Reads_vary),
+           (* CR uniqueness: This read might be on a unique allocation that could
+              be overwritten. We should ensure that it is never pushed down.
+              However, we can not use [Reads_vary] here, since this breaks
+              flambda2. *)
+           (Pfield (0, Pointer, Reads_agree),
             [ Lvar param ],
             Loc_unknown))
   in

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -85,9 +85,9 @@ let f = function
              (exit 8))
           with (8)
            (if (field_imm 1 param/32)
-             (let (tag/41 =o (field_mut 0 *match*/33))
+             (let (tag/41 =o (field_imm 0 *match*/33))
                (if (== tag/41 B/28) 2
-                 (let (tag/46 =o (field_mut 0 *match*/33))
+                 (let (tag/46 =o (field_imm 0 *match*/33))
                    (if (== tag/46 C/29) 3 4))))
              (if (field_imm 2 param/32) 12 11))))))
   (apply (field_imm 1 (global Toploop!)) "f" f/30))

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -85,10 +85,8 @@ let f = function
              (exit 8))
           with (8)
            (if (field_imm 1 param/32)
-             (let (tag/41 =o (field_imm 0 *match*/33))
-               (if (== tag/41 B/28) 2
-                 (let (tag/46 =o (field_imm 0 *match*/33))
-                   (if (== tag/46 C/29) 3 4))))
+             (if (== (field_imm 0 *match*/33) B/28) 2
+               (if (== (field_imm 0 *match*/33) C/29) 3 4))
              (if (field_imm 2 param/32) 12 11))))))
   (apply (field_imm 1 (global Toploop!)) "f" f/30))
 val f : t * bool * bool -> int = <fun>


### PR DESCRIPTION
As part of #3066 (and its cherry-pick #3198), we added a mechanism to the compiler to detect reads from unique allocations. Since unique allocations can be overwritten, those reads may not be pushed down. We achieved this by mapping these reads to `Reads_vary` in lambda. To be safe, we also made reads of tags `Reads_vary`. While reads of tags can not be pushed down anyway (since they are used immediately to select a branch), we felt that we could make the code safer by enforcing this invariant by mapping them to `Reads_vary` as well. However, this lead to a compilation failure in flambda2 and might lead to a performance degradation since flambda2 does not propagate tag information to remove branches that can never be taken if the pattern match uses a `Reads_vary` to read the tag. Therefore, this PR rolls back the change to tag reads. In particular, after this PR there should be no change to generated code unless the code uses uniqueness.

To reproduce this bug in the compiler before this PR, compile this file with `ocamlopt -O3` (thanks to @ncik-roberts):
```
let go input =
  let x, y =
    match input with
    | `A a -> 0, Some a
    | `B b -> b
  in
  x, y
;;

let make i =
  let list = [ i; 123 ] in
  go (`A list)
;;
```