### PR TITLE
Improve hugepage support

### DIFF
--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -429,7 +429,7 @@ Caml_inline unsigned caml_plat_spin_step(unsigned spins,
 
 /* Memory management primitives (mmap) */
 
-uintnat caml_mem_round_up_pages(uintnat size);
+uintnat caml_mem_round_up_mapping_size(uintnat size);
 /* The size given to caml_mem_map and caml_mem_commit must be a multiple of
    caml_plat_pagesize. The size given to caml_mem_unmap and caml_mem_decommit
    must match the size given to caml_mem_map/caml_mem_commit for mem.
@@ -490,6 +490,7 @@ Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
 }
 
 extern intnat caml_plat_pagesize;
+extern intnat caml_plat_hugepagesize; /* zero if unknown/unsupported */
 extern intnat caml_plat_mmap_alignment;
 
 #endif /* CAML_INTERNALS */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -890,8 +890,9 @@ void domain_resize_heap_reservation_from_stw_single(uintnat new_minor_wsz)
               "unreserve_minor_heaps");
 
   unreserve_minor_heaps_from_stw_single();
-  /* new_minor_wsz is page-aligned because caml_norm_minor_heap_size has
-     been called to normalize it earlier.
+  /* new_minor_wsz is (huge)page-aligned because caml_norm_minor_heap_size has
+     been called to normalize it earlier.  (An assertion checks this in
+     [reserve_minor_heaps_from_stw_single].)
   */
   caml_minor_heap_max_wsz = new_minor_wsz;
   caml_gc_log("stw_resize_minor_heap_reservation: reserve_minor_heaps");

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -384,7 +384,7 @@ asize_t caml_norm_minor_heap_size (intnat wsize)
 {
   asize_t bs;
   if (wsize < Minor_heap_min) wsize = Minor_heap_min;
-  bs = caml_mem_round_up_pages(Bsize_wsize (wsize));
+  bs = caml_mem_round_up_mapping_size(Bsize_wsize (wsize));
 
   return Wsize_bsize(bs);
 }
@@ -819,8 +819,9 @@ static void reserve_minor_heaps_from_stw_single(void) {
   uintnat minor_heap_reservation_bsize;
   uintnat minor_heap_max_bsz;
 
-  CAMLassert (caml_mem_round_up_pages(Bsize_wsize(caml_minor_heap_max_wsz))
-          == Bsize_wsize(caml_minor_heap_max_wsz));
+  CAMLassert (
+    caml_mem_round_up_mapping_size(Bsize_wsize(caml_minor_heap_max_wsz))
+    == Bsize_wsize(caml_minor_heap_max_wsz));
 
   minor_heap_max_bsz = (uintnat)Bsize_wsize(caml_minor_heap_max_wsz);
   minor_heap_reservation_bsize = minor_heap_max_bsz * Max_domains;

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -386,11 +386,16 @@ static uintnat round_up(uintnat size, uintnat align) {
 }
 
 intnat caml_plat_pagesize = 0;
+intnat caml_plat_hugepagesize = 0;
 intnat caml_plat_mmap_alignment = 0;
 
-uintnat caml_mem_round_up_pages(uintnat size)
+uintnat caml_mem_round_up_mapping_size(uintnat size)
 {
-  return round_up(size, caml_plat_pagesize);
+  if (caml_plat_hugepagesize > caml_plat_pagesize &&
+      size > caml_plat_hugepagesize/2)
+    return round_up(size, caml_plat_hugepagesize);
+  else
+    return round_up(size, caml_plat_pagesize);
 }
 
 #define Is_page_aligned(size) ((size & (caml_plat_pagesize - 1)) == 0)

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -206,6 +206,9 @@ static pool* pool_acquire(struct caml_heap_state* local) {
     if (pool_freelist.fresh_pools == 0) {
       uintnat new_pools = pool_freelist.active_pools * 15 / 100;
       if (new_pools < 8) new_pools = 8;
+      new_pools =
+        caml_mem_round_up_mapping_size(Bsize_wsize(POOL_WSIZE) * new_pools) /
+        Bsize_wsize(POOL_WSIZE);
 
       void* mem = caml_mem_map(Bsize_wsize(POOL_WSIZE) * new_pools, 0);
       if (mem) {

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -206,11 +206,12 @@ static pool* pool_acquire(struct caml_heap_state* local) {
     if (pool_freelist.fresh_pools == 0) {
       uintnat new_pools = pool_freelist.active_pools * 15 / 100;
       if (new_pools < 8) new_pools = 8;
-      new_pools =
-        caml_mem_round_up_mapping_size(Bsize_wsize(POOL_WSIZE) * new_pools) /
-        Bsize_wsize(POOL_WSIZE);
 
-      void* mem = caml_mem_map(Bsize_wsize(POOL_WSIZE) * new_pools, 0);
+      uintnat mapping_size =
+        caml_mem_round_up_mapping_size(Bsize_wsize(POOL_WSIZE) * new_pools);
+      new_pools = mapping_size / Bsize_wsize(POOL_WSIZE);
+
+      void* mem = caml_mem_map(mapping_size, 0);
       if (mem) {
         pool_freelist.fresh_pools = new_pools;
         pool_freelist.next_fresh_pool = mem;

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -518,7 +518,9 @@ void *caml_plat_mem_map(uintnat size, int reserve_only)
   if (size < alignment || alignment < caml_plat_pagesize) {
     /* Short mapping or unknown/bad hugepagesize.
        Either way, not worth bothering with alignment. */
-    return mmap(0, size, prot, flags, -1, 0);
+    mem = mmap(0, size, prot, flags, -1, 0);
+    if (mem == MAP_FAILED) mem = NULL;
+    return mem;
   }
 
   /* Sensible kernels (on Linux, that means >= 6.7) will always provide aligned


### PR DESCRIPTION
Rounds up memory mapping sizes to a multiple of hugepage size, and ensures they are aligned on hugepage boundaries. Helps particularly for the minor heap on Linux before 6.7, where hugepages are important but the kernel does not align mmap addresses itself.

Currently x86_64 only.

This patch greatly improves the L1 TLB hit rate for accesses to the minor heap. I used the following benchmark:
```
let rec list_init len f =
  match len with
  | 0 -> []
  | len -> f () :: list_init (len - 1) f

let () =
  let xs =
    Sys.opaque_identity (list_init 100 (fun _ ->
      let _ = list_init 200 ignore in
      1))
  in
  for i = 0 to 10_000_000 do
    assert (List.length xs = 100)
  done
```
which allocates a list of length 100, with its cons cells spaced out, and iterates over it many times. (I reimplemented List.init because the current version in the stdlib is cleverer than this, doing TRMC and unrolling to go faster. This makes its memory layout harder to understand).

On x86_64 Linux, this benchmark usually runs 'slow' (about 3 seconds), but runs 'fast' (about 1 second) if the minor heap happens to be aligned enough to allow the kernel to allocate a hugepage, which happens sometimes by coincidence. This patch makes it reliably run 'fast'.

This patch is not necessary on very recent (2024 vintage) Linux kernels, which (finally!) default to allocating large mappings on hugepage boundaries without the manual alignment in this patch. However, this patch does not hurt on such kernels, and helps on all older ones.