### PR TITLE
Extra protection against codegen pessimisation due to unique barriers

### DIFF
--- a/lambda/translmode.ml
+++ b/lambda/translmode.ml
@@ -46,4 +46,10 @@ let transl_modify_mode locality =
 let transl_unique_barrier barrier =
   match Typedtree.Unique_barrier.resolve barrier with
   | Uniqueness.Const.Aliased -> May_be_pushed_down
-  | Uniqueness.Const.Unique -> Must_stay_here
+  | Uniqueness.Const.Unique ->
+    (* CR uniqueness: this is a temporary measure to ensure that we can roll
+       the compiler without breaking existing code. Once uniqueness is stable,
+       we can simplify this to always return [Must_stay_here]. *)
+    if Language_extension.is_enabled Unique
+    then Must_stay_here
+    else May_be_pushed_down

--- a/lambda/translmode.ml
+++ b/lambda/translmode.ml
@@ -52,4 +52,4 @@ let transl_unique_barrier barrier =
        we can simplify this to always return [Must_stay_here]. *)
     if Language_extension.is_enabled Unique
     then Must_stay_here
-    else May_be_pushed_down
+    else assert false


### PR DESCRIPTION
This PR changes the `transl_unique_barrier` function to always return `May_be_pushed_down` when uniqueness is not enabled. This makes it easy to reason about the absence of codegen changes for the next compiler roll. To review this, please look through #3066 and #3230 again and convince yourself that if all occurences of `ubr` are `May_be_pushed_down`, then we will emit exactly the same code as before.