### PR TITLE
Fix & test the string setter primitives

### DIFF
--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -284,11 +284,13 @@ let indexing_primitives =
       ( (fun unsafe _boxed _index_kind ->
           Printf.sprintf "%%caml_string_set32%s" unsafe ),
         fun ~unsafe ~boxed:_ ~index_kind:_ ~mode:_ ->
-          Pbytes_set_32 {unsafe; index_kind= Ptagged_int_index; boxed= false} ) ;
+          Pbytes_set_32
+            { unsafe; index_kind = Ptagged_int_index; boxed = true } ) ;
       ( (fun unsafe _boxed _index_kind ->
           Printf.sprintf "%%caml_string_set64%s" unsafe ),
         fun ~unsafe ~boxed:_ ~index_kind:_ ~mode:_ ->
-          Pbytes_set_64 {unsafe; index_kind= Ptagged_int_index; boxed= false} )
+          Pbytes_set_64
+            { unsafe; index_kind = Ptagged_int_index; boxed = true } )
     ]
   in
   let index_kinds =

--- a/testsuite/tests/prim-bigstring/string_access.ml
+++ b/testsuite/tests/prim-bigstring/string_access.ml
@@ -70,6 +70,8 @@ let swap64 x =
   then bswap64 x
   else x
 
+let () = print_endline "bytes primitives:"
+
 let () =
   caml_bytes_set_16 s 0 (swap16 0x1234);
   Printf.printf "%x %x %x\n%!"
@@ -105,3 +107,59 @@ let () =
                 (swap64 (caml_bytes_get_64 s 0))
                 (swap64 (caml_bytes_get_64 s 1))
                 (swap64 (caml_bytes_get_64 s 2))
+
+
+(* The string-set versions of these primitives are deprecated but
+   useful to test to avoid regressions. *)
+let s = Bytes.make 10 '\x00'
+let empty_s = Bytes.create 0
+
+external caml_string_get_16 : bytes -> int -> int = "%caml_string_get16"
+external caml_string_get_32 : bytes -> int -> int32 = "%caml_string_get32"
+external caml_string_get_64 : bytes -> int -> int64 = "%caml_string_get64"
+
+external caml_string_set_16 : bytes -> int -> int -> unit =
+  "%caml_string_set16"
+external caml_string_set_32 : bytes -> int -> int32 -> unit =
+  "%caml_string_set32"
+external caml_string_set_64 : bytes -> int -> int64 -> unit =
+  "%caml_string_set64"
+
+let () = print_endline "string primitives:"
+
+let () =
+  caml_string_set_16 s 0 (swap16 0x1234);
+  Printf.printf "%x %x %x\n%!"
+                (swap16 (caml_string_get_16 s 0))
+                (swap16 (caml_string_get_16 s 1))
+                (swap16 (caml_string_get_16 s 2));
+  caml_string_set_16 s 0 (swap16 0xFEDC);
+  Printf.printf "%x %x %x\n%!"
+                (swap16 (caml_string_get_16 s 0))
+                (swap16 (caml_string_get_16 s 1))
+                (swap16 (caml_string_get_16 s 2))
+
+let () =
+  caml_string_set_32 s 0 (swap32 0x12345678l);
+  Printf.printf "%lx %lx %lx\n%!"
+                (swap32 (caml_string_get_32 s 0))
+                (swap32 (caml_string_get_32 s 1))
+                (swap32 (caml_string_get_32 s 2));
+  caml_string_set_32 s 0 (swap32 0xFEDCBA09l);
+  Printf.printf "%lx %lx %lx\n%!"
+                (swap32 (caml_string_get_32 s 0))
+                (swap32 (caml_string_get_32 s 1))
+                (swap32 (caml_string_get_32 s 2))
+
+let () =
+  caml_string_set_64 s 0 (swap64 0x1234567890ABCDEFL);
+  Printf.printf "%Lx %Lx %Lx\n%!"
+                (swap64 (caml_string_get_64 s 0))
+                (swap64 (caml_string_get_64 s 1))
+                (swap64 (caml_string_get_64 s 2));
+  caml_string_set_64 s 0 (swap64 0xFEDCBA0987654321L);
+  Printf.printf "%Lx %Lx %Lx\n%!"
+                (swap64 (caml_string_get_64 s 0))
+                (swap64 (caml_string_get_64 s 1))
+                (swap64 (caml_string_get_64 s 2))
+

--- a/testsuite/tests/prim-bigstring/string_access.reference
+++ b/testsuite/tests/prim-bigstring/string_access.reference
@@ -1,3 +1,11 @@
+bytes primitives:
+1234 12 0
+fedc fe 0
+12345678 123456 1234
+fedcba09 fedcba fedc
+1234567890abcdef 1234567890abcd 1234567890ab
+fedcba0987654321 fedcba09876543 fedcba098765
+string primitives:
 1234 12 0
 fedc fe 0
 12345678 123456 1234


### PR DESCRIPTION
#3193 unintentionally broke the deprecated string set primitives. This PR fixes the bug and adds a test. The test is broken if you revert the change in `lambda/translprim.ml`: it stores the bits of the pointer instead of its int64 payload.