### PR TITLE
Detect when a kind makes being a function type impossible

### DIFF
--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2857,3 +2857,20 @@ Error: This expression has type "float#" but an expression was expected of type
        But the layout of float# must be a sublayout of value
          because it's the type of the recursive variable x.
 |}]
+
+(**********************************************************)
+(* Test 46: errors when functions don't have layout value *)
+
+let f (x : ('a : bits64)) = x ()
+
+[%%expect{|
+Uncaught exception: Ctype.Unify(_)
+
+|}]
+
+let f (x : ('a : value mod portable)) = x ()
+
+[%%expect{|
+Uncaught exception: Ctype.Unify(_)
+
+|}]

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2864,13 +2864,21 @@ Error: This expression has type "float#" but an expression was expected of type
 let f (x : ('a : bits64)) = x ()
 
 [%%expect{|
-Uncaught exception: Ctype.Unify(_)
-
+Line 1, characters 28-29:
+1 | let f (x : ('a : bits64)) = x ()
+                                ^
+Error: This expression is used as a function, but its type "'a"
+       has kind "bits64", which cannot be the kind of a function.
+       (Functions always have kind "value mod unique uncontended".)
 |}]
 
 let f (x : ('a : value mod portable)) = x ()
 
 [%%expect{|
-Uncaught exception: Ctype.Unify(_)
-
+Line 1, characters 40-41:
+1 | let f (x : ('a : value mod portable)) = x ()
+                                            ^
+Error: This expression is used as a function, but its type "'a"
+       has kind "value mod portable", which cannot be the kind of a function.
+       (Functions always have kind "value mod unique uncontended".)
 |}]

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2882,3 +2882,11 @@ Error: This expression is used as a function, but its type "'a"
        has kind "value mod portable", which cannot be the kind of a function.
        (Functions always have kind "value mod unique uncontended".)
 |}]
+
+let f (x : ('a : value)) = x ()
+let f (x : ('a : value mod uncontended)) = x ()
+
+[%%expect{|
+val f : (unit -> 'a) -> 'a = <fun>
+val f : (unit -> 'a) -> 'a = <fun>
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -262,6 +262,7 @@ type error =
   | Cannot_stack_allocate of Env.locality_context option
   | Unsupported_stack_allocation of unsupported_stack_allocation
   | Not_allocation
+  | Impossible_function_jkind of type_expr * jkind_lr
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -3696,7 +3697,7 @@ let collect_unknown_apply_args env funct ty_fun mode_fun rev_args sargs ret_tvar
         let (sort_arg, mode_arg, ty_arg_mono, mode_ret, ty_res) =
           let ty_fun = expand_head env ty_fun in
           match get_desc ty_fun with
-          | Tvar _ ->
+          | Tvar { jkind; _ } ->
               let ty_arg_mono, sort_arg = new_rep_var ~why:Function_argument () in
               let ty_arg = newmono ty_arg_mono in
               let ty_res =
@@ -3711,8 +3712,14 @@ let collect_unknown_apply_args env funct ty_fun mode_fun rev_args sargs ret_tvar
               let mode_arg = Alloc.newvar () in
               let mode_ret = Alloc.newvar () in
               let kind = (lbl, mode_arg, mode_ret) in
-              unify env ty_fun
-                (newty (Tarrow(kind,ty_arg,ty_res,commu_var ())));
+              begin try
+                unify env ty_fun
+                  (newty (Tarrow(kind,ty_arg,ty_res,commu_var ())));
+              with
+              | Unify _ ->
+                raise(Error(funct.exp_loc, env,
+                            Impossible_function_jkind (ty_fun, jkind)))
+              end;
               (sort_arg, mode_arg, ty_arg_mono, mode_ret, ty_res)
         | Tarrow ((l, mode_arg, mode_ret), ty_arg, ty_res, _)
           when labels_match ~param:l ~arg:lbl ->
@@ -10424,6 +10431,14 @@ let report_error ~loc env = function
       print_unsupported_stack_allocation category
   | Not_allocation ->
       Location.errorf ~loc "This expression is not an allocation site."
+  | Impossible_function_jkind (ty, jkind) ->
+      Location.errorf ~loc
+        "@[@[This expression is used as a function, but its type@ %a@]@ \
+         has kind %a, which cannot be the kind of a function.@ \
+         (Functions always have kind %a.)@]"
+        (Style.as_inline_code Printtyp.type_expr) ty
+        (Style.as_inline_code Jkind.format) jkind
+        (Style.as_inline_code Jkind.format) Jkind.for_arrow
 
 let report_error ~loc env err =
   Printtyp.wrap_printing_env_error env

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -315,6 +315,7 @@ type error =
   | Cannot_stack_allocate of Env.locality_context option
   | Unsupported_stack_allocation of unsupported_stack_allocation
   | Not_allocation
+  | Impossible_function_jkind of type_expr * jkind_lr
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error


### PR DESCRIPTION
As reported by @tdelvecchio-jsc: `let f (x : ('a : bits64)) = x ()` produced an uncaught `Unify`.

First commit contains the tests; second fixes it.

Review: @dkalinichenko-js 