### PR TITLE
Fix soundness bug of uniqueness analysis on immutable array patterns

### DIFF
--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -640,3 +640,27 @@ Line 2, characters 11-19:
                ^^^^^^^^
 
 |}]
+
+let array_pats (arr : int option array) =
+  match arr with
+  | [| o |] -> let _ = unique_id arr in aliased_id o
+  | _ -> None
+[%%expect{|
+val array_pats : int option array @ unique -> int option = <fun>
+|}]
+
+let array_pats (arr : int option iarray) =
+  match arr with
+  | [: o :] -> let _ = unique_id arr in unique_id o
+  | _ -> None
+[%%expect{|
+Line 3, characters 50-51:
+3 |   | [: o :] -> let _ = unique_id arr in unique_id o
+                                                      ^
+Error: This value is used here,
+       but it is part of a value that has already been used as unique:
+Line 3, characters 33-36:
+3 |   | [: o :] -> let _ = unique_id arr in unique_id o
+                                     ^^^
+
+|}]


### PR DESCRIPTION
This PR fixes a soundness bug in the uniqueness analysis wrt immutable array patterns. The issue is that we used to make the elements of arrays their own roots in the `Ienv`. That used to be fine because mutable arrays can only hold many, aliased data. However, immutable arrays can hold unique elements and the old approach was unsound for them. I fixed this by correctly registering the elements of arrays as projections. To keep the old behaviour for mutable arrays, I added the `mutable_implied_modalities` to the projection.