### PR TITLE
Move unique barriers from pattern_data to pattern_desc

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -254,9 +254,9 @@ let iter_on_occurrences
     (fun (type a) sub
       ({ pat_desc; pat_extra; pat_env; _ } as pat : a general_pattern) ->
       (match pat_desc with
-      | Tpat_construct (lid, constr_desc, _, _) ->
+      | Tpat_construct (lid, constr_desc, _, _, _) ->
           add_constructor_description pat_env lid constr_desc
-      | Tpat_record (fields, _) ->
+      | Tpat_record (fields, _, _) ->
         List.iter (fun (lid, label_descr, pat) ->
           let lid =
             let open Location in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1453,7 +1453,7 @@ and transl_tupled_function
   match eligible_cases with
   | Some
       (cases, partial,
-       ({ pat_desc = Tpat_tuple pl } as arg_pat), arg_mode, arg_sort)
+       ({ pat_desc = Tpat_tuple (pl, _ubr) } as arg_pat), arg_mode, arg_sort)
     when is_alloc_heap mode
       && is_alloc_heap (transl_alloc_mode_l arg_mode)
       && !Clflags.native_code

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -261,12 +261,12 @@ module Analyser =
         | Typedtree.Tpat_alias (pat, _, _, _, _) ->
             iter_pattern pat
 
-        | Typedtree.Tpat_tuple patlist ->
+        | Typedtree.Tpat_tuple (patlist, _) ->
             Tuple
               (List.map (fun (_, p) -> iter_pattern p) patlist,
                Odoc_env.subst_type env pat.pat_type)
 
-        | Typedtree.Tpat_construct (_, cons_desc, _, _) when
+        | Typedtree.Tpat_construct (_, cons_desc, _, _, _) when
             (* we give a name to the parameter only if it is unit *)
             Path.same (Btype.cstr_type_path cons_desc) Predef.path_unit
           ->

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -355,8 +355,7 @@ let name_expression ~loc ~attrs sort exp =
       pat_extra = [];
       pat_type = exp.exp_type;
       pat_env = exp.exp_env;
-      pat_attributes = [];
-      pat_unique_barrier = Unique_barrier.not_computed () }
+      pat_attributes = []; }
   in
   let vb =
     { vb_pat = pat;

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -83,11 +83,11 @@ val get_mins : ('a -> 'a -> bool) -> 'a list -> 'a list
 val set_args : pattern -> pattern list -> pattern list
 val set_args_erase_mutable : pattern -> pattern list -> pattern list
 
-val pat_of_constr : pattern -> constructor_description -> pattern
+val pat_of_constr : pattern -> Unique_barrier.t -> constructor_description -> pattern
 val complete_constrs :
     constructor_description pattern_data ->
     constructor_description list ->
-    constructor_description list
+    (constructor_description * Unique_barrier.t) list
 
 (** [pats_of_type] builds a list of patterns from a given expected type,
     for explosion of wildcard patterns in Typecore.type_pat.

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -40,14 +40,14 @@ module Simple : sig
   type view = [
     | `Any
     | `Constant of constant
-    | `Tuple of (string option * pattern) list
+    | `Tuple of (string option * pattern) list * Unique_barrier.t
     | `Unboxed_tuple of (string option * pattern * Jkind.sort) list
     | `Construct of
-        Longident.t loc * constructor_description * pattern list
-    | `Variant of label * pattern option * row_desc ref
+        Longident.t loc * constructor_description * pattern list * Unique_barrier.t
+    | `Variant of label * pattern option * row_desc ref * Unique_barrier.t
     | `Record of
-        (Longident.t loc * label_description * pattern) list * closed_flag
-    | `Array of mutability * Jkind.sort * pattern list
+        (Longident.t loc * label_description * pattern) list * closed_flag * Unique_barrier.t
+    | `Array of mutability * Jkind.sort * pattern list * Unique_barrier.t
     | `Lazy of pattern
   ]
   type pattern = view pattern_data
@@ -80,18 +80,20 @@ end
 module Head : sig
   type desc =
     | Any
-    | Construct of constructor_description
+    | Construct of constructor_description * Unique_barrier.t
     | Constant of constant
-    | Tuple of string option list
+    | Tuple of string option list * Unique_barrier.t
     | Unboxed_tuple of (string option * Jkind.sort) list
-    | Record of label_description list
+    | Record of label_description list * Unique_barrier.t
     | Variant of
         { tag: label; has_arg: bool;
           cstr_row: row_desc ref;
-          type_row : unit -> row_desc; }
+          type_row : unit -> row_desc;
+          unique_barrier: Unique_barrier.t;
+        }
           (* the row of the type may evolve if [close_variant] is called,
              hence the (unit -> ...) delay *)
-    | Array of mutability * Jkind.sort * int
+    | Array of mutability * Jkind.sort * int * Unique_barrier.t
     | Lazy
 
   type t = desc pattern_data

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -63,15 +63,15 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
   | Tpat_any -> fprintf ppf "_"
   | Tpat_var (x,_,_,_) -> fprintf ppf "%s" (Ident.name x)
   | Tpat_constant c -> fprintf ppf "%s" (pretty_const c)
-  | Tpat_tuple vs ->
+  | Tpat_tuple (vs, _) ->
       fprintf ppf "@[(%a)@]" (pretty_list pretty_labeled_val ",") vs
   | Tpat_unboxed_tuple vs ->
       fprintf ppf "@[#(%a)@]" (pretty_list pretty_labeled_val_sort ",") vs
-  | Tpat_construct (_, cstr, [], _) ->
+  | Tpat_construct (_, cstr, [], _, _) ->
       fprintf ppf "%s" cstr.cstr_name
-  | Tpat_construct (_, cstr, [w], None) ->
+  | Tpat_construct (_, cstr, [w], None, _) ->
       fprintf ppf "@[<2>%s@ %a@]" cstr.cstr_name pretty_arg w
-  | Tpat_construct (_, cstr, vs, vto) ->
+  | Tpat_construct (_, cstr, vs, vto, _) ->
       let name = cstr.cstr_name in
       begin match (name, vs, vto) with
         ("::", [v1;v2], None) ->
@@ -85,11 +85,11 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
           fprintf ppf "@[<2>%s@ (type %s)@ @[(%a : _)@]@]"
             name (String.concat " " vars) (pretty_vals ",") vs
       end
-  | Tpat_variant (l, None, _) ->
+  | Tpat_variant (l, None, _, _) ->
       fprintf ppf "`%s" l
-  | Tpat_variant (l, Some w, _) ->
+  | Tpat_variant (l, Some w, _, _) ->
       fprintf ppf "@[<2>`%s@ %a@]" l pretty_arg w
-  | Tpat_record (lvs,_) ->
+  | Tpat_record (lvs,_, _) ->
       let filtered_lvs = List.filter
           (function
             | (_,_,{pat_desc=Tpat_any}) -> false (* do not show lbl=_ *)
@@ -105,7 +105,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
           fprintf ppf "@[{%a%t}@]"
             pretty_lvals filtered_lvs elision_mark
       end
-  | Tpat_array (am, _arg_sort, vs) ->
+  | Tpat_array (am, _arg_sort, vs, _) ->
       let punct = if Types.is_mutable am then '|' else ':' in
       fprintf ppf "@[[%c %a %c]@]" punct (pretty_vals " ;") vs punct
   | Tpat_lazy v ->
@@ -120,20 +120,20 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
       fprintf ppf "@[(%a)@]" pretty_or v
 
 and pretty_car ppf v = match v.pat_desc with
-| Tpat_construct (_,cstr, [_ ; _], None)
+| Tpat_construct (_,cstr, [_ ; _], None, _)
     when is_cons cstr ->
       fprintf ppf "(%a)" pretty_val v
 | _ -> pretty_val ppf v
 
 and pretty_cdr ppf v = match v.pat_desc with
-| Tpat_construct (_,cstr, [v1 ; v2], None)
+| Tpat_construct (_,cstr, [v1 ; v2], None, _)
     when is_cons cstr ->
       fprintf ppf "%a::@,%a" pretty_car v1 pretty_cdr v2
 | _ -> pretty_val ppf v
 
 and pretty_arg ppf v = match v.pat_desc with
-| Tpat_construct (_,_,_::_,None)
-| Tpat_variant (_, Some _, _) -> fprintf ppf "(%a)" pretty_val v
+| Tpat_construct (_,_,_::_,None, _)
+| Tpat_variant (_, Some _, _, _) -> fprintf ppf "(%a)" pretty_val v
 |  _ -> pretty_val ppf v
 
 and pretty_or : type k . _ -> k general_pattern -> _ = fun ppf v ->

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -326,13 +326,13 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
       value_mode i ppf m;
       pattern i ppf p;
   | Tpat_constant (c) -> line i ppf "Tpat_constant %a\n" fmt_constant c;
-  | Tpat_tuple (l) ->
+  | Tpat_tuple (l, _) ->
       line i ppf "Tpat_tuple\n";
       list i labeled_pattern ppf l;
   | Tpat_unboxed_tuple (l) ->
       line i ppf "Tpat_unboxed_tuple\n";
       list i labeled_pattern_with_sorts ppf l;
-  | Tpat_construct (li, _, po, vto) ->
+  | Tpat_construct (li, _, po, vto, _) ->
       line i ppf "Tpat_construct %a\n" fmt_longident li;
       list i pattern ppf po;
       option i
@@ -341,13 +341,13 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
           line i ppf "[%s]\n" (String.concat "; " names);
           core_type i ppf ct)
         ppf vto
-  | Tpat_variant (l, po, _) ->
+  | Tpat_variant (l, po, _, _) ->
       line i ppf "Tpat_variant \"%s\"\n" l;
       option i pattern ppf po;
-  | Tpat_record (l, _c) ->
+  | Tpat_record (l, _c, _) ->
       line i ppf "Tpat_record\n";
       list i longident_x_pattern ppf l;
-  | Tpat_array (am, arg_sort, l) ->
+  | Tpat_array (am, arg_sort, l, _) ->
       line i ppf "Tpat_array %a\n" fmt_mutable_mode_flag am;
       line i ppf "%a\n" Jkind.Sort.format arg_sort;
       list i pattern ppf l;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -256,17 +256,17 @@ let pat
   | Tpat_any  -> ()
   | Tpat_var (_, s, _, _) -> iter_loc sub s
   | Tpat_constant _ -> ()
-  | Tpat_tuple l -> List.iter (fun (_, p) -> sub.pat sub p) l
+  | Tpat_tuple (l, _) -> List.iter (fun (_, p) -> sub.pat sub p) l
   | Tpat_unboxed_tuple l -> List.iter (fun (_, p, _) -> sub.pat sub p) l
-  | Tpat_construct (lid, _, l, vto) ->
+  | Tpat_construct (lid, _, l, vto, _) ->
       iter_loc sub lid;
       List.iter (sub.pat sub) l;
       Option.iter (fun (ids, ct) ->
         List.iter (iter_loc sub) ids; sub.typ sub ct) vto
-  | Tpat_variant (_, po, _) -> Option.iter (sub.pat sub) po
-  | Tpat_record (l, _) ->
+  | Tpat_variant (_, po, _, _) -> Option.iter (sub.pat sub) po
+  | Tpat_record (l, _, _) ->
       List.iter (fun (lid, _, i) -> iter_loc sub lid; sub.pat sub i) l
-  | Tpat_array (_, _, l) -> List.iter (sub.pat sub) l
+  | Tpat_array (_, _, l, _) -> List.iter (sub.pat sub) l
   | Tpat_alias (p, _, s, _, _) -> sub.pat sub p; iter_loc sub s
   | Tpat_lazy p -> sub.pat sub p
   | Tpat_value p -> sub.pat sub (p :> pattern)

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -299,20 +299,21 @@ let pat
     | Tpat_any
     | Tpat_constant _ -> x.pat_desc
     | Tpat_var (id, s, uid, m) -> Tpat_var (id, map_loc sub s, uid, m)
-    | Tpat_tuple l ->
-        Tpat_tuple (List.map (fun (label, p) -> label, sub.pat sub p) l)
+    | Tpat_tuple (l, ubr) ->
+        Tpat_tuple (List.map (fun (label, p) -> label, sub.pat sub p) l, ubr)
     | Tpat_unboxed_tuple l ->
       Tpat_unboxed_tuple
         (List.map (fun (label, p, sort) -> label, sub.pat sub p, sort) l)
-    | Tpat_construct (loc, cd, l, vto) ->
+    | Tpat_construct (loc, cd, l, vto, ubr) ->
         let vto = Option.map (fun (vl,cty) ->
           List.map (map_loc sub) vl, sub.typ sub cty) vto in
-        Tpat_construct (map_loc sub loc, cd, List.map (sub.pat sub) l, vto)
-    | Tpat_variant (l, po, rd) ->
-        Tpat_variant (l, Option.map (sub.pat sub) po, rd)
-    | Tpat_record (l, closed) ->
-        Tpat_record (List.map (tuple3 (map_loc sub) id (sub.pat sub)) l, closed)
-    | Tpat_array (am, arg_sort, l) -> Tpat_array (am, arg_sort, List.map (sub.pat sub) l)
+        Tpat_construct (map_loc sub loc, cd, List.map (sub.pat sub) l, vto, ubr)
+    | Tpat_variant (l, po, rd, ubr) ->
+        Tpat_variant (l, Option.map (sub.pat sub) po, rd, ubr)
+    | Tpat_record (l, closed, ubr) ->
+        Tpat_record (List.map (tuple3 (map_loc sub) id (sub.pat sub)) l, closed, ubr)
+    | Tpat_array (am, arg_sort, l, ubr) ->
+        Tpat_array (am, arg_sort, List.map (sub.pat sub) l, ubr)
     | Tpat_alias (p, id, s, uid, m) ->
         Tpat_alias (sub.pat sub p, id, map_loc sub s, uid, m)
     | Tpat_lazy p -> Tpat_lazy (sub.pat sub p)

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -107,7 +107,7 @@ let rec extract_letop_patterns n pat =
   if n = 0 then pat, []
   else begin
     match pat.pat_desc with
-    | Tpat_tuple([None, first; None, rest]) ->
+    | Tpat_tuple([None, first; None, rest], _) ->
         (* Labels should always be None, from when [Texp_letop] are created in
            [Typecore.type_expect] *)
         let next, others = extract_letop_patterns (n-1) rest in
@@ -356,7 +356,7 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
     | Tpat_alias (pat, _id, name, _uid, _mode) ->
         Ppat_alias (sub.pat sub pat, name)
     | Tpat_constant cst -> Ppat_constant (constant cst)
-    | Tpat_tuple list ->
+    | Tpat_tuple (list, _) ->
         Ppat_tuple
           ( List.map (fun (label, p) -> label, sub.pat sub p) list
           , Closed)
@@ -364,7 +364,7 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
         Ppat_unboxed_tuple
           (List.map (fun (label, p, _) -> label, sub.pat sub p) list,
            Closed)
-    | Tpat_construct (lid, _, args, vto) ->
+    | Tpat_construct (lid, _, args, vto, _) ->
         let tyo =
           match vto with
             None -> None
@@ -387,12 +387,12 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
               Some (vl, Pat.mk ~loc (Ppat_constraint (arg, Some ty, [])))
           | None, Some arg -> Some ([], arg)
           | _, None -> None)
-    | Tpat_variant (label, pato, _) ->
+    | Tpat_variant (label, pato, _, _) ->
         Ppat_variant (label, Option.map (sub.pat sub) pato)
-    | Tpat_record (list, closed) ->
+    | Tpat_record (list, closed, _) ->
         Ppat_record (List.map (fun (lid, _, pat) ->
             map_loc sub lid, sub.pat sub pat) list, closed)
-    | Tpat_array (am, _, list) ->
+    | Tpat_array (am, _, list, _) ->
         Ppat_array (mutable_ am, List.map (sub.pat sub) list)
     | Tpat_lazy p -> Ppat_lazy (sub.pat sub p)
 

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -1417,7 +1417,7 @@ and is_destructuring_pattern : type k . k general_pattern -> bool =
     | Tpat_unboxed_tuple _ -> true
     | Tpat_construct _ -> true
     | Tpat_variant _ -> true
-    | Tpat_record (_, _) -> true
+    | Tpat_record (_, _, _) -> true
     | Tpat_array _ -> true
     | Tpat_lazy _ -> true
     | Tpat_value pat -> is_destructuring_pattern (pat :> pattern)

--- a/utils/profile_counters_functions.ml
+++ b/utils/profile_counters_functions.ml
@@ -101,9 +101,10 @@ let count_language_extensions typing_input =
           (fun (type k) sub
                ({ pat_desc; _ } as gen_pat : k Typedtree.general_pattern) ->
             (match pat_desc with
-            | Tpat_tuple label_opt_pair_list ->
+            | Tpat_tuple (label_opt_pair_list, _) ->
               check_for_labeled_tuples label_opt_pair_list
-            | Tpat_array (mutability, _, _) -> check_array_mutability mutability
+            | Tpat_array (mutability, _, _, _) ->
+              check_array_mutability mutability
             | _ -> ());
             default_iterator.pat sub gen_pat)
       }


### PR DESCRIPTION
In this PR, I change the design of #3066 to move the unique barriers from `pattern_data` to `pattern_desc`. The effect of this is that we generate far fewer unique barriers now and all of them will in fact be relevant: every time a unique barrier is enabled, it should also end up being resolved. If a unique barrier gets enabled but not resolved, we now fail after generating lambda.

This provides a strong guarantee for future correctness of unique barriers.
 - When adding a new pattern, you will see a comment warning you that you might need a unique barrier.
 - When adding the pattern to the unique analysis, you will see another comment telling you to enable the barrier.
 - Then, your compilation will fail with a warning that the barrier was enabled but not resolved.
 - So you add code to resolve the barrier in `matching.ml` and hopefully install the right projections.

This PR is currently a draft since the invariant is currently false: some unique barriers are getting enabled but not resolved.