### PR TITLE
Generate `META` files for otherlibs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -390,6 +390,10 @@ AS_IF([test "x$enable_runtime5" = "xyes"],
   ]
 )
 AC_CONFIG_FILES([compilerlibs/META])
+AC_CONFIG_FILES([otherlibs/stdlib_upstream_compatible/META])
+AC_CONFIG_FILES([otherlibs/stdlib_stable/META])
+AC_CONFIG_FILES([otherlibs/stdlib_beta/META])
+AC_CONFIG_FILES([otherlibs/stdlib_alpha/META])
 AC_CONFIG_FILES([otherlibs/dynlink/META])
 AC_CONFIG_FILES([otherlibs/runtime_events/META])
 AC_CONFIG_FILES([stdlib/META])

--- a/dune
+++ b/dune
@@ -791,10 +791,6 @@
 (install
  (files
   (compilerlibs/META as compiler-libs/META)
-  (otherlibs/stdlib_upstream_compatible/META as stdlib_upstream_compatible/META)
-  (otherlibs/stdlib_stable/META as stdlib_stable/META)
-  (otherlibs/stdlib_beta/META as stdlib_beta/META)
-  (otherlibs/stdlib_alpha/META as stdlib_alpha/META)
   (external/owee/libcompiler_owee_stubs.a
    as
    compiler-libs/libcompiler_owee_stubs.a)

--- a/dune
+++ b/dune
@@ -791,6 +791,10 @@
 (install
  (files
   (compilerlibs/META as compiler-libs/META)
+  (otherlibs/stdlib_upstream_compatible/META as stdlib_upstream_compatible/META)
+  (otherlibs/stdlib_stable/META as stdlib_stable/META)
+  (otherlibs/stdlib_beta/META as stdlib_beta/META)
+  (otherlibs/stdlib_alpha/META as stdlib_alpha/META)
   (external/owee/libcompiler_owee_stubs.a
    as
    compiler-libs/libcompiler_owee_stubs.a)

--- a/otherlibs/stdlib_alpha/META.in
+++ b/otherlibs/stdlib_alpha/META.in
@@ -1,0 +1,8 @@
+# @configure_input@
+
+version = "@VERSION@"
+description = "Alpha extensions"
+archive(byte) = "stdlib_alpha.cma"
+archive(native) = "stdlib_alpha.cmxa"
+plugin(byte) = "stdlib_alpha.cma"
+plugin(native) = "stdlib_alpha.cmxs"

--- a/otherlibs/stdlib_alpha/dune
+++ b/otherlibs/stdlib_alpha/dune
@@ -50,6 +50,7 @@
 
 (install
  (files
-  (dllstdlib_alpha_stubs.so as stublibs/dllstdlib_alpha_stubs.so))
+  (dllstdlib_alpha_stubs.so as stublibs/dllstdlib_alpha_stubs.so)
+  (META as stdlib_alpha/META))
  (section lib)
  (package ocaml))

--- a/otherlibs/stdlib_beta/META.in
+++ b/otherlibs/stdlib_beta/META.in
@@ -1,0 +1,8 @@
+# @configure_input@
+
+version = "@VERSION@"
+description = "Beta extensions"
+archive(byte) = "stdlib_beta.cma"
+archive(native) = "stdlib_beta.cmxa"
+plugin(byte) = "stdlib_beta.cma"
+plugin(native) = "stdlib_beta.cmxs"

--- a/otherlibs/stdlib_beta/dune
+++ b/otherlibs/stdlib_beta/dune
@@ -38,3 +38,9 @@
   (with-stdout-to
    to_install.sexp
    (run "%{first-dep}" "stdlib_beta"))))
+
+(install
+ (files
+  (META as stdlib_beta/META))
+ (section lib)
+ (package ocaml))

--- a/otherlibs/stdlib_stable/META.in
+++ b/otherlibs/stdlib_stable/META.in
@@ -1,0 +1,8 @@
+# @configure_input@
+
+version = "@VERSION@"
+description = "Stable extensions"
+archive(byte) = "stdlib_stable.cma"
+archive(native) = "stdlib_stable.cmxa"
+plugin(byte) = "stdlib_stable.cma"
+plugin(native) = "stdlib_stable.cmxs"

--- a/otherlibs/stdlib_stable/dune
+++ b/otherlibs/stdlib_stable/dune
@@ -74,3 +74,9 @@
   (with-stdout-to
    to_install.sexp
    (run "%{first-dep}" "stdlib_stable"))))
+
+(install
+ (files
+  (META as stdlib_stable/META))
+ (section lib)
+ (package ocaml))

--- a/otherlibs/stdlib_upstream_compatible/META.in
+++ b/otherlibs/stdlib_upstream_compatible/META.in
@@ -1,0 +1,8 @@
+# @configure_input@
+
+version = "@VERSION@"
+description = "Upstream-compatible extensions"
+archive(byte) = "stdlib_upstream_compatible.cma"
+archive(native) = "stdlib_upstream_compatible.cmxa"
+plugin(byte) = "stdlib_upstream_compatible.cma"
+plugin(native) = "stdlib_upstream_compatible.cmxs"

--- a/otherlibs/stdlib_upstream_compatible/dune
+++ b/otherlibs/stdlib_upstream_compatible/dune
@@ -38,3 +38,9 @@
   (with-stdout-to
    to_install.sexp
    (run "%{first-dep}" "stdlib_upstream_compatible"))))
+
+(install
+ (files
+  (META as stdlib_upstream_compatible/META))
+ (section lib)
+ (package ocaml))


### PR DESCRIPTION
Generate `META` files for extension otherlibs that had them missing. Tested by running `make install` and inspecting the generated folder.