### PR TITLE
Support for Null constant and Is_null primitive in the middle-end

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -169,7 +169,7 @@ let preserve_tailcall_for_prim = function
   | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
-  | Parrayrefs _ | Parraysets _ | Pisint _ | Pisout | Pbintofint _ | Pintofbint _
+  | Parrayrefs _ | Parraysets _ | Pisint _ | Pisnull | Pisout | Pbintofint _ | Pintofbint _
   | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _
   | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
   | Pasrbint _ | Pbintcomp _ | Punboxed_int_comp _
@@ -561,6 +561,7 @@ let comp_primitive stack_info p sz args =
        | Runtime5 -> "runtime5" in
      Kccall(Printf.sprintf "caml_sys_const_%s" const_name, 1)
   | Pisint _ -> Kisint
+  | Pisnull -> Misc.fatal_error "null not implemented in bytecode" (* CR layouts v3: support null in bytecode *)
   | Pisout -> Kisout
   | Pbintofint (bi,_) -> comp_bint_primitive bi "of_int" args
   | Pintofbint bi -> comp_bint_primitive bi "to_int" args

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -225,6 +225,8 @@ let rec transl_const = function
       List.iteri (fun i f -> Array.Floatarray.set res i (float_of_string f))
         fields;
       Obj.repr res
+  | Const_null -> Misc.fatal_error "[Const_null] not supported in bytecode."
+    (* CR layouts v3: add bytecode support. *)
 
 (* Initialization for batch linking *)
 

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -197,6 +197,8 @@ type primitive =
   | Parraysets of array_set_kind * array_index_kind
   (* Test if the argument is a block or an immediate integer *)
   | Pisint of { variant_only : bool }
+  (* Test if the argument is a null pointer *)
+  | Pisnull
   (* Test if the (integer) argument is outside an interval *)
   | Pisout
   (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)
@@ -1777,7 +1779,7 @@ let primitive_may_allocate : primitive -> locality_mode option = function
       | Punboxedvectorarray_ref _), _, _) -> None
   | Parrayrefu ((Pgenarray_ref m | Pfloatarray_ref m), _, _)
   | Parrayrefs ((Pgenarray_ref m | Pfloatarray_ref m), _, _) -> Some m
-  | Pisint _ | Pisout -> None
+  | Pisint _ | Pisnull | Pisout -> None
   | Pintofbint _ -> None
   | Pbintofint (_,m)
   | Pcvtbint (_,_,m)
@@ -1993,7 +1995,7 @@ let primitive_result_layout (p : primitive) =
   | Pfloatcomp (_, _) | Punboxed_float_comp (_, _)
   | Pstringlength | Pstringrefu | Pstringrefs
   | Pbyteslength | Pbytesrefu | Pbytesrefs
-  | Parraylength _ | Pisint _ | Pisout | Pintofbint _
+  | Parraylength _ | Pisint _ | Pisnull | Pisout | Pintofbint _
   | Pbintcomp _ | Punboxed_int_comp _
   | Pstring_load_16 _ | Pbytes_load_16 _ | Pbigstring_load_16 _
   | Pprobe_is_enabled _ | Pbswap16

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -577,6 +577,7 @@ type structured_constant =
   | Const_float_array of string list
   | Const_immstring of string
   | Const_float_block of string list
+  | Const_null
 
 type tailcall_attribute =
   | Tailcall_expectation of bool
@@ -1897,6 +1898,7 @@ let structured_constant_layout = function
     non_null_value Pgenval
   | Const_float_array _ | Const_float_block _ ->
     non_null_value (Parrayval Pfloatarray)
+  | Const_null -> nullable_value Pgenval
 
 let rec layout_of_const_sort (c : Jkind.Sort.Const.t) : layout =
   match c with

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -530,6 +530,7 @@ type structured_constant =
   | Const_float_array of string list
   | Const_immstring of string
   | Const_float_block of string list
+  | Const_null
 
 type tailcall_attribute =
   | Tailcall_expectation of bool

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -189,6 +189,8 @@ type primitive =
   | Parraysets of array_set_kind * array_index_kind
   (* Test if the argument is a block or an immediate integer *)
   | Pisint of { variant_only : bool }
+  (* Test if the argument is a null pointer *)
+  | Pisnull
   (* Test if the (integer) argument is outside an interval *)
   | Pisout
   (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -659,6 +659,7 @@ let primitive ppf = function
      fprintf ppf "sys.constant_%s" const_name
   | Pisint { variant_only } ->
       fprintf ppf (if variant_only then "isint" else "obj_is_int")
+  | Pisnull -> fprintf ppf "isnull"
   | Pisout -> fprintf ppf "isout"
   | Pbintofint (bi,m) -> print_boxed_integer "of_int" ppf bi m
   | Pintofbint bi -> print_boxed_integer "to_int" ppf bi alloc_heap
@@ -952,6 +953,7 @@ let name_of_primitive = function
   | Parraysets _ -> "Parraysets"
   | Pctconst _ -> "Pctconst"
   | Pisint _ -> "Pisint"
+  | Pisnull -> "Pisnull"
   | Pisout -> "Pisout"
   | Pbintofint _ -> "Pbintofint"
   | Pintofbint _ -> "Pintofbint"

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -59,6 +59,7 @@ let rec struct_const ppf = function
       let floats ppf fl =
         List.iter (fun f -> fprintf ppf "@ %s" f) fl in
       fprintf ppf "@[<1>[|@[%s%a@]|]@]" f1 floats fl
+  | Const_null -> fprintf ppf "<null>"
 
 and struct_consts ppf (hd, tl) =
   let sconsts ppf scl =

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -891,7 +891,7 @@ let rec choice ctx t =
     | Pstringlength | Pstringrefu  | Pstringrefs
     | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
     | Parraylength _ | Parrayrefu _ | Parraysetu _ | Parrayrefs _ | Parraysets _
-    | Pisint _ | Pisout
+    | Pisint _ | Pisnull | Pisout
     | Pignore
     | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
     | Preinterpret_tagged_int63_as_unboxed_int64

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -523,6 +523,7 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%floatarray_unsafe_set" ->
       Primitive ((Parraysetu (Pfloatarray_set, Ptagged_int_index)), 3)
     | "%obj_is_int" -> Primitive (Pisint { variant_only = false }, 1)
+    | "%is_null" -> Primitive (Pisnull, 1)
     | "%lazy_force" -> Lazy_force pos
     | "%nativeint_of_int" -> Primitive ((Pbintofint (Pnativeint, mode)), 1)
     | "%nativeint_to_int" -> Primitive ((Pintofbint Pnativeint), 1)
@@ -1648,7 +1649,7 @@ let lambda_primitive_needs_event_after = function
   | Pbytessetu
   | Pmakearray ((Pintarray | Paddrarray | Pfloatarray | Punboxedfloatarray _
       | Punboxedintarray _ | Punboxedvectorarray _), _, _)
-  | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint _ | Pisout
+  | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint _ | Pisnull | Pisout
   | Pprobe_is_enabled _
   | Patomic_exchange | Patomic_cas | Patomic_fetch_add | Patomic_load _
   | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer _ | Popaque _

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -305,6 +305,7 @@ let compute_static_size lam =
     | Parrayrefu _
     | Parrayrefs _
     | Pisint _
+    | Pisnull
     | Pisout
     | Pbintofint _
     | Pintofbint _

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -175,7 +175,7 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
             ~symbol:(fun _sym ~coercion:_ -> ())
             ~const:(fun cst ->
               match RWC.descr cst with
-              | Tagged_immediate _ -> ()
+              | Tagged_immediate _ | Null -> ()
               | Naked_immediate _ | Naked_float32 _ | Naked_float _
               | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
               | Naked_vec128 _ ->
@@ -200,7 +200,7 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
           | Const_int64 _ | Const_nativeint _ | Const_unboxed_int32 _
           | Const_unboxed_int64 _ | Const_unboxed_nativeint _ )
       | Const_block _ | Const_mixed_block _ | Const_float_array _
-      | Const_immstring _ | Const_float_block _ ->
+      | Const_immstring _ | Const_float_block _ | Const_null ->
         Misc.fatal_errorf
           "In constant mixed block, a field of kind Float_boxed contained the \
            constant %a"
@@ -231,6 +231,7 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
         Immutable (Mixed_record shape) fields
     in
     register_const acc dbg const "const_mixed_block"
+  | Const_null -> acc, reg_width RWC.const_null, "null"
 
 let close_const acc const =
   (* For this code path, the debuginfo is discarded (see just below). *)
@@ -1211,7 +1212,7 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
                           | Naked_float f -> Or_variable.Const f
                           | Tagged_immediate _ | Naked_immediate _
                           | Naked_float32 _ | Naked_int32 _ | Naked_int64 _
-                          | Naked_nativeint _ | Naked_vec128 _ ->
+                          | Naked_nativeint _ | Naked_vec128 _ | Null ->
                             Misc.fatal_errorf
                               "Binding of %a to %a contains the constant %a \
                                inside a float record, whereas only naked \

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -943,8 +943,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Punboxed_float_comp (_, _)
       | Pstringlength | Pstringrefu | Pstringrefs | Pbyteslength | Pbytesrefu
       | Pbytessetu | Pbytesrefs | Pbytessets | Pduparray _ | Parraylength _
-      | Parrayrefu _ | Parraysetu _ | Parrayrefs _ | Parraysets _ | Pisint _ | Pisnull
-      | Pisout | Pbintofint _ | Pintofbint _ | Pcvtbint _ | Pnegbint _
+      | Parrayrefu _ | Parraysetu _ | Parrayrefs _ | Parraysets _ | Pisint _
+      | Pisnull | Pisout | Pbintofint _ | Pintofbint _ | Pcvtbint _ | Pnegbint _
       | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _ | Pmodbint _
       | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
       | Pasrbint _ | Pbintcomp _ | Punboxed_int_comp _ | Pbigarrayref _

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -943,7 +943,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Punboxed_float_comp (_, _)
       | Pstringlength | Pstringrefu | Pstringrefs | Pbyteslength | Pbytesrefu
       | Pbytessetu | Pbytesrefs | Pbytessets | Pduparray _ | Parraylength _
-      | Parrayrefu _ | Parraysetu _ | Parrayrefs _ | Parraysets _ | Pisint _
+      | Parrayrefu _ | Parraysetu _ | Parrayrefs _ | Parraysets _ | Pisint _ | Pisnull
       | Pisout | Pbintofint _ | Pintofbint _ | Pcvtbint _ | Pnegbint _
       | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _ | Pmodbint _
       | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -708,8 +708,8 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Punboxed_float_comp (_, _)
   | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu | Pbytessetu
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
-  | Pisint _ | Pisout | Pbintofint _ | Pintofbint _ | Pcvtbint _ | Pnegbint _
-  | Paddbint _ | Psubbint _ | Pmulbint _
+  | Pisint _ | Pisnull | Pisout | Pbintofint _ | Pintofbint _ | Pcvtbint _
+  | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _
   | Pdivbint { is_safe = Unsafe; _ }
   | Pmodbint { is_safe = Unsafe; _ }
   | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _ | Pasrbint _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1509,6 +1509,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         Bytes ~boxed bytes ~index_kind index new_value ]
   | Pisint { variant_only }, [[arg]] ->
     [tag_int (Unary (Is_int { variant_only }, arg))]
+  | Pisnull, [[arg]] -> [tag_int (Unary (Is_null, arg))]
   | Pisout, [[arg1]; [arg2]] ->
     [ tag_int
         (Binary
@@ -2075,7 +2076,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       | Pabsfloat (_, _)
       | Pstringlength | Pbyteslength | Pbintofint _ | Pintofbint _ | Pnegbint _
       | Popaque _ | Pduprecord _ | Parraylength _ | Pduparray _ | Pfloatfield _
-      | Pcvtbint _ | Poffsetref _ | Pbswap16 | Pbbswap _ | Pisint _
+      | Pcvtbint _ | Poffsetref _ | Pbswap16 | Pbbswap _ | Pisint _ | Pisnull
       | Pint_as_pointer _ | Pbigarraydim _ | Pobj_dup | Pobj_magic _
       | Punbox_float _
       | Pbox_float (_, _)

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -48,6 +48,7 @@ module Const_data = struct
     | Naked_int64 of Int64.t
     | Naked_nativeint of Targetint_32_64.t
     | Naked_vec128 of Vector_types.Vec128.Bit_pattern.t
+    | Null
 
   let flags = const_flags
 
@@ -96,6 +97,10 @@ module Const_data = struct
           Flambda_colours.naked_number
           Vector_types.Vec128.Bit_pattern.print v
           Flambda_colours.pop
+      | Null ->
+        Format.fprintf ppf "%t#null%t"
+          Flambda_colours.naked_number
+          Flambda_colours.pop
 
     let compare t1 t2 =
       match t1, t2 with
@@ -111,6 +116,7 @@ module Const_data = struct
       | Naked_nativeint n1, Naked_nativeint n2 -> Targetint_32_64.compare n1 n2
       | Naked_vec128 v1, Naked_vec128 v2 ->
         Vector_types.Vec128.Bit_pattern.compare v1 v2
+      | Null, Null -> 0
       | Naked_immediate _, _ -> -1
       | _, Naked_immediate _ -> 1
       | Tagged_immediate _, _ -> -1
@@ -125,6 +131,8 @@ module Const_data = struct
       | _, Naked_int64 _ -> 1
       | Naked_vec128 _, _ -> -1
       | _, Naked_vec128 _ -> 1
+      | Null, _ -> -1
+      | _, Null -> 1
 
     let equal t1 t2 =
       if t1 == t2
@@ -143,9 +151,10 @@ module Const_data = struct
         | Naked_nativeint n1, Naked_nativeint n2 -> Targetint_32_64.equal n1 n2
         | Naked_vec128 v1, Naked_vec128 v2 ->
           Vector_types.Vec128.Bit_pattern.equal v1 v2
+        | Null, Null -> true
         | ( ( Naked_immediate _ | Tagged_immediate _ | Naked_float _
             | Naked_float32 _ | Naked_vec128 _ | Naked_int32 _ | Naked_int64 _
-            | Naked_nativeint _ ),
+            | Naked_nativeint _ | Null ),
             _ ) ->
           false
 
@@ -159,6 +168,7 @@ module Const_data = struct
       | Naked_int64 n -> Hashtbl.hash n
       | Naked_nativeint n -> Targetint_32_64.hash n
       | Naked_vec128 v -> Vector_types.Vec128.Bit_pattern.hash v
+      | Null -> Hashtbl.hash 0
   end)
 end
 
@@ -312,6 +322,8 @@ module Const = struct
   let const_one = tagged_immediate Targetint_31_63.one
 
   let const_unit = const_zero
+
+  let const_null = create Null
 
   let descr t = find_data t
 

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -45,6 +45,8 @@ module Const : sig
 
   val const_int : Targetint_31_63.t -> t
 
+  val const_null : t
+
   (** [naked_immediate] is similar to [naked_nativeint], but represents integers
       of width [n - 1] bits, where [n] is the native machine width. (By
       contrast, [naked_nativeint] represents integers of width [n] bits.) *)
@@ -74,6 +76,7 @@ module Const : sig
       | Naked_int64 of Int64.t
       | Naked_nativeint of Targetint_32_64.t
       | Naked_vec128 of Vector_types.Vec128.Bit_pattern.t
+      | Null
 
     include Container_types.S with type t := t
   end

--- a/middle_end/flambda2/identifiers/reg_width_const.ml
+++ b/middle_end/flambda2/identifiers/reg_width_const.ml
@@ -26,19 +26,20 @@ let of_descr (descr : Descr.t) =
   | Naked_int64 i -> naked_int64 i
   | Naked_nativeint i -> naked_nativeint i
   | Naked_vec128 v -> naked_vec128 v
+  | Null -> const_null
 
 let is_naked_immediate t =
   match descr t with
   | Naked_immediate i -> Some i
   | Tagged_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
-  | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ ->
+  | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ | Null ->
     None
 
 let is_tagged_immediate t =
   match descr t with
   | Tagged_immediate i -> Some i
   | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
-  | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ ->
+  | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ | Null ->
     None
 
 let of_int_of_kind (kind : Flambda_kind.t) i =

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -567,6 +567,7 @@ let unop env (op : Flambda_primitive.unary_primitive) : Fexpr.unop =
   | Int_arith (i, o) -> Int_arith (i, o)
   | Is_flat_float_array -> Is_flat_float_array
   | Is_int _ -> Is_int (* CR vlaviron: discuss *)
+  | Is_null -> Misc.fatal_error "null not implemented in fexpr"
   | Num_conv { src; dst } -> Num_conv { src; dst }
   | Opaque_identity _ -> Opaque_identity
   | Unbox_number bk -> Unbox_number bk

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -375,6 +375,7 @@ let const c : Fexpr.const =
   | Naked_vec128 bits ->
     Naked_vec128 (Vector_types.Vec128.Bit_pattern.to_bits bits)
   | Naked_nativeint i -> Naked_nativeint (i |> targetint)
+  | Null -> Misc.fatal_error "null not supported in fexpr"
 
 let depth_or_infinity (d : int Or_infinity.t) : Fexpr.rec_info =
   match d with Finite d -> Depth d | Infinity -> Infinity

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -98,7 +98,7 @@ let alias_kind name simple t =
       ~const:(fun const ->
         match Int_ids.Const.descr const with
         | Naked_immediate _ -> Flambda_kind.naked_immediate
-        | Tagged_immediate _ -> Flambda_kind.value
+        | Tagged_immediate _ | Null -> Flambda_kind.value
         | Naked_float _ -> Flambda_kind.naked_float
         | Naked_float32 _ -> Flambda_kind.naked_float32
         | Naked_int32 _ -> Flambda_kind.naked_int32

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -178,7 +178,7 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
               maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
             else maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
           | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
-          | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ ->
+          | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Null ->
             maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
         in
         Simple.pattern_match arg ~const ~name:(fun _ ~coercion:_ ->
@@ -267,7 +267,7 @@ let recognize_switch_with_single_arg_to_same_destination0 ~arms =
          a normal untagged [TI.t]. *)
       check_args Reg_width_const.is_tagged_immediate Leave_as_tagged_immediate
     | Naked_float _ | Naked_float32 _ | Naked_int32 _ | Naked_int64 _
-    | Naked_nativeint _ | Naked_vec128 _ ->
+    | Naked_nativeint _ | Naked_vec128 _ | Null ->
       None)
 
 let recognize_switch_with_single_arg_to_same_destination ~arms =

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -189,7 +189,7 @@ let simplify_tag_immediate dacc ~original_term ~arg:_ ~arg_ty:naked_number_ty
   let dacc = DA.add_variable dacc result_var ty in
   SPR.create original_term ~try_reify:true dacc
 
-let simplify_is_int_or_get_tag dacc ~original_term ~scrutinee ~scrutinee_ty:_
+let simplify_relational_primitive dacc ~original_term ~scrutinee ~scrutinee_ty:_
     ~result_var ~make_shape =
   (* CR vlaviron: We could use prover functions to simplify but it's probably
      not going to help that much.
@@ -207,7 +207,7 @@ let simplify_is_int ~variant_only dacc ~original_term ~arg:scrutinee
     ~arg_ty:scrutinee_ty ~result_var =
   if variant_only
   then
-    simplify_is_int_or_get_tag dacc ~original_term ~scrutinee ~scrutinee_ty
+    simplify_relational_primitive dacc ~original_term ~scrutinee ~scrutinee_ty
       ~result_var ~make_shape:(fun scrutinee ->
         T.is_int_for_scrutinee ~scrutinee)
   else
@@ -221,7 +221,7 @@ let simplify_is_int ~variant_only dacc ~original_term ~arg:scrutinee
 
 let simplify_get_tag dacc ~original_term ~arg:scrutinee ~arg_ty:scrutinee_ty
     ~result_var =
-  simplify_is_int_or_get_tag dacc ~original_term ~scrutinee ~scrutinee_ty
+  simplify_relational_primitive dacc ~original_term ~scrutinee ~scrutinee_ty
     ~result_var ~make_shape:(fun block -> T.get_tag_for_block ~block)
 
 let simplify_array_length _array_kind dacc ~original_term ~arg:_
@@ -889,8 +889,9 @@ let simplify_mutable_block_load _access_kind ~field:_ ~original_prim dacc
       ~original_term
 
 (* CR layouts v3: implement a real simplifier. *)
-let simplify_is_null dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
-  SPR.create_unknown dacc ~result_var K.naked_immediate ~original_term
+let simplify_is_null dacc ~original_term ~arg:scrutinee ~arg_ty:scrutinee_ty ~result_var =
+  simplify_relational_primitive dacc ~original_term ~scrutinee ~scrutinee_ty
+    ~result_var ~make_shape:(fun scrutinee -> T.is_null ~scrutinee)
 
 let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     ~arg_ty dbg ~result_var =

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -888,6 +888,10 @@ let simplify_mutable_block_load _access_kind ~field:_ ~original_prim dacc
       (P.result_kind' original_prim)
       ~original_term
 
+(* CR layouts v3: implement a real simplifier. *)
+let simplify_is_null dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
+  SPR.create_unknown dacc ~result_var K.naked_immediate ~original_term
+
 let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     ~arg_ty dbg ~result_var =
   let min_name_mode = Bound_var.name_mode result_var in
@@ -909,6 +913,7 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     | Tag_immediate -> simplify_tag_immediate
     | Untag_immediate -> simplify_untag_immediate
     | Is_int { variant_only } -> simplify_is_int ~variant_only
+    | Is_null -> simplify_is_null
     | Get_tag -> simplify_get_tag
     | Array_length array_kind -> simplify_array_length array_kind
     | String_length _ -> simplify_string_length

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -889,7 +889,8 @@ let simplify_mutable_block_load _access_kind ~field:_ ~original_prim dacc
       ~original_term
 
 (* CR layouts v3: implement a real simplifier. *)
-let simplify_is_null dacc ~original_term ~arg:scrutinee ~arg_ty:scrutinee_ty ~result_var =
+let simplify_is_null dacc ~original_term ~arg:scrutinee ~arg_ty:scrutinee_ty
+    ~result_var =
   simplify_relational_primitive dacc ~original_term ~scrutinee ~scrutinee_ty
     ~result_var ~make_shape:(fun scrutinee -> T.is_null ~scrutinee)
 

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -343,7 +343,7 @@ let unary_prim_size prim =
   match (prim : Flambda_primitive.unary_primitive) with
   | Block_load { kind; _ } -> block_load kind
   | Duplicate_array _ | Duplicate_block _ -> needs_caml_c_call_extcall_size + 1
-  | Is_int _ -> 1
+  | Is_int _ | Is_null -> 1
   | Get_tag -> 2
   | Array_length array_kind -> (
     match array_kind with

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1031,6 +1031,7 @@ type unary_primitive =
         destination_mutability : Mutability.t
       }
   | Is_int of { variant_only : bool }
+  | Is_null
   | Get_tag
   | Array_length of Array_kind_for_length.t
   | Bigarray_length of { dimension : int }
@@ -1075,7 +1076,7 @@ let unary_primitive_eligible_for_cse p ~arg =
   | Block_load _ -> false
   | Duplicate_array _ -> false
   | Duplicate_block { kind = _ } -> false
-  | Is_int _ | Get_tag | Get_header -> true
+  | Is_int _ | Is_null | Get_tag | Get_header -> true
   | Array_length _ -> true
   | Bigarray_length _ -> false
   | String_length _ -> true
@@ -1131,6 +1132,7 @@ let compare_unary_primitive p1 p2 =
     | Obj_dup -> 25
     | Get_header -> 26
     | Atomic_load _ -> 27
+    | Is_null -> 28
   in
   match p1, p2 with
   | ( Block_load { kind = kind1; mut = mut1; field = field1 },
@@ -1216,13 +1218,13 @@ let compare_unary_primitive p1 p2 =
   | End_try_region { ghost = ghost1 }, End_try_region { ghost = ghost2 } ->
     Bool.compare ghost1 ghost2
   | ( ( Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _
-      | Get_tag | String_length _ | Int_as_pointer _ | Opaque_identity _
-      | Int_arith _ | Num_conv _ | Boolean_not | Reinterpret_64_bit_word _
-      | Float_arith _ | Array_length _ | Bigarray_length _ | Unbox_number _
-      | Box_number _ | Untag_immediate | Tag_immediate | Project_function_slot _
-      | Project_value_slot _ | Is_boxed_float | Is_flat_float_array
-      | End_region _ | End_try_region _ | Obj_dup | Get_header | Atomic_load _
-        ),
+      | Is_null | Get_tag | String_length _ | Int_as_pointer _
+      | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
+      | Reinterpret_64_bit_word _ | Float_arith _ | Array_length _
+      | Bigarray_length _ | Unbox_number _ | Box_number _ | Untag_immediate
+      | Tag_immediate | Project_function_slot _ | Project_value_slot _
+      | Is_boxed_float | Is_flat_float_array | End_region _ | End_try_region _
+      | Obj_dup | Get_header | Atomic_load _ ),
       _ ) ->
     Stdlib.compare (unary_primitive_numbering p1) (unary_primitive_numbering p2)
 
@@ -1243,6 +1245,7 @@ let print_unary_primitive ppf p =
       Mutability.print destination_mutability
   | Is_int { variant_only } ->
     if variant_only then fprintf ppf "Is_int" else fprintf ppf "Is_int_generic"
+  | Is_null -> fprintf ppf "Is_null"
   | Get_tag -> fprintf ppf "Get_tag"
   | String_length _ -> fprintf ppf "String_length"
   | Int_as_pointer alloc_mode ->
@@ -1294,6 +1297,7 @@ let arg_kind_of_unary_primitive p =
   | Block_load _ -> block_kind
   | Duplicate_array _ | Duplicate_block _ -> K.value
   | Is_int _ -> K.value
+  | Is_null -> K.value
   | Get_tag -> K.value
   | String_length _ -> K.value
   | Int_as_pointer _ -> K.value
@@ -1327,7 +1331,7 @@ let result_kind_of_unary_primitive p : result_kind =
   | Block_load { kind; _ } ->
     Singleton (Block_access_kind.element_kind_for_load kind)
   | Duplicate_array _ | Duplicate_block _ -> Singleton K.value
-  | Is_int _ | Get_tag -> Singleton K.naked_immediate
+  | Is_int _ | Is_null | Get_tag -> Singleton K.naked_immediate
   | String_length _ -> Singleton K.naked_immediate
   | Int_as_pointer _ ->
     (* This primitive is *only* to be used when the resulting pointer points at
@@ -1382,7 +1386,7 @@ let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
     (* We have to assume that the fields might be mutable. (This information
        isn't currently propagated from [Lambda].) *)
     Only_generative_effects Mutable, Has_coeffects, Strict
-  | Is_int _ -> No_effects, No_coeffects, Strict
+  | Is_int _ | Is_null -> No_effects, No_coeffects, Strict
   | Get_tag ->
     (* [Obj.truncate] has now been removed. *)
     No_effects, No_coeffects, Strict
@@ -1452,8 +1456,8 @@ let unary_classify_for_printing p =
   match p with
   | Duplicate_array _ | Duplicate_block _ | Obj_dup -> Constructive
   | String_length _ | Get_tag -> Destructive
-  | Is_int _ | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
-  | Reinterpret_64_bit_word _ | Float_arith _ ->
+  | Is_int _ | Is_null | Opaque_identity _ | Int_arith _ | Num_conv _
+  | Boolean_not | Reinterpret_64_bit_word _ | Float_arith _ ->
     Neither
   | Array_length _ | Bigarray_length _ | Unbox_number _ | Untag_immediate ->
     Destructive
@@ -1479,9 +1483,9 @@ let free_names_unary_primitive p =
       (Name_occurrences.add_value_slot_in_projection Name_occurrences.empty
          value_slot Name_mode.normal)
       project_from Name_mode.normal
-  | Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _ | Get_tag
-  | String_length _ | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
-  | Reinterpret_64_bit_word _ | Float_arith _ | Array_length _
+  | Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _ | Is_null
+  | Get_tag | String_length _ | Opaque_identity _ | Int_arith _ | Num_conv _
+  | Boolean_not | Reinterpret_64_bit_word _ | Float_arith _ | Array_length _
   | Bigarray_length _ | Unbox_number _ | Untag_immediate | Tag_immediate
   | Is_boxed_float | Is_flat_float_array | End_region _ | End_try_region _
   | Obj_dup | Get_header
@@ -1500,9 +1504,9 @@ let apply_renaming_unary_primitive p renaming =
       Alloc_mode.For_allocations.apply_renaming alloc_mode renaming
     in
     if alloc_mode == alloc_mode' then p else Int_as_pointer alloc_mode'
-  | Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _ | Get_tag
-  | String_length _ | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
-  | Reinterpret_64_bit_word _ | Float_arith _ | Array_length _
+  | Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _ | Is_null
+  | Get_tag | String_length _ | Opaque_identity _ | Int_arith _ | Num_conv _
+  | Boolean_not | Reinterpret_64_bit_word _ | Float_arith _ | Array_length _
   | Bigarray_length _ | Unbox_number _ | Untag_immediate | Tag_immediate
   | Is_boxed_float | Is_flat_float_array | End_region _ | End_try_region _
   | Project_function_slot _ | Project_value_slot _ | Obj_dup | Get_header
@@ -1513,9 +1517,9 @@ let ids_for_export_unary_primitive p =
   match p with
   | Box_number (_, alloc_mode) | Int_as_pointer alloc_mode ->
     Alloc_mode.For_allocations.ids_for_export alloc_mode
-  | Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _ | Get_tag
-  | String_length _ | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
-  | Reinterpret_64_bit_word _ | Float_arith _ | Array_length _
+  | Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _ | Is_null
+  | Get_tag | String_length _ | Opaque_identity _ | Int_arith _ | Num_conv _
+  | Boolean_not | Reinterpret_64_bit_word _ | Float_arith _ | Array_length _
   | Bigarray_length _ | Unbox_number _ | Untag_immediate | Tag_immediate
   | Is_boxed_float | Is_flat_float_array | End_region _ | End_try_region _
   | Project_function_slot _ | Project_value_slot _ | Obj_dup | Get_header

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -366,6 +366,7 @@ type unary_primitive =
         destination_mutability : Mutability.t
       }
   | Is_int of { variant_only : bool }
+  | Is_null
   | Get_tag
   | Array_length of Array_kind_for_length.t
   | Bigarray_length of { dimension : int }

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -794,6 +794,7 @@ let unary_primitive env res dbg f arg =
         ~effects:Arbitrary_effects ~coeffects:Has_coeffects ~ty_args:[]
         "caml_obj_dup" Cmm.typ_val [arg] )
   | Is_int _ -> None, res, C.and_int arg (C.int ~dbg 1) dbg
+  | Is_null -> None, res, C.eq ~dbg arg (C.nativeint ~dbg 0n)
   | Get_tag -> None, res, C.get_tag arg dbg
   | Array_length (Array_kind array_kind) ->
     None, res, array_length ~dbg arg array_kind

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -182,6 +182,7 @@ let const ~dbg cst =
     in
     vec128 ~dbg { high; low }
   | Naked_nativeint t -> targetint ~dbg t
+  | Null -> targetint ~dbg Targetint_32_64.zero
 
 let simple ?consider_inlining_effectful_expressions ~dbg env res s =
   Simple.pattern_match s
@@ -232,6 +233,7 @@ let const_static cst =
       Vector_types.Vec128.Bit_pattern.to_bits v
     in
     [cvec128 { high; low }]
+  | Null -> [cint 0n]
 
 let simple_static res s =
   Simple.pattern_match s

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -368,8 +368,7 @@ let expand_head_of_alias_type env kind
       | Naked_vec128 i ->
         ET.create_naked_vec128 (TG.Head_of_kind_naked_vec128.create i)
       | Null ->
-        ET.create_unknown
-          Flambda_kind.value (* CR layouts v3: assign a precise kind? *))
+        ET.create_value TG.Head_of_kind_value.null)
     ~name
 
 let expand_head0 env ty ~known_canonical_simple_at_in_types_mode =

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -366,7 +366,10 @@ let expand_head_of_alias_type env kind
       | Naked_nativeint i ->
         ET.create_naked_nativeint (TG.Head_of_kind_naked_nativeint.create i)
       | Naked_vec128 i ->
-        ET.create_naked_vec128 (TG.Head_of_kind_naked_vec128.create i))
+        ET.create_naked_vec128 (TG.Head_of_kind_naked_vec128.create i)
+      | Null ->
+        ET.create_unknown
+          Flambda_kind.value (* CR layouts v3: assign a precise kind? *))
     ~name
 
 let expand_head0 env ty ~known_canonical_simple_at_in_types_mode =

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -367,8 +367,7 @@ let expand_head_of_alias_type env kind
         ET.create_naked_nativeint (TG.Head_of_kind_naked_nativeint.create i)
       | Naked_vec128 i ->
         ET.create_naked_vec128 (TG.Head_of_kind_naked_vec128.create i)
-      | Null ->
-        ET.create_value TG.Head_of_kind_value.null)
+      | Null -> ET.create_value TG.Head_of_kind_value.null)
     ~name
 
 let expand_head0 env ty ~known_canonical_simple_at_in_types_mode =

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -459,6 +459,8 @@ val is_int_for_scrutinee : scrutinee:Simple.t -> t
 
 val get_tag_for_block : block:Simple.t -> t
 
+val is_null : scrutinee:Simple.t -> t
+
 val any_block : t
 
 (** The type of an immutable block with a known tag, size and field types. *)

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -376,7 +376,7 @@ let type_for_const const =
   | Naked_int64 n -> TG.this_naked_int64 n
   | Naked_nativeint n -> TG.this_naked_nativeint n
   | Naked_vec128 n -> TG.this_naked_vec128 n
-  | Null -> TG.any_value (* CR layouts v3: assign a precise kind? *)
+  | Null -> TG.null
 
 let kind_for_const const = TG.kind (type_for_const const)
 

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -376,6 +376,7 @@ let type_for_const const =
   | Naked_int64 n -> TG.this_naked_int64 n
   | Naked_nativeint n -> TG.this_naked_nativeint n
   | Naked_vec128 n -> TG.this_naked_vec128 n
+  | Null -> TG.any_value (* CR layouts v3: assign a precise kind? *)
 
 let kind_for_const const = TG.kind (type_for_const const)
 

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -3457,6 +3457,8 @@ let create_from_head_region head = Region (TD.create head)
 module Head_of_kind_value = struct
   type t = head_of_kind_value
 
+  let null = { non_null = Bottom; is_null = Maybe_null }
+
   let mk_non_null non_null = { non_null = Ok non_null; is_null = Not_null }
 
   let create_variant ~is_unique ~blocks ~immediates ~extensions =

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -3661,7 +3661,7 @@ let rec recover_some_aliases t =
                     | Naked_immediate i -> this_tagged_immediate i
                     | Tagged_immediate _ | Naked_float _ | Naked_float32 _
                     | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
-                    | Naked_vec128 _ ->
+                    | Naked_vec128 _ | Null ->
                       Misc.fatal_errorf
                         "Immediates case returned wrong kind of constant:@ %a"
                         Reg_width_const.print const)

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -694,6 +694,8 @@ module Head_of_kind_value : sig
     array_contents Or_unknown.t ->
     Alloc_mode.For_types.t ->
     t
+
+  val null : t
 end
 
 module Head_of_kind_value_non_null : sig


### PR DESCRIPTION
This PR is the final piece for support of null-related features in the middle-end.
It includes support for the `Null` constant and the `Is_null` primitive in Lambda and Flambda2.
