### PR TITLE
Remove unused kind computations in From_lambda

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -232,13 +232,9 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
     in
     register_const acc dbg const "const_mixed_block"
 
-let close_const0 acc dbg (const : Lambda.structured_constant) =
-  let acc, const, name = declare_const acc dbg const in
-  acc, const, name
-
 let close_const acc const =
   (* For this code path, the debuginfo is discarded (see just below). *)
-  let acc, simple_with_dbg, name = close_const0 acc Debuginfo.none const in
+  let acc, simple_with_dbg, name = declare_const acc Debuginfo.none const in
   let named =
     Named.create_simple (Simple.With_debuginfo.simple simple_with_dbg)
   in
@@ -262,7 +258,7 @@ let find_simple acc env (simple : IR.simple) =
   match simple with
   | Const const ->
     (* For this code path, the debuginfo isn't relevant. *)
-    let acc, simple, _ = close_const0 acc Debuginfo.none const in
+    let acc, simple, _ = declare_const acc Debuginfo.none const in
     acc, Simple.With_debuginfo.simple simple
   | Var id -> acc, find_simple_from_id env id
 

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -234,31 +234,11 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
 
 let close_const0 acc dbg (const : Lambda.structured_constant) =
   let acc, const, name = declare_const acc dbg const in
-  let module KS = Flambda_kind.With_subkind in
-  let kind =
-    Simple.pattern_match'
-      (Simple.With_debuginfo.simple const)
-      ~var:(fun _var ~coercion:_ ->
-        Misc.fatal_errorf "Declaring a computed constant %s" name)
-      ~symbol:(fun _sym ~coercion:_ -> KS.any_value)
-      ~const:(fun cst ->
-        match Reg_width_const.descr cst with
-        | Naked_immediate _ -> KS.naked_immediate
-        | Tagged_immediate _ -> KS.tagged_immediate
-        | Naked_float32 _ -> KS.naked_float32
-        | Naked_float _ -> KS.naked_float
-        | Naked_int32 _ -> KS.naked_int32
-        | Naked_int64 _ -> KS.naked_int64
-        | Naked_nativeint _ -> KS.naked_nativeint
-        | Naked_vec128 _ -> KS.naked_vec128)
-  in
-  acc, const, name, kind
+  acc, const, name
 
 let close_const acc const =
   (* For this code path, the debuginfo is discarded (see just below). *)
-  let acc, simple_with_dbg, name, _kind =
-    close_const0 acc Debuginfo.none const
-  in
+  let acc, simple_with_dbg, name = close_const0 acc Debuginfo.none const in
   let named =
     Named.create_simple (Simple.With_debuginfo.simple simple_with_dbg)
   in
@@ -282,23 +262,12 @@ let find_simple acc env (simple : IR.simple) =
   match simple with
   | Const const ->
     (* For this code path, the debuginfo isn't relevant. *)
-    let acc, simple, _, _ = close_const0 acc Debuginfo.none const in
+    let acc, simple, _ = close_const0 acc Debuginfo.none const in
     acc, Simple.With_debuginfo.simple simple
   | Var id -> acc, find_simple_from_id env id
 
-let find_simple_with_kind acc env (simple : IR.simple) =
-  match simple with
-  | Const const ->
-    (* For this code path, the debuginfo isn't relevant. *)
-    let acc, simple, _, kind = close_const0 acc Debuginfo.none const in
-    acc, (Simple.With_debuginfo.simple simple, kind)
-  | Var id -> acc, find_simple_from_id_with_kind env id
-
 let find_simples acc env ids =
   List.fold_left_map (fun acc id -> find_simple acc env id) acc ids
-
-let find_simples_and_arity acc env ids =
-  List.fold_left_map (fun acc id -> find_simple_with_kind acc env id) acc ids
 
 let find_value_approximation env simple =
   Simple.pattern_match' simple
@@ -1498,8 +1467,7 @@ let close_exact_or_unknown_apply acc env
   let acc, apply_exn_continuation =
     close_exn_continuation acc env exn_continuation
   in
-  let acc, args_with_arity = find_simples_and_arity acc env args in
-  let args, _split_args_arity = List.split args_with_arity in
+  let acc, args = find_simples acc env args in
   let inlined_call = Inlined_attribute.from_lambda inlined in
   let probe = Probe.from_lambda probe in
   let position =
@@ -3159,7 +3127,6 @@ let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =
         first_complex_local_param,
         result_mode,
         contains_no_escaping_local_allocs ) -> (
-    let acc, _ = find_simples_and_arity acc env apply.args in
     let split_args =
       let non_unarized_arity, arity =
         let arity =


### PR DESCRIPTION
While working on #3257 I noticed that we compute kinds in `Closure_conversion` that are never used.
This PR removes these unused kinds.