### PR TITLE
Dedicated module to print registers

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -809,7 +809,7 @@ let move (src : Reg.t) (dst : Reg.t) =
   | (Float | Float32 | Vec128 | Int | Val | Addr), _, _, _ ->
     Misc.fatal_errorf
       "Illegal move between registers of differing types (%a to %a)\n"
-      Printmach.reg src Printmach.reg dst
+      Printreg.reg src Printreg.reg dst
   end
 
 let stack_to_stack_move (src : Reg.t) (dst : Reg.t) =
@@ -2315,7 +2315,7 @@ let emit_probe_notes0 () =
       | Reg reg -> Proc.register_name arg.Reg.typ reg
       | Unknown ->
         Misc.fatal_errorf "Cannot create probe: illegal argument: %a"
-          Printmach.reg arg
+          Printreg.reg arg
     in
     Printf.sprintf "%d@%s" (Reg.size_of_contents_in_bytes arg) arg_name
   in

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -331,7 +331,7 @@ let dump_basic ppf (basic : basic) =
   | Stack_check { max_frame_size_bytes } ->
     fprintf ppf "Stack_check size=%d" max_frame_size_bytes
 
-let dump_terminator' ?(print_reg = Printmach.reg) ?(res = [||]) ?(args = [||])
+let dump_terminator' ?(print_reg = Printreg.reg) ?(res = [||]) ?(args = [||])
     ?(specific_can_raise = fun ppf _ -> Format.fprintf ppf "specific_can_raise")
     ?(sep = "\n") ppf (terminator : terminator) =
   let first_arg =
@@ -347,11 +347,11 @@ let dump_terminator' ?(print_reg = Printmach.reg) ?(res = [||]) ?(args = [||])
   let print_args ppf args =
     if Array.length args = 0
     then ()
-    else Format.fprintf ppf " %a" (Printmach.regs' ~print_reg) args
+    else Format.fprintf ppf " %a" (Printreg.regs' ~print_reg) args
   in
   let print_res ppf =
     if Array.length res > 0
-    then Format.fprintf ppf "%a := " (Printmach.regs' ~print_reg) res
+    then Format.fprintf ppf "%a := " (Printreg.regs' ~print_reg) res
   in
   let dump_mach_op ppf op = Printmach.operation' ~print_reg op args ppf [||] in
   let open Format in

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -35,9 +35,9 @@ let check_invariants :
       Misc.fatal_errorf
         "Named live registers not a subset of available registers: live={%a}  \
          avail_before=%a missing={%a} insn=%a"
-        Printmach.regset live
-        (RAS.print ~print_reg:Printmach.reg)
-        (RAS.Ok avail_before) Printmach.regset
+        Printreg.regset live
+        (RAS.print ~print_reg:Printreg.reg)
+        (RAS.Ok avail_before) Printreg.regset
         (R.Set.diff live (RD.Set.forget_debug_info avail_before))
         print_instr instr;
     (* Every register that is an input to an instruction should be available. *)
@@ -48,8 +48,8 @@ let check_invariants :
       Misc.fatal_errorf
         "Instruction has unavailable input register(s): avail_before=%a \
          avail_before_fdi={%a} inputs={%a} insn=%a"
-        (RAS.print ~print_reg:Printmach.reg)
-        (RAS.Ok avail_before) Printmach.regset avail_before_fdi Printmach.regset
+        (RAS.print ~print_reg:Printreg.reg)
+        (RAS.Ok avail_before) Printreg.regset avail_before_fdi Printreg.regset
         args print_instr instr
 
 (* CR xclerc for xclerc: double check the whole `Domain` module. *)

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -342,7 +342,7 @@ end = struct
           ~some:(sprintf "instruction %d" << Instruction.Id.to_int)
           reg_node.direct_dependency
       in
-      fprintf ppf "argument %d, %a depends on %s\n" arg_i Printmach.reg
+      fprintf ppf "argument %d, %a depends on %s\n" arg_i Printreg.reg
         reg_node.reg dependency
     in
     let print_node (instruction : Instruction.t) =
@@ -482,7 +482,7 @@ end = struct
         \ unsure_allocs: %a"
         (Instruction.id instruction |> Instruction.Id.to_int)
         Instruction.print instruction print_memory_chunk t
-        (Arch.print_addressing Printmach.reg t.addressing_mode)
+        (Arch.print_addressing Printreg.reg t.addressing_mode)
         (memory_arguments t) print_set t.dependent_allocs print_set
         t.unsure_allocs
 

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -25,7 +25,7 @@ module Key = struct
   module Set = struct
     include Reg_availability_set
 
-    let print ppf t = print ~print_reg:Printmach.reg ppf t
+    let print ppf t = print ~print_reg:Printreg.reg ppf t
   end
 
   module Map = Map.Make (struct
@@ -34,7 +34,7 @@ module Key = struct
     let compare = Reg_with_debug_info.compare
   end)
 
-  let print ppf t = Reg_with_debug_info.print ~print_reg:Printmach.reg ppf t
+  let print ppf t = Reg_with_debug_info.print ~print_reg:Printreg.reg ppf t
 
   let all_parents _ = []
 end
@@ -97,7 +97,7 @@ module Vars = struct
       }
 
     let print ppf { reg; offset } =
-      Format.fprintf ppf "@[<hov 1>((reg %a)@ (offset %a))@]" Printmach.reg reg
+      Format.fprintf ppf "@[<hov 1>((reg %a)@ (offset %a))@]" Printreg.reg reg
         (Misc.Stdlib.Option.print Stack_reg_offset.print)
         offset
 

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -71,9 +71,9 @@ let check_invariants (instr : M.instruction) ~all_regs_that_might_be_named
       Misc.fatal_errorf
         "Named live registers not a subset of available registers: live={%a}  \
          avail_before=%a missing={%a} insn=%a"
-        Printmach.regset live
-        (RAS.print ~print_reg:Printmach.reg)
-        (RAS.Ok avail_before) Printmach.regset
+        Printreg.regset live
+        (RAS.print ~print_reg:Printreg.reg)
+        (RAS.Ok avail_before) Printreg.regset
         (R.Set.diff live (RD.Set.forget_debug_info avail_before))
         Printmach.instr
         { instr with M.next = M.end_instr () };
@@ -88,8 +88,8 @@ let check_invariants (instr : M.instruction) ~all_regs_that_might_be_named
       Misc.fatal_errorf
         "Instruction has unavailable input register(s): avail_before=%a \
          avail_before_fdi={%a} inputs={%a} insn=%a"
-        (RAS.print ~print_reg:Printmach.reg)
-        (RAS.Ok avail_before) Printmach.regset avail_before_fdi Printmach.regset
+        (RAS.print ~print_reg:Printreg.reg)
+        (RAS.Ok avail_before) Printreg.regset avail_before_fdi Printreg.regset
         args Printmach.instr
         { instr with M.next = M.end_instr () }
 

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_reg_locations.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_reg_locations.ml
@@ -26,7 +26,7 @@ let reg_location_description (reg : Reg.t) ~(offset : Stack_reg_offset.t option)
   else
     match reg.loc with
     | Unknown ->
-      Misc.fatal_errorf "Register without location: %a" Printmach.reg reg
+      Misc.fatal_errorf "Register without location: %a" Printreg.reg reg
     | Reg n -> (
       let dwarf_reg_number =
         let reg_class = Proc.register_class reg in
@@ -60,14 +60,14 @@ let reg_location_description (reg : Reg.t) ~(offset : Stack_reg_offset.t option)
         Misc.fatal_errorf
           "Register %a assigned to stack but no offset from CFA or domainstate \
            pointer provided"
-          Printmach.reg reg
+          Printreg.reg reg
       | Some offset -> (
         match offset with
         | Bytes_relative_to_cfa offset_in_bytes ->
           if offset_in_bytes mod Arch.size_addr <> 0
           then
             Misc.fatal_errorf "Misaligned stack slot at offset %d (reg %a)"
-              offset_in_bytes Printmach.reg reg;
+              offset_in_bytes Printreg.reg reg;
           let offset_in_words =
             Targetint.of_int_exn (offset_in_bytes / Arch.size_addr)
           in
@@ -85,7 +85,7 @@ let reg_location_description (reg : Reg.t) ~(offset : Stack_reg_offset.t option)
           then
             Misc.fatal_errorf
               "Misaligned domainstate slot at offset %d (reg %a)"
-              offset_in_bytes Printmach.reg reg;
+              offset_in_bytes Printreg.reg reg;
           let offset_in_words =
             Targetint.of_int_exn (offset_in_bytes / Arch.size_addr)
           in

--- a/backend/interf.ml
+++ b/backend/interf.ml
@@ -25,7 +25,7 @@ let assert_no_collisions set =
 let assert_compatible src dst =
   if not (Reg.types_are_compatible src dst) then
   Misc.fatal_errorf "found move between registers of incompatible types (%a to %a)"
-  Printmach.reg src Printmach.reg dst
+  Printreg.reg src Printreg.reg dst
 
 module IntPairSet =
   Hashtbl.Make(struct

--- a/backend/liveness.ml
+++ b/backend/liveness.ml
@@ -74,5 +74,5 @@ let fundecl f =
   let wrong_live = Reg.Set.diff initially_live (Reg.set_of_array f.fun_args) in
   if not (Reg.Set.is_empty wrong_live) then begin
     Misc.fatal_errorf "@[Liveness.fundecl:@\n%a@]"
-      Printmach.regset wrong_live
+      Printreg.regset wrong_live
   end

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -26,10 +26,10 @@ let section_name_to_string ppf = function
   | None -> ()
   | Some name -> fprintf ppf " in %s section" name
 
-let instr' ?(print_reg = Printmach.reg) ppf i =
+let instr' ?(print_reg = Printreg.reg) ppf i =
   let reg = print_reg in
-  let regs = Printmach.regs' ~print_reg in
-  let regsetaddr = Printmach.regsetaddr' ~print_reg in
+  let regs = Printreg.regs' ~print_reg in
+  let regsetaddr = Printreg.regsetaddr' ~print_reg in
   let test = Printmach.test' ~print_reg in
   let operation = Printmach.operation' ~print_reg in
   if !Flambda_backend_flags.davail then begin

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -24,68 +24,6 @@ open Interval
 
 module V = Backend_var
 
-let loc ?(wrap_out = fun ppf f -> f ppf) ~unknown ppf loc typ =
-  match loc with
-  | Unknown -> unknown ppf
-  | Reg r ->
-      wrap_out ppf (fun ppf -> fprintf ppf "%s" (Proc.register_name typ r))
-  | Stack(Local s) ->
-      wrap_out ppf (fun ppf ->
-        fprintf ppf "s[%s:%i]" (Proc.stack_class_tag (Proc.stack_slot_class typ)) s)
-  | Stack(Incoming s) ->
-      wrap_out ppf (fun ppf -> fprintf ppf "par[%i]" s)
-  | Stack(Outgoing s) ->
-      wrap_out ppf (fun ppf -> fprintf ppf "arg[%i]" s)
-  | Stack(Domainstate s) ->
-      wrap_out ppf (fun ppf -> fprintf ppf "ds[%i]" s)
-
-let reg ppf r =
-  if not (Reg.anonymous r) then fprintf ppf "%s:" (Reg.name r);
-  fprintf ppf "%s"
-    (match (r.typ : machtype_component) with
-    | Val -> "V"
-    | Addr -> "A"
-    | Int -> "I"
-    | Float -> "F"
-    | Vec128 -> "X"
-    | Float32 -> "S");
-  fprintf ppf "/%i" r.stamp;
-  loc
-    ~wrap_out:(fun ppf f -> fprintf ppf "[%t]" f)
-    ~unknown:(fun _ -> ()) ppf r.loc r.typ
-
-let regs' ?(print_reg = reg) ppf v =
-  let reg = print_reg in
-  match Array.length v with
-  | 0 -> ()
-  | 1 -> reg ppf v.(0)
-  | n -> reg ppf v.(0);
-         for i = 1 to n-1 do fprintf ppf " %a" reg v.(i) done
-
-let regs ppf v = regs' ppf v
-
-let regset ppf s =
-  let first = ref true in
-  Reg.Set.iter
-    (fun r ->
-      if !first then begin first := false; fprintf ppf "%a" reg r end
-      else fprintf ppf "@ %a" reg r)
-    s
-
-let regsetaddr' ?(print_reg = reg) ppf s =
-  let reg = print_reg in
-  let first = ref true in
-  Reg.Set.iter
-    (fun r ->
-      if !first then begin first := false; fprintf ppf "%a" reg r end
-      else fprintf ppf "@ %a" reg r;
-      match r.typ with
-      | Val -> fprintf ppf "*"
-      | Addr -> fprintf ppf "!"
-      | _ -> ())
-    s
-
-let regsetaddr ppf s = regsetaddr' ppf s
 
 let trap_stack ppf (ts : Simple_operation.trap_stack) =
   let has_specific = function
@@ -141,7 +79,7 @@ let floatop ppf op =
   | Inegf -> fprintf ppf "neg"
   | Icompf cmp -> fprintf ppf "%s" (Printcmm.float_comparison cmp)
 
-let test' ?(print_reg = reg) tst ppf arg =
+let test' ?(print_reg = Printreg.reg) tst ppf arg =
   let reg = print_reg in
   match tst with
   | Itruetest -> reg ppf arg.(0)
@@ -156,9 +94,9 @@ let test' ?(print_reg = reg) tst ppf arg =
 
 let test tst ppf arg = test' tst ppf arg
 
-let operation' ?(print_reg = reg) op arg ppf res =
+let operation' ?(print_reg = Printreg.reg) op arg ppf res =
   let reg = print_reg in
-  let regs = regs' ~print_reg in
+  let regs = Printreg.regs' ~print_reg in
   if Array.length res > 0 then fprintf ppf "%a := " regs res;
   match op with
   | Imove -> regs ppf arg
@@ -255,8 +193,8 @@ let operation op arg ppf res = operation' op arg ppf res
 
 let rec instr ppf i =
   if !Clflags.dump_live then begin
-    fprintf ppf "@[<1>{%a" regsetaddr i.live;
-    if Array.length i.arg > 0 then fprintf ppf "@ +@ %a" regs i.arg;
+    fprintf ppf "@[<1>{%a" Printreg.regsetaddr i.live;
+    if Array.length i.arg > 0 then fprintf ppf "@ +@ %a" Printreg.regs i.arg;
     fprintf ppf "}@]@,"
   end;
   if !Flambda_backend_flags.davail then begin
@@ -273,15 +211,15 @@ let rec instr ppf i =
     then (
       if Option.equal RAS.equal (Some i.available_before) i.available_across
       then
-        fprintf ppf "@[<1>AB=AA={%a}@]@," (RAS.print ~print_reg:reg)
+        fprintf ppf "@[<1>AB=AA={%a}@]@," (RAS.print ~print_reg:Printreg.reg)
           i.available_before
       else (
-        fprintf ppf "@[<1>AB={%a}" (RAS.print ~print_reg:reg)
+        fprintf ppf "@[<1>AB={%a}" (RAS.print ~print_reg:Printreg.reg)
           i.available_before;
         begin match i.available_across with
         | None -> ()
         | Some available_across ->
-          fprintf ppf ",AA={%a}" (RAS.print ~print_reg:reg) available_across
+          fprintf ppf ",AA={%a}" (RAS.print ~print_reg:Printreg.reg) available_across
         end;
         fprintf ppf "@]@,"
       )
@@ -292,7 +230,7 @@ let rec instr ppf i =
   | Iop op ->
       operation op i.arg ppf i.res
   | Ireturn traps ->
-      fprintf ppf "return%a %a" Printcmm.trap_action_list traps regs i.arg
+      fprintf ppf "return%a %a" Printcmm.trap_action_list traps Printreg.regs i.arg
   | Iifthenelse(tst, ifso, ifnot) ->
       fprintf ppf "@[<v 2>if %a then@,%a" (test tst) i.arg instr ifso;
       begin match ifnot.desc with
@@ -301,7 +239,7 @@ let rec instr ppf i =
       end;
       fprintf ppf "@;<0 -2>endif@]"
   | Iswitch(index, cases) ->
-      fprintf ppf "switch %a" reg i.arg.(0);
+      fprintf ppf "switch %a" Printreg.reg i.arg.(0);
       for i = 0 to Array.length cases - 1 do
         fprintf ppf "@,@[<v 2>@[";
         for j = 0 to Array.length index - 1 do
@@ -331,7 +269,7 @@ let rec instr ppf i =
       fprintf ppf "@[<v 2>try@,%a@;<0 -2>with(%d)%a@,%a@;<0 -2>endtry@]"
              instr body exn_cont trap_stack ts instr handler
   | Iraise k ->
-      fprintf ppf "%s %a" (Lambda.raise_kind k) reg i.arg.(0)
+      fprintf ppf "%s %a" (Lambda.raise_kind k) Printreg.reg i.arg.(0)
   end;
   if not (Debuginfo.is_none i.dbg) && !Clflags.locations then
     fprintf ppf "%s" (Debuginfo.to_string i.dbg);
@@ -347,7 +285,7 @@ let fundecl ppf f =
     else
       " " ^ Debuginfo.to_string f.fun_dbg in
   fprintf ppf "@[<v 2>%s(%a)%s%a@,%a@]"
-    f.fun_name regs f.fun_args dbg
+    f.fun_name Printreg.regs f.fun_args dbg
     Printcmm.print_codegen_options f.fun_codegen_options
     instr f.fun_body
 
@@ -357,9 +295,9 @@ let phase msg ppf f =
 let interference ppf r =
   let interf ppf =
    List.iter
-    (fun r -> fprintf ppf "@ %a" reg r)
+    (fun r -> fprintf ppf "@ %a" Printreg.reg r)
     r.interf in
-  fprintf ppf "@[<2>%a:%t@]@." reg r interf
+  fprintf ppf "@[<2>%a:%t@]@." Printreg.reg r interf
 
 let interferences ppf () =
   fprintf ppf "*** Interferences@.";
@@ -370,7 +308,7 @@ let interval ppf i =
     List.iter
       (fun r -> fprintf ppf "@ [%d;%d]" r.rbegin r.rend)
       i.ranges in
-  fprintf ppf "@[<2>%a:%t@]@." reg i.reg interv
+  fprintf ppf "@[<2>%a:%t@]@." Printreg.reg i.reg interv
 
 let intervals ppf () =
   fprintf ppf "*** Intervals@.";
@@ -380,9 +318,9 @@ let intervals ppf () =
 let preference ppf r =
   let prefs ppf =
     List.iter
-      (fun (r, w) -> fprintf ppf "@ %a weight %i" reg r w)
+      (fun (r, w) -> fprintf ppf "@ %a weight %i" Printreg.reg r w)
       r.prefer in
-  fprintf ppf "@[<2>%a: %t@]@." reg r prefs
+  fprintf ppf "@[<2>%a: %t@]@." Printreg.reg r prefs
 
 let preferences ppf () =
   fprintf ppf "*** Preferences@.";

--- a/backend/printreg.ml
+++ b/backend/printreg.ml
@@ -1,0 +1,82 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Pretty-printing of registers *)
+
+open Format
+open Reg
+
+let loc ?(wrap_out = fun ppf f -> f ppf) ~unknown ppf loc typ =
+  match loc with
+  | Unknown -> unknown ppf
+  | Reg r ->
+      wrap_out ppf (fun ppf -> fprintf ppf "%s" (Proc.register_name typ r))
+  | Stack(Local s) ->
+      wrap_out ppf (fun ppf ->
+        fprintf ppf "s[%s:%i]" (Proc.stack_class_tag (Proc.stack_slot_class typ)) s)
+  | Stack(Incoming s) ->
+      wrap_out ppf (fun ppf -> fprintf ppf "par[%i]" s)
+  | Stack(Outgoing s) ->
+      wrap_out ppf (fun ppf -> fprintf ppf "arg[%i]" s)
+  | Stack(Domainstate s) ->
+      wrap_out ppf (fun ppf -> fprintf ppf "ds[%i]" s)
+
+let reg ppf r =
+  if not (anonymous r) then fprintf ppf "%s:" (name r);
+  fprintf ppf "%s"
+    (match (r.typ : Cmm.machtype_component) with
+    | Val -> "V"
+    | Addr -> "A"
+    | Int -> "I"
+    | Float -> "F"
+    | Vec128 -> "X"
+    | Float32 -> "S");
+  fprintf ppf "/%i" r.stamp;
+  loc
+    ~wrap_out:(fun ppf f -> fprintf ppf "[%t]" f)
+    ~unknown:(fun _ -> ()) ppf r.loc r.typ
+
+let regs' ?(print_reg = reg) ppf v =
+  let reg = print_reg in
+  match Array.length v with
+  | 0 -> ()
+  | 1 -> reg ppf v.(0)
+  | n -> reg ppf v.(0);
+         for i = 1 to n-1 do fprintf ppf " %a" reg v.(i) done
+
+let regs ppf v = regs' ppf v
+
+let regset ppf s =
+  let first = ref true in
+  Set.iter
+    (fun r ->
+      if !first then begin first := false; fprintf ppf "%a" reg r end
+      else fprintf ppf "@ %a" reg r)
+    s
+
+let regsetaddr' ?(print_reg = reg) ppf s =
+  let reg = print_reg in
+  let first = ref true in
+  Set.iter
+    (fun r ->
+      if !first then begin first := false; fprintf ppf "%a" reg r end
+      else fprintf ppf "@ %a" reg r;
+      match r.typ with
+      | Val -> fprintf ppf "*"
+      | Addr -> fprintf ppf "!"
+      | _ -> ())
+    s
+
+let regsetaddr ppf s = regsetaddr' ppf s

--- a/backend/printreg.mli
+++ b/backend/printreg.mli
@@ -13,18 +13,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Pretty-printing of pseudo machine code *)
+(* Pretty-printing of registers *)
 
-open Format
-
-val operation': ?print_reg:(formatter -> Reg.t -> unit) -> Mach.operation -> Reg.t array -> formatter -> Reg.t array -> unit
-val operation: Mach.operation -> Reg.t array -> formatter -> Reg.t array -> unit
-val test': ?print_reg:(formatter -> Reg.t -> unit) -> Simple_operation.test -> formatter -> Reg.t array -> unit
-val test: Simple_operation.test -> formatter -> Reg.t array -> unit
-val instr: formatter -> Mach.instruction -> unit
-val fundecl: formatter -> Mach.fundecl -> unit
-val phase: string -> formatter -> Mach.fundecl -> unit
-val interferences: formatter -> unit -> unit
-val intervals: formatter -> unit -> unit
-val preferences: formatter -> unit -> unit
-val floatop: formatter -> Simple_operation.float_operation -> unit
+val loc: ?wrap_out:(Format.formatter -> (Format.formatter -> unit) -> unit) -> unknown:(Format.formatter -> unit) -> Format.formatter -> Reg.location -> Cmm.machtype_component -> unit
+val reg: Format.formatter -> Reg.t -> unit
+val regs': ?print_reg:(Format.formatter -> Reg.t -> unit) -> Format.formatter -> Reg.t array -> unit
+val regs: Format.formatter -> Reg.t array -> unit
+val regset: Format.formatter -> Reg.Set.t -> unit
+val regsetaddr': ?print_reg:(Format.formatter -> Reg.t -> unit) -> Format.formatter -> Reg.Set.t -> unit
+val regsetaddr: Format.formatter -> Reg.Set.t -> unit

--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -55,7 +55,7 @@ let update_register_locations : State.t -> unit =
       | Some location ->
         if gi_debug
         then
-          log ~indent:1 "updating %a to %a" Printmach.reg reg
+          log ~indent:1 "updating %a to %a" Printreg.reg reg
             Hardware_register.print_location location;
         reg.Reg.loc <- Hardware_register.reg_location_of_location location)
   in
@@ -86,7 +86,7 @@ let make_hardware_registers_and_prio_queue (cfg_with_infos : Cfg_with_infos.t) :
       | Reg _ ->
         if gi_debug
         then (
-          log ~indent:1 "pre-assigned register %a" Printmach.reg reg;
+          log ~indent:1 "pre-assigned register %a" Printreg.reg reg;
           log ~indent:2 "%a" Interval.print interval);
         let hardware_reg = Hardware_registers.of_reg hardware_registers reg in
         Hardware_register.add_non_evictable hardware_reg reg interval
@@ -94,14 +94,14 @@ let make_hardware_registers_and_prio_queue (cfg_with_infos : Cfg_with_infos.t) :
         let priority = priority_heuristics reg interval in
         if gi_debug
         then (
-          log ~indent:1 "register %a" Printmach.reg reg;
+          log ~indent:1 "register %a" Printreg.reg reg;
           log ~indent:2 "%a" Interval.print interval;
           log ~indent:2 "priority=%d" priority);
         Prio_queue.add prio_queue ~priority ~data:(reg, interval)
       | Stack _ ->
         if gi_debug
         then (
-          log ~indent:1 "stack register %a" Printmach.reg reg;
+          log ~indent:1 "stack register %a" Printreg.reg reg;
           log ~indent:2 "%a" Interval.print interval);
         ())
     intervals;
@@ -140,7 +140,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
     log ~indent:0 "spilling costs";
     List.iter (Reg.all_registers ()) ~f:(fun (reg : Reg.t) ->
         reg.Reg.spill <- false;
-        log ~indent:1 "%a: %d" Printmach.reg reg reg.spill_cost));
+        log ~indent:1 "%a: %d" Printreg.reg reg reg.spill_cost));
   let hardware_registers, prio_queue =
     make_hardware_registers_and_prio_queue cfg_with_infos
   in
@@ -154,12 +154,12 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
       Prio_queue.get_and_remove prio_queue
     in
     if gi_debug
-    then log ~indent:2 "got register %a (prio=%d)" Printmach.reg reg priority;
+    then log ~indent:2 "got register %a (prio=%d)" Printreg.reg reg priority;
     match Hardware_registers.find_available hardware_registers reg interval with
     | For_assignment { hardware_reg } ->
       if gi_debug
       then
-        log ~indent:3 "assigning %a to %a" Printmach.reg reg
+        log ~indent:3 "assigning %a to %a" Printreg.reg reg
           Hardware_register.print_location hardware_reg.location;
       State.add_assignment state reg ~to_:hardware_reg.location;
       hardware_reg.assigned
@@ -168,7 +168,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
     | For_eviction { hardware_reg; evicted_regs } ->
       if gi_debug
       then
-        log ~indent:3 "evicting %a from %a" Printmach.regs
+        log ~indent:3 "evicting %a from %a" Printreg.regs
           (Array.of_list
              (List.map evicted_regs
                 ~f:(fun { Hardware_register.pseudo_reg; _ } -> pseudo_reg)))
@@ -185,7 +185,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
             fatal
               "register %a has been picked up for eviction, but is not \
                evictable"
-              Printmach.reg evict_reg;
+              Printreg.reg evict_reg;
           State.remove_assignment state evict_reg;
           Prio_queue.add prio_queue
             ~priority:(priority_heuristics evict_reg evict_interval)
@@ -202,7 +202,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
                          Reg.same r r')))
     | Split_or_spill ->
       (* CR xclerc for xclerc: we should actually try to split. *)
-      if gi_debug then log ~indent:3 "spilling %a" Printmach.reg reg;
+      if gi_debug then log ~indent:3 "spilling %a" Printreg.reg reg;
       reg.Reg.spill <- true;
       spilling := (reg, interval) :: !spilling
   done;
@@ -215,7 +215,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
       log ~indent:1 "stack slots";
       Regalloc_stack_slots.iter (State.stack_slots state)
         ~f:(fun (reg : Reg.t) (slot : int) ->
-          log ~indent:2 "  - %a ~> %d" Printmach.reg reg slot);
+          log ~indent:2 "  - %a ~> %d" Printreg.reg reg slot);
       log ~indent:1 "needs to spill %d registers:" (List.length !spilling);
       List.iter !spilling ~f:(fun (_reg, interval) ->
           log ~indent:2 "  - %a" Interval.print interval);

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -554,7 +554,7 @@ module Hardware_register = struct
     }
 
   let print_assigned ppf { pseudo_reg; interval; evictable } =
-    Format.fprintf ppf "%a %a (evitable=%B)" Printmach.reg pseudo_reg
+    Format.fprintf ppf "%a %a (evitable=%B)" Printreg.reg pseudo_reg
       Interval.print interval evictable
 
   type t =
@@ -686,7 +686,7 @@ module Hardware_registers = struct
                   let overlap = Interval.overlap interval itv in
                   if gi_debug
                   then
-                    log ~indent:5 "%a is assigned / overlap=%B" Printmach.reg
+                    log ~indent:5 "%a is assigned / overlap=%B" Printreg.reg
                       pseudo_reg overlap;
                   overlap)
             in

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -73,7 +73,7 @@ let precondition : Cfg_with_layout.t -> unit =
     | Initial | Simplify | Freeze | Spill | Spilled | Coalesced | Colored
     | Select_stack ->
       fatal "instruction %d has a register (%a) already in a work list (%S)" id
-        Printmach.reg reg
+        Printreg.reg reg
         (Reg.string_of_irc_work_list reg.Reg.irc_work_list)
   in
   let register_must_be_on_unknown_list (id : Instruction.id)
@@ -109,7 +109,7 @@ let postcondition_layout : Cfg_with_layout.t -> unit =
     | Stack (Local _ | Incoming _ | Outgoing _ | Domainstate _) -> ()
     | Unknown ->
       fatal "instruction %d has a register (%a) with an unknown location" id
-        Printmach.reg reg
+        Printreg.reg reg
   in
   let registers_must_not_be_unknown (id : Instruction.id) (regs : Reg.t array) :
       unit =
@@ -150,7 +150,7 @@ let postcondition_layout : Cfg_with_layout.t -> unit =
         fatal
           "instruction %d assigned %a to register %i, which has an \
            incompatible class"
-          id Printmach.reg reg phys_reg)
+          id Printreg.reg reg phys_reg)
     | Stack _ | Unknown -> ()
   in
   let register_classes_must_be_consistent (id : Instruction.id)
@@ -240,9 +240,9 @@ let postcondition_liveness : Cfg_with_infos.t -> unit =
       | Unknown -> assert false (* already tested in `postcondition_layout` *)
       | Reg _ -> ()
       | Stack (Local _) ->
-        fatal "`Stack (Local _)`live at entry point: %a" Printmach.reg reg
+        fatal "`Stack (Local _)`live at entry point: %a" Printreg.reg reg
       | Stack (Incoming _) -> ()
       | Stack (Outgoing _) ->
-        fatal "`Stack (Outgoing _)` live at entry point: %a" Printmach.reg reg
+        fatal "`Stack (Outgoing _)` live at entry point: %a" Printreg.reg reg
       | Stack (Domainstate _) -> ())
     live_at_entry_point.before

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -102,7 +102,7 @@ let make_work_list : State.t -> unit =
       let deg = reg.Reg.degree in
       if irc_debug
       then
-        log ~indent:2 "- %a has degree=%s (k=%d)" Printmach.reg reg
+        log ~indent:2 "- %a has degree=%s (k=%d)" Printreg.reg reg
           (Degree.to_string deg) (k reg);
       if deg >= k reg
       then (
@@ -119,7 +119,7 @@ let make_work_list : State.t -> unit =
 let simplify : State.t -> unit =
  fun state ->
   let reg = State.choose_and_remove_simplify_work_list state in
-  if irc_debug then log ~indent:1 "simplify %a" Printmach.reg reg;
+  if irc_debug then log ~indent:1 "simplify %a" Printreg.reg reg;
   State.push_select_stack state reg;
   State.iter_adjacent state reg ~f:(fun adj -> State.decr_degree state adj)
 
@@ -156,7 +156,7 @@ let conservative : State.t -> Reg.t -> Reg.t -> bool =
 let combine : State.t -> Reg.t -> Reg.t -> unit =
  fun state u v ->
   if irc_debug
-  then log ~indent:2 "combine u=%a v=%a" Printmach.reg u Printmach.reg v;
+  then log ~indent:2 "combine u=%a v=%a" Printreg.reg u Printreg.reg v;
   if State.mem_freeze_work_list state v
   then State.remove_freeze_work_list state v
   else State.remove_spill_work_list state v;
@@ -189,12 +189,12 @@ let coalesce : State.t -> unit =
   let m = State.choose_and_remove_work_list_moves state in
   let x = m.res.(0) in
   let y = m.arg.(0) in
-  if irc_debug then log ~indent:2 "x=%a y=%a" Printmach.reg x Printmach.reg y;
+  if irc_debug then log ~indent:2 "x=%a y=%a" Printreg.reg x Printreg.reg y;
   let x = State.find_alias state x in
   let y = State.find_alias state y in
-  if irc_debug then log ~indent:2 "x=%a y=%a" Printmach.reg x Printmach.reg y;
+  if irc_debug then log ~indent:2 "x=%a y=%a" Printreg.reg x Printreg.reg y;
   let u, v = if State.is_precolored state y then y, x else x, y in
-  if irc_debug then log ~indent:2 "u=%a v=%a" Printmach.reg u Printmach.reg v;
+  if irc_debug then log ~indent:2 "u=%a v=%a" Printreg.reg u Printreg.reg v;
   if Reg.same u v
   then (
     if irc_debug then log ~indent:2 "case #1/4";
@@ -226,7 +226,7 @@ let coalesce : State.t -> unit =
 
 let freeze_moves : State.t -> Reg.t -> unit =
  fun state u ->
-  if irc_debug then log ~indent:2 "freeze_moves %a" Printmach.reg u;
+  if irc_debug then log ~indent:2 "freeze_moves %a" Printreg.reg u;
   State.iter_node_moves state u ~f:(fun m ->
       let x = m.res.(0) in
       let y = m.arg.(0) in
@@ -246,7 +246,7 @@ let freeze_moves : State.t -> Reg.t -> unit =
 let freeze : State.t -> unit =
  fun state ->
   let reg = State.choose_and_remove_freeze_work_list state in
-  if irc_debug then log ~indent:1 "freeze %a" Printmach.reg reg;
+  if irc_debug then log ~indent:1 "freeze %a" Printreg.reg reg;
   State.add_simplify_work_list state reg;
   freeze_moves state reg
 
@@ -274,7 +274,7 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
     let weighted_cost (reg : Reg.t) =
       if irc_debug
       then
-        log ~indent:2 "register %a has spill cost %d" Printmach.reg reg
+        log ~indent:2 "register %a has spill cost %d" Printreg.reg reg
           reg.Reg.spill_cost;
       (float reg.Reg.spill_cost /. float reg.Reg.degree)
       (* note: while this magic constant is questionable, it is key to not favor
@@ -290,7 +290,7 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
           let reg_cost = weighted_cost reg in
           if irc_debug
           then
-            log ~indent:2 "register %a has weighted cost %f" Printmach.reg reg
+            log ~indent:2 "register %a has weighted cost %f" Printreg.reg reg
               reg_cost;
           if reg_cost < curr_min_cost then reg, reg_cost else acc)
       |> fst)
@@ -301,7 +301,7 @@ let select_spill : State.t -> unit =
   let reg = select_spilling_register_using_heuristics state in
   if irc_debug
   then
-    log ~indent:2 "chose %a using heuristics %S" Printmach.reg reg
+    log ~indent:2 "chose %a using heuristics %S" Printreg.reg reg
       Spilling_heuristics.(to_string @@ Lazy.force value);
   State.remove_spill_work_list state reg;
   State.add_simplify_work_list state reg;
@@ -311,7 +311,7 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
  fun state _cfg_with_layout ->
   if irc_debug then log ~indent:1 "assign_colors";
   State.iter_and_clear_select_stack state ~f:(fun n ->
-      if irc_debug then log ~indent:2 "%a" Printmach.reg n;
+      if irc_debug then log ~indent:2 "%a" Printreg.reg n;
       let reg_class = Proc.register_class n in
       let reg_num_avail =
         Array.unsafe_get Proc.num_available_registers reg_class
@@ -490,7 +490,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
     if irc_debug
     then
       List.iter spilled_nodes ~f:(fun reg ->
-          log ~indent:1 "/!\\ register %a needs to be spilled" Printmach.reg reg);
+          log ~indent:1 "/!\\ register %a needs to be spilled" Printreg.reg reg);
     match
       rewrite state cfg_with_infos ~spilled_nodes ~reset:true
         ~block_temporaries:(round = 1)

--- a/backend/regalloc/regalloc_irc_state.ml
+++ b/backend/regalloc/regalloc_irc_state.ml
@@ -69,7 +69,7 @@ let[@inline] make ~initial ~stack_slots ~next_instruction_id () =
            | Reg color -> Some color
            | Unknown | Stack _ ->
              fatal "precolored register %a is not an hardware register"
-               Printmach.reg reg);
+               Printreg.reg reg);
       reg.Reg.irc_alias <- None;
       reg.Reg.interf <- [];
       reg.Reg.degree <- Degree.infinite)
@@ -466,7 +466,7 @@ let[@inline] rec find_alias state reg =
   if reg.Reg.irc_work_list = Reg.Coalesced
   then
     match reg.Reg.irc_alias with
-    | None -> fatal "register %a has no alias" Printmach.reg reg
+    | None -> fatal "register %a has no alias" Printreg.reg reg
     | Some reg' -> find_alias state reg'
   else reg
 
@@ -478,7 +478,7 @@ let[@inline] add_alias _state v u =
     fatal
       "trying to create an alias between %a and %a but they have incompatible \
        types"
-      Printmach.reg v Printmach.reg u;
+      Printreg.reg v Printreg.reg u;
   v.Reg.irc_alias <- Some u
 
 let[@inline] stack_slots state = state.stack_slots
@@ -521,7 +521,7 @@ let[@inline] check_set_and_field_consistency_reg (work_list, set, field_value) =
     (fun reg ->
       if reg.Reg.irc_work_list <> field_value
       then
-        fatal "register %a is in %s but its field equals %S" Printmach.reg reg
+        fatal "register %a is in %s but its field equals %S" Printreg.reg reg
           work_list
           (Reg.string_of_irc_work_list reg.Reg.irc_work_list))
     set
@@ -541,7 +541,7 @@ let[@inline] check_inter_has_no_duplicates (reg : Reg.t) : unit =
   let l = reg.Reg.interf in
   let s = Reg.Set.of_list l in
   if List.length l <> Reg.Set.cardinal s
-  then fatal "interf list for %a is not a set" Printmach.reg reg
+  then fatal "interf list for %a is not a set" Printreg.reg reg
 
 let reg_set_of_doubly_linked_list (l : Reg.t Doubly_linked_list.t) : Reg.Set.t =
   Doubly_linked_list.fold_right l ~init:Reg.Set.empty ~f:Reg.Set.add
@@ -629,7 +629,7 @@ let[@inline] invariant state =
       (fun u ->
         let degree = u.Reg.degree in
         if degree = Degree.infinite
-        then fatal "invariant: infinite degree for %a" Printmach.reg u
+        then fatal "invariant: infinite degree for %a" Printreg.reg u
         else
           let adj_list = Reg.Set.of_list (adj_list state u) in
           let cardinal =
@@ -638,20 +638,19 @@ let[@inline] invariant state =
           if not (Int.equal degree cardinal)
           then (
             List.iter u.Reg.interf ~f:(fun r ->
-                log ~indent:0 "%a <- interf[%a]" Printmach.reg r Printmach.reg u);
+                log ~indent:0 "%a <- interf[%a]" Printreg.reg r Printreg.reg u);
             Reg.Set.iter
               (fun r ->
-                log ~indent:0 "%a <- adj_list[%a]" Printmach.reg r Printmach.reg
-                  u)
+                log ~indent:0 "%a <- adj_list[%a]" Printreg.reg r Printreg.reg u)
               adj_list;
             Reg.Set.iter
               (fun r ->
-                log ~indent:0 "%a <- work_lists_or_precolored[%a]" Printmach.reg
-                  r Printmach.reg u)
+                log ~indent:0 "%a <- work_lists_or_precolored[%a]" Printreg.reg
+                  r Printreg.reg u)
               (Reg.Set.inter adj_list work_lists_or_precolored);
             fatal
               "invariant expected degree for %a to be %d but got %d\n\
-              \ (#adj_list=%d, #work_lists_or_precolored=%d)" Printmach.reg u
+              \ (#adj_list=%d, #work_lists_or_precolored=%d)" Printreg.reg u
               cardinal degree
               (Reg.Set.cardinal adj_list)
               (Reg.Set.cardinal work_lists_or_precolored)))

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -158,7 +158,7 @@ let update_register_locations : unit -> unit =
           ()
         | Some color ->
           if irc_debug
-          then log ~indent:1 "updating %a to %d" Printmach.reg reg color;
+          then log ~indent:1 "updating %a to %d" Printreg.reg reg color;
           reg.Reg.loc <- Reg color))
 
 module Spilling_heuristics = struct

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -117,7 +117,7 @@ type spilling_reg =
 
 let allocate_stack_slot : Reg.t -> spilling_reg =
  fun reg ->
-  log ~indent:3 "spilling register %a" Printmach.reg reg;
+  log ~indent:3 "spilling register %a" Printreg.reg reg;
   reg.spill <- true;
   Spilling reg
 
@@ -170,7 +170,7 @@ let allocate_free_register : State.t -> Interval.t -> spilling_reg =
           intervals.active
             <- Interval.List.insert_sorted intervals.active interval;
           if ls_debug
-          then log ~indent:3 "assigning %d to register %a" idx Printmach.reg reg;
+          then log ~indent:3 "assigning %d to register %a" idx Printreg.reg reg;
           Not_spilling)
         else assign (succ idx)
       in

--- a/backend/regalloc/regalloc_ls_state.ml
+++ b/backend/regalloc/regalloc_ls_state.ml
@@ -116,7 +116,7 @@ let[@inline] invariant_intervals state cfg_with_infos =
                 fatal
                   "Regalloc_ls_state.invariant_intervals: state.intervals \
                    duplicate register %a"
-                  Printmach.reg interval.reg)
+                  Printreg.reg interval.reg)
             acc)
     in
     let check_instr : type a. a Cfg.instruction -> unit =
@@ -128,7 +128,7 @@ let[@inline] invariant_intervals state cfg_with_infos =
             fatal
               "Regalloc_ls_state.invariant_intervals: register %a is not in \
                interval_map"
-              Printmach.reg reg
+              Printreg.reg reg
           | Some interval ->
             if instr.ls_order < interval.begin_
             then

--- a/backend/regalloc/regalloc_ls_utils.ml
+++ b/backend/regalloc/regalloc_ls_utils.ml
@@ -160,7 +160,7 @@ module Interval = struct
     }
 
   let print ppf t =
-    Format.fprintf ppf "%a[%d,%d]:" Printmach.reg t.reg t.begin_ t.end_;
+    Format.fprintf ppf "%a[%d,%d]:" Printreg.reg t.reg t.begin_ t.end_;
     DLL.iter t.ranges ~f:(fun r -> Format.fprintf ppf " %a" Range.print r)
 
   let overlap : t -> t -> bool =
@@ -256,7 +256,7 @@ end
 
 let log_interval ~indent ~kind (interval : Interval.t) =
   let reg_class = Proc.register_class interval.reg in
-  log ~indent "%s %a (class %d) [%d..%d]" kind Printmach.reg interval.reg
+  log ~indent "%s %a (class %d) [%d..%d]" kind Printreg.reg interval.reg
     reg_class interval.begin_ interval.end_;
   let ranges = Buffer.create 128 in
   let first = ref true in

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -138,8 +138,8 @@ let rewrite_gen :
         spilled.Reg.loc <- Reg.(Stack (Local slot));
         if Utils.debug
         then
-          Utils.log ~indent:2 "spilling %a to %a" Printmach.reg reg
-            Printmach.reg spilled;
+          Utils.log ~indent:2 "spilling %a to %a" Printreg.reg reg Printreg.reg
+            spilled;
         Reg.Tbl.replace spilled_map reg spilled;
         spilled_map)
   in
@@ -152,8 +152,8 @@ let rewrite_gen :
     new_inst_temporaries := res :: !new_inst_temporaries;
     if Utils.debug
     then
-      Utils.log ~indent:2 "adding temporary %a (to %s %a)" Printmach.reg res
-        (Move.to_string move) Printmach.reg reg;
+      Utils.log ~indent:2 "adding temporary %a (to %s %a)" Printreg.reg res
+        (Move.to_string move) Printreg.reg reg;
     res
   in
   let[@inline] array_contains_spilled (arr : Reg.t array) : bool =

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -25,7 +25,7 @@ let[@inline] remove_from_bindings :
       (fun reg _ ->
         let remove = Reg.Set.mem reg regs in
         if split_debug
-        then if remove then log ~indent:3 "removing %a" Printmach.reg reg;
+        then if remove then log ~indent:3 "removing %a" Printreg.reg reg;
         not remove)
       bindings
 
@@ -64,7 +64,7 @@ let rec compute_substitution_tree :
   Reg.Map.iter
     (fun old_reg new_reg ->
       if split_debug
-      then log ~indent:3 "%a -> %a" Printmach.reg old_reg Printmach.reg new_reg;
+      then log ~indent:3 "%a -> %a" Printreg.reg old_reg Printreg.reg new_reg;
       Reg.Tbl.replace subst old_reg new_reg)
     bindings;
   (* Third, add the definitions to the substitution and bindings. *)
@@ -82,8 +82,8 @@ let rec compute_substitution_tree :
             ~existing:old_reg;
           if split_debug
           then
-            log ~indent:3 "renaming %a to %a" Printmach.reg old_reg
-              Printmach.reg new_reg;
+            log ~indent:3 "renaming %a to %a" Printreg.reg old_reg Printreg.reg
+              new_reg;
           Reg.Tbl.replace subst old_reg new_reg;
           Reg.Map.add old_reg new_reg bindings)
         renames bindings
@@ -146,7 +146,7 @@ let make_spill : type a. a make_operation =
   in
   if split_debug
   then
-    log ~indent:3 "spill %a -> %a" Printmach.reg new_reg Printmach.reg stack_reg;
+    log ~indent:3 "spill %a -> %a" Printreg.reg new_reg Printreg.reg stack_reg;
   Move.make_instr Move.Store
     ~id:(State.get_and_incr_instruction_id state)
     ~copy ~from:new_reg ~to_:stack_reg
@@ -279,8 +279,7 @@ let make_reload : type a. a make_operation =
   in
   if split_debug
   then
-    log ~indent:3 "reload %a -> %a" Printmach.reg stack_reg Printmach.reg
-      new_reg;
+    log ~indent:3 "reload %a -> %a" Printreg.reg stack_reg Printreg.reg new_reg;
   Move.make_instr Move.Load
     ~id:(State.get_and_incr_instruction_id state)
     ~copy ~from:stack_reg ~to_:new_reg
@@ -336,11 +335,11 @@ let add_phi_moves_to_instr_list :
       | true ->
         if split_debug
         then
-          log ~indent:3 "(no phi necessary because %a == %a)" Printmach.reg from
-            Printmach.reg to_
+          log ~indent:3 "(no phi necessary because %a == %a)" Printreg.reg from
+            Printreg.reg to_
       | false ->
         if split_debug
-        then log ~indent:3 "phi %a -> %a" Printmach.reg from Printmach.reg to_;
+        then log ~indent:3 "phi %a -> %a" Printreg.reg from Printreg.reg to_;
         let phi_move =
           Move.make_instr Move.Plain
             ~id:(State.get_and_incr_instruction_id state)
@@ -360,7 +359,7 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
       if split_debug
       then
-        log ~indent:1 "insert_phi_moves for block %d: %a" label Printmach.regset
+        log ~indent:1 "insert_phi_moves for block %d: %a" label Printreg.regset
           to_unify;
       if block.is_trap_handler then fatal "phi block %d is a trap handler" label;
       Label.Set.iter

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -28,19 +28,19 @@ let log_renaming_info : indent:int -> t -> unit =
         (match kind with
         | Destruction_on_all_paths -> "[all-paths]"
         | Destruction_only_on_exceptional_path -> "[exn-only]")
-        Printmach.regset regset)
+        Printreg.regset regset)
     state.destructions_at_end;
   log ~indent:(indent + 1) "definitions:";
   Label.Map.iter
     (fun label regset ->
       log ~indent:(indent + 2) " - beginning of block %d (%a)" label
-        Printmach.regset regset)
+        Printreg.regset regset)
     state.definitions_at_beginning;
   log ~indent:1 "phi:";
   Label.Map.iter
     (fun label regset ->
       log ~indent:(indent + 2) " - beginning of block %d (%a)" label
-        Printmach.regset regset)
+        Printreg.regset regset)
     state.phi_at_beginning
 
 (* Optimizes `destructions_at_end` and `definitions_at_beginning`, by moving
@@ -109,7 +109,7 @@ end = struct
                   if split_debug
                   then
                     log ~indent:2 "moving %a from block %d to block %d"
-                      Printmach.regset to_move label successor_label;
+                      Printreg.regset to_move label successor_label;
                   definitions_at_beginning
                     := Label.Map.update label
                          (function
@@ -186,7 +186,7 @@ end = struct
               if split_debug
               then
                 log ~indent:2 "moving %a from block %d to block %d"
-                  Printmach.regset to_move label predecessor_label;
+                  Printreg.regset to_move label predecessor_label;
               destructions_at_end
                 := Label.Map.update label
                      (function
@@ -240,13 +240,13 @@ end = struct
           | Some (Destruction_on_all_paths, destructions) -> (
             if split_debug
             then (
-              log ~indent:2 "definitions: %a" Printmach.regset definitions;
-              log ~indent:2 "destructions: %a" Printmach.regset destructions);
+              log ~indent:2 "definitions: %a" Printreg.regset definitions;
+              log ~indent:2 "destructions: %a" Printreg.regset destructions);
             let can_be_removed : Reg.Set.t =
               Reg.Set.filter
                 (fun (reg : Reg.t) ->
                   if split_debug
-                  then log ~indent:3 "register %a" Printmach.reg reg;
+                  then log ~indent:3 "register %a" Printreg.reg reg;
                   match Reg.Set.mem reg destructions with
                   | false ->
                     if split_debug then log ~indent:3 "(not among destructions)";
@@ -262,7 +262,7 @@ end = struct
             in
             if split_debug
             then
-              log ~indent:2 "can be removed: %a" Printmach.regset can_be_removed;
+              log ~indent:2 "can be removed: %a" Printreg.regset can_be_removed;
             match Reg.Set.is_empty can_be_removed with
             | true -> definitions
             | false ->
@@ -321,7 +321,7 @@ end = struct
               Reg.Set.filter
                 (fun (reg : Reg.t) ->
                   if split_debug
-                  then log ~indent:2 "register %a" Printmach.reg reg;
+                  then log ~indent:2 "register %a" Printreg.reg reg;
                   let keep =
                     match Reg.Tbl.find_opt num_sets reg with
                     | None | Some Maybe_more_than_once -> true
@@ -400,7 +400,7 @@ end = struct
       log ~indent:1 "num_sets:";
       Reg.Tbl.iter
         (fun reg num_set ->
-          log ~indent:2 "%a ~> %s" Printmach.reg reg (string_of_set num_set))
+          log ~indent:2 "%a ~> %s" Printreg.reg reg (string_of_set num_set))
         num_sets);
     let doms = Cfg_with_infos.dominators cfg_with_infos in
     let forest = Cfg_dominators.dominator_forest doms in

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -54,7 +54,7 @@ let log_substitution : indent:int -> Substitution.t -> unit =
  fun ~indent subst ->
   Reg.Tbl.iter
     (fun old_reg new_reg ->
-      log ~indent "%a -> %a" Printmach.reg old_reg Printmach.reg new_reg)
+      log ~indent "%a -> %a" Printreg.reg old_reg Printreg.reg new_reg)
     subst
 
 let log_substitutions : indent:int -> Substitution.map -> unit =

--- a/backend/regalloc/regalloc_stack_slots.ml
+++ b/backend/regalloc/regalloc_stack_slots.ml
@@ -37,12 +37,12 @@ let[@inline] get_or_create t reg =
 
 let[@inline] get_or_fatal t reg =
   match Reg.Tbl.find_opt t.stack_slots reg with
-  | None -> fatal "register %a has no associated slot" Printmach.reg reg
+  | None -> fatal "register %a has no associated slot" Printreg.reg reg
   | Some slot -> slot
 
 let[@inline] use_same_slot_or_fatal t reg ~existing =
   match Reg.Tbl.find_opt t.stack_slots existing with
-  | None -> fatal "register %a has no associated slot" Printmach.reg existing
+  | None -> fatal "register %a has no associated slot" Printreg.reg existing
   | Some slot -> Reg.Tbl.replace t.stack_slots reg slot
 
 let[@inline] update_cfg_with_layout t cfg_with_layout =
@@ -327,7 +327,7 @@ let optimize (t : t) (cfg_with_infos : Cfg_with_infos.t) : unit =
                 then
                   Format.eprintf
                     "changing the slot index of %a (class %d): %d ~> %d\n%!"
-                    Printmach.reg reg stack_class slot_index bucket_index;
+                    Printreg.reg reg stack_class slot_index bucket_index;
                 reg.loc <- Stack (Local bucket_index);
                 max_bucket_indices.(stack_class)
                   <- Stdlib.Int.max

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -159,10 +159,10 @@ let log_instruction_suffix (instr : _ Cfg.instruction) (liveness : liveness) :
   in
   let live = live |> Reg.Set.elements |> Array.of_list in
   if Array.length instr.arg > 0
-  then Format.eprintf " arg:%a" Printmach.regs instr.arg;
+  then Format.eprintf " arg:%a" Printreg.regs instr.arg;
   if Array.length instr.res > 0
-  then Format.eprintf " res:%a" Printmach.regs instr.res;
-  if Array.length live > 0 then Format.eprintf " live:%a" Printmach.regs live;
+  then Format.eprintf " res:%a" Printreg.regs instr.res;
+  if Array.length live > 0 then Format.eprintf " live:%a" Printreg.regs live;
   Format.eprintf "\n%!"
 
 let make_log_body_and_terminator :
@@ -484,7 +484,7 @@ let check_same str1 reg1 str2 reg2 =
   if not (Reg.same reg1 reg2)
   then
     fatal "%s and %s were expected to be the same but they differ (%a vs %a)"
-      str1 str2 Printmach.reg reg1 Printmach.reg reg2
+      str1 str2 Printreg.reg reg1 Printreg.reg reg2
 
 type stack_operands_rewrite =
   | All_spilled_registers_rewritten
@@ -498,7 +498,7 @@ let use_stack_operand (map : spilled_map) (regs : Reg.t array) (index : int) :
     unit =
   let reg = regs.(index) in
   match Reg.Tbl.find_opt map reg with
-  | None -> fatal "register %a is missing from the map" Printmach.reg reg
+  | None -> fatal "register %a is missing from the map" Printreg.reg reg
   | Some spilled_reg -> regs.(index) <- spilled_reg
 
 let may_use_stack_operands_array : spilled_map -> Reg.t array -> unit =

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -128,7 +128,7 @@ end = struct
     | Stack stack -> Reg.Stack (Stack.to_stack_loc_lossy stack)
 
   let print typ ppf t =
-    Printmach.loc ~unknown:(fun _ -> assert false) ppf (to_loc_lossy t) typ
+    Printreg.loc ~unknown:(fun _ -> assert false) ppf (to_loc_lossy t) typ
 
   let compare (t1 : t) (t2 : t) : int =
     (* CR-someday azewierzejew: Implement proper comparison. *)
@@ -239,7 +239,7 @@ end = struct
     match t.reg_id with
     | Preassigned { location } ->
       Format.fprintf ppf "R[%a]" (Location.print t.for_print.typ) location
-    | Named _ -> Printmach.reg ppf (to_dummy_reg t)
+    | Named _ -> Printreg.reg ppf (to_dummy_reg t)
 
   let compare (t1 : t) (t2 : t) : int = Reg_id.compare t1.reg_id t2.reg_id
 
@@ -972,7 +972,7 @@ module type Description_value = sig
 end
 
 let print_reg_as_loc ppf reg =
-  Printmach.loc
+  Printreg.loc
     ~unknown:(fun ppf -> Format.fprintf ppf "<Unknown>")
     ppf reg.Reg.loc reg.Reg.typ
 

--- a/dune
+++ b/dune
@@ -461,6 +461,7 @@
   printcmm
   printlinear
   printmach
+  printreg
   proc
   simd
   simd_selection


### PR DESCRIPTION
Follow-up to #3234.

To be able to eventually delete `Printmach`, we
have to move the functions related to registers
to another module. This cannot be `Reg` itself,
unfortunately, because that would cause circular
dependencies. This pull request thus creates a
dedicated module, namely `Printreg`.