### PR TITLE
Use constant sorts in transl

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -104,17 +104,15 @@ exception Error of Location.t * error
 
 let dbg = false
 
-let jkind_layout_default_to_value_and_check_not_void loc jkind =
-  let rec contains_void : Jkind.Layout.Const.t -> bool = function
-    | Any -> false
+let sort_check_not_void loc sort =
+  let rec contains_void : Jkind.Sort.Const.t -> bool = function
     | Base Void -> true
     | Base (Value | Float64 | Float32 | Word | Bits32 | Bits64 | Vec128) -> false
     | Product [] ->
-      Misc.fatal_error "nil in jkind_layout_default_to_value_and_check_not_void"
-    | Product ts -> List.exists contains_void ts
+      Misc.fatal_error "nil in sort_check_not_void"
+    | Product ss -> List.exists contains_void ss
   in
-  let layout = Jkind.get_layout_defaulting_to_value jkind in
-  if contains_void layout then
+  if contains_void sort then
     raise (Error (loc, Void_layout))
 ;;
 
@@ -1910,9 +1908,7 @@ let get_pat_args_constr p rem =
   match p with
   | { pat_desc = Tpat_construct (_, {cstr_args}, args, _) } ->
     List.iter2
-      (fun { ca_jkind } arg ->
-         jkind_layout_default_to_value_and_check_not_void
-           arg.pat_loc ca_jkind)
+      (fun { ca_sort } arg -> sort_check_not_void arg.pat_loc ca_sort)
       cstr_args args;
       (* CR layouts v5: This sanity check will have to go (or be replaced with a
          void-specific check) when we have other non-value sorts *)
@@ -1928,12 +1924,11 @@ let get_expr_args_constr ~scopes head (arg, _mut, sort, layout) rem =
   let loc = head_loc ~scopes head in
   (* CR layouts v5: This sanity check should be removed or changed to
      specifically check for void when we add other non-value sorts. *)
-  List.iter (fun { ca_jkind } ->
-      jkind_layout_default_to_value_and_check_not_void head.pat_loc ca_jkind)
+  List.iter (fun { ca_sort } -> sort_check_not_void head.pat_loc ca_sort)
     cstr.cstr_args;
   let ubr = Translmode.transl_unique_barrier (head.pat_unique_barrier) in
   let sem = add_barrier_to_read ubr Reads_agree in
-  let make_field_access binding_kind jkind ~field ~pos =
+  let make_field_access binding_kind sort ~field ~pos =
     let prim =
       match cstr.cstr_shape with
       | Constructor_uniform_value -> Pfield (pos, Pointer, sem)
@@ -1955,8 +1950,6 @@ let get_expr_args_constr ~scopes head (arg, _mut, sort, layout) rem =
           let shape = Lambda.transl_mixed_product_shape shape in
           Pmixedfield (pos, read, shape, sem)
     in
-    let sort = Jkind.sort_of_jkind jkind in
-    let sort = Jkind.Sort.default_for_transl_and_get sort in
     let layout = Typeopt.layout_of_sort head.pat_loc sort in
     (Lprim (prim, [ arg ], loc), binding_kind, sort, layout)
   in
@@ -1967,15 +1960,15 @@ let get_expr_args_constr ~scopes head (arg, _mut, sort, layout) rem =
     match cstr.cstr_repr with
     | Variant_boxed _ ->
         List.mapi
-          (fun i { ca_jkind } ->
-             make_field_access str ca_jkind ~field:i ~pos:i)
+          (fun i { ca_sort } ->
+             make_field_access str ca_sort ~field:i ~pos:i)
           cstr.cstr_args
         @ rem
     | Variant_unboxed -> (arg, str, sort, layout) :: rem
     | Variant_extensible ->
         List.mapi
-          (fun i { ca_jkind } ->
-             make_field_access str ca_jkind ~field:i ~pos:(i+1))
+          (fun i { ca_sort } ->
+             make_field_access str ca_sort ~field:i ~pos:(i+1))
           cstr.cstr_args
         @ rem
 
@@ -2297,7 +2290,7 @@ let record_matching_line num_fields lbl_pat_list =
   List.iter (fun (_, lbl, pat) ->
     (* CR layouts v5: This void sanity check can be removed when we add proper
        void support (or whenever we remove `lbl_pos_void`) *)
-    jkind_layout_default_to_value_and_check_not_void pat.pat_loc lbl.lbl_jkind;
+    sort_check_not_void pat.pat_loc lbl.lbl_sort;
     patv.(lbl.lbl_pos) <- pat)
     lbl_pat_list;
   Array.to_list patv
@@ -2331,12 +2324,9 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
       rem
     else
       let lbl = all_labels.(pos) in
-      jkind_layout_default_to_value_and_check_not_void
-        head.pat_loc lbl.lbl_jkind;
+      sort_check_not_void head.pat_loc lbl.lbl_sort;
       let ptr = Typeopt.maybe_pointer_type head.pat_env lbl.lbl_arg in
-      let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
-      let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
-      let lbl_layout = Typeopt.layout_of_sort lbl.lbl_loc lbl_sort in
+      let lbl_layout = Typeopt.layout_of_sort lbl.lbl_loc lbl.lbl_sort in
       let sem =
         if Types.is_mutable lbl.lbl_mut then Reads_vary else Reads_agree
       in
@@ -2347,21 +2337,21 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
         | Record_boxed _
         | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
             Lprim (Pfield (lbl.lbl_pos, ptr, sem), [ arg ], loc),
-            lbl_sort, lbl_layout
+            lbl.lbl_sort, lbl_layout
         | Record_unboxed
         | Record_inlined (_, _, Variant_unboxed) -> arg, sort, layout
         | Record_float ->
            (* TODO: could optimise to Alloc_local sometimes *)
            Lprim (Pfloatfield (lbl.lbl_pos, sem, alloc_heap), [ arg ], loc),
            (* Here we are projecting a boxed float from a float record. *)
-           lbl_sort, lbl_layout
+           lbl.lbl_sort, lbl_layout
         | Record_ufloat ->
            Lprim (Pufloatfield (lbl.lbl_pos, sem), [ arg ], loc),
            (* Here we are projecting an unboxed float from a float record. *)
-           lbl_sort, lbl_layout
+           lbl.lbl_sort, lbl_layout
         | Record_inlined (_, Constructor_uniform_value, Variant_extensible) ->
             Lprim (Pfield (lbl.lbl_pos + 1, ptr, sem), [ arg ], loc),
-            lbl_sort, lbl_layout
+            lbl.lbl_sort, lbl_layout
         | Record_inlined (_, Constructor_mixed _, Variant_extensible) ->
             (* CR layouts v5.9: support this *)
             fatal_error
@@ -2388,7 +2378,7 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
               { value_prefix_len; flat_suffix }
             in
             Lprim (Pmixedfield (lbl.lbl_pos, read, shape, sem), [ arg ], loc),
-            lbl_sort, lbl_layout
+            lbl.lbl_sort, lbl_layout
       in
       let str = if Types.is_mutable lbl.lbl_mut then StrictOpt else Alias in
       let str = add_barrier_to_let_kind ubr str in
@@ -2410,9 +2400,7 @@ let get_expr_args_record_unboxed_product ~scopes head
   in
   let lbl_layouts =
     Array.map (fun lbl ->
-      let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
-      let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
-      Typeopt.layout_of_sort lbl.lbl_loc lbl_sort
+      Typeopt.layout_of_sort lbl.lbl_loc lbl.lbl_sort
     ) all_labels
     |> Array.to_list
   in
@@ -2421,8 +2409,7 @@ let get_expr_args_record_unboxed_product ~scopes head
       rem
     else
       let lbl = all_labels.(pos) in
-      jkind_layout_default_to_value_and_check_not_void
-        head.pat_loc lbl.lbl_jkind;
+      sort_check_not_void head.pat_loc lbl.lbl_sort;
       let access = if Array.length all_labels = 1 then
         arg (* erase singleton unboxed records before lambda *)
       else
@@ -2436,10 +2423,8 @@ let get_expr_args_record_unboxed_product ~scopes head
         else
           Alias
       in
-      let sort = Jkind.sort_of_jkind lbl.lbl_jkind in
-      let sort = Jkind.Sort.default_for_transl_and_get sort in
-      let layout = Typeopt.layout_of_sort lbl.lbl_loc sort in
-      (access, str, sort, layout) :: make_args (pos + 1)
+      let layout = Typeopt.layout_of_sort lbl.lbl_loc lbl.lbl_sort in
+      (access, str, lbl.lbl_sort, layout) :: make_args (pos + 1)
   in
   make_args 0
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -230,7 +230,7 @@ module Half_simple : sig
   type nonrec clause = pattern Non_empty_row.t clause
 
   val of_clause :
-    arg:lambda -> arg_sort:Jkind.sort -> General.clause -> clause
+    arg:lambda -> arg_sort:Jkind.Sort.Const.t -> General.clause -> clause
 end = struct
   include Patterns.Half_simple
 
@@ -307,7 +307,7 @@ module Simple : sig
 
   val explode_or_pat :
     arg:lambda ->
-    arg_sort:Jkind.sort ->
+    arg_sort:Jkind.Sort.Const.t ->
     Half_simple.pattern ->
     mk_action:(vars:Ident.t list -> lambda) ->
     patbound_action_vars:Ident.t list ->
@@ -1010,7 +1010,7 @@ end
 
 type 'row pattern_matching = {
   mutable cases : 'row list;
-  args : (lambda * let_kind * Jkind.sort * layout) list;
+  args : (lambda * let_kind * Jkind.Sort.Const.t * layout) list;
       (** args are not just Ident.t in at least the following cases:
         - when matching the arguments of a constructor,
           direct field projections are used (make_field_args)
@@ -1821,7 +1821,7 @@ let make_line_matching get_expr_args head def = function
       }
 
 type 'a division = {
-  args : (lambda * let_kind * Jkind.sort * layout) list;
+  args : (lambda * let_kind * Jkind.Sort.Const.t * layout) list;
   cells : ('a * cell) list
 }
 
@@ -1956,6 +1956,7 @@ let get_expr_args_constr ~scopes head (arg, _mut, sort, layout) rem =
           Pmixedfield (pos, read, shape, sem)
     in
     let sort = Jkind.sort_of_jkind jkind in
+    let sort = Jkind.Sort.default_for_transl_and_get sort in
     let layout = Typeopt.layout_of_sort head.pat_loc sort in
     (Lprim (prim, [ arg ], loc), binding_kind, sort, layout)
   in
@@ -2000,7 +2001,7 @@ let get_expr_args_variant_nonconst ~scopes head (arg, _mut, _sort, _layout)
   let ubr = Translmode.transl_unique_barrier (head.pat_unique_barrier) in
   let field_prim = nonconstant_variant_field ubr 1 in
   let str = add_barrier_to_let_kind ubr Alias in
-  (Lprim (field_prim, [ arg ], loc), str, Jkind.Sort.for_variant_arg,
+  (Lprim (field_prim, [ arg ], loc), str, Jkind.Sort.Const.for_variant_arg,
    layout_variant_arg)
   :: rem
 
@@ -2216,7 +2217,7 @@ let inline_lazy_force arg pos loc =
 
 let get_expr_args_lazy ~scopes head (arg, _mut, _sort, _layout) rem =
   let loc = head_loc ~scopes head in
-  (inline_lazy_force arg Rc_normal loc, Strict, Jkind.Sort.for_lazy_body,
+  (inline_lazy_force arg Rc_normal loc, Strict, Jkind.Sort.Const.for_lazy_body,
    layout_lazy_contents) :: rem
 
 let divide_lazy ~scopes head ctx pm =
@@ -2251,7 +2252,7 @@ let get_expr_args_tuple ~scopes head (arg, _mut, _sort, _layout) rem =
       rem
     else
       (Lprim (Pfield (pos, Pointer, sem), [ arg ], loc), str,
-       Jkind.Sort.for_tuple_element, layout_tuple_element)
+       Jkind.Sort.Const.for_tuple_element, layout_tuple_element)
         :: make_args (pos + 1)
   in
   make_args 0
@@ -2261,6 +2262,7 @@ let get_expr_args_unboxed_tuple ~scopes shape head (arg, _mut, _sort, _layout)
   let loc = head_loc ~scopes head in
   let shape =
     List.map (fun (_, sort) ->
+      let sort = Jkind.Sort.default_for_transl_and_get sort in
       sort,
       (* CR layouts v7.1: consider whether more accurate [Lambda.layout]s here
          would make a difference for later optimizations. *)
@@ -2333,6 +2335,7 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
         head.pat_loc lbl.lbl_jkind;
       let ptr = Typeopt.maybe_pointer_type head.pat_env lbl.lbl_arg in
       let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
+      let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
       let lbl_layout = Typeopt.layout_of_sort lbl.lbl_loc lbl_sort in
       let sem =
         if Types.is_mutable lbl.lbl_mut then Reads_vary else Reads_agree
@@ -2407,7 +2410,9 @@ let get_expr_args_record_unboxed_product ~scopes head
   in
   let lbl_layouts =
     Array.map (fun lbl ->
-      Typeopt.layout_of_sort lbl.lbl_loc (Jkind.sort_of_jkind lbl.lbl_jkind)
+      let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
+      let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
+      Typeopt.layout_of_sort lbl.lbl_loc lbl_sort
     ) all_labels
     |> Array.to_list
   in
@@ -2432,6 +2437,7 @@ let get_expr_args_record_unboxed_product ~scopes head
           Alias
       in
       let sort = Jkind.sort_of_jkind lbl.lbl_jkind in
+      let sort = Jkind.Sort.default_for_transl_and_get sort in
       let layout = Typeopt.layout_of_sort lbl.lbl_loc sort in
       (access, str, sort, layout) :: make_args (pos + 1)
   in
@@ -2474,6 +2480,7 @@ let get_expr_args_array ~scopes kind head (arg, _mut, _sort, _layout) rem =
     | Array (am, arg_sort, len) -> am, arg_sort, len
     | _ -> assert false
   in
+  let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
   let loc = head_loc ~scopes head in
   let rec make_args pos =
     if pos >= len then
@@ -3879,6 +3886,7 @@ and do_compile_matching ~scopes value_kind repr partial ctx pmh =
             (combine_constructor value_kind ploc arg ph.pat_env ph.pat_unique_barrier cstr partial)
             ctx pm
       | Array (_, elt_sort, _) ->
+          let elt_sort = Jkind.Sort.default_for_transl_and_get elt_sort in
           let kind = Typeopt.array_pattern_kind pomega elt_sort in
           compile_test
             (compile_match ~scopes value_kind repr partial)
@@ -4093,7 +4101,7 @@ let for_trywith ~scopes ~return_layout loc param pat_act_list =
      It is important to *not* include location information in
      the reraise (hence the [_noloc]) to avoid seeing this
      silent reraise in exception backtraces. *)
-  compile_matching ~scopes ~arg_sort:Jkind.Sort.for_predef_value
+  compile_matching ~scopes ~arg_sort:Jkind.Sort.Const.for_predef_value
     ~arg_layout:layout_block ~return_layout loc ~failer:(Reraise_noloc param)
     None param pat_act_list Partial
 
@@ -4210,12 +4218,12 @@ let assign_pat ~scopes body_layout opt nraise catch_ids loc pat pat_sort lam =
         opt := true;
         List.fold_left2
           (fun acc (_, pat) lam ->
-             collect Jkind.Sort.for_tuple_element acc pat lam)
+             collect Jkind.Sort.Const.for_tuple_element acc pat lam)
           acc patl lams
     | Tpat_tuple patl, Lconst (Const_block (_, scl)) ->
         opt := true;
         let collect_const acc (_, pat) sc =
-          collect Jkind.Sort.for_tuple_element acc pat (Lconst sc)
+          collect Jkind.Sort.Const.for_tuple_element acc pat (Lconst sc)
         in
         List.fold_left2 collect_const acc patl scl
     | _ ->
@@ -4292,7 +4300,7 @@ let for_tupled_function ~scopes ~return_layout loc paraml pats_act_list partial 
   (* The arguments of a tupled function are always values since they must be
      tuple elements *)
   let args =
-    List.map (fun id -> (Lvar id, Strict, Jkind.Sort.for_tuple_element,
+    List.map (fun id -> (Lvar id, Strict, Jkind.Sort.Const.for_tuple_element,
                          layout_tuple_element))
       paraml
   in
@@ -4392,12 +4400,12 @@ let do_for_multiple_match ~scopes ~return_layout loc paraml mode pat_act_list pa
     let sloc = Scoped_location.of_location ~scopes loc in
     Lprim (Pmakeblock (0, Immutable, None, mode), param_lambda, sloc)
   in
-  let arg_sort = Jkind.Sort.for_tuple in
+  let arg_sort = Jkind.Sort.Const.for_tuple in
   let handler =
     let partial = check_partial pat_act_list partial in
     let rows = map_on_rows (fun p -> (p, [])) pat_act_list in
     toplevel_handler ~scopes ~return_layout loc ~failer:Raise_match_failure
-      partial [ (arg, Strict, Jkind.Sort.for_tuple, layout_block) ] rows in
+      partial [ (arg, Strict, Jkind.Sort.Const.for_tuple, layout_block) ] rows in
   handler (fun partial pm1 ->
     let pm1_half =
       { pm1 with

--- a/lambda/matching.mli
+++ b/lambda/matching.mli
@@ -22,7 +22,7 @@ open Debuginfo.Scoped_location
 (* Entry points to match compiler *)
 val for_function:
         scopes:scopes ->
-        arg_sort:Jkind.sort -> arg_layout:layout -> return_layout:layout ->
+        arg_sort:Jkind.Sort.Const.t -> arg_layout:layout -> return_layout:layout ->
         Location.t -> int ref option -> lambda -> (pattern * lambda) list ->
         partial ->
         lambda
@@ -31,12 +31,12 @@ val for_trywith:
         lambda -> (pattern * lambda) list ->
         lambda
 val for_let:
-        scopes:scopes -> arg_sort:Jkind.sort -> return_layout:layout ->
+        scopes:scopes -> arg_sort:Jkind.Sort.Const.t -> return_layout:layout ->
         Location.t -> lambda -> pattern -> lambda ->
         lambda
 val for_multiple_match:
         scopes:scopes -> return_layout:layout -> Location.t ->
-        (lambda * Jkind.sort * layout) list -> locality_mode ->
+        (lambda * Jkind.Sort.Const.t * layout) list -> locality_mode ->
         (pattern * lambda) list -> partial ->
         lambda
 
@@ -57,7 +57,7 @@ val for_tupled_function:
 *)
 val for_optional_arg_default:
   scopes:scopes -> Location.t -> pattern -> param:Ident.t ->
-  default_arg:lambda -> default_arg_sort:Jkind.sort ->
+  default_arg:lambda -> default_arg_sort:Jkind.Sort.Const.t ->
   return_layout:layout -> lambda -> lambda
 
 exception Cannot_flatten

--- a/lambda/transl_array_comprehension.ml
+++ b/lambda/transl_array_comprehension.ml
@@ -444,7 +444,7 @@ let iterator ~transl_exp ~scopes ~loc :
   | Texp_comp_range { ident; pattern = _; start; stop; direction } ->
     let bound name value =
       Let_binding.make (Immutable Strict) layout_int name
-        (transl_exp ~scopes Jkind.Sort.for_predef_value value)
+        (transl_exp ~scopes Jkind.Sort.Const.for_predef_value value)
     in
     let start = bound "start" start in
     let stop = bound "stop" stop in
@@ -462,7 +462,7 @@ let iterator ~transl_exp ~scopes ~loc :
   | Texp_comp_in { pattern; sequence = iter_arr_exp } ->
     let iter_arr =
       Let_binding.make (Immutable Strict) layout_any_value "iter_arr"
-        (transl_exp ~scopes Jkind.Sort.for_predef_value iter_arr_exp)
+        (transl_exp ~scopes Jkind.Sort.Const.for_predef_value iter_arr_exp)
     in
     let iter_arr_kind =
       (* CR layouts v4: [~elt_sort:None] here is not ideal and
@@ -493,7 +493,7 @@ let iterator ~transl_exp ~scopes ~loc :
           for_dir = Upto;
           for_body =
             Matching.for_let ~scopes
-              ~arg_sort:Jkind.Sort.for_array_comprehension_element
+              ~arg_sort:Jkind.Sort.Const.for_array_comprehension_element
               ~return_layout:layout_int pattern.pat_loc
               (Lprim
                  ( Parrayrefu
@@ -550,7 +550,7 @@ let clause ~transl_exp ~scopes ~loc = function
   | Texp_comp_when cond ->
     fun body ->
       Lifthenelse
-        ( transl_exp ~scopes Jkind.Sort.for_predef_value cond,
+        ( transl_exp ~scopes Jkind.Sort.Const.for_predef_value cond,
           body,
           lambda_unit,
           layout_unit )
@@ -872,8 +872,8 @@ let comprehension ~transl_exp ~scopes ~loc ~(array_kind : Lambda.array_kind)
                   (* CR layouts v4: Ensure that the [transl_exp] here can cope
                      with non-values. *)
                 ~body:
-                  (transl_exp ~scopes Jkind.Sort.for_array_comprehension_element
-                     comp_body)),
+                  (transl_exp ~scopes
+                     Jkind.Sort.Const.for_array_comprehension_element comp_body)),
            (* If it was dynamically grown, cut it down to size *)
            match array_sizing with
            | Fixed_size -> array.var

--- a/lambda/transl_array_comprehension.mli
+++ b/lambda/transl_array_comprehension.mli
@@ -22,7 +22,7 @@ open Debuginfo.Scoped_location
     so is parameterized by [Translcore.transl_exp], its [scopes] argument, and
     the [loc]ation. *)
 val comprehension :
-  transl_exp:(scopes:scopes -> Jkind.sort -> expression -> lambda) ->
+  transl_exp:(scopes:scopes -> Jkind.Sort.Const.t -> expression -> lambda) ->
   scopes:scopes ->
   loc:scoped_location ->
   array_kind:array_kind ->

--- a/lambda/transl_list_comprehension.ml
+++ b/lambda/transl_list_comprehension.ml
@@ -169,7 +169,7 @@ let iterator ~transl_exp ~scopes = function
        correct (i.e., left-to-right) order *)
     let transl_bound var bound =
       Let_binding.make (Immutable Strict) layout_int var
-        (transl_exp ~scopes Jkind.Sort.for_predef_value bound)
+        (transl_exp ~scopes Jkind.Sort.Const.for_predef_value bound)
     in
     let start = transl_bound "start" start in
     let stop = transl_bound "stop" stop in
@@ -185,7 +185,7 @@ let iterator ~transl_exp ~scopes = function
   | Texp_comp_in { pattern; sequence } ->
     let iter_list =
       Let_binding.make (Immutable Strict) layout_any_value "iter_list"
-        (transl_exp ~scopes Jkind.Sort.for_predef_value sequence)
+        (transl_exp ~scopes Jkind.Sort.Const.for_predef_value sequence)
     in
     (* Create a fresh variable to use as the function argument *)
     let element = Ident.create_local "element" in
@@ -194,10 +194,10 @@ let iterator ~transl_exp ~scopes = function
       element;
       element_kind =
         Typeopt.layout pattern.pat_env pattern.pat_loc
-          Jkind.Sort.for_list_element pattern.pat_type;
+          Jkind.Sort.Const.for_list_element pattern.pat_type;
       add_bindings =
         (* CR layouts: to change when we allow non-values in sequences *)
-        Matching.for_let ~scopes ~arg_sort:Jkind.Sort.for_list_element
+        Matching.for_let ~scopes ~arg_sort:Jkind.Sort.Const.for_list_element
           ~return_layout:layout_any_value pattern.pat_loc (Lvar element) pattern
     }
 
@@ -287,7 +287,7 @@ let rec translate_clauses ~transl_exp ~scopes ~loc ~comprehension_body
       Let_binding.let_all arg_lets bindings
     | Texp_comp_when cond ->
       Lifthenelse
-        ( transl_exp ~scopes Jkind.Sort.for_predef_value cond,
+        ( transl_exp ~scopes Jkind.Sort.Const.for_predef_value cond,
           body ~accumulator,
           accumulator,
           layout_any_value (* [list]s have the standard representation *) ))
@@ -298,7 +298,7 @@ let comprehension ~transl_exp ~scopes ~loc { comp_body; comp_clauses } =
     translate_clauses ~transl_exp ~scopes ~loc
       ~comprehension_body:(fun ~accumulator ->
         rev_list_snoc_local ~loc ~init:accumulator
-          ~last:(transl_exp ~scopes Jkind.Sort.for_list_element comp_body))
+          ~last:(transl_exp ~scopes Jkind.Sort.Const.for_list_element comp_body))
       ~accumulator:rev_list_nil comp_clauses
   in
   Lambda_utils.apply ~loc ~mode:alloc_heap

--- a/lambda/transl_list_comprehension.mli
+++ b/lambda/transl_list_comprehension.mli
@@ -15,7 +15,7 @@ open Debuginfo.Scoped_location
     so is parameterized by [Translcore.transl_exp], its [scopes] argument, and
     the [loc]ation. *)
 val comprehension :
-  transl_exp:(scopes:scopes -> Jkind.sort -> expression -> lambda) ->
+  transl_exp:(scopes:scopes -> Jkind.Sort.Const.t -> expression -> lambda) ->
   scopes:scopes ->
   loc:scoped_location ->
   comprehension ->

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -105,7 +105,7 @@ let transl_meth_list lst =
 
 let set_inst_var ~scopes obj id expr =
   Lprim(Psetfield_computed (Typeopt.maybe_pointer expr, Assignment modify_heap),
-    [Lvar obj; Lvar id; transl_exp ~scopes Jkind.Sort.for_instance_var expr],
+    [Lvar obj; Lvar id; transl_exp ~scopes Jkind.Sort.Const.for_instance_var expr],
         Loc_unknown)
 
 let transl_val tbl create name =
@@ -212,7 +212,7 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
       (inh_init,
        let build params rem =
          let param = name_pattern "param" pat in
-         let arg_sort = Jkind.Sort.for_class_arg in
+         let arg_sort = Jkind.Sort.Const.for_class_arg in
          let arg_layout =
            Typeopt.layout pat.pat_env pat.pat_loc arg_sort pat.pat_type
          in
@@ -366,7 +366,7 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
             | Tcf_method (name, _, Tcfk_concrete (_, exp)) ->
                 let scopes = enter_method_definition ~scopes name.txt in
                 let met_code =
-                  msubst true (transl_scoped_exp ~scopes Jkind.Sort.for_method exp)
+                  msubst true (transl_scoped_exp ~scopes Jkind.Sort.Const.for_method exp)
                 in
                 let met_code =
                   if !Clflags.native_code && List.length met_code = 1 then
@@ -383,7 +383,7 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
                  Lsequence(mkappl (oo_prim "add_initializer",
                                    Lvar cla :: msubst false
                                                  (transl_exp ~scopes
-                                                    Jkind.Sort.for_initializer exp),
+                                                    Jkind.Sort.Const.for_initializer exp),
                                    layout_unit),
                            cl_init),
                  methods, values)
@@ -502,7 +502,7 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
         transl_class_rebind ~scopes obj_init cl vf in
       let build params rem =
         let param = name_pattern "param" pat in
-        let arg_sort = Jkind.Sort.for_class_arg in
+        let arg_sort = Jkind.Sort.Const.for_class_arg in
         let arg_layout =
           Typeopt.layout pat.pat_env pat.pat_loc arg_sort pat.pat_type
         in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -527,11 +527,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
             of_location ~scopes e.exp_loc)
   | Texp_construct(_, cstr, args, alloc_mode) ->
       let args_with_sorts =
-        List.map2 (fun { ca_jkind } e ->
-            let sort = Jkind.sort_of_jkind ca_jkind in
-            let sort = Jkind.Sort.default_for_transl_and_get sort in
-            e, sort)
-          cstr.cstr_args args
+        List.map2 (fun { ca_sort } e -> e, ca_sort) cstr.cstr_args args
       in
       let ll =
         List.map (fun (e, sort) -> transl_exp ~scopes sort e) args_with_sorts
@@ -647,9 +643,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         if Types.is_mutable lbl.lbl_mut then Reads_vary else Reads_agree
       in
       let sem = add_barrier_to_read (transl_unique_barrier ubr) sem in
-      let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
-      let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
-      check_record_field_sort id.loc lbl_sort;
+      check_record_field_sort id.loc lbl.lbl_sort;
       begin match lbl.lbl_repres with
           Record_boxed _
         | Record_inlined (_, Constructor_uniform_value, Variant_boxed _) ->
@@ -707,11 +701,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
   | Texp_unboxed_field(arg, arg_sort, _id, lbl, _) ->
     begin match lbl.lbl_repres with
     | Record_unboxed_product ->
-      let lbl_layout l =
-        let lbl_sort = Jkind.sort_of_jkind l.lbl_jkind in
-        let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
-        layout e.exp_env l.lbl_loc lbl_sort l.lbl_arg
-      in
+      let lbl_layout l = layout e.exp_env l.lbl_loc l.lbl_sort l.lbl_arg in
       let layouts = Array.to_list (Array.map lbl_layout lbl.lbl_all) in
       let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
       let targ = transl_exp ~scopes arg_sort arg in
@@ -727,9 +717,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
          representability on construction, [sort_of_jkind] will be unsafe here.
          Probably we should add a sort to `Texp_setfield` in the typed tree,
          then. *)
-      let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
-      let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
-      check_record_field_sort id.loc lbl_sort;
+      check_record_field_sort id.loc lbl.lbl_sort;
       let mode =
         Assignment (transl_modify_mode arg_mode)
       in
@@ -767,7 +755,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         end
       in
       Lprim(access, [transl_exp ~scopes Jkind.Sort.Const.for_record arg;
-                     transl_exp ~scopes lbl_sort newval],
+                     transl_exp ~scopes lbl.lbl_sort newval],
             of_location ~scopes e.exp_loc)
   | Texp_array (amut, element_sort, expr_list, alloc_mode) ->
       let mode = transl_alloc_mode alloc_mode in
@@ -1888,9 +1876,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     let copy_id = Ident.create_local "newrecord" in
     let update_field cont (lbl, definition) =
       (* CR layouts v5: allow more unboxed types here. *)
-      let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
-      let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
-      check_record_field_sort lbl.lbl_loc lbl_sort;
+      check_record_field_sort lbl.lbl_loc lbl.lbl_sort;
       match definition with
       | Kept _ -> cont
       | Overridden (_lid, expr) ->
@@ -1937,7 +1923,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
               end
           in
           Lsequence(Lprim(upd, [Lvar copy_id;
-                                transl_exp ~scopes lbl_sort expr],
+                                transl_exp ~scopes lbl.lbl_sort expr],
                           of_location ~scopes loc),
                     cont)
     in
@@ -1955,15 +1941,9 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     let lv =
       Array.mapi
         (fun i (lbl, definition) ->
-           (* CR layouts v2.5: When we allow `any` in record fields and check
-              representability on construction, [sort_of_layout] will be unsafe
-              here.  Probably we should add sorts to record construction in the
-              typed tree, then. *)
-           let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
-           let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
            match definition with
            | Kept (typ, mut, _) ->
-               let field_layout = layout env lbl.lbl_loc lbl_sort typ in
+               let field_layout = layout env lbl.lbl_loc lbl.lbl_sort typ in
                let sem =
                  if Types.is_mutable mut then Reads_vary else Reads_agree
                in
@@ -2019,8 +1999,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                      of_location ~scopes loc),
                field_layout
            | Overridden (_lid, expr) ->
-               let field_layout = layout_exp lbl_sort expr in
-               transl_exp ~scopes lbl_sort expr, field_layout)
+               let field_layout = layout_exp lbl.lbl_sort expr in
+               transl_exp ~scopes lbl.lbl_sort expr, field_layout)
         fields
     in
     let ll, shape = List.split (Array.to_list lv) in
@@ -2115,11 +2095,9 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
     let shape =
       Array.map
         (fun (lbl, definition) ->
-            let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
-            let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
             match definition with
-            | Kept (typ, _mut, _) -> layout env lbl.lbl_loc lbl_sort typ
-            | Overridden (_lid, expr) -> layout_exp lbl_sort expr)
+            | Kept (typ, _mut, _) -> layout env lbl.lbl_loc lbl.lbl_sort typ
+            | Overridden (_lid, expr) -> layout_exp lbl.lbl_sort expr)
         fields
       |> Array.to_list
     in
@@ -2131,9 +2109,7 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
               let access = Punboxed_product_field (i, shape) in
               Lprim (access, [Lvar init_id], of_location ~scopes loc)
             | Overridden (_lid, expr) ->
-              let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
-              let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
-              transl_exp ~scopes lbl_sort expr)
+              transl_exp ~scopes lbl.lbl_sort expr)
         fields
       |> Array.to_list
     in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -51,13 +51,12 @@ let use_dup_for_constant_mutable_arrays_bigger_than = 4
    appropriately.
 *)
 let sort_must_not_be_void loc ty sort =
-  if Jkind.Sort.is_void_defaulting sort then raise (Error (loc, Void_sort ty))
+  if Jkind.Sort.Const.(equal void sort) then raise (Error (loc, Void_sort ty))
 
 let layout_exp sort e = layout e.exp_env e.exp_loc sort e.exp_type
 let layout_pat sort p = layout p.pat_env p.pat_loc sort p.pat_type
 
-let check_record_field_sort loc sort =
-  match Jkind.Sort.default_to_value_and_get sort with
+let check_record_field_sort loc : Jkind.Sort.Const.t -> _ = function
   | Base (Value | Float64 | Float32 | Bits32 | Bits64 | Vec128 | Word) -> ()
   | Base Void -> raise (Error (loc, Illegal_void_record_field))
   | Product _ as c -> raise (Error (loc, Illegal_product_record_field c))
@@ -267,7 +266,7 @@ let assert_failed loc ~scopes exp =
 type fusable_function =
   { params : function_param list
   ; body : function_body
-  ; return_sort : Jkind.sort
+  ; return_sort : Jkind.Sort.Const.t
   ; return_mode : locality_mode
   ; region : bool
   }
@@ -309,10 +308,11 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
               Mode.Alloc.disallow_right Mode.Alloc.legacy }
         }
       in
+      let return_sort = Jkind.Sort.default_for_transl_and_get method_.ret_sort in
       { params = self_param :: method_.params;
         body = method_.body;
         return_mode = transl_alloc_mode_l method_.ret_mode;
-        return_sort = method_.ret_sort;
+        return_sort;
         region = true;
       }
   | _ -> parent
@@ -418,6 +418,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         (event_before ~scopes body (transl_exp ~scopes sort body))
   | Texp_function { params; body; ret_sort; ret_mode; alloc_mode;
                     zero_alloc } ->
+      let ret_sort = Jkind.Sort.default_for_transl_and_get ret_sort in
       transl_function ~in_new_scope ~scopes e params body
         ~alloc_mode ~ret_mode ~ret_sort ~region:true ~zero_alloc
   | Texp_apply({ exp_desc = Texp_ident(path, _, {val_kind = Val_prim p},
@@ -432,8 +433,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         | ((_, arg_repr) :: prim_repr), ((_, Arg (x, _)) :: oargs) ->
           let arg_exps, extra_args = cut_args prim_repr oargs in
           let arg_sort =
-            Jkind.Sort.of_const
-              (Translprim.sort_of_native_repr arg_repr ~poly_sort:psort)
+              Translprim.sort_of_native_repr arg_repr ~poly_sort:psort
           in
           (x, arg_sort) :: arg_exps, extra_args
         | _, ((_, Omitted _) :: _) -> assert false
@@ -489,9 +489,10 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         (transl_apply ~scopes ~tailcall ~inlined ~specialised
            ~assume_zero_alloc
            ~result_layout
-           ~position ~mode (transl_exp ~scopes Jkind.Sort.for_function funct)
+           ~position ~mode (transl_exp ~scopes Jkind.Sort.Const.for_function funct)
            oargs (of_location ~scopes e.exp_loc))
   | Texp_match(arg, arg_sort, pat_expr_list, partial) ->
+      let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
       transl_match ~scopes ~arg_sort ~return_sort:sort e arg pat_expr_list
         partial
   | Texp_try(body, pat_expr_list) ->
@@ -504,7 +505,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
   | Texp_tuple (el, alloc_mode) ->
       let ll, shape =
         transl_value_list_with_shape ~scopes
-          (List.map (fun (_, a) -> (a, Jkind.Sort.for_tuple_element)) el)
+          (List.map (fun (_, a) -> (a, Jkind.Sort.Const.for_tuple_element)) el)
       in
       begin try
         Lconst(Const_block(0, List.map extract_constant ll))
@@ -515,6 +516,10 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
               (of_location ~scopes e.exp_loc))
       end
   | Texp_unboxed_tuple el ->
+      let el =
+        List.map (fun (l, e, s) ->
+            (l, e, Jkind.Sort.default_for_transl_and_get s)) el
+      in
       let shape = List.map (fun (_, e, s) -> layout_exp s e) el in
       let ll = List.map (fun (_, e, s) -> transl_exp ~scopes s e) el in
       Lprim(Pmake_unboxed_product shape,
@@ -524,6 +529,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let args_with_sorts =
         List.map2 (fun { ca_jkind } e ->
             let sort = Jkind.sort_of_jkind ca_jkind in
+            let sort = Jkind.Sort.default_for_transl_and_get sort in
             e, sort)
           cstr.cstr_args args
       in
@@ -617,7 +623,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       begin match arg with
         None -> Lconst(const_int tag)
       | Some (arg, alloc_mode) ->
-          let lam = transl_exp ~scopes Jkind.Sort.for_poly_variant arg in
+          let lam = transl_exp ~scopes Jkind.Sort.Const.for_poly_variant arg in
           try
             Lconst(Const_block(0, [const_int tag;
                                    extract_constant lam]))
@@ -636,12 +642,13 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       transl_record_unboxed_product ~scopes e.exp_loc e.exp_env
         fields representation extended_expression
   | Texp_field(arg, id, lbl, float, ubr) ->
-      let targ = transl_exp ~scopes Jkind.Sort.for_record arg in
+      let targ = transl_exp ~scopes Jkind.Sort.Const.for_record arg in
       let sem =
         if Types.is_mutable lbl.lbl_mut then Reads_vary else Reads_agree
       in
       let sem = add_barrier_to_read (transl_unique_barrier ubr) sem in
       let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
+      let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
       check_record_field_sort id.loc lbl_sort;
       begin match lbl.lbl_repres with
           Record_boxed _
@@ -701,9 +708,12 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
     begin match lbl.lbl_repres with
     | Record_unboxed_product ->
       let lbl_layout l =
-        layout e.exp_env l.lbl_loc (Jkind.sort_of_jkind l.lbl_jkind) l.lbl_arg
+        let lbl_sort = Jkind.sort_of_jkind l.lbl_jkind in
+        let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
+        layout e.exp_env l.lbl_loc lbl_sort l.lbl_arg
       in
       let layouts = Array.to_list (Array.map lbl_layout lbl.lbl_all) in
+      let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
       let targ = transl_exp ~scopes arg_sort arg in
       if Array.length lbl.lbl_all == 1 then
         (* erase singleton unboxed records before lambda *)
@@ -718,6 +728,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
          Probably we should add a sort to `Texp_setfield` in the typed tree,
          then. *)
       let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
+      let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
       check_record_field_sort id.loc lbl_sort;
       let mode =
         Assignment (transl_modify_mode arg_mode)
@@ -755,11 +766,12 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
            Psetmixedfield(lbl.lbl_pos, write, shape, mode)
         end
       in
-      Lprim(access, [transl_exp ~scopes Jkind.Sort.for_record arg;
+      Lprim(access, [transl_exp ~scopes Jkind.Sort.Const.for_record arg;
                      transl_exp ~scopes lbl_sort newval],
             of_location ~scopes e.exp_loc)
   | Texp_array (amut, element_sort, expr_list, alloc_mode) ->
       let mode = transl_alloc_mode alloc_mode in
+      let element_sort = Jkind.Sort.default_for_transl_and_get element_sort in
       let kind = array_kind e element_sort in
       let ll =
         transl_list ~scopes
@@ -835,6 +847,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
          type checker; both mutable and immutable arrays are created the same
          way *)
       let loc = of_location ~scopes e.exp_loc in
+      let elt_sort = Jkind.Sort.default_for_transl_and_get elt_sort in
       let array_kind = Typeopt.array_kind e elt_sort in
       begin match array_kind with
       | Pgenarray | Paddrarray | Pintarray | Pfloatarray
@@ -847,22 +860,24 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       Transl_array_comprehension.comprehension
         ~transl_exp ~scopes ~loc ~array_kind comp
   | Texp_ifthenelse(cond, ifso, Some ifnot) ->
-      Lifthenelse(transl_exp ~scopes Jkind.Sort.for_predef_value cond,
+      Lifthenelse(transl_exp ~scopes Jkind.Sort.Const.for_predef_value cond,
                   event_before ~scopes ifso (transl_exp ~scopes sort ifso),
                   event_before ~scopes ifnot (transl_exp ~scopes sort ifnot),
                   layout_exp sort e)
   | Texp_ifthenelse(cond, ifso, None) ->
-      Lifthenelse(transl_exp ~scopes Jkind.Sort.for_predef_value cond,
+      Lifthenelse(transl_exp ~scopes Jkind.Sort.Const.for_predef_value cond,
                   event_before ~scopes ifso (transl_exp ~scopes sort ifso),
                   lambda_unit,
                   Lambda.layout_unit)
   | Texp_sequence(expr1, sort', expr2) ->
+      let sort' = Jkind.Sort.default_for_transl_and_get sort' in
       sort_must_not_be_void expr1.exp_loc expr1.exp_type sort';
       Lsequence(transl_exp ~scopes sort' expr1,
                 event_before ~scopes expr2 (transl_exp ~scopes sort expr2))
   | Texp_while {wh_body; wh_body_sort; wh_cond} ->
+      let wh_body_sort = Jkind.Sort.default_for_transl_and_get wh_body_sort in
       sort_must_not_be_void wh_body.exp_loc wh_body.exp_type wh_body_sort;
-      let cond = transl_exp ~scopes Jkind.Sort.for_predef_value wh_cond in
+      let cond = transl_exp ~scopes Jkind.Sort.Const.for_predef_value wh_cond in
       let body = transl_exp ~scopes wh_body_sort wh_body in
       Lwhile {
         wh_cond = maybe_region_layout layout_int cond;
@@ -870,13 +885,14 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                     (maybe_region_layout layout_unit body);
       }
   | Texp_for {for_id; for_from; for_to; for_dir; for_body; for_body_sort} ->
+      let for_body_sort = Jkind.Sort.default_for_transl_and_get for_body_sort in
       sort_must_not_be_void for_body.exp_loc for_body.exp_type for_body_sort;
       let body = transl_exp ~scopes for_body_sort for_body in
       Lfor {
         for_id;
         for_loc = of_location ~scopes e.exp_loc;
-        for_from = transl_exp ~scopes Jkind.Sort.for_predef_value for_from;
-        for_to = transl_exp ~scopes Jkind.Sort.for_predef_value for_to;
+        for_from = transl_exp ~scopes Jkind.Sort.Const.for_predef_value for_from;
+        for_to = transl_exp ~scopes Jkind.Sort.Const.for_predef_value for_to;
         for_dir;
         for_body = event_before ~scopes for_body
                      (maybe_region_layout layout_unit body);
@@ -889,10 +905,10 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         let layout = layout_exp sort e in
         match met with
         | Tmeth_val id ->
-            let obj = transl_exp ~scopes Jkind.Sort.for_object expr in
+            let obj = transl_exp ~scopes Jkind.Sort.Const.for_object expr in
             Lsend (Self, Lvar id, obj, [], pos, mode, loc, layout)
         | Tmeth_name nm ->
-            let obj = transl_exp ~scopes Jkind.Sort.for_object expr in
+            let obj = transl_exp ~scopes Jkind.Sort.Const.for_object expr in
             let (tag, cache) = Translobj.meth obj nm in
             let kind = if cache = [] then Public else Cached in
             Lsend (kind, tag, obj, cache, pos, mode, loc, layout)
@@ -986,7 +1002,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       then lambda_unit
       else begin
         Lifthenelse
-          (transl_exp ~scopes Jkind.Sort.for_predef_value cond,
+          (transl_exp ~scopes Jkind.Sort.Const.for_predef_value cond,
            lambda_unit,
            assert_failed loc ~scopes e,
            Lambda.layout_unit)
@@ -999,14 +1015,14 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       | `Constant_or_function ->
         (* A constant expr (of type <> float if [Config.flat_float_array] is
            true) gets compiled as itself. *)
-         transl_exp ~scopes Jkind.Sort.for_lazy_body e
+         transl_exp ~scopes Jkind.Sort.Const.for_lazy_body e
       | `Float_that_cannot_be_shortcut ->
           (* We don't need to wrap with Popaque: this forward
              block will never be shortcutted since it points to a float
              and Config.flat_float_array is true. *)
          Lprim(Pmakeblock(Obj.forward_tag, Immutable, None,
                           alloc_heap),
-                [transl_exp ~scopes Jkind.Sort.for_lazy_body e],
+                [transl_exp ~scopes Jkind.Sort.Const.for_lazy_body e],
                of_location ~scopes e.exp_loc)
       | `Identifier `Forward_value ->
          (* CR-someday mshinwell: Consider adding a new primitive
@@ -1018,11 +1034,11 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
          Lprim (Popaque Lambda.layout_lazy,
                 [Lprim(Pmakeblock(Obj.forward_tag, Immutable, None,
                                   alloc_heap),
-                       [transl_exp ~scopes Jkind.Sort.for_lazy_body e],
+                       [transl_exp ~scopes Jkind.Sort.Const.for_lazy_body e],
                        of_location ~scopes e.exp_loc)],
                 of_location ~scopes e.exp_loc)
       | `Identifier `Other ->
-         transl_exp ~scopes Jkind.Sort.for_lazy_body e
+         transl_exp ~scopes Jkind.Sort.Const.for_lazy_body e
       | `Other ->
          (* other cases compile to a lazy block holding a function.  The
             typechecker enforces that e has jkind value.  *)
@@ -1044,7 +1060,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                             ~region:true
                             ~body:(maybe_region_layout
                                      Lambda.layout_lazy_contents
-                                     (transl_exp ~scopes Jkind.Sort.for_lazy_body e))
+                                     (transl_exp ~scopes Jkind.Sort.Const.for_lazy_body e))
          in
           Lprim(Pmakeblock(Config.lazy_tag, Mutable, None, alloc_heap), [fn],
                 of_location ~scopes e.exp_loc)
@@ -1060,6 +1076,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           cl_attributes = [];
          }
   | Texp_letop{let_; ands; param; param_sort; body; body_sort; partial} ->
+      let body_sort = Jkind.Sort.default_for_transl_and_get body_sort in
       event_after ~scopes e
         (transl_letop ~scopes e.exp_loc e.exp_env let_ ands
            param param_sort body body_sort partial)
@@ -1092,7 +1109,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       end
   | Texp_probe {name; handler=exp; enabled_at_init} ->
     if !Clflags.native_code && !Clflags.probes then begin
-      let lam = transl_exp ~scopes Jkind.Sort.for_probe_body exp in
+      let lam = transl_exp ~scopes Jkind.Sort.Const.for_probe_body exp in
       let map =
         Ident.Set.fold (fun v acc -> Ident.Map.add v (Ident.rename v) acc)
           (free_variables lam)
@@ -1261,7 +1278,7 @@ and transl_guard ~scopes guard rhs_sort rhs =
   | None -> expr
   | Some cond ->
       event_before ~scopes cond
-        (Lifthenelse(transl_exp ~scopes Jkind.Sort.for_predef_value cond,
+        (Lifthenelse(transl_exp ~scopes Jkind.Sort.Const.for_predef_value cond,
                      expr, staticfail, layout))
 
 and transl_case ~scopes rhs_sort {c_lhs; c_guard; c_rhs} =
@@ -1396,6 +1413,8 @@ and transl_apply ~scopes
           let mode = transl_alloc_mode_r mode_closure in
           let arg_mode = transl_alloc_mode_l mode_arg in
           let ret_mode = transl_alloc_mode_l mode_ret in
+          let sort_arg = Jkind.Sort.default_for_transl_and_get sort_arg in
+          let sort_ret = Jkind.Sort.default_for_transl_and_get sort_ret in
           let result_layout = layout_of_sort (to_location loc) sort_ret in
           let body =
             build_apply handle [Lvar id_arg] loc Rc_normal ret_mode
@@ -1437,6 +1456,7 @@ and transl_apply ~scopes
          match arg with
          | Omitted _ as arg -> arg
          | Arg (exp, sort_arg) ->
+           let sort_arg = Jkind.Sort.default_for_transl_and_get sort_arg in
            Arg (transl_exp ~scopes sort_arg exp, layout_exp sort_arg exp))
       sargs
   in
@@ -1479,9 +1499,11 @@ and transl_tupled_function
       Tfunction_cases
         { fc_cases = { c_lhs; _ } :: _ as cases;
           fc_partial; fc_arg_mode; fc_arg_sort } ->
+        let fc_arg_sort = Jkind.Sort.default_for_transl_and_get fc_arg_sort in
         Some (cases, fc_partial, c_lhs, fc_arg_mode, fc_arg_sort)
     | [{ fp_kind = Tparam_pat pat; fp_partial; fp_mode; fp_sort }],
       Tfunction_body body ->
+        let fp_sort = Jkind.Sort.default_for_transl_and_get fp_sort in
         let case = { c_lhs = pat; c_guard = None; c_rhs = body } in
         Some ([ case ], fp_partial, pat, fp_mode, fp_sort)
     | _ -> None
@@ -1559,6 +1581,7 @@ and transl_curried_function ~scopes loc repr params body
     | Tfunction_cases
         { fc_cases; fc_partial; fc_param; fc_loc; fc_arg_sort; fc_arg_mode }
       ->
+        let fc_arg_sort = Jkind.Sort.default_for_transl_and_get fc_arg_sort in
         let arg_layout =
           match fc_cases with
           | { c_lhs } :: _ -> layout_pat fc_arg_sort c_lhs
@@ -1600,6 +1623,7 @@ and transl_curried_function ~scopes loc repr params body
           | Tparam_optional_default (pat, expr, _) ->
               expr.exp_env, Predef.type_option expr.exp_type, Translattribute.transl_param_attributes pat
         in
+        let fp_sort = Jkind.Sort.default_for_transl_and_get fp_sort in
         let arg_layout = layout arg_env fp_loc fp_sort arg_type in
         let arg_mode = transl_alloc_mode_l fp_mode in
         let param =
@@ -1618,6 +1642,7 @@ and transl_curried_function ~scopes loc repr params body
                 ~arg_sort:fp_sort ~arg_layout
                 ~return_layout
           | Tparam_optional_default (pat, default_arg, default_arg_sort) ->
+              let default_arg_sort = Jkind.Sort.default_for_transl_and_get default_arg_sort in
               let default_arg =
                 event_before ~scopes default_arg
                   (transl_exp ~scopes default_arg_sort default_arg)
@@ -1809,6 +1834,7 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
           fun body -> body
       | {vb_pat=pat; vb_expr=expr; vb_sort=sort; vb_rec_kind=_; vb_attributes; vb_loc}
         :: rem ->
+          let sort = Jkind.Sort.default_for_transl_and_get sort in
           let lam =
             transl_bound_exp ~scopes ~in_structure pat sort expr vb_loc vb_attributes
           in
@@ -1831,6 +1857,7 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
       let transl_case
             {vb_expr=expr; vb_sort; vb_attributes; vb_rec_kind = rkind;
              vb_loc; vb_pat} id =
+        let vb_sort = Jkind.Sort.default_for_transl_and_get vb_sort in
         let def =
           transl_bound_exp ~scopes ~in_structure vb_pat vb_sort expr vb_loc vb_attributes
         in
@@ -1843,7 +1870,7 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
 
 and transl_setinstvar ~scopes loc self var expr =
   Lprim(Psetfield_computed (maybe_pointer expr, Assignment modify_heap),
-    [self; var; transl_exp ~scopes Jkind.Sort.for_instance_var expr], loc)
+    [self; var; transl_exp ~scopes Jkind.Sort.Const.for_instance_var expr], loc)
 
 (* CR layouts v5: Invariant - this is only called on values.  Relax that. *)
 and transl_record ~scopes loc env mode fields repres opt_init_expr =
@@ -1862,6 +1889,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     let update_field cont (lbl, definition) =
       (* CR layouts v5: allow more unboxed types here. *)
       let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
+      let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
       check_record_field_sort lbl.lbl_loc lbl_sort;
       match definition with
       | Kept _ -> cont
@@ -1916,7 +1944,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     assert (is_heap_mode (Option.get mode)); (* Pduprecord must be Alloc_heap and not unboxed *)
     Llet(Strict, Lambda.layout_block, copy_id,
          Lprim(Pduprecord (repres, size),
-               [transl_exp ~scopes Jkind.Sort.for_record init_expr],
+               [transl_exp ~scopes Jkind.Sort.Const.for_record init_expr],
                of_location ~scopes loc),
          Array.fold_left update_field (Lvar copy_id) fields)
   | Some _ | None ->
@@ -1932,6 +1960,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
               here.  Probably we should add sorts to record construction in the
               typed tree, then. *)
            let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
+           let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
            match definition with
            | Kept (typ, mut, _) ->
                let field_layout = layout env lbl.lbl_loc lbl_sort typ in
@@ -2076,7 +2105,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     begin match opt_init_expr with
       None -> lam
     | Some (init_expr, _) -> Llet(Strict, Lambda.layout_block, init_id,
-                             transl_exp ~scopes Jkind.Sort.for_record init_expr, lam)
+                             transl_exp ~scopes Jkind.Sort.Const.for_record init_expr, lam)
     end
 
 and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
@@ -2087,6 +2116,7 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
       Array.map
         (fun (lbl, definition) ->
             let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
+            let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
             match definition with
             | Kept (typ, _mut, _) -> layout env lbl.lbl_loc lbl_sort typ
             | Overridden (_lid, expr) -> layout_exp lbl_sort expr)
@@ -2102,6 +2132,7 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
               Lprim (access, [Lvar init_id], of_location ~scopes loc)
             | Overridden (_lid, expr) ->
               let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
+              let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
               transl_exp ~scopes lbl_sort expr)
         fields
       |> Array.to_list
@@ -2113,6 +2144,9 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
     match opt_init_expr with
     | None -> lam
     | Some (init_expr, init_expr_sort) ->
+      let init_expr_sort =
+        Jkind.Sort.default_for_transl_and_get init_expr_sort
+      in
       let layout = layout_exp init_expr_sort init_expr in
       let exp = transl_exp ~scopes init_expr_sort init_expr in
       Llet(Strict, layout, init_id, exp, lam)
@@ -2209,13 +2243,13 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
       assert (static_handlers = []);
       let mode = transl_alloc_mode alloc_mode in
       let argl =
-        List.map (fun (_, a) -> (a, Jkind.Sort.for_tuple_element)) argl
+        List.map (fun (_, a) -> (a, Jkind.Sort.Const.for_tuple_element)) argl
       in
       Matching.for_multiple_match ~scopes ~return_layout e.exp_loc
         (transl_list_with_layout ~scopes argl) mode val_cases partial
     | {exp_desc = Texp_tuple (argl, alloc_mode)}, _ :: _ ->
         let argl =
-          List.map (fun (_, a) -> (a, Jkind.Sort.for_tuple_element)) argl
+          List.map (fun (_, a) -> (a, Jkind.Sort.Const.for_tuple_element)) argl
         in
         let val_ids, lvars =
           List.map
@@ -2259,10 +2293,16 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
           transl_ident (of_location ~scopes and_.bop_op_name.loc) env
             and_.bop_op_type and_.bop_op_path and_.bop_op_val Id_value
         in
-        let exp = transl_exp ~scopes and_.bop_exp_sort and_.bop_exp in
-        let right_layout = layout_exp and_.bop_exp_sort and_.bop_exp in
+        let and_bop_exp_sort =
+          Jkind.Sort.default_for_transl_and_get and_.bop_exp_sort
+        in
+        let and_bop_op_return_sort =
+          Jkind.Sort.default_for_transl_and_get and_.bop_op_return_sort
+        in
+        let exp = transl_exp ~scopes and_bop_exp_sort and_.bop_exp in
+        let right_layout = layout_exp and_bop_exp_sort and_.bop_exp in
         let result_layout =
-          function2_return_layout env and_.bop_loc and_.bop_op_return_sort
+          function2_return_layout env and_.bop_loc and_bop_op_return_sort
             and_.bop_op_type
         in
         let lam =
@@ -2286,9 +2326,15 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
     transl_ident (of_location ~scopes let_.bop_op_name.loc) env
       let_.bop_op_type let_.bop_op_path let_.bop_op_val Id_value
   in
+  let let_bop_exp_sort =
+    Jkind.Sort.default_for_transl_and_get let_.bop_exp_sort
+  in
+  let let_bop_op_return_sort =
+    Jkind.Sort.default_for_transl_and_get let_.bop_op_return_sort
+  in
   let exp =
-    loop (layout_exp let_.bop_exp_sort let_.bop_exp)
-      (transl_exp ~scopes let_.bop_exp_sort let_.bop_exp) ands
+    loop (layout_exp let_bop_exp_sort let_.bop_exp)
+      (transl_exp ~scopes let_bop_exp_sort let_.bop_exp) ands
   in
   let func =
     let return_mode = alloc_heap (* XXX fixme: use result of is_function_type *) in
@@ -2319,7 +2365,7 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
     ap_func = op;
     ap_args=[exp; func];
     ap_result_layout=
-      function2_return_layout env let_.bop_loc let_.bop_op_return_sort
+      function2_return_layout env let_.bop_loc let_bop_op_return_sort
         let_.bop_op_type;
     ap_region_close=Rc_normal;
     ap_mode=alloc_heap;

--- a/lambda/translcore.mli
+++ b/lambda/translcore.mli
@@ -24,7 +24,7 @@ open Debuginfo.Scoped_location
 val pure_module : module_expr -> let_kind
 
 (* Used for translating Alloc_heap values in classes and modules. *)
-val transl_exp: scopes:scopes -> Jkind.sort -> expression -> lambda
+val transl_exp: scopes:scopes -> Jkind.Sort.Const.t -> expression -> lambda
 val transl_apply: scopes:scopes
                   -> ?tailcall:tailcall_attribute
                   -> ?inlined:inlined_attribute
@@ -42,7 +42,7 @@ val transl_extension_constructor: scopes:scopes ->
   Env.t -> Longident.t option ->
   extension_constructor -> lambda
 
-val transl_scoped_exp : scopes:scopes -> Jkind.sort -> expression -> lambda
+val transl_scoped_exp : scopes:scopes -> Jkind.Sort.Const.t -> expression -> lambda
 
 type error =
     Free_super_var

--- a/lambda/translmod.mli
+++ b/lambda/translmod.mli
@@ -81,7 +81,7 @@ type unsafe_info =
 type error =
   Circular_dependency of (Ident.t * unsafe_info) list
 | Conflicting_inline_attributes
-| Non_value_jkind of Types.type_expr * Jkind.sort
+| Non_value_jkind of Types.type_expr * Jkind.Sort.Const.t
 | Instantiating_packed of Compilation_unit.t
 
 exception Error of Location.t * error

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1270,7 +1270,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       let shape =
         List.map (fun typ ->
           Lambda.must_be_value (Typeopt.layout env (to_location loc)
-                                  Jkind.Sort.for_block_element typ))
+                                  Jkind.Sort.Const.for_block_element typ))
           fields
       in
       let useful = List.exists (fun knd -> knd <> Lambda.generic_value) shape in
@@ -1630,10 +1630,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
   let rec make_params ty repr_args repr_res =
     match repr_args, repr_res with
     | [], (_, res_repr) ->
-      let res_sort =
-        Jkind.Sort.of_const
-          (sort_of_native_repr res_repr ~poly_sort)
-      in
+      let res_sort = sort_of_native_repr res_repr ~poly_sort in
       [], Typeopt.layout env error_loc res_sort ty
     | (((_, arg_repr) as arg) :: repr_args), _ ->
       match Typeopt.is_function_type env ty with
@@ -1641,10 +1638,7 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
           Misc.fatal_errorf "Primitive %s type does not correspond to arity"
             (Primitive.byte_name p)
       | Some (arg_ty, ret_ty) ->
-          let arg_sort =
-            Jkind.Sort.of_const
-              (sort_of_native_repr arg_repr ~poly_sort)
-          in
+          let arg_sort = sort_of_native_repr arg_repr ~poly_sort in
           let arg_layout =
             Typeopt.layout env error_loc arg_sort arg_ty
           in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -515,7 +515,7 @@ let unarize_extern_repr alloc_mode (extern_repr : Lambda.extern_repr) =
   match extern_repr with
   | Same_as_ocaml_repr (Base _ as sort) ->
     let kind =
-      Typeopt.layout_of_const_sort sort
+      Typeopt.layout_of_non_void_sort sort
       |> K.With_subkind.from_lambda_values_and_unboxed_numbers_only
       |> K.With_subkind.kind
     in

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -496,7 +496,7 @@ module Analyser =
           { Typedtree.ld_id; ld_mutable; ld_type; ld_loc; ld_attributes } =
         get_field env comments @@
         {Types.ld_id; ld_mutable; ld_modalities = Mode.Modality.Value.Const.id;
-         ld_jkind=Jkind.Builtin.any ~why:Dummy_jkind (* ignored *);
+         ld_sort=Jkind.Sort.Const.void (* ignored *);
          ld_type=ld_type.Typedtree.ctyp_type;
          ld_loc; ld_attributes; ld_uid=Types.Uid.internal_not_actually_unique} in
       let open Typedtree in

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -249,16 +249,9 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
       | Print_as_value (* can interpret as a value and print *)
       | Print_as of string (* can't print *)
 
-    let get_and_default_jkind_for_printing jkind =
-      let layout = Jkind.get_layout_defaulting_to_value jkind in
-      match layout with
-      (* CR layouts v3.0: [Value_or_null] should probably require special
-         printing to avoid descending into NULL. (This module uses
-         lots of unsafe Obj features.)
-      *)
+    let print_sort : Jkind.Sort.Const.t -> _ = function
       | Base Value -> Print_as_value
       | Base Void -> Print_as "<void>"
-      | Any -> Print_as "<any>"
       | Base (Float64 | Float32 | Bits32 | Bits64 | Vec128 | Word) -> Print_as "<abstr>"
       | Product _ -> Print_as "<unboxed product>"
 
@@ -457,9 +450,8 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                             instantiate_types env type_params ty_list l in
                           let ty_args =
                             List.map2
-                              (fun { ca_jkind } ty_arg ->
-                                 (ty_arg,
-                                 get_and_default_jkind_for_printing ca_jkind)
+                              (fun { ca_sort } ty_arg ->
+                                 (ty_arg, print_sort ca_sort)
                               ) l ty_args
                           in
                           tree_of_constr_with_args (tree_of_constr env path)
@@ -574,12 +566,12 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
           lbl_list pos obj rep =
         let rec tree_of_fields first pos = function
           | [] -> []
-          | {ld_id; ld_type; ld_jkind} :: remainder ->
+          | {ld_id; ld_type; ld_sort} :: remainder ->
               let ty_arg = instantiate_type env type_params ty_list ld_type in
               let name = Ident.name ld_id in
               (* PR#5722: print full module path only
                  for first record field *)
-              let is_void = Jkind.is_void_defaulting ld_jkind in
+              let is_void = Jkind.Sort.Const.(equal void ld_sort) in
               let lid =
                 if first then tree_of_label env path (Out_name.create name)
                 else Oide_ident (Out_name.create name)
@@ -619,17 +611,17 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
             ty_list lbl_list pos obj =
         let rec tree_of_fields first pos = function
           | [] -> []
-          | {ld_id; ld_type; ld_jkind} :: remainder ->
+          | {ld_id; ld_type; ld_sort} :: remainder ->
               let ty_arg = instantiate_type env type_params ty_list ld_type in
               let name = Ident.name ld_id in
               (* PR#5722: print full module path only
                  for first record field *)
-              let is_void = Jkind.is_void_defaulting ld_jkind in
+              let is_void = Jkind.Sort.Const.(equal void ld_sort) in
               let lid =
                 if first then tree_of_label env path (Out_name.create name)
                 else Oide_ident (Out_name.create name)
               and v =
-                match get_and_default_jkind_for_printing ld_jkind with
+                match print_sort ld_sort with
                 | Print_as msg -> Oval_stuff msg
                 | Print_as_value ->
                   match lbl_list with
@@ -737,8 +729,8 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
           | _ -> assert false
         in
         let args = instantiate_types env type_params ty_list cstr.cstr_args in
-        let args = List.map2 (fun { ca_jkind } arg ->
-            (arg, get_and_default_jkind_for_printing ca_jkind))
+        let args = List.map2 (fun { ca_sort } arg ->
+            (arg, print_sort ca_sort))
             cstr.cstr_args args
         in
         tree_of_constr_with_args

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -62,6 +62,54 @@ module type Sort = sig
     module Debug_printers : sig
       val t : Format.formatter -> t -> unit
     end
+
+    (* CR layouts: These are sorts for the types of ocaml expressions that are
+       currently required to be values, but for which we expect to relax that
+       restriction in versions 2 and beyond.  Naming them makes it easy to find
+       where in the translation to lambda they are assume to be value. *)
+    (* CR layouts: add similarly named jkinds and use those names everywhere (not
+       just the translation to lambda) rather than writing specific jkinds and
+       sorts in the code. *)
+    val for_class_arg : t
+
+    val for_instance_var : t
+
+    val for_lazy_body : t
+
+    val for_tuple_element : t
+
+    val for_variant_arg : t
+
+    val for_record : t
+
+    val for_block_element : t
+
+    val for_array_get_result : t
+
+    val for_array_comprehension_element : t
+
+    val for_list_element : t
+
+    (** These are sorts for the types of ocaml expressions that we expect will
+        always be "value".  These names are used in the translation to lambda to
+        make the code clearer. *)
+    val for_function : t
+
+    val for_probe_body : t
+
+    val for_poly_variant : t
+
+    val for_object : t
+
+    val for_initializer : t
+
+    val for_method : t
+
+    val for_module : t
+
+    val for_predef_value : t (* Predefined value types, e.g. int and string *)
+
+    val for_tuple : t
   end
 
   module Var : sig
@@ -119,6 +167,13 @@ module type Sort = sig
       it is set to [value] first. *)
   val default_to_value_and_get : t -> Const.t
 
+  (* CR layouts v12: Default this to void. *)
+
+  (** [default_for_transl_and_get] extracts the sort as a `const`.  If it's a variable,
+      it is set to [value] first. After we have support for [void], this will default to
+      [void] instead. *)
+  val default_for_transl_and_get : t -> Const.t
+
   (** To record changes to sorts, for use with `Types.{snapshot, backtrack}` *)
   type change
 
@@ -131,54 +186,6 @@ module type Sort = sig
 
     val var : Format.formatter -> var -> unit
   end
-
-  (* CR layouts: These are sorts for the types of ocaml expressions that are
-     currently required to be values, but for which we expect to relax that
-     restriction in versions 2 and beyond.  Naming them makes it easy to find
-     where in the translation to lambda they are assume to be value. *)
-  (* CR layouts: add similarly named jkinds and use those names everywhere (not
-     just the translation to lambda) rather than writing specific jkinds and
-     sorts in the code. *)
-  val for_class_arg : t
-
-  val for_instance_var : t
-
-  val for_lazy_body : t
-
-  val for_tuple_element : t
-
-  val for_variant_arg : t
-
-  val for_record : t
-
-  val for_block_element : t
-
-  val for_array_get_result : t
-
-  val for_array_comprehension_element : t
-
-  val for_list_element : t
-
-  (** These are sorts for the types of ocaml expressions that we expect will
-      always be "value".  These names are used in the translation to lambda to
-      make the code clearer. *)
-  val for_function : t
-
-  val for_probe_body : t
-
-  val for_poly_variant : t
-
-  val for_object : t
-
-  val for_initializer : t
-
-  val for_method : t
-
-  val for_module : t
-
-  val for_predef_value : t (* Predefined value types, e.g. int and string *)
-
-  val for_tuple : t
 end
 
 module History = struct

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -115,6 +115,44 @@ module Sort = struct
         in
         pp_element ~nested:false ppf c
     end
+
+    let for_function = value
+
+    let for_predef_value = value
+
+    let for_block_element = value
+
+    let for_probe_body = value
+
+    let for_poly_variant = value
+
+    let for_record = value
+
+    let for_object = value
+
+    let for_lazy_body = value
+
+    let for_tuple_element = value
+
+    let for_variant_arg = value
+
+    let for_instance_var = value
+
+    let for_class_arg = value
+
+    let for_method = value
+
+    let for_initializer = value
+
+    let for_module = value
+
+    let for_tuple = value
+
+    let for_array_get_result = value
+
+    let for_array_comprehension_element = value
+
+    let for_list_element = value
   end
 
   module Var = struct
@@ -327,6 +365,9 @@ module Sort = struct
         (* path compression *)
         result)
 
+  (* CR layouts v12: Default to void instead. *)
+  let default_for_transl_and_get s = default_to_value_and_get s
+
   (***********************)
   (* equality *)
 
@@ -465,44 +506,6 @@ module Sort = struct
     pp_element ~nested:false ppf t
 
   include Static.T
-
-  let for_function = value
-
-  let for_predef_value = value
-
-  let for_block_element = value
-
-  let for_probe_body = value
-
-  let for_poly_variant = value
-
-  let for_record = value
-
-  let for_object = value
-
-  let for_lazy_body = value
-
-  let for_tuple_element = value
-
-  let for_variant_arg = value
-
-  let for_instance_var = value
-
-  let for_class_arg = value
-
-  let for_method = value
-
-  let for_initializer = value
-
-  let for_module = value
-
-  let for_tuple = value
-
-  let for_array_get_result = value
-
-  let for_array_comprehension_element = value
-
-  let for_list_element = value
 end
 
 module Layout = struct

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -180,9 +180,9 @@ let tuple_component_label i ppf = function
 let typevars ppf vs =
   List.iter (typevar_jkind ~print_quote:true ppf) vs
 
-let jkind_array i ppf jkinds =
-  array (i+1) (fun _ ppf l -> fprintf ppf "%a;@ " Jkind.format l)
-    ppf jkinds
+let sort_array i ppf sorts =
+  array (i+1) (fun _ ppf l -> fprintf ppf "%a;@ " Jkind.Sort.Const.format l)
+    ppf sorts
 
 let tag ppf = let open Types in function
   | Ordinary {src_index;runtime_tag} ->
@@ -194,8 +194,8 @@ let variant_representation i ppf = let open Types in function
     line i ppf "Variant_unboxed\n"
   | Variant_boxed cstrs ->
     line i ppf "Variant_boxed %a\n"
-      (array (i+1) (fun _ ppf (_cstr, jkinds) ->
-         jkind_array (i+1) ppf jkinds))
+      (array (i+1) (fun _ ppf (_cstr, sorts) ->
+         sort_array (i+1) ppf sorts))
       cstrs
   | Variant_extensible -> line i ppf "Variant_inlined\n"
 
@@ -205,8 +205,8 @@ let flat_element i ppf flat_element =
 let record_representation i ppf = let open Types in function
   | Record_unboxed ->
     line i ppf "Record_unboxed\n"
-  | Record_boxed jkinds ->
-    line i ppf "Record_boxed %a\n" (jkind_array i) jkinds
+  | Record_boxed sorts ->
+    line i ppf "Record_boxed %a\n" (sort_array i) sorts
   | Record_inlined (t, _c, v) ->
     line i ppf "Record_inlined (%a, %a)\n" tag t (variant_representation i) v
   | Record_float -> line i ppf "Record_float\n"

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -124,11 +124,6 @@ let with_additional_action =
   in
   { s with additional_action; last_compose = None }
 
-let apply_prepare_jkind s lay loc =
-  match s.additional_action with
-  | Prepare_for_saving { prepare_jkind } -> prepare_jkind loc lay
-  | Duplicate_variables | No_action -> lay
-
 let change_locs s loc = { s with loc = Some loc; last_compose = None }
 
 let loc s x =
@@ -467,7 +462,7 @@ let label_declaration copy_scope s l =
     ld_id = l.ld_id;
     ld_mutable = l.ld_mutable;
     ld_modalities = l.ld_modalities;
-    ld_jkind = apply_prepare_jkind s l.ld_jkind l.ld_loc;
+    ld_sort = l.ld_sort;
     ld_type = typexp copy_scope s l.ld_loc l.ld_type;
     ld_loc = loc s l.ld_loc;
     ld_attributes = attrs s l.ld_attributes;
@@ -477,13 +472,7 @@ let label_declaration copy_scope s l =
 let constructor_argument copy_scope s ca =
   {
     ca_type = typexp copy_scope s ca.ca_loc ca.ca_type;
-    ca_jkind = begin match s.additional_action with
-      | Prepare_for_saving { prepare_jkind } ->
-        prepare_jkind ca.ca_loc ca.ca_jkind
-      (* CR layouts v2.8: This will have to be copied once we
-         have with-types. *)
-      | Duplicate_variables | No_action -> ca.ca_jkind
-    end;
+    ca_sort = ca.ca_sort;
     ca_loc = loc s ca.ca_loc;
     ca_modalities = ca.ca_modalities;
   }
@@ -504,30 +493,6 @@ let constructor_declaration copy_scope s c =
     cd_uid = c.cd_uid;
   }
 
-(* called only when additional_action is [Prepare_for_saving] *)
-let variant_representation ~prepare_jkind loc = function
-  | Variant_unboxed -> Variant_unboxed
-  | Variant_boxed cstrs_and_jkinds  ->
-    Variant_boxed
-      (Array.map
-         (fun (cstr, jkinds) -> cstr, Array.map (prepare_jkind loc) jkinds)
-         cstrs_and_jkinds)
-  | Variant_extensible -> Variant_extensible
-
-(* called only when additional_action is [Prepare_for_saving] *)
-let record_representation ~prepare_jkind loc = function
-  | Record_unboxed -> Record_unboxed
-  | Record_inlined (tag, constructor_rep, variant_rep) ->
-    Record_inlined (tag,
-                    constructor_rep,
-                    variant_representation ~prepare_jkind loc variant_rep)
-  | Record_boxed lays ->
-      Record_boxed (Array.map (prepare_jkind loc) lays)
-  | (Record_float | Record_ufloat | Record_mixed _) as rep -> rep
-
-let record_unboxed_product_representation ~prepare_jkind:_ _loc = function
-  | Record_unboxed_product -> Record_unboxed_product
-
 let type_declaration' copy_scope s decl =
   { type_params = List.map (typexp copy_scope s decl.type_loc) decl.type_params;
     type_arity = decl.type_arity;
@@ -535,30 +500,11 @@ let type_declaration' copy_scope s decl =
       begin match decl.type_kind with
         Type_abstract r -> Type_abstract r
       | Type_variant (cstrs, rep) ->
-          let rep =
-            match s.additional_action with
-            | No_action | Duplicate_variables -> rep
-            | Prepare_for_saving { prepare_jkind } ->
-                variant_representation ~prepare_jkind decl.type_loc rep
-          in
           Type_variant (List.map (constructor_declaration copy_scope s) cstrs,
                         rep)
       | Type_record(lbls, rep) ->
-          let rep =
-            match s.additional_action with
-            | No_action | Duplicate_variables -> rep
-            | Prepare_for_saving { prepare_jkind } ->
-                record_representation ~prepare_jkind decl.type_loc rep
-          in
           Type_record (List.map (label_declaration copy_scope s) lbls, rep)
       | Type_record_unboxed_product(lbls, rep) ->
-          let rep =
-            match s.additional_action with
-            | No_action | Duplicate_variables -> rep
-            | Prepare_for_saving { prepare_jkind } ->
-              record_unboxed_product_representation
-                ~prepare_jkind decl.type_loc rep
-          in
           Type_record_unboxed_product
             (List.map (label_declaration copy_scope s) lbls, rep)
       | Type_open -> Type_open

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -9634,7 +9634,8 @@ and type_comprehension_expr ~loc ~env ~ty_expected ~attributes cexpr =
         container_type,
         (fun tcomp ->
           Texp_array_comprehension
-            (mut, Jkind.Sort.for_array_comprehension_element, tcomp)),
+            (mut, Jkind.Sort.of_const
+                    Jkind.Sort.Const.for_array_comprehension_element, tcomp)),
         comp,
         (* CR layouts v4: When this changes from [value], you will also have to
            update the use of [transl_exp] in transl_array_comprehension.ml. See

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -484,8 +484,8 @@ let transl_labels (type rep) ~(record_form : rep record_form) ~new_var_jkind
          {Types.ld_id = ld.ld_id;
           ld_mutable = ld.ld_mutable;
           ld_modalities = ld.ld_modalities;
-          ld_jkind = Jkind.Builtin.any ~why:Dummy_jkind;
-            (* Updated by [update_label_jkinds] *)
+          ld_sort = Jkind.Sort.Const.void;
+            (* Updated by [update_label_sorts] *)
           ld_type = ty;
           ld_loc = ld.ld_loc;
           ld_attributes = ld.ld_attributes;
@@ -516,8 +516,8 @@ let transl_types_gf ~new_var_jkind ~allow_unboxed
       Types.ca_modalities = ca.ca_modalities;
       ca_loc = ca.ca_loc;
       ca_type = ca.ca_type.ctyp_type;
-      ca_jkind = Jkind.Builtin.any ~why:Dummy_jkind;
-            (* Updated by [update_constructor_arguments_jkinds] *)
+      ca_sort = Jkind.Sort.Const.void;
+            (* Updated by [update_constructor_arguments_sorts] *)
     }) tyl_gfl
   in
   tyl_gfl, tyl_gfl'
@@ -546,7 +546,7 @@ let transl_constructor_arguments ~new_var_jkind ~unboxed
 (* Note that [make_constructor] does not fill in the [ld_jkind] field of any
    computed record types, because it's called too early in the translation of a
    type declaration to compute accurate jkinds in the presence of recursively
-   defined types. It is updated later by [update_constructor_arguments_jkinds]
+   defined types. It is updated later by [update_constructor_arguments_sorts]
 *)
 let make_constructor
       env loc ~cstr_path ~type_path ~unboxed type_params svars
@@ -797,7 +797,6 @@ let transl_declaration env sdecl (id, uid) =
       let cty = transl_simple_type ~new_var_jkind:Any env ~closed:no_row Mode.Alloc.Const.legacy sty in
       Some cty, Some cty.ctyp_type
   in
-  let any = Jkind.Builtin.any ~why:Initial_typedecl_env in
   (* jkind_default is the jkind to use for now as the type_jkind when there
      is no annotation and no manifest.
      See Note [Default jkinds in transl_declaration].
@@ -891,21 +890,21 @@ let transl_declaration env sdecl (id, uid) =
             Variant_unboxed,
             Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type
           else
-            (* We mark all arg jkinds "any" here.  They are updated later,
-               after the circular type checks make it safe to check jkinds.
+            (* We mark all arg sorts "void" here.  They are updated later,
+               after the circular type checks make it safe to check sorts.
                Likewise, [Constructor_uniform_value] is potentially wrong
                and will be updated later.
             *)
             Variant_boxed (
               Array.map
                 (fun cstr ->
-                   let jkinds =
+                   let sorts =
                      match Types.(cstr.cd_args) with
                      | Cstr_tuple args ->
-                       Array.make (List.length args) any
-                     | Cstr_record _ -> [| any |]
+                       Array.make (List.length args) Jkind.Sort.Const.void
+                     | Cstr_record _ -> [| Jkind.Sort.Const.value |]
                    in
-                   Constructor_uniform_value, jkinds)
+                   Constructor_uniform_value, sorts)
                 (Array.of_list cstrs)
             ),
             Jkind.Builtin.value ~why:Boxed_variant
@@ -927,8 +926,8 @@ let transl_declaration env sdecl (id, uid) =
             (* Note this is inaccurate, using `Record_boxed` in cases where the
                correct representation is [Record_float], [Record_ufloat], or
                [Record_mixed].  Those cases are fixed up after we can get
-               accurate jkinds for the fields, in [update_decl_jkind]. *)
-              Record_boxed (Array.make (List.length lbls) any),
+               accurate sorts for the fields, in [update_decl_jkind]. *)
+              Record_boxed (Array.make (List.length lbls) Jkind.Sort.Const.void),
               Jkind.Builtin.value ~why:Boxed_record
           in
           Ttype_record lbls, Type_record(lbls', rep), jkind
@@ -942,7 +941,9 @@ let transl_declaration env sdecl (id, uid) =
           (* The jkinds below, and the ones in [lbls], are dummy jkinds which
              are replaced and made to correspond to each other in
              [update_decl_jkind]. *)
-          let jkind_ls = List.map (fun _ -> any) lbls in
+          let jkind_ls =
+            List.map (fun _ -> Jkind.Builtin.any ~why:Initial_typedecl_env) lbls
+          in
           let jkind = Jkind.Builtin.product ~why:Unboxed_record jkind_ls in
           Ttype_record_unboxed_product lbls,
           Type_record_unboxed_product(lbls', Record_unboxed_product), jkind
@@ -1237,59 +1238,70 @@ let check_coherence env loc dpath decl =
 let check_abbrev env sdecl (id, decl) =
   (id, check_coherence env sdecl.ptype_loc (Path.Pident id) decl)
 
-(* The [update_x_jkinds] functions infer more precise jkinds in the type kind,
+(* The [update_x_sorts] functions infer more precise jkinds in the type kind,
    including which fields of a record are void.  This would be hard to do during
    [transl_declaration] due to mutually recursive types.
 *)
-(* [update_label_jkinds] additionally returns whether all the jkinds
-   were void *)
-let update_label_jkinds env loc lbls named =
-  (* [named] is [Some jkinds] for top-level records (we will update the
-     jkinds) and [None] for inlined records. *)
+(* [update_label_sorts] additionally returns whether all the jkinds
+   were void, and the jkinds of the labels *)
+let update_label_sorts env loc lbls named =
+  (* [named] is [Some sorts] for top-level records (we will update the
+     sorts) and [None] for inlined records. *)
   (* CR layouts v5: it wouldn't be too hard to support records that are all
      void.  just needs a bit of refactoring in translcore *)
   let update =
     match named with
     | None -> fun _ _ -> ()
-    | Some jkinds -> fun idx jkind -> jkinds.(idx) <- jkind
+    | Some sorts -> fun idx sort -> sorts.(idx) <- sort
   in
-  let lbls =
+  let lbls_and_jkinds =
     List.mapi (fun idx (Types.{ld_type} as lbl) ->
-      let ld_jkind = Ctype.type_jkind env ld_type in
-      update idx ld_jkind;
-      {lbl with ld_jkind}
+      let jkind = Ctype.type_jkind env ld_type in
+      (* Next line guaranteed to be safe because of [check_representable] *)
+      let sort = Jkind.sort_of_jkind jkind in
+      let ld_sort = Jkind.Sort.default_to_value_and_get sort in
+      update idx ld_sort;
+      {lbl with ld_sort}, jkind
     ) lbls
   in
-  if List.for_all (fun l -> Jkind.is_void_defaulting l.ld_jkind) lbls then
+  let lbls, jkinds = List.split lbls_and_jkinds in
+  if List.for_all (fun l -> Jkind.Sort.Const.(equal void l.ld_sort)) lbls then
     raise (Error (loc, Jkind_empty_record))
-  else lbls, false
+  else lbls, false, jkinds
 (* CR layouts v5: return true for a record with all voids *)
 
 (* In addition to updated constructor arguments, returns whether
    all arguments are void, useful for detecting enumerations that
    can be [immediate]. *)
-let update_constructor_arguments_jkinds env loc cd_args jkinds =
+let update_constructor_arguments_sorts env loc cd_args sorts =
   let update =
-    match jkinds with
+    match sorts with
     | None -> fun _ _ -> ()
-    | Some jkinds -> fun idx jkind -> jkinds.(idx) <- jkind
+    | Some sorts -> fun idx sort -> sorts.(idx) <- sort
   in
   match cd_args with
   | Types.Cstr_tuple args ->
-    let args =
+    let args_and_jkinds =
       List.mapi (fun idx ({Types.ca_type; _} as arg) ->
-        let ca_jkind = Ctype.type_jkind env ca_type in
-        update idx ca_jkind;
-        {arg with ca_jkind}) args
+          let jkind = Ctype.type_jkind env ca_type in
+          (* Next line guaranteed to be safe because of [check_representable] *)
+          let sort = Jkind.sort_of_jkind jkind in
+          let ca_sort = Jkind.Sort.default_to_value_and_get sort in
+          update idx ca_sort;
+          {arg with ca_sort}, jkind)
+        args
     in
+    let args, jkinds = List.split args_and_jkinds in
     Types.Cstr_tuple args,
-    List.for_all (fun { ca_jkind } -> Jkind.is_void_defaulting ca_jkind) args
+    List.for_all
+      (fun { ca_sort } -> Jkind_types.Sort.Const.(equal void ca_sort)) args,
+    jkinds
   | Types.Cstr_record lbls ->
-    let lbls, all_void =
-      update_label_jkinds env loc lbls None
+    let lbls, all_void, jkinds =
+      update_label_sorts env loc lbls None
     in
-    update 0 (Jkind.Builtin.value ~why:Boxed_record);
-    Types.Cstr_record lbls, all_void
+    update 0 Jkind.Sort.Const.value;
+    Types.Cstr_record lbls, all_void, jkinds
 
 let assert_mixed_product_support =
   let required_reserved_header_bits = 8 in
@@ -1443,17 +1455,17 @@ module Element_repr = struct
 end
 
 let update_constructor_representation
-    env (cd_args : Types.constructor_arguments) ~loc
+    env (cd_args : Types.constructor_arguments) arg_jkinds ~loc
     ~is_extension_constructor
   =
   let flat_suffix =
     match cd_args with
     | Cstr_tuple arg_types_and_modes ->
         let arg_reprs =
-          List.map (fun {Types.ca_type=arg_type; ca_jkind=arg_jkind; _} ->
+          List.map2 (fun {Types.ca_type=arg_type; _} arg_jkind ->
             let kloc : jkind_sort_loc = Cstr_tuple { unboxed = false } in
             Element_repr.classify env loc kloc arg_type arg_jkind, arg_type)
-            arg_types_and_modes
+            arg_types_and_modes arg_jkinds
         in
         Element_repr.mixed_product_shape loc arg_reprs Cstr_tuple
           ~on_flat_field_expected:(fun ~non_value ~boxed ->
@@ -1466,11 +1478,11 @@ let update_constructor_representation
               raise (Error (loc, Illegal_mixed_product violation)))
     | Cstr_record fields ->
         let arg_reprs =
-          List.map (fun ld ->
+          List.map2 (fun ld arg_jkind ->
               let kloc = Inlined_record { unboxed = false } in
-              Element_repr.classify env loc kloc ld.Types.ld_type ld.ld_jkind,
+              Element_repr.classify env loc kloc ld.Types.ld_type arg_jkind,
               ld)
-            fields
+            fields arg_jkinds
         in
         Element_repr.mixed_product_shape loc arg_reprs Cstr_record
           ~on_flat_field_expected:(fun ~non_value ~boxed ->
@@ -1522,20 +1534,24 @@ let update_decl_jkind env dpath decl =
   let update_record_kind loc lbls rep =
     match lbls, rep with
     | [Types.{ld_type} as lbl], Record_unboxed ->
-      let ld_jkind = Ctype.type_jkind env ld_type in
-      [{lbl with ld_jkind}], Record_unboxed, ld_jkind
-    | _, Record_boxed jkinds ->
-      let lbls, all_void =
-        update_label_jkinds env loc lbls (Some jkinds)
+      let jkind = Ctype.type_jkind env ld_type in
+      (* This next line is guaranteed to be OK because of a call to
+         [check_representable] *)
+      let sort = Jkind.sort_of_jkind jkind in
+      let ld_sort = Jkind.Sort.default_to_value_and_get sort in
+      [{lbl with ld_sort}], Record_unboxed, jkind
+    | _, Record_boxed sorts ->
+      let lbls, all_void, jkinds =
+        update_label_sorts env loc lbls (Some sorts)
       in
       let jkind = Jkind.for_boxed_record ~all_void in
       let reprs =
-        List.mapi
-          (fun i lbl ->
+        List.map2
+          (fun lbl jkind ->
              let kloc = Record { unboxed = false } in
-             Element_repr.classify env loc kloc lbl.Types.ld_type jkinds.(i),
+             Element_repr.classify env loc kloc lbl.Types.ld_type jkind,
              lbl)
-          lbls
+          lbls jkinds
       in
       let repr_summary =
         { values = false; imms = false; floats = false; float64s = false;
@@ -1635,16 +1651,20 @@ let update_decl_jkind env dpath decl =
     | [{Types.cd_args} as cstr], Variant_unboxed -> begin
         match cd_args with
         | Cstr_tuple [{ca_type=ty; _} as arg] -> begin
-            let ca_jkind = Ctype.type_jkind env ty in
+            let jkind = Ctype.type_jkind env ty in
+            let sort = Jkind.sort_of_jkind jkind in
+            let ca_sort = Jkind.Sort.default_to_value_and_get sort in
             [{ cstr with Types.cd_args =
-                           Cstr_tuple [{ arg with ca_jkind }] }],
-            Variant_unboxed, ca_jkind
+                           Cstr_tuple [{ arg with ca_sort }] }],
+            Variant_unboxed, jkind
           end
         | Cstr_record [{ld_type} as lbl] -> begin
-            let ld_jkind = Ctype.type_jkind env ld_type in
+            let jkind = Ctype.type_jkind env ld_type in
+            let sort = Jkind.sort_of_jkind jkind in
+            let ld_sort = Jkind.Sort.default_to_value_and_get sort in
             [{ cstr with Types.cd_args =
-                           Cstr_record [{ lbl with ld_jkind }] }],
-            Variant_unboxed, ld_jkind
+                           Cstr_record [{ lbl with ld_sort }] }],
+            Variant_unboxed, jkind
           end
         | (Cstr_tuple ([] | _ :: _ :: _) | Cstr_record ([] | _ :: _ :: _)) ->
           assert false
@@ -1652,27 +1672,27 @@ let update_decl_jkind env dpath decl =
     | cstrs, Variant_boxed cstr_shapes ->
       let (_,cstrs,all_voids) =
         List.fold_left (fun (idx,cstrs,all_voids) cstr ->
-          let arg_jkinds =
+          let arg_sorts =
             match cstr_shapes.(idx) with
-            | Constructor_uniform_value, arg_jkinds -> arg_jkinds
+            | Constructor_uniform_value, arg_sorts -> arg_sorts
             | Constructor_mixed _, _ ->
                 fatal_error
                   "Typedecl.update_variant_kind doesn't expect mixed \
                    constructor as input"
           in
-          let cd_args, all_void =
-            update_constructor_arguments_jkinds env cstr.Types.cd_loc
-              cstr.Types.cd_args (Some arg_jkinds)
+          let cd_args, all_void, jkinds =
+            update_constructor_arguments_sorts env cstr.Types.cd_loc
+              cstr.Types.cd_args (Some arg_sorts)
           in
           let cstr_repr =
-            update_constructor_representation env cd_args
+            update_constructor_representation env cd_args jkinds
               ~is_extension_constructor:false
               ~loc:cstr.Types.cd_loc
           in
           let () =
             match cstr_repr with
             | Constructor_uniform_value -> ()
-            | Constructor_mixed _ -> cstr_shapes.(idx) <- cstr_repr, arg_jkinds
+            | Constructor_mixed _ -> cstr_shapes.(idx) <- cstr_repr, arg_sorts
           in
           let cstr = { cstr with Types.cd_args } in
           (idx+1,cstr::cstrs,all_voids && all_void)
@@ -1713,8 +1733,12 @@ let update_decl_jkind env dpath decl =
         | Record_unboxed_product ->
           let lbls, jkinds =
             List.map (fun (Types.{ld_type} as lbl) ->
-              let ld_jkind = Ctype.type_jkind env ld_type in
-              {lbl with ld_jkind}, ld_jkind
+              let jkind = Ctype.type_jkind env ld_type in
+              (* This next line is guaranteed to be OK because of a call to
+                 [check_representable] *)
+              let sort = Jkind.sort_of_jkind jkind in
+              let ld_sort = Jkind.Sort.default_to_value_and_get sort in
+              {lbl with ld_sort}, jkind
             ) lbls
             |> List.split
           in
@@ -2395,11 +2419,11 @@ let transl_extension_constructor_decl
       ~cstr_path:(Pident id) ~type_path ~unboxed:false typext_params
       svars sargs sret_type
   in
-  let args, constant =
-    update_constructor_arguments_jkinds env loc args None
+  let args, constant, jkinds =
+    update_constructor_arguments_sorts env loc args None
   in
   let constructor_shape =
-    update_constructor_representation env args ~loc
+    update_constructor_representation env args jkinds ~loc
       ~is_extension_constructor:true
   in
   args, constructor_shape, constant, ret_type,

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -1125,18 +1125,17 @@ let iter_pattern_full ~of_sort ~of_const_sort ~both_sides_of_or f sort pat =
             match cstr.cstr_repr with
             | Variant_unboxed -> [ sort ]
             | Variant_boxed _ | Variant_extensible ->
-              (List.map (fun { ca_jkind } ->
-                 of_sort (Jkind.sort_of_jkind ca_jkind) )
+              (List.map (fun { ca_sort } -> of_const_sort ca_sort )
                  cstr.cstr_args)
           in
           List.iter2 (loop f) sorts patl
       | Tpat_record (lbl_pat_list, _) ->
           List.iter (fun (_, lbl, pat) ->
-            (loop f) (of_sort (Jkind.sort_of_jkind lbl.lbl_jkind)) pat)
+            (loop f) (of_const_sort lbl.lbl_sort) pat)
             lbl_pat_list
       | Tpat_record_unboxed_product (lbl_pat_list, _) ->
           List.iter (fun (_, lbl, pat) ->
-            (loop f) (of_sort (Jkind.sort_of_jkind lbl.lbl_jkind)) pat)
+            (loop f) (of_const_sort lbl.lbl_sort) pat)
             lbl_pat_list
       (* Cases where the inner things must be value: *)
       | Tpat_variant (_, pat, _) -> Option.iter (loop f value) pat

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1271,11 +1271,9 @@ val mknoloc: 'a -> 'a Asttypes.loc
 val mkloc: 'a -> Location.t -> 'a Asttypes.loc
 
 val pat_bound_idents: 'k general_pattern -> Ident.t list
-val pat_bound_idents_with_types:
-  'k general_pattern -> (Ident.t * Types.type_expr) list
 val pat_bound_idents_full:
-  Jkind.sort -> 'k general_pattern
-  -> (Ident.t * string loc * Types.type_expr * Types.Uid.t * Jkind.sort) list
+  Jkind.Sort.Const.t -> 'k general_pattern
+  -> (Ident.t * string loc * Types.type_expr * Types.Uid.t * Jkind.Sort.Const.t) list
 
 (** Splits an or pattern into its value (left) and exception (right) parts. *)
 val split_pattern:

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -566,7 +566,7 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       | _ -> assert false
     end
-  | Variant_boxed cstrs_and_jkinds ->
+  | Variant_boxed cstrs_and_sorts ->
     let depth = depth + 1 in
     let for_constructor_fields fields ~depth ~num_nodes_visited ~field_to_type =
       List.fold_left_map
@@ -654,7 +654,7 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
           | None -> None
           | Some (num_nodes_visited,
                   next_const, consts, next_tag, non_consts) ->
-            let cstr_shape, _ = cstrs_and_jkinds.(idx) in
+            let cstr_shape, _ = cstrs_and_sorts.(idx) in
             let (is_mutable, num_nodes_visited), fields =
               for_one_constructor constructor ~depth ~num_nodes_visited
                 ~cstr_shape

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -136,7 +136,7 @@ type 'a classification =
    See comment on [classification] above to understand [classify_product]. *)
 let classify ~classify_product env loc ty sort : _ classification =
   let ty = scrape_ty env ty in
-  match Jkind.(Sort.default_to_value_and_get sort) with
+  match (sort : Jkind.Sort.Const.t) with
   | Base Value -> begin
   if is_always_gc_ignorable env ty then Int
   else match get_desc ty with
@@ -224,7 +224,8 @@ let array_kind_of_elt ~elt_sort env loc ty =
     match elt_sort with
     | Some s -> s
     | None ->
-      type_legacy_sort ~why:Array_element env loc ty
+      Jkind.Sort.default_for_transl_and_get
+        (type_legacy_sort ~why:Array_element env loc ty)
   in
   let classify_product ty sorts =
     if Language_extension.(is_at_least Layouts Alpha) then
@@ -818,8 +819,7 @@ let[@inline always] rec layout_of_const_sort_generic ~value_kind ~error
     error const
 
 let layout env loc sort ty =
-  layout_of_const_sort_generic
-    (Jkind.Sort.default_to_value_and_get sort)
+  layout_of_const_sort_generic sort
     ~value_kind:(lazy (value_kind env loc ty))
     ~error:(function
       | Base Value -> assert false
@@ -838,9 +838,7 @@ let layout env loc sort ty =
     )
 
 let layout_of_sort loc sort =
-  layout_of_const_sort_generic
-    (Jkind.Sort.default_to_value_and_get sort)
-    ~value_kind:(lazy Lambda.generic_value)
+  layout_of_const_sort_generic sort ~value_kind:(lazy Lambda.generic_value)
     ~error:(function
     | Base Value -> assert false
     | Base Void ->
@@ -856,7 +854,7 @@ let layout_of_sort loc sort =
                            (Jkind.Sort.of_const const, Stable, None)))
     )
 
-let layout_of_const_sort c =
+let layout_of_non_void_sort c =
   layout_of_const_sort_generic
     c
     ~value_kind:(lazy Lambda.generic_value)
@@ -882,7 +880,7 @@ let function_arg_layout env loc sort ty =
 (** Whether a forward block is needed for a lazy thunk on a value, i.e.
     if the value can be represented as a float/forward/lazy *)
 let lazy_val_requires_forward env loc ty =
-  let sort = Jkind.Sort.for_lazy_body in
+  let sort = Jkind.Sort.Const.for_lazy_body in
   let classify_product _ sorts =
     let kind = Jkind.Sort.Const.Product sorts in
     raise (Error (loc, Unsupported_product_in_lazy kind))

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -26,16 +26,16 @@ val maybe_pointer : Typedtree.expression -> Lambda.immediate_or_pointer
 (* Supplying [None] for [elt_sort] should be avoided when possible. It
    will result in a call to [Ctype.type_sort] which can be expensive. *)
 val array_type_kind :
-  elt_sort:(Jkind.Sort.t option)
+  elt_sort:(Jkind.Sort.Const.t option)
   -> Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
 val array_type_mut : Env.t -> Types.type_expr -> Lambda.mutable_flag
 val array_kind_of_elt :
-  elt_sort:(Jkind.Sort.t option)
+  elt_sort:(Jkind.Sort.Const.t option)
   -> Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
 val array_kind :
-  Typedtree.expression -> Jkind.Sort.t -> Lambda.array_kind
+  Typedtree.expression -> Jkind.Sort.Const.t -> Lambda.array_kind
 val array_pattern_kind :
-  Typedtree.pattern -> Jkind.Sort.t -> Lambda.array_kind
+  Typedtree.pattern -> Jkind.Sort.Const.t -> Lambda.array_kind
 
 (* If [kind] or [layout] is unknown, attempt to specialize it by examining the
    type parameters of the bigarray. If [kind] or [length] is not unknown, returns
@@ -50,30 +50,30 @@ val bigarray_specialize_kind_and_layout :
    take that check out.
 *)
 val layout :
-  Env.t -> Location.t -> Jkind.sort -> Types.type_expr -> Lambda.layout
+  Env.t -> Location.t -> Jkind.Sort.Const.t -> Types.type_expr -> Lambda.layout
 
 (* These translate a type system sort to a lambda layout.  The function [layout]
    gives a more precise result---this should only be used when the kind is
    needed for compilation but the precise Lambda.layout isn't needed for
    optimization.  [layout_of_sort] gracefully errors on void, while
-   [layout_of_base] loudly fails on void. *)
-val layout_of_sort : Location.t -> Jkind.sort -> Lambda.layout
-val layout_of_const_sort : Jkind.Sort.Const.t -> Lambda.layout
+   [layout_of_non_void_sort] loudly fails on void. *)
+val layout_of_sort : Location.t -> Jkind.Sort.Const.t -> Lambda.layout
+val layout_of_non_void_sort : Jkind.Sort.Const.t -> Lambda.layout
 
 (* Given a function type and the sort of its return type, compute the layout of
    its return type. *)
 val function_return_layout :
-  Env.t -> Location.t -> Jkind.sort -> Types.type_expr -> Lambda.layout
+  Env.t -> Location.t -> Jkind.Sort.Const.t -> Types.type_expr -> Lambda.layout
 
 (* Given a function type with two arguments and the sort of its return type,
    compute the layout of its return type. *)
 val function2_return_layout :
-  Env.t -> Location.t -> Jkind.sort -> Types.type_expr -> Lambda.layout
+  Env.t -> Location.t -> Jkind.Sort.Const.t -> Types.type_expr -> Lambda.layout
 
 (* Given a function type and the sort of its argument, compute the layout
    of its argument.  Fails loudly if the type isn't a function type. *)
 val function_arg_layout :
-  Env.t -> Location.t -> Jkind.sort -> Types.type_expr -> Lambda.layout
+  Env.t -> Location.t -> Jkind.Sort.Const.t -> Types.type_expr -> Lambda.layout
 
 val value_kind : Env.t -> Location.t -> Types.type_expr -> Lambda.value_kind
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -311,7 +311,7 @@ and mixed_product_shape =
 and record_representation =
   | Record_unboxed
   | Record_inlined of tag * constructor_representation * variant_representation
-  | Record_boxed of (allowed * disallowed) jkind array
+  | Record_boxed of Jkind_types.Sort.Const.t array
   | Record_float
   | Record_ufloat
   | Record_mixed of mixed_product_shape
@@ -322,7 +322,7 @@ and record_unboxed_product_representation =
 and variant_representation =
   | Variant_unboxed
   | Variant_boxed of (constructor_representation *
-                      (allowed * disallowed) jkind array) array
+                      Jkind_types.Sort.Const.t array) array
   | Variant_extensible
 
 and constructor_representation =
@@ -335,7 +335,7 @@ and label_declaration =
     ld_mutable: mutability;
     ld_modalities: Mode.Modality.Value.Const.t;
     ld_type: type_expr;
-    ld_jkind : jkind_l;
+    ld_sort: Jkind_types.Sort.Const.t;
     ld_loc: Location.t;
     ld_attributes: Parsetree.attributes;
     ld_uid: Uid.t;
@@ -355,7 +355,7 @@ and constructor_argument =
   {
     ca_modalities: Mode.Modality.Value.Const.t;
     ca_type: type_expr;
-    ca_jkind: jkind_l;
+    ca_sort: Jkind_types.Sort.Const.t;
     ca_loc: Location.t;
   }
 
@@ -660,12 +660,13 @@ let equal_constructor_representation r1 r2 = r1 == r2 || match r1, r2 with
 let equal_variant_representation r1 r2 = r1 == r2 || match r1, r2 with
   | Variant_unboxed, Variant_unboxed ->
       true
-  | Variant_boxed cstrs_and_jkinds1, Variant_boxed cstrs_and_jkinds2 ->
-      Misc.Stdlib.Array.equal (fun (cstr1, jkinds1) (cstr2, jkinds2) ->
+  | Variant_boxed cstrs_and_sorts1, Variant_boxed cstrs_and_sorts2 ->
+      Misc.Stdlib.Array.equal (fun (cstr1, sorts1) (cstr2, sorts2) ->
           equal_constructor_representation cstr1 cstr2
-          && Misc.Stdlib.Array.equal !jkind_equal jkinds1 jkinds2)
-        cstrs_and_jkinds1
-        cstrs_and_jkinds2
+          && Misc.Stdlib.Array.equal Jkind_types.Sort.Const.equal
+               sorts1 sorts2)
+        cstrs_and_sorts1
+        cstrs_and_sorts2
   | Variant_extensible, Variant_extensible ->
       true
   | (Variant_unboxed | Variant_boxed _ | Variant_extensible), _ ->
@@ -680,8 +681,8 @@ let equal_record_representation r1 r2 = match r1, r2 with
       ignore (cr1 : constructor_representation);
       ignore (cr2 : constructor_representation);
       equal_tag tag1 tag2 && equal_variant_representation vr1 vr2
-  | Record_boxed lays1, Record_boxed lays2 ->
-      Misc.Stdlib.Array.equal !jkind_equal lays1 lays2
+  | Record_boxed sorts1, Record_boxed sorts2 ->
+      Misc.Stdlib.Array.equal Jkind_types.Sort.Const.equal sorts1 sorts2
   | Record_float, Record_float ->
       true
   | Record_ufloat, Record_ufloat ->
@@ -709,7 +710,7 @@ type 'a gen_label_description =
     lbl_arg: type_expr;                 (* Type of the argument *)
     lbl_mut: mutability;                (* Is this a mutable field? *)
     lbl_modalities: Mode.Modality.Value.Const.t;(* Modalities on the field *)
-    lbl_jkind : jkind_l;                (* Jkind of the argument *)
+    lbl_sort: Jkind_types.Sort.Const.t; (* Sort of the argument *)
     lbl_pos: int;                       (* Position in block *)
     lbl_num: int;                       (* Position in type *)
     lbl_all: 'a gen_label_description array;   (* All the labels in this type *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -603,7 +603,7 @@ and record_representation =
   (* For an inlined record, we record the representation of the variant that
      contains it and the tag/representation of the relevant constructor of that
      variant. *)
-  | Record_boxed of jkind_l array
+  | Record_boxed of Jkind_types.Sort.Const.t array
   | Record_float (* All fields are floats *)
   | Record_ufloat
   (* All fields are [float#]s.  Same runtime representation as [Record_float],
@@ -623,7 +623,7 @@ and record_unboxed_product_representation =
 and variant_representation =
   | Variant_unboxed
   | Variant_boxed of (constructor_representation *
-                      jkind_l array) array
+                      Jkind_types.Sort.Const.t array) array
   (* The outer array has an element for each constructor. Each inner array
      has a jkind for each argument of the corresponding constructor.
 
@@ -650,7 +650,7 @@ and label_declaration =
     ld_mutable: mutability;
     ld_modalities: Mode.Modality.Value.Const.t;
     ld_type: type_expr;
-    ld_jkind : jkind_l;
+    ld_sort: Jkind_types.Sort.Const.t;
     ld_loc: Location.t;
     ld_attributes: Parsetree.attributes;
     ld_uid: Uid.t;
@@ -670,7 +670,7 @@ and constructor_argument =
   {
     ca_modalities: Mode.Modality.Value.Const.t;
     ca_type: type_expr;
-    ca_jkind: jkind_l;
+    ca_sort: Jkind_types.Sort.Const.t;
     ca_loc: Location.t;
   }
 
@@ -896,7 +896,7 @@ type 'a gen_label_description =
     lbl_mut: mutability;                (* Is this a mutable field? *)
     lbl_modalities: Mode.Modality.Value.Const.t;
                                         (* Modalities on the field *)
-    lbl_jkind : jkind_l;                (* Jkind of the argument *)
+    lbl_sort: Jkind_types.Sort.Const.t; (* Sort of the argument *)
     lbl_pos: int;                       (* Position in block *)
     lbl_num: int;                       (* Position in the type *)
     lbl_all: 'a gen_label_description array;   (* All the labels in this type *)
@@ -906,9 +906,6 @@ type 'a gen_label_description =
     lbl_attributes: Parsetree.attributes;
     lbl_uid: Uid.t;
   }
-(* CR layouts v5: once we allow [any] in record fields, change [lbl_jkind] to
-   be a [sort option].  This will allow a fast path for representability checks
-   at record construction, and currently only the sort is used anyway. *)
 
 type label_description = record_representation gen_label_description
 

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -718,11 +718,13 @@ let rec expression : Typedtree.expression -> term_judg =
     | Texp_unboxed_tuple exprs ->
       list expression (List.map (fun (_, e, _) -> e) exprs) << Return
     | Texp_array (_, elt_sort, exprs, _) ->
+      let elt_sort = Jkind.Sort.default_for_transl_and_get elt_sort in
       list expression exprs << array_mode exp elt_sort
     | Texp_list_comprehension { comp_body; comp_clauses } ->
       join ((expression comp_body << Guard) ::
             comprehension_clauses comp_clauses)
     | Texp_array_comprehension (_, elt_sort, { comp_body; comp_clauses }) ->
+      let elt_sort = Jkind.Sort.default_for_transl_and_get elt_sort in
       join ((expression comp_body << array_mode exp elt_sort) ::
             comprehension_clauses comp_clauses)
     | Texp_construct (_, desc, exprs, _) ->


### PR DESCRIPTION
As discussed with @ccasin, all of the `transl` functions can really work over `Sort.Const.t`, not `Sort.t`. This PR makes this change.

Motivation: The second commit, which replaces `Jkind.t` with `Jkind.Sort.Const.t` in `variant_representation`, `label_description`, and `record_representation`. This actually was possible without the first commit, but there were a sad number of calls to `Jkind.Sort.of_const` to reconsistute the non-constant sorts for transl... so I wrote the first commit.

Review: commit-by-commit. The changes are very boring; it's the design change that's interesting.

* [ ] 1. f39bd0aef40d9b475118ee3c7199a6f35dcf7ab1 changes the transl functions to work over `Jkind.Sort.Const.t` instead of `Jkind.Sort.t` (aka `Jkind.sort`). The there are two sad bits. (a) There are *lots* more calls to `default_for_transl_and_get`. Previously, we called this function only in Typeopt when we actually needed the sort. Now this function has to be called for every sort stored in the typedtree. I think this is OK, though, because though the function call is written more, it is executed either less or the same amount (previously, sometimes a sort flowed through multiple paths, and it had to be `got`ten more than once). It might be reasonable to object to this commit based on the new calls. (b) There is a sad little dance in typedtree because a function needs to deal with both constant and non-constant sorts. The dance is local, but regrettable.
* [ ] 2. 540cc234e5cca4f47fd27949ea19b932b0a48345 changes the representations of structures to use `Jkind.Sort.Const.t`. This, in turn, is motivated by trying to use kinds as little as possible, because they're about to get a lot more complicated. But actually it's a nice change on its own.

If you like (2) but don't like (1) (reasonable! I'm not sure about (1) myself), you can check out https://github.com/goldfirere/flambda-backend/commit/ce8f169a7511a8c37cf04841048377d972a40014, which is a version of commit (2) without needing (1). It works. But see the number of `of_const` calls in translcore. These made me sad and is the concrete motivation for (1).

If you say to take (2) with the sad `of_const`s because that's better than (1), I won't push back.

Review: I'd love @ccasin to push back on the design. If he doesn't want to review the rest of the details, I'm sure @dkalinichenko-js could do so. I recommend looking at the commits separately.