### PR TITLE
Fix Numbers.Int_base.compare

### DIFF
--- a/utils/numbers.ml
+++ b/utils/numbers.ml
@@ -17,7 +17,7 @@
 module Int_base = Identifiable.Make (struct
   type t = int
 
-  let compare x y = x - y
+  let compare = Int.compare
   let output oc x = Printf.fprintf oc "%i" x
   let hash i = i
   let equal (i : int) j = i = j


### PR DESCRIPTION
There is an embarrassing error in `Numbers.Int_base.compare` which causes wrong results in the event of overflow.  This can lead to strange behaviour in Flambda 2, as this function is used for the comparison on e.g. `Simple.t`...