### PR TITLE
Fix layouts bug for applications with omitted arguments

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1323,8 +1323,9 @@ and transl_apply ~scopes
        will occur exactly when all the arguments up to this parameter
        have been received.
   *)
-  let rec build_apply lam args loc pos ap_mode = function
-    | Omitted { mode_closure; mode_arg; mode_ret; sort_arg } :: l ->
+  let rec build_apply lam args loc pos ap_mode result_layout = function
+    | Omitted { mode_closure; mode_arg; mode_ret; sort_arg;
+                sort_eta_expansion_ret } :: l ->
         (* Out-of-order partial application; we will need to build a closure *)
         assert (pos = Rc_normal);
         let defs = ref [] in
@@ -1361,7 +1362,13 @@ and transl_apply ~scopes
           let mode = transl_alloc_mode_r mode_closure in
           let arg_mode = transl_alloc_mode_l mode_arg in
           let ret_mode = transl_alloc_mode_l mode_ret in
-          let body = build_apply handle [Lvar id_arg] loc Rc_normal ret_mode l in
+          let result_layout =
+            layout_of_sort (to_location loc) sort_eta_expansion_ret
+          in
+          let body =
+            build_apply handle [Lvar id_arg] loc Rc_normal ret_mode
+              result_layout l
+          in
           let nlocal =
             match join_locality_mode mode (join_locality_mode arg_mode ret_mode) with
             | Alloc_local -> 1
@@ -1388,7 +1395,8 @@ and transl_apply ~scopes
         List.fold_right
           (fun (id, layout, lam) body -> Llet(Strict, layout, id, lam, body))
           !defs body
-    | Arg (arg, _) :: l -> build_apply lam (arg :: args) loc pos ap_mode l
+    | Arg (arg, _) :: l ->
+      build_apply lam (arg :: args) loc pos ap_mode result_layout l
     | [] -> lapply lam (List.rev args) loc pos ap_mode result_layout
   in
   let args =
@@ -1400,7 +1408,7 @@ and transl_apply ~scopes
            Arg (transl_exp ~scopes sort_arg exp, layout_exp sort_arg exp))
       sargs
   in
-  build_apply lam [] loc position mode args
+  build_apply lam [] loc position mode result_layout args
 
 (* There are two cases in function translation:
     - [Tupled]. It takes a tupled argument, and we can flatten it.

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1324,8 +1324,7 @@ and transl_apply ~scopes
        have been received.
   *)
   let rec build_apply lam args loc pos ap_mode result_layout = function
-    | Omitted { mode_closure; mode_arg; mode_ret; sort_arg;
-                sort_eta_expansion_ret } :: l ->
+    | Omitted { mode_closure; mode_arg; mode_ret; sort_arg; sort_ret } :: l ->
         (* Out-of-order partial application; we will need to build a closure *)
         assert (pos = Rc_normal);
         let defs = ref [] in
@@ -1362,9 +1361,7 @@ and transl_apply ~scopes
           let mode = transl_alloc_mode_r mode_closure in
           let arg_mode = transl_alloc_mode_l mode_arg in
           let ret_mode = transl_alloc_mode_l mode_ret in
-          let result_layout =
-            layout_of_sort (to_location loc) sort_eta_expansion_ret
-          in
+          let result_layout = layout_of_sort (to_location loc) sort_ret in
           let body =
             build_apply handle [Lvar id_arg] loc Rc_normal ret_mode
               result_layout l

--- a/testsuite/tests/typing-layouts/omitted_arguments.ml
+++ b/testsuite/tests/typing-layouts/omitted_arguments.ml
@@ -1,0 +1,74 @@
+(* TEST
+ reference = "${test_source_directory}/omitted_arguments.reference";
+ include stdlib_upstream_compatible;
+ flambda2;
+ {
+   native;
+ } {
+   flags = "-Oclassic";
+   native;
+ } {
+   flags = "-O3";
+   native;
+ } {
+   bytecode;
+ }
+*)
+
+(* This is a test for applications where some arguments are omitted. We
+   previously had a bug where the layouts recorded in the eta-expansion the
+   compiler generates for such functions were incorrect. *)
+
+external box_float : float# -> float = "%box_float"
+external unbox_float : float -> float# = "%unbox_float"
+
+(* Omitting named arg *)
+let f1 ~name:x y = unbox_float (x +. y)
+
+let f2 (f : name:float -> float#) = f ~name:3.14
+
+let f3 () = f2 (f1 3.15)
+
+let _ =
+  Printf.printf "Omitting named arg (6.29): %.2f\n" (box_float (f3 ()))
+
+(* Omitting unnamed arg *)
+let f4 x ~name:y = unbox_float (x +. y)
+
+let f5 (f : float -> float#) = f 3.14
+
+let f6 () = f5 (f4 ~name:3.13)
+
+let _ =
+  Printf.printf "Omitting named arg (6.27): %.2f\n" (box_float (f6 ()))
+
+(* Omitting two named args*)
+let f7 ~name1 ~name2 x = unbox_float (name1 +. name2 +. x)
+
+let f8 (f : name1:float -> name2:float -> float#) = f ~name1:3.13 ~name2:3.15
+
+let f9 () = f8 (f7 3.14)
+
+let _ =
+  Printf.printf "Omitting named arg (9.42): %.2f\n" (box_float (f9 ()))
+
+(* Example adapted from real code *)
+
+let float_test : float# -> bool =
+  fun f -> Stdlib_upstream_compatible.Float_u.(equal f #3.0)
+let e : int -> size:int -> float# =
+  fun s ~size -> unbox_float (Float.of_int s +. Float.of_int size)
+
+let evaluate_1 () : 'a Array.t -> eval:local_ ('a -> float#) -> float# =
+  fun ts ~(local_ eval) ->
+    let eval i = eval (Array.get ts i) in
+    if float_test (eval 0) then #3.14 else #10.0
+
+let evaluate =
+  let evaluate_2 = evaluate_1 () in
+  fun t ~size ->
+    evaluate_2 t ~eval:(e ~size)
+
+let _ =
+  Printf.printf "\"real\" code (3.14): %.2f\n"
+    (box_float (evaluate [|2; 3; 4|] ~size:1))

--- a/testsuite/tests/typing-layouts/omitted_arguments.reference
+++ b/testsuite/tests/typing-layouts/omitted_arguments.reference
@@ -1,0 +1,4 @@
+Omitting named arg (6.29): 6.29
+Omitting named arg (6.27): 6.27
+Omitting named arg (9.42): 9.42
+"real" code (3.14): 3.14

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1397,7 +1397,9 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                       let mode_arg = Mode.Alloc.disallow_right Mode.Alloc.legacy in
                       let mode_ret = Mode.Alloc.disallow_right Mode.Alloc.legacy in
                       let sort_arg = Jkind.Sort.value in
-                      Omitted { mode_closure; mode_arg; mode_ret; sort_arg }
+                      let sort_eta_expansion_ret = Jkind.Sort.value in
+                      Omitted { mode_closure; mode_arg; mode_ret; sort_arg;
+                                sort_eta_expansion_ret }
                     end
             in
             let omitted =

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1397,9 +1397,9 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                       let mode_arg = Mode.Alloc.disallow_right Mode.Alloc.legacy in
                       let mode_ret = Mode.Alloc.disallow_right Mode.Alloc.legacy in
                       let sort_arg = Jkind.Sort.value in
-                      let sort_eta_expansion_ret = Jkind.Sort.value in
+                      let sort_ret = Jkind.Sort.value in
                       Omitted { mode_closure; mode_arg; mode_ret; sort_arg;
-                                sort_eta_expansion_ret }
+                                sort_ret }
                     end
             in
             let omitted =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3896,7 +3896,7 @@ let type_omitted_parameters expected_mode env loc ty_ret mode_ret args =
              (ty_ret, mode_ret, open_args, closed_args, args)
          | Omitted { mode_fun; ty_arg; mode_arg; level; sort_arg } ->
              let arrow_desc = (lbl, mode_arg, mode_ret) in
-             let sort_eta_expansion_ret =
+             let sort_ret =
                match type_sort ~why:Function_result ~fixed:false env ty_ret with
                | Ok sort -> sort
                | Error err ->
@@ -3929,7 +3929,7 @@ let type_omitted_parameters expected_mode env loc ty_ret mode_ret args =
                 mode_arg = Alloc.disallow_right mode_arg;
                 mode_ret = Alloc.disallow_right mode_ret;
                 sort_arg;
-                sort_eta_expansion_ret; }
+                sort_ret }
              in
              let args = (lbl, arg) :: args in
              (ty_ret, mode_closure, open_args, closed_args, args))

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -375,7 +375,7 @@ and omitted_parameter =
     mode_arg : Mode.Alloc.l;
     mode_ret : Mode.Alloc.l;
     sort_arg : Jkind.sort;
-    sort_eta_expansion_ret : Jkind.sort }
+    sort_ret : Jkind.sort }
 
 and apply_arg = (expression * Jkind.sort, omitted_parameter) arg_or_omitted
 

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -374,7 +374,8 @@ and omitted_parameter =
   { mode_closure : Mode.Alloc.r;
     mode_arg : Mode.Alloc.l;
     mode_ret : Mode.Alloc.l;
-    sort_arg : Jkind.sort }
+    sort_arg : Jkind.sort;
+    sort_eta_expansion_ret : Jkind.sort }
 
 and apply_arg = (expression * Jkind.sort, omitted_parameter) arg_or_omitted
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -602,7 +602,7 @@ and omitted_parameter =
     mode_arg : Mode.Alloc.l;
     mode_ret : Mode.Alloc.l;
     sort_arg : Jkind.sort;
-    sort_eta_expansion_ret : Jkind.sort }
+    sort_ret : Jkind.sort }
 
 and apply_arg = (expression * Jkind.sort, omitted_parameter) arg_or_omitted
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -601,7 +601,8 @@ and omitted_parameter =
   { mode_closure : Mode.Alloc.r;
     mode_arg : Mode.Alloc.l;
     mode_ret : Mode.Alloc.l;
-    sort_arg : Jkind.sort }
+    sort_arg : Jkind.sort;
+    sort_eta_expansion_ret : Jkind.sort }
 
 and apply_arg = (expression * Jkind.sort, omitted_parameter) arg_or_omitted
 


### PR DESCRIPTION
In the following code, we partially apply `f1`:
```ocaml
let f1 ~name:x y = unbox_float (x +. y)

let f2 (f : name:float -> float#) = f1 ~name:3.14

let f3 () = f2 (f1 3.15)
```
During translation to lambda, we translate `f1 3.15` to an eta-expanded version, roughly `fun param -> f1 ~name:param 3.15`.  Until this PR, that translation mistakenly assumes the layout of the return value of this eta-expanded function is the same as the layout of the original application.  This is wrong: the original application is partial so it is always a `value`, while the eta-expanded version in this case returns a `float#`.

I didn't find a particularly clean fix.  I considered two options: (1) having omitted arguments carry the sort that should be used when we construct this eta expansion, or (2) having the application node record the sort you'd get if you fully applied it to all the omitted arguments.

I went with (2), because this sort is really related to the whole application, not the individual omitted arguments.  But the result doesn't fill me with joy: applications now carry around this slightly weird sort that isn't actually the sort of the application, but rather the sort of some related compilation artifact.  And some functions in `transl` grow an extra parameter to pass this sort around.

Perhaps there is a third, better option - I'm open to suggestions.

I've added a test with several examples that previously caused the middle-end issues. One of the tests has two omitted arguments, to check a slight subtlety: we'll construct two eta expanded functions in that case, and only one of them should get the new return layout (the other returns a function).

Some existing layout error messages change slightly (for the better, I think) just because we now sometimes check that a function's return is representable a little earlier.

