### PR TITLE
Add a .git-blame-ignore-rev file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Reformat middle_end/flambda2/ (#230)
+331c16734636a218261d4835fb77b38c5788f50a
+
+# Reformat after #2142 (#2149)
+6d21416746f4d712a164359d706cf00aae539f93
+
+# Reformat to cope with .ocamlformat change
+9777982cfb3733cd21896797b0b21980f5473462


### PR DESCRIPTION
`git blame` can be configured to ignore certain commits, such as formatting commits. This patch adds a `.git-blame-ignore-revs` file (using a common name) with a few reformatting commits that can be used with `git blame --ignore-revs-file .git-blame-ignore-revs` or configured as a default ignore file with:

```
$ git config blame.ignoreRevsFile .git-blame-ignore-revs
```

Hopefully we should rarely need to add new commits to this file (except on .ocamlformat changes) thanks to better formatting discipline, but 331c1673 (Reformat middle_end/flambda2/) is making `git blame` effectively useless for archeological tasks. I also heuristically added a few other commits with "Reformat" in the name, but I have not seen them actually show up as problematic.