### PR TITLE
Zap modalities to identity for mli-less files

### DIFF
--- a/testsuite/tests/typing-modes/def_nonportable.ml
+++ b/testsuite/tests/typing-modes/def_nonportable.ml
@@ -1,1 +1,0 @@
-let (f @ nonportable) x = x

--- a/testsuite/tests/typing-modes/use_portable.reference
+++ b/testsuite/tests/typing-modes/use_portable.reference
@@ -1,4 +1,4 @@
 File "use_portable.ml", line 3, characters 22-38:
 3 | let () = portable_use Maybe_portable.f
                           ^^^^^^^^^^^^^^^^
-Error: This value is nonportable but expected to be portable.
+Error: This value is "nonportable" but expected to be "portable".

--- a/testsuite/tests/typing-modes/val_modalities_floor.ml
+++ b/testsuite/tests/typing-modes/val_modalities_floor.ml
@@ -1,12 +1,8 @@
-(* We test that cmi generated without mli has the modalities pushed to the
-strongest instead of legacy *)
-
 (* TEST
  readonly_files = "\
    def_portable.ml \
-   def_nonportable.ml \
-   use_portable.ml use_portable.bad.reference \
- ";
+   use_portable.ml use_portable.reference \
+  ";
 {
    setup-ocamlopt.byte-build-env;
    flags = "-extension mode_alpha";
@@ -21,27 +17,15 @@ strongest instead of legacy *)
     ocamlopt.byte;
 
     module = "use_portable.ml";
-
-    ocamlopt_byte_exit_status = "0";
-    ocamlopt.byte;
-   }
-
-   {
-    src = "def_nonportable.ml";
-    dst = "maybe_portable.ml";
-    copy;
-
-    module = "maybe_portable.ml";
-    ocamlopt_byte_exit_status = "0";
-    ocamlopt.byte;
-
-    module = "use_portable.ml";
-    compiler_output = "use_portable.bad.output";
+    compiler_output = "use_portable.output";
     ocamlopt_byte_exit_status = "2";
     ocamlopt.byte;
 
-    compiler_reference = "use_portable.bad.reference";
+    compiler_reference = "use_portable.reference";
     check-ocamlopt.byte-output;
     }
 }
 *)
+
+(* We test that cmi generated without mli has the modalities pushed to the
+legacy instead of strongest *)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3801,10 +3801,10 @@ let type_implementation target modulename initial_env ast =
           in
           check_nongen_signature finalenv simple_sg;
           let simple_sg =
-            (* Generating [cmi] without [mli]. This [cmi] will only be on the
-               LHS of inclusion check, so we zap to floor (strongest). *)
+            (* Generating [cmi] without [mli]. This [cmi] could be on either side of
+              inclusion check, so we zap to identity for legacy compatibility. *)
             remove_modality_and_zero_alloc_variables_sg finalenv
-              ~zap_modality:Mode.Modality.Value.zap_to_floor simple_sg
+              ~zap_modality:Mode.Modality.Value.zap_to_id simple_sg
           in
           normalize_signature simple_sg;
           let argument_interface =


### PR DESCRIPTION
For `.ml` files without a corresponding `.mli`, previously we thought the generated `.cmi` will only be on the LHS of inclusion check, and therefore it's always better to infer the strongest modalities. This is obviously wrong, because another module could invoke `module type of` on the `.cmi` and use it on RHS of inclusion check. This has broken legacy code in practice.

This PR therefore zaps modalitites to identity, which is more legacy compatible.

Side note: In the future we should add two flags to override the default behavior:
- one flag on mli-less files, to indicate the direction of zapping when exporting `cmx`. It should error if `.mli` exists:
```
[@@@zap_modalities_to_floor]
(rest of the ml file)
``` 
- One flag on `module type of`, to indicate the direction of zapping when calculating the module type. It should error if the module already has a user-annotated module type:
```
module M = struct
  ...
end

module type S = module type of M [@@zap_modalities_to_floor]
```