### PR TITLE
Make `Linear` independent of `Mach`

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -25,8 +25,14 @@ emitaux.ml
 emitaux.mli
 generic_fns.ml
 generic_fns.mli
+operation.ml
+operation.mli
 peephole/**/*.ml
 peephole/**/*.mli
+printoperation.ml
+printoperation.mli
+printreg.ml
+printreg.mli
 regalloc/**/*.ml
 regalloc/**/*.mli
 select_utils.ml

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -68,7 +68,7 @@ class cfg_cse = object
   inherit Cfg_cse.cse_generic as super
 
   method! class_of_operation
-  : Cfg.operation -> op_class
+  : Operation.t -> op_class
   = fun op ->
   match op with
     | Specific spec ->

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -25,7 +25,7 @@ let specific x =
   Cfg_selectgen.Basic (Op (Specific x))
 
 let pseudoregs_for_operation op arg res =
-  match (op : Cfg.operation) with
+  match (op : Operation.t) with
   (* Two-address binary operations: arg.(0) and res.(0) must be the same *)
   | Intop (Iadd | Isub | Imul | Iand | Ior | Ixor)
   | Floatop ((Float32 | Float64), (Iaddf | Isubf | Imulf | Idivf)) ->

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -25,7 +25,6 @@ open Arch
 open Proc
 open Reg
 open Simple_operation
-open Mach
 open Linear
 open Emitaux
 

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1325,9 +1325,9 @@ let emit_instr ~first ~fallthrough i =
         cfi_adjust_cfa_offset n;
       end;
     end
-  | Lop(Imove | Ispill | Ireload) ->
+  | Lop(Move | Spill | Reload) ->
       move i.arg.(0) i.res.(0)
-  | Lop(Iconst_int n) ->
+  | Lop(Const_int n) ->
       if n = 0n then begin
         match i.res.(0).loc with
         | Reg _ ->
@@ -1346,7 +1346,7 @@ let emit_instr ~first ~fallthrough i =
           I.mov (nat n) (res i 0)
       end else
         I.mov (nat n) (res i 0)
-  | Lop(Iconst_float32 f) ->
+  | Lop(Const_float32 f) ->
       begin match f with
       | 0x0000_0000l ->       (* +0.0 *)
           I.xorpd (res i 0) (res i 0)
@@ -1355,7 +1355,7 @@ let emit_instr ~first ~fallthrough i =
           let lbl = add_float_constant (Int64.of_int32 f) in
           I.movss (mem64_rip REAL4 (emit_label lbl)) (res i 0)
       end
-  | Lop(Iconst_float f) ->
+  | Lop(Const_float f) ->
       begin match f with
       | 0x0000_0000_0000_0000L ->       (* +0.0 *)
           I.xorpd (res i 0) (res i 0)
@@ -1363,7 +1363,7 @@ let emit_instr ~first ~fallthrough i =
           let lbl = add_float_constant f in
           I.movsd (mem64_rip REAL8 (emit_label lbl)) (res i 0)
       end
-  | Lop(Iconst_vec128 {high; low}) ->
+  | Lop(Const_vec128 {high; low}) ->
       begin match (high, low) with
       | 0x0000_0000_0000_0000L, 0x0000_0000_0000_0000L ->
           I.xorpd (res i 0) (res i 0)
@@ -1371,19 +1371,19 @@ let emit_instr ~first ~fallthrough i =
           let lbl = add_vec128_constant {high; low} in
           I.movapd (mem64_rip VEC128 (emit_label lbl)) (res i 0)
       end
-  | Lop(Iconst_symbol s) ->
+  | Lop(Const_symbol s) ->
       add_used_symbol s.sym_name;
       load_symbol_addr s (res i 0)
-  | Lop(Icall_ind) ->
+  | Lcall_op(Lcall_ind) ->
       I.call (arg i 0);
       record_frame i.live (Dbg_other i.dbg)
-  | Lop(Icall_imm { func; }) ->
+  | Lcall_op(Lcall_imm { func; }) ->
       add_used_symbol func.sym_name;
       emit_call func;
       record_frame i.live (Dbg_other i.dbg)
-  | Lop(Itailcall_ind) ->
+  | Lcall_op(Ltailcall_ind) ->
       output_epilogue (fun () -> I.jmp (arg i 0))
-  | Lop(Itailcall_imm { func; }) ->
+  | Lcall_op(Ltailcall_imm { func; }) ->
       begin
         if func.sym_name = !function_name then
           match !tailrec_entry_point with
@@ -1396,7 +1396,7 @@ let emit_instr ~first ~fallthrough i =
           end
         end
       end
-  | Lop(Iextcall { func; alloc; stack_ofs }) ->
+  | Lcall_op(Lextcall { func; alloc; stack_ofs }) ->
       add_used_symbol func;
       if Config.runtime5 && stack_ofs > 0 then begin
         I.mov rsp r13;
@@ -1435,10 +1435,10 @@ let emit_instr ~first ~fallthrough i =
           I.mov rbx rsp;
           cfi_restore_state ();
         end;
-      end
-  | Lop(Istackoffset n) ->
+           end
+  | Lop(Stackoffset n) ->
       emit_stack_offset n
-  | Lop(Iload { memory_chunk; addressing_mode; _ }) ->
+  | Lop(Load { memory_chunk; addressing_mode; _ }) ->
       let dest = res i 0 in
       begin match memory_chunk with
       | Word_int | Word_val ->
@@ -1466,7 +1466,7 @@ let emit_instr ~first ~fallthrough i =
       | Double ->
           I.movsd (addressing addressing_mode REAL8 i 0) dest
       end
-  | Lop(Istore(chunk, addr, _)) ->
+  | Lop(Store(chunk, addr, _)) ->
       begin match chunk with
       | Word_int | Word_val ->
           I.mov (arg i 0) (addressing addr QWORD i 1)
@@ -1488,7 +1488,7 @@ let emit_instr ~first ~fallthrough i =
       | Double ->
           I.movsd (arg i 0) (addressing addr REAL8 i 1)
       end
-  | Lop(Ialloc { bytes = n; dbginfo; mode = Heap }) ->
+  | Lop(Alloc { bytes = n; dbginfo; mode = Heap }) ->
       assert (n <= (Config.max_young_wosize + 1) * Arch.size_addr);
       if !fastcode_flag then begin
         I.sub (int n) r15;
@@ -1519,7 +1519,7 @@ let emit_instr ~first ~fallthrough i =
         def_label label;
         I.lea (mem64 NONE 8 R15) (res i 0)
       end
-  | Lop(Ialloc { bytes = n; dbginfo=_; mode = Local }) ->
+  | Lop(Alloc { bytes = n; dbginfo=_; mode = Local }) ->
       let r = res i 0 in
       I.mov (domain_field Domainstate.Domain_local_sp) r;
       I.sub (int n) r;
@@ -1535,71 +1535,63 @@ let emit_instr ~first ~fallthrough i =
         { lr_lbl = lbl_call;
           lr_dbg = i.dbg;
           lr_return_lbl = lbl_after_alloc } :: !local_realloc_sites
-  | Lop(Ipoll { return_label }) ->
+  | Lop (Poll) ->
       I.cmp (domain_field Domainstate.Domain_young_limit) r15;
       let gc_call_label = new_label () in
-      let lbl_after_poll = match return_label with
-                  | None -> new_label()
-                  | Some(lbl) -> lbl in
+      let lbl_after_poll = new_label() in
       let lbl_frame =
         record_frame_label i.live (Dbg_alloc [])
       in
-      begin match return_label with
-      | None -> I.jbe (label gc_call_label)
-      | Some return_label -> I.ja (label return_label)
-      end;
+      I.jbe (label gc_call_label);
       call_gc_sites :=
         { gc_lbl = gc_call_label;
           gc_return_lbl = lbl_after_poll;
           gc_dbg = i.dbg;
           gc_frame = lbl_frame; } :: !call_gc_sites;
-      begin match return_label with
-      | None -> def_label lbl_after_poll
-      | Some _ -> I.jmp (label gc_call_label)
-      end
-  | Lop(Iintop(Icomp cmp)) ->
+      def_label lbl_after_poll
+  | Lop(Intop(Icomp cmp)) ->
       I.cmp (arg i 1) (arg i 0);
       I.set (cond cmp) al;
       I.movzx al (res i 0)
-  | Lop(Iintop_imm(Icomp cmp, n)) ->
+  | Lop(Intop_imm(Icomp cmp, n)) ->
       I.cmp (int n) (arg i 0);
       I.set (cond cmp) al;
       I.movzx al (res i 0)
-  | Lop(Iintop_imm (Iand, n)) when n >= 0 && n <= 0xFFFF_FFFF && Reg.is_reg i.res.(0) ->
+  | Lop(Intop_imm (Iand, n)) when n >= 0 && n <= 0xFFFF_FFFF && Reg.is_reg i.res.(0) ->
       I.and_ (int n) (res32 i 0)
-  | Lop(Iintop Ixor) when i.arg.(1).loc = i.res.(0).loc && Reg.is_reg i.res.(0) ->
+  | Lop(Intop Ixor) when i.arg.(1).loc = i.res.(0).loc && Reg.is_reg i.res.(0) ->
       I.xor (res32 i 0) (res32 i 0)
-  | Lop(Iintop(Idiv | Imod)) ->
+  | Lop(Intop(Idiv | Imod)) ->
       I.cqo ();
       I.idiv (arg i 1)
-  | Lop(Iintop(Ilsl | Ilsr | Iasr as op)) ->
+  | Lop(Intop(Ilsl | Ilsr | Iasr as op)) ->
       (* We have i.arg.(0) = i.res.(0) and i.arg.(1) = %rcx *)
       instr_for_intop op cl (res i 0)
-  | Lop(Iintop (Imulh { signed = true })) ->
+  | Lop(Intop (Imulh { signed = true })) ->
       I.imul (arg i 1) None
-  | Lop(Iintop (Imulh { signed = false })) ->
+  | Lop(Intop (Imulh { signed = false })) ->
       I.mul (arg i 1)
-  | Lop(Iintop ((Iadd|Isub|Imul|Iand|Ior|Ixor) as op)) ->
+  | Lop(Intop ((Iadd|Isub|Imul|Iand|Ior|Ixor) as op)) ->
       (* We have i.arg.(0) = i.res.(0) *)
       instr_for_intop op (arg i 1) (res i 0)
-  | Lop(Iintop_imm(Iadd, n)) when i.arg.(0).loc <> i.res.(0).loc ->
+  | Lop(Intop_imm(Iadd, n)) when i.arg.(0).loc <> i.res.(0).loc ->
       I.lea (mem64 NONE n (arg64 i 0)) (res i 0)
-  | Lop(Iintop_imm(Iadd, 1) | Iintop_imm(Isub, -1)) ->
+  | Lop(Intop_imm(Iadd, 1) | Intop_imm(Isub, -1)) ->
       I.inc (res i 0)
-  | Lop(Iintop_imm(Iadd, -1) | Iintop_imm(Isub, 1)) ->
+  | Lop(Intop_imm(Iadd, -1) | Intop_imm(Isub, 1)) ->
       I.dec (res i 0)
-  | Lop(Iintop_imm(op, n)) ->
+  | Lop(Intop_imm(op, n)) ->
       (* We have i.arg.(0) = i.res.(0) *)
       instr_for_intop op (int n) (res i 0)
-  | Lop(Iintop_atomic{op; size; addr}) ->
+  | Lop(Intop_atomic{op; size; addr}) ->
       emit_atomic i op size addr
-  | Lop(Ifloatop(Float64, Icompf cmp)) ->
+  | Lop(Floatop(Float64, Icompf cmp)) ->
       let cond, need_swap = float_cond_and_need_swap cmp in
       let a0, a1 = if need_swap then arg i 1, arg i 0 else arg i 0, arg i 1 in
       I.cmpsd cond a1 a0;
       I.movq a0 (res i 0);
       I.neg (res i 0)
-  | Lop(Ifloatop(Float32, Icompf cmp)) ->
+  | Lop(Floatop(Float32, Icompf cmp)) ->
       let cond, need_swap = float_cond_and_need_swap cmp in
       let a0, a1 = if need_swap then arg i 1, arg i 0 else arg i 0, arg i 1 in
       I.cmpss cond a1 a0;
@@ -1608,40 +1600,40 @@ let emit_instr ~first ~fallthrough i =
          copy the result to the top 32 bits. *)
       I.movsxd (res32 i 0) (res i 0);
       I.neg (res i 0)
-  | Lop(Ifloatop(Float64, Inegf)) ->
+  | Lop(Floatop(Float64, Inegf)) ->
       I.xorpd (mem64_rip VEC128 (emit_symbol "caml_negf_mask")) (res i 0)
-  | Lop(Ifloatop(Float64, Iabsf)) ->
+  | Lop(Floatop(Float64, Iabsf)) ->
       I.andpd (mem64_rip VEC128 (emit_symbol "caml_absf_mask")) (res i 0)
-  | Lop(Ifloatop(Float32, Inegf)) ->
+  | Lop(Floatop(Float32, Inegf)) ->
       I.xorps (mem64_rip VEC128 (emit_symbol "caml_negf32_mask")) (res i 0)
-  | Lop(Ifloatop(Float32, Iabsf)) ->
+  | Lop(Floatop(Float32, Iabsf)) ->
       I.andps (mem64_rip VEC128 (emit_symbol "caml_absf32_mask")) (res i 0)
-  | Lop(Ifloatop(width, (Iaddf | Isubf | Imulf | Idivf as floatop))) ->
+  | Lop(Floatop(width, (Iaddf | Isubf | Imulf | Idivf as floatop))) ->
       instr_for_floatop width floatop (arg i 1) (res i 0)
-  | Lop(Iopaque) ->
+  | Lop(Opaque) ->
       assert (i.arg.(0).loc = i.res.(0).loc)
-  | Lop(Ispecific(Ilea addr)) ->
+  | Lop(Specific(Ilea addr)) ->
       I.lea (addressing addr NONE i 0) (res i 0)
-  | Lop(Ispecific(Istore_int(n, addr, _))) ->
+  | Lop(Specific(Istore_int(n, addr, _))) ->
       I.mov (nat n) (addressing addr QWORD i 0)
-  | Lop(Ispecific(Ioffset_loc(n, addr))) ->
+  | Lop(Specific(Ioffset_loc(n, addr))) ->
       I.add (int n) (addressing addr QWORD i 0)
-  | Lop(Ispecific(Ifloatarithmem(Float64, op, addr))) ->
+  | Lop(Specific(Ifloatarithmem(Float64, op, addr))) ->
       instr_for_floatarithmem Float64 op (addressing addr REAL8 i 1) (res i 0)
-  | Lop(Ispecific(Ifloatarithmem(Float32, op, addr))) ->
+  | Lop(Specific(Ifloatarithmem(Float32, op, addr))) ->
       instr_for_floatarithmem Float32 op (addressing addr REAL4 i 1) (res i 0)
-  | Lop(Ispecific(Ibswap { bitwidth = Sixteen })) ->
+  | Lop(Specific(Ibswap { bitwidth = Sixteen })) ->
       I.xchg ah al;
       I.movzx (res16 i 0) (res i 0)
-  | Lop(Ispecific(Ibswap { bitwidth = Thirtytwo })) ->
+  | Lop(Specific(Ibswap { bitwidth = Thirtytwo })) ->
       I.bswap (res32 i 0);
-  | Lop(Ispecific(Ibswap { bitwidth = Sixtyfour })) ->
+  | Lop(Specific(Ibswap { bitwidth = Sixtyfour })) ->
       I.bswap (res i 0)
-  | Lop(Ispecific(Isextend32)) ->
+  | Lop(Specific(Isextend32)) ->
       I.movsxd (arg32 i 0) (res i 0)
-  | Lop(Ispecific(Izextend32)) ->
+  | Lop(Specific(Izextend32)) ->
       I.mov (arg32 i 0) (res32 i 0)
-  | Lop(Iintop(Iclz { arg_is_non_zero; })) ->
+  | Lop(Intop(Iclz { arg_is_non_zero; })) ->
       (* CR-someday gyorsh: can we do it at selection?
          mshinwell: We need to address this and the similar CRs below.
          My feeling is that we should try to do this earlier, based on
@@ -1666,7 +1658,7 @@ let emit_instr ~first ~fallthrough i =
         I.mov (int 64) (res i 0);
         def_label lbl_nz
       end
-  | Lop(Iintop(Ictz { arg_is_non_zero; })) ->
+  | Lop(Intop(Ictz { arg_is_non_zero; })) ->
     (* CR-someday gyorsh: can we do it at selection? *)
     if Arch.Extension.enabled BMI then begin
       I.tzcnt (arg i 0) (res i 0)
@@ -1680,10 +1672,10 @@ let emit_instr ~first ~fallthrough i =
       I.mov (int 64) (res i 0);
       def_label lbl_nz
     end
-  | Lop(Iintop Ipopcnt) ->
+  | Lop(Intop Ipopcnt) ->
       assert (Arch.Extension.enabled POPCNT);
       I.popcnt (arg i 0) (res i 0)
-  | Lop(Icsel tst) ->
+  | Lop(Csel tst) ->
     let len = Array.length i.arg in
     let ifso = i.arg.(len - 2) in
     let ifnot = i.arg.(len - 1) in
@@ -1692,7 +1684,7 @@ let emit_instr ~first ~fallthrough i =
       I.cmov c (reg ifso) (res i 0)
     in
     emit_test i tst ~taken
-  | Lop(Ispecific Irdtsc) ->
+  | Lop(Specific Irdtsc) ->
     I.rdtsc ();
     let rdx = Reg64 RDX in
     (* The instruction fills in the low 32 bits of the result registers. *)
@@ -1707,7 +1699,7 @@ let emit_instr ~first ~fallthrough i =
        (* combine high and low into res *)
        I.mov rax (res i 0);
        I.or_ rdx (res i 0))
-  | Lop(Ispecific Irdpmc) ->
+  | Lop(Specific Irdpmc) ->
     assert (arg64 i 0 = RCX);
     I.rdpmc ();
     let rdx = Reg64 RDX in
@@ -1716,23 +1708,23 @@ let emit_instr ~first ~fallthrough i =
     I.sal (int 32) rdx; (* shift edx to the high part of rdx *)
     I.mov eax (res32 i 0); (* zero-extend eax *)
     I.or_ rdx (res i 0) (* combine high and low into rax *)
-  | Lop (Ispecific Ilfence) ->
+  | Lop (Specific Ilfence) ->
     I.lfence ()
-  | Lop (Ispecific Isfence) ->
+  | Lop (Specific Isfence) ->
     I.sfence ()
-  | Lop (Ispecific Imfence) ->
+  | Lop (Specific Imfence) ->
     I.mfence ()
-  | Lop (Ispecific (Isimd op)) ->
+  | Lop (Specific (Isimd op)) ->
     emit_simd_instr op i
-  | Lop (Istatic_cast cast) ->
+  | Lop (Static_cast cast) ->
     emit_static_cast cast i
-  | Lop (Ireinterpret_cast cast) ->
+  | Lop (Reinterpret_cast cast) ->
     emit_reinterpret_cast cast i
-  | Lop (Ispecific Ipause) ->
+  | Lop (Specific Ipause) ->
     I.pause ()
-  | Lop (Ispecific (Icldemote addr)) ->
+  | Lop (Specific (Icldemote addr)) ->
     I.cldemote (addressing addr QWORD i 0)
-  | Lop (Ispecific (Iprefetch { is_write; locality; addr; })) ->
+  | Lop (Specific (Iprefetch { is_write; locality; addr; })) ->
     let locality =
       match locality with
       | Nonlocal -> Nta
@@ -1741,12 +1733,12 @@ let emit_instr ~first ~fallthrough i =
       | High -> T0
     in
     I.prefetch is_write locality (addressing addr QWORD i 0)
-  | Lop(Ibeginregion) ->
+  | Lop(Begin_region) ->
       I.mov (domain_field Domainstate.Domain_local_sp) (res i 0)
-  | Lop(Iendregion) ->
+  | Lop(End_region) ->
       I.mov (arg i 0) (domain_field Domainstate.Domain_local_sp)
-  | Lop (Iname_for_debugger _) -> ()
-  | Lop (Iprobe { enabled_at_init; _ }) ->
+  | Lop (Name_for_debugger _) -> ()
+  | Lcall_op (Lprobe { enabled_at_init; _ }) ->
     let probe_label = new_label () in
     let probe =
       { probe_label;
@@ -1762,8 +1754,8 @@ let emit_instr ~first ~fallthrough i =
        intervening wrapper that deals with getting the arguments to the probe
        in the correct place and managing the spilling/reloading of live
        registers.  See [emit_probe_handler_wrapper] below. *)
-    emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label
-  | Lop (Iprobe_is_enabled { name; }) ->
+                                    emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label
+  | Lop (Probe_is_enabled { name; }) ->
     let semaphore_sym = find_or_add_semaphore name None i.dbg in
     (* Load unsigned 2-byte integer value of the semaphore.
        According to the documentation [1],
@@ -1779,7 +1771,7 @@ let emit_instr ~first ~fallthrough i =
     I.cmp (int 0) (res16 i 0);
     I.set (cond (Iunsigned Cne)) (res8 i 0);
     I.movzx (res8 i 0) (res i 0)
-  | Lop (Idls_get) ->
+  | Lop (Dls_get) ->
     if Config.runtime5
     then I.mov (domain_field Domainstate.Domain_dls_root) (res i 0)
     else Misc.fatal_error "Dls is not supported in runtime4.";
@@ -2167,8 +2159,8 @@ let emit_probe_handler_wrapper p =
   let wrap_label = probe_handler_wrapper_name p.probe_label in
   let probe_name, handler_code_sym =
     match p.probe_insn.desc with
-    | Lop (Iprobe { name; handler_code_sym; enabled_at_init = _; }) ->
-      name, handler_code_sym
+    | Lcall_op (Lprobe { name; handler_code_sym; enabled_at_init = _; }) ->
+       name, handler_code_sym
     | _ -> assert false
   in
   (* Restore stack frame info as it was at the probe site, so we can easily
@@ -2326,8 +2318,8 @@ let emit_probe_notes0 () =
   let describe_one_probe p =
     let probe_name, enabled_at_init =
       match p.probe_insn.desc with
-      | Lop (Iprobe { name; enabled_at_init; handler_code_sym=_; }) ->
-        name, enabled_at_init
+      | Lcall_op (Lprobe { name; enabled_at_init; handler_code_sym=_; }) ->
+         name, enabled_at_init
       | _ -> assert false
     in
     let args =

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1753,7 +1753,7 @@ let emit_instr ~first ~fallthrough i =
        intervening wrapper that deals with getting the arguments to the probe
        in the correct place and managing the spilling/reloading of live
        registers.  See [emit_probe_handler_wrapper] below. *)
-                                    emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label
+    emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label
   | Lop (Probe_is_enabled { name; }) ->
     let semaphore_sym = find_or_add_semaphore name None i.dbg in
     (* Load unsigned 2-byte integer value of the semaphore.

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -437,7 +437,7 @@ let select_operation op args =
 
 let select_operation_cfg op args =
   select_simd_instr op args
-  |> Option.map (fun (op, args) -> Cfg.Specific (Isimd op), args)
+  |> Option.map (fun (op, args) -> Operation.Specific (Isimd op), args)
 
 let pseudoregs_for_operation op arg res =
   let rax = Proc.phys_reg Int 0 in

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -28,7 +28,6 @@ open Arch
 open Proc
 open Reg
 open Simple_operation
-open Mach
 open Linear
 open Emitaux
 

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -415,14 +415,14 @@ let num_call_gc_points instr =
   let rec loop instr call_gc =
     match instr.desc with
     | Lend -> call_gc
-    | Lop (Ialloc { mode = Heap; _ }) when !fastcode_flag ->
+    | Lop (Alloc { mode = Heap; _ }) when !fastcode_flag ->
       loop instr.next (call_gc + 1)
-    | Lop (Ipoll _) ->
+    | Lop Poll ->
       loop instr.next (call_gc + 1)
     (* The following four should never be seen, since this function is run
        before branch relaxation. *)
-    | Lop (Ispecific (Ifar_alloc _))
-    | Lop (Ispecific (Ifar_poll _)) -> assert false
+    | Lop (Specific (Ifar_alloc _))
+    | Lop (Specific (Ifar_poll _)) -> assert false
     | _ -> loop instr.next call_gc
   in
   loop instr 0
@@ -459,8 +459,8 @@ module BR = Branch_relaxation.Make (struct
       | CB | Bcc -> 1 * 1024 * 1024 / 4  (* +/- 1Mb *)
 
     let classify_instr = function
-      | Lop (Ialloc _)
-      | Lop (Ipoll _) -> Some Bcc
+      | Lop (Alloc _)
+      | Lop Poll -> Some Bcc
       (* The various "far" variants in [specific_operation] don't need to
          return [Some] here, since their code sequences never contain any
          conditional branches that might need relaxing. *)
@@ -487,36 +487,36 @@ module BR = Branch_relaxation.Make (struct
   let instr_size = function
     | Lend -> 0
     | Lprologue -> prologue_size ()
-    | Lop (Imove | Ispill | Ireload) -> 1
-    | Lop (Iconst_int n) ->
+    | Lop (Move | Spill | Reload) -> 1
+    | Lop (Const_int n) ->
       num_instructions_for_intconst n
-    | Lop (Iconst_float32 _) ->
+    | Lop (Const_float32 _) ->
       (* CR mslater: (float32) arm64 *)
       Misc.fatal_error "float32 is not supported on this architecture"
-    | Lop (Iconst_float _) -> 2
-    | Lop (Iconst_symbol _) -> 2
-    | Lop (Iconst_vec128 _) ->
+    | Lop (Const_float _) -> 2
+    | Lop (Const_symbol _) -> 2
+    | Lop (Const_vec128 _) ->
       (* CR mslater: (SIMD) arm64 *)
       Misc.fatal_error "SIMD is not supported on this architecture"
-    | Lop (Iintop_atomic _) ->
+    | Lop (Intop_atomic _) ->
       (* Never generated; builtins are not yet translated to atomics *)
       assert false
-    | Lop (Icall_ind) -> 1
-    | Lop (Icall_imm _) -> 1
-    | Lop (Itailcall_ind) -> epilogue_size ()
-    | Lop (Itailcall_imm { func; _ }) ->
+    | Lcall_op (Lcall_ind) -> 1
+    | Lcall_op (Lcall_imm _) -> 1
+    | Lcall_op (Ltailcall_ind) -> epilogue_size ()
+    | Lcall_op (Ltailcall_imm { func; _ }) ->
       if func.sym_name = !function_name then 1 else epilogue_size ()
-    | Lop (Iextcall {alloc; stack_ofs} ) ->
+    | Lcall_op (Lextcall {alloc; stack_ofs} ) ->
       if Config.runtime5 && stack_ofs > 0 then 5
       else if alloc then 3
       else 5
-    | Lop (Istackoffset _) -> 2
-    | Lop (Iload  { memory_chunk; addressing_mode; is_atomic }) ->
+    | Lop (Stackoffset _) -> 2
+    | Lop (Load  { memory_chunk; addressing_mode; is_atomic }) ->
       let based = match addressing_mode with Iindexed _ -> 0 | Ibased _ -> 1
       and barrier = if is_atomic then 1 else 0
       and single = match memory_chunk with Single { reg = Float64 } -> 2 | _ -> 1 in
       based + barrier + single
-    | Lop (Istore (memory_chunk, addressing_mode, assignment)) ->
+    | Lop (Store (memory_chunk, addressing_mode, assignment)) ->
       let based = match addressing_mode with Iindexed _ -> 0 | Ibased _ -> 1
       and barrier =
         match memory_chunk, assignment with
@@ -524,66 +524,66 @@ module BR = Branch_relaxation.Make (struct
         | _ -> 0
       and single = match memory_chunk with Single { reg = Float64 } -> 2 | _ -> 1 in
       based + barrier + single
-    | Lop (Ialloc { mode = Local; _ }) -> 9
-    | Lop (Ialloc _) when !fastcode_flag -> 5
-    | Lop (Ispecific (Ifar_alloc _)) when !fastcode_flag -> 6
-    | Lop (Ipoll _) -> 3
-    | Lop (Ispecific (Ifar_poll _)) -> 4
-    | Lop (Ialloc { bytes = num_bytes; _ })
-    | Lop (Ispecific (Ifar_alloc { bytes = num_bytes; _ })) ->
+    | Lop (Alloc { mode = Local; _ }) -> 9
+    | Lop (Alloc _) when !fastcode_flag -> 5
+    | Lop (Specific (Ifar_alloc _)) when !fastcode_flag -> 6
+    | Lop Poll -> 3
+    | Lop (Specific (Ifar_poll _)) -> 4
+    | Lop (Alloc { bytes = num_bytes; _ })
+    | Lop (Specific (Ifar_alloc { bytes = num_bytes; _ })) ->
       begin match num_bytes with
       | 16 | 24 | 32 -> 1
       | _ -> 1 + num_instructions_for_intconst (Nativeint.of_int num_bytes)
       end
-    | Lop (Icsel _) -> 4
-    | Lop (Ibeginregion | Iendregion) -> 1
-    | Lop (Iintop (Icomp _)) -> 2
-    | Lop (Ifloatop (Float64, Icompf _)) -> 2
-    | Lop (Ifloatop (Float32, Icompf _)) ->
+    | Lop (Csel _) -> 4
+    | Lop (Begin_region | End_region) -> 1
+    | Lop (Intop (Icomp _)) -> 2
+    | Lop (Floatop (Float64, Icompf _)) -> 2
+    | Lop (Floatop (Float32, Icompf _)) ->
       (* CR mslater: (float32) arm64 *)
       Misc.fatal_error "float32 is not supported on this architecture"
-    | Lop (Iintop_imm (Icomp _, _)) -> 2
-    | Lop (Iintop Imod) -> 2
-    | Lop (Iintop (Imulh _)) -> 1
-    | Lop (Iintop _) -> 1
-    | Lop (Iintop_imm _) -> 1
-    | Lop (Ifloatop (Float64, (Iabsf | Inegf)) | Ispecific Isqrtf) -> 1
-    | Lop (Ifloatop (Float32, (Iabsf | Inegf))) ->
+    | Lop (Intop_imm (Icomp _, _)) -> 2
+    | Lop (Intop Imod) -> 2
+    | Lop (Intop (Imulh _)) -> 1
+    | Lop (Intop _) -> 1
+    | Lop (Intop_imm _) -> 1
+    | Lop (Floatop (Float64, (Iabsf | Inegf)) | Specific Isqrtf) -> 1
+    | Lop (Floatop (Float32, (Iabsf | Inegf))) ->
       (* CR mslater: (float32) arm64 *)
       Misc.fatal_error "float32 is not supported on this architecture"
-    | Lop (Ireinterpret_cast (Value_of_int | Int_of_value |
+    | Lop (Reinterpret_cast (Value_of_int | Int_of_value |
                               Float_of_int64 | Int64_of_float)) -> 1
-    | Lop (Ireinterpret_cast (Float32_of_float | Float_of_float32 |
+    | Lop (Reinterpret_cast (Float32_of_float | Float_of_float32 |
                               Float32_of_int32 | Int32_of_float32)) ->
       (* CR mslater: (float32) arm64 *)
       Misc.fatal_error "float32 is not supported on this architecture"
-    | Lop (Ireinterpret_cast V128_of_v128) ->
+    | Lop (Reinterpret_cast V128_of_v128) ->
       (* CR mslater: (SIMD) arm64 *)
       Misc.fatal_error "SIMD is not supported on this architecture"
-    | Lop (Istatic_cast (Float_of_int Float64 | Int_of_float Float64)) -> 1
-    | Lop (Istatic_cast (Float_of_int Float32 | Int_of_float Float32 |
+    | Lop (Static_cast (Float_of_int Float64 | Int_of_float Float64)) -> 1
+    | Lop (Static_cast (Float_of_int Float32 | Int_of_float Float32 |
                          Float_of_float32 | Float32_of_float)) ->
       (* CR mslater: (float32) arm64 *)
       Misc.fatal_error "float32 is not supported on this architecture"
-    | Lop (Istatic_cast (V128_of_scalar _ | Scalar_of_v128 _)) ->
+    | Lop (Static_cast (V128_of_scalar _ | Scalar_of_v128 _)) ->
       (* CR mslater: (SIMD) arm64 *)
       Misc.fatal_error "SIMD is not supported on this architecture"
-    | Lop (Ifloatop (Float64, (Iaddf | Isubf | Imulf | Idivf)) | Ispecific Inegmulf) -> 1
-    | Lop (Ifloatop (Float32, (Iaddf | Isubf | Imulf | Idivf))) ->
+    | Lop (Floatop (Float64, (Iaddf | Isubf | Imulf | Idivf)) | Specific Inegmulf) -> 1
+    | Lop (Floatop (Float32, (Iaddf | Isubf | Imulf | Idivf))) ->
       (* CR mslater: (float32) arm64 *)
       Misc.fatal_error "float32 is not supported on this architecture"
-    | Lop (Iopaque) -> 0
-    | Lop (Ispecific (Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf)) -> 1
-    | Lop (Ispecific (Ishiftarith _)) -> 1
-    | Lop (Ispecific (Imuladd | Imulsub)) -> 1
-    | Lop (Ispecific (Ibswap { bitwidth = Sixteen } )) -> 2
-    | Lop (Ispecific (Ibswap { bitwidth = (Thirtytwo | Sixtyfour) })) -> 1
-    | Lop (Ispecific Imove32) -> 1
-    | Lop (Ispecific (Isignext _)) -> 1
-    | Lop (Iname_for_debugger _) -> 0
-    | Lop (Iprobe _ | Iprobe_is_enabled _) ->
+    | Lop (Opaque) -> 0
+    | Lop (Specific (Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf)) -> 1
+    | Lop (Specific (Ishiftarith _)) -> 1
+    | Lop (Specific (Imuladd | Imulsub)) -> 1
+    | Lop (Specific (Ibswap { bitwidth = Sixteen } )) -> 2
+    | Lop (Specific (Ibswap { bitwidth = (Thirtytwo | Sixtyfour) })) -> 1
+    | Lop (Specific Imove32) -> 1
+    | Lop (Specific (Isignext _)) -> 1
+    | Lop (Name_for_debugger _) -> 0
+    | Lcall_op (Lprobe _) | Lop (Probe_is_enabled _) ->
       fatal_error ("Probes not supported.")
-    | Lop (Idls_get) -> 1
+    | Lop (Dls_get) -> 1
     | Lreloadretaddr -> 0
     | Lreturn -> epilogue_size ()
     | Llabel _ -> 0
@@ -616,10 +616,10 @@ module BR = Branch_relaxation.Make (struct
     | Lstackcheck _ -> 5
 
   let relax_poll ~return_label =
-    Lop (Ispecific (Ifar_poll { return_label }))
+    Lop (Specific (Ifar_poll { return_label }))
 
   let relax_allocation ~num_bytes ~dbginfo =
-    Lop (Ispecific (Ifar_alloc { bytes = num_bytes; dbginfo }))
+    Lop (Specific (Ifar_alloc { bytes = num_bytes; dbginfo }))
 end)
 
 let name_for_float_comparison = function
@@ -784,28 +784,28 @@ let emit_instr i =
         cfi_offset ~reg:30 (* return address *) ~offset:(-8);
         `	str	x30, [sp, #{emit_int (n-8)}]\n`
       end
-    | Lop(Iintop_atomic _) ->
+    | Lop(Intop_atomic _) ->
       (* Never generated; builtins are not yet translated to atomics *)
       assert false
-    | Lop (Ireinterpret_cast (Int64_of_float | Float_of_int64)) ->
+    | Lop (Reinterpret_cast (Int64_of_float | Float_of_int64)) ->
         `	fmov {emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
-    | Lop(Istatic_cast (Int_of_float Float64)) ->
+    | Lop(Static_cast (Int_of_float Float64)) ->
         `	fcvtzs {emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
-    | Lop(Istatic_cast (Float_of_int Float64)) ->
+    | Lop(Static_cast (Float_of_int Float64)) ->
         `	scvtf	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
-    | Lop (Ireinterpret_cast (Float32_of_float | Float_of_float32 |
+    | Lop (Reinterpret_cast (Float32_of_float | Float_of_float32 |
                               Int32_of_float32 | Float32_of_int32))
-    | Lop (Istatic_cast (Float_of_int Float32 | Int_of_float Float32 |
+    | Lop (Static_cast (Float_of_int Float32 | Int_of_float Float32 |
                           Float_of_float32 | Float32_of_float)) ->
         (* CR mslater: (float32) arm64 *)
         Misc.fatal_error "float32 not supported on this architecture"
-    | Lop(Ireinterpret_cast V128_of_v128)
-    | Lop(Istatic_cast (V128_of_scalar _ | Scalar_of_v128 _)) ->
+    | Lop(Reinterpret_cast V128_of_v128)
+    | Lop(Static_cast (V128_of_scalar _ | Scalar_of_v128 _)) ->
         (* CR mslater: (SIMD) arm64 *)
         Misc.fatal_error "SIMD is not supported on this architecture"
-    | Lop(Imove | Ispill | Ireload) ->
+    | Lop(Move | Spill | Reload) ->
         move i.arg.(0) i.res.(0)
-    | Lop(Ispecific Imove32) ->
+    | Lop(Specific Imove32) ->
         let src = i.arg.(0) and dst = i.res.(0) in
         if src.loc <> dst.loc then begin
           match (src, dst) with
@@ -818,12 +818,12 @@ let emit_instr i =
           | _ ->
               assert false
         end
-    | Lop(Iconst_int n) ->
+    | Lop(Const_int n) ->
         emit_intconst i.res.(0) n
-    | Lop (Iconst_float32 _) ->
+    | Lop (Const_float32 _) ->
         (* CR mslater: (float32) arm64 *)
         Misc.fatal_error "float32 is not supported on this architecture"
-    | Lop(Iconst_float f) ->
+    | Lop(Const_float f) ->
         if f = 0L then
           `	fmov	{emit_reg i.res.(0)}, xzr\n`
         else if is_immediate_float f then
@@ -832,27 +832,27 @@ let emit_instr i =
           let lbl = float_literal f in
           emit_load_literal i.res.(0) lbl
         end
-    | Lop(Iconst_vec128 _) ->
+    | Lop(Const_vec128 _) ->
         (* CR mslater: (SIMD) arm64 *)
         Misc.fatal_error "SIMD is not supported on this architecture"
-    | Lop(Iconst_symbol s) ->
+    | Lop(Const_symbol s) ->
         emit_load_symbol_addr i.res.(0) s.sym_name
-    | Lop(Icall_ind) ->
+    | Lcall_op(Lcall_ind) ->
         `	blr	{emit_reg i.arg.(0)}\n`;
         `{record_frame i.live (Dbg_other i.dbg)}\n`
-    | Lop(Icall_imm { func; }) ->
+    | Lcall_op(Lcall_imm { func; }) ->
         `	bl	{emit_symbol func.sym_name}\n`;
         `{record_frame i.live (Dbg_other i.dbg)}\n`
-    | Lop(Itailcall_ind) ->
+    | Lcall_op(Ltailcall_ind) ->
         output_epilogue (fun () -> `	br	{emit_reg i.arg.(0)}\n`)
-    | Lop(Itailcall_imm { func; }) ->
+    | Lcall_op(Ltailcall_imm { func; }) ->
         if func.sym_name = !function_name then
           match !tailrec_entry_point with
           | None -> Misc.fatal_error "jump to missing tailrec entry point"
           | Some tailrec_entry_point -> `	b	{emit_label tailrec_entry_point}\n`
         else
           output_epilogue (fun () -> `	b	{emit_symbol func.sym_name}\n`)
-    | Lop(Iextcall {func; alloc; stack_ofs}) ->
+    | Lcall_op(Lextcall {func; alloc; stack_ofs}) ->
         if Config.runtime5 && stack_ofs > 0 then begin
           `	mov	{emit_reg reg_stack_arg_begin}, sp\n`;
           `	add	{emit_reg reg_stack_arg_end}, sp, #{emit_int (Misc.align stack_ofs 16)}\n`;
@@ -881,11 +881,11 @@ let emit_instr i =
           end;
           cfi_restore_state ()
         end
-    | Lop(Istackoffset n) ->
+    | Lop(Stackoffset n) ->
         assert (n mod 16 = 0);
         emit_stack_adjustment (-n);
         stack_offset := !stack_offset + n
-    | Lop(Iload { memory_chunk; addressing_mode; is_atomic }) ->
+    | Lop(Load { memory_chunk; addressing_mode; is_atomic }) ->
         assert(memory_chunk = Word_int || memory_chunk = Word_val || is_atomic = false);
         let dst = i.res.(0) in
         let base =
@@ -927,7 +927,7 @@ let emit_instr i =
             (* CR mslater: (SIMD) arm64 *)
             fatal_error "arm64: got 128 bit memory chunk"
         end
-    | Lop(Istore(size, addr, assignment)) ->
+    | Lop(Store(size, addr, assignment)) ->
       (* NB: assignments other than Word_int and Word_val do not follow the
       Multicore OCaml memory model and so do not emit a barrier *)
       let src = i.arg.(0) in
@@ -961,63 +961,63 @@ let emit_instr i =
             (* CR mslater: (SIMD) arm64 *)
             fatal_error "arm64: got 128 bit memory chunk"
         end
-    | Lop(Ialloc { bytes = n; dbginfo; mode = Heap }) ->
+    | Lop(Alloc { bytes = n; dbginfo; mode = Heap }) ->
         assembly_code_for_allocation i ~n ~local:false ~far:false ~dbginfo
-    | Lop(Ispecific (Ifar_alloc { bytes = n; dbginfo })) ->
+    | Lop(Specific (Ifar_alloc { bytes = n; dbginfo })) ->
         assembly_code_for_allocation i ~n ~local:false ~far:true ~dbginfo
-    | Lop(Ialloc { bytes = n; dbginfo; mode = Local }) ->
+    | Lop(Alloc { bytes = n; dbginfo; mode = Local }) ->
         assembly_code_for_allocation i ~n ~local:true ~far:false ~dbginfo
-    | Lop(Ibeginregion) ->
+    | Lop(Begin_region) ->
         let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
         `	ldr	{emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`
-    | Lop(Iendregion) ->
+    | Lop(End_region) ->
         let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
         `	str	{emit_reg i.arg.(0)}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`
-    | Lop(Ipoll { return_label }) ->
-        assembly_code_for_poll i ~far:false ~return_label
-    | Lop(Ispecific (Ifar_poll { return_label })) ->
+    | Lop(Poll) ->
+        assembly_code_for_poll i ~far:false ~return_label:None
+    | Lop(Specific (Ifar_poll { return_label })) ->
         assembly_code_for_poll i ~far:true ~return_label
-    | Lop(Iintop_imm(Iadd, n)) ->
+    | Lop(Intop_imm(Iadd, n)) ->
         emit_addimm i.res.(0) i.arg.(0) n
-    | Lop(Iintop_imm(Isub, n)) ->
+    | Lop(Intop_imm(Isub, n)) ->
         emit_subimm i.res.(0) i.arg.(0) n
-    | Lop(Iintop(Icomp cmp)) ->
+    | Lop(Intop(Icomp cmp)) ->
         `	cmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
         `	cset	{emit_reg i.res.(0)}, {emit_string (name_for_comparison cmp)}\n`
-    | Lop(Ifloatop(Float64, Icompf cmp)) ->
+    | Lop(Floatop(Float64, Icompf cmp)) ->
         let comp = name_for_float_comparison cmp in
         `	fcmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
         `	cset	{emit_reg i.res.(0)}, {emit_string comp}\n`
-    | Lop(Ifloatop(Float32, Icompf _)) ->
+    | Lop(Floatop(Float32, Icompf _)) ->
         (* CR mslater: (float32) arm64 *)
         Misc.fatal_error "float32 is not supported on this architecture"
-    | Lop(Iintop_imm(Icomp cmp, n)) ->
+    | Lop(Intop_imm(Icomp cmp, n)) ->
         emit_cmpimm i.arg.(0) n;
         `	cset	{emit_reg i.res.(0)}, {emit_string (name_for_comparison cmp)}\n`
-    | Lop(Iintop Imod) ->
+    | Lop(Intop Imod) ->
         `	sdiv	{emit_reg reg_tmp1}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
         `	msub	{emit_reg i.res.(0)}, {emit_reg reg_tmp1}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(0)}\n`
-    | Lop(Iintop (Imulh { signed = true })) ->
+    | Lop(Intop (Imulh { signed = true })) ->
         `	smulh	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
-    | Lop(Iintop (Imulh { signed = false })) ->
+    | Lop(Intop (Imulh { signed = false })) ->
         `	umulh	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
-    | Lop(Iintop op) ->
+    | Lop(Intop op) ->
         let instr = name_for_int_operation op in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
-    | Lop(Iintop_imm(op, n)) ->
+    | Lop(Intop_imm(op, n)) ->
         let instr = name_for_int_operation op in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, #{emit_int n}\n`
-    | Lop(Ifloatop (Float64, (Iabsf | Inegf)) | Ispecific Isqrtf as op) ->
+    | Lop(Floatop (Float64, (Iabsf | Inegf)) | Specific Isqrtf as op) ->
         let instr = (match op with
-                     | Ifloatop (Float64, Iabsf) -> "fabs"
-                     | Ifloatop (Float64, Inegf) -> "fneg"
-                     | Ispecific Isqrtf          -> "fsqrt"
-                     | _                         -> assert false) in
+                     | Floatop (Float64, Iabsf) -> "fabs"
+                     | Floatop (Float64, Inegf) -> "fneg"
+                     | Specific Isqrtf          -> "fsqrt"
+                     | _                        -> assert false) in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
-    | Lop(Ifloatop (Float32, (Iabsf | Inegf))) ->
+    | Lop(Floatop (Float32, (Iabsf | Inegf))) ->
         (* CR mslater: (float32) arm64 *)
         Misc.fatal_error "float32 is not supported on this architecture"
-    | Lop(Ireinterpret_cast (Int_of_value | Value_of_int)) ->
+    | Lop(Reinterpret_cast (Int_of_value | Value_of_int)) ->
         let src = i.arg.(0) and dst = i.res.(0) in
         if src.loc <> dst.loc then begin
           match (src, dst) with
@@ -1030,19 +1030,19 @@ let emit_instr i =
           | _ ->
               assert false
         end
-    | Lop(Ifloatop (Float64, (Iaddf | Isubf | Imulf | Idivf)) | Ispecific Inegmulf as op) ->
+    | Lop(Floatop (Float64, (Iaddf | Isubf | Imulf | Idivf)) | Specific Inegmulf as op) ->
         let instr = (match op with
-                     | Ifloatop (Float64, Iaddf) -> "fadd"
-                     | Ifloatop (Float64, Isubf) -> "fsub"
-                     | Ifloatop (Float64, Imulf) -> "fmul"
-                     | Ifloatop (Float64, Idivf) -> "fdiv"
-                     | Ispecific Inegmulf        -> "fnmul"
-                     | _                         -> assert false) in
+                     | Floatop (Float64, Iaddf) -> "fadd"
+                     | Floatop (Float64, Isubf) -> "fsub"
+                     | Floatop (Float64, Imulf) -> "fmul"
+                     | Floatop (Float64, Idivf) -> "fdiv"
+                     | Specific Inegmulf        -> "fnmul"
+                     | _                        -> assert false) in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
-    | Lop(Ifloatop (Float32, (Iaddf | Isubf | Imulf | Idivf))) ->
+    | Lop(Floatop (Float32, (Iaddf | Isubf | Imulf | Idivf))) ->
         (* CR mslater: (float32) arm64 *)
         Misc.fatal_error "float32 is not supported on this architecture"
-    | Lop(Ispecific(Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf as op)) ->
+    | Lop(Specific(Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf as op)) ->
         let instr = (match op with
                      | Imuladdf    -> "fmadd"
                      | Inegmuladdf -> "fnmadd"
@@ -1050,9 +1050,9 @@ let emit_instr i =
                      | Inegmulsubf -> "fnmsub"
                      | _ -> assert false) in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, {emit_reg i.arg.(0)}\n`
-    | Lop(Iopaque) ->
+    | Lop(Opaque) ->
         assert (i.arg.(0).loc = i.res.(0).loc)
-    | Lop(Ispecific(Ishiftarith(op, shift))) ->
+    | Lop(Specific(Ishiftarith(op, shift))) ->
         let instr = (match op with
                        Ishiftadd    -> "add"
                      | Ishiftsub    -> "sub") in
@@ -1060,13 +1060,13 @@ let emit_instr i =
         if shift >= 0
         then `, lsl #{emit_int shift}\n`
         else `, asr #{emit_int (-shift)}\n`
-    | Lop(Ispecific(Imuladd | Imulsub as op)) ->
+    | Lop(Specific(Imuladd | Imulsub as op)) ->
         let instr = (match op with
                        Imuladd -> "madd"
                      | Imulsub -> "msub"
                      | _ -> assert false) in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
-    | Lop(Ispecific(Ibswap { bitwidth })) ->
+    | Lop(Specific(Ibswap { bitwidth })) ->
         begin match bitwidth with
         | Sixteen ->
             `	rev16	{emit_wreg i.res.(0)}, {emit_wreg i.arg.(0)}\n`;
@@ -1076,17 +1076,17 @@ let emit_instr i =
         | Sixtyfour ->
             `	rev	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
         end
-    | Lop(Ispecific(Isignext size)) ->
+    | Lop(Specific(Isignext size)) ->
         `	sbfm	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, #0, #{emit_int (size - 1)}\n`
-    | Lop (Iname_for_debugger _) -> ()
-    | Lop (Iprobe _ | Iprobe_is_enabled _) ->
+    | Lop (Name_for_debugger _) -> ()
+    | Lcall_op (Lprobe _) | Lop (Probe_is_enabled _) ->
       fatal_error ("Probes not supported.")
-    | Lop(Idls_get) ->
+    | Lop(Dls_get) ->
       if Config.runtime5 then
         let offset = Domainstate.(idx_of_field Domain_dls_root) * 8 in
         `	ldr	{emit_reg i.res.(0)}, [{emit_reg reg_domain_state_ptr}, {emit_int offset}]\n`
       else Misc.fatal_error "Dls is not supported in runtime4."
-    | Lop (Icsel tst) ->
+    | Lop (Csel tst) ->
       let len = Array.length i.arg in
       let ifso = i.arg.(len - 2) in
       let ifnot = i.arg.(len - 1) in

--- a/backend/branch_relaxation.ml
+++ b/backend/branch_relaxation.ml
@@ -50,9 +50,9 @@ module Make (T : Branch_relaxation_intf.S) = struct
         T.Cond_branch.max_displacement branch - 12
       in
       match instr.desc with
-      | Lop (Ialloc _)
-      | Lop (Ipoll { return_label = None })
-      | Lop (Ispecific _) ->
+      | Lop (Alloc _)
+      | Lop (Poll)
+      | Lop (Specific _) ->
         (* We assume that any branches eligible for relaxation generated
            by these instructions only branch forward.  We further assume
            that any of these may branch to an out-of-line code block. *)
@@ -63,11 +63,6 @@ module Make (T : Branch_relaxation_intf.S) = struct
         opt_branch_overflows map pc lbl0 max_branch_offset
           || opt_branch_overflows map pc lbl1 max_branch_offset
           || opt_branch_overflows map pc lbl2 max_branch_offset
-      | Lop (Ipoll { return_label = Some lbl }) ->
-        (* A poll-and-branch instruction can branch to the label lbl,
-           but also to an out-of-line code block. *)
-        code_size + max_out_of_line_code_offset - pc >= max_branch_offset
-        || branch_overflows map pc lbl max_branch_offset
       | _ ->
         Misc.fatal_error "Unsupported instruction for branch relaxation"
 
@@ -92,10 +87,9 @@ module Make (T : Branch_relaxation_intf.S) = struct
           fixup did_fix (pc + T.instr_size instr.desc) instr.next
         else
           match instr.desc with
-          | Lop (Ipoll { return_label }) ->
-            instr.desc <- T.relax_poll ~return_label;
-            fixup true (pc + T.instr_size instr.desc) instr.next
-          | Lop (Ialloc { bytes = num_bytes; dbginfo }) ->
+          | Lop (Poll) ->
+             fixup true (pc + T.instr_size instr.desc) instr.next
+          | Lop (Alloc { bytes = num_bytes; dbginfo }) ->
             instr.desc <- T.relax_allocation ~num_bytes ~dbginfo;
             fixup true (pc + T.instr_size instr.desc) instr.next
           | Lcondbranch (test, lbl) ->

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -248,83 +248,10 @@ let register_predecessors_for_all_blocks (t : t) =
 
 (* Printing for debug *)
 
-(* The next 2 functions are copied almost as is from asmcomp/printmach.ml
-   because there is no interface to call them. Eventually this won't be needed
-   when we change cfg to have its own types rather than referring back to mach
-   and cmm. *)
-(* CR-someday gyorsh: implement desc printing, and args/res/dbg, etc, properly,
-   with regs, use the dreaded Format. *)
-
-let intcomp (comp : Simple_operation.integer_comparison) =
-  match comp with
-  | Isigned c -> Printf.sprintf " %ss " (Printcmm.integer_comparison c)
-  | Iunsigned c -> Printf.sprintf " %su " (Printcmm.integer_comparison c)
-
-let intop_atomic (op : Cmm.atomic_op) =
-  match op with Fetch_and_add -> " += " | Compare_and_swap -> " cas "
-
-let intop (op : Simple_operation.integer_operation) =
-  match op with
-  | Iadd -> " + "
-  | Isub -> " - "
-  | Imul -> " * "
-  | Imulh { signed : bool } -> " *h" ^ if signed then " " else "u "
-  | Idiv -> " div "
-  | Imod -> " mod "
-  | Iand -> " & "
-  | Ior -> " | "
-  | Ixor -> " ^ "
-  | Ilsl -> " << "
-  | Ilsr -> " >>u "
-  | Iasr -> " >>s "
-  | Ipopcnt -> " pop "
-  | Iclz _ -> " clz "
-  | Ictz _ -> " ctz "
-  | Icomp cmp -> intcomp cmp
-
-let dump_operation ppf = function
-  | Move -> Format.fprintf ppf "mov"
-  | Spill -> Format.fprintf ppf "spill"
-  | Reload -> Format.fprintf ppf "reload"
-  | Const_int n -> Format.fprintf ppf "const_int %nd" n
-  | Const_float32 f ->
-    Format.fprintf ppf "const_float32 %Fs" (Int32.float_of_bits f)
-  | Const_float f -> Format.fprintf ppf "const_float %F" (Int64.float_of_bits f)
-  | Const_symbol s -> Format.fprintf ppf "const_symbol %s" s.sym_name
-  | Const_vec128 { high; low } ->
-    Format.fprintf ppf "const vec128 %016Lx:%016Lx" high low
-  | Stackoffset n -> Format.fprintf ppf "stackoffset %d" n
-  | Load _ -> Format.fprintf ppf "load"
-  | Store _ -> Format.fprintf ppf "store"
-  | Intop op -> Format.fprintf ppf "intop %s" (intop op)
-  | Intop_imm (op, n) -> Format.fprintf ppf "intop %s %d" (intop op) n
-  | Intop_atomic { op; size = _; addr = _ } ->
-    Format.fprintf ppf "intop atomic %s" (intop_atomic op)
-  | Floatop (Float64, op) ->
-    Format.fprintf ppf "floatop %a" Printmach.floatop op
-  | Floatop (Float32, op) ->
-    Format.fprintf ppf "float32op %a" Printmach.floatop op
-  | Csel _ -> Format.fprintf ppf "csel"
-  | Reinterpret_cast cast ->
-    Format.fprintf ppf "%s" (Printcmm.reinterpret_cast cast)
-  | Static_cast cast -> Format.fprintf ppf "%s" (Printcmm.static_cast cast)
-  | Specific _ -> Format.fprintf ppf "specific"
-  | Probe_is_enabled { name } -> Format.fprintf ppf "probe_is_enabled %s" name
-  | Opaque -> Format.fprintf ppf "opaque"
-  | Begin_region -> Format.fprintf ppf "beginregion"
-  | End_region -> Format.fprintf ppf "endregion"
-  | Name_for_debugger _ -> Format.fprintf ppf "name_for_debugger"
-  | Dls_get -> Format.fprintf ppf "dls_get"
-  | Poll -> Format.fprintf ppf "poll"
-  | Alloc { bytes; dbginfo = _; mode = Heap } ->
-    Format.fprintf ppf "alloc %i" bytes
-  | Alloc { bytes; dbginfo = _; mode = Local } ->
-    Format.fprintf ppf "alloc_local %i" bytes
-
 let dump_basic ppf (basic : basic) =
   let open Format in
   match basic with
-  | Op op -> dump_operation ppf op
+  | Op op -> Operation.dump ppf op
   | Reloadretaddr -> fprintf ppf "Reloadretaddr"
   | Pushtrap { lbl_handler } ->
     fprintf ppf "Pushtrap handler=%a" Label.format lbl_handler
@@ -491,45 +418,8 @@ let is_pure_terminator desc =
     (* CR gyorsh: fix for memory operands *)
     true
 
-let is_pure_operation : operation -> bool = function
-  | Move -> true
-  | Spill -> true
-  | Reload -> true
-  | Const_int _ -> true
-  | Const_float32 _ -> true
-  | Const_float _ -> true
-  | Const_symbol _ -> true
-  | Const_vec128 _ -> true
-  | Stackoffset _ -> false
-  | Load _ -> true
-  | Store _ -> false
-  | Intop _ -> true
-  | Intop_imm _ -> true
-  | Intop_atomic _ -> false
-  | Floatop _ -> true
-  | Csel _ -> true
-  | Reinterpret_cast
-      ( V128_of_v128 | Float32_of_float | Float32_of_int32 | Float_of_float32
-      | Float_of_int64 | Int64_of_float | Int32_of_float32 ) ->
-    true
-  | Static_cast _ -> true
-  (* Conservative to ensure valueofint/intofvalue are not eliminated before
-     emit. *)
-  | Reinterpret_cast (Value_of_int | Int_of_value) -> false
-  | Probe_is_enabled _ -> true
-  | Opaque -> false
-  | Begin_region -> false
-  | End_region -> false
-  | Specific s ->
-    assert (not (Arch.operation_can_raise s));
-    Arch.operation_is_pure s
-  | Name_for_debugger _ -> false
-  | Dls_get -> true
-  | Poll -> false
-  | Alloc _ -> false
-
 let is_pure_basic : basic -> bool = function
-  | Op op -> is_pure_operation op
+  | Op op -> Operation.is_pure op
   | Reloadretaddr ->
     (* This is a no-op on supported backends but on some others like "power" it
        wouldn't be. Saying it's not pure doesn't decrease the generated code

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -194,15 +194,11 @@ val is_pure_terminator : terminator -> bool
 
 val is_pure_basic : basic -> bool
 
-val is_pure_operation : operation -> bool
-
 val is_noop_move : basic instruction -> bool
 
 val set_stack_offset : 'a instruction -> int -> unit
 
 val string_of_irc_work_list : irc_work_list -> string
-
-val dump_operation : Format.formatter -> operation -> unit
 
 val dump_basic : Format.formatter -> basic -> unit
 

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -6,7 +6,7 @@ module List = ListLabels
 module Array = ArrayLabels
 
 module CSE_utils_numbering = CSE_utils.Make (struct
-  type t = Cfg.operation
+  type t = Operation.t
 end)
 
 open CSE_utils
@@ -64,7 +64,7 @@ let insert_move :
 
 class cse_generic =
   object (self)
-    method class_of_operation : Cfg.operation -> op_class =
+    method class_of_operation : Operation.t -> op_class =
       function
       | Move | Spill | Reload -> assert false (* treated specially *)
       | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
@@ -93,7 +93,7 @@ class cse_generic =
       | Begin_region | End_region -> Op_other
       | Dls_get -> Op_load Mutable
 
-    method is_cheap_operation : Cfg.operation -> bool =
+    method is_cheap_operation : Operation.t -> bool =
       function Const_int _ -> true | _ -> false
     [@@warning "-4"]
 

--- a/backend/cfg/cfg_cse.mli
+++ b/backend/cfg/cfg_cse.mli
@@ -9,9 +9,9 @@ class cse_generic :
   object
     (* The following methods can be overridden to handle processor-specific
        operations. *)
-    method class_of_operation : Cfg.operation -> op_class
+    method class_of_operation : Operation.t -> op_class
 
-    method is_cheap_operation : Cfg.operation -> bool
+    method is_cheap_operation : Operation.t -> bool
     (* Operations that are so cheap that it isn't worth factoring them. *)
 
     (* The following method is the entry point and should not be overridden *)

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -50,54 +50,6 @@ module S = struct
           enabled_at_init : bool
         }
 
-  type operation =
-    | Move
-    | Spill
-    | Reload
-    | Const_int of nativeint (* CR-someday xclerc: change to `Targetint.t` *)
-    | Const_float32 of int32
-    | Const_float of int64
-    | Const_symbol of Cmm.symbol
-    | Const_vec128 of Cmm.vec128_bits
-    | Stackoffset of int
-    | Load of
-        { memory_chunk : Cmm.memory_chunk;
-          addressing_mode : Arch.addressing_mode;
-          mutability : Simple_operation.mutable_flag;
-          is_atomic : bool
-        }
-    | Store of Cmm.memory_chunk * Arch.addressing_mode * bool
-    | Intop of Simple_operation.integer_operation
-    | Intop_imm of Simple_operation.integer_operation * int
-    | Intop_atomic of
-        { op : Cmm.atomic_op;
-          size : Cmm.atomic_bitwidth;
-          addr : Arch.addressing_mode
-        }
-    | Floatop of Simple_operation.float_width * Simple_operation.float_operation
-    | Csel of Simple_operation.test
-    | Reinterpret_cast of Cmm.reinterpret_cast
-    | Static_cast of Cmm.static_cast
-    | Probe_is_enabled of { name : string }
-    | Opaque
-    | Begin_region
-    | End_region
-    | Specific of Arch.specific_operation
-    | Name_for_debugger of
-        { ident : Ident.t;
-          which_parameter : int option;
-          provenance : Backend_var.Provenance.t option;
-          is_assignment : bool;
-          regs : Reg.t array
-        }
-    | Dls_get
-    | Poll
-    | Alloc of
-        { bytes : int;
-          dbginfo : Debuginfo.alloc_dbginfo;
-          mode : Cmm.Alloc_mode.t
-        }
-
   type bool_test =
     { ifso : Label.t;  (** if test is true goto [ifso] label *)
       ifnot : Label.t  (** if test is false goto [ifnot] label *)
@@ -153,7 +105,7 @@ module S = struct
 
   (* [basic] instruction cannot raise *)
   type basic =
-    | Op of operation
+    | Op of Operation.t
     | Reloadretaddr
         (** This instruction loads the return address from a predefined hidden
             address (e.g. bottom of the current frame) and stores it in a

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -7,44 +7,4 @@ let from_basic (basic : basic) : Linear.instruction_desc =
   | Pushtrap { lbl_handler } -> Lpushtrap { lbl_handler }
   | Poptrap -> Lpoptrap
   | Stack_check { max_frame_size_bytes } -> Lstackcheck { max_frame_size_bytes }
-  | Op op ->
-    let op : Mach.operation =
-      match op with
-      | Move -> Imove
-      | Spill -> Ispill
-      | Reload -> Ireload
-      | Const_int n -> Iconst_int n
-      | Const_float32 n -> Iconst_float32 n
-      | Const_float n -> Iconst_float n
-      | Const_symbol n -> Iconst_symbol n
-      | Const_vec128 bits -> Iconst_vec128 bits
-      | Stackoffset n -> Istackoffset n
-      | Load { memory_chunk; addressing_mode; mutability; is_atomic } ->
-        Iload
-          { memory_chunk;
-            addressing_mode;
-            mutability = Simple_operation.to_ast_mutable_flag mutability;
-            is_atomic
-          }
-      | Store (c, m, b) -> Istore (c, m, b)
-      | Intop op -> Iintop op
-      | Intop_imm (op, i) -> Iintop_imm (op, i)
-      | Intop_atomic { op; size; addr } -> Iintop_atomic { op; size; addr }
-      | Floatop (w, op) -> Ifloatop (w, op)
-      | Csel c -> Icsel c
-      | Reinterpret_cast cast -> Ireinterpret_cast cast
-      | Static_cast cast -> Istatic_cast cast
-      | Probe_is_enabled { name } -> Iprobe_is_enabled { name }
-      | Opaque -> Iopaque
-      | Specific op -> Ispecific op
-      | Begin_region -> Ibeginregion
-      | End_region -> Iendregion
-      | Name_for_debugger
-          { ident; which_parameter; provenance; is_assignment; regs } ->
-        Iname_for_debugger
-          { ident; which_parameter; provenance; is_assignment; regs }
-      | Dls_get -> Idls_get
-      | Poll -> Ipoll { return_label = None }
-      | Alloc { bytes; dbginfo; mode } -> Ialloc { bytes; dbginfo; mode }
-    in
-    Lop op
+  | Op op -> Lop op

--- a/backend/cfg/cfgize.ml
+++ b/backend/cfg/cfgize.ml
@@ -735,7 +735,7 @@ let fundecl :
       | Iop
           (Iname_for_debugger
             { ident; which_parameter; provenance; is_assignment; regs }) ->
-        let cfg_op : Cfg.operation =
+        let cfg_op : Operation.t =
           Name_for_debugger
             { ident; which_parameter; provenance; is_assignment; regs }
         in

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -35,7 +35,7 @@ let maybe_emit_naming_op env ~bound_name seq regs =
     then
       let bound_name = Backend_var.With_provenance.var bound_name in
       let naming_op =
-        Cfg.Name_for_debugger
+        Operation.Name_for_debugger
           { ident = bound_name;
             provenance;
             which_parameter = None;
@@ -250,38 +250,38 @@ end
 
 class virtual selector_generic =
   object (self : 'self)
-    inherit [Label.t, Cfg.operation, Cfg.basic] Select_utils.common_selector
+    inherit [Label.t, Operation.t, Cfg.basic] Select_utils.common_selector
 
     method is_store op = match op with Store (_, _, _) -> true | _ -> false
 
     method lift_op op = Cfg.Op op
 
     method make_store mem_chunk addr_mode is_assignment =
-      Cfg.Op (Cfg.Store (mem_chunk, addr_mode, is_assignment))
+      Cfg.Op (Operation.Store (mem_chunk, addr_mode, is_assignment))
 
     method make_stack_offset stack_ofs = Cfg.Op (Stackoffset stack_ofs)
 
     method make_name_for_debugger ~ident ~which_parameter ~provenance
         ~is_assignment ~regs =
       Cfg.Op
-        (Cfg.Name_for_debugger
+        (Operation.Name_for_debugger
            { ident; which_parameter; provenance; is_assignment; regs })
 
-    method make_const_int x = Cfg.Const_int x
+    method make_const_int x = Operation.Const_int x
 
-    method make_const_float32 x = Cfg.Const_float32 x
+    method make_const_float32 x = Operation.Const_float32 x
 
-    method make_const_float x = Cfg.Const_float x
+    method make_const_float x = Operation.Const_float x
 
-    method make_const_vec128 x = Cfg.Const_vec128 x
+    method make_const_vec128 x = Operation.Const_vec128 x
 
-    method make_const_symbol x = Cfg.Const_symbol x
+    method make_const_symbol x = Operation.Const_symbol x
 
-    method make_opaque () = Cfg.Opaque
+    method make_opaque () = Operation.Opaque
 
     (* Default instruction selection for stores (of words) *)
 
-    method select_store is_assign addr arg : Cfg.operation * Cmm.expression =
+    method select_store is_assign addr arg : Operation.t * Cmm.expression =
       Store (Word_val, addr, is_assign), arg
 
     (* Default instruction selection for operators *)
@@ -527,7 +527,7 @@ class virtual selector_generic =
               then
                 let bound_name = VP.var bound_name in
                 let naming_op =
-                  Cfg.Name_for_debugger
+                  Operation.Name_for_debugger
                     { ident = bound_name;
                       provenance;
                       which_parameter = None;
@@ -656,7 +656,7 @@ class virtual selector_generic =
             let bytes = Select_utils.size_expr env (Ctuple new_args) in
             let alloc_words = (bytes + Arch.size_addr - 1) / Arch.size_addr in
             let op =
-              Cfg.Alloc
+              Operation.Alloc
                 { bytes = alloc_words * Arch.size_addr;
                   dbginfo = [{ alloc_words; alloc_dbg = dbg }];
                   mode
@@ -836,7 +836,7 @@ class virtual selector_generic =
                     then
                       let var = VP.var var in
                       let naming_op =
-                        Cfg.Name_for_debugger
+                        Operation.Name_for_debugger
                           { ident = var;
                             provenance;
                             which_parameter = None;
@@ -995,7 +995,7 @@ class virtual selector_generic =
                 then
                   let var = VP.var v in
                   let naming_op =
-                    Cfg.Name_for_debugger
+                    Operation.Name_for_debugger
                       { ident = var;
                         provenance;
                         which_parameter = None;
@@ -1307,7 +1307,7 @@ class virtual selector_generic =
                     then
                       let var = VP.var var in
                       let naming_op =
-                        Cfg.Name_for_debugger
+                        Operation.Name_for_debugger
                           { ident = var;
                             provenance;
                             which_parameter = None;
@@ -1387,7 +1387,7 @@ class virtual selector_generic =
                 then
                   let var = VP.var v in
                   let naming_op =
-                    Cfg.Name_for_debugger
+                    Operation.Name_for_debugger
                       { ident = var;
                         provenance;
                         which_parameter = None;
@@ -1493,7 +1493,7 @@ class virtual selector_generic =
             if Option.is_some provenance
             then
               let naming_op =
-                Cfg.Name_for_debugger
+                Operation.Name_for_debugger
                   { ident = var;
                     provenance;
                     which_parameter = Some param_index;

--- a/backend/cfg_selectgen.mli
+++ b/backend/cfg_selectgen.mli
@@ -45,9 +45,9 @@ val reset_next_instr_id : unit -> unit
 
 class virtual selector_generic :
   object
-    method is_store : Cfg.operation -> bool
+    method is_store : Operation.t -> bool
 
-    method lift_op : Cfg.operation -> Cfg.basic
+    method lift_op : Operation.t -> Cfg.basic
 
     method make_store :
       Cmm.memory_chunk -> Arch.addressing_mode -> bool -> Cfg.basic
@@ -62,17 +62,17 @@ class virtual selector_generic :
       regs:Reg.t array ->
       Cfg.basic
 
-    method make_const_int : nativeint -> Cfg.operation
+    method make_const_int : nativeint -> Operation.t
 
-    method make_const_float32 : int32 -> Cfg.operation
+    method make_const_float32 : int32 -> Operation.t
 
-    method make_const_float : int64 -> Cfg.operation
+    method make_const_float : int64 -> Operation.t
 
-    method make_const_vec128 : Cmm.vec128_bits -> Cfg.operation
+    method make_const_vec128 : Cmm.vec128_bits -> Operation.t
 
-    method make_const_symbol : Cmm.symbol -> Cfg.operation
+    method make_const_symbol : Cmm.symbol -> Operation.t
 
-    method make_opaque : unit -> Cfg.operation
+    method make_opaque : unit -> Operation.t
 
     (* The following methods must or can be overridden by the processor
        description *)
@@ -113,7 +113,7 @@ class virtual selector_generic :
       bool ->
       Arch.addressing_mode ->
       Cmm.expression ->
-      Cfg.operation * Cmm.expression
+      Operation.t * Cmm.expression
     (* Can be overridden to deal with special store constant instructions *)
 
     method regs_for : Cmm.machtype -> Reg.t array
@@ -122,13 +122,13 @@ class virtual selector_generic :
        stored as pairs of integer registers. *)
 
     method insert_op :
-      environment -> Cfg.operation -> Reg.t array -> Reg.t array -> Reg.t array
+      environment -> Operation.t -> Reg.t array -> Reg.t array -> Reg.t array
     (* Can be overridden to deal with 2-address instructions or instructions
        with hardwired input/output registers *)
 
     method insert_op_debug :
       environment ->
-      Cfg.operation ->
+      Operation.t ->
       Debuginfo.t ->
       Reg.t array ->
       Reg.t array ->

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -67,13 +67,13 @@ module Vars = struct
     let advance_over_instruction t (insn : L.instruction) =
       let stack_offset =
         match insn.desc with
-        | Lop (Istackoffset delta) -> t.stack_offset + delta
+        | Lop (Stackoffset delta) -> t.stack_offset + delta
         | Lpushtrap _ -> t.stack_offset + Proc.trap_frame_size_in_bytes
         | Lpoptrap -> t.stack_offset - Proc.trap_frame_size_in_bytes
         | Ladjust_stack_offset { delta_bytes } -> t.stack_offset + delta_bytes
-        | Lend | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _
-        | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap
-        | Lraise _ | Lstackcheck _ ->
+        | Lend | Lprologue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn
+        | Llabel _ | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _
+        | Lentertrap | Lraise _ | Lstackcheck _ ->
           t.stack_offset
       in
       { stack_offset }

--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -513,9 +513,10 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
               KS.print should_be_open KS.print currently_open_subranges));
     match insn.desc with
     | Lend -> first_insn
-    | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _ | Lbranch _
-    | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lpushtrap _
-    | Lpoptrap | Ladjust_stack_offset _ | Lraise _ | Lstackcheck _ ->
+    | Lprologue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn | Llabel _
+    | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap
+    | Lpushtrap _ | Lpoptrap | Ladjust_stack_offset _ | Lraise _ | Lstackcheck _
+      ->
       let subrange_state =
         Subrange_state.advance_over_instruction subrange_state insn
       in

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -609,12 +609,13 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
       let s = fs + trap_size in
       loop i.next s (max s max_fs) nontail_flag
     | Lpoptrap -> loop i.next (fs - trap_size) max_fs nontail_flag
-    | Lop (Istackoffset n) ->
+    | Lop (Stackoffset n) ->
       let s = fs + n in
       loop i.next s (max s max_fs) nontail_flag
-    | Lop (Icall_ind | Icall_imm _) -> loop i.next fs max_fs true
-    | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _ | Lbranch _
-    | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lraise _ ->
+    | Lcall_op (Lcall_ind | Lcall_imm _) -> loop i.next fs max_fs true
+    | Lprologue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn | Llabel _
+    | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap
+    | Lraise _ ->
       loop i.next fs max_fs nontail_flag
     | Lstackcheck _ ->
       (* should not be already present *)

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -12,7 +12,6 @@
 (*   special exception on linking described in the file LICENSE.          *)
 (*                                                                        *)
 (**************************************************************************)
-open Mach
 
 (* Transformation of Mach code into a list of pseudo-instructions. *)
 type label = Cmm.label
@@ -32,7 +31,8 @@ type instruction =
 and instruction_desc =
   | Lprologue
   | Lend
-  | Lop of Mach.operation
+  | Lop of Operation.t
+  | Lcall_op of call_operation
   | Lreloadretaddr
   | Lreturn
   | Llabel of { label : label; section_name : string option }
@@ -47,10 +47,20 @@ and instruction_desc =
   | Lraise of Lambda.raise_kind
   | Lstackcheck of { max_frame_size_bytes : int; }
 
+and call_operation =
+  | Lcall_ind
+  | Lcall_imm of { func : Cmm.symbol; }
+  | Ltailcall_ind
+  | Ltailcall_imm of { func : Cmm.symbol; }
+  | Lextcall of { func : string;
+                  ty_res : Cmm.machtype; ty_args : Cmm.exttype list;
+                  alloc : bool; returns : bool;
+                  stack_ofs : int; }
+  | Lprobe of { name: string; handler_code_sym: string; enabled_at_init: bool; }
+
 let has_fallthrough = function
   | Lreturn | Lbranch _ | Lswitch _ | Lraise _
-  | Lop Itailcall_ind | Lop (Itailcall_imm _)
-  | Lop (Ipoll { return_label = Some _ }) -> false
+  | Lcall_op Ltailcall_ind | Lcall_op (Ltailcall_imm _)
   | _ -> true
 
 type fundecl =

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -32,7 +32,8 @@ type instruction =
 and instruction_desc =
   | Lprologue
   | Lend
-  | Lop of Mach.operation
+  | Lop of Operation.t
+  | Lcall_op of call_operation
   | Lreloadretaddr
   | Lreturn
   | Llabel of { label : label; section_name : string option }
@@ -46,6 +47,17 @@ and instruction_desc =
   | Lpoptrap
   | Lraise of Lambda.raise_kind
   | Lstackcheck of { max_frame_size_bytes : int; }
+
+and call_operation =
+  | Lcall_ind
+  | Lcall_imm of { func : Cmm.symbol; }
+  | Ltailcall_ind
+  | Ltailcall_imm of { func : Cmm.symbol; }
+  | Lextcall of { func : string;
+                  ty_res : Cmm.machtype; ty_args : Cmm.exttype list;
+                  alloc : bool; returns : bool;
+                  stack_ofs : int; }
+  | Lprobe of { name: string; handler_code_sym: string; enabled_at_init: bool; }
 
 val has_fallthrough :  instruction_desc -> bool
 val end_instr: instruction

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -1,0 +1,194 @@
+(**********************************************************************************
+ *                             MIT License                                        *
+ *                                                                                *
+ *                                                                                *
+ * Copyright (c) 2019-2021 Jane Street Group LLC                                  *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ *                                                                                *
+ **********************************************************************************)
+
+[@@@ocaml.warning "+a-4-9-40-41-42"]
+
+type t =
+  | Move
+  | Spill
+  | Reload
+  | Const_int of nativeint (* CR-someday xclerc: change to `Targetint.t` *)
+  | Const_float32 of int32
+  | Const_float of int64
+  | Const_symbol of Cmm.symbol
+  | Const_vec128 of Cmm.vec128_bits
+  | Stackoffset of int
+  | Load of
+      { memory_chunk : Cmm.memory_chunk;
+        addressing_mode : Arch.addressing_mode;
+        mutability : Simple_operation.mutable_flag;
+        is_atomic : bool
+      }
+  | Store of Cmm.memory_chunk * Arch.addressing_mode * bool
+  | Intop of Simple_operation.integer_operation
+  | Intop_imm of Simple_operation.integer_operation * int
+  | Intop_atomic of
+      { op : Cmm.atomic_op;
+        size : Cmm.atomic_bitwidth;
+        addr : Arch.addressing_mode
+      }
+  | Floatop of Simple_operation.float_width * Simple_operation.float_operation
+  | Csel of Simple_operation.test
+  | Reinterpret_cast of Cmm.reinterpret_cast
+  | Static_cast of Cmm.static_cast
+  | Probe_is_enabled of { name : string }
+  | Opaque
+  | Begin_region
+  | End_region
+  | Specific of Arch.specific_operation
+  | Name_for_debugger of
+      { ident : Ident.t;
+        which_parameter : int option;
+        provenance : Backend_var.Provenance.t option;
+        is_assignment : bool;
+        regs : Reg.t array
+      }
+  | Dls_get
+  | Poll
+  | Alloc of
+      { bytes : int;
+        dbginfo : Debuginfo.alloc_dbginfo;
+        mode : Cmm.Alloc_mode.t
+      }
+
+let is_pure = function
+  | Move -> true
+  | Spill -> true
+  | Reload -> true
+  | Const_int _ -> true
+  | Const_float32 _ -> true
+  | Const_float _ -> true
+  | Const_symbol _ -> true
+  | Const_vec128 _ -> true
+  | Stackoffset _ -> false
+  | Load _ -> true
+  | Store _ -> false
+  | Intop _ -> true
+  | Intop_imm _ -> true
+  | Intop_atomic _ -> false
+  | Floatop _ -> true
+  | Csel _ -> true
+  | Reinterpret_cast
+      ( V128_of_v128 | Float32_of_float | Float32_of_int32 | Float_of_float32
+      | Float_of_int64 | Int64_of_float | Int32_of_float32 ) ->
+    true
+  | Static_cast _ -> true
+  (* Conservative to ensure valueofint/intofvalue are not eliminated before
+     emit. *)
+  | Reinterpret_cast (Value_of_int | Int_of_value) -> false
+  | Probe_is_enabled _ -> true
+  | Opaque -> false
+  | Begin_region -> false
+  | End_region -> false
+  | Specific s ->
+    assert (not (Arch.operation_can_raise s));
+    Arch.operation_is_pure s
+  | Name_for_debugger _ -> false
+  | Dls_get -> true
+  | Poll -> false
+  | Alloc _ -> false
+
+(* The next 2 functions are copied almost as is from asmcomp/printmach.ml
+   because there is no interface to call them. Eventually this won't be needed
+   when we change cfg to have its own types rather than referring back to mach
+   and cmm. *)
+(* CR-someday gyorsh: implement desc printing, and args/res/dbg, etc, properly,
+   with regs, use the dreaded Format. *)
+
+let intcomp (comp : Simple_operation.integer_comparison) =
+  match comp with
+  | Isigned c -> Printf.sprintf " %ss " (Printcmm.integer_comparison c)
+  | Iunsigned c -> Printf.sprintf " %su " (Printcmm.integer_comparison c)
+
+let intop_atomic (op : Cmm.atomic_op) =
+  match op with Fetch_and_add -> " += " | Compare_and_swap -> " cas "
+
+let intop (op : Simple_operation.integer_operation) =
+  match op with
+  | Iadd -> " + "
+  | Isub -> " - "
+  | Imul -> " * "
+  | Imulh { signed : bool } -> " *h" ^ if signed then " " else "u "
+  | Idiv -> " div "
+  | Imod -> " mod "
+  | Iand -> " & "
+  | Ior -> " | "
+  | Ixor -> " ^ "
+  | Ilsl -> " << "
+  | Ilsr -> " >>u "
+  | Iasr -> " >>s "
+  | Ipopcnt -> " pop "
+  | Iclz _ -> " clz "
+  | Ictz _ -> " ctz "
+  | Icomp cmp -> intcomp cmp
+
+let floatop ppf (op : Simple_operation.float_operation) =
+  match op with
+  | Iaddf -> Format.fprintf ppf "+."
+  | Isubf -> Format.fprintf ppf "-."
+  | Imulf -> Format.fprintf ppf "*."
+  | Idivf -> Format.fprintf ppf "/."
+  | Iabsf -> Format.fprintf ppf "abs"
+  | Inegf -> Format.fprintf ppf "neg"
+  | Icompf cmp -> Format.fprintf ppf "%s" (Printcmm.float_comparison cmp)
+
+let dump ppf op =
+  match op with
+  | Move -> Format.fprintf ppf "mov"
+  | Spill -> Format.fprintf ppf "spill"
+  | Reload -> Format.fprintf ppf "reload"
+  | Const_int n -> Format.fprintf ppf "const_int %nd" n
+  | Const_float32 f ->
+    Format.fprintf ppf "const_float32 %Fs" (Int32.float_of_bits f)
+  | Const_float f -> Format.fprintf ppf "const_float %F" (Int64.float_of_bits f)
+  | Const_symbol s -> Format.fprintf ppf "const_symbol %s" s.sym_name
+  | Const_vec128 { high; low } ->
+    Format.fprintf ppf "const vec128 %016Lx:%016Lx" high low
+  | Stackoffset n -> Format.fprintf ppf "stackoffset %d" n
+  | Load _ -> Format.fprintf ppf "load"
+  | Store _ -> Format.fprintf ppf "store"
+  | Intop op -> Format.fprintf ppf "intop %s" (intop op)
+  | Intop_imm (op, n) -> Format.fprintf ppf "intop %s %d" (intop op) n
+  | Intop_atomic { op; size = _; addr = _ } ->
+    Format.fprintf ppf "intop atomic %s" (intop_atomic op)
+  | Floatop (Float64, op) -> Format.fprintf ppf "floatop %a" floatop op
+  | Floatop (Float32, op) -> Format.fprintf ppf "float32op %a" floatop op
+  | Csel _ -> Format.fprintf ppf "csel"
+  | Reinterpret_cast cast ->
+    Format.fprintf ppf "%s" (Printcmm.reinterpret_cast cast)
+  | Static_cast cast -> Format.fprintf ppf "%s" (Printcmm.static_cast cast)
+  | Specific _ -> Format.fprintf ppf "specific"
+  | Probe_is_enabled { name } -> Format.fprintf ppf "probe_is_enabled %s" name
+  | Opaque -> Format.fprintf ppf "opaque"
+  | Begin_region -> Format.fprintf ppf "beginregion"
+  | End_region -> Format.fprintf ppf "endregion"
+  | Name_for_debugger _ -> Format.fprintf ppf "name_for_debugger"
+  | Dls_get -> Format.fprintf ppf "dls_get"
+  | Poll -> Format.fprintf ppf "poll"
+  | Alloc { bytes; dbginfo = _; mode = Heap } ->
+    Format.fprintf ppf "alloc %i" bytes
+  | Alloc { bytes; dbginfo = _; mode = Local } ->
+    Format.fprintf ppf "alloc_local %i" bytes

--- a/backend/operation.mli
+++ b/backend/operation.mli
@@ -23,20 +23,62 @@
  * SOFTWARE.                                                                      *
  *                                                                                *
  **********************************************************************************)
-[@@@ocaml.warning "+a-30-40-41-42"]
 
-type labelled_insn =
-  { label : Label.t;
-    insn : Linear.instruction
-  }
+(* Operations common to CFG and Linear. *)
 
-let labelled_insn_end = { label = Label.none; insn = Linear.end_instr }
+[@@@ocaml.warning "+a-4-9-40-41-42"]
 
-let rec defines_label (i : Linear.instruction) =
-  match i.desc with
-  | Lend | Llabel _ -> true
-  | Ladjust_stack_offset _ -> defines_label i.next
-  | Lprologue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn | Lbranch _
-  | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lpushtrap _
-  | Lpoptrap | Lraise _ | Lstackcheck _ ->
-    false
+(* CR-soon xclerc for xclerc: consider whether `Simple_operation` and
+   `Operation` should be merged into a single module. *)
+
+type t =
+  | Move
+  | Spill
+  | Reload
+  | Const_int of nativeint (* CR-someday xclerc: change to `Targetint.t` *)
+  | Const_float32 of int32
+  | Const_float of int64
+  | Const_symbol of Cmm.symbol
+  | Const_vec128 of Cmm.vec128_bits
+  | Stackoffset of int
+  | Load of
+      { memory_chunk : Cmm.memory_chunk;
+        addressing_mode : Arch.addressing_mode;
+        mutability : Simple_operation.mutable_flag;
+        is_atomic : bool
+      }
+  | Store of Cmm.memory_chunk * Arch.addressing_mode * bool
+  | Intop of Simple_operation.integer_operation
+  | Intop_imm of Simple_operation.integer_operation * int
+  | Intop_atomic of
+      { op : Cmm.atomic_op;
+        size : Cmm.atomic_bitwidth;
+        addr : Arch.addressing_mode
+      }
+  | Floatop of Simple_operation.float_width * Simple_operation.float_operation
+  | Csel of Simple_operation.test
+  | Reinterpret_cast of Cmm.reinterpret_cast
+  | Static_cast of Cmm.static_cast
+  | Probe_is_enabled of { name : string }
+  | Opaque
+  | Begin_region
+  | End_region
+  | Specific of Arch.specific_operation
+  | Name_for_debugger of
+      { ident : Ident.t;
+        which_parameter : int option;
+        provenance : Backend_var.Provenance.t option;
+        is_assignment : bool;
+        regs : Reg.t array
+      }
+  | Dls_get
+  | Poll
+  | Alloc of
+      { bytes : int;
+        dbginfo : Debuginfo.alloc_dbginfo;
+        mode : Cmm.Alloc_mode.t
+      }
+
+val is_pure : t -> bool
+
+val dump : Format.formatter -> t -> unit

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -25,28 +25,29 @@ let section_name_to_string ppf = function
   | None -> ()
   | Some name -> fprintf ppf " in %s section" name
 
+let call_operation ?(print_reg = Printreg.reg) ppf op arg =
+  let regs = Printreg.regs' ~print_reg in
+  match op with
+  | Lcall_ind ->
+    fprintf ppf "call %a" regs arg
+  | Lcall_imm { func; } ->
+    fprintf ppf "call \"%s\" %a" func.sym_name regs arg
+  | Ltailcall_ind ->
+    fprintf ppf "tailcall %a" regs arg
+  | Ltailcall_imm { func; } ->
+    fprintf ppf "tailcall \"%s\" %a" func.sym_name regs arg
+  | Lextcall { func; alloc; _ } ->
+    fprintf ppf "extcall \"%s\" %a%s" func regs arg
+      (if alloc then "" else " (noalloc)")
+  | Lprobe {name;handler_code_sym} ->
+    fprintf ppf "probe \"%s\" %s %a" name handler_code_sym regs arg
+
 let instr' ?(print_reg = Printreg.reg) ppf i =
   let reg = print_reg in
   let regs = Printreg.regs' ~print_reg in
   let regsetaddr = Printreg.regsetaddr' ~print_reg in
   let test = Simple_operation.format_test ~print_reg in
   let operation = Printoperation.operation ~print_reg in
-  let call_operation op arg ppf res =
-    match op with
-    | Lcall_ind ->
-      fprintf ppf "call %a" regs arg
-    | Lcall_imm { func; } ->
-      fprintf ppf "call \"%s\" %a" func.sym_name regs arg
-    | Ltailcall_ind ->
-      fprintf ppf "tailcall %a" regs arg
-    | Ltailcall_imm { func; } ->
-      fprintf ppf "tailcall \"%s\" %a" func.sym_name regs arg
-    | Lextcall { func; alloc; _ } ->
-      fprintf ppf "extcall \"%s\" %a%s" func regs arg
-        (if alloc then "" else " (noalloc)")
-    | Lprobe {name;handler_code_sym} ->
-      fprintf ppf "probe \"%s\" %s %a" name handler_code_sym regs arg
-  in
   if !Flambda_backend_flags.davail then begin
     let module RAS = Reg_availability_set in
     let ras_is_nonempty (set : RAS.t) =
@@ -94,7 +95,7 @@ let instr' ?(print_reg = Printreg.reg) ppf i =
           fprintf ppf "@[<1>{%a}@]@," regsetaddr i.live
       | _ -> ()
     end;
-    call_operation op i.arg ppf i.res
+    call_operation ppf op i.arg
   | Lreloadretaddr ->
       fprintf ppf "reload retaddr"
   | Lreturn ->

--- a/backend/printlinear.mli
+++ b/backend/printlinear.mli
@@ -18,6 +18,7 @@
 open Format
 open Linear
 
+val call_operation : ?print_reg:(formatter -> Reg.t -> unit) -> formatter -> Linear.call_operation -> Reg.t array -> unit
 val instr': ?print_reg:(formatter -> Reg.t -> unit) -> formatter -> instruction -> unit
 val instr: formatter -> instruction -> unit
 val fundecl: formatter -> fundecl -> unit

--- a/backend/printmach.mli
+++ b/backend/printmach.mli
@@ -19,7 +19,6 @@ open Format
 
 val operation': ?print_reg:(formatter -> Reg.t -> unit) -> Mach.operation -> Reg.t array -> formatter -> Reg.t array -> unit
 val operation: Mach.operation -> Reg.t array -> formatter -> Reg.t array -> unit
-val test': ?print_reg:(formatter -> Reg.t -> unit) -> Simple_operation.test -> formatter -> Reg.t array -> unit
 val test: Simple_operation.test -> formatter -> Reg.t array -> unit
 val instr: formatter -> Mach.instruction -> unit
 val fundecl: formatter -> Mach.fundecl -> unit
@@ -27,4 +26,3 @@ val phase: string -> formatter -> Mach.fundecl -> unit
 val interferences: formatter -> unit -> unit
 val intervals: formatter -> unit -> unit
 val preferences: formatter -> unit -> unit
-val floatop: formatter -> Simple_operation.float_operation -> unit

--- a/backend/printoperation.ml
+++ b/backend/printoperation.ml
@@ -1,0 +1,98 @@
+[@@@ocaml.warning "+a-4-9-40-41-42"]
+
+open Format
+
+let operation ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf res =
+  let reg = print_reg in
+  let regs = Printreg.regs' ~print_reg in
+  if Array.length res > 0 then fprintf ppf "%a := " regs res;
+  match op with
+  | Move -> regs ppf arg
+  | Spill -> fprintf ppf "%a (spill)" regs arg
+  | Reload -> fprintf ppf "%a (reload)" regs arg
+  | Const_int n -> fprintf ppf "%s" (Nativeint.to_string n)
+  | Const_float32 f -> fprintf ppf "%Fs" (Int32.float_of_bits f)
+  | Const_float f -> fprintf ppf "%F" (Int64.float_of_bits f)
+  | Const_symbol s -> fprintf ppf "\"%s\"" s.sym_name
+  | Const_vec128 { high; low } -> fprintf ppf "%016Lx:%016Lx" high low
+  | Stackoffset n -> fprintf ppf "offset stack %i" n
+  | Load { memory_chunk; addressing_mode; mutability = Immutable; is_atomic } ->
+    fprintf ppf "%s %a[%a]"
+      (Printcmm.chunk memory_chunk)
+      (fun pp a -> if a then fprintf pp "atomic" else ())
+      is_atomic
+      (Arch.print_addressing reg addressing_mode)
+      arg
+  | Load { memory_chunk; addressing_mode; mutability = Mutable; is_atomic } ->
+    fprintf ppf "%s %a mut[%a]"
+      (Printcmm.chunk memory_chunk)
+      (fun pp a -> if a then fprintf pp "atomic" else ())
+      is_atomic
+      (Arch.print_addressing reg addressing_mode)
+      arg
+  | Store (chunk, addr, is_assign) ->
+    fprintf ppf "%s[%a] := %a %s" (Printcmm.chunk chunk)
+      (Arch.print_addressing reg addr)
+      (Array.sub arg 1 (Array.length arg - 1))
+      reg arg.(0)
+      (if is_assign then "(assign)" else "(init)")
+  | Alloc { bytes = n; mode = Cmm.Alloc_mode.Heap } -> fprintf ppf "alloc %i" n
+  | Alloc { bytes = n; mode = Cmm.Alloc_mode.Local } ->
+    fprintf ppf "alloc_local %i" n
+  | Intop op ->
+    if Simple_operation.is_unary_integer_operation op
+    then (
+      assert (Array.length arg = 1);
+      fprintf ppf "%s%a"
+        (Simple_operation.string_of_integer_operation op)
+        reg arg.(0))
+    else (
+      assert (Array.length arg = 2);
+      fprintf ppf "%a%s%a" reg arg.(0)
+        (Simple_operation.string_of_integer_operation op)
+        reg arg.(1))
+  | Intop_imm (op, n) ->
+    fprintf ppf "%a%s%i" reg arg.(0)
+      (Simple_operation.string_of_integer_operation op)
+      n
+  | Intop_atomic { op = Compare_and_swap; size; addr } ->
+    fprintf ppf "lock cas %s[%a] ?%a %a"
+      (Printcmm.atomic_bitwidth size)
+      (Arch.print_addressing reg addr)
+      (Array.sub arg 2 (Array.length arg - 2))
+      reg arg.(0) reg arg.(1)
+  | Intop_atomic { op = Fetch_and_add; size; addr } ->
+    fprintf ppf "lock %s[%a] += %a"
+      (Printcmm.atomic_bitwidth size)
+      (Arch.print_addressing reg addr)
+      (Array.sub arg 1 (Array.length arg - 1))
+      reg arg.(0)
+  | Floatop (_, ((Icompf _ | Iaddf | Isubf | Imulf | Idivf) as op)) ->
+    fprintf ppf "%a %a %a" reg arg.(0) Simple_operation.format_float_operation
+      op reg arg.(1)
+  | Floatop (_, ((Inegf | Iabsf) as op)) ->
+    fprintf ppf "%a %a" Simple_operation.format_float_operation op reg arg.(0)
+  | Csel tst ->
+    let len = Array.length arg in
+    fprintf ppf "csel %a ? %a : %a"
+      (Simple_operation.format_test ~print_reg:Printreg.reg tst)
+      arg reg
+      arg.(len - 2)
+      reg
+      arg.(len - 1)
+  | Reinterpret_cast cast ->
+    fprintf ppf "%s %a" (Printcmm.reinterpret_cast cast) reg arg.(0)
+  | Static_cast cast ->
+    fprintf ppf "%s %a" (Printcmm.static_cast cast) reg arg.(0)
+  | Opaque -> fprintf ppf "opaque %a" reg arg.(0)
+  | Name_for_debugger { ident; which_parameter; regs = r } ->
+    fprintf ppf "%a holds the value of %a%s" regs r Backend_var.print ident
+      (match which_parameter with
+      | None -> ""
+      | Some index -> sprintf "[P%d]" index)
+  | Begin_region -> fprintf ppf "beginregion"
+  | End_region -> fprintf ppf "endregion %a" reg arg.(0)
+  | Specific op -> Arch.print_specific_operation reg op ppf arg
+  | Dls_get -> fprintf ppf "dls_get"
+  | Poll -> fprintf ppf "poll call"
+  | Probe_is_enabled { name } -> fprintf ppf "probe_is_enabled \"%s\"" name

--- a/backend/printoperation.mli
+++ b/backend/printoperation.mli
@@ -1,0 +1,9 @@
+[@@@ocaml.warning "+a-4-9-40-41-42"]
+
+val operation :
+  ?print_reg:(Format.formatter -> Reg.t -> unit) ->
+  Operation.t ->
+  Reg.t array ->
+  Format.formatter ->
+  Reg.t array ->
+  unit

--- a/backend/printreg.ml
+++ b/backend/printreg.ml
@@ -15,23 +15,24 @@
 
 (* Pretty-printing of registers *)
 
+[@@@ocaml.warning "+a-4-9-40-41-42"]
+
 open Format
-open Reg
+open! Reg
 
 let loc ?(wrap_out = fun ppf f -> f ppf) ~unknown ppf loc typ =
   match loc with
   | Unknown -> unknown ppf
   | Reg r ->
-      wrap_out ppf (fun ppf -> fprintf ppf "%s" (Proc.register_name typ r))
-  | Stack(Local s) ->
-      wrap_out ppf (fun ppf ->
-        fprintf ppf "s[%s:%i]" (Proc.stack_class_tag (Proc.stack_slot_class typ)) s)
-  | Stack(Incoming s) ->
-      wrap_out ppf (fun ppf -> fprintf ppf "par[%i]" s)
-  | Stack(Outgoing s) ->
-      wrap_out ppf (fun ppf -> fprintf ppf "arg[%i]" s)
-  | Stack(Domainstate s) ->
-      wrap_out ppf (fun ppf -> fprintf ppf "ds[%i]" s)
+    wrap_out ppf (fun ppf -> fprintf ppf "%s" (Proc.register_name typ r))
+  | Stack (Local s) ->
+    wrap_out ppf (fun ppf ->
+        fprintf ppf "s[%s:%i]"
+          (Proc.stack_class_tag (Proc.stack_slot_class typ))
+          s)
+  | Stack (Incoming s) -> wrap_out ppf (fun ppf -> fprintf ppf "par[%i]" s)
+  | Stack (Outgoing s) -> wrap_out ppf (fun ppf -> fprintf ppf "arg[%i]" s)
+  | Stack (Domainstate s) -> wrap_out ppf (fun ppf -> fprintf ppf "ds[%i]" s)
 
 let reg ppf r =
   if not (anonymous r) then fprintf ppf "%s:" (name r);
@@ -46,15 +47,19 @@ let reg ppf r =
   fprintf ppf "/%i" r.stamp;
   loc
     ~wrap_out:(fun ppf f -> fprintf ppf "[%t]" f)
-    ~unknown:(fun _ -> ()) ppf r.loc r.typ
+    ~unknown:(fun _ -> ())
+    ppf r.loc r.typ
 
 let regs' ?(print_reg = reg) ppf v =
   let reg = print_reg in
   match Array.length v with
   | 0 -> ()
   | 1 -> reg ppf v.(0)
-  | n -> reg ppf v.(0);
-         for i = 1 to n-1 do fprintf ppf " %a" reg v.(i) done
+  | n ->
+    reg ppf v.(0);
+    for i = 1 to n - 1 do
+      fprintf ppf " %a" reg v.(i)
+    done
 
 let regs ppf v = regs' ppf v
 
@@ -62,7 +67,10 @@ let regset ppf s =
   let first = ref true in
   Set.iter
     (fun r ->
-      if !first then begin first := false; fprintf ppf "%a" reg r end
+      if !first
+      then (
+        first := false;
+        fprintf ppf "%a" reg r)
       else fprintf ppf "@ %a" reg r)
     s
 
@@ -71,7 +79,10 @@ let regsetaddr' ?(print_reg = reg) ppf s =
   let first = ref true in
   Set.iter
     (fun r ->
-      if !first then begin first := false; fprintf ppf "%a" reg r end
+      if !first
+      then (
+        first := false;
+        fprintf ppf "%a" reg r)
       else fprintf ppf "@ %a" reg r;
       match r.typ with
       | Val -> fprintf ppf "*"

--- a/backend/printreg.mli
+++ b/backend/printreg.mli
@@ -15,10 +15,32 @@
 
 (* Pretty-printing of registers *)
 
-val loc: ?wrap_out:(Format.formatter -> (Format.formatter -> unit) -> unit) -> unknown:(Format.formatter -> unit) -> Format.formatter -> Reg.location -> Cmm.machtype_component -> unit
-val reg: Format.formatter -> Reg.t -> unit
-val regs': ?print_reg:(Format.formatter -> Reg.t -> unit) -> Format.formatter -> Reg.t array -> unit
-val regs: Format.formatter -> Reg.t array -> unit
-val regset: Format.formatter -> Reg.Set.t -> unit
-val regsetaddr': ?print_reg:(Format.formatter -> Reg.t -> unit) -> Format.formatter -> Reg.Set.t -> unit
-val regsetaddr: Format.formatter -> Reg.Set.t -> unit
+[@@@ocaml.warning "+a-4-9-40-41-42"]
+
+val loc :
+  ?wrap_out:(Format.formatter -> (Format.formatter -> unit) -> unit) ->
+  unknown:(Format.formatter -> unit) ->
+  Format.formatter ->
+  Reg.location ->
+  Cmm.machtype_component ->
+  unit
+
+val reg : Format.formatter -> Reg.t -> unit
+
+val regs' :
+  ?print_reg:(Format.formatter -> Reg.t -> unit) ->
+  Format.formatter ->
+  Reg.t array ->
+  unit
+
+val regs : Format.formatter -> Reg.t array -> unit
+
+val regset : Format.formatter -> Reg.Set.t -> unit
+
+val regsetaddr' :
+  ?print_reg:(Format.formatter -> Reg.t -> unit) ->
+  Format.formatter ->
+  Reg.Set.t ->
+  unit
+
+val regsetaddr : Format.formatter -> Reg.Set.t -> unit

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -224,9 +224,9 @@ module Move = struct
     | Store
 
   let op_of_move = function
-    | Plain -> Cfg.Move
-    | Load -> Cfg.Reload
-    | Store -> Cfg.Spill
+    | Plain -> Operation.Move
+    | Load -> Operation.Reload
+    | Store -> Operation.Spill
 
   let make_instr :
       t ->

--- a/backend/simple_operation.mli
+++ b/backend/simple_operation.mli
@@ -15,6 +15,8 @@
 
 (* Operations common to Mach and CFG. *)
 
+[@@@ocaml.warning "+a-4-9-40-41-42"]
+
 type trap_stack =
   | Uncaught  (** Exceptions escape the current function *)
   | Specific_trap of Cmm.trywith_shared_label * trap_stack
@@ -25,6 +27,8 @@ val equal_trap_stack : trap_stack -> trap_stack -> bool
 type integer_comparison =
   | Isigned of Cmm.integer_comparison
   | Iunsigned of Cmm.integer_comparison
+
+val string_of_integer_comparison : integer_comparison -> string
 
 val equal_integer_comparison : integer_comparison -> integer_comparison -> bool
 
@@ -48,6 +52,10 @@ type integer_operation =
   | Ipopcnt
   | Icomp of integer_comparison
 
+val string_of_integer_operation : integer_operation -> string
+
+val is_unary_integer_operation : integer_operation -> bool
+
 val equal_integer_operation : integer_operation -> integer_operation -> bool
 
 type float_comparison = Cmm.float_comparison
@@ -67,6 +75,10 @@ type float_operation =
   | Idivf
   | Icompf of float_comparison
 
+val string_of_float_operation : float_operation -> string
+
+val format_float_operation : Format.formatter -> float_operation -> unit
+
 val equal_float_operation : float_operation -> float_operation -> bool
 
 type mutable_flag =
@@ -85,5 +97,12 @@ type test =
   | Ifloattest of float_width * float_comparison
   | Ioddtest
   | Ieventest
+
+val format_test :
+  print_reg:(Format.formatter -> Reg.t -> unit) ->
+  test ->
+  Format.formatter ->
+  Reg.t array ->
+  unit
 
 val invert_test : test -> test

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2574,7 +2574,7 @@ end = struct
           ~desc:("direct tailcall to " ^ func)
           dbg
 
-      let operation t ~next (op : Cfg.operation) dbg =
+      let operation t ~next (op : Operation.t) dbg =
         match op with
         | Move | Spill | Reload | Const_int _ | Const_float32 _ | Const_float _
         | Const_symbol _ | Const_vec128 _ | Load _ | Floatop _
@@ -2590,10 +2590,10 @@ end = struct
             | Int64_of_float | Float32_of_int32 | Int32_of_float32
             | V128_of_v128 )
         | Static_cast _ | Csel _ ->
-          if not (Cfg.is_pure_operation op)
+          if not (Operation.is_pure op)
           then
-            Misc.fatal_errorf "Expected pure operation, got %a\n"
-              Cfg.dump_operation op;
+            Misc.fatal_errorf "Expected pure operation, got %a\n" Operation.dump
+              op;
           next
         | Reinterpret_cast (Int_of_value | Value_of_int)
         | Name_for_debugger _ | Stackoffset _ | Probe_is_enabled _ | Opaque

--- a/dune
+++ b/dune
@@ -462,7 +462,7 @@
   printcmm
   printlinear
   printmach
- printoperation
+  printoperation
   printreg
   proc
   simd

--- a/dune
+++ b/dune
@@ -454,6 +454,7 @@
   linscan
   liveness
   mach
+  operation
   peephole_optimize
   peephole_rules
   peephole_utils
@@ -461,6 +462,7 @@
   printcmm
   printlinear
   printmach
+ printoperation
   printreg
   proc
   simd


### PR DESCRIPTION
This pull reqesut makes `Linear` independent
of `Mach`, so that the latter is easier to delete.

The main dependency was the `Lop` constructor,
which is "split" by this PR into:

- `Lop` that will share its nested value with CFG
  (through a new module, namely `Operation`);
- `Lcall_op` that will get the constructors from
  the old `Lop` that cannot be mere operation
  in CFG.

The diff is large, but is mainly about moves and
renames. 

I think it is now handled automatically, but the
magic number for linear should definitely be
bumped.