### PR TITLE
Fix the kind of poison constants generated for unboxed value slots

### DIFF
--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -181,7 +181,10 @@ module Closure_field = struct
 
   let unboxer function_slot value_slot =
     { var_name = "closure_field_at_use";
-      poison_const = Const.const_zero;
+      poison_const =
+        Const.of_int_of_kind
+          (Flambda_kind.With_subkind.kind (Value_slot.kind value_slot))
+          0;
       unboxing_prim =
         (fun closure -> unboxing_prim function_slot ~closure value_slot);
       prove_simple =

--- a/testsuite/tests/flambda/unboxing_poison_value_slot.ml
+++ b/testsuite/tests/flambda/unboxing_poison_value_slot.ml
@@ -1,0 +1,28 @@
+(* TEST
+   flags = "-flambda2-advanced-meet";
+   native;
+*)
+
+(* This test checks for an issue when unboxing closures under variants.
+   It is only relevant at higher optimisation levels. *)
+[@@@ocaml.flambda_o3]
+
+let maybe_make_closure () =
+  if Sys.opaque_identity true
+  then None
+  else (
+    let zero = Sys.opaque_identity #0L in
+    (* This closure will be unboxed, with a value slot of kind Naked_int64 *)
+    Some (fun () -> zero))
+;;
+
+(* First unboxing: generate the extra args, including poison constants *)
+let f () =
+  match maybe_make_closure () with
+  | None -> #0L
+  | Some get -> get ()
+;;
+
+(* Resimplifying [f] triggers an error if the poison constants don't have
+   the right kind *)
+let g () = f ()


### PR DESCRIPTION
When unboxing a closure under a variant, the branches corresponding to the other tags get a poison constant for the unboxed values slots. The constant must be of the right kind.
