### PR TITLE
Fixes to obscure mark-delay problems

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1821,11 +1821,17 @@ static void major_collection_slice(intnat howmuch,
 
   if (domain_state->sweeping_done) {
     /* We do not immediately trigger a minor GC, but instead wait for
-       the next one to happen normally. This gives some chance that
-       other domains will finish sweeping as well. */
+       the next one to happen normally, when marking will start. This
+       gives some chance that other domains will finish sweeping as
+       well. */
     request_mark_phase();
+    /* If there was no sweeping to do, but marking hasn't started,
+       then minor GC has not occurred naturally between major slices -
+       so we should force one now. */
+    if (sweep_work == 0 && !caml_marking_started()) {
+        caml_request_minor_gc();
+    }
   }
-
 
 mark_again:
   if (caml_marking_started() &&

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1431,13 +1431,14 @@ void caml_mark_roots_stw (int participant_count, caml_domain_state** barrier_par
   Caml_global_barrier_if_final(participant_count) {
     caml_gc_phase = Phase_sweep_and_mark_main;
     atomic_store_relaxed(&global_roots_scanned, WORK_UNSTARTED);
+    /* Adopt orphaned work from domains that were spawned and
+       terminated in the previous cycle. Do this in the barrier,
+       before any domain can terminate on this cycle. */
+    adopt_orphaned_work (caml_global_heap_state.UNMARKED);
   }
 
   caml_domain_state* domain = Caml_state;
 
-  /* Adopt orphaned work from domains that were spawned and terminated in the
-     previous cycle. */
-  adopt_orphaned_work (caml_global_heap_state.UNMARKED);
 
   begin_ephe_marking();
 


### PR DESCRIPTION
When upstreaming #2348 / #2358 / #3029 to ocaml/ocaml#13580, two problems were detected by CI. This PR has fixes for each, in separate commits, and also a fix for a third problem spotted by @stedolan during review discussions.

The first is a pacing problem in which major GC work performed can, in some circumstances, fall further and further behind the estimated work required. See the discussion on ocaml/ocaml#13580 for more details. In a long-running process this could be problematic, leading to longer GC pauses. On 32-bit platforms the flawed estimation can lead to an overflow which stops GC altogether, fatally. The short-term fix in this PR applies a "catch-up" adjustment when it may be necessary. Work is in progress on replacing all the pacing code, which should result in a longer-term fix.

The second problem concerns adopting ephemerons which have been orphaned by a terminating domain. They are marked by the terminating domain, so survive that GC cycle. They are then adopted at the start of marking in the next cycle, when they should be unmarked (due to the major GC cycle colour-switch). However, at present all domains attempt to adopt orphans at the start of marking, without a subsequent barrier, so it is possible for the terminating domain to get past this point, mark the ephemerons and then orphan them, before some other domain attempts to adopt and picks up the ephemerons. The fact that the ephemerons have already been marked in this cycle is detected in the debug runtime by a failing assertion. It is unclear whether this difference in marking is harmless; the multicore major GC ephemeron marking system is complex and it seems unwise to change this behaviour. In this PR, orphan adoption is moved inside the barrier at the start of marking; it starts with a very cheap check (`no_orphaned_work()`) so this change is almost free in the common case and fairly cheap even if there are orphans.

This second problem was detected by the ocaml-multicore/multicoretests run automatically by CI on ocaml/ocaml#13580 due to the `run-multicoretests` label.

The third problem is due to the fact that marking is requested in one slice, but then actually begun on the next minor GC. If insufficient allocation takes place to trigger a minor GC, successive major slices may occur without the major GC progressing. This is now detected on the following slice: if no sweeping is available and yet marking has not started, a minor GC is requested.