### PR TITLE
Delete regions_closed_early

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -367,7 +367,6 @@ module Acc = struct
       seen_a_function : bool;
       slot_offsets : Slot_offsets.t;
       code_slot_offsets : Slot_offsets.t Code_id.Map.t;
-      regions_closed_early : Ident.Set.t;
       closure_infos : closure_info list;
       symbol_short_name_counter : int
     }
@@ -456,7 +455,6 @@ module Acc = struct
       seen_a_function = false;
       slot_offsets = Slot_offsets.empty;
       code_slot_offsets = Code_id.Map.empty;
-      regions_closed_early = Ident.Set.empty;
       closure_infos = [];
       symbol_short_name_counter = 0
     }


### PR DESCRIPTION
There is an unused field called `regions_closed_early` in the accumulator for closure conversion, which this PR deletes.

This actually follows from considering the following tricky question: is the translation to Flambda 2 safe if the Lambda code contains duplicate bound identifiers (where a reasonable meaning can be given; this excludes obviously crazy cases such as a parameter list containing duplicates)?  I claim that this would be the case if the closure conversion accumulator (which I think is the only one used during translation to Flambda 2) does not use any types from `Lambda` (e.g. `Ident.t`).  The reason is that all of the Flambda 2 types for the various identifiers are constructed using environment-style maps with the usual scoping, so a duplicate wouldn't seem to cause problems.

This question is interesting because we'd like to stop `Simplif` from deleting the function declarations for functions to which the local function transformation has been applied, in the case where they have zero-alloc attributes on them (in a manner analogous to what happens inside Flambda 2).  Of course, we should move this transformation into Flambda 2 in the future anyway...