### PR TITLE
Add replay history to match names between two downwards traversals

### DIFF
--- a/middle_end/flambda2/bound_identifiers/bound_continuations.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_continuations.ml
@@ -50,6 +50,9 @@ let ids_for_export t =
 
 let rename t = List.map Continuation.rename t
 
+let is_renamed_version_of t t' =
+  Misc.Stdlib.List.equal Continuation.is_renamed_version_of t t'
+
 let renaming t1 ~guaranteed_fresh:t2 =
   try List.fold_left2 Renaming.add_continuation Renaming.empty t1 t2
   with Invalid_argument _ ->

--- a/middle_end/flambda2/bound_identifiers/bound_for_function.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_for_function.ml
@@ -214,7 +214,8 @@ let is_renamed_version_of t t' =
   && Bound_parameters.is_renamed_version_of t.params t'.params
   && Variable.is_renamed_version_of t.my_closure t'.my_closure
   && Option.equal Variable.is_renamed_version_of t.my_region t'.my_region
-  && Option.equal Variable.is_renamed_version_of t.my_ghost_region t'.my_ghost_region
+  && Option.equal Variable.is_renamed_version_of t.my_ghost_region
+       t'.my_ghost_region
   && Variable.is_renamed_version_of t.my_depth t'.my_depth
 
 let renaming

--- a/middle_end/flambda2/bound_identifiers/bound_for_function.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_for_function.ml
@@ -207,6 +207,22 @@ let rename
     my_depth = Variable.rename my_depth
   }
 
+let region_is_renamed_version_of region1 region2 =
+  match region1, region2 with
+  | None, None -> true
+  | Some r1, Some r2 -> Variable.is_renamed_version_of r1 r2
+  | Some _, None | None, Some _ -> false
+
+let is_renamed_version_of t t' =
+  Continuation.is_renamed_version_of t.return_continuation
+    t'.return_continuation
+  && Continuation.is_renamed_version_of t.exn_continuation t'.exn_continuation
+  && Bound_parameters.is_renamed_version_of t.params t'.params
+  && Variable.is_renamed_version_of t.my_closure t'.my_closure
+  && region_is_renamed_version_of t.my_region t'.my_region
+  && region_is_renamed_version_of t.my_ghost_region t'.my_ghost_region
+  && Variable.is_renamed_version_of t.my_depth t'.my_depth
+
 let renaming
     { return_continuation = return_continuation1;
       exn_continuation = exn_continuation1;

--- a/middle_end/flambda2/bound_identifiers/bound_for_function.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_for_function.ml
@@ -219,8 +219,8 @@ let is_renamed_version_of t t' =
   && Continuation.is_renamed_version_of t.exn_continuation t'.exn_continuation
   && Bound_parameters.is_renamed_version_of t.params t'.params
   && Variable.is_renamed_version_of t.my_closure t'.my_closure
-  && region_is_renamed_version_of t.my_region t'.my_region
-  && region_is_renamed_version_of t.my_ghost_region t'.my_ghost_region
+  && Option.equal Variable.is_renamed_version_of t.my_region t'.my_region
+  && Option.equal Variable.is_renamed_version_of t.my_ghost_region t'.my_ghost_region
   && Variable.is_renamed_version_of t.my_depth t'.my_depth
 
 let renaming

--- a/middle_end/flambda2/bound_identifiers/bound_for_function.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_for_function.ml
@@ -207,12 +207,6 @@ let rename
     my_depth = Variable.rename my_depth
   }
 
-let region_is_renamed_version_of region1 region2 =
-  match region1, region2 with
-  | None, None -> true
-  | Some r1, Some r2 -> Variable.is_renamed_version_of r1 r2
-  | Some _, None | None, Some _ -> false
-
 let is_renamed_version_of t t' =
   Continuation.is_renamed_version_of t.return_continuation
     t'.return_continuation

--- a/middle_end/flambda2/bound_identifiers/bound_parameter.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameter.ml
@@ -56,6 +56,10 @@ let with_kind t kind = { t with kind }
 
 let rename t = { t with param = Variable.rename t.param }
 
+let is_renamed_version_of t t' =
+  Flambda_kind.With_subkind.equal t.kind t'.kind
+  && Variable.is_renamed_version_of t.param t'.param
+
 let free_names ({ param = _; kind = _ } as t) =
   Name_occurrences.singleton_variable (var t) Name_mode.normal
 

--- a/middle_end/flambda2/bound_identifiers/bound_parameter.mli
+++ b/middle_end/flambda2/bound_identifiers/bound_parameter.mli
@@ -36,6 +36,8 @@ val with_kind : t -> Flambda_kind.With_subkind.t -> t
 
 val rename : t -> t
 
+val is_renamed_version_of : t -> t -> bool
+
 include Container_types.S with type t := t
 
 include Contains_names.S with type t := t

--- a/middle_end/flambda2/bound_identifiers/bound_parameters.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameters.ml
@@ -60,6 +60,9 @@ let var_set t = Variable.Set.of_list (vars t)
 
 let rename t = List.map (fun t -> BP.rename t) t
 
+let is_renamed_version_of t t' =
+  Misc.Stdlib.List.equal BP.is_renamed_version_of t t'
+
 let arity t =
   List.map
     (fun t -> Flambda_arity.Component_for_creation.Singleton (BP.kind t))

--- a/middle_end/flambda2/bound_identifiers/bound_pattern.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_pattern.ml
@@ -88,6 +88,21 @@ let rename t =
     Set_of_closures bound_vars
   | Static _ -> t
 
+let is_renamed_version_of t t' =
+  match t, t' with
+  | Singleton bound_var, Singleton bound_var' ->
+    Bound_var.is_renamed_version_of bound_var bound_var'
+  | Set_of_closures bound_vars, Set_of_closures bound_vars' ->
+    Misc.Stdlib.List.equal Bound_var.is_renamed_version_of bound_vars
+      bound_vars'
+  | Static _bound_static, Static _bound_static' ->
+    (* CR gbury/ncourant: We should try and compare the bound statics here *)
+    true
+  | Singleton _, (Set_of_closures _ | Static _)
+  | Set_of_closures _, (Singleton _ | Static _)
+  | Static _, (Singleton _ | Set_of_closures _) ->
+    false
+
 let renaming t1 ~guaranteed_fresh:t2 =
   match t1, t2 with
   | Singleton bound_var1, Singleton bound_var2 ->

--- a/middle_end/flambda2/bound_identifiers/bound_var.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_var.ml
@@ -37,6 +37,10 @@ let with_name_mode t name_mode = { t with name_mode }
 
 let rename t = with_var t (Variable.rename t.var)
 
+let is_renamed_version_of t t' =
+  Name_mode.equal t.name_mode t'.name_mode
+  && Variable.is_renamed_version_of t.var t'.var
+
 let apply_renaming t renaming =
   with_var t (Renaming.apply_variable renaming t.var)
 

--- a/middle_end/flambda2/identifiers/continuation.ml
+++ b/middle_end/flambda2/identifiers/continuation.ml
@@ -133,6 +133,11 @@ let rename t =
   let { Data.name; sort; name_stamp = _; compilation_unit = _ } = find_data t in
   create ~sort ~name ()
 
+let is_renamed_version_of t t' =
+  let data = find_data t in
+  let data' = find_data t' in
+  Sort.equal data.sort data'.sort && String.equal data.name data'.name
+
 let name t = (find_data t).name
 
 let name_stamp t = (find_data t).name_stamp

--- a/middle_end/flambda2/identifiers/continuation.mli
+++ b/middle_end/flambda2/identifiers/continuation.mli
@@ -38,6 +38,8 @@ val create : ?sort:Sort.t -> ?name:string -> unit -> t
 
 val rename : t -> t
 
+val is_renamed_version_of : t -> t -> bool
+
 val name : t -> string
 
 val sort : t -> Sort.t

--- a/middle_end/flambda2/identifiers/variable.ml
+++ b/middle_end/flambda2/identifiers/variable.ml
@@ -24,6 +24,10 @@ let rename ?append t =
   let user_visible = if user_visible t then Some () else None in
   create ?user_visible name
 
+let is_renamed_version_of t t' =
+  (* We only keep track of variables renamed with an empty {append} parameter *)
+  String.equal (name t) (name t')
+
 let raw_name = name
 
 let unique_name t = name t ^ string_of_int (name_stamp t)

--- a/middle_end/flambda2/identifiers/variable.mli
+++ b/middle_end/flambda2/identifiers/variable.mli
@@ -24,6 +24,8 @@ val create_with_same_name_as_ident : ?user_visible:unit -> Ident.t -> t
     the current unit, not the unit of the variable passed in. *)
 val rename : ?append:string -> t -> t
 
+val is_renamed_version_of : t -> t -> bool
+
 val unique_name : t -> string
 
 val raw_name : t -> string

--- a/middle_end/flambda2/nominal/bindable.ml
+++ b/middle_end/flambda2/nominal/bindable.ml
@@ -29,6 +29,17 @@ module type S = sig
   (** Freshen the given name. *)
   val rename : t -> t
 
+  (** Equivalence relation on renamed variables.
+
+      [is_renamed_version_of x y] is [true] if there exists a bindable [z]
+      such that [x] and [y] are renamed versions of [z].
+
+      Note: this function can return [true] in other cases (if there are some name collisions
+      for instance), this is (at least currently) only used for a sanity check, so
+      users should not rely too much on its expected semantics.
+      *)
+  val is_renamed_version_of : t -> t -> bool
+
   (** [renaming stale ~guaranteed_fresh:fresh] is to create a renaming that
       turns all occurrences of the name [stale] into [fresh] (in a
       capture-avoiding manner, but that is inherent in [Renaming]). *)

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -73,7 +73,11 @@ val get_continuation_scope : t -> Scope.t
 
 val typing_env : t -> Flambda2_types.Typing_env.t
 
+val define_continuations : t -> Continuation.t list -> t
+
 val define_variable : t -> Bound_var.t -> Flambda_kind.t -> t
+
+val define_extra_variable : t -> Bound_var.t -> Flambda_kind.t -> t
 
 val add_name : t -> Bound_name.t -> Flambda2_types.t -> t
 
@@ -211,5 +215,11 @@ val variables_defined_in_current_continuation : t -> Lifted_cont_params.t
 val cost_of_lifting_continuations_out_of_current_one : t -> int
 
 val add_lifting_cost : int -> t -> t
+
+val must_inline : t -> bool
+
+val replay_history : t -> Replay_history.t
+
+val with_replay_history : (Replay_history.t * bool) option -> t -> t
 
 val denv_for_lifted_continuation : denv_for_join:t -> denv:t -> t

--- a/middle_end/flambda2/simplify/env/replay_history.ml
+++ b/middle_end/flambda2/simplify/env/replay_history.ml
@@ -1,0 +1,182 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Guillaume Bury, Pierre Chambart and Nathanaëlle Courant, OCamlPro    *)
+(*                                                                        *)
+(*   Copyright 2013--2024 OCamlPro SAS                                    *)
+(*   Copyright 2014--2024 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* List of actions that should be replayed, currently only cares about bound
+   variables and continuations. In the future, we may want to also store
+   inlining decisions.
+
+   CR gbury: move to a [Replay_action.ml] file ? *)
+module Action = struct
+  type t =
+    | Bound_variable of Variable.t
+    | Bound_continuations of Continuation.t list
+
+  let[@ocamlformat "disable"] print ppf = function
+    | Bound_variable v -> Variable.print ppf v
+    | Bound_continuations l ->
+        Format.pp_print_list ~pp_sep:Format.pp_print_space Continuation.print ppf l
+end
+
+(* Type def *)
+(* ******** *)
+
+type t =
+  | First_pass of
+      { history : Action.t list
+            (* Bindables opened, with the head of the list being the
+               innermost/last binder opened *)
+      }
+  | Replaying of
+      { always_inline : bool;
+        (* Force inlining of all function calls during replay. This is for
+           instance set by the match-in-match specialization. *)
+        previous_history : Action.t list;
+        (* Bindables opened during the first pass, with the head of the list
+           being the outermost/first one opened. *)
+        variables : Variable.t Variable.Map.t;
+        (* Map from the variables of the current pass to the corresponding
+           variable from the first pass. *)
+        continuations : Continuation.t Continuation.Map.t
+            (* Map from the continuations of the current pass to the
+               corresponding variable from the first pass. *)
+      }
+
+let[@ocamlformat "disable"] print ppf = function
+  | First_pass { history; } ->
+      Format.fprintf ppf "@[<hov 1>(first_pass@ \
+        @[<hov 1>(history@ %a)@]\
+        )@]"
+        (Format.pp_print_list ~pp_sep:Format.pp_print_space Action.print) history
+  | Replaying { always_inline; previous_history; variables; continuations; } ->
+      Format.fprintf ppf "@[<hov 1>(replaying@ \
+        @[<hov 1>(always_inline@ %b)@]@ \
+        @[<hov 1>(previous_history@ %a)@]@ \
+        @[<hov 1>(variables@ %a)@]@ \
+        @[<hov 1>(continuations@ %a)@]\
+        )@]"
+        always_inline
+        (Format.pp_print_list ~pp_sep:Format.pp_print_space Action.print) previous_history
+        (Variable.Map.print Variable.print) variables
+        (Continuation.Map.print Continuation.print) continuations
+
+(* Creating API *)
+(* ************ *)
+
+let first_pass = First_pass { history = [] }
+
+let replay ~always_inline = function
+  | First_pass { history } ->
+    let previous_history = List.rev history in
+    Replaying
+      { always_inline;
+        previous_history;
+        variables = Variable.Map.empty;
+        continuations = Continuation.Map.empty
+      }
+  | Replaying _ ->
+    (* CR gbury: we could support this use-case (which might be useful for
+       widening in loops) in the future by also storing the original history in
+       the [Replaying] case *)
+    Misc.fatal_errorf "Cannot replay an already replayed binding history"
+
+let error_empty_history replay action =
+  Misc.fatal_errorf
+    "@[<v>@[<hov>Found an empty replay history when replaying action:@ %a.@]@ \
+     Replay: %a@]"
+    Action.print action print replay
+
+let error_mismatched_action replay old_action new_action =
+  Misc.fatal_errorf
+    "@[<v>Action mismatch when replaying history:@ old action: %a@ new action: \
+     %a@ replay: %a"
+    Action.print old_action Action.print new_action print replay
+
+let error_not_renamed_version_of replay old_action new_action =
+  Misc.fatal_errorf
+    "@[<v>Actions are not renamed versions when replaying history:@ old \
+     action: %a@ new action: %a@ replay: %a"
+    Action.print old_action Action.print new_action print replay
+
+let define_variable var replay =
+  let action : Action.t = Bound_variable var in
+  match replay with
+  | First_pass { history } -> First_pass { history = action :: history }
+  | Replaying
+      { previous_history = prev_bound :: previous_history;
+        variables;
+        continuations;
+        always_inline
+      } -> (
+    match prev_bound with
+    | Bound_variable prev_var ->
+      if not (Variable.is_renamed_version_of prev_var var)
+      then error_not_renamed_version_of replay prev_bound action
+      else
+        let variables = Variable.Map.add var prev_var variables in
+        Replaying { previous_history; variables; continuations; always_inline }
+    | Bound_continuations _ -> error_mismatched_action replay prev_bound action)
+  | Replaying { previous_history = []; _ } -> error_empty_history replay action
+
+let define_continuations conts replay =
+  let action : Action.t = Bound_continuations conts in
+  match replay with
+  | First_pass { history } -> First_pass { history = action :: history }
+  | Replaying
+      { previous_history = prev_bound :: previous_history;
+        variables;
+        continuations;
+        always_inline
+      } -> (
+    match prev_bound with
+    | Bound_continuations prev_conts ->
+      if not
+           (List.compare_lengths prev_conts conts = 0
+           && Misc.Stdlib.List.equal Continuation.is_renamed_version_of
+                prev_conts conts)
+      then error_not_renamed_version_of replay prev_bound action
+      else
+        let continuations =
+          List.fold_left2
+            (fun acc prev_cont cont -> Continuation.Map.add cont prev_cont acc)
+            continuations prev_conts conts
+        in
+        Replaying { previous_history; variables; continuations; always_inline }
+    | Bound_variable _ -> error_mismatched_action replay prev_bound action)
+  | Replaying { previous_history = []; _ } -> error_empty_history replay action
+
+(* Inspection API *)
+(* ************** *)
+
+let must_inline = function
+  | First_pass _ -> false
+  | Replaying { always_inline; _ } -> always_inline
+
+type 'a replay_result =
+  | Still_recording
+  | Replayed of 'a
+
+let replay_variable_mapping = function
+  | First_pass _ -> Still_recording
+  | Replaying
+      { variables; previous_history = _; continuations = _; always_inline = _ }
+    ->
+    Replayed variables
+
+let replay_continuation_mapping = function
+  | First_pass _ -> Still_recording
+  | Replaying
+      { continuations; previous_history = _; variables = _; always_inline = _ }
+    ->
+    Replayed continuations

--- a/middle_end/flambda2/simplify/env/replay_history.mli
+++ b/middle_end/flambda2/simplify/env/replay_history.mli
@@ -72,14 +72,14 @@ val define_continuations : Continuation.t list -> t -> t
 (** {2 Inspection API} *)
 
 (** Returns [true] is the replay history was created with the `always_inline` flag. (first pass
-    histories have the flage set to false). *)
+    histories have the flag set to false). *)
 val must_inline : t -> bool
 
 (** Type of results for inspection functions for which the result only makes sense
     when replaying a downwards pass. *)
 type 'a replay_result =
   | Still_recording
-  | Replayed of 'a (**)
+  | Replayed of 'a
 
 (** If called on a history created with {!replay}, returns the mapping from variables
     of the current pass to variables bound during the first pass.

--- a/middle_end/flambda2/simplify/env/replay_history.mli
+++ b/middle_end/flambda2/simplify/env/replay_history.mli
@@ -1,0 +1,95 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Guillaume Bury, Pierre Chambart and Nathanaëlle Courant, OCamlPro    *)
+(*                                                                        *)
+(*   Copyright 2013--2024 OCamlPro SAS                                    *)
+(*   Copyright 2014--2024 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** {1 Replay Histories}
+
+    In some cases (e.g. continuation specialization for match-in-match), we are
+    interested in doing multiple downwards pass on a single term. In such
+    cases, it might be necessary to relate the names of variables and
+    continuations from the first pass to those from the subsequent passes. The
+    predominant use of that is currently to correctly handle continuations that
+    have been lifted during the first pass, and whose calls should be rewritten
+    in subsequent passes (including their lifted arguments).
+
+    This module provides a way to "replay" a downwards pass and more specifically
+    its sequence of bindings, so that the names of continuations and variables
+    generated during the second pass can be mapped to the names generated during
+    the first pass.
+
+    As a safety measure, before mapping two names, we check that they are in
+    the same "renaming equivalence class", though note that this is not a
+    guarantee (for isntance, by default all continuation have no names and
+    therefore will all be in the same "renaming equivalence class").
+
+    Additionally, and this is more specific to continuation specialization but
+    generalizable to other future uses, it is necessary to have some kind of
+    replayability of inlining decisions. Indeed each inlining decision will
+    change the sequence of bound names that are opened during the downwards
+    pass, which would currently break the hypothesis of replay histories that
+    exactly the same sequence of binders are opened during both downwards
+    passes. In the case of match-in-match this is simple: the handler that we
+    want to specialize ends with a switch, which means that any call inside the
+    handler have been inlined, so the replay history has a boolean to denote
+    that we want to inline everything while replaying the handler downwards
+    pass. For other more complex uses, inlining decisions could be stored
+    alongside the bound variables and continuations, so that they can be
+    replayed, either as is, or within some notion of compatibility. *)
+
+(** The type of a replay history, used both when recording during the first
+    downwards pass **and** when replaying during a subsequent downwards pass
+    on the same term. *)
+type t
+
+val print : Format.formatter -> t -> unit
+
+(** {2 Creation API} *)
+
+(** Create an empty replay history for a first downwards pass. *)
+val first_pass : t
+
+(** Given a history generated during a first downwards pass on an expression [expr], create a new history
+    that is suitable for use for subsequent passes on [expr]. *)
+val replay : always_inline:bool -> t -> t
+
+(** Define a new bound variable. *)
+val define_variable : Variable.t -> t -> t
+
+(** Define a new set of bound mutually recursive continuations. *)
+val define_continuations : Continuation.t list -> t -> t
+
+(** {2 Inspection API} *)
+
+(** Returns [true] is the replay history was created with the `always_inline` flag. (first pass
+    histories have the flage set to false). *)
+val must_inline : t -> bool
+
+(** Type of results for inspection functions for which the result only makes sense
+    when replaying a downwards pass. *)
+type 'a replay_result =
+  | Still_recording
+  | Replayed of 'a (**)
+
+(** If called on a history created with {!replay}, returns the mapping from variables
+    of the current pass to variables bound during the first pass.
+
+    On a first pass replay, this will raise a fatal error. *)
+val replay_variable_mapping : t -> Variable.t Variable.Map.t replay_result
+
+(** If called on a history created with {!replay}, returns the mapping from continuations
+    of the current pass to continuations bound during the first pass.
+
+    On a first pass replay, this will raise a fatal error. *)
+val replay_continuation_mapping :
+  t -> Continuation.t Continuation.Map.t replay_result

--- a/middle_end/flambda2/simplify/env/replay_history.mli
+++ b/middle_end/flambda2/simplify/env/replay_history.mli
@@ -82,14 +82,10 @@ type 'a replay_result =
   | Replayed of 'a
 
 (** If called on a history created with {!replay}, returns the mapping from variables
-    of the current pass to variables bound during the first pass.
-
-    On a first pass replay, this will raise a fatal error. *)
+    of the current pass to variables bound during the first pass. *)
 val replay_variable_mapping : t -> Variable.t Variable.Map.t replay_result
 
 (** If called on a history created with {!replay}, returns the mapping from continuations
-    of the current pass to continuations bound during the first pass.
-
-    On a first pass replay, this will raise a fatal error. *)
+    of the current pass to continuations bound during the first pass. *)
 val replay_continuation_mapping :
   t -> Continuation.t Continuation.Map.t replay_result

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -73,11 +73,11 @@ let introduce_extra_params_for_join denv use_envs_with_ids
     in
     denv, use_envs_with_ids
 
-let join ?cut_after denv params ~consts_lifted_during_body ~use_envs_with_ids
-    ~lifted_cont_extra_params_and_args =
+let join ?cut_after denv params ~consts_lifted_after_fork ~use_envs_with_ids
+    ~previous_extra_params_and_args =
   let definition_scope = DE.get_continuation_scope denv in
   let extra_lifted_consts_in_use_envs =
-    LCS.all_defined_symbols consts_lifted_during_body
+    LCS.all_defined_symbols consts_lifted_after_fork
   in
   let module CSE = Common_subexpression_elimination in
   let cse_join_result =
@@ -92,11 +92,11 @@ let join ?cut_after denv params ~consts_lifted_during_body ~use_envs_with_ids
   in
   let extra_params_and_args =
     match cse_join_result with
-    | None -> lifted_cont_extra_params_and_args
+    | None -> previous_extra_params_and_args
     | Some cse_join_result ->
       (* CR gbury: the order of the EPA should not matter here *)
       EPA.concat ~outer:cse_join_result.extra_params
-        ~inner:lifted_cont_extra_params_and_args
+        ~inner:previous_extra_params_and_args
   in
   let denv, use_envs_with_ids' =
     introduce_extra_params_for_join denv use_envs_with_ids
@@ -173,33 +173,36 @@ let add_equations_on_params typing_env ~is_recursive ~params:params'
   in
   add_equations_on_params typing_env params param_types
 
-let compute_handler_env ?cut_after uses ~is_recursive ~env_at_fork
-    ~consts_lifted_during_body ~params ~lifted_cont_extra_params_and_args =
+let compute_use_env_with_ids ?replay ~is_recursive ~params use =
+  let add_or_meet_param_type typing_env =
+    let param_types = U.arg_types use in
+    add_equations_on_params typing_env ~is_recursive ~params ~param_types
+  in
+  let use_env =
+    let use_env = DE.with_replay_history replay (U.env_at_use use) in
+    let use_env = DE.define_parameters ~extra:false use_env ~params in
+    DE.map_typing_env use_env ~f:add_or_meet_param_type
+  in
+  use_env, U.id use, U.use_kind use
+
+let compute_handler_env ?replay ?cut_after uses ~is_recursive ~env_at_fork
+    ~consts_lifted_after_fork ~params ~previous_extra_params_and_args =
   (* Augment the environment at each use with the parameter definitions and
      associated equations. *)
-  let use_envs_with_ids =
-    List.map
-      (fun use ->
-        let add_or_meet_param_type typing_env =
-          let param_types = U.arg_types use in
-          add_equations_on_params typing_env ~is_recursive ~params ~param_types
-        in
-        let use_env =
-          let use_env =
-            DE.define_parameters ~extra:false (U.env_at_use use) ~params
-          in
-          DE.map_typing_env use_env ~f:add_or_meet_param_type
-        in
-        use_env, U.id use, U.use_kind use)
-      uses
-  in
-  match use_envs_with_ids with
-  | [(use_env, use_id, Inlinable)] when not is_recursive ->
+  match uses with
+  | [use]
+    when (not is_recursive)
+         &&
+         match U.use_kind use with
+         | Inlinable -> true
+         | Non_inlinable _ -> false ->
     (* First add the extra params and args equations in the typing env *)
+    let ((use_env, _use_id, _use_kind) as use) =
+      compute_use_env_with_ids ?replay ~is_recursive ~params use
+    in
     let use_tenv =
-      let use = use_env, use_id, Continuation_use_kind.Inlinable in
       match
-        introduce_extra_params_in_use_env lifted_cont_extra_params_and_args use
+        introduce_extra_params_in_use_env previous_extra_params_and_args use
       with
       | Some (use_env, _, _) -> use_env
       | None ->
@@ -224,8 +227,7 @@ let compute_handler_env ?cut_after uses ~is_recursive ~env_at_fork
        because they were defined on the path between the fork point and this
        particular use). *)
     let handler_env =
-      LCS.add_to_denv ~maybe_already_defined:() use_env
-        consts_lifted_during_body
+      LCS.add_to_denv ~maybe_already_defined:() use_env consts_lifted_after_fork
     in
     (* The use environment might have a deeper inlining depth increment than the
        fork environment. (e.g. where an [Apply] was inlined, revealing the
@@ -246,19 +248,24 @@ let compute_handler_env ?cut_after uses ~is_recursive ~env_at_fork
         (DE.at_unit_toplevel env_at_fork)
     in
     { handler_env;
-      extra_params_and_args = EPA.empty;
+      extra_params_and_args = previous_extra_params_and_args;
       is_single_inlinable_use = true;
       escapes = false
     }
-  | [] | [(_, _, Non_inlinable _)] | (_, _, (Inlinable | Non_inlinable _)) :: _
-    ->
+  | _ ->
+    let use_envs_with_ids =
+      List.map
+        (compute_use_env_with_ids ?replay:None ~is_recursive ~params)
+        uses
+    in
     (* This is the general case.
 
        The lifted constants are put into the _fork_ environment now because it
        overall makes things easier; the join operation can just discard any
        equation about a lifted constant (any such equation could not be
        materially more precise anyway). *)
-    let denv = LCS.add_to_denv env_at_fork consts_lifted_during_body in
+    let denv = DE.with_replay_history replay env_at_fork in
+    let denv = LCS.add_to_denv denv consts_lifted_after_fork in
     let should_do_join =
       Flambda_features.join_points ()
       || match use_envs_with_ids with [] | [_] -> true | _ :: _ :: _ -> false
@@ -270,8 +277,8 @@ let compute_handler_env ?cut_after uses ~is_recursive ~env_at_fork
            environments *)
         let denv = DE.define_parameters denv ~extra:false ~params in
         Profile.record_call ~accumulate:true "join" (fun () ->
-            join ?cut_after denv params ~consts_lifted_during_body
-              ~use_envs_with_ids ~lifted_cont_extra_params_and_args)
+            join ?cut_after denv params ~consts_lifted_after_fork
+              ~use_envs_with_ids ~previous_extra_params_and_args)
       else
         (* Define parameters with basic equations from the subkinds *)
         let denv =
@@ -279,9 +286,9 @@ let compute_handler_env ?cut_after uses ~is_recursive ~env_at_fork
         in
         let denv =
           DE.add_parameters_with_unknown_types denv ~extra:true
-            (EPA.extra_params lifted_cont_extra_params_and_args)
+            (EPA.extra_params previous_extra_params_and_args)
         in
-        denv, lifted_cont_extra_params_and_args
+        denv, previous_extra_params_and_args
     in
     let escapes =
       List.exists

--- a/middle_end/flambda2/simplify/join_points.mli
+++ b/middle_end/flambda2/simplify/join_points.mli
@@ -26,11 +26,12 @@ type result = private
   }
 
 val compute_handler_env :
+  ?replay:Replay_history.t * bool ->
   ?cut_after:Scope.t ->
   One_continuation_use.t list ->
   is_recursive:bool ->
   env_at_fork:Downwards_env.t ->
-  consts_lifted_during_body:Lifted_constant_state.t ->
+  consts_lifted_after_fork:Lifted_constant_state.t ->
   params:Bound_parameters.t ->
-  lifted_cont_extra_params_and_args:Continuation_extra_params_and_args.t ->
+  previous_extra_params_and_args:Continuation_extra_params_and_args.t ->
   result

--- a/middle_end/flambda2/simplify/lifted_cont_params.ml
+++ b/middle_end/flambda2/simplify/lifted_cont_params.ml
@@ -30,10 +30,17 @@ let is_empty { len; new_params_indexed = _ } = len = 0
 
 let length { len; new_params_indexed = _ } = len
 
-let new_param t bound_param =
-  let new_params_indexed =
-    BP.Map.add bound_param bound_param t.new_params_indexed
+let new_param t ~replay_history bound_param =
+  let key =
+    match Replay_history.replay_variable_mapping replay_history with
+    | Still_recording -> bound_param
+    | Replayed variable_mapping ->
+      let original_var =
+        Variable.Map.find (BP.var bound_param) variable_mapping
+      in
+      BP.create original_var (BP.kind bound_param)
   in
+  let new_params_indexed = BP.Map.add key bound_param t.new_params_indexed in
   { len = t.len + 1; new_params_indexed }
 
 let rename t =

--- a/middle_end/flambda2/simplify/lifted_cont_params.mli
+++ b/middle_end/flambda2/simplify/lifted_cont_params.mli
@@ -53,7 +53,7 @@ val is_empty : t -> bool
 val length : t -> int
 
 (** Add a new parameter *)
-val new_param : t -> Bound_parameter.t -> t
+val new_param : t -> replay_history:Replay_history.t -> Bound_parameter.t -> t
 
 (** Rename all new parameters, and returns the corresponding renaming. *)
 val rename : t -> t * Renaming.t

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -1041,7 +1041,8 @@ and prepare_dacc_for_handlers dacc ~env_at_fork ~params ~is_recursive
        enabling unboxing for those (while avoiding re-unboxing parameters that
        have already been unboxed). *)
     Join_points.compute_handler_env uses ~params ~is_recursive ~env_at_fork
-      ~consts_lifted_during_body ~lifted_cont_extra_params_and_args
+      ~consts_lifted_after_fork:consts_lifted_during_body
+      ~previous_extra_params_and_args:lifted_cont_extra_params_and_args
   in
   let code_age_relation = TE.code_age_relation (DA.typing_env dacc) in
   let handler_env =
@@ -1475,7 +1476,11 @@ let simplify_let_cont0 ~(simplify_expr : _ Simplify_common.expr_simplifier) dacc
       Lifted_cont_params.length
         (DE.variables_defined_in_current_continuation denv_for_body)
     in
-    DE.add_lifting_cost lifting_cost denv_for_body
+    let bound_continuations =
+      Original_handlers.bound_continuations data.handlers
+    in
+    DE.add_lifting_cost lifting_cost
+      (DE.define_continuations denv_for_body bound_continuations)
   in
   let dacc = DA.with_denv dacc denv_for_body in
   let body = data.body in

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -301,8 +301,8 @@ let compute_result_types ~is_a_functor ~is_opaque ~return_cont_uses
         ~cut_after:(Scope.prev (DE.get_continuation_scope env_at_fork))
         (Continuation_uses.get_uses uses)
         ~is_recursive:false ~params:return_cont_params ~env_at_fork
-        ~consts_lifted_during_body:lifted_consts_this_function
-        ~lifted_cont_extra_params_and_args:EPA.empty
+        ~consts_lifted_after_fork:lifted_consts_this_function
+        ~previous_extra_params_and_args:EPA.empty
     in
     let bound_params_and_results =
       Bound_parameters.append params return_cont_params

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
@@ -170,9 +170,10 @@ let report_reason fmt t =
   | Attribute_always ->
     Format.fprintf fmt "the@ call@ has@ an@ [@@inline always]@ attribute"
   | Replay_history_says_must_inline ->
-    (* CR gbury: We should probably not include in the inlining report inlining
+    (* CR gbury: We could decide not to include in the inlining report inlining
        decisions that were made during replays (e.G. continuation
-       specialization). *)
+       specialization), or alternatively to store the initial inlining decision
+       so that we can report it each time. *)
     Format.fprintf fmt
       "the@ call@ was@ inlined@ during@ the@ first@ pass@ on@ the@ current@ \
        continuation@ handler"

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
@@ -39,6 +39,7 @@ type t =
         threshold : float
       }
   | Attribute_always
+  | Replay_history_says_must_inline
   | Begin_unrolling of int
   | Continue_unrolling
   | Definition_says_inline of { was_inline_always : bool }
@@ -67,6 +68,8 @@ let [@ocamlformat "disable"] print ppf t =
     Format.fprintf ppf "Never_inlined_attribute"
   | Attribute_always ->
     Format.fprintf ppf "Attribute_always"
+  | Replay_history_says_must_inline ->
+    Format.fprintf ppf "Replay_history_says_must_inline"
   | Definition_says_inline { was_inline_always } ->
     Format.fprintf ppf
       "@[<hov 1>(Definition_says_inline@ \
@@ -139,6 +142,8 @@ let can_inline (t : t) : can_inline =
   | Speculatively_inline _ ->
     Inline { unroll_to = None; was_inline_always = false }
   | Attribute_always -> Inline { unroll_to = None; was_inline_always = true }
+  | Replay_history_says_must_inline ->
+    Inline { unroll_to = None; was_inline_always = false }
 
 let report_reason fmt t =
   match (t : t) with
@@ -164,6 +169,13 @@ let report_reason fmt t =
     Format.fprintf fmt "the@ call@ has@ an@ attribute@ forbidding@ inlining"
   | Attribute_always ->
     Format.fprintf fmt "the@ call@ has@ an@ [@@inline always]@ attribute"
+  | Replay_history_says_must_inline ->
+    (* CR gbury: We should probably not include in the inlining report inlining
+       decisions that were made during replays (e.G. continuation
+       specialization). *)
+    Format.fprintf fmt
+      "the@ call@ was@ inlined@ during@ the@ first@ pass@ on@ the@ current@ \
+       continuation@ handler"
   | Begin_unrolling n ->
     Format.fprintf fmt "the@ call@ has@ an@ [@@unroll %d]@ attribute" n
   | Continue_unrolling ->

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -32,6 +32,7 @@ type t =
         threshold : float
       }
   | Attribute_always
+  | Replay_history_says_must_inline
   | Begin_unrolling of int
   | Continue_unrolling
   | Definition_says_inline of { was_inline_always : bool }

--- a/middle_end/flambda2/terms/result_types.ml
+++ b/middle_end/flambda2/terms/result_types.ml
@@ -61,6 +61,12 @@ module Bound = struct
     let other_vars = List.map (fun var -> Variable.rename var) other_vars in
     { params; results; other_vars }
 
+  let is_renamed_version_of t t' =
+    Bound_parameters.is_renamed_version_of t.params t'.params
+    && Bound_parameters.is_renamed_version_of t.results t'.results
+    && Misc.Stdlib.List.equal Variable.is_renamed_version_of t.other_vars
+         t'.other_vars
+
   let print ppf { params; results; other_vars } =
     Format.fprintf ppf
       "@[<hov 1>(@[<hov 1>(params@ (%a))@]@ @[<hov 1>(results@ (%a))@]@ @[<hov \


### PR DESCRIPTION
[Note: This is a pre-requisite of match-in-match; the mechanism introduced is not yet used in this PR, but will be used by continuation specialization when the PR for match-in-match is opened]

In some cases (mostly the upcoming continuation specialization for match-in-match), we are interested in doing multiple downwards pass on a single term. In such cases, it might be necessary to relate the names of variables and continuations from the first pass to those from the subsequent passes. The predominant use of that for now should be to correctly handle continuations that have been lifted during the first pass, and whose calls should be rewritten in subsequent passes (including their lifted arguments).

This is done by storing the sequence of names generated when opening name abstractions during the first downwards pass. On subsequent passes, each new variable and continuation "consumes" an element of that sequence, allowing to establish the correspondance between names. As a safety measure, we check that correspondings names are in the same "renaming equivalence class", though note that this is not a guarantee (for isntance, by default all continuation have no names and therefore will all be in the same "renaming equivalence class").

Additionally, and this is more specific to continuation specialization but generalizable to other future uses, it is necessary to have some kind of replayability of inlining decisions. Indeed each inlining decision will change the sequence of bound names that are opened during the downwards pass, which would currently break the hypothesis of replay histories that exactly the same sequence of binders are opened during both downwards passes. In the case of match-in-match this is simple: the handler that we want to specialize ends with a switch, which means that any call inside the handler have been inlined, so the replay history has a boolean to denote that we want to inline everything while replaying the handler downwards pass. For other more complex uses, inlining decisions could be stored alongside the bound variables and continuations, so that they can be replayed, either as is, or within some notion of compatibility.

Finally, we also need to make it so that recursive continuations are bound in an order that is stable through renaming, so we change the map of continuation to an Lmap for recursive continuation bindings.

In the future, this replay mechanism would also be useful to do widening for recursive continuations (but that's a far away future).