### PR TITLE
Peek and poke

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -199,7 +199,7 @@ let preserve_tailcall_for_prim = function
   | Patomic_exchange | Patomic_compare_exchange
   | Patomic_cas | Patomic_fetch_add | Patomic_load _
   | Pdls_get | Preinterpret_tagged_int63_as_unboxed_int64
-  | Preinterpret_unboxed_int64_as_tagged_int63 | Ppoll ->
+  | Preinterpret_unboxed_int64_as_tagged_int63 | Ppoll | Ppeek _ | Ppoke _ ->
       false
 
 (* Add a Kpop N instruction in front of a continuation *)
@@ -737,6 +737,8 @@ let comp_primitive stack_info p sz args =
   | Punbox_float _ | Pbox_float (_, _) | Punbox_int _ | Pbox_int _
     ->
       fatal_error "Bytegen.comp_primitive"
+  | Ppeek _ | Ppoke _ ->
+      fatal_error "Bytegen.comp_primitive: Ppeek/Ppoke not supported in bytecode"
 
 let is_immed n = immed_min <= n && n <= immed_max
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -343,6 +343,8 @@ type primitive =
   | Parray_of_iarray (* Unsafely reinterpret an immutable array as a mutable
                         one; O(1) *)
   | Pget_header of locality_mode
+  | Ppeek of peek_or_poke
+  | Ppoke of peek_or_poke
   (* Get the header of a block. This primitive is invalid if provided with an
      immediate value.
      Note: The GC color bits in the header are not reliable except for checking
@@ -523,6 +525,14 @@ and boxed_integer = Primitive.boxed_integer =
 
 and boxed_vector = Primitive.boxed_vector =
   | Boxed_vec128
+
+and peek_or_poke =
+  | Ppp_tagged_immediate
+  | Ppp_unboxed_float32
+  | Ppp_unboxed_float
+  | Ppp_unboxed_int32
+  | Ppp_unboxed_int64
+  | Ppp_unboxed_nativeint
 
 and bigarray_kind =
     Pbigarray_unknown

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -478,6 +478,15 @@ let field_read_semantics ppf sem =
   | Reads_agree -> ()
   | Reads_vary -> fprintf ppf "_mut"
 
+let peek_or_poke ppf (pp : peek_or_poke) =
+  match pp with
+  | Ppp_tagged_immediate -> fprintf ppf "tagged_immediate"
+  | Ppp_unboxed_float32 -> fprintf ppf "unboxed_float32"
+  | Ppp_unboxed_float -> fprintf ppf "unboxed_float"
+  | Ppp_unboxed_int32 -> fprintf ppf "unboxed_int32"
+  | Ppp_unboxed_int64 -> fprintf ppf "unboxed_int64"
+  | Ppp_unboxed_nativeint -> fprintf ppf "unboxed_nativeint"
+
 let primitive ppf = function
   | Pbytes_to_string -> fprintf ppf "bytes_to_string"
   | Pbytes_of_string -> fprintf ppf "bytes_of_string"
@@ -930,6 +939,12 @@ let primitive ppf = function
       fprintf ppf "reinterpret_tagged_int63_as_unboxed_int64"
   | Preinterpret_unboxed_int64_as_tagged_int63 ->
       fprintf ppf "reinterpret_unboxed_int64_as_tagged_int63"
+  | Ppeek layout ->
+      fprintf ppf "(peek@ %a)"
+        peek_or_poke layout
+  | Ppoke layout ->
+      fprintf ppf "(poke@ %a)"
+        peek_or_poke layout
 
 let name_of_primitive = function
   | Pbytes_of_string -> "Pbytes_of_string"
@@ -1107,6 +1122,8 @@ let name_of_primitive = function
       "Preinterpret_tagged_int63_as_unboxed_int64"
   | Preinterpret_unboxed_int64_as_tagged_int63 ->
       "Preinterpret_unboxed_int64_as_tagged_int63"
+  | Ppeek _ -> "Ppeek"
+  | Ppoke _ -> "Ppoke"
 
 let zero_alloc_attribute ppf check =
   match check with

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -974,6 +974,7 @@ let rec choice ctx t =
     | Pint_as_pointer _
     | Psequand | Psequor
     | Ppoll
+    | Ppeek _ | Ppoke _
       ->
         let primargs = traverse_list ctx primargs in
         Choice.lambda (Lprim (prim, primargs, loc))

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -28,6 +28,7 @@ module String = Misc.Stdlib.String
 type error =
   | Unknown_builtin_primitive of string
   | Wrong_arity_builtin_primitive of string
+  | Wrong_layout_for_peek_or_poke of string
   | Invalid_floatarray_glb
   | Product_iarrays_unsupported
   | Invalid_array_kind_for_uninitialized_makearray_dynamic
@@ -123,6 +124,10 @@ type prim =
   | Identity
   | Apply of Lambda.region_close * Lambda.layout
   | Revapply of Lambda.region_close * Lambda.layout
+  | Peek of Lambda.peek_or_poke option
+  | Poke of Lambda.peek_or_poke option
+    (* For [Peek] and [Poke] the [option] is [None] until the primitive
+       specialization code (below) has been run. *)
   | Unsupported of Lambda.primitive
 
 let units_with_used_primitives = Hashtbl.create 7
@@ -916,6 +921,8 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
       Primitive(Preinterpret_tagged_int63_as_unboxed_int64, 1)
     | "%reinterpret_unboxed_int64_as_tagged_int63" ->
       Primitive(Preinterpret_unboxed_int64_as_tagged_int63, 1)
+    | "%peek" -> Peek None
+    | "%poke" -> Poke None
     | s when String.length s > 0 && s.[0] = '%' ->
       (match String.Map.find_opt s indexing_primitives with
        | Some prim -> prim ~mode
@@ -1185,6 +1192,27 @@ let glb_array_set_type loc t1 t2 =
   (* Pfloatarray is a minimum *)
   | Pfloatarray_set, Pfloatarray -> Pfloatarray_set
 
+let peek_or_poke_layout_from_type ~prim_name error_loc env ty
+      : Lambda.peek_or_poke option =
+  match Ctype.type_sort ~why:Peek_or_poke ~fixed:true env ty with
+  | Error _ -> None
+  | Ok sort ->
+    let sort = Jkind.Sort.default_to_value_and_get sort in
+    let layout = Typeopt.layout env error_loc sort ty in
+    match layout with
+    | Punboxed_float Unboxed_float32 -> Some Ppp_unboxed_float32
+    | Punboxed_float Unboxed_float64 -> Some Ppp_unboxed_float
+    | Punboxed_int Unboxed_int32 -> Some Ppp_unboxed_int32
+    | Punboxed_int Unboxed_int64 -> Some Ppp_unboxed_int64
+    | Punboxed_int Unboxed_nativeint -> Some Ppp_unboxed_nativeint
+    | Pvalue { raw_kind = Pintval ; _ } -> Some Ppp_tagged_immediate
+    | Ptop
+    | Pvalue _
+    | Punboxed_vector _
+    | Punboxed_product _
+    | Pbottom ->
+      raise (Error (error_loc, Wrong_layout_for_peek_or_poke prim_name))
+
 (* Specialize a primitive from available type information. *)
 (* CR layouts v7: This function had a loc argument added just to support the void
    check error message.  Take it out when we remove that. *)
@@ -1367,6 +1395,25 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     end else begin
       None
     end
+  | Peek _, _ -> (
+    match is_function_type env ty with
+    | None -> None
+    | Some (_p1, result_ty) ->
+      match
+        peek_or_poke_layout_from_type ~prim_name:"peek"
+          (to_location loc) env result_ty
+      with
+      | None -> None
+      | Some contents_layout -> Some (Peek (Some contents_layout))
+  )
+  | Poke _, _ptr_ty :: new_value_ty :: _ -> (
+    match
+      peek_or_poke_layout_from_type ~prim_name:"poke"
+        (to_location loc) env new_value_ty
+    with
+    | None -> None
+    | Some contents_layout -> Some (Poke (Some contents_layout))
+  )
   | _ -> None
 
 let caml_equal =
@@ -1613,6 +1660,12 @@ let lambda_of_prim prim_name prim loc args arg_exps =
         ap_region_close = pos;
         ap_mode = alloc_heap;
       }
+  | Peek None, _ | Poke None, _ ->
+      raise(Error(to_location loc, Wrong_layout_for_peek_or_poke prim_name))
+  | Peek (Some layout), [ptr] ->
+      Lprim (Ppeek layout, [ptr], loc)
+  | Poke (Some layout), [ptr; new_value] ->
+      Lprim (Ppoke layout, [ptr; new_value], loc)
   | Unsupported prim, _ ->
       let exn =
         transl_extension_path loc (Lazy.force Env.initial)
@@ -1631,7 +1684,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
   | (Raise _ | Raise_with_backtrace
     | Lazy_force _ | Loc _ | Primitive _ | Sys_argv | Comparison _
     | Send _ | Send_self _ | Send_cache _ | Frame_pointers | Identity
-    | Apply _ | Revapply _), _ ->
+    | Apply _ | Revapply _ | Peek _ | Poke _), _ ->
       raise(Error(to_location loc, Wrong_arity_builtin_primitive prim_name))
 
 let check_primitive_arity loc p =
@@ -1663,8 +1716,8 @@ let check_primitive_arity loc p =
     | Send _ | Send_self _ -> p.prim_arity = 2
     | Send_cache _ -> p.prim_arity = 4
     | Frame_pointers -> p.prim_arity = 0
-    | Identity -> p.prim_arity = 1
-    | Apply _ | Revapply _ -> p.prim_arity = 2
+    | Identity | Peek _ -> p.prim_arity = 1
+    | Apply _ | Revapply _ | Poke _ -> p.prim_arity = 2
     | Unsupported _ -> true
   in
   if not ok then raise(Error(loc, Wrong_arity_builtin_primitive p.prim_name))
@@ -1850,7 +1903,7 @@ let lambda_primitive_needs_event_after = function
   | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer _ | Popaque _
   | Pdls_get
   | Pobj_magic _ | Punbox_float _ | Punbox_int _ | Punbox_vector _
-  | Preinterpret_unboxed_int64_as_tagged_int63
+  | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _
   (* These don't allocate in bytecode; they're just identity functions: *)
   | Pbox_float (_, _) | Pbox_int _ | Pbox_vector (_, _)
     -> false
@@ -1864,7 +1917,7 @@ let primitive_needs_event_after = function
   | Lazy_force _ | Send _ | Send_self _ | Send_cache _
   | Apply _ | Revapply _ -> true
   | Raise _ | Raise_with_backtrace | Loc _ | Frame_pointers | Identity
-  | Unsupported _ -> false
+  | Peek _ | Poke _ | Unsupported _ -> false
 
 let transl_primitive_application loc p env ty ~poly_mode ~poly_sort
     path exp args arg_exps pos =
@@ -1908,6 +1961,8 @@ let report_error ppf = function
   | Wrong_arity_builtin_primitive prim_name ->
       fprintf ppf "Wrong arity for builtin primitive %a"
         Style.inline_code prim_name
+  | Wrong_layout_for_peek_or_poke prim_name ->
+      fprintf ppf "Unsupported layout for the %s primitive" prim_name
   | Invalid_floatarray_glb ->
       fprintf ppf
         "@[Floatarray primitives can't be used on arrays containing@ \

--- a/lambda/translprim.mli
+++ b/lambda/translprim.mli
@@ -62,6 +62,7 @@ val sort_of_native_repr :
 type error =
   | Unknown_builtin_primitive of string
   | Wrong_arity_builtin_primitive of string
+  | Wrong_layout_for_peek_or_poke of string
   | Invalid_floatarray_glb
   | Product_iarrays_unsupported
   | Invalid_array_kind_for_uninitialized_makearray_dynamic

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -350,7 +350,9 @@ let compute_static_size lam =
     | Patomic_cas
     | Patomic_fetch_add
     | Popaque _
-    | Pdls_get ->
+    | Pdls_get
+    | Ppeek _
+    | Ppoke _ ->
         dynamic_size lam
 
     (* Primitives specific to flambda-backend *)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1049,7 +1049,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Patomic_exchange | Patomic_compare_exchange | Patomic_cas
       | Patomic_fetch_add | Pdls_get | Ppoll | Patomic_load _
       | Preinterpret_tagged_int63_as_unboxed_int64
-      | Preinterpret_unboxed_int64_as_tagged_int63 ->
+      | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _ ->
         (* Inconsistent with outer match *)
         assert false
     in

--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -414,65 +414,6 @@ module Standard_int = struct
     | Naked_nativeint -> Format.pp_print_string ppf "naked_nativeint"
 end
 
-module Standard_int_or_float = struct
-  type t =
-    | Tagged_immediate
-    | Naked_immediate
-    | Naked_float32
-    | Naked_float
-    | Naked_int32
-    | Naked_int64
-    | Naked_nativeint
-
-  let of_standard_int (t : Standard_int.t) : t =
-    match t with
-    | Tagged_immediate -> Tagged_immediate
-    | Naked_immediate -> Naked_immediate
-    | Naked_int32 -> Naked_int32
-    | Naked_int64 -> Naked_int64
-    | Naked_nativeint -> Naked_nativeint
-
-  let to_kind t : kind =
-    match t with
-    | Tagged_immediate -> Value
-    | Naked_immediate -> Naked_number Naked_immediate
-    | Naked_float32 -> Naked_number Naked_float32
-    | Naked_float -> Naked_number Naked_float
-    | Naked_int32 -> Naked_number Naked_int32
-    | Naked_int64 -> Naked_number Naked_int64
-    | Naked_nativeint -> Naked_number Naked_nativeint
-
-  include Container_types.Make (struct
-    type nonrec t = t
-
-    let print ppf t =
-      match t with
-      | Tagged_immediate -> Format.pp_print_string ppf "Tagged_immediate"
-      | Naked_immediate -> Format.pp_print_string ppf "Naked_immediate"
-      | Naked_float32 -> Format.pp_print_string ppf "Naked_float32"
-      | Naked_float -> Format.pp_print_string ppf "Naked_float"
-      | Naked_int32 -> Format.pp_print_string ppf "Naked_int32"
-      | Naked_int64 -> Format.pp_print_string ppf "Naked_int64"
-      | Naked_nativeint -> Format.pp_print_string ppf "Naked_nativeint"
-
-    let compare = Stdlib.compare
-
-    let equal t1 t2 = compare t1 t2 = 0
-
-    let hash = Hashtbl.hash
-  end)
-
-  let print_lowercase ppf t =
-    match t with
-    | Tagged_immediate -> Format.pp_print_string ppf "tagged_immediate"
-    | Naked_immediate -> Format.pp_print_string ppf "naked_immediate"
-    | Naked_float32 -> Format.pp_print_string ppf "naked_float32"
-    | Naked_float -> Format.pp_print_string ppf "naked_float"
-    | Naked_int32 -> Format.pp_print_string ppf "naked_int32"
-    | Naked_int64 -> Format.pp_print_string ppf "naked_int64"
-    | Naked_nativeint -> Format.pp_print_string ppf "naked_nativeint"
-end
-
 module Boxable_number = struct
   type t =
     | Naked_float32
@@ -1088,4 +1029,70 @@ module Flat_suffix_element = struct
     | Naked_int64 -> With_subkind.naked_int64
     | Naked_nativeint -> With_subkind.naked_nativeint
     | Naked_vec128 -> With_subkind.naked_vec128
+end
+
+module Standard_int_or_float = struct
+  type t =
+    | Tagged_immediate
+    | Naked_immediate
+    | Naked_float32
+    | Naked_float
+    | Naked_int32
+    | Naked_int64
+    | Naked_nativeint
+
+  let of_standard_int (t : Standard_int.t) : t =
+    match t with
+    | Tagged_immediate -> Tagged_immediate
+    | Naked_immediate -> Naked_immediate
+    | Naked_int32 -> Naked_int32
+    | Naked_int64 -> Naked_int64
+    | Naked_nativeint -> Naked_nativeint
+
+  let to_kind t : kind =
+    match t with
+    | Tagged_immediate -> Value
+    | Naked_immediate -> Naked_number Naked_immediate
+    | Naked_float32 -> Naked_number Naked_float32
+    | Naked_float -> Naked_number Naked_float
+    | Naked_int32 -> Naked_number Naked_int32
+    | Naked_int64 -> Naked_number Naked_int64
+    | Naked_nativeint -> Naked_number Naked_nativeint
+
+  include Container_types.Make (struct
+    type nonrec t = t
+
+    let print ppf t =
+      match t with
+      | Tagged_immediate -> Format.pp_print_string ppf "Tagged_immediate"
+      | Naked_immediate -> Format.pp_print_string ppf "Naked_immediate"
+      | Naked_float32 -> Format.pp_print_string ppf "Naked_float32"
+      | Naked_float -> Format.pp_print_string ppf "Naked_float"
+      | Naked_int32 -> Format.pp_print_string ppf "Naked_int32"
+      | Naked_int64 -> Format.pp_print_string ppf "Naked_int64"
+      | Naked_nativeint -> Format.pp_print_string ppf "Naked_nativeint"
+
+    let compare = Stdlib.compare
+
+    let equal t1 t2 = compare t1 t2 = 0
+
+    let hash = Hashtbl.hash
+  end)
+
+  let print_lowercase ppf t =
+    match t with
+    | Tagged_immediate -> Format.pp_print_string ppf "tagged_immediate"
+    | Naked_immediate -> Format.pp_print_string ppf "naked_immediate"
+    | Naked_float32 -> Format.pp_print_string ppf "naked_float32"
+    | Naked_float -> Format.pp_print_string ppf "naked_float"
+    | Naked_int32 -> Format.pp_print_string ppf "naked_int32"
+    | Naked_int64 -> Format.pp_print_string ppf "naked_int64"
+    | Naked_nativeint -> Format.pp_print_string ppf "naked_nativeint"
+
+  let to_kind_with_subkind t =
+    match t with
+    | Tagged_immediate -> With_subkind.tagged_immediate
+    | Naked_immediate | Naked_float32 | Naked_float | Naked_int32 | Naked_int64
+    | Naked_nativeint ->
+      With_subkind.anything (to_kind t)
 end

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -154,26 +154,6 @@ module Standard_int : sig
   include Container_types.S with type t := t
 end
 
-module Standard_int_or_float : sig
-  (** The same as [Standard_int], but also permitting naked floats. *)
-  type t =
-    | Tagged_immediate
-    | Naked_immediate
-    | Naked_float32
-    | Naked_float
-    | Naked_int32
-    | Naked_int64
-    | Naked_nativeint
-
-  val of_standard_int : Standard_int.t -> t
-
-  val to_kind : t -> kind
-
-  val print_lowercase : Format.formatter -> t -> unit
-
-  include Container_types.S with type t := t
-end
-
 module Boxable_number : sig
   (** These kinds are those of the numbers for which a tailored boxed
       representation exists. *)
@@ -342,4 +322,26 @@ module Flat_suffix_element : sig
   val compare : t -> t -> int
 
   val to_kind_with_subkind : t -> With_subkind.t
+end
+
+module Standard_int_or_float : sig
+  (** The same as [Standard_int], but also permitting naked floats. *)
+  type t =
+    | Tagged_immediate
+    | Naked_immediate
+    | Naked_float32
+    | Naked_float
+    | Naked_int32
+    | Naked_int64
+    | Naked_nativeint
+
+  val of_standard_int : Standard_int.t -> t
+
+  val to_kind : t -> kind
+
+  val to_kind_with_subkind : t -> With_subkind.t
+
+  val print_lowercase : Format.formatter -> t -> unit
+
+  include Container_types.S with type t := t
 end

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -584,7 +584,7 @@ let unop env (op : Flambda_primitive.unary_primitive) : Fexpr.unop =
   | Boolean_not -> Boolean_not
   | Int_as_pointer _ | Duplicate_block _ | Duplicate_array _ | Bigarray_length _
   | Float_arith _ | Reinterpret_64_bit_word _ | Is_boxed_float | Obj_dup
-  | Get_header | Atomic_load _ ->
+  | Get_header | Atomic_load _ | Peek _ ->
     Misc.fatal_errorf "TODO: Unary primitive: %a"
       Flambda_primitive.Without_args.print
       (Flambda_primitive.Without_args.Unary op)
@@ -609,7 +609,7 @@ let binop env (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
   | Float_comp (w, c) -> Infix (Float_comp (w, c))
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
   | Bigarray_get_alignment align -> Bigarray_get_alignment align
-  | Bigarray_load _ | Atomic_exchange | Atomic_fetch_and_add ->
+  | Bigarray_load _ | Atomic_exchange | Atomic_fetch_and_add | Poke _ ->
     Misc.fatal_errorf "TODO: Binary primitive: %a"
       Flambda_primitive.Without_args.print
       (Flambda_primitive.Without_args.Binary op)

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1027,6 +1027,10 @@ let simplify_block_set _block_access_kind _init_or_assign ~field:_ dacc
     ~original_term _dbg ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
   SPR.create_unit dacc ~result_var ~original_term
 
+let simplify_poke dacc ~original_term _dbg ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_
+    ~result_var =
+  SPR.create_unit dacc ~result_var ~original_term
+
 let simplify_binary_primitive0 dacc original_prim (prim : P.binary_primitive)
     ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var =
   let original_term = Named.create_prim original_prim dbg in
@@ -1075,6 +1079,7 @@ let simplify_binary_primitive0 dacc original_prim (prim : P.binary_primitive)
       simplify_bigarray_get_alignment align ~original_prim
     | Atomic_exchange -> simplify_atomic_exchange ~original_prim
     | Atomic_fetch_and_add -> simplify_atomic_fetch_and_add ~original_prim
+    | Poke _ -> simplify_poke
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var
 
@@ -1084,7 +1089,7 @@ let recover_comparison_primitive dacc (prim : P.binary_primitive) ~arg1 ~arg2 =
   | Int_comp (_, Yielding_int_like_compare_functions _)
   | Float_arith _ | Float_comp _ | Phys_equal _ | String_or_bigstring_load _
   | Bigarray_load _ | Bigarray_get_alignment _ | Atomic_exchange
-  | Atomic_fetch_and_add ->
+  | Atomic_fetch_and_add | Poke _ ->
     None
   | Int_comp (kind, Yielding_bool op) -> (
     match kind with

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -894,6 +894,12 @@ let simplify_is_null dacc ~original_term ~arg:scrutinee ~arg_ty:scrutinee_ty
   simplify_relational_primitive dacc ~original_term ~scrutinee ~scrutinee_ty
     ~result_var ~make_shape:(fun scrutinee -> T.is_null ~scrutinee)
 
+let simplify_peek ~original_prim dacc ~original_term ~arg:_ ~arg_ty:_
+    ~result_var =
+  SPR.create_unknown dacc ~result_var
+    (P.result_kind' original_prim)
+    ~original_term
+
 let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     ~arg_ty dbg ~result_var =
   let min_name_mode = Bound_var.name_mode result_var in
@@ -955,5 +961,6 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     | Get_header -> simplify_get_header ~original_prim
     | Atomic_load block_access_field_kind ->
       simplify_atomic_load block_access_field_kind ~original_prim
+    | Peek _ -> simplify_peek ~original_prim
   in
   simplifier dacc ~original_term ~arg ~arg_ty ~result_var

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -381,7 +381,7 @@ let unary_prim_size prim =
   | End_region { ghost } | End_try_region { ghost } -> if ghost then 0 else 1
   | Obj_dup -> needs_caml_c_call_extcall_size + 1
   | Get_header -> 2
-  | Atomic_load _ -> 1
+  | Atomic_load _ | Peek _ -> 1
 
 let binary_prim_size prim =
   match (prim : Flambda_primitive.binary_primitive) with
@@ -405,6 +405,7 @@ let binary_prim_size prim =
   | Bigarray_get_alignment _ -> 3 (* load data + add index + and *)
   | Atomic_exchange | Atomic_fetch_and_add ->
     does_not_need_caml_c_call_extcall_size
+  | Poke _ -> 1
 
 let ternary_prim_size prim =
   match (prim : Flambda_primitive.ternary_primitive) with

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -443,6 +443,9 @@ type unary_primitive =
           (by the type system) should always go through caml_obj_tag, which is
           opaque to the compiler. *)
   | Atomic_load of Block_access_field_kind.t
+  (* CR mshinwell: consider putting atomicity onto [Peek] and [Poke] then
+     deleting [Atomic_load] *)
+  | Peek of Flambda_kind.Standard_int_or_float.t
 
 (** Whether a comparison is to yield a boolean result, as given by a particular
     comparison operator, or whether it is to behave in the manner of "compare"
@@ -501,6 +504,7 @@ type binary_primitive =
   | Bigarray_get_alignment of int
   | Atomic_exchange
   | Atomic_fetch_and_add
+  | Poke of Flambda_kind.Standard_int_or_float.t
 
 (** Primitives taking exactly three arguments. *)
 type ternary_primitive =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -981,6 +981,12 @@ let unary_primitive env res dbg f arg =
       | Immediate -> Immediate
     in
     None, res, C.atomic_load ~dbg imm_or_ptr arg
+  | Peek kind ->
+    let memory_chunk =
+      K.Standard_int_or_float.to_kind_with_subkind kind
+      |> C.memory_chunk_of_kind
+    in
+    None, res, C.load ~dbg memory_chunk Mutable ~addr:arg
 
 let binary_primitive env dbg f x y =
   match (f : P.binary_primitive) with
@@ -1007,6 +1013,13 @@ let binary_primitive env dbg f x y =
   | Bigarray_get_alignment align -> C.bigstring_get_alignment x y align dbg
   | Atomic_exchange -> C.atomic_exchange ~dbg x y
   | Atomic_fetch_and_add -> C.atomic_fetch_and_add ~dbg x y
+  | Poke kind ->
+    let memory_chunk =
+      K.Standard_int_or_float.to_kind_with_subkind kind
+      |> C.memory_chunk_of_kind
+    in
+    C.store ~dbg memory_chunk Assignment ~addr:x ~new_value:y
+    |> C.return_unit dbg
 
 let ternary_primitive _env dbg f x y z =
   match (f : P.ternary_primitive) with

--- a/testsuite/tests/peek_and_poke/peek_and_poke.ml
+++ b/testsuite/tests/peek_and_poke/peek_and_poke.ml
@@ -1,0 +1,85 @@
+(* TEST
+   native;
+*)
+
+(* Preliminaries to minimize deps *)
+
+external int32_u_to_int32 : int32# -> int32
+  = "%box_int32" [@@warning "-187"]
+
+external int64_u_to_int64 : int64# -> int64
+  = "%box_int64" [@@warning "-187"]
+
+external nativeint_u_to_nativeint : nativeint# -> nativeint
+  = "%box_nativeint" [@@warning "-187"]
+
+external nativeint_to_nativeint_u : nativeint -> nativeint#
+  = "%unbox_nativeint" [@@warning "-187"]
+
+external float_u_to_float : float# -> float
+  = "%box_float" [@@warning "-187"]
+
+(* CR mshinwell for gyorsh: enable these float32 cases *)
+  (*
+external float32_u_to_float : float32# -> float32
+  = "%box_float32" [@@warning "-187"]
+  *)
+
+let nativeint_u_add u1 n2 =
+  let n1 = nativeint_u_to_nativeint u1 in
+  let n = Nativeint.add n1 n2 in
+  nativeint_to_nativeint_u n
+
+(* The test itself starts here *)
+
+(* For the real API we don't plan to expose the type equality, but it
+   makes it easier to write the test below. *)
+type ('a : any) t = nativeint#
+
+external read : ('a : any mod external_). 'a t -> 'a = "%peek"
+  [@@layout_poly]
+
+external write : ('a : any mod external_). 'a t -> 'a -> unit = "%poke"
+  [@@layout_poly]
+
+external calloc :
+  count:(int[@untagged]) -> size:(int[@untagged]) -> nativeint# =
+  "caml_no_bytecode_impl" "calloc"
+  [@@noalloc]
+
+let test_read p1 p2 p3 p4 p5 p6
+  : #(int * int32# * int64# * nativeint# * float# * float#) =
+  #(read p1, read p2, read p3, read p4, read p5, read p6)
+
+(* CR mshinwell for gyorsh: the last number here should be #0.1234s *)
+let values () = #(min_int, #400l, #9999999999L, #123456n, #0.87654, #0.1234)
+
+let test_write p1 p2 p3 p4 p5 p6 =
+  let #(n1, n2, n3, n4, n5, n6) = values () in
+  write p1 n1;
+  write p2 n2;
+  write p3 n3;
+  write p4 n4;
+  write p5 n5;
+  write p6 n6
+
+let () =
+  let buf = calloc ~count:6 ~size:8 in
+  let int_buf = buf in
+  let int32_buf = nativeint_u_add buf 8n in
+  let int64_buf = nativeint_u_add buf 16n in
+  let nativeint_buf = nativeint_u_add buf 24n in
+  let float_buf = nativeint_u_add buf 32n in
+  let float32_buf = nativeint_u_add buf 40n in
+  test_write int_buf int32_buf int64_buf nativeint_buf float_buf float32_buf;
+  let #(n1, n2, n3, n4, n5, n6) =
+    test_read int_buf int32_buf int64_buf nativeint_buf float_buf float32_buf
+  in
+  let #(n1', n2', n3', n4', n5', n6') = values () in
+  assert (Int.equal n1 n1');
+  assert (Int32.equal (int32_u_to_int32 n2) (int32_u_to_int32 n2'));
+  assert (Int64.equal (int64_u_to_int64 n3) (int64_u_to_int64 n3'));
+  assert (Nativeint.equal (nativeint_u_to_nativeint n4)
+    (nativeint_u_to_nativeint n4'));
+  assert (Float.equal (float_u_to_float n5) (float_u_to_float n5'));
+  assert (Float.equal (float_u_to_float n6) (float_u_to_float n6'))

--- a/testsuite/tests/peek_and_poke/peek_and_poke_forbidden_for_value.ml
+++ b/testsuite/tests/peek_and_poke/peek_and_poke_forbidden_for_value.ml
@@ -1,0 +1,35 @@
+(* TEST
+   expect;
+*)
+
+type ('a : any) t
+
+external read : ('a : any mod external_). 'a t -> 'a = "%peek"
+  [@@layout_poly]
+
+external write : ('a : any mod external_). 'a t -> 'a -> unit = "%poke"
+  [@@layout_poly]
+
+[%%expect {|
+type ('a : any) t
+external read : ('a : any mod external_). 'a t -> 'a = "%peek"
+  [@@layout_poly]
+external write : ('a : any mod external_). 'a t -> 'a -> unit = "%poke"
+  [@@layout_poly]
+|}]
+
+let bad_read p : string = read p
+[%%expect {|
+Line 1, characters 26-32:
+1 | let bad_read p : string = read p
+                              ^^^^^^
+Error: Unsupported layout for the peek primitive
+|}]
+
+let bad_write p (s : string) = write p s
+[%%expect {|
+Line 1, characters 31-40:
+1 | let bad_write p (s : string) = write p s
+                                   ^^^^^^^^^
+Error: Unsupported layout for the poke primitive
+|}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1362,6 +1362,8 @@ module Format_history = struct
         "it's the layout polymorphic type in an external declaration@ \
          ([@@layout_poly] forces all variables of layout 'any' to be@ \
          representable at call sites)"
+    | Peek_or_poke ->
+      fprintf ppf "it's the type being used for a peek or poke primitive"
 
   let format_concrete_legacy_creation_reason ppf :
       History.concrete_legacy_creation_reason -> unit = function
@@ -1901,6 +1903,7 @@ module Debug_printers = struct
     | Optional_arg_default -> fprintf ppf "Optional_arg_default"
     | Layout_poly_in_external -> fprintf ppf "Layout_poly_in_external"
     | Unboxed_tuple_element -> fprintf ppf "Unboxed_tuple_element"
+    | Peek_or_poke -> fprintf ppf "Peek_or_poke"
 
   let concrete_legacy_creation_reason ppf :
       History.concrete_legacy_creation_reason -> unit = function

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -207,6 +207,7 @@ module History = struct
     | Optional_arg_default
     | Layout_poly_in_external
     | Unboxed_tuple_element
+    | Peek_or_poke
 
   (* For sort variables that are in the "legacy" position
      on the jkind lattice, defaulting exactly to [value]. *)

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -680,13 +680,14 @@ let prim_has_valid_reprs ~loc prim =
         is (Same_as_ocaml_repr C.value);
         is (Same_as_ocaml_repr C.value);
       ]
-
     | "%array_element_size_in_bytes" ->
       check [
         is (Same_as_ocaml_repr C.value);
         is (Same_as_ocaml_repr C.value);
       ]
-
+    | "%peek" | "%poke" ->
+      (* Arities and layouts of these primitives are checked in [Translprim] *)
+      fun _ -> Success
     | "%box_float" ->
       exactly [Same_as_ocaml_repr C.float64; Same_as_ocaml_repr C.value]
     | "%unbox_float" ->


### PR DESCRIPTION
These are unsafe, but the idea is for them to be used via a specific library, if I understand correctly.

```
type ('a : any) t = nativeint#

external read : ('a : any). 'a t -> 'a = "%peek"
  [@@layout_poly]

external write : ('a : any). 'a t -> 'a -> unit = "%poke"
  [@@layout_poly]
```

cc @ccasin for an initial look (some frontend fixes required in here).