### PR TITLE
CFG selection: avoid polymorphic compare

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -15,6 +15,8 @@
 
 (* Instruction selection for the AMD64 *)
 
+open! Int_replace_polymorphic_compare
+
 [@@@ocaml.warning "+a-4-9-40-41-42"]
 
 open Arch
@@ -227,7 +229,7 @@ class selector =
       | Cstore (((Word_int | Word_val) as chunk), _init) -> (
         match args with
         | [loc; Cop (Caddi, [Cop (Cload _, [loc'], _); Cconst_int (n, _dbg)], _)]
-          when loc = loc' && is_immediate n ->
+          when Stdlib.( = ) loc loc' && is_immediate n ->
           let addr, arg = self#select_addressing chunk loc in
           specific (Ioffset_loc (n, addr)), [arg]
         | _ -> super#select_operation op args dbg ~label_after)

--- a/backend/amd64/selection_utils.ml
+++ b/backend/amd64/selection_utils.ml
@@ -15,6 +15,8 @@
 
 (* Instruction selection for the AMD64 *)
 
+open! Int_replace_polymorphic_compare
+
 [@@@ocaml.warning "+a-4-9-40-41-42"]
 
 open Arch
@@ -112,4 +114,6 @@ let inline_ops = ["sqrt"]
 
 let is_immediate n = n <= 0x7FFF_FFFF && n >= -0x8000_0000
 
-let is_immediate_natint n = n <= 0x7FFF_FFFFn && n >= -0x8000_0000n
+let is_immediate_natint n =
+  Nativeint.compare n 0x7FFF_FFFFn <= 0
+  && Nativeint.compare n (-0x8000_0000n) >= 0

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -17,6 +17,8 @@
 
 (* Instruction selection for the ARM processor *)
 
+open! Int_replace_polymorphic_compare
+
 [@@@ocaml.warning "+a-4-9-40-41-42"]
 
 open Arch
@@ -167,7 +169,12 @@ class selector =
       | _ -> super#select_operation op args dbg ~label_after
 
     method! insert_move_extcall_arg env ty_arg src dst =
-      if macosx && ty_arg = XInt32 && is_stack_slot dst
+      let ty_arg_is_int32 =
+        match ty_arg with
+        | XInt32 -> true
+        | XInt | XInt64 | XFloat32 | XFloat | XVec128 -> false
+      in
+      if macosx && ty_arg_is_int32 && is_stack_slot dst
       then self#insert env (Op (Specific Imove32)) src dst
       else self#insert_moves env src dst
   end

--- a/backend/arm64/selection_utils.ml
+++ b/backend/arm64/selection_utils.ml
@@ -17,6 +17,8 @@
 
 (* Instruction selection for the ARM processor *)
 
+open! Int_replace_polymorphic_compare
+
 [@@@ocaml.warning "+a-4-9-40-41-42"]
 
 open Arch

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -420,6 +420,22 @@ let is_pure_terminator desc =
     (* CR gyorsh: fix for memory operands *)
     true
 
+let is_never_terminator desc =
+  match (desc : terminator) with
+  | Never -> true
+  | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+  | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _
+  | Call_no_return _ | Call _ | Prim _ | Specific_can_raise _ ->
+    false
+
+let is_return_terminator desc =
+  match (desc : terminator) with
+  | Return -> true
+  | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+  | Switch _ | Raise _ | Tailcall_self _ | Tailcall_func _ | Call_no_return _
+  | Call _ | Prim _ | Specific_can_raise _ ->
+    false
+
 let is_pure_basic : basic -> bool = function
   | Op op -> Operation.is_pure op
   | Reloadretaddr ->

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -192,6 +192,10 @@ val can_raise_terminator : terminator -> bool
 
 val is_pure_terminator : terminator -> bool
 
+val is_never_terminator : terminator -> bool
+
+val is_return_terminator : terminator -> bool
+
 val is_pure_basic : basic -> bool
 
 val is_noop_move : basic instruction -> bool

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -112,17 +112,14 @@ module Polls_before_prtc_transfer = struct
 end
 
 let potentially_recursive_tailcall :
-    future_funcnames:String.Set.t ->
-    Cfg_with_layout.t ->
-    Polls_before_prtc_domain.t =
- fun ~future_funcnames cfg_with_layout ->
+    future_funcnames:String.Set.t -> Cfg.t -> Polls_before_prtc_domain.t =
+ fun ~future_funcnames cfg ->
   let module PTRCAnalysis =
     Cfg_dataflow.Backward
       (Polls_before_prtc_domain)
       (Polls_before_prtc_transfer)
   in
   let init : Polls_before_prtc_domain.t = Polls_before_prtc_domain.bot in
-  let cfg = Cfg_with_layout.cfg cfg_with_layout in
   match
     PTRCAnalysis.run ~init ~map:PTRCAnalysis.Block cfg { future_funcnames }
   with
@@ -349,12 +346,12 @@ let instrument_fundecl :
 let requires_prologue_poll :
     future_funcnames:Misc.Stdlib.String.Set.t ->
     fun_name:string ->
-    Cfg_with_layout.t ->
+    Cfg.t ->
     bool =
- fun ~future_funcnames ~fun_name cfg_with_layout ->
+ fun ~future_funcnames ~fun_name cfg ->
   if Polling_utils.is_disabled fun_name
   then false
   else
-    match potentially_recursive_tailcall ~future_funcnames cfg_with_layout with
+    match potentially_recursive_tailcall ~future_funcnames cfg with
     | Might_not_poll -> true
     | Always_polls -> false

--- a/backend/cfg/cfg_polling.mli
+++ b/backend/cfg/cfg_polling.mli
@@ -8,7 +8,4 @@ val instrument_fundecl :
   Cfg_with_layout.t
 
 val requires_prologue_poll :
-  future_funcnames:Misc.Stdlib.String.Set.t ->
-  fun_name:string ->
-  Cfg_with_layout.t ->
-  bool
+  future_funcnames:Misc.Stdlib.String.Set.t -> fun_name:string -> Cfg.t -> bool

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -16,6 +16,8 @@
 (* Selection of pseudo-instructions, assignment of pseudo-registers,
    sequentialization. *)
 
+open! Int_replace_polymorphic_compare
+
 [@@@ocaml.warning "+a-4-9-40-41-42"]
 
 open Cmm
@@ -252,15 +254,15 @@ end = struct
     add_block sub_cfg (make_never_block ~label ())
 
   let add_instruction sub_cfg desc arg res dbg =
-    assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+    assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
     DLL.add_end sub_cfg.exit.body (make_instr desc arg res dbg)
 
   let set_terminator sub_cfg desc arg res dbg =
-    assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+    assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
     sub_cfg.exit.terminator <- make_instr desc arg res dbg
 
   let link_if_needed ~(from : Cfg.basic_block) ~(to_ : Cfg.basic_block) () =
-    if from.terminator.desc = Cfg.Never
+    if Cfg.is_never_terminator from.terminator.desc
     then
       from.terminator
         <- { from.terminator with
@@ -351,17 +353,17 @@ class virtual selector_generic =
         ( basic_op
             (Load { memory_chunk; addressing_mode; mutability; is_atomic }),
           [eloc] )
-      | Cstore (chunk, init), [arg1; arg2] ->
+      | Cstore (chunk, init), [arg1; arg2] -> (
         let addr, eloc = self#select_addressing chunk arg1 in
         let is_assign =
           match init with Initialization -> false | Assignment -> true
         in
-        if chunk = Word_int || chunk = Word_val
-        then
+        match chunk with
+        | Word_int | Word_val ->
           let op, newarg2 = self#select_store is_assign addr arg2 in
           basic_op op, [newarg2; eloc]
-        else basic_op (Store (chunk, addr, is_assign)), [arg2; eloc]
-        (* Inversion addr/datum in Istore *)
+        | _ -> basic_op (Store (chunk, addr, is_assign)), [arg2; eloc]
+        (* Inversion addr/datum in Istore *))
       | Cdls_get, _ -> basic_op Dls_get, args
       | Calloc mode, _ ->
         basic_op (Alloc { bytes = 0; dbginfo = []; mode }), args
@@ -507,7 +509,7 @@ class virtual selector_generic =
       match self#emit_parts_list env args with
       | None -> None
       | Some (simple_args, env) -> (
-        assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+        assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
         let add_naming_op_for_bound_name regs =
           match bound_name with
           | None -> ()
@@ -657,7 +659,7 @@ class virtual selector_generic =
       match self#emit_expr env earg ~bound_name:None with
       | None -> None
       | Some rarg ->
-        assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+        assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
         let rif, (sif : 'self) = self#emit_sequence env eif ~bound_name in
         let relse, (selse : 'self) = self#emit_sequence env eelse ~bound_name in
         let r = join env rif sif relse selse ~bound_name in
@@ -688,7 +690,7 @@ class virtual selector_generic =
       match self#emit_expr env esel ~bound_name:None with
       | None -> None
       | Some rsel ->
-        assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+        assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
         let sub_cases : (Reg.t array option * 'self) array =
           Array.map
             (fun (case, _dbg) -> self#emit_sequence env case ~bound_name)
@@ -789,7 +791,10 @@ class virtual selector_generic =
       let rec build_all_reachable_handlers ~already_built ~not_built =
         let not_built, to_build =
           Int.Map.partition
-            (fun _n (r, _) -> !r = Select_utils.Unreachable)
+            (fun _n (r, _) ->
+                               match !r with
+                | Select_utils.Unreachable -> true
+                | Select_utils.Reachable _ -> false)
             not_built
         in
         if Int.Map.is_empty to_build
@@ -809,7 +814,7 @@ class virtual selector_generic =
       in
       let a = Array.of_list ((r_body, s_body) :: List.map snd l) in
       let r = join_array env a ~bound_name in
-      assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+      assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
       let s_body : Sub_cfg.t = s_body#extract in
       let s_handlers =
         List.map
@@ -859,10 +864,15 @@ class virtual selector_generic =
              src are present in dest *)
           let tmp_regs = Reg.createv_like src in
           (* Ccatch registers must not contain out of heap pointers *)
-          Array.iter (fun reg -> assert (reg.Reg.typ <> Addr)) src;
+            Array.iter
+              (fun reg ->
+                match reg.Reg.typ with
+                | Addr -> assert false
+                | Val | Int | Float | Vec128 | Float32 -> ())
+              src;
           self#insert_moves env src tmp_regs;
           self#insert_moves env tmp_regs (Array.concat handler.regs);
-          assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+          assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
           List.iter
             (fun trap ->
               let instr_desc =
@@ -900,7 +910,7 @@ class virtual selector_generic =
     method emit_expr_aux_trywith env bound_name e1 exn_cont v e2
         (_dbg : Debuginfo.t) (_value_kind : Cmm.kind_for_unboxing) =
       (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
-      assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+      assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
       let exn_label = Cmm.new_label () in
       let env_body = Select_utils.env_enter_trywith env exn_cont exn_label in
       let r1, s1 = self#emit_sequence env_body e1 ~bound_name in
@@ -1010,7 +1020,7 @@ class virtual selector_generic =
         self#insert' env Cfg.Return loc [||]
 
     method emit_return (env : environment) exp traps =
-      assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+      assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
       self#insert_return env (self#emit_expr_aux env exp ~bound_name:None) traps
 
     method emit_tail_apply env ty op args dbg =
@@ -1052,7 +1062,7 @@ class virtual selector_generic =
           let loc_res, stack_ofs_res = Proc.loc_results_call (Reg.typv rd) in
           let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
           if stack_ofs = 0
-             && func.sym_name = !Select_utils.current_function_name
+             && String.equal func.sym_name !Select_utils.current_function_name
              && Select_utils.trap_stack_is_empty env
           then (
             let call = Cfg.Tailcall_self { destination = tailrec_label } in
@@ -1081,7 +1091,7 @@ class virtual selector_generic =
       match self#emit_expr env earg ~bound_name:None with
       | None -> ()
       | Some rarg ->
-        assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+        assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
         let sub_if = self#emit_tail_sequence env eif in
         let sub_else = self#emit_tail_sequence env eelse in
         let term_desc =
@@ -1105,7 +1115,7 @@ class virtual selector_generic =
       match self#emit_expr env esel ~bound_name:None with
       | None -> ()
       | Some rsel ->
-        assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+        assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
         let sub_cases =
           Array.map
             (fun (case, _dbg) -> self#emit_tail_sequence env case)
@@ -1152,7 +1162,7 @@ class virtual selector_generic =
             env, Int.Map.add nfail (r, (ids, rs, e2, dbg, is_cold, label)) map)
           (env, Int.Map.empty) handlers
       in
-      assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+      assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
       let s_body = self#emit_tail_sequence env e1 in
       let translate_one_handler nfail
           (trap_info, (ids, rs, e2, _dbg, is_cold, label)) =
@@ -1201,7 +1211,10 @@ class virtual selector_generic =
       let rec build_all_reachable_handlers ~already_built ~not_built =
         let not_built, to_build =
           Int.Map.partition
-            (fun _n (r, _) -> !r = Select_utils.Unreachable)
+            (fun _n (r, _) ->
+                               match !r with
+                | Select_utils.Unreachable -> true
+                | Select_utils.Reachable _ -> false)
             not_built
         in
         if Int.Map.is_empty to_build
@@ -1220,7 +1233,7 @@ class virtual selector_generic =
         build_all_reachable_handlers ~already_built:[] ~not_built:handlers_map
         (* Note: we're dropping unreachable handlers here *)
       in
-      assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+      assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
       let term_desc = Cfg.Always s_body.Sub_cfg.entry.start in
       sub_cfg.exit.terminator
         <- { sub_cfg.exit.terminator with
@@ -1236,7 +1249,7 @@ class virtual selector_generic =
     method emit_tail_trywith env e1 exn_cont v e2 (_dbg : Debuginfo.t)
         (_value_kind : Cmm.kind_for_unboxing) =
       (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
-      assert (sub_cfg.exit.terminator.desc = Cfg.Never);
+      assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
       let exn_label = Cmm.new_label () in
       let env_body = Select_utils.env_enter_trywith env exn_cont exn_label in
       let s1 : Sub_cfg.t = self#emit_tail_sequence env_body e1 in
@@ -1422,10 +1435,10 @@ class virtual selector_generic =
       Cfg.add_block_exn cfg tailrec_block;
       DLL.add_end layout tailrec_block.start;
       Sub_cfg.iter_basic_blocks body ~f:(fun (block : Cfg.basic_block) ->
-          if block.terminator.desc <> Cfg.Never
+          if not (Cfg.is_never_terminator block.terminator.desc)
           then (
             block.can_raise <- Cfg.can_raise_terminator block.terminator.desc;
-            if block.terminator.desc = Cfg.Return
+            if Cfg.is_return_terminator block.terminator.desc
             then
               DLL.add_end block.body
                 (Sub_cfg.make_instr Cfg.Reloadretaddr [||] [||] Debuginfo.none);

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -16,6 +16,8 @@
 (* Selection of pseudo-instructions, assignment of pseudo-registers,
    sequentialization. *)
 
+open! Int_replace_polymorphic_compare
+
 [@@@ocaml.warning "+a-4-9-40-41-42"]
 
 open Cmm
@@ -99,7 +101,7 @@ let set_traps nfail traps_ref base_traps exit_traps =
     (* Format.eprintf "Traps for %d set to %a@." nfail print_traps traps; *)
     traps_ref := Reachable traps
   | Reachable prev_traps ->
-    if prev_traps <> traps
+    if Stdlib.( = ) prev_traps traps
     then
       Misc.fatal_errorf
         "Mismatching trap stacks for continuation %d@.Previous traps: %a@.New \
@@ -739,7 +741,9 @@ class virtual ['env, 'op, 'instr] common_selector =
     method emit_extcall_args env ty_args args =
       let args = self#emit_tuple_not_flattened env args in
       let ty_args =
-        if ty_args = [] then List.map (fun _ -> XInt) args else ty_args
+        match ty_args with
+        | [] -> List.map (fun _ -> XInt) args
+        | _ :: _ -> ty_args
       in
       let locs, stack_ofs = Proc.loc_external_arguments ty_args in
       let ty_args = Array.of_list ty_args in

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -101,7 +101,7 @@ let set_traps nfail traps_ref base_traps exit_traps =
     (* Format.eprintf "Traps for %d set to %a@." nfail print_traps traps; *)
     traps_ref := Reachable traps
   | Reachable prev_traps ->
-    if Stdlib.( = ) prev_traps traps
+    if Stdlib.( <> ) prev_traps traps
     then
       Misc.fatal_errorf
         "Mismatching trap stacks for continuation %d@.Previous traps: %a@.New \


### PR DESCRIPTION
(as per title, only two uses of polymorphic compare left.
The one in `backend/amd64/cfg_selection.ml` is a bit
worrying.)