### PR TITLE
Implement %arrayblit

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -688,6 +688,8 @@ let comp_primitive stack_info p sz args =
        blocks that can't be marshalled. We've decided to ignore that problem in
        the short term, as it's unlikely to cause issues - see the internal arrays
        epic for out plan to deal with it. *)
+    (* XXX mshinwell: this needs special handling for the case where the
+       initializer is absent (%makearray_dynamic_uninit) *)
     begin match kind with
     | Punboxedvectorarray _ ->
       fatal_error "SIMD is not supported in bytecode mode."

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -701,8 +701,8 @@ let comp_primitive stack_info p sz args =
     | Alloc_heap -> Kccall("caml_make_vect", 2)
     | Alloc_local -> Kccall("caml_make_local_vect", 2)
     end
-  | Parrayblit(kind) ->
-    begin match kind with
+  | Parrayblit { src_mutability = _; dst_array_set_kind } ->
+    begin match dst_array_set_kind with
     | Punboxedvectorarray_set _ ->
       fatal_error "SIMD is not supported in bytecode mode."
     | Pgenarray_set _ | Pintarray_set | Paddrarray_set _

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -191,7 +191,10 @@ type primitive =
   | Pmakearray of array_kind * mutable_flag * locality_mode
   | Pmakearray_dynamic of array_kind * locality_mode
   | Pduparray of array_kind * mutable_flag
-  | Parrayblit of array_set_kind (* Kind of the dest array. *)
+  | Parrayblit of {
+      src_mutability : mutable_flag;
+      dst_array_set_kind : array_set_kind;
+    }
   | Parraylength of array_kind
   | Parrayrefu of array_ref_kind * array_index_kind * mutable_flag
   | Parraysetu of array_set_kind * array_index_kind
@@ -2369,6 +2372,23 @@ let array_set_kind mode = function
   | Punboxedvectorarray vec_kind -> Punboxedvectorarray_set vec_kind
   | Pgcscannableproductarray kinds -> Pgcscannableproductarray_set (mode, kinds)
   | Pgcignorableproductarray kinds -> Pgcignorableproductarray_set kinds
+
+let array_ref_kind_of_array_set_kind_for_unboxed_types_and_int
+      (kind : array_set_kind) : array_ref_kind =
+  match kind with
+  | Pintarray_set -> Pintarray_ref
+  | Punboxedfloatarray_set uf -> Punboxedfloatarray_ref uf
+  | Punboxedintarray_set ui -> Punboxedintarray_ref ui
+  | Punboxedvectorarray_set uv -> Punboxedvectorarray_ref uv
+  | Pgcscannableproductarray_set (_, scannables) ->
+    Pgcscannableproductarray_ref scannables
+  | Pgcignorableproductarray_set ignorables ->
+    Pgcignorableproductarray_ref ignorables
+  | Pgenarray_set _
+  | Paddrarray_set _
+  | Pfloatarray_set ->
+    Misc.fatal_error "Array set kind %a cannot be converted via \
+      array_ref_kind_of_array_set_kind_for_unboxed_types_and_int"
 
 let may_allocate_in_region lam =
   (* loop_region raises, if the lambda might allocate in parent region *)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -921,6 +921,10 @@ let lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~ret_mode ~region =
 
 let lambda_unit = Lconst const_unit
 
+let of_bool = function
+  | true -> Lconst (const_int 1)
+  | false -> Lconst (const_int 0)
+
 (* CR vlaviron: review the following cases *)
 let non_null_value raw_kind =
   Pvalue { raw_kind; nullable = Non_nullable }
@@ -2457,3 +2461,42 @@ let rec try_to_find_location lam =
 
 let try_to_find_debuginfo lam =
   Debuginfo.from_location (try_to_find_location lam)
+
+let rec count_initializers_scannable
+      (scannable : scannable_product_element_kind) =
+  match scannable with
+  | Pint_scannable | Paddr_scannable -> 1
+  | Pproduct_scannable scannables ->
+    List.fold_left
+      (fun acc scannable -> acc + count_initializers_scannable scannable)
+      0 scannables
+
+let rec count_initializers_ignorable
+    (ignorable : ignorable_product_element_kind) =
+  match ignorable with
+  | Pint_ignorable | Punboxedfloat_ignorable _ | Punboxedint_ignorable _ -> 1
+  | Pproduct_ignorable ignorables ->
+    List.fold_left
+      (fun acc ignorable -> acc + count_initializers_ignorable ignorable)
+      0 ignorables
+
+let count_initializers_array_kind (lambda_array_kind : array_kind) =
+  match lambda_array_kind with
+  | Pgenarray | Paddrarray | Pintarray | Pfloatarray | Punboxedfloatarray _
+  | Punboxedintarray _ | Punboxedvectorarray _ -> 1
+  | Pgcscannableproductarray scannables ->
+    List.fold_left
+      (fun acc scannable -> acc + count_initializers_scannable scannable)
+      0 scannables
+  | Pgcignorableproductarray ignorables ->
+    List.fold_left
+      (fun acc ignorable -> acc + count_initializers_ignorable ignorable)
+      0 ignorables
+
+let rec ignorable_product_element_kind_involves_int
+    (kind : ignorable_product_element_kind) =
+  match kind with
+  | Pint_ignorable -> true
+  | Punboxedfloat_ignorable _ | Punboxedint_ignorable _ -> false
+  | Pproduct_ignorable kinds ->
+    List.exists ignorable_product_element_kind_involves_int kinds

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -186,10 +186,14 @@ type primitive =
   (** For [Pduparray], the argument must be an immutable array.
       The arguments of [Pduparray] give the kind and mutability of the
       array being *produced* by the duplication. *)
-  | Parrayblit of array_set_kind
+  | Parrayblit of {
+      src_mutability : mutable_flag;
+      dst_array_set_kind : array_set_kind;
+    }
   (** For [Parrayblit], we record the [array_set_kind] of the destination
       array. We check that the source array has the same shape, but do not
-      need to know anything about its locality. *)
+      need to know anything about its locality. We do however request the
+      mutability of the source array. *)
   | Parraylength of array_kind
   | Parrayrefu of array_ref_kind * array_index_kind * mutable_flag
   | Parraysetu of array_set_kind * array_index_kind
@@ -1090,6 +1094,10 @@ val array_ref_kind : locality_mode -> array_kind -> array_ref_kind
 
 (** The mode will be discarded if unnecessary for the given [array_kind] *)
 val array_set_kind : modify_mode -> array_kind -> array_set_kind
+
+(** Note that this fails on [Pfloatarray_set] *)
+val array_ref_kind_of_array_set_kind_for_unboxed_types_and_int
+  : array_set_kind -> array_ref_kind
 
 (* Returns true if the given lambda can allocate on the local stack *)
 val may_allocate_in_region : lambda -> bool

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -179,6 +179,9 @@ type primitive =
   (* Array operations *)
   | Pmakearray of array_kind * mutable_flag * locality_mode
   | Pmakearray_dynamic of array_kind * locality_mode
+  (** For [Pmakearray_dynamic], if the array kind specifies an unboxed
+      product, the float array optimization will never apply -- even if such
+      unboxed product is a singleton. *)
   | Pduparray of array_kind * mutable_flag
   (** For [Pduparray], the argument must be an immutable array.
       The arguments of [Pduparray] give the kind and mutability of the
@@ -844,6 +847,8 @@ val const_unit: structured_constant
 val const_int : int -> structured_constant
 val lambda_unit: lambda
 
+val of_bool : bool -> lambda
+
 val layout_unit : layout
 val layout_int : layout
 val layout_array : array_kind -> layout
@@ -1101,3 +1106,7 @@ val try_to_find_location : lambda -> scoped_location
 val try_to_find_debuginfo : lambda -> Debuginfo.t
 
 val primitive_can_raise : primitive -> bool
+
+val count_initializers_array_kind : array_kind -> int
+val ignorable_product_element_kind_involves_int :
+  ignorable_product_element_kind -> bool

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -670,7 +670,10 @@ let primitive ppf = function
   | Pduparray (k, Immutable) -> fprintf ppf "duparray_imm[%s]" (array_kind k)
   | Pduparray (k, Immutable_unique) ->
       fprintf ppf "duparray_unique[%s]" (array_kind k)
-  | Parrayblit sk -> fprintf ppf "arrayblit[%a]" array_set_kind sk
+  | Parrayblit { src_mutability; dst_array_set_kind } ->
+      fprintf ppf "arrayblit[%s -> %a]"
+        (array_mut src_mutability)
+        array_set_kind dst_array_set_kind
   | Parrayrefu (rk, idx, mut) -> fprintf ppf "%s.unsafe_get[%a indexed by %a]"
                                  (array_mut mut)
                                  array_ref_kind rk

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -533,6 +533,9 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%makearray_dynamic" ->
       Language_extension.assert_enabled ~loc Layouts Language_extension.Alpha;
       Primitive (Pmakearray_dynamic (gen_array_kind, mode), 2)
+    | "%makearray_dynamic_uninit" ->
+      Language_extension.assert_enabled ~loc Layouts Language_extension.Alpha;
+      Primitive (Pmakearray_dynamic (gen_array_kind, mode), 1)
     | "%arrayblit" ->
       Language_extension.assert_enabled ~loc Layouts Language_extension.Alpha;
       Primitive (Parrayblit (gen_array_set_kind (get_third_arg_mode ())), 5)
@@ -1228,9 +1231,9 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       if st = array_set_type then None
       else Some (Primitive (Parraysets (array_set_type, index_kind), arity))
     end
-  | Primitive (Pmakearray_dynamic (at, mode), arity),
-    _ :: p2 :: _ -> begin
+  | Primitive (Pmakearray_dynamic (at, mode), 2), _ :: p2 :: [] -> begin
       let loc = to_location loc in
+      (* CR mshinwell: rename array_type -> array_kind *)
       let array_type =
         glb_array_type loc at
           (array_kind_of_elt ~elt_sort:None env loc p2)
@@ -1238,8 +1241,28 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       let array_mut = array_type_mut env rest_ty in
       unboxed_product_iarray_check loc array_type array_mut;
       if at = array_type then None
-      else Some (Primitive (Pmakearray_dynamic (array_type, mode), arity))
+      else Some (Primitive (Pmakearray_dynamic (array_type, mode), 2))
     end
+  | Primitive (Pmakearray_dynamic (at, mode), 1), _ :: [] -> begin
+      let loc = to_location loc in
+      match is_function_type env ty with
+      | None -> None
+      | Some (_, array_type) ->
+        match array_kind_of_array_type env loc array_type with
+        | None ->
+          (* XXX mshinwell: should this produce an error? *)
+          None
+        | Some array_type ->
+          let array_type = glb_array_type loc at array_type in
+          let array_mut = array_type_mut env rest_ty in
+          unboxed_product_iarray_check loc array_type array_mut;
+          if at = array_type then None
+          else Some (Primitive (Pmakearray_dynamic (array_type, mode), 1))
+    end
+  | Primitive (Pmakearray_dynamic _, arity), args ->
+    Misc.fatal_errorf
+      "Wrong arity for Pmakearray_dynamic (arity=%d, args length %d)"
+      arity (List.length args)
   | Primitive (Parrayblit st, arity),
     _p1 :: _ :: p2 :: _ ->
     let loc = to_location loc in

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -531,13 +531,13 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
           (gen_array_set_kind (get_first_arg_mode ()), Punboxed_int_index Pnativeint)),
         3)
     | "%makearray_dynamic" ->
-      Language_extension.assert_enabled ~loc Layouts Language_extension.Alpha;
+      Language_extension.assert_enabled ~loc Layouts Language_extension.Beta;
       Primitive (Pmakearray_dynamic (gen_array_kind, mode), 2)
     | "%makearray_dynamic_uninit" ->
       Language_extension.assert_enabled ~loc Layouts Language_extension.Alpha;
       Primitive (Pmakearray_dynamic (gen_array_kind, mode), 1)
     | "%arrayblit" ->
-      Language_extension.assert_enabled ~loc Layouts Language_extension.Alpha;
+      Language_extension.assert_enabled ~loc Layouts Language_extension.Beta;
       Primitive (Parrayblit (gen_array_set_kind (get_third_arg_mode ())), 5)
     | "%obj_size" -> Primitive ((Parraylength Pgenarray), 1)
     | "%obj_field" -> Primitive ((Parrayrefu (Pgenarray_ref mode, Ptagged_int_index, Mutable)), 2)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -922,19 +922,18 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Pmakearray (array_kind, _, _mode) ->
         let array_kind = Empty_array_kind.of_lambda array_kind in
         register_const0 acc (Static_const.empty_array array_kind) "empty_array"
-      | Pmakearray_dynamic (_array_kind, _mode) ->
-        Misc.fatal_error "Closure_conversion.close_primitive: unimplemented"
       | Parrayblit _array_set_kind ->
         Misc.fatal_error "Closure_conversion.close_primitive: unimplemented"
-      | Pbytes_to_string | Pbytes_of_string | Parray_of_iarray
-      | Parray_to_iarray | Pignore | Pgetglobal _ | Psetglobal _ | Pgetpredef _
-      | Pfield _ | Pfield_computed _ | Psetfield _ | Psetfield_computed _
-      | Pfloatfield _ | Psetfloatfield _ | Pduprecord _ | Pccall _ | Praise _
-      | Pufloatfield _ | Psetufloatfield _ | Psequand | Psequor | Pnot | Pnegint
-      | Pmixedfield _ | Psetmixedfield _ | Paddint | Psubint | Pmulint
-      | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
-      | Pasrint | Pintcomp _ | Pcompare_ints | Pcompare_floats _
-      | Pcompare_bints _ | Poffsetint _ | Poffsetref _ | Pintoffloat _
+      | Pmakearray_dynamic _ | Pbytes_to_string | Pbytes_of_string
+      | Parray_of_iarray | Parray_to_iarray | Pignore | Pgetglobal _
+      | Psetglobal _ | Pgetpredef _ | Pfield _ | Pfield_computed _ | Psetfield _
+      | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
+      | Pccall _ | Praise _ | Pufloatfield _ | Psetufloatfield _ | Psequand
+      | Psequor | Pnot | Pnegint | Pmixedfield _ | Psetmixedfield _ | Paddint
+      | Psubint | Pmulint | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint
+      | Plslint | Plsrint | Pasrint | Pintcomp _ | Pcompare_ints
+      | Pcompare_floats _ | Pcompare_bints _ | Poffsetint _ | Poffsetref _
+      | Pintoffloat _
       | Pfloatofint (_, _)
       | Pfloatoffloat32 _ | Pfloat32offloat _
       | Pnegfloat (_, _)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -535,7 +535,10 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         id,
         Lprim (prim, args, loc),
         body ) -> (
-    match Lambda_to_lambda_transforms.transform_primitive env prim args loc with
+    let env, result =
+      Lambda_to_lambda_transforms.transform_primitive env prim args loc
+    in
+    match result with
     | Primitive (prim, args, loc) ->
       (* This case avoids extraneous continuations. *)
       let exn_continuation : IR.exn_continuation option =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1390,7 +1390,9 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
               Variadic (Make_array (Values, mutability, mode), args),
               [K.With_subkind.any_value] ) ]))
   | Pmakearray_dynamic (_lambda_array_kind, _mode), _ ->
-    Misc.fatal_error "Lambda_to_flambda_primitives.convert_lprim: unimplemented"
+    Misc.fatal_error
+      "Lambda_to_flambda_primitives.convert_lprim: Pmakearray_dynamic should \
+       have been expanded in [Lambda_to_flambda]"
   | Parrayblit _array_set_kind, _ ->
     Misc.fatal_error "Lambda_to_flambda_primitives.convert_lprim: unimplemented"
   | Popaque layout, [arg] -> opaque layout arg ~middle_end_only:false
@@ -1922,6 +1924,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     [Binary (Int_arith (I.Tagged_immediate, Div), arg1, arg2)]
   | Pdivint Safe, [[arg1]; [arg2]] ->
     [checked_arith_op ~dbg None Div None arg1 arg2 ~current_region]
+  | Pmodint Unsafe, [[arg1]; [arg2]] ->
+    [H.Binary (Int_arith (I.Tagged_immediate, Mod), arg1, arg2)]
   | Pmodint Safe, [[arg1]; [arg2]] ->
     [checked_arith_op ~dbg None Mod None arg1 arg2 ~current_region]
   | Pdivbint { size = Pint32; is_safe = Safe; mode }, [[arg1]; [arg2]] ->
@@ -2287,8 +2291,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         "Preinterpret_tagged_int63_as_unboxed_int64 can only be used on 64-bit \
          targets";
     [Unary (Reinterpret_64_bit_word Tagged_int63_as_unboxed_int64, i)]
-  | ( ( Pmodint Unsafe
-      | Pdivbint { is_safe = Unsafe; size = _; mode = _ }
+  | ( ( Pdivbint { is_safe = Unsafe; size = _; mode = _ }
       | Pmodbint { is_safe = Unsafe; size = _; mode = _ }
       | Psetglobal _ | Praise _ | Pccall _ ),
       _ ) ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1389,12 +1389,10 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
                   List.map unbox_float args ),
               Variadic (Make_array (Values, mutability, mode), args),
               [K.With_subkind.any_value] ) ]))
-  | Pmakearray_dynamic (_lambda_array_kind, _mode), _ ->
+  | Pmakearray_dynamic _, _ | Parrayblit _, _ ->
     Misc.fatal_error
-      "Lambda_to_flambda_primitives.convert_lprim: Pmakearray_dynamic should \
-       have been expanded in [Lambda_to_flambda]"
-  | Parrayblit _array_set_kind, _ ->
-    Misc.fatal_error "Lambda_to_flambda_primitives.convert_lprim: unimplemented"
+      "Lambda_to_flambda_primitives.convert_lprim: Pmakearray_dynamic and \
+       Parrayblit should have been expanded in [Lambda_to_lambda_transforms]"
   | Popaque layout, [arg] -> opaque layout arg ~middle_end_only:false
   | Pobj_magic layout, [arg] -> opaque layout arg ~middle_end_only:true
   | Pduprecord (repr, num_fields), [[arg]] ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.mli
@@ -17,6 +17,8 @@
 module Acc = Closure_conversion_aux.Acc
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
+val check_float_array_optimisation_enabled : string -> unit
+
 val convert_and_bind :
   Acc.t ->
   big_endian:bool ->

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -424,6 +424,76 @@ let makearray_dynamic env (lambda_array_kind : L.array_kind)
     makearray_dynamic_non_scannable_unboxed_product env lambda_array_kind mode
       ~length ~init loc
 
+let arrayblit env ~(src_mutability : L.mutable_flag) ~dst_array_set_kind args
+    loc =
+  let src_array_ref_kind =
+    L.array_ref_kind_of_array_set_kind_for_unboxed_types_and_int
+      dst_array_set_kind
+  in
+  match args with
+  | [src_expr; src_start_pos_expr; dst_expr; dst_start_pos_expr; length_expr] ->
+    (* Care: the [args] are arbitrary Lambda expressions, so need to be
+       [let]-bound *)
+    let id = Ident.create_local in
+    let bind = L.bind_with_layout in
+    let src = id "src" in
+    let src_start_pos = id "src_start_pos" in
+    let dst = id "dst" in
+    let dst_start_pos = id "dst_start_pos" in
+    let length = id "length" in
+    (* CR mshinwell: support indexing by other types apart from [int] *)
+    let src_end_pos_exclusive =
+      L.Lprim (Paddint, [Lvar src_start_pos; Lvar length], loc)
+    in
+    let src_end_pos_inclusive =
+      L.Lprim (Psubint, [src_end_pos_exclusive; Lconst (L.const_int 1)], loc)
+    in
+    let dst_start_pos_minus_src_start_pos =
+      L.Lprim (Psubint, [Lvar dst_start_pos; Lvar src_start_pos], loc)
+    in
+    let dst_start_pos_minus_src_start_pos_var =
+      Ident.create_local "dst_start_pos_minus_src_start_pos"
+    in
+    let env, loop =
+      let src_index = Ident.create_local "index" in
+      rec_catch_for_for_loop env loc src_index (Lvar src_start_pos)
+        src_end_pos_inclusive Upto
+        (Lprim
+           ( Parraysetu (dst_array_set_kind, Ptagged_int_index),
+             [ Lvar dst;
+               Lprim
+                 ( Paddint,
+                   [Lvar src_index; dst_start_pos_minus_src_start_pos],
+                   loc );
+               Lprim
+                 ( Parrayrefu
+                     ( src_array_ref_kind,
+                       Ptagged_int_index,
+                       match src_mutability with
+                       | Immutable | Immutable_unique -> Immutable
+                       | Mutable -> Mutable ),
+                   [Lvar src; Lvar src_index],
+                   loc ) ],
+             loc ))
+    in
+    let expr =
+      bind Strict (src, L.layout_any_value) src_expr
+      @@ bind Strict (src_start_pos, L.layout_int) src_start_pos_expr
+      @@ bind Strict (dst, L.layout_any_value) dst_expr
+      @@ bind Strict (dst_start_pos, L.layout_int) dst_start_pos_expr
+      @@ bind Strict (length, L.layout_int) length_expr
+      @@ bind Strict
+           (dst_start_pos_minus_src_start_pos_var, L.layout_int)
+           dst_start_pos_minus_src_start_pos loop
+    in
+    env, Transformed expr
+  | _ ->
+    Misc.fatal_errorf
+      "Wrong arity for Parrayblit{,_immut} (expected src, src_offset, \
+       dst_offset and length):@ %a"
+      Debuginfo.print_compact
+      (Debuginfo.from_location loc)
+
 let transform_primitive0 env (prim : L.primitive) args loc =
   match prim, args with
   | Psequor, [arg1; arg2] ->
@@ -570,5 +640,7 @@ let transform_primitive env (prim : L.primitive) args loc =
   match prim with
   | Pmakearray_dynamic (lambda_array_kind, mode) ->
     makearray_dynamic env lambda_array_kind mode args loc
+  | Parrayblit { src_mutability; dst_array_set_kind } ->
+    arrayblit env ~src_mutability ~dst_array_set_kind args loc
   | _ -> env, transform_primitive0 env prim args loc
   [@@ocaml.warning "-fragile-match"]

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -346,7 +346,8 @@ let makearray_dynamic env (lambda_array_kind : L.array_kind)
    * heap and local modes.
    * Additionally, if the initializer is omitted, an uninitialized array will
    * be returned.  Initializers must however be provided when the array kind is
-   * Pgenarray, Paddrarray, Pintarray, Pfloatarray or Pgcscannableproductarray.
+   * Pgenarray, Paddrarray, Pintarray, Pfloatarray or Pgcscannableproductarray;
+   * or when a Pgcignorablearray involves an [int].  (See comment below.)
    *)
   let dbg = Debuginfo.from_location loc in
   let length, init =

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.mli
@@ -46,4 +46,4 @@ val transform_primitive :
   Lambda.primitive ->
   Lambda.lambda list ->
   Lambda.scoped_location ->
-  primitive_transform_result
+  Lambda_to_flambda_env.t * primitive_transform_result

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -59,6 +59,13 @@ CAMLextern value caml_alloc_custom(const struct custom_operations * ops,
                                    mlsize_t mem, /*resources consumed*/
                                    mlsize_t max  /*max resources*/);
 
+// The local version will fail if a finalizer is supplied in the [ops],
+// since finalizers on locally-allocated values are not yet supported.
+CAMLextern value caml_alloc_custom_local(const struct custom_operations * ops,
+                                         uintnat size, /*size in bytes*/
+                                         mlsize_t mem, /*resources consumed*/
+                                         mlsize_t max  /*max resources*/);
+
 /* [caml_alloc_custom_mem] allocates a custom block with dependent memory
    (memory outside the heap that will be reclaimed when the block is
    finalized). If [mem] is greater than [custom_minor_max_size] (see gc.mli)

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -37,6 +37,7 @@ CAMLextern value caml_alloc_shr (mlsize_t wosize, tag_t);
 CAMLextern value caml_alloc_shr_noexc(mlsize_t wosize, tag_t);
 CAMLextern value caml_alloc_shr_reserved (mlsize_t, tag_t, reserved_t);
 CAMLextern value caml_alloc_local(mlsize_t, tag_t);
+CAMLextern value caml_alloc_local_reserved(mlsize_t, tag_t, reserved_t);
 
 CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_adjust_minor_gc_speed (mlsize_t, mlsize_t);

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -111,6 +111,17 @@ CAMLexport value caml_alloc_custom(const struct custom_operations * ops,
   return alloc_custom_gen (ops, bsz, mem, max_major, max_minor);
 }
 
+CAMLexport value caml_alloc_custom_local(const struct custom_operations * ops,
+                                         uintnat bsz,
+                                         mlsize_t mem,
+                                         mlsize_t max)
+{
+  if (ops->finalize != NULL)
+    caml_invalid_argument("alloc_custom_local: finalizers not supported");
+
+   return caml_alloc_custom(ops, bsz, mem, max);
+}
+
 CAMLexport value caml_alloc_custom_mem(const struct custom_operations * ops,
                                        uintnat bsz,
                                        mlsize_t mem)

--- a/runtime/float32.c
+++ b/runtime/float32.c
@@ -853,7 +853,7 @@ CAMLexport const struct custom_operations caml_unboxed_float32_array_ops[2] = {
     custom_fixed_length_default },
 };
 
-CAMLprim value caml_make_unboxed_float32_vect(value len)
+static value caml_make_unboxed_float32_vect0(value len, int local)
 {
   /* This is only used on 64-bit targets. */
 
@@ -863,8 +863,23 @@ CAMLprim value caml_make_unboxed_float32_vect(value len)
   /* [num_fields] does not include the custom operations field. */
   mlsize_t num_fields = num_elements / 2 + num_elements % 2;
 
-  return caml_alloc_custom(&caml_unboxed_float32_array_ops[num_elements % 2],
-                           num_fields * sizeof(value), 0, 0);
+  const struct custom_operations* ops =
+    &caml_unboxed_float32_array_ops[num_elements % 2];
+
+  if (local)
+    return caml_alloc_custom_local(ops, num_fields * sizeof(value), 0, 0);
+  else
+    return caml_alloc_custom(ops, num_fields * sizeof(value), 0, 0);
+}
+
+CAMLprim value caml_make_unboxed_float32_vect(value len)
+{
+  return caml_make_unboxed_float32_vect0(len, 0);
+}
+
+CAMLprim value caml_make_unboxed_float32_vect_local(value len)
+{
+  return caml_make_unboxed_float32_vect0(len, 1);
 }
 
 CAMLprim value caml_make_unboxed_float32_vect_bytecode(value len)

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -524,6 +524,33 @@ void caml_local_realloc(void)
   CAMLassert(Caml_state->local_limit <= Caml_state->local_sp);
 }
 
+// XXX mshinwell: dedup code with caml_alloc_local
+CAMLexport value caml_alloc_local_reserved(mlsize_t wosize, tag_t tag,
+  reserved_t reserved)
+{
+#if defined(NATIVE_CODE) && defined(STACK_ALLOCATION)
+  intnat sp = Caml_state->local_sp;
+  header_t* hp;
+  sp -= Bhsize_wosize(wosize);
+  Caml_state->local_sp = sp;
+  if (sp < Caml_state->local_limit)
+    caml_local_realloc();
+  hp = (header_t*)((char*)Caml_state->local_top + sp);
+  *hp = Make_header_with_reserved(wosize, tag, NOT_MARKABLE, reserved);
+  return Val_hp(hp);
+#else
+  if (wosize <= Max_young_wosize) {
+    return caml_alloc_small_with_reserved(wosize, tag, reserved);
+  } else {
+    /* The return value is initialised directly using Field.
+       This is invalid if it may create major -> minor pointers.
+       So, perform a minor GC to prevent this. (See caml_make_vect) */
+    caml_minor_collection();
+    return caml_alloc_shr_reserved(wosize, tag, reserved);
+  }
+#endif
+}
+
 CAMLexport value caml_alloc_local(mlsize_t wosize, tag_t tag)
 {
 #if defined(NATIVE_CODE) && defined(STACK_ALLOCATION)

--- a/runtime/simd.c
+++ b/runtime/simd.c
@@ -75,20 +75,37 @@ CAMLprim value caml_unboxed_vec128_vect_blit(value a1, value ofs1, value a2,
     return Val_unit;
 }
 
-CAMLprim value caml_make_unboxed_vec128_vect(value len) {
-    /* This is only used on 64-bit targets. */
+static value caml_make_unboxed_vec128_vect(value len, int local)
+{
+  /* This is only used on 64-bit targets. */
 
-    mlsize_t num_elements = Long_val(len);
-    if (num_elements > Max_unboxed_vec128_array_wosize) caml_invalid_argument("Array.make");
+  mlsize_t num_elements = Long_val(len);
+  if (num_elements > Max_unboxed_vec128_array_wosize)
+    caml_invalid_argument("Array.make");
 
-    /* [num_fields] does not include the custom operations field. */
-    mlsize_t num_fields = num_elements * 2;
+  /* [num_fields] does not include the custom operations field. */
+  mlsize_t num_fields = num_elements * 2;
 
-    return caml_alloc_custom(&caml_unboxed_vec128_array_ops, num_fields * sizeof(value), 0, 0);
+  if (local)
+    return caml_alloc_custom_local(&caml_unboxed_vec128_array_ops,
+      num_fields * sizeof(value), 0, 0);
+  else
+    return caml_alloc_custom(&caml_unboxed_vec128_array_ops,
+      num_fields * sizeof(value), 0, 0);
+}
+
+CAMLprim value caml_make_unboxed_vec128_vect(value len)
+{
+  return caml_make_unboxed_vec128_vect(len, 0);
+}
+
+CAMLprim value caml_make_local_unboxed_vec128_vect(value len)
+{
+  return caml_make_unboxed_vec128_vect(len, 1);
 }
 
 CAMLprim value caml_make_unboxed_vec128_vect_bytecode(value len) {
-    caml_failwith("SIMD is not supported in bytecode mode.");
+  caml_failwith("SIMD is not supported in bytecode mode.");
 }
 
 #else
@@ -99,6 +116,10 @@ CAMLprim value caml_unboxed_vec128_vect_blit(value a1, value ofs1, value a2,
 }
 
 CAMLprim value caml_make_unboxed_vec128_vect(value len) {
+  caml_failwith("SIMD is not supported on this platform.");
+}
+
+CAMLprim value caml_make_local_unboxed_vec128_vect(value len) {
   caml_failwith("SIMD is not supported on this platform.");
 }
 

--- a/runtime4/array.c
+++ b/runtime4/array.c
@@ -467,6 +467,7 @@ static value make_vect_gen(value len, value init, int local)
   CAMLreturn (res);
 }
 
+// XXX mshinwell: add caml_makearray_dynamic for runtime4
 
 CAMLprim value caml_make_vect(value len, value init)
 {
@@ -963,3 +964,6 @@ CAMLprim value caml_array_unsafe_set_indexed_by_nativeint(value, value, value);
 Array_access_index_by(int64, int64_t, Int64_val)
 Array_access_index_by(int32, int32_t, Int32_val)
 Array_access_index_by(nativeint, intnat, Nativeint_val)
+
+// XXX mshinwell: add the %makearray_dynamic prims here for runtime4
+// once the runtime5 versions have been reviewed and tested

--- a/testsuite/tests/typing-layouts-arrays/README.md
+++ b/testsuite/tests/typing-layouts-arrays/README.md
@@ -1,0 +1,29 @@
+This directory has tests for arrays of unboxed types. The tests assume the array
+contains something that is like a number.
+
+Using the test framework here still involves a fair amount of copy and paste to
+build your new test. This is mainly because we don't have layout polymorphism,
+so it's not really possible to build it as one nice big functor. Hopefully we
+can improve it in the future.
+
+## Basic use
+
+The files `gen_u_array.ml` and `test_gen_u_array.ml` contain the basic
+framework. Rather than reading them, you are probably better off looking at an
+example.  E.g., see `test_int64_u_array.ml`.
+
+## Errors
+
+The testing framework is not very helpful in the event of errors - you'll get an
+assertion failure with an uninformative backtrace. One way to debug is to
+copy the framework and your test file elsewhere, compile and run it as a normal
+ocaml program, then comment out parts of the big test functor from
+`test_gen_u_array.ml` until you locate the line causing the error.  This should
+be improved.
+
+## Unboxed products
+
+The file `gen_product_array_helpers.ml` has additional infrastructure for
+testing arrays of unboxed products. To add a new test, copy one of the existing
+ones (e.g., `test_ignorable_product_array_1.ml`) and follow the instructions
+in its comments about which parts you need to edit.

--- a/testsuite/tests/typing-layouts-arrays/gen_product_array_helpers.ml
+++ b/testsuite/tests/typing-layouts-arrays/gen_product_array_helpers.ml
@@ -1,0 +1,353 @@
+module type Element_intf = Test_gen_u_array.Element_intf
+
+type 'a elem =
+  | Number : { ops : (module Element_intf with type t = 'a) } -> 'a elem
+  | Option : 'a elem -> ('a option) elem
+  | Tup2 : 'a1 elem * 'a2 elem -> ('a1 * 'a2) elem
+  | Tup3 : 'a1 elem * 'a2 elem * 'a3 elem -> ('a1 * 'a2 * 'a3) elem
+  | Tup4 : 'a1 elem * 'a2 elem * 'a3 elem * 'a4 elem
+      -> ('a1 * 'a2 * 'a3 * 'a4) elem
+  | Tup5 : 'a1 elem * 'a2 elem * 'a3 elem * 'a4 elem * 'a5 elem
+      -> ('a1 * 'a2 * 'a3 * 'a4 * 'a5) elem
+  | Tup6 : 'a1 elem * 'a2 elem * 'a3 elem * 'a4 elem * 'a5 elem * 'a6 elem
+      -> ('a1 * 'a2 * 'a3 * 'a4 * 'a5 * 'a6) elem
+
+module Int_elem : Element_intf with type t = int =
+struct
+  include Int
+  let of_int x = x
+  let max_val = max_int
+  let min_val = min_int
+  let rand = Random.full_int
+  let print i = Printf.printf "%d" i
+end
+
+let int_elem = Number { ops = (module Int_elem) }
+
+module Int32_elem : Element_intf with type t = int32 =
+struct
+  include Int32
+  let max_val = max_int
+  let min_val = min_int
+  let rand = Random.int32
+  let print i = Printf.printf "%ld" i
+end
+
+let int32_elem = Number { ops = (module Int32_elem) }
+
+module Int64_elem : Element_intf with type t = int64 =
+struct
+  include Int64
+  let max_val = max_int
+  let min_val = min_int
+  let rand = Random.int64
+  let print i = Printf.printf "%Ld" i
+end
+
+let int64_elem = Number { ops = (module Int64_elem) }
+
+module Nativeint_elem : Element_intf with type t = nativeint =
+struct
+  include Nativeint
+  let max_val = max_int
+  let min_val = min_int
+  let rand = Random.nativeint
+  let print i = Printf.printf "%nd" i
+end
+
+let nativeint_elem = Number { ops = (module Nativeint_elem) }
+
+module Float_elem : Element_intf with type t = float =
+struct
+  include Float
+  let max_val = max_float
+  let min_val = min_float
+  let rand = Random.float
+  let print i = Printf.printf "%f" i
+end
+
+let float_elem = Number { ops = (module Float_elem) }
+
+module Float32_elem : Element_intf with type t = float32 =
+struct
+  include Stdlib_stable.Float32
+  let max_val = max_float
+  let min_val = min_float
+  let rand x = of_float (Random.float (to_float x))
+  let print i = Printf.printf "%f" (to_float i)
+end
+
+let float32_elem = Number { ops = (module Float32_elem) }
+
+let traverse0 (f : 'a. (module Element_intf with type t = 'a) -> 'a) =
+  let rec go : type a . a elem -> a =
+    fun (elem : a elem) ->
+      match elem with
+      | Number {ops} -> f ops
+      | Option elem -> Some (go elem)
+      | Tup2 (e1, e2) -> (go e1, go e2)
+      | Tup3 (e1, e2, e3) -> (go e1, go e2, go e3)
+      | Tup4 (e1, e2, e3, e4) -> (go e1, go e2, go e3, go e4)
+      | Tup5 (e1, e2, e3, e4, e5) -> (go e1, go e2, go e3, go e4, go e5)
+      | Tup6 (e1, e2, e3, e4, e5, e6) ->
+        (go e1, go e2, go e3, go e4, go e5, go e6)
+  in
+  go
+
+let traverse1 (f : 'a. (module Element_intf with type t = 'a) -> 'a -> 'a) =
+  let rec go : type a . a elem -> a -> a =
+    fun (elem : a elem) (a : a) ->
+      match elem with
+      | Number {ops} -> f ops a
+      | Option elem -> Option.map (go elem) a
+      | Tup2 (e1, e2) ->
+        let a1, a2 = a in
+        (go e1 a1, go e2 a2)
+      | Tup3 (e1, e2, e3) ->
+        let a1, a2, a3 = a in
+        (go e1 a1, go e2 a2, go e3 a3)
+      | Tup4 (e1, e2, e3, e4) ->
+        let a1, a2, a3, a4 = a in
+        (go e1 a1, go e2 a2, go e3 a3, go e4 a4)
+      | Tup5 (e1, e2, e3, e4, e5) ->
+        let a1, a2, a3, a4, a5 = a in
+        (go e1 a1, go e2 a2, go e3 a3, go e4 a4, go e5 a5)
+      | Tup6 (e1, e2, e3, e4, e5, e6) ->
+        let a1, a2, a3, a4, a5, a6 = a in
+        (go e1 a1, go e2 a2, go e3 a3, go e4 a4, go e5 a5, go e6 a6)
+  in
+  go
+
+let traverse2
+      (f : 'a. (module Element_intf with type t = 'a) -> 'a -> 'a -> 'a) =
+  let rec go : type a . a elem -> a -> a -> a =
+    fun (elem : a elem) (a1 : a) (a2 : a) ->
+      match elem with
+      | Number {ops} -> f ops a1 a2
+      | Option elem ->
+        begin match a1, a2 with
+        | None, _ | _, None -> None
+        | Some a1, Some a2 -> Some (go elem a1 a2)
+        end
+      | Tup2 (e1, e2) ->
+        let a11, a12 = a1 in
+        let a21, a22 = a2 in
+        (go e1 a11 a21, go e2 a12 a22)
+      | Tup3 (e1, e2, e3) ->
+        let a11, a12, a13 = a1 in
+        let a21, a22, a23 = a2 in
+        (go e1 a11 a21, go e2 a12 a22, go e3 a13 a23)
+      | Tup4 (e1, e2, e3, e4) ->
+        let a11, a12, a13, a14 = a1 in
+        let a21, a22, a23, a24 = a2 in
+        (go e1 a11 a21, go e2 a12 a22, go e3 a13 a23, go e4 a14 a24)
+      | Tup5 (e1, e2, e3, e4, e5) ->
+        let a11, a12, a13, a14, a15 = a1 in
+        let a21, a22, a23, a24, a25 = a2 in
+        (go e1 a11 a21, go e2 a12 a22, go e3 a13 a23, go e4 a14 a24,
+         go e5 a15 a25)
+      | Tup6 (e1, e2, e3, e4, e5, e6) ->
+        let a11, a12, a13, a14, a15, a16 = a1 in
+        let a21, a22, a23, a24, a25, a26 = a2 in
+        (go e1 a11 a21, go e2 a12 a22, go e3 a13 a23, go e4 a14 a24,
+         go e5 a15 a25, go e6 a16 a26)
+  in
+  go
+
+let rec of_int : type a . a elem -> int -> a =
+  fun elem i ->
+    match elem with
+    | Number {ops} ->
+      let module O = (val ops) in
+      O.of_int i
+    | Option elem -> Some (of_int elem i)
+    | Tup2 (e1, e2) -> (of_int e1 i, of_int e2 i)
+    | Tup3 (e1, e2, e3) -> (of_int e1 i, of_int e2 i, of_int e3 i)
+    | Tup4 (e1, e2, e3, e4) ->
+      (of_int e1 i, of_int e2 i, of_int e3 i, of_int e4 i)
+    | Tup5 (e1, e2, e3, e4, e5) ->
+      (of_int e1 i, of_int e2 i, of_int e3 i, of_int e4 i, of_int e5 i)
+    | Tup6 (e1, e2, e3, e4, e5, e6) ->
+      (of_int e1 i, of_int e2 i, of_int e3 i, of_int e4 i, of_int e5 i,
+       of_int e6 i)
+
+let add elem a1 a2 =
+  let f (type a) (module E : Element_intf with type t = a) (a1 : a) (a2 : a) =
+    E.add a1 a2
+  in
+  traverse2 f elem a1 a2
+
+let sub elem a1 a2 =
+  let f (type a) (module E : Element_intf with type t = a) (a1 : a) (a2 : a) =
+    E.sub a1 a2
+  in
+  traverse2 f elem a1 a2
+
+let mul elem a1 a2 =
+  let f (type a) (module E : Element_intf with type t = a) (a1 : a) (a2 : a) =
+    E.mul a1 a2
+  in
+  traverse2 f elem a1 a2
+
+let neg elem a =
+  let f (type a) (module E : Element_intf with type t = a) (a : a) =
+    E.neg a
+  in
+  traverse1 f elem a
+
+let max_val elem =
+  let f (type a) (module E : Element_intf with type t = a) =
+    E.max_val
+  in
+  traverse0 f elem
+
+let min_val elem =
+  let rec go : type a . a elem -> a =
+    fun (elem : a elem) ->
+      match elem with
+      | Number {ops} ->
+        let module E = (val ops) in
+        E.min_val
+      | Option elem -> None
+      | Tup2 (e1, e2) -> (go e1, go e2)
+      | Tup3 (e1, e2, e3) -> (go e1, go e2, go e3)
+      | Tup4 (e1, e2, e3, e4) -> (go e1, go e2, go e3, go e4)
+      | Tup5 (e1, e2, e3, e4, e5) -> (go e1, go e2, go e3, go e4, go e5)
+      | Tup6 (e1, e2, e3, e4, e5, e6) ->
+        (go e1, go e2, go e3, go e4, go e5, go e6)
+  in
+  go elem
+
+let rand elem a =
+  let f (type a) (module E : Element_intf with type t = a) (a : a) =
+    E.rand a
+  in
+  traverse1 f elem a
+
+let rec compare : type a . a elem -> a -> a -> int =
+  fun elem a1 a2 ->
+    match elem with
+    | Number {ops} ->
+      let module E = (val ops) in
+      E.compare a1 a2
+    | Option elem -> Option.compare (compare elem) a1 a2
+    | Tup2 (e1, e2) ->
+      let a11, a12 = a1 in
+      let a21, a22 = a2 in
+      let x = compare e1 a11 a21 in
+      if x <> 0 then x
+      else compare e2 a12 a22
+    | Tup3 (e1, e2, e3) ->
+      let a11, a12, a13 = a1 in
+      let a21, a22, a23 = a2 in
+      let x = compare e1 a11 a21 in
+      if x <> 0 then x
+      else
+        let x = compare e2 a12 a22 in
+        if x <> 0 then x else compare e3 a13 a23
+    | Tup4 (e1, e2, e3, e4) ->
+      let a11, a12, a13, a14 = a1 in
+      let a21, a22, a23, a24 = a2 in
+      let x = compare e1 a11 a21 in
+      if x <> 0 then x
+      else
+        let x = compare e2 a12 a22 in
+        if x <> 0 then x else
+          let x = compare e3 a13 a23 in
+          if x <> 0 then x else compare e4 a14 a24
+    | Tup5 (e1, e2, e3, e4, e5) ->
+      let a11, a12, a13, a14, a15 = a1 in
+      let a21, a22, a23, a24, a25 = a2 in
+      let x = compare e1 a11 a21 in
+      if x <> 0 then x
+      else
+        let x = compare e2 a12 a22 in
+        if x <> 0 then x else
+          let x = compare e3 a13 a23 in
+          if x <> 0 then x else
+            let x = compare e4 a14 a24 in
+            if x <> 0 then x else compare e5 a15 a25
+    | Tup6 (e1, e2, e3, e4, e5, e6) ->
+      let a11, a12, a13, a14, a15, a16 = a1 in
+      let a21, a22, a23, a24, a25, a26 = a2 in
+      let x = compare e1 a11 a21 in
+      if x <> 0 then x
+      else
+        let x = compare e2 a12 a22 in
+        if x <> 0 then x else
+          let x = compare e3 a13 a23 in
+          if x <> 0 then x else
+            let x = compare e4 a14 a24 in
+            if x <> 0 then x else
+              let x = compare e5 a15 a25 in
+              if x <> 0 then x else
+                compare e6 a16 a26
+
+let rec print : type a . a elem -> a -> unit =
+  let open struct
+    type packed = P : 'a elem * 'a -> packed
+
+    let print_comma_sep l =
+      Printf.printf "(";
+      let rec go l =
+        match l with
+        | [] -> assert false
+        | [P (e,a)] ->
+          print e a;
+          Printf.printf ")"
+        | (P (e,a)) :: l ->
+          print e a;
+          Printf.printf ", ";
+          go l
+      in
+      go l
+  end
+  in
+  fun elem a ->
+    match elem with
+    | Number {ops} ->
+      let module E = (val ops) in
+      E.print a
+    | Option elem ->
+      begin match a with
+      | None -> Printf.printf "None"
+      | Some a -> begin
+          Printf.printf "Some ";
+          print elem a
+        end
+      end
+    | Tup2 (e1, e2) ->
+      let a1, a2 = a in
+      print_comma_sep [P (e1, a1); P (e2, a2)]
+    | Tup3 (e1, e2, e3) ->
+      let a1, a2, a3 = a in
+      print_comma_sep [P (e1, a1); P (e2, a2); P (e3, a3)]
+    | Tup4 (e1, e2, e3, e4) ->
+      let a1, a2, a3, a4 = a in
+      print_comma_sep [P (e1, a1); P (e2, a2); P (e3, a3); P (e4, a4)]
+    | Tup5 (e1, e2, e3, e4, e5) ->
+      let a1, a2, a3, a4, a5 = a in
+      print_comma_sep
+        [P (e1, a1); P (e2, a2); P (e3, a3); P (e4, a4); P (e5, a5)]
+    | Tup6 (e1, e2, e3, e4, e5, e6) ->
+      let a1, a2, a3, a4, a5, a6 = a in
+      print_comma_sep
+        [P (e1, a1); P (e2, a2); P (e3, a3); P (e4, a4); P (e5, a5);
+         P (e6, a6)]
+
+let make_element_ops (type a) (elem : a elem)
+  : (module Element_intf with type t = a) =
+  (module struct
+    type t = a
+
+    let of_int i = of_int elem i
+    let add t1 t2 = add elem t1 t2
+    let sub t1 t2 = sub elem t1 t2
+    let mul t1 t2 = mul elem t1 t2
+    let neg t = neg elem t
+    let max_val = max_val elem
+    let min_val = min_val elem
+    let rand t = rand elem t
+    let compare t1 t2 = compare elem t1 t2
+    let print t = print elem t
+  end)

--- a/testsuite/tests/typing-layouts-arrays/gen_product_array_helpers.mli
+++ b/testsuite/tests/typing-layouts-arrays/gen_product_array_helpers.mli
@@ -1,0 +1,26 @@
+(* This module defines some helpers for writing tests on arays of unboxed
+   products.  See [README.md] in this directory. *)
+
+module type Element_intf = Test_gen_u_array.Element_intf
+
+type 'a elem =
+  | Number : { ops : (module Element_intf with type t = 'a) } -> 'a elem
+  | Option : 'a elem -> ('a option) elem
+  | Tup2 : 'a1 elem * 'a2 elem -> ('a1 * 'a2) elem
+  | Tup3 : 'a1 elem * 'a2 elem * 'a3 elem -> ('a1 * 'a2 * 'a3) elem
+  | Tup4 : 'a1 elem * 'a2 elem * 'a3 elem * 'a4 elem
+      -> ('a1 * 'a2 * 'a3 * 'a4) elem
+  | Tup5 : 'a1 elem * 'a2 elem * 'a3 elem * 'a4 elem * 'a5 elem
+      -> ('a1 * 'a2 * 'a3 * 'a4 * 'a5) elem
+  | Tup6 : 'a1 elem * 'a2 elem * 'a3 elem * 'a4 elem * 'a5 elem * 'a6 elem
+      -> ('a1 * 'a2 * 'a3 * 'a4 * 'a5 * 'a6) elem
+
+val int_elem : int elem
+val int32_elem : int32 elem
+val int64_elem : int64 elem
+val nativeint_elem : nativeint elem
+
+val float_elem : float elem
+val float32_elem : float32 elem
+
+val make_element_ops : 'a elem -> (module Element_intf with type t = 'a)

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_1.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_1.ml
@@ -1,0 +1,86 @@
+(* TEST
+ include stdlib_stable;
+ include stdlib_upstream_compatible;
+ readonly_files =
+   "gen_u_array.ml test_gen_u_array.ml gen_product_array_helpers.ml";
+ modules = "${readonly_files}";
+ flambda2;
+ {
+   flags = "-extension layouts_beta";
+   bytecode;
+ }
+*)
+
+open Gen_product_array_helpers
+open Stdlib_stable
+open Stdlib_upstream_compatible
+
+(* If copying this test for a new product shape, you should only have to
+   change the bit between here and the next comment. See README.md in this
+   test directory. *)
+type boxed_t = float * int * int64
+type unboxed_t = #(float# * int * int64#)
+
+let elem : boxed_t elem = Tup3 (float_elem, int_elem, int64_elem)
+let words_wide : int = 3
+let zero () : unboxed_t = #(#0., 0, #0L)
+
+let to_boxed #(a, b, c) = (Float_u.to_float a, b, Int64_u.to_int64 c)
+let of_boxed (a, b, c) = #(Float_u.of_float a, b, Int64_u.of_int64 c)
+
+(* Below here is copy pasted due to the absence of layout polymorphism. Don't
+   change it.  See README.md in this test directory. *)
+module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
+
+module UTuple_array0 :
+  Gen_u_array.S0 with type element_t = unboxed_t
+                  and type ('a : any) array_t = 'a array = struct
+  type element_t = unboxed_t
+
+  type ('a : any) array_t = 'a array
+
+  type element_arg = unit -> element_t
+  type t = element_t array
+  let max_length = Sys.max_array_length
+  external length : element_t array -> int = "%array_length"
+  external get: element_t array -> int -> element_t = "%array_safe_get"
+  let get t i = let a = get t i in fun () -> a
+  external set: element_t array -> int -> element_t -> unit = "%array_safe_set"
+  let set t i e = set t i (e ())
+  external unsafe_get: element_t array -> int -> element_t = "%array_unsafe_get"
+  let unsafe_get t i = let a = unsafe_get t i in fun () -> a
+  external unsafe_set: element_t array -> int -> element_t -> unit =
+    "%array_unsafe_set"
+  let unsafe_set t i e = unsafe_set t i (e ())
+
+  external makearray_dynamic : int -> element_t -> element_t array =
+    "%makearray_dynamic"
+
+  let unsafe_create : int -> element_t array =
+    (* We don't actually have an uninitialized creation function for these, yet,
+       so we just use [makearray_dynamic] (which is what we want to test anyway)
+       with the zero element. *)
+    fun i -> makearray_dynamic i (zero ())
+
+  external unsafe_blit :
+    element_t array -> int -> element_t array -> int -> int -> unit =
+    "%arrayblit"
+
+  let empty () : unboxed_t array = [||]
+  let to_boxed = to_boxed
+
+  let compare_element x y =
+    Element_ops.compare (to_boxed (x ())) (to_boxed (y ()))
+end
+
+module UTuple_array = Gen_u_array.Make (UTuple_array0)
+
+module UTuple_array_boxed = Test_gen_u_array.Make_boxed (struct
+    module M = UTuple_array
+    module I = Element_ops
+    module E = struct
+      let to_boxed x = to_boxed (x ())
+      let of_boxed x () = of_boxed x
+    end
+  end)
+module _ = Test_gen_u_array.Test (UTuple_array_boxed)

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_2.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_2.ml
@@ -1,0 +1,107 @@
+(* TEST
+ include stdlib_stable;
+ include stdlib_upstream_compatible;
+ readonly_files =
+   "gen_u_array.ml test_gen_u_array.ml gen_product_array_helpers.ml";
+ modules = "${readonly_files}";
+ flambda2;
+ {
+   flags = "-extension layouts_beta";
+   bytecode;
+ }
+*)
+
+open Gen_product_array_helpers
+open Stdlib_stable
+open Stdlib_upstream_compatible
+
+(* If copying this test for a new product shape, you should only have to
+   change the bit between here and the next comment. See README.md in this
+   test directory. *)
+type boxed_t =
+  float * (int * int64) * float32 * (int32 * (float32 * float)) * int
+type unboxed_t =
+  #(float# * #(int * int64#) * float32# * #(int32# * #(float32# * float#))
+    * int)
+
+let elem : boxed_t elem =
+  Tup5 (float_elem,
+        Tup2 (int_elem, int64_elem),
+        float32_elem,
+        Tup2 (int32_elem, (Tup2 (float32_elem, float_elem))),
+        int_elem)
+
+let words_wide : int = 8
+let zero () : unboxed_t =
+  #(#0., #(0, #0L), #0.s, #(#0l, #(#0.s, #0.)), 0)
+
+let to_boxed #(a, #(b, c), d, #(e, #(f, g)), h) =
+  (Float_u.to_float a,
+   (b, Int64_u.to_int64 c),
+   Float32_u.to_float32 d,
+   (Int32_u.to_int32 e, (Float32_u.to_float32 f, Float_u.to_float g)),
+   h)
+
+let of_boxed (a, (b, c), d, (e, (f, g)), h) =
+  #(Float_u.of_float a,
+    #(b, Int64_u.of_int64 c),
+    Float32_u.of_float32 d,
+    #(Int32_u.of_int32 e, #(Float32_u.of_float32 f, Float_u.of_float g)),
+    h)
+
+(* Below here is copy pasted due to the absence of layout polymorphism. Don't
+   change it.  See README.md in this test directory. *)
+module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
+
+module UTuple_array0 :
+  Gen_u_array.S0 with type element_t = unboxed_t
+                  and type ('a : any) array_t = 'a array = struct
+  type element_t = unboxed_t
+
+  type ('a : any) array_t = 'a array
+
+  type element_arg = unit -> element_t
+  type t = element_t array
+  let max_length = Sys.max_array_length
+  external length : element_t array -> int = "%array_length"
+  external get: element_t array -> int -> element_t = "%array_safe_get"
+  let get t i = let a = get t i in fun () -> a
+  external set: element_t array -> int -> element_t -> unit = "%array_safe_set"
+  let set t i e = set t i (e ())
+  external unsafe_get: element_t array -> int -> element_t = "%array_unsafe_get"
+  let unsafe_get t i = let a = unsafe_get t i in fun () -> a
+  external unsafe_set: element_t array -> int -> element_t -> unit =
+    "%array_unsafe_set"
+  let unsafe_set t i e = unsafe_set t i (e ())
+
+  external makearray_dynamic : int -> element_t -> element_t array =
+    "%makearray_dynamic"
+
+  let unsafe_create : int -> element_t array =
+    (* We don't actually have an uninitialized creation function for these, yet,
+       so we just use [makearray_dynamic] (which is what we want to test anyway)
+       with the zero element. *)
+    fun i -> makearray_dynamic i (zero ())
+
+  external unsafe_blit :
+    element_t array -> int -> element_t array -> int -> int -> unit =
+    "%arrayblit"
+
+  let empty () : unboxed_t array = [||]
+  let to_boxed = to_boxed
+
+  let compare_element x y =
+    Element_ops.compare (to_boxed (x ())) (to_boxed (y ()))
+end
+
+module UTuple_array = Gen_u_array.Make (UTuple_array0)
+
+module UTuple_array_boxed = Test_gen_u_array.Make_boxed (struct
+    module M = UTuple_array
+    module I = Element_ops
+    module E = struct
+      let to_boxed x = to_boxed (x ())
+      let of_boxed x () = of_boxed x
+    end
+  end)
+module _ = Test_gen_u_array.Test (UTuple_array_boxed)

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_1.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_1.ml
@@ -1,0 +1,86 @@
+(* TEST
+ include stdlib_stable;
+ include stdlib_upstream_compatible;
+ readonly_files =
+   "gen_u_array.ml test_gen_u_array.ml gen_product_array_helpers.ml";
+ modules = "${readonly_files}";
+ flambda2;
+ {
+   flags = "-extension layouts_beta";
+   bytecode;
+ }
+*)
+
+open Gen_product_array_helpers
+open Stdlib_stable
+open Stdlib_upstream_compatible
+
+(* If copying this test for a new product shape, you should only have to
+   change the bit between here and the next comment. See README.md in this
+   test directory. *)
+type boxed_t = int * int64
+type unboxed_t = #(int * int64)
+
+let elem : boxed_t elem = Tup2 (int_elem, int64_elem)
+let words_wide : int = 2
+let zero () : unboxed_t = #(0, 0L)
+
+let to_boxed #(i, i64) = (i, i64)
+let of_boxed (i, i64) = #(i, i64)
+
+(* Below here is copy pasted due to the absence of layout polymorphism. Don't
+   change it.  See README.md in this test directory. *)
+module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
+
+module UTuple_array0 :
+  Gen_u_array.S0 with type element_t = unboxed_t
+                  and type ('a : any) array_t = 'a array = struct
+  type element_t = unboxed_t
+
+  type ('a : any) array_t = 'a array
+
+  type element_arg = unit -> element_t
+  type t = element_t array
+  let max_length = Sys.max_array_length
+  external length : element_t array -> int = "%array_length"
+  external get: element_t array -> int -> element_t = "%array_safe_get"
+  let get t i = let a = get t i in fun () -> a
+  external set: element_t array -> int -> element_t -> unit = "%array_safe_set"
+  let set t i e = set t i (e ())
+  external unsafe_get: element_t array -> int -> element_t = "%array_unsafe_get"
+  let unsafe_get t i = let a = unsafe_get t i in fun () -> a
+  external unsafe_set: element_t array -> int -> element_t -> unit =
+    "%array_unsafe_set"
+  let unsafe_set t i e = unsafe_set t i (e ())
+
+  external makearray_dynamic : int -> element_t -> element_t array =
+    "%makearray_dynamic"
+
+  let unsafe_create : int -> element_t array =
+    (* We don't actually have an uninitialized creation function for these, yet,
+       so we just use [makearray_dynamic] (which is what we want to test anyway)
+       with the zero element. *)
+    fun i -> makearray_dynamic i (zero ())
+
+  external unsafe_blit :
+    element_t array -> int -> element_t array -> int -> int -> unit =
+    "%arrayblit"
+
+  let empty () : unboxed_t array = [||]
+  let to_boxed = to_boxed
+
+  let compare_element x y =
+    Element_ops.compare (to_boxed (x ())) (to_boxed (y ()))
+end
+
+module UTuple_array = Gen_u_array.Make (UTuple_array0)
+
+module UTuple_array_boxed = Test_gen_u_array.Make_boxed (struct
+    module M = UTuple_array
+    module I = Element_ops
+    module E = struct
+      let to_boxed x = to_boxed (x ())
+      let of_boxed x () = of_boxed x
+    end
+  end)
+module _ = Test_gen_u_array.Test (UTuple_array_boxed)

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_2.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_2.ml
@@ -1,0 +1,108 @@
+(* TEST
+ include stdlib_stable;
+ include stdlib_upstream_compatible;
+ readonly_files =
+   "gen_u_array.ml test_gen_u_array.ml gen_product_array_helpers.ml";
+ modules = "${readonly_files}";
+ flambda2;
+ {
+   flags = "-extension layouts_beta";
+   bytecode;
+ }
+*)
+
+open Gen_product_array_helpers
+open Stdlib_stable
+open Stdlib_upstream_compatible
+
+(* If copying this test for a new product shape, you should only have to
+   change the bit between here and the next comment. See README.md in this
+   test directory. *)
+type boxed_t =
+  int64 option
+  * (int * int32 * float)
+  * float
+  * (float32 * (nativeint * nativeint) option)
+  * int32
+
+type unboxed_t =
+  #(int64 option
+    * #(int * int32 * float)
+    * float
+    * #(float32 * (nativeint * nativeint) option)
+    * int32)
+
+let elem : boxed_t elem =
+  Tup5 (Option int64_elem,
+        Tup3 (int_elem, int32_elem, float_elem),
+        float_elem,
+        Tup2 (float32_elem, Option (Tup2 (nativeint_elem, nativeint_elem))),
+        int32_elem)
+
+let words_wide : int = 8
+let zero () : unboxed_t =
+  #(Some 0L,
+    #(0, 0l, 0.),
+    0.,
+    #(0.s, Some (0n, 0n)),
+    0l)
+
+let to_boxed #(a, #(b, c, d), e, #(f, g), h) = (a, (b, c, d), e, (f, g), h)
+let of_boxed (a, (b, c, d), e, (f, g), h) = #(a, #(b, c, d), e, #(f, g), h)
+
+(* Below here is copy pasted due to the absence of layout polymorphism. Don't
+   change it.  See README.md in this test directory. *)
+module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
+
+module UTuple_array0 :
+  Gen_u_array.S0 with type element_t = unboxed_t
+                  and type ('a : any) array_t = 'a array = struct
+  type element_t = unboxed_t
+
+  type ('a : any) array_t = 'a array
+
+  type element_arg = unit -> element_t
+  type t = element_t array
+  let max_length = Sys.max_array_length
+  external length : element_t array -> int = "%array_length"
+  external get: element_t array -> int -> element_t = "%array_safe_get"
+  let get t i = let a = get t i in fun () -> a
+  external set: element_t array -> int -> element_t -> unit = "%array_safe_set"
+  let set t i e = set t i (e ())
+  external unsafe_get: element_t array -> int -> element_t = "%array_unsafe_get"
+  let unsafe_get t i = let a = unsafe_get t i in fun () -> a
+  external unsafe_set: element_t array -> int -> element_t -> unit =
+    "%array_unsafe_set"
+  let unsafe_set t i e = unsafe_set t i (e ())
+
+  external makearray_dynamic : int -> element_t -> element_t array =
+    "%makearray_dynamic"
+
+  let unsafe_create : int -> element_t array =
+    (* We don't actually have an uninitialized creation function for these, yet,
+       so we just use [makearray_dynamic] (which is what we want to test anyway)
+       with the zero element. *)
+    fun i -> makearray_dynamic i (zero ())
+
+  external unsafe_blit :
+    element_t array -> int -> element_t array -> int -> int -> unit =
+    "%arrayblit"
+
+  let empty () : unboxed_t array = [||]
+  let to_boxed = to_boxed
+
+  let compare_element x y =
+    Element_ops.compare (to_boxed (x ())) (to_boxed (y ()))
+end
+
+module UTuple_array = Gen_u_array.Make (UTuple_array0)
+
+module UTuple_array_boxed = Test_gen_u_array.Make_boxed (struct
+    module M = UTuple_array
+    module I = Element_ops
+    module E = struct
+      let to_boxed x = to_boxed (x ())
+      let of_boxed x () = of_boxed x
+    end
+  end)
+module _ = Test_gen_u_array.Test (UTuple_array_boxed)

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_3.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_3.ml
@@ -1,0 +1,88 @@
+(* TEST
+ include stdlib_stable;
+ include stdlib_upstream_compatible;
+ readonly_files =
+   "gen_u_array.ml test_gen_u_array.ml gen_product_array_helpers.ml";
+ modules = "${readonly_files}";
+ flambda2;
+ {
+   flags = "-extension layouts_beta";
+   bytecode;
+ }
+*)
+
+open Gen_product_array_helpers
+open Stdlib_stable
+open Stdlib_upstream_compatible
+
+(* If copying this test for a new product shape, you should only have to
+   change the bit between here and the next comment. See README.md in this
+   test directory. *)
+type boxed_t = float * float * float
+
+type unboxed_t = #(float * float * float)
+
+let elem : boxed_t elem = Tup3 (float_elem, float_elem, float_elem)
+
+let words_wide : int = 3
+let zero () : unboxed_t = #(0., 0., 0.)
+
+let to_boxed #(a, b, c) = a, b, c
+let of_boxed (a, b, c) = #(a, b, c)
+
+(* Below here is copy pasted due to the absence of layout polymorphism. Don't
+   change it.  See README.md in this test directory. *)
+module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
+
+module UTuple_array0 :
+  Gen_u_array.S0 with type element_t = unboxed_t
+                  and type ('a : any) array_t = 'a array = struct
+  type element_t = unboxed_t
+
+  type ('a : any) array_t = 'a array
+
+  type element_arg = unit -> element_t
+  type t = element_t array
+  let max_length = Sys.max_array_length
+  external length : element_t array -> int = "%array_length"
+  external get: element_t array -> int -> element_t = "%array_safe_get"
+  let get t i = let a = get t i in fun () -> a
+  external set: element_t array -> int -> element_t -> unit = "%array_safe_set"
+  let set t i e = set t i (e ())
+  external unsafe_get: element_t array -> int -> element_t = "%array_unsafe_get"
+  let unsafe_get t i = let a = unsafe_get t i in fun () -> a
+  external unsafe_set: element_t array -> int -> element_t -> unit =
+    "%array_unsafe_set"
+  let unsafe_set t i e = unsafe_set t i (e ())
+
+  external makearray_dynamic : int -> element_t -> element_t array =
+    "%makearray_dynamic"
+
+  let unsafe_create : int -> element_t array =
+    (* We don't actually have an uninitialized creation function for these, yet,
+       so we just use [makearray_dynamic] (which is what we want to test anyway)
+       with the zero element. *)
+    fun i -> makearray_dynamic i (zero ())
+
+  external unsafe_blit :
+    element_t array -> int -> element_t array -> int -> int -> unit =
+    "%arrayblit"
+
+  let empty () : unboxed_t array = [||]
+  let to_boxed = to_boxed
+
+  let compare_element x y =
+    Element_ops.compare (to_boxed (x ())) (to_boxed (y ()))
+end
+
+module UTuple_array = Gen_u_array.Make (UTuple_array0)
+
+module UTuple_array_boxed = Test_gen_u_array.Make_boxed (struct
+    module M = UTuple_array
+    module I = Element_ops
+    module E = struct
+      let to_boxed x = to_boxed (x ())
+      let of_boxed x () = of_boxed x
+    end
+  end)
+module _ = Test_gen_u_array.Test (UTuple_array_boxed)

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_4.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_4.ml
@@ -1,0 +1,92 @@
+(* TEST
+ include stdlib_stable;
+ include stdlib_upstream_compatible;
+ readonly_files =
+   "gen_u_array.ml test_gen_u_array.ml gen_product_array_helpers.ml";
+ modules = "${readonly_files}";
+ flambda2;
+ {
+   flags = "-extension layouts_beta";
+   bytecode;
+ }
+*)
+
+open Gen_product_array_helpers
+open Stdlib_stable
+open Stdlib_upstream_compatible
+
+(* If copying this test for a new product shape, you should only have to
+   change the bit between here and the next comment. See README.md in this
+   test directory. *)
+type boxed_t = float * (float * float) * (float * (float * float * float))
+
+type unboxed_t =
+  #(float * #(float * float) * #(float * #(float * float * float)))
+
+let elem : boxed_t elem =
+  Tup3 (float_elem,
+        Tup2 (float_elem, float_elem),
+        Tup2 (float_elem, Tup3 (float_elem, float_elem, float_elem)))
+
+let words_wide : int = 7
+let zero () : unboxed_t = #(0., #(0., 0.), #(0., #(0., 0., 0.)))
+
+let to_boxed #(a, #(b, c), #(d, #(e, f, g))) = a, (b, c), (d, (e, f, g))
+let of_boxed (a, (b, c), (d, (e, f, g))) = #(a, #(b, c), #(d, #(e, g, f)))
+
+(* Below here is copy pasted due to the absence of layout polymorphism. Don't
+   change it.  See README.md in this test directory. *)
+module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
+
+module UTuple_array0 :
+  Gen_u_array.S0 with type element_t = unboxed_t
+                  and type ('a : any) array_t = 'a array = struct
+  type element_t = unboxed_t
+
+  type ('a : any) array_t = 'a array
+
+  type element_arg = unit -> element_t
+  type t = element_t array
+  let max_length = Sys.max_array_length
+  external length : element_t array -> int = "%array_length"
+  external get: element_t array -> int -> element_t = "%array_safe_get"
+  let get t i = let a = get t i in fun () -> a
+  external set: element_t array -> int -> element_t -> unit = "%array_safe_set"
+  let set t i e = set t i (e ())
+  external unsafe_get: element_t array -> int -> element_t = "%array_unsafe_get"
+  let unsafe_get t i = let a = unsafe_get t i in fun () -> a
+  external unsafe_set: element_t array -> int -> element_t -> unit =
+    "%array_unsafe_set"
+  let unsafe_set t i e = unsafe_set t i (e ())
+
+  external makearray_dynamic : int -> element_t -> element_t array =
+    "%makearray_dynamic"
+
+  let unsafe_create : int -> element_t array =
+    (* We don't actually have an uninitialized creation function for these, yet,
+       so we just use [makearray_dynamic] (which is what we want to test anyway)
+       with the zero element. *)
+    fun i -> makearray_dynamic i (zero ())
+
+  external unsafe_blit :
+    element_t array -> int -> element_t array -> int -> int -> unit =
+    "%arrayblit"
+
+  let empty () : unboxed_t array = [||]
+  let to_boxed = to_boxed
+
+  let compare_element x y =
+    Element_ops.compare (to_boxed (x ())) (to_boxed (y ()))
+end
+
+module UTuple_array = Gen_u_array.Make (UTuple_array0)
+
+module UTuple_array_boxed = Test_gen_u_array.Make_boxed (struct
+    module M = UTuple_array
+    module I = Element_ops
+    module E = struct
+      let to_boxed x = to_boxed (x ())
+      let of_boxed x () = of_boxed x
+    end
+  end)
+module _ = Test_gen_u_array.Test (UTuple_array_boxed)

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -786,13 +786,7 @@ type t4 = #(string * #(float# * bool option)) array
    arrays to beta. *)
 let _ = [| #(1,2) |]
 [%%expect{|
-Line 1, characters 8-20:
-1 | let _ = [| #(1,2) |]
-            ^^^^^^^^^^^^
-Error: Non-value layout value & value detected as sort for type #(int * int),
-       but this requires extension layouts_alpha, which is not enabled.
-       If you intended to use this layout, please add this flag to your build file.
-       Otherwise, please report this error to the Jane Street compilers team.
+- : #(int * int) array = [|#(1, 2)|]
 |}]
 
 let _ = Array.init 3 (fun _ -> #(1,2))
@@ -836,13 +830,7 @@ let f x : #(int * int) = array_get x 3
 [%%expect{|
 external array_get : ('a : any). 'a array -> int -> 'a = "%array_safe_get"
   [@@layout_poly]
-Line 3, characters 25-38:
-3 | let f x : #(int * int) = array_get x 3
-                             ^^^^^^^^^^^^^
-Error: Non-value layout value & value detected as sort for type #(int * int),
-       but this requires extension layouts_alpha, which is not enabled.
-       If you intended to use this layout, please add this flag to your build file.
-       Otherwise, please report this error to the Jane Street compilers team.
+val f : #(int * int) array -> #(int * int) = <fun>
 |}]
 
 external[@layout_poly] array_set : ('a : any) . 'a array -> int -> 'a -> unit =
@@ -851,13 +839,7 @@ let f x = array_set x 3 #(1,2)
 [%%expect{|
 external array_set : ('a : any). 'a array -> int -> 'a -> unit
   = "%array_safe_set" [@@layout_poly]
-Line 3, characters 10-30:
-3 | let f x = array_set x 3 #(1,2)
-              ^^^^^^^^^^^^^^^^^^^^
-Error: Non-value layout value & value detected as sort for type #(int * int),
-       but this requires extension layouts_alpha, which is not enabled.
-       If you intended to use this layout, please add this flag to your build file.
-       Otherwise, please report this error to the Jane Street compilers team.
+val f : #(int * int) array -> unit = <fun>
 |}]
 
 

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -721,19 +721,15 @@ Error: "[@layout_poly]" on this external declaration has no
 external[@layout_poly] makearray_dynamic : ('a : any). int -> 'a -> 'a array =
   "%makearray_dynamic"
 [%%expect{|
-Lines 1-2, characters 0-22:
-1 | external[@layout_poly] makearray_dynamic : ('a : any). int -> 'a -> 'a array =
-2 |   "%makearray_dynamic"
-Error: This construct requires the alpha version of the extension "layouts", which is disabled and cannot be used
+external makearray_dynamic : ('a : any). int -> 'a -> 'a array
+  = "%makearray_dynamic" [@@layout_poly]
 |}]
 
 external[@layout_poly] arrayblit :
   ('a : any). 'a array -> int -> 'a array -> int -> int -> unit =
   "%arrayblit"
 [%%expect{|
-Lines 1-3, characters 0-14:
-1 | external[@layout_poly] arrayblit :
-2 |   ('a : any). 'a array -> int -> 'a array -> int -> int -> unit =
-3 |   "%arrayblit"
-Error: This construct requires the alpha version of the extension "layouts", which is disabled and cannot be used
+external arrayblit :
+  ('a : any). 'a array -> int -> 'a array -> int -> int -> unit
+  = "%arrayblit" [@@layout_poly]
 |}]

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -654,6 +654,14 @@ let prim_has_valid_reprs ~loc prim =
         any;
         is (Same_as_ocaml_repr C.value);
       ]
+    | "%makearray_dynamic_uninit" ->
+      (* XXX this primitive is not supported for Pgcscannableproductarray and
+         the upstream array kinds (Pgenarray etc).  See comment in
+         lambda_to_lambda_transforms.ml. *)
+      check [
+        is (Same_as_ocaml_repr C.value);
+        is (Same_as_ocaml_repr C.value);
+      ]
 
     | "%box_float" ->
       exactly [Same_as_ocaml_repr C.float64; Same_as_ocaml_repr C.value]

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -244,6 +244,14 @@ let array_kind_of_elt ~elt_sort env loc ty =
   | Unboxed_vector v -> Punboxedvectorarray v
   | Product c -> c
 
+let array_kind_of_array_type env loc ty =
+  match scrape_poly env ty with
+  | Tconstr(p, [elt_ty], _)
+      when Path.same p Predef.path_iarray
+        || Path.same p Predef.path_array ->
+    Some (array_kind_of_elt ~elt_sort:None env loc elt_ty)
+  | _ -> None
+
 let array_type_kind ~elt_sort env loc ty =
   match scrape_poly env ty with
   | Tconstr(p, [elt_ty], _) when Path.same p Predef.path_array ->

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -225,7 +225,7 @@ let array_kind_of_elt ~elt_sort env loc ty =
       type_legacy_sort ~why:Array_element env loc ty
   in
   let classify_product ty sorts =
-    if Language_extension.(is_at_least Layouts Alpha) then
+    if Language_extension.(is_at_least Layouts Beta) then
       if is_always_gc_ignorable env ty then
         Pgcignorableproductarray (ignorable_product_array_kind loc sorts)
       else

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -32,6 +32,8 @@ val array_type_mut : Env.t -> Types.type_expr -> Lambda.mutable_flag
 val array_kind_of_elt :
   elt_sort:(Jkind.Sort.t option)
   -> Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
+val array_kind_of_array_type :
+  Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind option
 val array_kind :
   Typedtree.expression -> Jkind.Sort.t -> Lambda.array_kind
 val array_pattern_kind :


### PR DESCRIPTION
Implements something like:
```
external[@layout_poly] arrayblit :
  ('a : any). 'a array -> int -> 'a array -> int -> int -> unit =
  "%arrayblit"

external[@layout_poly] arrayblit_immut :
  ('a : any). 'a iarray -> int -> 'a array -> int -> int -> unit =
  "%arrayblit_immut"
```
This is done via a Lambda-to-Lambda transformation on the way into Flambda 2.

Actually, the signatures above are a bit of a lie, because this is not currently supported for any array of kind `Pgenarray`, `Paddrarray` or `Pfloatarray`.  @ccasin if we propagated the mode of the source array, we could remove this restriction I think.  (The problem is that we need to be able to convert an `array_set_kind` into an `array_ref_kind`.)