### PR TITLE
Tweak macOS CI

### DIFF
--- a/flambda-backend/tests/backend/regalloc_validator/dune
+++ b/flambda-backend/tests/backend/regalloc_validator/dune
@@ -1,5 +1,6 @@
 (tests
  (names check_regalloc_validation)
+ ; CR xclerc: on arm64, we currently get a different Reg.t stamp in a test
  (enabled_if (= %{architecture} "amd64"))
  ; FIXME Fix warnings
  (flags

--- a/flambda-backend/tests/backend/regalloc_validator/dune
+++ b/flambda-backend/tests/backend/regalloc_validator/dune
@@ -1,5 +1,6 @@
 (tests
  (names check_regalloc_validation)
+ (enabled_if (= %{architecture} "amd64"))
  ; FIXME Fix warnings
  (flags
   (:standard -no-principal -w -27-32))

--- a/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
+++ b/flambda-backend/tests/backend/zero_alloc_checker/dune.inc
@@ -1,30 +1,30 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps s.ml t.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps t5.ml test_assume.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_match_on_mutable_state.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_flambda.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail1.output.corrected)
  (deps (:ml fail1.ml) filter.sh)
  (action
@@ -38,12 +38,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail1.output fail1.output.corrected)
  (action (diff fail1.output fail1.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail2.output.corrected)
  (deps (:ml fail2.ml) filter.sh)
  (action
@@ -57,12 +57,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail2.output fail2.output.corrected)
  (action (diff fail2.output fail2.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail3.output.corrected)
  (deps (:ml t3.ml fail3.ml) filter.sh)
  (action
@@ -76,12 +76,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail3.output fail3.output.corrected)
  (action (diff fail3.output fail3.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail4.output.corrected)
  (deps (:ml t4.ml fail4.ml) filter.sh)
  (action
@@ -95,12 +95,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail4.output fail4.output.corrected)
  (action (diff fail4.output fail4.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail5.output.corrected)
  (deps (:ml fail5.ml) filter.sh)
  (action
@@ -114,12 +114,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail5.output fail5.output.corrected)
  (action (diff fail5.output fail5.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail6.output.corrected)
  (deps (:ml fail6.ml) filter.sh)
  (action
@@ -133,12 +133,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail6.output fail6.output.corrected)
  (action (diff fail6.output fail6.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail7.output.corrected)
  (deps (:ml fail7.ml) filter.sh)
  (action
@@ -152,12 +152,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail7.output fail7.output.corrected)
  (action (diff fail7.output fail7.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail8.output.corrected)
  (deps (:ml fail8.ml) filter.sh)
  (action
@@ -171,12 +171,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail8.output fail8.output.corrected)
  (action (diff fail8.output fail8.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail9.output.corrected)
  (deps (:ml fail9.ml) filter.sh)
  (action
@@ -190,12 +190,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail9.output fail9.output.corrected)
  (action (diff fail9.output fail9.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail10.output.corrected)
  (deps (:ml fail10.ml) filter.sh)
  (action
@@ -209,12 +209,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail10.output fail10.output.corrected)
  (action (diff fail10.output fail10.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail12.output.corrected)
  (deps (:ml fail12.ml) filter.sh)
  (action
@@ -228,12 +228,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail12.output fail12.output.corrected)
  (action (diff fail12.output fail12.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail13.output.corrected)
  (deps (:ml fail13.ml) filter.sh)
  (action
@@ -247,12 +247,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail13.output fail13.output.corrected)
  (action (diff fail13.output fail13.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail14.output.corrected)
  (deps (:ml fail14.ml) filter.sh)
  (action
@@ -266,12 +266,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail14.output fail14.output.corrected)
  (action (diff fail14.output fail14.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail15.output.corrected)
  (deps (:ml fail15.ml) filter.sh)
  (action
@@ -285,12 +285,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail15.output fail15.output.corrected)
  (action (diff fail15.output fail15.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail16.output.corrected)
  (deps (:ml fail16.ml) filter.sh)
  (action
@@ -304,12 +304,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail16.output fail16.output.corrected)
  (action (diff fail16.output fail16.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail17.output.corrected)
  (deps (:ml fail17.ml) filter.sh)
  (action
@@ -323,12 +323,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail17.output fail17.output.corrected)
  (action (diff fail17.output fail17.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail18.output.corrected)
  (deps (:ml fail18.ml) filter.sh)
  (action
@@ -342,12 +342,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail18.output fail18.output.corrected)
  (action (diff fail18.output fail18.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail19.output.corrected)
  (deps (:ml dep19.ml fail19.ml) filter.sh)
  (action
@@ -361,12 +361,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail19.output fail19.output.corrected)
  (action (diff fail19.output fail19.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail20.output.corrected)
  (deps (:ml fail20.ml) filter.sh)
  (action
@@ -380,12 +380,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail20.output fail20.output.corrected)
  (action (diff fail20.output fail20.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail21.output.corrected)
  (deps (:ml fail21.ml) filter.sh)
  (action
@@ -399,12 +399,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail21.output fail21.output.corrected)
  (action (diff fail21.output fail21.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_attribute_error_duplicate.output.corrected)
  (deps (:ml test_attribute_error_duplicate.ml) filter.sh)
  (action
@@ -418,12 +418,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_attribute_error_duplicate.output test_attribute_error_duplicate.output.corrected)
  (action (diff test_attribute_error_duplicate.output test_attribute_error_duplicate.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_attr_unused.output.corrected)
  (deps (:ml test_attr_unused.ml) filter.sh)
  (action
@@ -437,12 +437,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_attr_unused.output test_attr_unused.output.corrected)
  (action (diff test_attr_unused.output test_attr_unused.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets t6.output.corrected)
  (deps (:ml t6.ml) filter.sh)
  (action
@@ -456,24 +456,24 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps t6.output t6.output.corrected)
  (action (diff t6.output t6.output.corrected)))
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps t7.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_stub_dep.ml test_stub.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets t1.output.corrected)
  (deps (:ml t1.ml) filter.sh)
  (action
@@ -487,12 +487,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps t1.output t1.output.corrected)
  (action (diff t1.output t1.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_warning199.output.corrected)
  (deps (:ml test_warning199.mli test_warning199.ml) filter.sh)
  (action
@@ -506,12 +506,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_warning199.output test_warning199.output.corrected)
  (action (diff test_warning199.output test_warning199.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_never_returns_normally.output.corrected)
  (deps (:ml test_never_returns_normally.ml) filter.sh)
  (action
@@ -525,12 +525,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_never_returns_normally.output test_never_returns_normally.output.corrected)
  (action (diff test_never_returns_normally.output test_never_returns_normally.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail22.output.corrected)
  (deps (:ml fail22.ml) filter.sh)
  (action
@@ -544,12 +544,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail22.output fail22.output.corrected)
  (action (diff fail22.output fail22.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail23.output.corrected)
  (deps (:ml fail23.ml) filter.sh)
  (action
@@ -563,24 +563,24 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail23.output fail23.output.corrected)
  (action (diff fail23.output fail23.output.corrected)))
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_zero_alloc_opt1.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check opt -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_zero_alloc_opt2.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check opt -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_assume_fail.output.corrected)
  (deps (:ml test_assume_fail.ml) filter.sh)
  (action
@@ -594,12 +594,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_fail.output test_assume_fail.output.corrected)
  (action (diff test_assume_fail.output test_assume_fail.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_assume_on_call.output.corrected)
  (deps (:ml test_assume_on_call.ml) filter.sh)
  (action
@@ -613,12 +613,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_on_call.output test_assume_on_call.output.corrected)
  (action (diff test_assume_on_call.output test_assume_on_call.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_misplaced_assume.output.corrected)
  (deps (:ml test_misplaced_assume.ml) filter.sh)
  (action
@@ -632,12 +632,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_misplaced_assume.output test_misplaced_assume.output.corrected)
  (action (diff test_misplaced_assume.output test_misplaced_assume.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_attr_check.output.corrected)
  (deps (:ml test_attr_check.ml) filter.sh)
  (action
@@ -651,12 +651,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_attr_check.output test_attr_check.output.corrected)
  (action (diff test_attr_check.output test_attr_check.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_attr_check_all.output.corrected)
  (deps (:ml test_attr_check_all.ml) filter.sh)
  (action
@@ -670,12 +670,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_attr_check_all.output test_attr_check_all.output.corrected)
  (action (diff test_attr_check_all.output test_attr_check_all.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_attr_check_opt.output.corrected)
  (deps (:ml test_attr_check_opt.ml) filter.sh)
  (action
@@ -689,12 +689,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_attr_check_opt.output test_attr_check_opt.output.corrected)
  (action (diff test_attr_check_opt.output test_attr_check_opt.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_attr_check_none.output.corrected)
  (deps (:ml test_attr_check_none.ml) filter.sh)
  (action
@@ -708,12 +708,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_attr_check_none.output test_attr_check_none.output.corrected)
  (action (diff test_attr_check_none.output test_attr_check_none.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail24.output.corrected)
  (deps (:ml fail24.ml) filter.sh)
  (action
@@ -727,18 +727,18 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail24.output fail24.output.corrected)
  (action (diff fail24.output fail24.output.corrected)))
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_raise_message.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -function-layout topological -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail25.output.corrected)
  (deps (:ml fail25.ml) filter.sh)
  (action
@@ -752,12 +752,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail25.output fail25.output.corrected)
  (action (diff fail25.output fail25.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets fail26.output.corrected)
  (deps (:ml fail26.ml) filter.sh)
  (action
@@ -771,12 +771,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps fail26.output fail26.output.corrected)
  (action (diff fail26.output fail26.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_all_opt.output.corrected)
  (deps (:ml test_all_opt.ml) filter.sh)
  (action
@@ -790,12 +790,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_all_opt.output test_all_opt.output.corrected)
  (action (diff test_all_opt.output test_all_opt.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_all_opt2.output.corrected)
  (deps (:ml test_all_opt2.ml) filter.sh)
  (action
@@ -809,12 +809,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_all_opt2.output test_all_opt2.output.corrected)
  (action (diff test_all_opt2.output test_all_opt2.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_all_opt3.output.corrected)
  (deps (:ml test_all_opt3.ml) filter.sh)
  (action
@@ -828,12 +828,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_all_opt3.output test_all_opt3.output.corrected)
  (action (diff test_all_opt3.output test_all_opt3.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_arity.output.corrected)
  (deps (:ml test_arity.ml) filter.sh)
  (action
@@ -847,7 +847,7 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_arity.output test_arity.output.corrected)
  (action (diff test_arity.output test_arity.output.corrected)))
 
@@ -855,11 +855,11 @@
  (alias runtest)
  (deps stop_after_typing.ml)
  (target stop_after_typing.cmi)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (action (run %{bin:ocamlopt.opt} stop_after_typing.ml -g -c -opaque -stop-after typing -O3 -warn-error +a)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_signatures_functors.output.corrected)
  (deps (:ml test_signatures_functors.ml) filter.sh)
  (action
@@ -873,12 +873,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_signatures_functors.output test_signatures_functors.output.corrected)
  (action (diff test_signatures_functors.output test_signatures_functors.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_signatures_first_class_modules.output.corrected)
  (deps (:ml test_signatures_first_class_modules.ml) filter.sh)
  (action
@@ -892,7 +892,7 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_signatures_first_class_modules.output test_signatures_first_class_modules.output.corrected)
  (action (diff test_signatures_first_class_modules.output test_signatures_first_class_modules.output.corrected)))
 
@@ -900,11 +900,11 @@
  (alias runtest)
  (deps test_signatures_separate_a.ml)
  (target test_signatures_separate_a.cmi)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (action (run %{bin:ocamlopt.opt} test_signatures_separate_a.ml -g -c -opaque -stop-after typing -O3 -warn-error +a)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_signatures_separate.output.corrected)
  (deps test_signatures_separate_a.cmi (:ml test_signatures_separate_b.ml) filter.sh)
  (action
@@ -918,12 +918,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_signatures_separate.output test_signatures_separate.output.corrected)
  (action (diff test_signatures_separate.output test_signatures_separate.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_signatures_separate.opt.output.corrected)
  (deps test_signatures_separate_a.cmi (:ml test_signatures_separate_b.ml) filter.sh)
  (action
@@ -937,12 +937,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_signatures_separate.opt.output test_signatures_separate.opt.output.corrected)
  (action (diff test_signatures_separate.opt.output test_signatures_separate.opt.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_assume_inlining.output.corrected)
  (deps (:ml test_assume_inlining.ml) filter.sh)
  (action
@@ -956,12 +956,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_inlining.output test_assume_inlining.output.corrected)
  (action (diff test_assume_inlining.output test_assume_inlining.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_assume_error.output.corrected)
  (deps (:ml test_assume_error.ml) filter.sh)
  (action
@@ -975,12 +975,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_error.output test_assume_error.output.corrected)
  (action (diff test_assume_error.output test_assume_error.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_assume_stub.output.corrected)
  (deps (:ml test_assume_stub.ml) filter.sh)
  (action
@@ -994,12 +994,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_assume_stub.output test_assume_stub.output.corrected)
  (action (diff test_assume_stub.output test_assume_stub.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_bounded_join.output.corrected)
  (deps (:ml test_bounded_join.ml) filter_fatal_error.sh)
  (action
@@ -1013,12 +1013,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_bounded_join.output test_bounded_join.output.corrected)
  (action (diff test_bounded_join.output test_bounded_join.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_bounded_join2.output.corrected)
  (deps (:ml test_bounded_join2.ml) filter.sh)
  (action
@@ -1032,12 +1032,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_bounded_join2.output test_bounded_join2.output.corrected)
  (action (diff test_bounded_join2.output test_bounded_join2.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_bounded_join3.output.corrected)
  (deps (:ml test_bounded_join3.ml) filter.sh)
  (action
@@ -1051,12 +1051,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_bounded_join3.output test_bounded_join3.output.corrected)
  (action (diff test_bounded_join3.output test_bounded_join3.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_bounded_join4.output.corrected)
  (deps (:ml test_bounded_join4.ml) filter.sh)
  (action
@@ -1070,12 +1070,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_bounded_join4.output test_bounded_join4.output.corrected)
  (action (diff test_bounded_join4.output test_bounded_join4.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_inference.output.corrected)
  (deps (:ml test_inference.mli test_inference.ml) filter.sh)
  (action
@@ -1089,12 +1089,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_inference.output test_inference.output.corrected)
  (action (diff test_inference.output test_inference.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_inference.opt.output.corrected)
  (deps (:ml test_inference.mli test_inference.ml) filter.sh)
  (action
@@ -1108,12 +1108,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_inference.opt.output test_inference.opt.output.corrected)
  (action (diff test_inference.opt.output test_inference.opt.output.corrected)))
 
 (rule
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_remove_inferred_assume.output.corrected)
  (deps (:ml test_remove_inferred_assume.ml) filter.sh)
  (action
@@ -1127,12 +1127,12 @@
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_remove_inferred_assume.output test_remove_inferred_assume.output.corrected)
  (action (diff test_remove_inferred_assume.output test_remove_inferred_assume.output.corrected)))
 
 (rule
  (alias   runtest)
- (enabled_if (= %{context_name} "main"))
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_remove_inferred_assume_workaround.ml)
  (action (run %{bin:ocamlopt.opt} %{deps} -g -c -zero-alloc-check default -dcse -dzero-alloc -dump-into-file -O3 -warn-error +a)))

--- a/flambda-backend/tests/backend/zero_alloc_checker/gen/gen_dune.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/gen/gen_dune.ml
@@ -1,6 +1,6 @@
 let () =
   let enabled_if =
-      {|(enabled_if (= %{context_name} "main"))|}
+      {|(enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )|}
   in
   let buf = Buffer.create 1000 in
   let print_test ?(extra_flags="-zero-alloc-check default") deps =

--- a/flambda-backend/tests/backend/zero_alloc_checker/gen/gen_dune.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/gen/gen_dune.ml
@@ -1,5 +1,6 @@
 let () =
   let enabled_if =
+    (* CR xclerc: on arm64, we currently get different results for a couple of cases (e.g. probes) *)
       {|(enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )|}
   in
   let buf = Buffer.create 1000 in


### PR DESCRIPTION
A couple of tests (unit test for register allocation,
and some zero-alloc tests) currently fail on arm64.
This pull request simply disables them for now.