### PR TITLE
Split out Sub_cfg

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -327,5 +327,5 @@ class selector =
   end
 
 let fundecl ~future_funcnames f =
-  Cfg_selectgen.reset_next_instr_id ();
+  Cfg.reset_next_instr_id ();
   (new selector)#emit_fundecl ~future_funcnames f

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -180,5 +180,5 @@ class selector =
   end
 
 let fundecl ~future_funcnames f =
-  Cfg_selectgen.reset_next_instr_id ();
+  Cfg.reset_next_instr_id ();
   (new selector)#emit_fundecl ~future_funcnames f

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -223,3 +223,14 @@ val make_instruction :
   ?available_across:Reg_availability_set.t option ->
   unit ->
   'a instruction
+
+(* CR mshinwell: consolidate with [make_instruction] and tidy up ID interface *)
+val make_instr :
+  'a -> Reg.t array -> Reg.t array -> Debuginfo.t -> 'a instruction
+
+(** These IDs are also used by [make_instr] *)
+val next_instr_id : unit -> int
+
+val reset_next_instr_id : unit -> unit
+
+val make_empty_block : ?label:Label.t -> terminator instruction -> basic_block

--- a/backend/cfg/sub_cfg.ml
+++ b/backend/cfg/sub_cfg.ml
@@ -1,0 +1,129 @@
+(* MIT License
+
+   Copyright (c) 2024 Jane Street Group LLC
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+module DLL = Flambda_backend_utils.Doubly_linked_list
+
+type t =
+  { entry : Cfg.basic_block;
+    exit : Cfg.basic_block;
+    layout : Cfg.basic_block DLL.t
+  }
+
+let exit_has_never_terminator sub_cfg =
+  Cfg.is_never_terminator sub_cfg.exit.terminator.desc
+
+let make_never_block ?label () : Cfg.basic_block =
+  Cfg.make_empty_block ?label
+    (Cfg.make_instr Cfg.Never [||] [||] Debuginfo.none)
+
+let make_empty () =
+  let exit = make_never_block () in
+  let entry =
+    Cfg.make_empty_block
+      (Cfg.make_instr (Cfg.Always exit.start) [||] [||] Debuginfo.none)
+  in
+  let layout = DLL.make_empty () in
+  DLL.add_end layout entry;
+  DLL.add_end layout exit;
+  { entry; exit; layout }
+
+let start_label sub_cfg = sub_cfg.entry.start
+
+let add_block_at_start sub_cfg block =
+  DLL.add_begin sub_cfg.layout block;
+  { sub_cfg with entry = block }
+
+let add_empty_block_at_start sub_cfg ~label =
+  Cfg.make_empty_block ~label
+    (Cfg.make_instr (Cfg.Always (start_label sub_cfg)) [||] [||] Debuginfo.none)
+  |> add_block_at_start sub_cfg
+
+let add_block sub_cfg block =
+  DLL.add_end sub_cfg.layout block;
+  { sub_cfg with exit = block }
+
+let add_never_block sub_cfg ~label =
+  add_block sub_cfg (make_never_block ~label ())
+
+let add_instruction_at_start sub_cfg desc arg res dbg =
+  (* We don't check [exit_has_never_terminator] since we're adding at the start,
+     and this function is only used in very specific situations (note comment in
+     the interface). *)
+  DLL.add_begin sub_cfg.entry.body (Cfg.make_instr desc arg res dbg)
+
+let add_instruction' sub_cfg instr =
+  assert (exit_has_never_terminator sub_cfg);
+  DLL.add_end sub_cfg.exit.body instr
+
+let add_instruction sub_cfg desc arg res dbg =
+  add_instruction' sub_cfg (Cfg.make_instr desc arg res dbg)
+
+let set_terminator sub_cfg desc arg res dbg =
+  assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
+  sub_cfg.exit.terminator <- Cfg.make_instr desc arg res dbg
+
+let link_if_needed ~(from : Cfg.basic_block) ~(to_ : Cfg.basic_block) () =
+  if Cfg.is_never_terminator from.terminator.desc
+  then
+    from.terminator
+      <- { from.terminator with
+           desc = Always to_.start;
+           id = Cfg.next_instr_id ()
+         }
+
+let iter_basic_blocks sub_cfg ~f = DLL.iter sub_cfg.layout ~f
+
+let exists_basic_blocks sub_cfg ~f = DLL.exists sub_cfg.layout ~f
+
+let transfer ~from ~to_ = DLL.transfer ~from:from.layout ~to_:to_.layout ()
+
+let join ~from ~to_ =
+  List.iter (fun from -> transfer ~from ~to_) from;
+  let join_block = make_never_block () in
+  List.iter (fun from -> link_if_needed ~from:from.exit ~to_:join_block ()) from;
+  add_block to_ join_block
+
+let join_tail ~from ~to_ =
+  List.iter (fun from -> transfer ~from ~to_) from;
+  add_never_block to_ ~label:(Cmm.new_label ())
+
+let update_exit_terminator ?arg sub_cfg desc =
+  sub_cfg.exit.terminator
+    <- { sub_cfg.exit.terminator with
+         desc;
+         id = Cfg.next_instr_id ();
+         arg = Option.value arg ~default:sub_cfg.exit.terminator.arg
+       }
+
+let mark_as_trap_handler sub_cfg ~exn_label =
+  sub_cfg.entry.start <- exn_label;
+  sub_cfg.entry.is_trap_handler <- true
+
+let dump sub_cfg =
+  let liveness = Cfg_dataflow.Instr.Tbl.create 32 in
+  DLL.iter sub_cfg.layout ~f:(fun (block : Cfg.basic_block) ->
+      Format.eprintf "Block %a@." Label.print block.start;
+      Regalloc_irc_utils.log_body_and_terminator ~indent:0 block.body
+        block.terminator liveness)
+
+(* note: `dump` is for debugging, and thus not always in use. *)
+let (_ : t -> unit) = dump

--- a/backend/cfg/sub_cfg.mli
+++ b/backend/cfg/sub_cfg.mli
@@ -1,3 +1,25 @@
+(* MIT License
+
+   Copyright (c) 2024 Jane Street Group LLC
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
 (** A "sub" CFG is the counterpart of an instruction list in the original Mach
     selection pass.
 

--- a/backend/cfg/sub_cfg.mli
+++ b/backend/cfg/sub_cfg.mli
@@ -1,0 +1,55 @@
+(** A "sub" CFG is the counterpart of an instruction list in the original Mach
+    selection pass.
+
+    It is essentially a collection of blocks (stored as a layout, i.e. as a
+    list), with two designated blocks:
+
+    - an entry block;
+
+    - an exit block.
+
+    The exit block is where more instructions are being added, which means that
+    the terminator of an in-construction "sub" CFG is `Never`, and will be
+    changed only when no additional instructions will be inserted to the
+    block. *)
+
+type t
+
+val exit_has_never_terminator : t -> bool
+
+val make_empty : unit -> t
+
+val add_empty_block_at_start : t -> label:Label.t -> t
+
+val add_never_block : t -> label:Label.t -> t
+
+(** Use [add_instruction] in preference to this function. *)
+val add_instruction_at_start :
+  t -> Cfg.basic -> Reg.t array -> Reg.t array -> Debuginfo.t -> unit
+
+(** [add_instruction] can only be called when the terminator is [Never]. *)
+val add_instruction :
+  t -> Cfg.basic -> Reg.t array -> Reg.t array -> Debuginfo.t -> unit
+
+(** [add_instruction'] can only be called when the terminator is [Never]. *)
+val add_instruction' : t -> Cfg.basic Cfg.instruction -> unit
+
+(** [set_terminator] can only be called when the terminator is [Never]. *)
+val set_terminator :
+  t -> Cfg.terminator -> Reg.t array -> Reg.t array -> Debuginfo.t -> unit
+
+val iter_basic_blocks : t -> f:(Cfg.basic_block -> unit) -> unit
+
+val exists_basic_blocks : t -> f:(Cfg.basic_block -> bool) -> bool
+
+val join : from:t list -> to_:t -> t
+
+val join_tail : from:t list -> to_:t -> t
+
+val update_exit_terminator : ?arg:Reg.t array -> t -> Cfg.terminator -> unit
+
+val start_label : t -> Label.t
+
+val mark_as_trap_handler : t -> exn_label:Label.t -> unit
+
+val dump : t -> unit

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -122,214 +122,6 @@ type basic_or_terminator =
 
 let basic_op x = Basic (Op x)
 
-let next_instr_id = ref 0
-
-let reset_next_instr_id () = next_instr_id := 0
-
-let next_instr_id () : int =
-  let res = !next_instr_id in
-  incr next_instr_id;
-  res
-
-(* XXX mshinwell: move the next two functions into Cfg proper? *)
-let make_instr desc arg res dbg =
-  { Cfg.desc;
-    arg;
-    res;
-    dbg;
-    fdo = Fdo_info.none;
-    live = Reg.Set.empty;
-    stack_offset = -1;
-    id = next_instr_id ();
-    irc_work_list = Unknown_list;
-    ls_order = 0;
-    available_before =
-      (* CR mshinwell/xclerc: should this be [None]? *)
-      Some (Reg_availability_set.Ok Reg_with_debug_info.Set.empty);
-    available_across = None
-  }
-
-let make_empty_block ?label terminator : Cfg.basic_block =
-  let start =
-    match label with None -> Cmm.new_label () | Some label -> label
-  in
-  { start;
-    body = DLL.make_empty ();
-    terminator;
-    predecessors = Label.Set.empty;
-    stack_offset = -1;
-    exn = None;
-    can_raise = false;
-    is_trap_handler = false;
-    dead = false;
-    cold = false
-  }
-
-(* XXX mshinwell: I think this could reasonably be moved to its own file now. *)
-(* A "sub" CFG is the counterpart of an instruction list in the original Mach
-   selection pass.
-
-   It is essentially a collection of blocks (stored as a layout, i.e. as a
-   list), with two designated blocks:
-
-   - an entry block;
-
-   - an exit block.
-
-   The exit block is where more instructions are being added, which means that
-   the terminator of an in-construction "sub" CFG is `Never`, and will be
-   changed only when no additional instructions will be inserted to the
-   block. *)
-module Sub_cfg : sig
-  type t
-
-  val exit_has_never_terminator : t -> bool
-
-  val make_empty : unit -> t
-
-  val add_empty_block_at_start : t -> label:Label.t -> t
-
-  val add_never_block : t -> label:Label.t -> t
-
-  (** Use [add_instruction] in preference to this function. *)
-  val add_instruction_at_start :
-    t -> Cfg.basic -> Reg.t array -> Reg.t array -> Debuginfo.t -> unit
-
-  (** [add_instruction] can only be called when the terminator is [Never]. *)
-  val add_instruction :
-    t -> Cfg.basic -> Reg.t array -> Reg.t array -> Debuginfo.t -> unit
-
-  (** [add_instruction'] can only be called when the terminator is [Never]. *)
-  val add_instruction' : t -> Cfg.basic Cfg.instruction -> unit
-
-  (** [set_terminator] can only be called when the terminator is [Never]. *)
-  val set_terminator :
-    t -> Cfg.terminator -> Reg.t array -> Reg.t array -> Debuginfo.t -> unit
-
-  val iter_basic_blocks : t -> f:(Cfg.basic_block -> unit) -> unit
-
-  val exists_basic_blocks : t -> f:(Cfg.basic_block -> bool) -> bool
-
-  val join : from:t list -> to_:t -> t
-
-  val join_tail : from:t list -> to_:t -> t
-
-  val update_exit_terminator : ?arg:Reg.t array -> t -> Cfg.terminator -> unit
-
-  val start_label : t -> Label.t
-
-  val mark_as_trap_handler : t -> exn_label:Label.t -> unit
-
-  val dump : t -> unit
-end = struct
-  type t =
-    { entry : Cfg.basic_block;
-      exit : Cfg.basic_block;
-      layout : Cfg.basic_block DLL.t
-    }
-
-  let exit_has_never_terminator sub_cfg =
-    Cfg.is_never_terminator sub_cfg.exit.terminator.desc
-
-  let make_never_block ?label () : Cfg.basic_block =
-    make_empty_block ?label (make_instr Cfg.Never [||] [||] Debuginfo.none)
-
-  let make_empty () =
-    let exit = make_never_block () in
-    let entry =
-      make_empty_block
-        (make_instr (Cfg.Always exit.start) [||] [||] Debuginfo.none)
-    in
-    let layout = DLL.make_empty () in
-    DLL.add_end layout entry;
-    DLL.add_end layout exit;
-    { entry; exit; layout }
-
-  let start_label sub_cfg = sub_cfg.entry.start
-
-  let add_block_at_start sub_cfg block =
-    DLL.add_begin sub_cfg.layout block;
-    { sub_cfg with entry = block }
-
-  let add_empty_block_at_start sub_cfg ~label =
-    make_empty_block ~label
-      (make_instr (Cfg.Always (start_label sub_cfg)) [||] [||] Debuginfo.none)
-    |> add_block_at_start sub_cfg
-
-  let add_block sub_cfg block =
-    DLL.add_end sub_cfg.layout block;
-    { sub_cfg with exit = block }
-
-  let add_never_block sub_cfg ~label =
-    add_block sub_cfg (make_never_block ~label ())
-
-  let add_instruction_at_start sub_cfg desc arg res dbg =
-    (* We don't check [exit_has_never_terminator] since we're adding at the
-       start, and this function is only used in very specific situations (note
-       comment in the interface). *)
-    DLL.add_begin sub_cfg.entry.body (make_instr desc arg res dbg)
-
-  let add_instruction' sub_cfg instr =
-    assert (exit_has_never_terminator sub_cfg);
-    DLL.add_end sub_cfg.exit.body instr
-
-  let add_instruction sub_cfg desc arg res dbg =
-    add_instruction' sub_cfg (make_instr desc arg res dbg)
-
-  let set_terminator sub_cfg desc arg res dbg =
-    assert (Cfg.is_never_terminator sub_cfg.exit.terminator.desc);
-    sub_cfg.exit.terminator <- make_instr desc arg res dbg
-
-  let link_if_needed ~(from : Cfg.basic_block) ~(to_ : Cfg.basic_block) () =
-    if Cfg.is_never_terminator from.terminator.desc
-    then
-      from.terminator
-        <- { from.terminator with
-             desc = Always to_.start;
-             id = next_instr_id ()
-           }
-
-  let iter_basic_blocks sub_cfg ~f = DLL.iter sub_cfg.layout ~f
-
-  let exists_basic_blocks sub_cfg ~f = DLL.exists sub_cfg.layout ~f
-
-  let transfer ~from ~to_ = DLL.transfer ~from:from.layout ~to_:to_.layout ()
-
-  let join ~from ~to_ =
-    List.iter (fun from -> transfer ~from ~to_) from;
-    let join_block = make_never_block () in
-    List.iter
-      (fun from -> link_if_needed ~from:from.exit ~to_:join_block ())
-      from;
-    add_block to_ join_block
-
-  let join_tail ~from ~to_ =
-    List.iter (fun from -> transfer ~from ~to_) from;
-    add_never_block to_ ~label:(Cmm.new_label ())
-
-  let update_exit_terminator ?arg sub_cfg desc =
-    sub_cfg.exit.terminator
-      <- { sub_cfg.exit.terminator with
-           desc;
-           id = next_instr_id ();
-           arg = Option.value arg ~default:sub_cfg.exit.terminator.arg
-         }
-
-  let mark_as_trap_handler sub_cfg ~exn_label =
-    sub_cfg.entry.start <- exn_label;
-    sub_cfg.entry.is_trap_handler <- true
-
-  let dump sub_cfg =
-    let liveness = Cfg_dataflow.Instr.Tbl.create 32 in
-    DLL.iter sub_cfg.layout ~f:(fun (block : Cfg.basic_block) ->
-        Format.eprintf "Block %a@." Label.print block.start;
-        Regalloc_irc_utils.log_body_and_terminator ~indent:0 block.body
-          block.terminator liveness)
-end
-
-(* note: `dump` is for debugging, and thus not always in use. *)
-let _ = Sub_cfg.dump
-
 class virtual selector_generic =
   object (self : 'self)
     inherit [Label.t, Operation.t, Cfg.basic] Select_utils.common_selector
@@ -518,7 +310,7 @@ class virtual selector_generic =
 
     method private insert_op_debug_returning_id (_env : environment) op dbg arg
         res =
-      let instr = make_instr (Cfg.Op op) arg res dbg in
+      let instr = Cfg.make_instr (Cfg.Op op) arg res dbg in
       Sub_cfg.add_instruction' sub_cfg instr;
       instr.id
 
@@ -1373,16 +1165,16 @@ class virtual selector_generic =
       in
       let layout = DLL.make_empty () in
       let entry_block =
-        make_empty_block ~label:(Cfg.entry_label cfg)
-          (make_instr (Cfg.Always tailrec_label) [||] [||] Debuginfo.none)
+        Cfg.make_empty_block ~label:(Cfg.entry_label cfg)
+          (Cfg.make_instr (Cfg.Always tailrec_label) [||] [||] Debuginfo.none)
       in
       DLL.add_begin entry_block.body
-        (make_instr Cfg.Prologue [||] [||] Debuginfo.none);
+        (Cfg.make_instr Cfg.Prologue [||] [||] Debuginfo.none);
       Cfg.add_block_exn cfg entry_block;
       DLL.add_end layout entry_block.start;
       let tailrec_block =
-        make_empty_block ~label:tailrec_label
-          (make_instr
+        Cfg.make_empty_block ~label:tailrec_label
+          (Cfg.make_instr
              (Cfg.Always (Sub_cfg.start_label body))
              [||] [||] Debuginfo.none)
       in
@@ -1411,7 +1203,7 @@ class virtual selector_generic =
             if Cfg.is_return_terminator block.terminator.desc
             then
               DLL.add_end block.body
-                (make_instr Cfg.Reloadretaddr [||] [||] Debuginfo.none);
+                (Cfg.make_instr Cfg.Reloadretaddr [||] [||] Debuginfo.none);
             Cfg.add_block_exn cfg block;
             DLL.add_end layout block.start)
           else assert (DLL.is_empty block.body));

--- a/backend/cfg_selectgen.mli
+++ b/backend/cfg_selectgen.mli
@@ -24,20 +24,6 @@ type basic_or_terminator =
   | Basic of Cfg.basic
   | Terminator of Cfg.terminator
 
-module Sub_cfg : sig
-  type t
-
-  val make_empty : unit -> t
-
-  val add_instruction :
-    t -> Cfg.basic -> Reg.t array -> Reg.t array -> Debuginfo.t -> unit
-
-  val set_terminator :
-    t -> Cfg.terminator -> Reg.t array -> Reg.t array -> Debuginfo.t -> unit
-end
-
-val reset_next_instr_id : unit -> unit
-
 class virtual selector_generic :
   object
     method is_store : Operation.t -> bool

--- a/dune
+++ b/dune
@@ -476,6 +476,7 @@
   simd_proc
   simple_operation
   stack_check
+  sub_cfg
   reg
   reload
   reloadgen


### PR DESCRIPTION
This moves `Sub_cfg` into its own module and two associated utility functions into `Cfg`.  It seems that the interface for generating IDs here is suboptimal, but we can fix that in a cleanup PR in due course.  This PR deliberately does not change any actual implementation code.

Based on #3321.