### PR TITLE
Move the "contains calls" judgement to cfg.ml

### DIFF
--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -234,3 +234,6 @@ val next_instr_id : unit -> int
 val reset_next_instr_id : unit -> unit
 
 val make_empty_block : ?label:Label.t -> terminator instruction -> basic_block
+
+(** "Contains calls" in the traditional sense as used in upstream [Selectgen]. *)
+val basic_block_contains_calls : basic_block -> bool


### PR DESCRIPTION
This moves the "contains calls" judgement to `Cfg` itself, since it's not specific to instruction selection.  After this, the new `Cfg_selectgen` is only 1,200 lines, which seems pretty good.  Based on #3322.