### PR TITLE
Supports mode annotation on function body

### DIFF
--- a/jane/doc/extensions/modes/syntax.md
+++ b/jane/doc/extensions/modes/syntax.md
@@ -62,7 +62,15 @@ let foo ((x, y) @ modes) = .. (error)
 let x @ modes = ..
 let x : ty @@ modes = ..
 let x : type a b. ty @@ modes = ..
+```
+
+## Functions and their return
+```ocaml
 let (foo @ modes) x y = ..
+let foo x y @ modes = ..
+let foo x y : ty @@ modes = ..
+fun foo x y @ modes -> ..
+fun foo x y : ty @@ modes -> ..
 ```
 
 ## Arrow types

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -152,7 +152,7 @@ module Exp:
     val let_: ?loc:loc -> ?attrs:attrs -> rec_flag -> value_binding list
               -> expression -> expression
     val function_ : ?loc:loc -> ?attrs:attrs -> function_param list
-                   -> function_constraint option -> function_body
+                   -> function_constraint -> function_body
                    -> expression
     val apply: ?loc:loc -> ?attrs:attrs -> expression
                -> (arg_label * expression) list -> expression

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -487,9 +487,10 @@ module E = struct
     | Pcoerce (ty1, ty2) ->
         Pcoerce (Option.map (sub.typ sub) ty1, sub.typ sub ty2)
 
-  let map_function_constraint sub { mode_annotations; type_constraint } =
+  let map_function_constraint sub { mode_annotations; ret_type_constraint; ret_mode_annotations } =
     { mode_annotations = sub.modes sub mode_annotations;
-      type_constraint = map_type_constraint sub type_constraint;
+      ret_type_constraint = Option.map (map_type_constraint sub) ret_type_constraint;
+      ret_mode_annotations = sub.modes sub ret_mode_annotations
     }
 
   let map_iterator sub = function
@@ -534,7 +535,7 @@ module E = struct
     | Pexp_function (ps, c, b) ->
       function_ ~loc ~attrs
         (List.map (map_function_param sub) ps)
-        (map_opt (map_function_constraint sub) c)
+        (map_function_constraint sub c)
         (map_function_body sub b)
     | Pexp_apply (e, l) ->
         apply ~loc ~attrs (sub.expr sub e) (List.map (map_snd (sub.expr sub)) l)

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -243,7 +243,7 @@ let rec add_expr bv exp =
       let bv = add_bindings rf bv pel in add_expr bv e
   | Pexp_function (params, constraint_, body) ->
       let bv = List.fold_left add_function_param bv params in
-      add_opt add_function_constraint bv constraint_;
+      add_function_constraint bv constraint_;
       add_function_body bv body
   | Pexp_apply(e, el) ->
       add_expr bv e; List.iter (fun (_,e) -> add_expr bv e) el
@@ -365,13 +365,14 @@ and add_function_body bv body =
   | Pfunction_cases (cases, _, _) ->
       add_cases bv cases
 
-and add_function_constraint bv { mode_annotations = _; type_constraint } =
-  match type_constraint with
-  | Pconstraint ty ->
+and add_function_constraint bv { mode_annotations = _; ret_type_constraint; ret_mode_annotations = _ } =
+  match ret_type_constraint with
+  | Some (Pconstraint ty) ->
       add_type bv ty
-  | Pcoerce (ty1, ty2) ->
+  | Some (Pcoerce (ty1, ty2)) ->
       add_opt add_type bv ty1;
       add_type bv ty2
+  | None -> ()
 
 and add_cases bv cases =
   List.iter (add_case bv) cases

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -368,7 +368,7 @@ and expression_desc =
                when [flag] is {{!Asttypes.rec_flag.Recursive}[Recursive]}.
          *)
   | Pexp_function of
-      function_param list * function_constraint option * function_body
+      function_param list * function_constraint * function_body
   (** [Pexp_function ([P1; ...; Pn], C, body)] represents any construct
       involving [fun] or [function], including:
       - [fun P1 ... Pn -> E]
@@ -595,11 +595,23 @@ and type_constraint =
 
 and function_constraint =
   { mode_annotations : modes;
-    (** The mode annotation placed on a function let-binding when the function
-            has a type constraint on the body, e.g.
-            [let local_ f x : int -> int = ...].
+    (** The mode annotation placed on a function let-binding, e.g.
+       [let local_ f x : int -> int = ...].
+       The [local_] syntax is parsed into two nodes: the field here, and [pvb_modes].
+       This field only affects the interpretation of [ret_type_constraint], while the
+       latter is translated in [typecore] to [Pexp_constraint] to contrain the mode of the
+       function.
+       (* CR zqian: This field is not failthful representation of the user syntax, and
+       complicates [pprintast]. It should be removed and their functionality should be
+       moved to [pvb_modes]. *)
     *)
-    type_constraint : type_constraint;
+    ret_mode_annotations : modes;
+    (** The mode annotation placed on a function's body, e.g.
+       [let f x : int -> int @@ local = ...].
+       This field constrains the mode of function's body.
+    *)
+    ret_type_constraint : type_constraint option;
+    (** The type constraint placed on a function's body. *)
   }
 (** See the comment on {{!expression_desc.Pexp_function}[Pexp_function]}. *)
 

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -311,7 +311,7 @@ and expression i ppf x =
   | Pexp_function (params, c, body) ->
       line i ppf "Pexp_function\n";
       list i function_param ppf params;
-      option i function_constraint ppf c;
+      function_constraint i ppf c;
       function_body i ppf body
   | Pexp_apply (e, l) ->
       line i ppf "Pexp_apply\n";
@@ -548,9 +548,10 @@ and type_constraint i ppf type_constraint =
       option (i+1) core_type ppf ty1;
       core_type (i+1) ppf ty2
 
-and function_constraint i ppf { type_constraint = c; mode_annotations } =
-  type_constraint i ppf c;
-  modes i ppf mode_annotations
+and function_constraint i ppf { ret_type_constraint = c; mode_annotations; ret_mode_annotations } =
+  option i type_constraint ppf c;
+  modes i ppf mode_annotations;
+  modes i ppf ret_mode_annotations
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_string_loc

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -548,9 +548,8 @@ and type_constraint i ppf type_constraint =
       option (i+1) core_type ppf ty1;
       core_type (i+1) ppf ty2
 
-and function_constraint i ppf { ret_type_constraint = c; mode_annotations; ret_mode_annotations } =
-  option i type_constraint ppf c;
-  modes i ppf mode_annotations;
+and function_constraint i ppf { ret_type_constraint; ret_mode_annotations; mode_annotations = _ } =
+  option i type_constraint ppf ret_type_constraint;
   modes i ppf ret_mode_annotations
 
 and value_description i ppf x =

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -575,8 +575,7 @@ and type_constraint i ppf type_constraint =
       core_type (i+1) ppf ty2
 
 and function_constraint i ppf
-  { ret_type_constraint; mode_annotations; ret_mode_annotations } =
-  modes i ppf mode_annotations;
+  { ret_type_constraint; ret_mode_annotations; mode_annotations = _ } =
   option i type_constraint ppf ret_type_constraint;
   modes i ppf ret_mode_annotations
 

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -335,7 +335,7 @@ and expression i ppf x =
   | Pexp_function (params, c, body) ->
       line i ppf "Pexp_function\n";
       list i function_param ppf params;
-      option i function_constraint ppf c;
+      function_constraint i ppf c;
       function_body i ppf body
   | Pexp_apply (e, l) ->
       line i ppf "Pexp_apply\n";
@@ -574,9 +574,11 @@ and type_constraint i ppf type_constraint =
       option (i+1) core_type ppf ty1;
       core_type (i+1) ppf ty2
 
-and function_constraint i ppf { type_constraint = c; mode_annotations } =
-  type_constraint i ppf c;
-  modes i ppf mode_annotations
+and function_constraint i ppf
+  { ret_type_constraint; mode_annotations; ret_mode_annotations } =
+  modes i ppf mode_annotations;
+  option i type_constraint ppf ret_type_constraint;
+  modes i ppf ret_mode_annotations
 
 and value_description i ppf x =
   with_location_mapping ~loc:x.pval_loc ppf (fun () ->

--- a/testsuite/tests/parsetree/modes_ast_mapper.reference
+++ b/testsuite/tests/parsetree/modes_ast_mapper.reference
@@ -1,5 +1,6 @@
 modes: local [File "_none_", line 1, characters 7-13]
 ------------------------------
+modes: unique [File "_none_", line 1, characters 4-11]
 modes: local [File "_none_", line 1, characters 15-21]
 modes: unique [File "_none_", line 1, characters 4-11]
 ------------------------------

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -308,6 +308,11 @@ let g () =
   let local_ unique_ once_ f : int -> int = fun z -> z + z in
   let local_ f x: int -> int = x in
   let local_ f x y : int -> int = fun z -> x + y + z in
+
+  let foo a b @ local = exclave_ "hello" in
+  let foo = fun a b @ local -> exclave_ "hello" in
+  let foo a b : int @@ local = 42 in
+  let foo = fun a b : int @@ local -> 42 in
   ();;
 
 [%%expect{|
@@ -340,6 +345,26 @@ Line 7, characters 13-14:
 7 |   let local_ f x y : int -> int = fun z -> x + y + z in
                  ^
 Warning 26 [unused-var]: unused variable f.
+
+Line 9, characters 6-9:
+9 |   let foo a b @ local = exclave_ "hello" in
+          ^^^
+Warning 26 [unused-var]: unused variable foo.
+
+Line 10, characters 6-9:
+10 |   let foo = fun a b @ local -> exclave_ "hello" in
+           ^^^
+Warning 26 [unused-var]: unused variable foo.
+
+Line 11, characters 6-9:
+11 |   let foo a b : int @@ local = 42 in
+           ^^^
+Warning 26 [unused-var]: unused variable foo.
+
+Line 12, characters 6-9:
+12 |   let foo = fun a b : int @@ local -> 42 in
+           ^^^
+Warning 26 [unused-var]: unused variable foo.
 
 val g : unit -> unit @@ global many = <fun>
 |}]

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -523,6 +523,183 @@ val f2 : local_ float -> (float -> float) @ once -> local_ t2 @ once @@
   global many = <fun>
 |}]
 
+
+module type S = sig
+  val bar : 'a -> 'a
+  module M : sig
+    val foo : 'a -> 'a
+  end
+end
+
+module type S' = sig
+  include [@no_recursive_modalities] S @@ portable
+end
+
+[%%expect{|
+module type S =
+  sig val bar : 'a -> 'a module M : sig val foo : 'a -> 'a end end
+module type S' =
+  sig
+    val bar : 'a -> 'a @@ portable
+    module M : sig val foo : 'a -> 'a end
+  end
+|}]
+
+(* Modules *)
+
+module type S = sig end
+module M = struct end
+[%%expect{|
+module type S = sig end
+module M : sig end
+|}]
+
+module F (X : S @@ portable) = struct
+end
+[%%expect{|
+Line 1, characters 19-27:
+1 | module F (X : S @@ portable) = struct
+                       ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module F (_ : S @@ portable) = struct
+end
+[%%expect{|
+Line 1, characters 19-27:
+1 | module F (_ : S @@ portable) = struct
+                       ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module M' = (M : S @@ portable)
+[%%expect{|
+Line 1, characters 22-30:
+1 | module M' = (M : S @@ portable)
+                          ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module F (M : S @@ portable) : S @@ portable = struct
+end
+[%%expect{|
+Line 1, characters 19-27:
+1 | module F (M : S @@ portable) : S @@ portable = struct
+                       ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module F (M : S @@ portable) @ portable = struct
+end
+[%%expect{|
+Line 1, characters 19-27:
+1 | module F (M : S @@ portable) @ portable = struct
+                       ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+
+
+(* CR zqian: the similar syntax for expressions are not allowed because @ might
+  be an binary operator *)
+module M' = (M @ portable)
+[%%expect{|
+Line 1, characters 17-25:
+1 | module M' = (M @ portable)
+                     ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module M' = (M : S @@ portable)
+[%%expect{|
+Line 1, characters 22-30:
+1 | module M' = (M : S @@ portable)
+                          ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module M @ portable = struct end
+[%%expect{|
+Line 1, characters 11-19:
+1 | module M @ portable = struct end
+               ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module M : S @@ portable = struct end
+[%%expect{|
+Line 1, characters 16-24:
+1 | module M : S @@ portable = struct end
+                    ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module type S' = functor () (M : S @@ portable) (_ : S @@ portable) -> S @ portable
+[%%expect{|
+Line 1, characters 38-46:
+1 | module type S' = functor () (M : S @@ portable) (_ : S @@ portable) -> S @ portable
+                                          ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+
+module type S' = () -> S @ portable -> S @ portable -> S @ portable
+[%%expect{|
+Line 1, characters 27-35:
+1 | module type S' = () -> S @ portable -> S @ portable -> S @ portable
+                               ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module (F @ portable) () = struct end
+[%%expect{|
+Line 1, characters 12-20:
+1 | module (F @ portable) () = struct end
+                ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module rec (F @ portable) () = struct end
+and (G @ portable) () = struct end
+[%%expect{|
+Line 1, characters 16-24:
+1 | module rec (F @ portable) () = struct end
+                    ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module type T = sig
+  module M : S @@ portable
+  module M = N @ portable
+  module (M @ portable) = N
+  module M0 (_ : S @@ portable) (X : S @@ portable) : S @@ portable
+  (* The above [@@ portable] is the return mode of the functor, not the modality on the
+  module declaration; To do that, one must write in the following ways. *)
+  module (M0 @ portable) (_ : S @@ portable) (X : S @@ portable) : S @@ portable
+  module M0 : functor (_ : S @@ portable) (X : S @@ portable) -> S @ portable @@ portable
+
+  module M0 : S @ portable -> S @ portable -> S @ portable @@ portable
+
+  module rec F : sig end @@ portable
+  and G : sig end @@ portable
+end
+[%%expect{|
+Line 3, characters 13-14:
+3 |   module M = N @ portable
+                 ^
+Error: Unbound module "N"
+|}]
+
+let foo () =
+  let module (F @ portable) () = struct end in
+  ()
+[%%expect{|
+Line 2, characters 18-26:
+2 |   let module (F @ portable) () = struct end in
+                      ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
 (**********)
 (* unique *)
 
@@ -1023,183 +1200,6 @@ Line 9, characters 11-95:
 9 | module _ = Base(Name1)(Value1)(Name2)(Value2(Name2_1)(Value2_1)) [@jane.non_erasable.instances]
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unbound module "Base[Name1:Value1][Name2:Value2[Name2_1:Value2_1]]"
-|}](*********)
-(* modes *)
-
-module type S = sig
-  val bar : 'a -> 'a
-  module M : sig
-    val foo : 'a -> 'a
-  end
-end
-
-module type S' = sig
-  include [@no_recursive_modalities] S @@ portable
-end
-
-[%%expect{|
-module type S =
-  sig val bar : 'a -> 'a module M : sig val foo : 'a -> 'a end end
-module type S' =
-  sig
-    val bar : 'a -> 'a @@ portable
-    module M : sig val foo : 'a -> 'a end
-  end
-|}]
-
-(* Modules *)
-
-module type S = sig end
-module M = struct end
-[%%expect{|
-module type S = sig end
-module M : sig end
-|}]
-
-module F (X : S @@ portable) = struct
-end
-[%%expect{|
-Line 1, characters 19-27:
-1 | module F (X : S @@ portable) = struct
-                       ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module F (_ : S @@ portable) = struct
-end
-[%%expect{|
-Line 1, characters 19-27:
-1 | module F (_ : S @@ portable) = struct
-                       ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module M' = (M : S @@ portable)
-[%%expect{|
-Line 1, characters 22-30:
-1 | module M' = (M : S @@ portable)
-                          ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module F (M : S @@ portable) : S @@ portable = struct
-end
-[%%expect{|
-Line 1, characters 19-27:
-1 | module F (M : S @@ portable) : S @@ portable = struct
-                       ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module F (M : S @@ portable) @ portable = struct
-end
-[%%expect{|
-Line 1, characters 19-27:
-1 | module F (M : S @@ portable) @ portable = struct
-                       ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-
-
-(* CR zqian: the similar syntax for expressions are not allowed because @ might
-  be an binary operator *)
-module M' = (M @ portable)
-[%%expect{|
-Line 1, characters 17-25:
-1 | module M' = (M @ portable)
-                     ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module M' = (M : S @@ portable)
-[%%expect{|
-Line 1, characters 22-30:
-1 | module M' = (M : S @@ portable)
-                          ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module M @ portable = struct end
-[%%expect{|
-Line 1, characters 11-19:
-1 | module M @ portable = struct end
-               ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module M : S @@ portable = struct end
-[%%expect{|
-Line 1, characters 16-24:
-1 | module M : S @@ portable = struct end
-                    ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module type S' = functor () (M : S @@ portable) (_ : S @@ portable) -> S @ portable
-[%%expect{|
-Line 1, characters 38-46:
-1 | module type S' = functor () (M : S @@ portable) (_ : S @@ portable) -> S @ portable
-                                          ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-
-module type S' = () -> S @ portable -> S @ portable -> S @ portable
-[%%expect{|
-Line 1, characters 27-35:
-1 | module type S' = () -> S @ portable -> S @ portable -> S @ portable
-                               ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module (F @ portable) () = struct end
-[%%expect{|
-Line 1, characters 12-20:
-1 | module (F @ portable) () = struct end
-                ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module rec (F @ portable) () = struct end
-and (G @ portable) () = struct end
-[%%expect{|
-Line 1, characters 16-24:
-1 | module rec (F @ portable) () = struct end
-                    ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
-|}]
-
-module type T = sig
-  module M : S @@ portable
-  module M = N @ portable
-  module (M @ portable) = N
-  module M0 (_ : S @@ portable) (X : S @@ portable) : S @@ portable
-  (* The above [@@ portable] is the return mode of the functor, not the modality on the
-  module declaration; To do that, one must write in the following ways. *)
-  module (M0 @ portable) (_ : S @@ portable) (X : S @@ portable) : S @@ portable
-  module M0 : functor (_ : S @@ portable) (X : S @@ portable) -> S @ portable @@ portable
-
-  module M0 : S @ portable -> S @ portable -> S @ portable @@ portable
-
-  module rec F : sig end @@ portable
-  and G : sig end @@ portable
-end
-[%%expect{|
-Line 3, characters 13-14:
-3 |   module M = N @ portable
-                 ^
-Error: Unbound module "N"
-|}]
-
-let foo () =
-  let module (F @ portable) () = struct end in
-  ()
-[%%expect{|
-Line 2, characters 18-26:
-2 |   let module (F @ portable) () = struct end in
-                      ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
 |}]
 
 (***************)

--- a/testsuite/tests/typing-modes/modes.ml
+++ b/testsuite/tests/typing-modes/modes.ml
@@ -66,9 +66,98 @@ Line 2, characters 18-23:
 Error: The locality axis has already been specified.
 |}]
 
-(* CR zqian: this should be supported *)
-(* let foo a b @ local = "hello"
-let foo a b : _ @@ local = "hello" *)
+let foo a b @ local = local_ "hello"
+[%%expect{|
+Line 1, characters 22-36:
+1 | let foo a b @ local = local_ "hello"
+                          ^^^^^^^^^^^^^^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
+|}]
+
+let foo = fun a b @ local -> local_ "hello"
+[%%expect{|
+Line 1, characters 29-43:
+1 | let foo = fun a b @ local -> local_ "hello"
+                                 ^^^^^^^^^^^^^^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
+|}]
+
+let foo a b @ local = exclave_ "hello"
+[%%expect{|
+val foo : 'a -> 'b -> local_ string = <fun>
+|}]
+
+let foo = fun a b @ local -> exclave_ "hello"
+[%%expect{|
+val foo : 'a -> 'b -> local_ string = <fun>
+|}]
+
+
+let foo a b @ local = local_ 42
+[%%expect{|
+Line 1, characters 22-31:
+1 | let foo a b @ local = local_ 42
+                          ^^^^^^^^^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
+|}]
+
+let foo = fun a b @ local -> local_ 42
+[%%expect{|
+Line 1, characters 29-38:
+1 | let foo = fun a b @ local -> local_ 42
+                                 ^^^^^^^^^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
+|}]
+
+let foo a b : int @@ local = local_ 42
+[%%expect{|
+val foo : 'a -> 'b -> local_ int = <fun>
+|}]
+
+let foo = fun a b : int @@ local -> local_ 42
+[%%expect{|
+val foo : 'a -> 'b -> local_ int = <fun>
+|}]
+
+let foo a b : _ @@ local = local_ 42
+[%%expect{|
+Line 1, characters 27-36:
+1 | let foo a b : _ @@ local = local_ 42
+                               ^^^^^^^^^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
+|}]
+
+let foo = fun a b : _ @@ local -> local_ 42
+[%%expect{|
+Line 1, characters 34-43:
+1 | let foo = fun a b : _ @@ local -> local_ 42
+                                      ^^^^^^^^^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
+|}]
+
+
+(* the return mode annotation is used to interpret the return type annotation, giving the
+    expected currying behavior *)
+let foo a : string -> string -> unit @@ local = fun b c -> ()
+[%%expect{|
+val foo : 'a -> local_ (string -> string -> unit) = <fun>
+|}]
+
+(* the return mode annotation overrides the whole-function mode annotation, even when they
+    describe different axes. *)
+(* CR zqian: this should probably be improved somehow. *)
+let bar () = exclave_
+  let (foo @ local) a : string -> string -> unit @@ nonportable = fun b c -> () in
+  foo
+[%%expect{|
+val bar : unit -> local_ ('a -> (string -> string -> unit)) = <fun>
+|}]
 
 (* Expressions *)
 let foo = ("hello" : _ @@ local)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -420,11 +420,10 @@ and function_body i ppf (body : function_body) =
 
 and expression_extra i ppf x attrs =
   match x with
-  | Texp_constraint (ct, m) ->
+  | Texp_constraint (ct) ->
       line i ppf "Texp_constraint\n";
       attributes i ppf attrs;
-      option i core_type ppf ct;
-      alloc_const_option_mode i ppf m;
+      core_type i ppf ct;
   | Texp_coerce (cto1, cto2) ->
       line i ppf "Texp_coerce\n";
       attributes i ppf attrs;
@@ -440,6 +439,10 @@ and expression_extra i ppf x attrs =
   | Texp_stack ->
       line i ppf "Texp_stack\n";
       attributes i ppf attrs
+  | Texp_mode m ->
+      line i ppf "Texp_mode\n";
+      attributes i ppf attrs;
+      alloc_const_option_mode i ppf m
 
 and alloc_mode_raw: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
   = fun i ppf m -> line i ppf "alloc_mode %a\n" (Mode.Alloc.print ()) m

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -279,13 +279,14 @@ let pat
       sub.pat sub p2
 
 let extra sub = function
-  | Texp_constraint (cty, _modes) -> Option.iter (sub.typ sub) cty
+  | Texp_constraint (cty) -> sub.typ sub cty
   | Texp_coerce (cty1, cty2) ->
       Option.iter (sub.typ sub) cty1;
       sub.typ sub cty2
   | Texp_newtype _ -> ()
   | Texp_poly cto -> Option.iter (sub.typ sub) cto
   | Texp_stack -> ()
+  | Texp_mode _ -> ()
 
 let function_param sub { fp_loc; fp_kind; fp_newtypes; _ } =
   sub.location sub fp_loc;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -371,13 +371,14 @@ let function_param sub
   }
 
 let extra sub = function
-  | Texp_constraint (cty, modes) ->
-    Texp_constraint (Option.map (sub.typ sub) cty, modes)
+  | Texp_constraint cty ->
+    Texp_constraint (sub.typ sub cty)
   | Texp_coerce (cty1, cty2) ->
     Texp_coerce (Option.map (sub.typ sub) cty1, sub.typ sub cty2)
   | Texp_newtype _ as d -> d
   | Texp_poly cto -> Texp_poly (Option.map (sub.typ sub) cto)
   | Texp_stack as d -> d
+  | Texp_mode _ as d -> d
 
 let function_body sub body =
   match body with

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -284,7 +284,7 @@ let make_method loc cl_num expr =
         pparam_loc = pat.ppat_loc;
       }
     ]
-    None (Pfunction_body expr)
+    {ret_type_constraint=None; ret_mode_annotations=[]; mode_annotations=[]} (Pfunction_body expr)
 
 (*******************************)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7342,8 +7342,8 @@ and type_function
             ret_mode
         | [] ->
             (* otherwise, we do not constrain the body mode, and we use the mode of the whole
-            function to interpret the return type, which is not precise and need to be fixed.
-            *)
+            function to interpret the return type *)
+            (* CR zqian: We should infer from [mode], instead of using directly. *)
             mode
       in
       match body with

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -193,12 +193,13 @@ and expression =
    }
 
 and exp_extra =
-  | Texp_constraint of core_type option * Mode.Alloc.Const.Option.t
+  | Texp_constraint of core_type
   | Texp_coerce of core_type option * core_type
   | Texp_poly of core_type option
   | Texp_newtype of Ident.t * string loc *
                     Parsetree.jkind_annotation option * Uid.t
   | Texp_stack
+  | Texp_mode of Mode.Alloc.Const.Option.t
 
 and arg_label = Types.arg_label =
   | Nolabel

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -264,8 +264,8 @@ and expression =
    }
 
 and exp_extra =
-  | Texp_constraint of core_type option * Mode.Alloc.Const.Option.t
-        (** E : T @@ M *)
+  | Texp_constraint of core_type
+        (** E : T *)
   | Texp_coerce of core_type option * core_type
         (** E :> T           [Texp_coerce (None, T)]
             E : T0 :> T      [Texp_coerce (Some T0, T)]
@@ -282,6 +282,8 @@ and exp_extra =
         them here, as the cost of tracking this additional information is minimal. *)
   | Texp_stack
         (** stack_ E *)
+  | Texp_mode of Mode.Alloc.Const.Option.t
+        (** E : _ @@ M  *)
 
 and arg_label = Types.arg_label =
   | Nolabel

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -422,7 +422,8 @@ let exp_extra sub (extra, loc, attrs) sexp =
     | Texp_newtype (_, label_loc, jkind, _) ->
         Pexp_newtype (label_loc, jkind, sexp)
     | Texp_stack -> Pexp_stack sexp
-    | Texp_mode _ -> Misc.fatal_error "not supported Texp_mode"
+    | Texp_mode modes ->
+        Pexp_constraint (sexp, None, Typemode.untransl_mode_annots ~loc modes)
   in
   Exp.mk ~loc ~attrs desc
 
@@ -509,7 +510,7 @@ let expression sub exp =
                       (Pcoerce (Option.map (sub.typ sub) ty1, sub.typ sub ty2))
                 | Some (Texp_constraint ty) ->
                   Some (Pconstraint (sub.typ sub ty))
-                | Some (Texp_mode _) -> Misc.fatal_error "not supported Texp_mode"
+                | Some (Texp_mode _) (* CR zqian: [Texp_mode] should be possible here *)
                 | Some (Texp_poly _ | Texp_newtype _)
                 | Some Texp_stack
                 | None -> None

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -416,15 +416,13 @@ let exp_extra sub (extra, loc, attrs) sexp =
         Pexp_coerce (sexp,
                      Option.map (sub.typ sub) cty1,
                      sub.typ sub cty2)
-    | Texp_constraint (cty, modes) ->
-      Pexp_constraint
-        (sexp,
-         Option.map (sub.typ sub) cty,
-         Typemode.untransl_mode_annots ~loc modes)
+    | Texp_constraint (cty) ->
+        Pexp_constraint (sexp, Some (sub.typ sub cty), [])
     | Texp_poly cto -> Pexp_poly (sexp, Option.map (sub.typ sub) cto)
     | Texp_newtype (_, label_loc, jkind, _) ->
         Pexp_newtype (label_loc, jkind, sexp)
     | Texp_stack -> Pexp_stack sexp
+    | Texp_mode _ -> Misc.fatal_error "not supported Texp_mode"
   in
   Exp.mk ~loc ~attrs desc
 
@@ -497,30 +495,27 @@ let expression sub exp =
           | Tfunction_body body ->
               (* Unlike function cases, the [exp_extra] is placed on the body
                  itself. *)
-              Pfunction_body (sub.expr sub body), None
+              Pfunction_body (sub.expr sub body),
+              { mode_annotations = []; ret_type_constraint = None; ret_mode_annotations = []}
           | Tfunction_cases
               { fc_cases = cases; fc_loc = loc; fc_exp_extra = exp_extra;
                 fc_attributes = attributes; _ }
             ->
               let cases = List.map (sub.case sub) cases in
-              let constraint_ =
+              let ret_type_constraint =
                 match exp_extra with
                 | Some (Texp_coerce (ty1, ty2)) ->
                     Some
-                      (Pcoerce (Option.map (sub.typ sub) ty1, sub.typ sub ty2), [])
-                | Some (Texp_constraint (Some ty, modes)) ->
-                  Some (
-                    Pconstraint (sub.typ sub ty),
-                    Typemode.untransl_mode_annots ~loc modes
-                  )
-                | Some (Texp_poly _ | Texp_newtype _) | Some (Texp_constraint (None, _))
+                      (Pcoerce (Option.map (sub.typ sub) ty1, sub.typ sub ty2))
+                | Some (Texp_constraint ty) ->
+                  Some (Pconstraint (sub.typ sub ty))
+                | Some (Texp_mode _) -> Misc.fatal_error "not supported Texp_mode"
+                | Some (Texp_poly _ | Texp_newtype _)
                 | Some Texp_stack
                 | None -> None
               in
               let constraint_ =
-                Option.map
-                  (fun (type_constraint, mode_annotations) -> { mode_annotations; type_constraint })
-                  constraint_
+                { ret_type_constraint; mode_annotations=[]; ret_mode_annotations = [] }
               in
               Pfunction_cases (cases, loc, attributes), constraint_
         in


### PR DESCRIPTION
This PR adds the support for the following syntax:

```
let foo a b @ modes = ..
let foo a b : ty @@ modes = ..
fun a b @ modes -> ..
fun a b : ty @@ modes -> ..
```

Please review by commits.

Please do not merge until I finish the internal migration for the new parsetree.