### PR TITLE
Module inclusion check looks at module mode

### DIFF
--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -84,7 +84,8 @@ let typecheck_intf info ast =
         Format.(fprintf std_formatter) "%a@."
           (Printtyp.printed_signature (Unit_info.source_file info.target))
           sg);
-  ignore (Includemod.signatures info.env ~mark:Mark_both sg sg);
+  ignore (Includemod.signatures info.env ~mark:Mark_both sg sg
+    ~modes:(Some ()));
   Typecore.force_delayed_checks ();
   Builtin_attributes.warn_unused ();
   Warnings.check_fatal ();

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -84,8 +84,7 @@ let typecheck_intf info ast =
         Format.(fprintf std_formatter) "%a@."
           (Printtyp.printed_signature (Unit_info.source_file info.target))
           sg);
-  ignore (Includemod.signatures info.env ~mark:Mark_both sg sg
-    ~modes:(Some ()));
+  ignore (Includemod.signatures info.env ~mark:Mark_both ~modes:Legacy sg sg);
   Typecore.force_delayed_checks ();
   Builtin_attributes.warn_unused ();
   Warnings.check_fatal ();

--- a/testsuite/tests/typing-modes/md_modalities.ml
+++ b/testsuite/tests/typing-modes/md_modalities.ml
@@ -142,5 +142,5 @@ Error: Signature mismatch:
          val foo : 'a -> 'a
        is not included in
          val foo : 'a -> 'a @@ portable
-       The second is portable and the first is not.
+       The second is portable and the first is nonportable.
 |}]

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -721,7 +721,10 @@ Error: Signature mismatch:
        The second is global_ and the first is not.
 |}]
 
-(* Similar for functor type declaration *)
+(* functor type inclusion: the following two functor types are equivalent,
+  because a functor of the first type at any mode, can be zero-runtime casted
+  to the second type at the same mode. Essentially, the parameter and return
+  mode is in the functor type, and doesn't depend on the mode of the functor. *)
 module M : sig
   module type F = (sig val foo : 'a @@ global many end) ->
     (sig end)
@@ -730,37 +733,8 @@ end = struct
     (sig end)
 end
 [%%expect{|
-Lines 4-7, characters 6-3:
-4 | ......struct
-5 |   module type F = (sig val foo : 'a end) ->
-6 |     (sig end)
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig module type F = sig val foo : 'a end -> sig end end
-       is not included in
-         sig
-           module type F = sig val foo : 'a @@ global many end -> sig end
-         end
-       Module type declarations do not match:
-         module type F = sig val foo : 'a end -> sig end
-       does not match
-         module type F = sig val foo : 'a @@ global many end -> sig end
-       The second module type is not included in the first
-       At position "module type F = <here>"
-       Modules do not match:
-         functor $S1 -> ...
-       is not included in
-         functor $T1 -> ...
-       Module types do not match:
-         $S1 = sig val foo : 'a @@ global many end
-       does not include
-         $T1 = sig val foo : 'a end
-       Values do not match:
-         val foo : 'a
-       is not included in
-         val foo : 'a @@ global many
-       The second is global_ and the first is not.
+module M :
+  sig module type F = sig val foo : 'a @@ global many end -> sig end end
 |}]
 
 module M : sig
@@ -771,39 +745,7 @@ end = struct
     (sig end) -> (sig val foo : 'a @@ global many end)
 end
 [%%expect{|
-Lines 4-7, characters 6-3:
-4 | ......struct
-5 |   module type F =
-6 |     (sig end) -> (sig val foo : 'a @@ global many end)
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module type F = sig end -> sig val foo : 'a @@ global many end
-         end
-       is not included in
-         sig module type F = sig end -> sig val foo : 'a end end
-       Module type declarations do not match:
-         module type F = sig end -> sig val foo : 'a @@ global many end
-       does not match
-         module type F = sig end -> sig val foo : 'a end
-       The second module type is not included in the first
-       At position "module type F = <here>"
-       Module types do not match:
-         sig end -> sig val foo : 'a end
-       is not equal to
-         sig end -> sig val foo : 'a @@ global many end
-       At position "module type F = <here>"
-       Modules do not match:
-         sig val foo : 'a end
-       is not included in
-         sig val foo : 'a @@ global many end
-       At position "module type F = <here>"
-       Values do not match:
-         val foo : 'a
-       is not included in
-         val foo : 'a @@ global many
-       The second is global_ and the first is not.
+module M : sig module type F = sig end -> sig val foo : 'a end end
 |}]
 
 module type T = sig @@ portable

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -126,7 +126,7 @@ let execute_phrase print_outcome ppf phr =
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv sn sg in
       ignore (Includemod.signatures ~mark:Mark_positive oldenv
-        ~modes:(Some ()) sg sg');
+        ~modes:Legacy sg sg');
       Typecore.force_delayed_checks ();
       let shape = Shape_reduce.local_reduce Env.empty shape in
       if !Clflags.dump_shape then Shape.print ppf shape;

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -125,7 +125,8 @@ let execute_phrase print_outcome ppf phr =
       in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv sn sg in
-      ignore (Includemod.signatures ~mark:Mark_positive oldenv sg sg');
+      ignore (Includemod.signatures ~mark:Mark_positive oldenv
+        ~modes:(Some ()) sg sg');
       Typecore.force_delayed_checks ();
       let shape = Shape_reduce.local_reduce Env.empty shape in
       if !Clflags.dump_shape then Shape.print ppf shape;

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -400,7 +400,9 @@ let execute_phrase print_outcome ppf phr =
       in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv names sg in
-      let coercion = Includemod.signatures oldenv ~mark:Mark_positive sg sg' in
+      let coercion =
+        Includemod.signatures oldenv ~mark:Mark_positive ~modes:(Some ()) sg sg'
+      in
       Typecore.force_delayed_checks ();
       let str, sg', rewritten =
         match str.str_items with

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -401,7 +401,7 @@ let execute_phrase print_outcome ppf phr =
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv names sg in
       let coercion =
-        Includemod.signatures oldenv ~mark:Mark_positive ~modes:(Some ()) sg sg'
+        Includemod.signatures oldenv ~mark:Mark_positive ~modes:Legacy sg sg'
       in
       Typecore.force_delayed_checks ();
       let str, sg', rewritten =

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -43,6 +43,7 @@ type value_mismatch =
   | Type of Errortrace.moregen_error
   | Zero_alloc of Zero_alloc.error
   | Modality of Mode.Modality.Value.error
+  | Mode of Mode.Value.error
 
 exception Dont_match of value_mismatch
 
@@ -90,6 +91,7 @@ let primitive_descriptions pd1 pd2 =
     native_repr_args pd1.prim_native_repr_args pd2.prim_native_repr_args
 
 let value_descriptions ~loc env name
+    ~mmodes
     (vd1 : Types.value_description)
     (vd2 : Types.value_description) =
   Builtin_attributes.check_alerts_inclusion
@@ -102,9 +104,29 @@ let value_descriptions ~loc env name
   | Ok () -> ()
   | Error e -> raise (Dont_match (Zero_alloc e))
   end;
-  begin match Mode.Modality.Value.sub vd1.val_modalities vd2.val_modalities with
-  | Ok () -> ()
-  | Error e -> raise (Dont_match (Modality e))
+  begin match mmodes with
+  | None -> begin
+      match Mode.Modality.Value.sub vd1.val_modalities vd2.val_modalities with
+      | Ok () -> ()
+      | Error e -> raise (Dont_match (Modality e))
+      end;
+  | Some _
+      (* [wrap_constraint_with_shape] invokes inclusion check with idential
+        inferred modalities, which we need to workaround. *)
+      when (vd1.val_modalities == vd2.val_modalities) ->
+      (* The caller ensures [mmode1 <= mmode2] beforing calling us, so nothing
+          to check here *)
+      ()
+  | Some () ->
+      let mmode1, mmode2 = Mode.Value.legacy, Mode.Value.legacy in
+      let mode1 = Mode.Modality.Value.apply vd1.val_modalities mmode1 in
+      let mode2 =
+        Mode.Modality.Value.(Const.apply (to_const_exn vd2.val_modalities) mmode2)
+      in
+      begin match Mode.Value.submode mode1 mode2 with
+      | Ok () -> ()
+      | Error e -> raise (Dont_match (Mode e))
+      end
   end;
   match vd1.val_kind with
   | Val_prim p1 -> begin
@@ -280,6 +302,14 @@ let report_modality_sub_error first second ppf e =
     first
     (print_modality "not") (Atom (ax, left) : Modality.t)
 
+let report_mode_sub_error first second ppf e =
+  let Mode.Value.Error(ax, {left; right}) = e in
+  Format.fprintf ppf "%s is %a and %s is %a."
+    (String.capitalize_ascii second)
+    (Value.Const.print_axis ax) right
+    first
+    (Value.Const.print_axis ax) left
+
 let report_modality_equate_error first second ppf ((equate_step, sub_error) : Modality.Value.equate_error) =
   match equate_step with
   | Left_le_right -> report_modality_sub_error first second ppf sub_error
@@ -330,6 +360,7 @@ let report_value_mismatch first second env ppf err =
         (fun ppf -> Format.fprintf ppf "is not compatible with the type")
   | Zero_alloc e -> Zero_alloc.print_error ppf e
   | Modality e -> report_modality_sub_error first second ppf e
+  | Mode e -> report_mode_sub_error first second ppf e
 
 let report_type_inequality env ppf err =
   Printtyp.report_equality_error ppf Type_scheme env err

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -47,6 +47,10 @@ type value_mismatch =
 
 exception Dont_match of value_mismatch
 
+type mmodes =
+  | All
+  | Legacy
+
 let native_repr_args nra1 nra2 =
   let rec loop i nra1 nra2 =
     match nra1, nra2 with
@@ -105,19 +109,19 @@ let value_descriptions ~loc env name
   | Error e -> raise (Dont_match (Zero_alloc e))
   end;
   begin match mmodes with
-  | None -> begin
+  | All -> begin
       match Mode.Modality.Value.sub vd1.val_modalities vd2.val_modalities with
       | Ok () -> ()
       | Error e -> raise (Dont_match (Modality e))
       end;
-  | Some _
+  | Legacy
       (* [wrap_constraint_with_shape] invokes inclusion check with idential
         inferred modalities, which we need to workaround. *)
       when (vd1.val_modalities == vd2.val_modalities) ->
       (* The caller ensures [mmode1 <= mmode2] beforing calling us, so nothing
           to check here *)
       ()
-  | Some () ->
+  | Legacy ->
       let mmode1, mmode2 = Mode.Value.legacy, Mode.Value.legacy in
       let mode1 = Mode.Modality.Value.apply vd1.val_modalities mmode1 in
       let mode2 =

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -114,12 +114,9 @@ let value_descriptions ~loc env name
       | Ok () -> ()
       | Error e -> raise (Dont_match (Modality e))
       end;
-  | Legacy
-      (* [wrap_constraint_with_shape] invokes inclusion check with idential
+  | Legacy when (vd1.val_modalities == vd2.val_modalities) ->
+      (* [wrap_constraint_with_shape] invokes inclusion check with identical
         inferred modalities, which we need to workaround. *)
-      when (vd1.val_modalities == vd2.val_modalities) ->
-      (* The caller ensures [mmode1 <= mmode2] beforing calling us, so nothing
-          to check here *)
       ()
   | Legacy ->
       let mmode1, mmode2 = Mode.Value.legacy, Mode.Value.legacy in

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -38,6 +38,7 @@ type value_mismatch =
   | Type of Errortrace.moregen_error
   | Zero_alloc of Zero_alloc.error
   | Modality of Mode.Modality.Value.error
+  | Mode of Mode.Value.error
 
 exception Dont_match of value_mismatch
 
@@ -122,6 +123,9 @@ type type_mismatch =
 
 val value_descriptions:
   loc:Location.t -> Env.t -> string ->
+  mmodes:unit option ->
+  (* [unit] because modules are fixed to legacy. Will be replaced by
+     [Mode.Value.(l * r)] when allow modal modules. *)
   value_description -> value_description -> module_coercion
 
 val type_declarations:

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -121,11 +121,16 @@ type type_mismatch =
   | Extensible_representation of position
   | Jkind of Jkind.Violation.t
 
+type mmodes =
+  | All
+  (** Check module inclusion [M1 : MT1 @ m1 <= M2 : MT2 @ m2]
+      for all [m1 <= m2]. *)
+  | Legacy
+  (** Check module inclusion [M1 : MT1 @ legacy <= M2 : MT2 @ legacy]. *)
+
 val value_descriptions:
   loc:Location.t -> Env.t -> string ->
-  mmodes:unit option ->
-  (* [unit] because modules are fixed to legacy. Will be replaced by
-     [Mode.Value.(l * r)] when allow modal modules. *)
+  mmodes:mmodes ->
   value_description -> value_description -> module_coercion
 
 val type_declarations:

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -717,11 +717,7 @@ and strengthened_module_decl ~loc ~aliasable env ~mark
   let md1 = Subst.Lazy.of_module_decl md1 in
   let md1 = Mtype.strengthen_lazy_decl ~aliasable md1 path1 in
   let mty2 = Subst.Lazy.of_modtype md2.md_type in
-  let modes =
-    match mmodes with
-    | All -> All
-    | Legacy -> Legacy
-  in
+  let modes = mmodes in
   modtypes ~in_eq:false ~loc env ~mark subst ~modes md1.md_type mty2 shape
 
 (* Inclusion between signatures *)
@@ -924,11 +920,7 @@ and module_declarations  ~in_eq ~loc env ~mark  subst id1 ~mmodes md1 md2 orig_s
   let p1 = Path.Pident id1 in
   if mark_positive mark then
     Env.mark_module_used md1.md_uid;
-  let modes =
-    match mmodes with
-    | All -> All
-    | Legacy -> Legacy
-  in
+  let modes = mmodes in
   strengthened_modtypes  ~in_eq ~loc ~aliasable:true env ~mark subst ~modes
     md1.md_type p1 md2.md_type orig_shape
 

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -450,8 +450,8 @@ module Functor_suberror = struct
             Format.dprintf
               "The functor was expected to be generative at this position"
 
-      let patch env got expected =
-        Includemod.Functor_inclusion_diff.diff env got expected
+      let patch env ~modes got expected =
+        Includemod.Functor_inclusion_diff.diff env ~modes got expected
         |> prepare_patch ~drop:false ~ctx:Inclusion
 
     end
@@ -758,8 +758,10 @@ and module_type_symptom ~eqmode ~expansion_token ~env ~before ~ctx = function
       in
       dwith_context ctx printer :: before
 
-and functor_params ~expansion_token ~env ~before ~ctx {got;expected;_} =
-  let d = Functor_suberror.Inclusion.patch env got expected in
+and functor_params ~expansion_token ~env ~before ~ctx
+    {got;expected;symptom = modal} =
+  let modes = if modal then Some () else None in
+  let d = Functor_suberror.Inclusion.patch env ~modes got expected in
   let actual = Functor_suberror.Inclusion.got d in
   let expected = Functor_suberror.expected d in
   let main =

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -450,8 +450,8 @@ module Functor_suberror = struct
             Format.dprintf
               "The functor was expected to be generative at this position"
 
-      let patch env ~modes got expected =
-        Includemod.Functor_inclusion_diff.diff env ~modes got expected
+      let patch env got expected =
+        Includemod.Functor_inclusion_diff.diff env got expected
         |> prepare_patch ~drop:false ~ctx:Inclusion
 
     end
@@ -758,10 +758,8 @@ and module_type_symptom ~eqmode ~expansion_token ~env ~before ~ctx = function
       in
       dwith_context ctx printer :: before
 
-and functor_params ~expansion_token ~env ~before ~ctx
-    {got;expected;symptom = modal} =
-  let modes = if modal then Some () else None in
-  let d = Functor_suberror.Inclusion.patch env ~modes got expected in
+and functor_params ~expansion_token ~env ~before ~ctx {got;expected;_} =
+  let d = Functor_suberror.Inclusion.patch env got expected in
   let actual = Functor_suberror.Inclusion.got d in
   let expected = Functor_suberror.expected d in
   let main =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -815,8 +815,7 @@ let merge_constraint initial_env loc sg lid constr =
         in
         let md'' = { md' with md_type = mty } in
         let newmd = Mtype.strengthen_decl ~aliasable:false md'' path in
-        ignore(Includemod.modtypes  ~mark:Mark_both ~loc sig_env
-                 ~modes:(Some ())
+        ignore(Includemod.modtypes  ~mark:Mark_both ~loc sig_env ~modes:Legacy
                  newmd.md_type md.md_type);
         return
           ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
@@ -827,7 +826,7 @@ let merge_constraint initial_env loc sg lid constr =
         let aliasable = not (Env.is_functor_arg path sig_env) in
         ignore
           (Includemod.strengthened_module_decl ~loc ~mark:Mark_both
-             ~aliasable sig_env ~mmodes:(Some ()) md' path md);
+             ~aliasable sig_env ~mmodes:Legacy md' path md);
         real_ids := [Pident id];
         return ~replace_by:None
           (Pident id, lid, Some (Twith_modsubst (path, lid')))
@@ -1712,8 +1711,7 @@ and transl_modtype_aux env smty =
       let aliasable = not (Env.is_functor_arg path env) in
       try
         ignore
-          (Includemod.modtypes ~loc env
-            ~modes:(Some ())
+          (Includemod.modtypes ~loc env ~modes:Legacy
             ~mark:Includemod.Mark_both md.md_type tmty.mty_type);
         mkmty
           (Tmty_strengthen (tmty, path, mod_id))
@@ -2410,8 +2408,7 @@ let check_recmodule_inclusion env bindings =
           try
             Includemod.modtypes_with_shape ~shape
               ~loc:modl.mod_loc ~mark:Mark_both
-              ~modes:(Some ())
-              env mty_actual' mty_decl'
+              env ~modes:Legacy mty_actual' mty_decl'
           with Includemod.Error msg ->
             raise(Error(modl.mod_loc, env, Not_included msg)) in
         let modl' =
@@ -2501,9 +2498,7 @@ let package_subtype env p1 fl1 p2 fl2 =
   | exception Error(_, _, Cannot_scrape_package_type _) -> false
   | mty1, mty2 ->
     let loc = Location.none in
-    match
-      Includemod.modtypes ~loc ~mark:Mark_both env ~modes:None mty1 mty2
-    with
+    match Includemod.modtypes ~loc ~mark:Mark_both env ~modes:All mty1 mty2 with
     | Tcoerce_none -> true
     | _ | exception Includemod.Error _ -> false
 
@@ -2515,8 +2510,7 @@ let wrap_constraint_package env mark arg mty explicit =
   let mty2 = Subst.modtype Keep Subst.identity mty in
   let coercion =
     try
-      Includemod.modtypes ~loc:arg.mod_loc env ~mark mty1 mty2
-        ~modes:(Some ())
+      Includemod.modtypes ~loc:arg.mod_loc env ~mark ~modes:Legacy mty1 mty2
     with Includemod.Error msg ->
       raise(Error(arg.mod_loc, env, Not_included msg)) in
   { mod_desc = Tmod_constraint(arg, mty, explicit, coercion);
@@ -2531,8 +2525,7 @@ let wrap_constraint_with_shape env mark arg mty
   let coercion, shape =
     try
       Includemod.modtypes_with_shape ~shape ~loc:arg.mod_loc env ~mark
-        ~modes:(Some ())
-        arg.mod_type mty
+        ~modes:Legacy arg.mod_type mty
     with Includemod.Error msg ->
       raise(Error(arg.mod_loc, env, Not_included msg)) in
   { mod_desc = Tmod_constraint(arg, mty, explicit, coercion);
@@ -2845,7 +2838,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
       let coercion =
         try Includemod.modtypes
               ~loc:arg.mod_loc ~mark:Mark_both env arg.mod_type mty_param
-              ~modes:(Some ())
+              ~modes:Legacy
         with Includemod.Error _ -> apply_error ()
       in
       let mty_appl =
@@ -2877,7 +2870,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
             begin match
               Includemod.modtypes
                 ~loc:app_loc ~mark:Mark_neither env mty_res nondep_mty
-                ~modes:(Some ())
+                ~modes:Legacy
             with
             | Tcoerce_none -> ()
             | _ ->


### PR DESCRIPTION
Value description inclusion check now considers the mode of the modules, as opposed to looking at the value modalities only. 

This PR is surprisingly simple, because modules are currently fixed to be legacy. When we support non-legacy modules in the future, we will have to pipe those data through.

Based on this PR, I will shortly make another PR that simplifies inferred modalities.