### PR TITLE
Allow more minor custom blocks in runtime5

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -256,12 +256,12 @@ typedef uint64_t uintnat;
 
 /* Default setting for the ratio of custom garbage to minor heap size.
    Documented in gc.mli */
-#define Custom_minor_ratio_def 100
+#define Custom_minor_ratio_def 400
 
 /* Default setting for maximum size of custom objects counted as garbage
    in the minor heap.
    Documented in gc.mli */
-#define Custom_minor_max_bsz_def 70000
+#define Custom_minor_max_bsz_def 10
 
 /* Minimum amount of work to do in a major GC slice. */
 #define Major_slice_work_min 512

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -117,7 +117,7 @@ CAMLexport value caml_alloc_custom_mem(const struct custom_operations * ops,
                                        mlsize_t mem)
 {
   mlsize_t max_minor = get_max_minor (); /* total allocs before minor GC */
-  mlsize_t max_minor_single;     /* largest single alloc before minor GC */
+  mlsize_t max_minor_single;      /* largest allowed alloc on minor heap */
   if (caml_custom_minor_max_bsz > 100) {
     max_minor_single = caml_custom_minor_max_bsz;
   } else {

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -66,14 +66,15 @@ static value alloc_custom_gen (const struct custom_operations * ops,
                                uintnat bsz,
                                mlsize_t mem,
                                mlsize_t max_major,
-                               mlsize_t max_minor)
+                               mlsize_t max_minor,
+                               int minor_ok)
 {
   mlsize_t wosize;
   CAMLparam0();
   CAMLlocal1(result);
 
   wosize = 1 + (bsz + sizeof(value) - 1) / sizeof(value);
-  if (wosize <= Max_young_wosize && mem <= caml_custom_minor_max_bsz) {
+  if (wosize <= Max_young_wosize && minor_ok) {
     result = caml_alloc_small(wosize, Custom_tag);
     Custom_ops_val(result) = ops;
     if (ops->finalize != NULL || mem != 0) {
@@ -108,14 +109,22 @@ CAMLexport value caml_alloc_custom(const struct custom_operations * ops,
 {
   mlsize_t max_major = max;
   mlsize_t max_minor = max == 0 ? get_max_minor() : max;
-  return alloc_custom_gen (ops, bsz, mem, max_major, max_minor);
+  return alloc_custom_gen (ops, bsz, mem, max_major, max_minor, 1);
 }
 
 CAMLexport value caml_alloc_custom_mem(const struct custom_operations * ops,
                                        uintnat bsz,
                                        mlsize_t mem)
 {
-  value v = alloc_custom_gen (ops, bsz, mem, 0, get_max_minor());
+  mlsize_t max_minor = get_max_minor (); /* total allocs before minor GC */
+  mlsize_t max_minor_single;     /* largest single alloc before minor GC */
+  if (caml_custom_minor_max_bsz > 100) {
+    max_minor_single = caml_custom_minor_max_bsz;
+  } else {
+    max_minor_single = max_minor * caml_custom_minor_max_bsz / 100;
+  }
+  value v = alloc_custom_gen (ops, bsz, mem, 0,
+                              max_minor, (mem < max_minor_single));
   size_t mem_words = (mem + sizeof(value) - 1) / sizeof(value);
   caml_memprof_sample_block(v, mem_words, mem_words, CAML_MEMPROF_SRC_CUSTOM);
   return v;

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -248,7 +248,15 @@ type control =
         heap. Expressed as a percentage of minor heap size.
         Note: this only applies to values allocated with
         [caml_alloc_custom_mem] (e.g. bigarrays).
-        Default: 100.
+
+        The main reason to limit the size of memory held in the minor
+        heap is to avoid long minor GC pauses. Since custom values are
+        typically faster to GC than normal values (they cannot hold
+        pointers so need no scanning), an large amount of data can be
+        held by the minor heap in custom blocks without significantly
+        affecting GC time. So, by default, this value is above 100%.
+
+        Default: 400.
         @since 4.08 *)
 
     custom_minor_max_size : int;
@@ -268,7 +276,10 @@ type control =
         than this many bytes are allocated on the major heap.
         Note: this only applies to values allocated with
         [caml_alloc_custom_mem] (e.g. bigarrays).
-        Default: 70000 bytes.
+        Numbers <=100 are interpreted as percentages of the size
+        that would immediately trigger minor GC (minor heap size
+        times custom_minor_ratio).
+        Default: 10 %.
 
         @since 4.08 *)
   }


### PR DESCRIPTION
Runtime5 is currently overly aggressive in allocating bigarrays directly on the major heap, skipping the minor heap for anything over 70kB.

This patch changes the defaults to allow larger bigarrays to be collected by the minor collector, both by allowing more total minor bigarrays (up to 4x minor heap by default), and by allowing larger single bigarrays (10% of the amount that would trigger minor GC by default). There's some explanation of the new parameter defaults in `gc.mli`.