### PR TITLE
Fix ephemeron-adoption problem in mark-delay

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1410,13 +1410,14 @@ void caml_mark_roots_stw (int participant_count, caml_domain_state** barrier_par
   Caml_global_barrier_if_final(participant_count) {
     caml_gc_phase = Phase_sweep_and_mark_main;
     atomic_store_relaxed(&global_roots_scanned, WORK_UNSTARTED);
+    /* Adopt orphaned work from domains that were spawned and
+       terminated in the previous cycle. Do this in the barrier,
+       before any domain can terminate on this cycle. */
+    adopt_orphaned_work (caml_global_heap_state.UNMARKED);
   }
 
   caml_domain_state* domain = Caml_state;
 
-  /* Adopt orphaned work from domains that were spawned and terminated in the
-     previous cycle. */
-  adopt_orphaned_work (caml_global_heap_state.UNMARKED);
 
   begin_ephe_marking();
 


### PR DESCRIPTION
This fixes a problem found by CI when upstreaming mark-delay (#2348 / #2358 / #3029) in ocaml/ocaml#13580. The problem concerns adopting ephemerons which have been orphaned by a terminating domain. They are marked by the terminating domain, so survive that GC cycle. They are then adopted at the start of marking in the next cycle, when they should be unmarked (due to the major GC cycle colour-switch). However, at present all domains attempt to adopt orphans at the start of marking, without a subsequent barrier, so it is possible for the terminating domain to get past this point, mark the ephemerons and then orphan them, before some other domain attempts to adopt and picks up the ephemerons. The fact that the ephemerons have already been marked in this cycle is detected in the debug runtime by a failing assertion. It is unclear whether this difference in marking is harmless; the multicore major GC ephemeron marking system is complex and it seems unwise to change this behaviour. In this PR, orphan adoption is moved inside the barrier at the start of marking; it starts with a very cheap check (`no_orphaned_work()`) so this change is almost free in the common case and fairly cheap even if there are orphans.

This problem was detected by the ocaml-multicore/multicoretests run automatically by CI on ocaml/ocaml#13580 due to the `run-multicoretests` label.

This is one of the three fixes in #3297, which @mshinwell asked to be separated out.