### PR TITLE
Request a minor GC if marking has failed to start since the last slice.

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1799,11 +1799,17 @@ static void major_collection_slice(intnat howmuch,
 
   if (domain_state->sweeping_done) {
     /* We do not immediately trigger a minor GC, but instead wait for
-       the next one to happen normally. This gives some chance that
-       other domains will finish sweeping as well. */
+       the next one to happen normally, when marking will start. This
+       gives some chance that other domains will finish sweeping as
+       well. */
     request_mark_phase();
+    /* If there was no sweeping to do, but marking hasn't started,
+       then minor GC has not occurred naturally between major slices -
+       so we should force one now. */
+    if (sweep_work == 0 && !caml_marking_started()) {
+        caml_request_minor_gc();
+    }
   }
-
 
 mark_again:
   if (caml_marking_started() &&


### PR DESCRIPTION
This fixes a problem found by @stedolan while reviewing ocaml/ocaml#13580, which upstreams the mark-delay GC change (#2348 / #2358 / #3029). The problem is due to the fact that marking is requested in one slice, but then actually begun on the next minor GC. If insufficient allocation takes place to trigger a minor GC, successive major slices may occur without the major GC progressing. This is now detected on the following slice: if no sweeping is available and yet marking has not started, a minor GC is requested.

This is one of the three fixes in #3297, which @mshinwell asked to be separated out.