### PR TITLE
Simplify consecutive sign extensions

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -445,7 +445,7 @@ let untag_int i dbg =
   | Cconst_int (n, _) -> Cconst_int (n asr 1, dbg)
   | Cop (Cor, [Cop (Casr, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
     when n > 0 && n < (size_int * 8) - 1 ->
-    Cop (Casr, [c; Cconst_int (n + 1, dbg)], dbg)
+    asr_int c (Cconst_int (n + 1, dbg)) dbg
   | Cop (Cor, [Cop (Clsr, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
     when n > 0 && n < (size_int * 8) - 1 ->
     Cop (Clsr, [c; Cconst_int (n + 1, dbg)], dbg)
@@ -650,15 +650,14 @@ let rec div_int c1 c2 is_safe dbg =
          t = shift-right(t, W - l)
 
          t = c1 + t res = shift-right-signed(c1 + t, l) *)
-      Cop
-        ( Casr,
-          [ bind "dividend" c1 (fun c1 ->
-                assert (l >= 1);
-                let t = asr_int c1 (Cconst_int (l - 1, dbg)) dbg in
-                let t = lsr_int t (Cconst_int (Nativeint.size - l, dbg)) dbg in
-                add_int c1 t dbg);
-            Cconst_int (l, dbg) ],
-          dbg )
+      asr_int
+        (bind "dividend" c1 (fun c1 ->
+             assert (l >= 1);
+             let t = asr_int c1 (Cconst_int (l - 1, dbg)) dbg in
+             let t = lsr_int t (Cconst_int (Nativeint.size - l, dbg)) dbg in
+             add_int c1 t dbg))
+        (Cconst_int (l, dbg))
+        dbg
     else if n < 0
     then
       sub_int
@@ -682,9 +681,7 @@ let rec div_int c1 c2 is_safe dbg =
               (Cmulhi { signed = true }, [c1; natint_const_untagged dbg m], dbg)
           in
           let t = if m < 0n then Cop (Caddi, [t; c1], dbg) else t in
-          let t =
-            if p > 0 then Cop (Casr, [t; Cconst_int (p, dbg)], dbg) else t
-          in
+          let t = if p > 0 then asr_int t (Cconst_int (p, dbg)) dbg else t in
           add_int t (lsr_int c1 (Cconst_int (Nativeint.size - 1, dbg)) dbg) dbg)
   | c1, c2 when !Clflags.unsafe || is_safe = Lambda.Unsafe ->
     Cop (Cdivi, [c1; c2], dbg)
@@ -1286,10 +1283,10 @@ let sign_extend_32 dbg e =
         args,
         dbg )
   | e ->
-    Cop
-      ( Casr,
-        [Cop (Clsl, [e; Cconst_int (32, dbg)], dbg); Cconst_int (32, dbg)],
-        dbg )
+    asr_int
+      (Cop (Clsl, [e; Cconst_int (32, dbg)], dbg))
+      (Cconst_int (32, dbg))
+      dbg
 
 let unboxed_packed_array_ref arr index dbg ~memory_chunk ~elements_per_word =
   bind "arr" arr (fun arr ->
@@ -1981,10 +1978,10 @@ let sign_extend_63 dbg e =
     e
   | _ ->
     let e = low_63 dbg e in
-    Cop
-      ( Casr,
-        [Cop (Clsl, [e; Cconst_int (1, dbg)], dbg); Cconst_int (1, dbg)],
-        dbg )
+    asr_int
+      (Cop (Clsl, [e; Cconst_int (1, dbg)], dbg))
+      (Cconst_int (1, dbg))
+      dbg
 
 (* zero_extend_32 zero-extends values from 32 bits to the word size. *)
 let zero_extend_32 dbg e =
@@ -2652,11 +2649,10 @@ let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
             Cifthenelse
               ( Cop
                   ( Ccmpi Ceq,
-                    [ Cop
-                        ( Casr,
-                          [ get_field_gen mut clos 1 dbg;
-                            Cconst_int (pos_arity_in_closinfo, dbg) ],
-                          dbg );
+                    [ asr_int
+                        (get_field_gen mut clos 1 dbg)
+                        (Cconst_int (pos_arity_in_closinfo, dbg))
+                        dbg;
                       Cconst_int (List.length extended_args_type, dbg) ],
                     dbg ),
                 dbg,
@@ -2926,11 +2922,10 @@ let apply_function_body arity result (mode : Cmx_format.alloc_mode) =
       Cifthenelse
         ( Cop
             ( Ccmpi Ceq,
-              [ Cop
-                  ( Casr,
-                    [ get_field_gen Asttypes.Mutable (Cvar clos) 1 (dbg ());
-                      Cconst_int (pos_arity_in_closinfo, dbg ()) ],
-                    dbg () );
+              [ asr_int
+                  (get_field_gen Asttypes.Mutable (Cvar clos) 1 (dbg ()))
+                  (Cconst_int (pos_arity_in_closinfo, dbg ()))
+                  (dbg ());
                 Cconst_int (List.length arity, dbg ()) ],
               dbg () ),
           dbg (),


### PR DESCRIPTION
Unboxed 32-bit ints reside sign-extended in 64-bit registers, so converting an untagged immediate to a 32-bit int requires a sign-extension that is represented in cmm as `(>>s (<< x 32) 32)`. If `x` is the result of an untag or a smaller-length sign extension, the generated code has redundant shifts.

Example program:
```ocaml
type bigstring =
  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t

external unsafe_get_16
  :  bigstring
  -> pos:int64#
  -> int
  = "%caml_bigstring_get16u_indexed_by_int64#"

let sign_extend_16 u = (u lsl (Sys.int_size - 16)) asr (Sys.int_size - 16)

let unsafe_get_16_as_32 t ~pos =
  unsafe_get_16 t ~pos |> Stdlib_upstream_compatible.Int32_u.of_int

let unsafe_get_16_signed_as_32 t ~pos =
  unsafe_get_16 t ~pos
  |> sign_extend_16
  |> Stdlib_upstream_compatible.Int32_u.of_int
```

The cmm and asm of `unsafe_get_16_as_32` and `unsafe_get_16_signed_as_32` are:
<details>
<summary>
unsafe_get_16_as_32
</summary>

```
(function{/tmp/a.ml:8,24-98} camlA__unsafe_get_16_as_32_1_10_code
     (t/655: val pos/656: int)
 (>>s
   (<<
     (>>s
       (<<
         (let ba_data/658 (load_mut int (+a t/655 8))
           (load_mut unsigned int16 (+ ba_data/658 pos/656)))
         1)
       1)
     32)
   32))
```

```
movq	8(%rax), %rax
movzwq	(%rax,%rbx), %rax
salq	$1, %rax
sarq	$1, %rax
movslq	%eax, %rax
ret
```
</details>
<details>
<summary>
unsafe_get_16_signed_as_32
</summary>

```
(function{/tmp/a.ml:13,31-125} camlA__unsafe_get_16_signed_as_32_3_12_code
     (t/674: val pos/675: int)
 (>>s
   (<<
     (>>s
       (<<
         (let ba_data/677 (load_mut int (+a t/674 8))
           (load_mut unsigned int16 (+ ba_data/677 pos/675)))
         48)
       48)
     32)
   32))
```

```
movq	8(%rax), %rax
movzwq	(%rax,%rbx), %rax
salq	$48, %rax
sarq	$48, %rax
movslq	%eax, %rax
ret
```
</details>

This PR adds the following simplification to the flambda-cmm conversion: if generating two consecutive pairs of `lsl`/`asr` (i.e. sign extensions), keep only the one that corresponds to the sign extension on the shorter integer length. At the tip of this branch, the cmm and asm for those functions are instead:
<details>
<summary>
unsafe_get_16_as_32
</summary>

```
(function{/tmp/a.ml:9,24-98} camlA__unsafe_get_16_as_32_1_10_code
     (t/655: val pos/656: int)
 (>>s
   (<<
     (let ba_data/658 (load_mut int (+a t/655 8))
       (load_mut unsigned int16 (+ ba_data/658 pos/656)))
     32)
   32))
```

```
movq	8(%rax), %rax
movzwq	(%rax,%rbx), %rax
movslq	%eax, %rax
ret
```
</details>
<details>
<summary>
unsafe_get_16_signed_as_32
</summary>

```
(function{/tmp/a.ml:14,31-125} camlA__unsafe_get_16_signed_as_32_3_12_code
     (t/674: val pos/675: int)
 (>>s
   (<<
     (let ba_data/677 (load_mut int (+a t/674 8))
       (load_mut unsigned int16 (+ ba_data/677 pos/675)))
     48)
   48))
```

```
movq	8(%rax), %rax
movzwq	(%rax,%rbx), %rax
salq	$48, %rax
sarq	$48, %rax
ret
```
</details>

This code is still not perfect (for example, the `movslq` in the `unsafe_get_16_as_32` asm is unnecessary, because sign-extending the lower 32 bits immediately after zero-extending the lower 16 is a noop), but this PR focuses just on simplifying consecutive sign-extensions.

There are currently two commits:
- The first is just a refactoring change that should be approximately a noop. It changes all manually-constructed `Cop Casr` throughout `cmm_helpers` to use the `asr_int` helper instead.
- The second adds the simplification to `asr_int`