### PR TITLE
Fix for PR2755 (ocamltest fail-if-test-does-nothing)

### DIFF
--- a/ocamltest/tests.ml
+++ b/ocamltest/tests.ml
@@ -29,13 +29,6 @@ let null = {
   test_description = "dummy test inserted by parser; always pass"
 }
 
-let does_nothing = {
-  test_name = "test does nothing";
-  test_run_by_default = false;
-  test_actions = [Actions_helpers.fail_with_reason "test does nothing"];
-  test_description = "inserted when a test does not do any substantive action"
-}
-
 let compare t1 t2 = String.compare t1.test_name t2.test_name
 
 let (tests: (string, t) Hashtbl.t) = Hashtbl.create 20
@@ -98,3 +91,6 @@ module TestSet = Set.Make
   type nonrec t = t
   let compare = compare
 end)
+
+let does_something t =
+  List.exists Actions.does_something t.test_actions

--- a/ocamltest/tests.mli
+++ b/ocamltest/tests.mli
@@ -24,8 +24,6 @@ type t = {
 
 val null : t
 
-val does_nothing : t
-
 val compare : t -> t -> int
 
 val register : t -> unit
@@ -41,3 +39,5 @@ val run : out_channel -> Environments.t -> t -> Result.t * Environments.t
 val test_of_action : Actions.t -> t
 
 module TestSet : Set.S with type elt = t
+
+val does_something : t -> bool

--- a/ocamltest/tsl_semantics.ml
+++ b/ocamltest/tsl_semantics.ml
@@ -74,19 +74,6 @@ type test_tree =
     string located list *
     (test_tree list)
 
-let tests_do_something (tests : Tests.t) =
-  List.exists Actions.does_something tests.test_actions
-
-(* CR mshinwell/xclerc: maybe sequences of actions that "do something" and
-   then have further actions that do not "do something" should be
-   flagged *)
-let rec test_tree_does_something_on_all_branches tree =
-  match tree with
-  | Node (_, tests, _, []) -> tests_do_something tests
-  | Node (_, tests, _, children) ->
-    tests_do_something tests
-    || List.for_all test_tree_does_something_on_all_branches children
-
 let too_deep testname max_level real_level =
   Printf.eprintf "Test %s should have depth atmost %d but has depth %d\n%!"
     testname max_level real_level;
@@ -152,21 +139,6 @@ let test_trees_of_tsl_block tsl_block =
     | [] -> (env, trees)
     | (Environment_statement s)::_ -> unexpected_environment_statement s
     | _ -> assert false
-
-let test_trees_of_tsl_block tsl_block =
-  let (env, trees) = test_trees_of_tsl_block tsl_block in
-  let does_something =
-    List.for_all test_tree_does_something_on_all_branches trees
-  in
-  if does_something then env, trees
-  else
-    let tree =
-      match trees with
-      | [] -> []
-      | Node (_, _, name, _) :: _ ->
-        [Node ([], Tests.does_nothing, name, [])]
-    in
-    env, tree
 
 let tests_in_stmt set stmt =
   match stmt with

--- a/testsuite/tests/lib-domain/DLS_thread_safety.ml
+++ b/testsuite/tests/lib-domain/DLS_thread_safety.ml
@@ -1,6 +1,8 @@
 (* TEST
    include systhreads;
    hassysthreads;
+   { bytecode; }
+   { native; }
 *)
 
 (* This test creates [nb_keys] DLS keys, each storing an atomic integer.

--- a/testsuite/tests/lib-domain/DLS_thread_safety.ml
+++ b/testsuite/tests/lib-domain/DLS_thread_safety.ml
@@ -1,6 +1,7 @@
 (* TEST
    include systhreads;
    hassysthreads;
+   runtime5;
    { bytecode; }
    { native; }
 *)

--- a/testsuite/tests/lib-unix/common/bigarrays.ml
+++ b/testsuite/tests/lib-unix/common/bigarrays.ml
@@ -1,6 +1,8 @@
 (* TEST
 include unix;
 hasunix;
+{ bytecode; }
+{ native; }
 *)
 
 let filename = "test.out"


### PR DESCRIPTION
#2755 caused ocamltest to produce test failures for stanzas that (often surprisingly!) do not actually run any tests.  For example before that PR, this:
```
(* TEST
   runtime5;
*)
```
caused nothing to be tested even on runtime5 (the test passes silently), but #2755 causes it to fail.  Unfortunately this functionality got lost in the 5.2 merge - I thought it had been merged correctly at the time but was mistaken.  This PR reworks the previous one and should restore things.

There only seems to be one test (fixed in this PR) which was silently failing to run, namely `lib-unix/common/bigarrays.ml`.