### PR TITLE
On Linux, use PR_SET_VMA_ANON_NAME to name memory mappings

### DIFF
--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -106,9 +106,9 @@ extern int caml_format_timestamp(char* buf, size_t sz, int formatted);
 
 /* Memory management platform-specific operations */
 
-void *caml_plat_mem_map(uintnat, int);
-void *caml_plat_mem_commit(void *, uintnat);
-void caml_plat_mem_decommit(void *, uintnat);
+void *caml_plat_mem_map(uintnat, int, const char*);
+void *caml_plat_mem_commit(void *, uintnat, const char*);
+void caml_plat_mem_decommit(void *, uintnat, const char*);
 void caml_plat_mem_unmap(void *, uintnat);
 
 #ifdef _WIN32

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -434,9 +434,9 @@ uintnat caml_mem_round_up_mapping_size(uintnat size);
    caml_plat_pagesize. The size given to caml_mem_unmap and caml_mem_decommit
    must match the size given to caml_mem_map/caml_mem_commit for mem.
 */
-void* caml_mem_map(uintnat size, int reserve_only);
-void* caml_mem_commit(void* mem, uintnat size);
-void caml_mem_decommit(void* mem, uintnat size);
+void* caml_mem_map(uintnat size, int reserve_only, const char* name);
+void* caml_mem_commit(void* mem, uintnat size, const char* name);
+void caml_mem_decommit(void* mem, uintnat size, const char* name);
 void caml_mem_unmap(void* mem, uintnat size);
 
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -183,7 +183,7 @@ Caml_inline struct stack_info* alloc_for_stack (mlsize_t wosize)
   // 2Mb (= extra_size)
   // -------------------- <- [stack], returned from [mmap], page-aligned
   char* stack;
-  stack = caml_mem_map(len + stack_extra_size_for_mmap, 0);
+  stack = caml_mem_map(len + stack_extra_size_for_mmap, 0, "stack");
   if (stack == MAP_FAILED) {
     return NULL;
   }

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -20,6 +20,7 @@
 
 #include "caml/config.h"
 #include <string.h>
+#include <stdio.h>
 #ifdef HAS_UNISTD
 #include <unistd.h>
 #endif
@@ -43,6 +44,11 @@
 #endif
 #if defined(USE_MMAP_MAP_STACK) || !defined(STACK_CHECKS_ENABLED)
 #include <sys/mman.h>
+#endif
+#ifdef __linux__
+/* for gettid */
+#include <sys/types.h>
+#include <sys/syscall.h>
 #endif
 
 #ifdef DEBUG
@@ -183,7 +189,15 @@ Caml_inline struct stack_info* alloc_for_stack (mlsize_t wosize)
   // 2Mb (= extra_size)
   // -------------------- <- [stack], returned from [mmap], page-aligned
   char* stack;
-  stack = caml_mem_map(len + stack_extra_size_for_mmap, 0, "stack");
+#ifdef __linux__
+  /* On Linux, record the current TID in the mapping name */
+  char mapping_name[64];
+  snprintf(mapping_name, sizeof mapping_name,
+           "stack (tid %ld)", (long)syscall(SYS_gettid));
+#else
+  const char* mapping_name = "stack";
+#endif
+  stack = caml_mem_map(len + stack_extra_size_for_mmap, 0, mapping_name);
   if (stack == MAP_FAILED) {
     return NULL;
   }

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -400,9 +400,9 @@ uintnat caml_mem_round_up_mapping_size(uintnat size)
 
 #define Is_page_aligned(size) ((size & (caml_plat_pagesize - 1)) == 0)
 
-void* caml_mem_map(uintnat size, int reserve_only)
+void* caml_mem_map(uintnat size, int reserve_only, const char* name)
 {
-  void* mem = caml_plat_mem_map(size, reserve_only);
+  void* mem = caml_plat_mem_map(size, reserve_only, name);
 
   if (mem == 0) {
     caml_gc_message(0x1000, "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d bytes failed",
@@ -411,32 +411,32 @@ void* caml_mem_map(uintnat size, int reserve_only)
   }
 
   caml_gc_message(0x1000, "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                          " bytes at %p for heaps\n", size, mem);
+                          " bytes at %p for %s\n", size, mem, name);
 
   return mem;
 }
 
-void* caml_mem_commit(void* mem, uintnat size)
+void* caml_mem_commit(void* mem, uintnat size, const char* name)
 {
   CAMLassert(Is_page_aligned(size));
   caml_gc_message(0x1000, "commit %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                          " bytes at %p for heaps\n", size, mem);
-  return caml_plat_mem_commit(mem, size);
+                          " bytes at %p for %s\n", size, mem, name);
+  return caml_plat_mem_commit(mem, size, name);
 }
 
-void caml_mem_decommit(void* mem, uintnat size)
+void caml_mem_decommit(void* mem, uintnat size, const char* name)
 {
   if (size) {
     caml_gc_message(0x1000, "decommit %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                            " bytes at %p for heaps\n", size, mem);
-    caml_plat_mem_decommit(mem, size);
+                            " bytes at %p for %s\n", size, mem, name);
+    caml_plat_mem_decommit(mem, size, name);
   }
 }
 
 void caml_mem_unmap(void* mem, uintnat size)
 {
   caml_gc_message(0x1000, "munmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                          " bytes at %p for heaps\n", size, mem);
+                          " bytes at %p\n", size, mem);
   caml_plat_mem_unmap(mem, size);
 }
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -211,7 +211,7 @@ static pool* pool_acquire(struct caml_heap_state* local) {
         caml_mem_round_up_mapping_size(Bsize_wsize(POOL_WSIZE) * new_pools);
       new_pools = mapping_size / Bsize_wsize(POOL_WSIZE);
 
-      void* mem = caml_mem_map(mapping_size, 0);
+      void* mem = caml_mem_map(mapping_size, 0, "major heap");
       if (mem) {
         pool_freelist.fresh_pools = new_pools;
         pool_freelist.next_fresh_pool = mem;


### PR DESCRIPTION
This new Linux `prctl` call allows a name to be set for anonymous memory mappings. This is useful for debugging (especially performance debugging), as the names show up in `/proc/$PID/smaps` and are not coalesced with other mappings. (This means that questions like "how much of this process's RSS is OCaml heap" are answerable from `smaps`).

On a kernel that supports it, here's what part of smaps looks like:
```
7fa54de00000-7fa54e600000 rw-p 00000000 00:00 0                          [anon:OCaml: minor heap 0]
Size:               8192 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:                4096 kB
Pss:                4096 kB
Pss_Dirty:          4096 kB
Shared_Clean:          0 kB
Shared_Dirty:          0 kB
Private_Clean:         0 kB
Private_Dirty:      4096 kB
Referenced:         4096 kB
Anonymous:          4096 kB
LazyFree:              0 kB
AnonHugePages:      4096 kB
ShmemPmdMapped:        0 kB
FilePmdMapped:         0 kB
Shared_Hugetlb:        0 kB
Private_Hugetlb:       0 kB
Swap:                  0 kB
SwapPss:               0 kB
Locked:                0 kB
THPeligible:    1
VmFlags: rd wr mr mw me ac sd 
```