### PR TITLE
Simplify inferred comonadic modality

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -24,10 +24,10 @@ let f (type (a : immediate) (b : immediate)) (x : a) = x;;
 let f (type (a : immediate) (b : immediate) c) (x : a) = x;;
 
 [%%expect{|
-val f : ('a : immediate). 'a -> 'a @@ global many = <fun>
-val f : ('a : immediate). 'a -> 'a @@ global many = <fun>
-val f : ('a : immediate). 'a -> 'a @@ global many = <fun>
-val f : ('a : immediate). 'a -> 'a @@ global many = <fun>
+val f : ('a : immediate). 'a -> 'a = <fun>
+val f : ('a : immediate). 'a -> 'a = <fun>
+val f : ('a : immediate). 'a -> 'a = <fun>
+val f : ('a : immediate). 'a -> 'a = <fun>
 |}]
 
 let f y (type a : immediate) (x : a) = x;;
@@ -35,12 +35,9 @@ let f y (type (a : immediate)) (x : a) = x;;
 let f y (type (a : immediate) (b : immediate)) (x : a) = x;;
 
 [%%expect{|
-val f : ('b : value_or_null) ('a : immediate). 'b -> 'a -> 'a @@ global many =
-  <fun>
-val f : ('b : value_or_null) ('a : immediate). 'b -> 'a -> 'a @@ global many =
-  <fun>
-val f : ('b : value_or_null) ('a : immediate). 'b -> 'a -> 'a @@ global many =
-  <fun>
+val f : ('b : value_or_null) ('a : immediate). 'b -> 'a -> 'a = <fun>
+val f : ('b : value_or_null) ('a : immediate). 'b -> 'a -> 'a = <fun>
+val f : ('b : value_or_null) ('a : immediate). 'b -> 'a -> 'a = <fun>
 |}]
 
 let f y (type a : immediate) = y;;
@@ -49,10 +46,10 @@ let f y (type (a : immediate) (b : immediate)) = y;;
 let f y (type (a : immediate) (b : immediate) c) = y;;
 
 [%%expect{|
-val f : ('a : value_or_null). 'a -> 'a @@ global many = <fun>
-val f : ('a : value_or_null). 'a -> 'a @@ global many = <fun>
-val f : ('a : value_or_null). 'a -> 'a @@ global many = <fun>
-val f : ('a : value_or_null). 'a -> 'a @@ global many = <fun>
+val f : ('a : value_or_null). 'a -> 'a = <fun>
+val f : ('a : value_or_null). 'a -> 'a = <fun>
+val f : ('a : value_or_null). 'a -> 'a = <fun>
+val f : ('a : value_or_null). 'a -> 'a = <fun>
 |}]
 
 (* Just newtypes, no value parameters *)
@@ -61,7 +58,7 @@ let f (type a : immediate) (type b : immediate)
   = ();;
 
 [%%expect{|
-val f : unit @@ global many = ()
+val f : unit = ()
 |}]
 
 module type S_for_layouts = sig
@@ -94,10 +91,10 @@ let f : (unit as (_ : immediate)) -> unit = fun () -> ()
 
 [%%expect{|
 type ('a : immediate) for_layouts = 'a
-val f : ('a : float64) ('b : bits64). 'a -> 'b -> 'a @@ global many = <fun>
-val f : ('a : float64). 'a -> 'a @@ global many = <fun>
-val f : (('a : float64). 'a -> 'a) -> int @@ global many = <fun>
-val f : unit -> unit @@ global many = <fun>
+val f : ('a : float64) ('b : bits64). 'a -> 'b -> 'a = <fun>
+val f : ('a : float64). 'a -> 'a = <fun>
+val f : (('a : float64). 'a -> 'a) -> int = <fun>
+val f : unit -> unit = <fun>
 |}]
 
 type (_ : any) ignore = K1
@@ -160,8 +157,7 @@ let f xs = match xs with
 
 [%%expect{|
 type t = #(int * float#)
-val f : ('a : value_or_null). #('a * float#) -> #('a * float#) @@ global many =
-  <fun>
+val f : ('a : value_or_null). #('a * float#) -> #('a * float#) = <fun>
 |}]
 
 module M = struct
@@ -171,7 +167,7 @@ let x () = #( M.Null, M.This "hi" )
 
 [%%expect{|
 module M : sig type 'a t = 'a or_null = Null | This of 'a end
-val x : unit -> #('a M.t * string M.t) @@ global many = <fun>
+val x : unit -> #('a M.t * string M.t) = <fun>
 |}]
 
 external id : ('a : any). 'a -> 'a = "%identity" [@@layout_poly]
@@ -189,21 +185,21 @@ let nums = [| x for x = 0 to 100 |];;
 let nums = [  x for x = 0 to 100   ];;
 
 [%%expect{|
-val nums : int iarray @@ global many =
+val nums : int iarray =
   [:0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15; 16; 17; 18; 19; 20;
     21; 22; 23; 24; 25; 26; 27; 28; 29; 30; 31; 32; 33; 34; 35; 36; 37; 38;
     39; 40; 41; 42; 43; 44; 45; 46; 47; 48; 49; 50; 51; 52; 53; 54; 55; 56;
     57; 58; 59; 60; 61; 62; 63; 64; 65; 66; 67; 68; 69; 70; 71; 72; 73; 74;
     75; 76; 77; 78; 79; 80; 81; 82; 83; 84; 85; 86; 87; 88; 89; 90; 91; 92;
     93; 94; 95; 96; 97; 98; 99; 100:]
-val nums : int array @@ global many =
+val nums : int array =
   [|0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15; 16; 17; 18; 19; 20;
     21; 22; 23; 24; 25; 26; 27; 28; 29; 30; 31; 32; 33; 34; 35; 36; 37; 38;
     39; 40; 41; 42; 43; 44; 45; 46; 47; 48; 49; 50; 51; 52; 53; 54; 55; 56;
     57; 58; 59; 60; 61; 62; 63; 64; 65; 66; 67; 68; 69; 70; 71; 72; 73; 74;
     75; 76; 77; 78; 79; 80; 81; 82; 83; 84; 85; 86; 87; 88; 89; 90; 91; 92;
     93; 94; 95; 96; 97; 98; 99; 100|]
-val nums : int list @@ global many =
+val nums : int list =
   [0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15; 16; 17; 18; 19; 20;
    21; 22; 23; 24; 25; 26; 27; 28; 29; 30; 31; 32; 33; 34; 35; 36; 37; 38;
    39; 40; 41; 42; 43; 44; 45; 46; 47; 48; 49; 50; 51; 52; 53; 54; 55; 56;
@@ -218,9 +214,9 @@ let nums = [| x for x in [| 1; 2; 3 |] |];;
 let nums = [  x for x in [  1; 2; 3  ]  ];;
 
 [%%expect{|
-val nums : int iarray @@ global many = [:1; 2; 3:]
-val nums : int array @@ global many = [|1; 2; 3|]
-val nums : int list @@ global many = [1; 2; 3]
+val nums : int iarray = [:1; 2; 3:]
+val nums : int array = [|1; 2; 3|]
+val nums : int list = [1; 2; 3]
 |}]
 
 (* complex comprehension *)
@@ -251,10 +247,10 @@ let nums = [| n, m, x
   |];;
 
 [%%expect{|
-val nums : int iarray @@ global many = [:7; 7; 8; 7; 8; 9:]
-val nums : int array @@ global many = [|7; 7; 8; 7; 8; 9|]
-val nums : int list @@ global many = [7; 7; 8; 7; 8; 9]
-val nums : (int * int * int) array @@ global many =
+val nums : int iarray = [:7; 7; 8; 7; 8; 9:]
+val nums : int array = [|7; 7; 8; 7; 8; 9|]
+val nums : int list = [7; 7; 8; 7; 8; 9]
+val nums : (int * int * int) array =
   [|(1, 5, 6); (1, 5, 2); (1, 2, 3); (1, 2, 3); (2, 4, 2); (2, 1, 3);
     (3, 3, 4); (3, 3, 2); (3, 0, 1); (3, 0, 3); (4, 5, 3); (4, 2, 2);
     (5, 4, 5); (5, 4, 3); (5, 1, 2); (5, 1, 2); (6, 3, 3); (6, 0, 2);
@@ -279,7 +275,7 @@ let nums =
   ([(x[@test.attr1]) for (x[@test.attr2]) in ([][@test.attr3])] [@test.attr4]);;
 
 [%%expect{|
-val nums : 'a list @@ global many = []
+val nums : 'a list = []
 |}]
 
 (*********)
@@ -296,8 +292,8 @@ val f :
     local_ 'a @ unique ->
     y:local_ 'b @ once ->
     z:'c @ once unique ->
-    ?foo:local_ int @ once unique -> ?bar:local_ int -> unit -> unit
-  @@ global many = <fun>
+    ?foo:local_ int @ once unique -> ?bar:local_ int -> unit -> unit =
+  <fun>
 |}]
 
 (* bindings *)
@@ -366,7 +362,7 @@ Line 12, characters 6-9:
            ^^^
 Warning 26 [unused-var]: unused variable foo.
 
-val g : unit -> unit @@ global many = <fun>
+val g : unit -> unit = <fun>
 |}]
 
 (* expressions *)
@@ -386,7 +382,7 @@ Line 3, characters 6-7:
           ^
 Warning 26 [unused-var]: unused variable f.
 
-val g : unit -> local_ unit @ once @@ global many = <fun>
+val g : unit -> local_ unit @ once = <fun>
 |}]
 
 (* types *)
@@ -463,16 +459,16 @@ val f :
     local_ 'd -> local_
     'b * string * (string -> string) * ('e -> 'e) * 'c * string * string *
     int array * string * (int -> local_ (int -> int)) *
-    (int -> local_ (int -> int)) @ contended
-  @@ global many = <fun>
+    (int -> local_ (int -> int)) @ contended =
+  <fun>
 |}]
 
 let f1 (_ @ local) = ()
 let f2 () = let x @ local = [1; 2; 3] in f1 x [@nontail]
 
 [%%expect{|
-val f1 : ('a : value_or_null). local_ 'a -> unit @@ global many = <fun>
-val f2 : unit -> unit @@ global many = <fun>
+val f1 : ('a : value_or_null). local_ 'a -> unit = <fun>
+val f2 : unit -> unit = <fun>
 |}]
 
 module type S = sig @@ portable contended
@@ -544,8 +540,7 @@ Error: This value escapes its region.
 let f2 (x @ local) (f @ once) : t2 = exclave_ { x; f }
 
 [%%expect{|
-val f2 : local_ float -> (float -> float) @ once -> local_ t2 @ once @@
-  global many = <fun>
+val f2 : local_ float -> (float -> float) @ once -> local_ t2 @ once = <fun>
 |}]
 
 
@@ -766,7 +761,7 @@ let f x =
   | _ -> assert false;;
 
 [%%expect{|
-val f : 'a iarray -> 'a iarray @@ global many = <fun>
+val f : 'a iarray -> 'a iarray = <fun>
 |}]
 
 (******************)
@@ -782,25 +777,25 @@ let (x : (x:int * y:int)) = (~x:1, ~y:2)
 let (x : ((x:int * y:int) [@test.attr])) = (~x:1, ~y:2)
 
 [%%expect{|
-val z : int @@ global many = 4
-val punned : int @@ global many = 5
-val x_must_be_even : ('a : value_or_null) ('b : value_or_null). 'a -> 'b @@
-  global many = <fun>
+val z : int = 4
+val punned : int = 5
+val x_must_be_even : ('a : value_or_null) ('b : value_or_null). 'a -> 'b =
+  <fun>
 exception Odd
-val x : x:int * y:int @@ global many = (~x:1, ~y:2)
-val x : x:int * y:int @@ global many = (~x:1, ~y:2)
+val x : x:int * y:int = (~x:1, ~y:2)
+val x : x:int * y:int = (~x:1, ~y:2)
 - : x:int * int * z:int * punned:int = (~x:5, 2, ~z:4, ~punned:5)
-val x : x:int * y:int @@ global many = (~x:1, ~y:2)
-val x : x:int * y:int @@ global many = (~x:1, ~y:2)
+val x : x:int * y:int = (~x:1, ~y:2)
+val x : x:int * y:int = (~x:1, ~y:2)
 |}]
 
 let (~x:x0, ~s, ~(y:int), ..) : (x:int * s:string * y:int * string) =
    (~x: 1, ~s: "a", ~y: 2, "ignore me")
 
 [%%expect{|
-val x0 : int @@ global many portable = 1
-val s : string @@ global many portable = "a"
-val y : int @@ global many portable = 2
+val x0 : int @@ portable = 1
+val s : string @@ portable = "a"
+val y : int @@ portable = 2
 |}]
 
 module M : sig
@@ -837,14 +832,14 @@ let f ((~(x:int),y) : (x:int * int)) : int = x + y
 [%%expect{|
 val foo :
   ('a : value_or_null) ('b : value_or_null).
-    'a -> (unit -> 'b) -> (unit -> 'b) -> 'b
-  @@ global many = <fun>
-val x : int @@ global many portable = 1
-val y : int @@ global many = 2
-val x : int @@ global many portable = 1
-val y : int @@ global many = 2
-val f : (foo:int * bar:int) -> int @@ global many = <fun>
-val f : (x:int * int) -> int @@ global many = <fun>
+    'a -> (unit -> 'b) -> (unit -> 'b) -> 'b =
+  <fun>
+val x : int @@ portable = 1
+val y : int = 2
+val x : int @@ portable = 1
+val y : int = 2
+val f : (foo:int * bar:int) -> int = <fun>
+val f : (x:int * int) -> int = <fun>
 |}]
 
 type xy = (x:int * y:int)
@@ -862,9 +857,9 @@ let matches =
 
 [%%expect{|
 type xy = x:int * y:int
-val lt : x:int * y:int * x:int * int @@ global many = (~x:1, ~y:2, ~x:3, 4)
-val matches : int @@ global many = 1
-val matches : int * int @@ global many = (1, 2)
+val lt : x:int * y:int * x:int * int = (~x:1, ~y:2, ~x:3, 4)
+val matches : int = 1
+val matches : int * int = (1, 2)
 |}]
 
 (********************)
@@ -892,10 +887,10 @@ let test_nativeint s f =
   Format.printf "%s: %s\n" s (Nativeint_u.to_string f); Format.print_flush ()
 
 [%%expect{|
-val test_float : string -> Float_u.t -> unit @@ global many = <fun>
-val test_int32 : string -> Int32_u.t -> unit @@ global many = <fun>
-val test_int64 : string -> Int64_u.t -> unit @@ global many = <fun>
-val test_nativeint : string -> Nativeint_u.t -> unit @@ global many = <fun>
+val test_float : string -> Float_u.t -> unit = <fun>
+val test_int32 : string -> Int32_u.t -> unit = <fun>
+val test_int64 : string -> Int64_u.t -> unit = <fun>
+val test_nativeint : string -> Nativeint_u.t -> unit = <fun>
 |}]
 
 (* Expressions *)
@@ -924,45 +919,45 @@ let x = test_int64 "forty_two_in_binary" (#0b101010L)
 
 [%%expect{|
 e: 2.718282
-val x : unit @@ global many = ()
+val x : unit = ()
 negative_one_half: -0.500000
-val x : unit @@ global many = ()
+val x : unit = ()
 negative_one_half: -0.500000
-val x : unit @@ global many = ()
+val x : unit = ()
 negative_one_half: -0.500000
-val x : unit @@ global many = ()
+val x : unit = ()
 negative_one_half: -0.500000
-val x : unit @@ global many = ()
+val x : unit = ()
 positive_one_dot: 1.000000
-val x : unit @@ global many = ()
+val x : unit = ()
 positive_one_dot: 1.000000
-val x : unit @@ global many = ()
+val x : unit = ()
 positive_one_dot: 1.000000
-val x : unit @@ global many = ()
+val x : unit = ()
 positive_one_dot: 1.000000
-val x : unit @@ global many = ()
+val x : unit = ()
 one_billion: 1000000000.000000
-val x : unit @@ global many = ()
+val x : unit = ()
 one_twenty_seven_point_two_five_in_floating_hex: 127.250000
-val x : unit @@ global many = ()
+val x : unit = ()
 five_point_three_seven_five_in_floating_hexponent: 5.375000
-val x : unit @@ global many = ()
+val x : unit = ()
 zero: 0
-val x : unit @@ global many = ()
+val x : unit = ()
 positive_one: 1
-val x : unit @@ global many = ()
+val x : unit = ()
 positive_one: 1
-val x : unit @@ global many = ()
+val x : unit = ()
 negative_one: -1
-val x : unit @@ global many = ()
+val x : unit = ()
 negative_one: -1
-val x : unit @@ global many = ()
+val x : unit = ()
 two_fifty_five_in_hex: 255
-val x : unit @@ global many = ()
+val x : unit = ()
 twenty_five_in_octal: 25
-val x : unit @@ global many = ()
+val x : unit = ()
 forty_two_in_binary: 42
-val x : unit @@ global many = ()
+val x : unit = ()
 |}]
 
 (* Patterns *)
@@ -987,9 +982,9 @@ let f x =
 ;;
 
 [%%expect{|
-val f : float# -> [> `Five | `Four | `Other ] @@ global many = <fun>
-val x : unit @@ global many = ()
-val f : float# -> float# @@ global many = <fun>
+val f : float# -> [> `Five | `Four | `Other ] = <fun>
+val x : unit = ()
+val f : float# -> float# = <fun>
 |}]
 ;;
 test_float "result" (f #7.);;
@@ -1020,10 +1015,10 @@ let f x =
 [%%expect{|
 result: 7.000000
 - : unit = ()
-val f : float# -> float# @@ global many = <fun>
+val f : float# -> float# = <fun>
 larger match result: 3.000000
 - : unit = ()
-val f : int64# -> [> `Five | `Four | `Other ] @@ global many = <fun>
+val f : int64# -> [> `Five | `Four | `Other ] = <fun>
 |}]
 
 let x =
@@ -1041,8 +1036,8 @@ let f x =
 test_int64 "result" (f #7L);;
 
 [%%expect{|
-val x : unit @@ global many = ()
-val f : int64# -> int64# @@ global many = <fun>
+val x : unit = ()
+val f : int64# -> int64# = <fun>
 result: 7
 - : unit = ()
 |}]
@@ -1056,9 +1051,9 @@ let #{ data = payload; _ } = #{ data = "payload" ; i = 0 }
 let inc r = #{ r with i = r.#i + 1 }
 [%%expect{|
 type 'a with_idx = #{ data : 'a; i : int; }
-val idx : 'a with_idx -> int @@ global many = <fun>
-val payload : string @@ global many = "payload"
-val inc : 'a with_idx -> 'a with_idx @@ global many = <fun>
+val idx : 'a with_idx -> int = <fun>
+val payload : string = "payload"
+val inc : 'a with_idx -> 'a with_idx = <fun>
 |}]
 
 (***************)
@@ -1102,7 +1097,7 @@ let f (_ : 'a. 'a -> 'a) = ()
 
 [%%expect{|
 type t = ('a. 'a -> 'a) -> int
-val f : ('a. 'a -> 'a) -> unit @@ global many = <fun>
+val f : ('a. 'a -> 'a) -> unit = <fun>
 |}]
 
 (************************)
@@ -1140,8 +1135,8 @@ let x () = #3.14s
 [%%expect{|
 type t1 = float32
 type t2 = float32#
-val x : float32 @@ global many = 3.1400001s
-val x : unit -> float32# @@ global many = <fun>
+val x : float32 = 3.1400001s
+val x : unit -> float32# = <fun>
 |}]
 
 (********)

--- a/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -1,5 +1,5 @@
-File "source_jane_street.ml", line 156, characters 0-24:
-156 | type t = #(int * float#)
+File "source_jane_street.ml", line 153, characters 0-24:
+153 | type t = #(int * float#)
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the type name "t".
        Names must be unique in a given structure or signature.

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -14,17 +14,17 @@ type r = {
 let uncontended_use (_ @ uncontended) = ()
 [%%expect{|
 type r = { mutable x : string; }
-val uncontended_use : 'a -> unit @@ global many = <fun>
+val uncontended_use : 'a -> unit = <fun>
 |}]
 
 let share_use : 'a -> unit @@ portable = fun _ -> ()
 [%%expect{|
-val share_use : 'a -> unit @@ global many = <fun>
+val share_use : 'a -> unit = <fun>
 |}]
 
 let (portable_use @ portable) (_ @ portable) = ()
 [%%expect{|
-val portable_use : 'a @ portable -> unit @@ global many = <fun>
+val portable_use : 'a @ portable -> unit = <fun>
 |}]
 
 (* The compiler building itself is a comprehensive test of legacy modules/values.
@@ -34,7 +34,7 @@ module M = struct
   let foo = {x = "hello"}
 end
 [%%expect{|
-module M : sig val foo : r @@ global many end
+module M : sig val foo : r end
 |}]
 
 module type S = sig
@@ -62,7 +62,7 @@ module M = struct
     let x @ contended = "hello"
 end
 [%%expect{|
-module M : sig val x : string @@ global many portable contended end
+module M : sig val x : string @@ portable contended end
 |}]
 
 (* Testing the defaulting behaviour.
@@ -106,11 +106,11 @@ Lines 8-10, characters 35-7:
 10 |     end
 Error: Signature mismatch:
        Modules do not match:
-         sig val x : string @@ global many portable contended end
+         sig val x : string @@ portable contended end
        is not included in
          sig val x : string end
        Values do not match:
-         val x : string @@ global many portable contended
+         val x : string @@ portable contended
        is not included in
          val x : string
        The second is uncontended and the first is contended.
@@ -141,9 +141,8 @@ Lines 8-13, characters 35-7:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           val x : string @@ global many portable
-           module N :
-             sig val y : string @@ global many portable contended end
+           val x : string @@ portable
+           module N : sig val y : string @@ portable contended end
          end
        is not included in
          sig
@@ -152,12 +151,12 @@ Error: Signature mismatch:
          end
        In module "N":
        Modules do not match:
-         sig val y : string @@ global many portable contended end
+         sig val y : string @@ portable contended end
        is not included in
          sig val y : string end
        In module "N":
        Values do not match:
-         val y : string @@ global many portable contended
+         val y : string @@ portable contended
        is not included in
          val y : string
        The second is uncontended and the first is contended.
@@ -176,7 +175,7 @@ module Without_inclusion = struct
 end
 [%%expect{|
 module Without_inclusion :
-  sig module M : sig val x : 'a -> 'a @@ global many portable end end
+  sig module M : sig val x : 'a -> 'a @@ portable end end
 |}]
 
 module Without_inclusion = struct
@@ -206,11 +205,11 @@ Lines 4-6, characters 10-7:
 6 |     end
 Error: Signature mismatch:
        Modules do not match:
-         sig val x : string @@ global many portable contended end
+         sig val x : string @@ portable contended end
        is not included in
          sig val x : string end
        Values do not match:
-         val x : string @@ global many portable contended
+         val x : string @@ portable contended
        is not included in
          val x : string
        The second is uncontended and the first is contended.
@@ -270,8 +269,8 @@ end
 [%%expect{|
 module Close_over_value :
   sig
-    module M : sig val x : string @@ global many portable end
-    val foo : unit -> unit @@ global many portable
+    module M : sig val x : string @@ portable end
+    val foo : unit -> unit @@ portable
   end
 |}]
 
@@ -441,7 +440,7 @@ Lines 13-19, characters 6-3:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           module Plain : sig val f : int -> int @@ global many end
+           module Plain : sig val f : int -> int end
            module type S_plain =
              sig module M : sig val f : int -> int end end
          end
@@ -453,12 +452,12 @@ Error: Signature mismatch:
          end
        In module "Plain":
        Modules do not match:
-         sig val f : int -> int @@ global many end
+         sig val f : int -> int end
        is not included in
          sig val f : int -> int @@ portable end
        In module "Plain":
        Values do not match:
-         val f : int -> int @@ global many
+         val f : int -> int
        is not included in
          val f : int -> int @@ portable
        The second is portable and the first is nonportable.
@@ -508,17 +507,17 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig module N : sig val foo : int @@ global many end end
+         sig module N : sig val foo : int end end
        is not included in
          sig module N : sig val foo : int @@ portable end end
        In module "N":
        Modules do not match:
-         sig val foo : int @@ global many end
+         sig val foo : int end
        is not included in
          sig val foo : int @@ portable end
        In module "N":
        Values do not match:
-         val foo : int @@ global many
+         val foo : int
        is not included in
          val foo : int @@ portable
        The second is portable and the first is nonportable.
@@ -586,7 +585,7 @@ let f (x : (module S)) = (x : (module S) :> (module S'))
 [%%expect{|
 module type S = sig val foo : 'a -> 'a @@ global many end
 module type S' = sig val foo : 'a -> 'a end
-val f : (module S) -> (module S') @@ global many = <fun>
+val f : (module S) -> (module S') = <fun>
 |}]
 
 let f (x : (module S')) = (x : (module S') :> (module S))
@@ -825,8 +824,8 @@ module M_portable = struct
     let f @ portable = fun () -> ()
     end
 [%%expect{|
-module M_nonportable : sig val f : unit -> unit @@ global many end
-module M_portable : sig val f : unit -> unit @@ global many portable end
+module M_nonportable : sig val f : unit -> unit end
+module M_portable : sig val f : unit -> unit @@ portable end
 |}]
 
 let (foo @ portable) () =
@@ -846,7 +845,7 @@ let (_foo @ portable) () =
     ()
 
 [%%expect{|
-val _foo : unit -> unit @@ global many = <fun>
+val _foo : unit -> unit = <fun>
 |}]
 
 let () =

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -42,7 +42,7 @@ let overwrite_shared (r : record_update) =
   let x = overwrite_ r with { x = "foo" } in
   x.x
 [%%expect{|
-val id : ('a : value_or_null). 'a -> 'a @@ global many = <fun>
+val id : ('a : value_or_null). 'a -> 'a = <fun>
 Line 5, characters 21-22:
 5 |   let x = overwrite_ r with { x = "foo" } in
                          ^
@@ -727,7 +727,7 @@ let guards_good = function
   end
   | OptionB _ -> false
 [%%expect{|
-val is_option_a : options -> bool @@ global many = <fun>
+val is_option_a : options -> bool = <fun>
 Line 8, characters 30-59:
 8 |     | Some s when is_option_a (overwrite_ v with OptionA s) -> true
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -807,8 +807,7 @@ let mutable_field_aliased r =
 [%%expect{|
 type 'a mutable_record = { mutable m : 'a; }
 val mutable_field_aliased :
-  options mutable_record @ unique -> options mutable_record * options @@
-  global many = <fun>
+  options mutable_record @ unique -> options mutable_record * options = <fun>
 |}]
 
 let mutable_field_aliased r =

--- a/testsuite/tests/typing-unique/overwriting_lift_constants.ml
+++ b/testsuite/tests/typing-unique/overwriting_lift_constants.ml
@@ -73,7 +73,7 @@ let () =
 
 [%%expect{|
 type point = { mutable dim : int; x : float; y : float; z : float; }
-val unsafe_dup : '_a @ unique -> '_a * '_a @ unique @@ global many = <fun>
+val unsafe_dup : '_a @ unique -> '_a * '_a @ unique = <fun>
 Line 9, characters 10-66:
 9 |   let p = overwrite_ p with { dim = 4; x = 1.0; y = 2.0; z = 3.0 } in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -19,15 +19,14 @@ let aliased_use x = x
 [%%expect{|
 (let (aliased_use/280 = (function {nlocal = 0} x/282 x/282))
   (apply (field_imm 1 (global Toploop!)) "aliased_use" aliased_use/280))
-val aliased_use : ('a : value_or_null). 'a -> 'a @@ global many = <fun>
+val aliased_use : ('a : value_or_null). 'a -> 'a = <fun>
 |}]
 
 let unique_use (unique_ x) = x
 [%%expect{|
 (let (unique_use/283 = (function {nlocal = 0} x/285 x/285))
   (apply (field_imm 1 (global Toploop!)) "unique_use" unique_use/283))
-val unique_use : ('a : value_or_null). 'a @ unique -> 'a @@ global many =
-  <fun>
+val unique_use : ('a : value_or_null). 'a @ unique -> 'a = <fun>
 |}]
 
 (* This output is fine with overwriting: The [r.y] is not pushed down. *)
@@ -48,7 +47,7 @@ let proj_aliased r =
             (apply aliased_use/280 r/288))
          (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/290 y/289))))
   (apply (field_imm 1 (global Toploop!)) "proj_aliased" proj_aliased/286))
-val proj_aliased : record -> record * string @@ global many = <fun>
+val proj_aliased : record -> record * string = <fun>
 |}]
 
 let proj_unique r =
@@ -68,7 +67,7 @@ let proj_unique r =
             (apply unique_use/283 r/293))
          (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/295 y/294))))
   (apply (field_imm 1 (global Toploop!)) "proj_unique" proj_unique/291))
-val proj_unique : record @ unique -> record * string @@ global many = <fun>
+val proj_unique : record @ unique -> record * string = <fun>
 |}]
 
 (* This output would be unsound if [aliased_use] was able to overwrite [r]
@@ -91,7 +90,7 @@ let match_aliased r =
          (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/300
            (field_imm 1 r/298)))))
   (apply (field_imm 1 (global Toploop!)) "match_aliased" match_aliased/296))
-val match_aliased : record -> record * string @@ global many = <fun>
+val match_aliased : record -> record * string = <fun>
 |}]
 
 (* This is sound since we bind [y] before the [unique_use] *)
@@ -113,7 +112,7 @@ let match_unique r =
             (apply unique_use/283 r/304))
          (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/306 y/305))))
   (apply (field_imm 1 (global Toploop!)) "match_unique" match_unique/302))
-val match_unique : record @ unique -> record * string @@ global many = <fun>
+val match_unique : record @ unique -> record * string = <fun>
 |}]
 
 (* Similarly, this would be unsound since Lambda performs a mini ANF pass. *)
@@ -139,7 +138,7 @@ let match_mini_anf_aliased r =
            (field_imm 1 r/310)))))
   (apply (field_imm 1 (global Toploop!)) "match_mini_anf_aliased"
     match_mini_anf_aliased/308))
-val match_mini_anf_aliased : record -> record * string @@ global many = <fun>
+val match_mini_anf_aliased : record -> record * string = <fun>
 |}]
 
 (* This is sound since we bind [y] before the [unique_use] *)
@@ -165,8 +164,7 @@ let match_mini_anf_unique r =
          (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/323 y/322))))
   (apply (field_imm 1 (global Toploop!)) "match_mini_anf_unique"
     match_mini_anf_unique/318))
-val match_mini_anf_unique : record @ unique -> record * string @@ global many =
-  <fun>
+val match_mini_anf_unique : record @ unique -> record * string = <fun>
 |}]
 
 let match_anf_aliased r =
@@ -196,7 +194,7 @@ let match_anf_aliased r =
              y/331)))))
   (apply (field_imm 1 (global Toploop!)) "match_anf_aliased"
     match_anf_aliased/328))
-val match_anf_aliased : record -> record * string @@ global many = <fun>
+val match_anf_aliased : record -> record * string = <fun>
 |}]
 
 (* This is sound since we bind [y] using [field_mut] *)
@@ -228,8 +226,7 @@ let match_anf_unique r =
              y/343)))))
   (apply (field_imm 1 (global Toploop!)) "match_anf_unique"
     match_anf_unique/340))
-val match_anf_unique : record @ unique -> record * string @@ global many =
-  <fun>
+val match_anf_unique : record @ unique -> record * string = <fun>
 |}]
 
 type tree =
@@ -325,7 +322,7 @@ let swap_inner (t : tree) =
            (exit 19))
         with (19) t/360)))
   (apply (field_imm 1 (global Toploop!)) "swap_inner" swap_inner/358))
-val swap_inner : tree -> tree @@ global many = <fun>
+val swap_inner : tree -> tree = <fun>
 |}]
 
 (* CR uniqueness: Update this test once overwriting is fully implemented.
@@ -374,7 +371,7 @@ let match_guard r =
              (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/451
                y/380))))))
   (apply (field_imm 1 (global Toploop!)) "match_guard" match_guard/376))
-val match_guard : record @ unique -> record * string @@ global many = <fun>
+val match_guard : record @ unique -> record * string = <fun>
 |}]
 
 let match_guard_unique (unique_ r) =

--- a/testsuite/tests/typing-unique/overwriting_syntax.ml
+++ b/testsuite/tests/typing-unique/overwriting_syntax.ml
@@ -42,7 +42,7 @@ Uncaught exception: File "parsing/location.ml", line 1107, characters 2-8: Asser
 let with_record = function
     { a; b } as t -> { t with b = a }
 [%%expect{|
-val with_record : record -> record @@ global many = <fun>
+val with_record : record -> record = <fun>
 |}]
 
 let overwrite_record = function

--- a/testsuite/tests/typing-unique/rbtree.ml
+++ b/testsuite/tests/typing-unique/rbtree.ml
@@ -472,13 +472,13 @@ type ('k, 'v) tree =
   | Leaf
 val fold :
   'a 'b ('c : value_or_null).
-    ('a -> 'b -> 'c -> 'c) -> 'c -> ('a, 'b) tree -> 'c
-  @@ global many = <fun>
+    ('a -> 'b -> 'c -> 'c) -> 'c -> ('a, 'b) tree -> 'c =
+  <fun>
 val work :
   ('a : value_or_null) ('b : value_or_null) ('c : value_or_null).
     insert:(int -> bool -> 'a -> 'a) ->
-    fold:(('b -> bool -> int -> int) -> int -> 'a -> 'c) -> empty:'a -> 'c
-  @@ global many = <fun>
+    fold:(('b -> bool -> int -> int) -> int -> 'a -> 'c) -> empty:'a -> 'c =
+  <fun>
 Line 85, characters 16-71:
 85 |                 balance_right (Node { t with right = ins k v t.right }) [@nontail]
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -508,16 +508,11 @@ module Make_Okasaki :
       val fold :
         'a 'b ('c : value_or_null).
           ('a -> 'b -> 'c -> 'c) -> 'c -> ('a, 'b) tree -> 'c
-        @@ global many
-      val balance_left : ('a, 'b) tree -> ('a, 'b) tree @@ global many
-        portable
-      val balance_right : ('a, 'b) tree -> ('a, 'b) tree @@ global many
-        portable
-      val ins : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree @@ global
-        many
-      val set_black : ('a, 'b) tree -> ('a, 'b) tree @@ global many portable
-      val insert : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree @@
-        global many
+      val balance_left : ('a, 'b) tree -> ('a, 'b) tree @@ portable
+      val balance_right : ('a, 'b) tree -> ('a, 'b) tree @@ portable
+      val ins : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree
+      val set_black : ('a, 'b) tree -> ('a, 'b) tree @@ portable
+      val insert : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree
     end
 Line 110, characters 16-52:
 110 |     | Node _ -> overwrite_ t with Node { color = c }

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2253,9 +2253,20 @@ module Modality = struct
         | Join_const c -> Format.fprintf ppf "join_const(%a)" Mode.Const.print c
     end
 
+    (* Similar to constant modalities, an inferred modality maps the mode of a
+       record/structure to the mode of a value therein. An inferred modality [f] is
+       inferred from the structure/record mode [mm] and the value mode [m].
+
+       Soundness: You should not get a value from a record/structure at a mode strictly
+       stronger than how it was put in. That is, [f mm >= m].
+
+       Completeness: You should be able to get a value from a record/structure at a mode
+       not strictly weaker than how it was put in. That is, [f mm <= m]. *)
+
     type t =
       | Const of Const.t
       | Diff of Mode.lr * Mode.l
+          (** inferred modality. See [apply] for its behavior. *)
       | Undefined
 
     let sub_log left right ~log : (unit, error) Result.t =
@@ -2388,6 +2399,7 @@ module Modality = struct
       | Const of Const.t
       | Undefined
       | Exactly of Mode.lr * Mode.l
+          (** inferred modality. See [apply] for its behavior. *)
 
     let sub_log left right ~log : (unit, error) Result.t =
       match left, right with

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2472,20 +2472,20 @@ module Modality = struct
             To prove soundness [meet_with (imply_with mm m) mm >= m], we need to prove:
             - [imply_with mm m >= m], or equivalently [meet mm m <= m] which is trivial.
             - [mm >= m], which is guaranteed by the caller of [infer].
-            Note that the soundness condition holds if we take [c] to be [imply_with _ m]
-            where the underscore can be anything.
+            In fact, the soundness condition holds for any [c]  taken to be
+            [imply_with _ m] where the underscore can be anything.
 
-            Note that [imply_with] requires its first argument to be constant, so we need
-            to get a constant out of [mm]. We have several choices:
-            - Take its floor [mm' <= mm]. This gives us a higher [c] and might be
-              incomplete.
-            - Take its ceil [mm' >= mm]. This gives us a lower [c] that is complete,but
-            - not
-               simple.
-            - Zap to floor. This gives us a [c] that is complete and simple. But we are
-               imposing extra constraint to [mm] not requested by the caller.
-            - Zap to ceil. This gives us a [c] that is complete and not simple. And we are
-               imposing extra constraint.
+            Note that [imply_with] requires its first argument to be a constant, so we
+            need to get a constant out of [mm]. First recall that [imply_with] is antitone
+            in its first argument. Now, we have several choices:
+            - Take its floor [mm' <= mm], and then [c' = imply_with mm' m]. [c'] is higher
+              than [c] and thus might be incomplete.
+            - Take its ceil [mm' >= mm]. Then, [c'] is lower than [c] and thus complete,
+              but might be less simple than [c].
+            - Zap to floor. This gives us a [c' = c] that is complete and simple, but we
+               are imposing extra constraint to [mm] not requested by the caller.
+            - Zap to ceil. This gives us a [c' = c] that is complete, but less simple than
+              zapping it to floor. Also, we are imposing extra constraint.
 
             We prioritize completeness and "not imposing extra constarint" over
             simplicity. So we take its ceil [mm' >= mm].

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2460,8 +2460,26 @@ module Modality = struct
     let zap_to_floor = function
       | Const c -> c
       | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
-      | Exactly (_, m) ->
-        let c = Mode.zap_to_floor m in
+      | Exactly (mm, m) ->
+        let m = Mode.zap_to_floor m in
+        (* For soundness, we want some [c] such that [meet_with c mm >= m].
+           For completeness, we want [meet_with c mm <= m].
+
+           We will find the highest [c] that satisfy completeness, and then
+           prove soundness for such [c].
+
+           To find the former, we have [c <= imply_with mm m]. Note that [mm]
+           is a variable but we need a constant, so we take its ceil [mm' >= mm]
+           and have [c <= imply_with mm' m <= imply_with mm m].
+
+           Let [c] be [imply_with mm' m], and we can't satisfy soundness
+           condition.
+
+           To address this, we need to zap [mm]. Either direction suffices to
+           fix soundness, but we will zap to floor to get a higher [c].
+        *)
+        let mm' = Mode.zap_to_floor mm in
+        let c = Mode.Const.imply mm' m in
         Const.Meet_const c
 
     let to_const_exn = function

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1335,9 +1335,9 @@ module Common (Obj : Obj) = struct
 
     let get_ceil m = Solver.get_ceil obj m
 
-    let get_conservative_floor m = Solver.get_conservative_floor obj m
+    let get_loose_floor m = Solver.get_loose_floor obj m
 
-    let get_conservative_ceil m = Solver.get_conservative_ceil obj m
+    let get_loose_ceil m = Solver.get_loose_ceil obj m
   end
 end
 [@@inline]
@@ -1370,8 +1370,8 @@ module Locality = struct
       if Const.le ceil floor then Some ceil else None
 
     let check_const_conservative m =
-      let floor = Guts.get_conservative_floor m in
-      let ceil = Guts.get_conservative_ceil m in
+      let floor = Guts.get_loose_floor m in
+      let ceil = Guts.get_loose_ceil m in
       if Const.le ceil floor then Some ceil else None
   end
 end

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -545,7 +545,9 @@ module type S = sig
 
       (** Given [md_mode] the mode of a module, and [mode] the mode of a value
       to be put in that module, return the inferred modality to be put on the
-      value description in the inferred module type. *)
+      value description in the inferred module type.
+
+      The caller should ensure that for comonadic axes, [md_mode >= mode]. *)
       val infer : md_mode:Value.lr -> mode:Value.l -> t
 
       (* The following zapping functions possibly mutate a potentially inferred

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -542,7 +542,7 @@ module Solver_mono (C : Lattices_mono) = struct
     in
     loop (C.max obj) VarMap.empty l
 
-  let get_conservative_ceil : type a l r. a C.obj -> (a, l * r) mode -> a =
+  let get_loose_ceil : type a l r. a C.obj -> (a, l * r) mode -> a =
    fun obj m ->
     match m with
     | Amode a -> a
@@ -552,7 +552,7 @@ module Solver_mono (C : Lattices_mono) = struct
     | Amodejoin (a, mvs) ->
       VarMap.fold (fun _ mv acc -> C.join obj acc (mupper obj mv)) mvs a
 
-  let get_conservative_floor : type a l r. a C.obj -> (a, l * r) mode -> a =
+  let get_loose_floor : type a l r. a C.obj -> (a, l * r) mode -> a =
    fun obj m ->
     match m with
     | Amode a -> a
@@ -563,7 +563,7 @@ module Solver_mono (C : Lattices_mono) = struct
       VarMap.fold (fun _ mv acc -> C.meet obj acc (mlower obj mv)) mvs a
 
   (* Due to our biased implementation, the ceil is precise. *)
-  let get_ceil = get_conservative_ceil
+  let get_ceil = get_loose_ceil
 
   let zap_to_ceil : type a l. a C.obj -> (a, l * allowed) mode -> log:_ -> a =
    fun obj m ~log ->
@@ -641,8 +641,8 @@ module Solver_mono (C : Lattices_mono) = struct
       type a l r.
       ?verbose:bool -> a C.obj -> Format.formatter -> (a, l * r) mode -> unit =
    fun ?verbose (obj : a C.obj) ppf m ->
-    let ceil = get_conservative_ceil obj m in
-    let floor = get_conservative_floor obj m in
+    let ceil = get_loose_ceil obj m in
+    let floor = get_loose_floor obj m in
     if C.le obj ceil floor
     then C.print obj ppf ceil
     else print_raw ?verbose obj ppf m
@@ -745,9 +745,9 @@ module Solvers_polarized (C : Lattices_mono) = struct
 
     let get_floor = S.get_floor
 
-    let get_conservative_ceil = S.get_conservative_ceil
+    let get_loose_ceil = S.get_loose_ceil
 
-    let get_conservative_floor = S.get_conservative_floor
+    let get_loose_floor = S.get_loose_floor
 
     let print ?(verbose = false) = S.print ~verbose
 
@@ -807,9 +807,9 @@ module Solvers_polarized (C : Lattices_mono) = struct
 
     let get_floor = S.get_ceil
 
-    let get_conservative_ceil = S.get_conservative_floor
+    let get_loose_ceil = S.get_loose_floor
 
-    let get_conservative_floor = S.get_conservative_ceil
+    let get_loose_floor = S.get_loose_ceil
 
     let print ?(verbose = false) = S.print ~verbose
 

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -256,14 +256,14 @@ module type Solver_polarized = sig
   val get_ceil : 'a obj -> ('a, 'l * allowed) mode -> 'a
 
   (** Similar to [get_floor] but does not run the further constraining needed
-      for a precise bound. As a result, the returned bound is conservative;
+      for a precise bound. As a result, the returned bound is loose;
       i.e., it might be lower than the real floor. *)
-  val get_conservative_floor : 'a obj -> ('a, 'l * 'r) mode -> 'a
+  val get_loose_floor : 'a obj -> ('a, 'l * 'r) mode -> 'a
 
   (** Similar to [get_ceil] but does not run the further constraining needed
-      for a precise bound. As a result, the returned bound is conservative;
+      for a precise bound. As a result, the returned bound is loose;
       i.e., it might be higher than the real ceil. *)
-  val get_conservative_ceil : 'a obj -> ('a, 'l * 'r) mode -> 'a
+  val get_loose_ceil : 'a obj -> ('a, 'l * 'r) mode -> 'a
 
   (** Printing a mode for debugging. *)
   val print :


### PR DESCRIPTION
This is based on #3328 

This simplifies the inferred comonadic modality when being zapped to constant. More specifically, if a module and a value therein are both `global many`, the value doesn't need the `global many` modality.

**_Please review by commits._**