### PR TITLE
Fix soundness bug in capsule api exception handling

### DIFF
--- a/otherlibs/stdlib_alpha/capsule.ml
+++ b/otherlibs/stdlib_alpha/capsule.ml
@@ -12,6 +12,40 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(* Like [int Stdlib.Atomic.t], but [portable]. *)
+module A = struct
+  type t : value mod portable uncontended
+
+  external make : int -> t @@ portable = "%makemutable"
+  external fetch_and_add : t -> int -> int @@ portable = "%atomic_fetch_add"
+end
+
+(* Like [Stdlib.Magic], but [portable]. *)
+module O = struct
+  external magic : 'a -> 'b @@ portable = "%obj_magic"
+end
+
+(* Like [Stdlib.( = ), but [portable]. *)
+external ( = ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%equal"
+
+module Name : sig
+  type 'k t : value mod global portable many uncontended unique
+  type packed = P : 'k t -> packed
+
+  val make : unit -> packed @@ portable
+  val equality_witness : 'k1 t -> 'k2 t -> ('k1, 'k2) Type.eq option @@ portable
+end = struct
+  type 'k t = int
+  type packed = P : 'k t -> packed
+
+  let ctr = A.make 0
+  let make () = P (A.fetch_and_add ctr 1)
+
+  let equality_witness t1 t2 =
+    if t1 = t2
+    then Some (O.magic Type.Equal)
+    else None
+end
 
 module Access : sig
   (* CR layouts v5: this should have layout [void], but
@@ -52,7 +86,8 @@ module Password : sig
   type 'k t : value mod portable many unique uncontended
 
   (* Can break the soundness of the API. *)
-  val unsafe_mk : unit -> 'k t @@ portable
+  val unsafe_mk : 'k Name.t -> 'k t @@ portable
+  val name : 'k t @ local -> 'k Name.t @@ portable
 
   module Shared : sig
     (* CR layouts v5: this should have layout [void], but
@@ -60,22 +95,25 @@ module Password : sig
     type 'k t
 
     (* Can break the soundness of the API. *)
-    val unsafe_mk : unit -> 'k t @@ portable
+    val unsafe_mk : 'k Name.t -> 'k t @@ portable
+    val name : 'k t @ local -> 'k Name.t @@ portable
   end
 
   val shared : 'k t @ local -> 'k Shared.t @ local @@ portable
 end = struct
-  type 'k t = unit
+  type 'k t = 'k Name.t
 
-  let unsafe_mk () = ()
+  let unsafe_mk name = name
+  let name t = t
 
   module Shared = struct
-    type 'k t = unit
+    type 'k t = 'k Name.t
 
-    let unsafe_mk () = ()
+    let unsafe_mk name = name
+    let name t = t
   end
 
-  let shared () = ()
+  let shared t = t
 
 end
 
@@ -83,10 +121,10 @@ end
    it never returns is also [portable] *)
 external reraise : exn -> 'a @ portable @@ portable = "%reraise"
 
-exception Contended of exn @@ contended
-
 module Data = struct
   type ('a, 'k) t : value mod portable uncontended
+
+  exception Encapsulated : 'k Name.t * (exn, 'k) t -> exn
 
   external unsafe_mk : 'a -> ('a, 'k) t @@ portable = "%identity"
 
@@ -100,11 +138,17 @@ module Data = struct
 
   let create f = unsafe_mk (f ())
 
-  let map _ f t =
+  let reraise_encapsulated password exn =
+    reraise (Encapsulated (Password.name password, unsafe_mk exn))
+
+  let reraise_encapsulated_shared password exn =
+    reraise (Encapsulated (Password.Shared.name password, unsafe_mk exn))
+
+  let map pw f t =
     let v = unsafe_get t in
     match f v with
     | res -> unsafe_mk res
-    | exception exn -> reraise (Contended exn)
+    | exception exn -> reraise_encapsulated pw exn
 
   let fst t =
     let t1, _ = unsafe_get t in
@@ -116,49 +160,51 @@ module Data = struct
 
   let both t1 t2 = unsafe_mk (unsafe_get t1, unsafe_get t2)
 
-  let extract _ f t =
+  let extract pw f t =
     let v = unsafe_get t in
     try f v with
-    |  exn -> reraise (Contended exn)
+    |  exn -> reraise_encapsulated pw exn
 
   let inject = unsafe_mk
 
   let project = unsafe_get
 
-  let bind _ f t =
+  let bind pw f t =
     let v = unsafe_get t in
     try f v with
-    | exn -> reraise (Contended exn)
+    | exn -> reraise_encapsulated pw exn
 
-  let iter _ f t =
+  let iter pw f t =
     let v = unsafe_get t in
     try f v with
-    | exn -> reraise (Contended exn)
+    | exn -> reraise_encapsulated pw exn
 
-  let map_shared _ f t =
+  let map_shared pw f t =
     let v = unsafe_get t in
     match f v with
     | res -> unsafe_mk res
-    | exception exn -> reraise (Contended exn)
+    | exception exn -> reraise_encapsulated_shared pw exn
 
-  let extract_shared _ f t =
+  let extract_shared pw f t =
     let v = unsafe_get t in
     try f v with
-    | exn -> reraise (Contended exn)
+    | exn -> reraise_encapsulated_shared pw exn
 
 end
 
-let access (type k) (_ : k Password.t) f =
-  let c : k Access.t = Access.unsafe_mk () in
-  match f c with
-  | res -> res
-  | exception exn -> reraise (Contended exn)
+exception Encapsulated = Data.Encapsulated
 
-let access_shared (type k) (_ : k Password.Shared.t) f =
+let access (type k) (pw : k Password.t) f =
   let c : k Access.t = Access.unsafe_mk () in
   match f c with
   | res -> res
-  | exception exn -> reraise (Contended exn)
+  | exception exn -> Data.reraise_encapsulated pw exn
+
+let access_shared (type k) (pw : k Password.Shared.t) f =
+  let c : k Access.t = Access.unsafe_mk () in
+  match f c with
+  | res -> res
+  | exception exn -> Data.reraise_encapsulated_shared pw exn
 
 (* Like [Stdlib.Mutex], but [portable]. *)
 module M = struct
@@ -182,17 +228,24 @@ module Mutex = struct
   (* Illegal mode crossing: ['k t] has a mutable field [poisoned]. It's safe,
      since [poisoned] protected by [mutex] and not exposed in the API, but
      is not allowed by the type system. *)
-  type 'k t : value mod portable uncontended = { mutex : M.t; mutable poisoned : bool }
+  type 'k t : value mod portable uncontended =
+    { name : 'k Name.t
+    ; mutex : M.t
+    ; mutable poisoned : bool
+    }
 
   (* CR: illegal mode crossing on the current version of the compiler,
      but should be legal. *)
   type packed : value mod portable uncontended = P : 'k t -> packed
 
+  let name t = t.name
+
   exception Poisoned
 
   let with_lock :
-    'k t
-    -> ('k Password.t @ local -> 'a) @ local
+    type k.
+    k t
+    -> (k Password.t @ local -> 'a) @ local
     -> 'a
     @@ portable
     = fun t f ->
@@ -200,12 +253,20 @@ module Mutex = struct
       match t.poisoned with
       | true -> M.unlock t.mutex; reraise Poisoned
       | false ->
-        match f (Password.unsafe_mk ()) with
+        match f (Password.unsafe_mk t.name) with
         | x -> M.unlock t.mutex; x
         | exception exn ->
           t.poisoned <- true;
           (* NOTE: [unlock] does not poll for asynchronous exceptions *)
           M.unlock t.mutex;
+          let exn =
+            match exn with
+            | Encapsulated (name, data) ->
+              (match Name.equality_witness name t.name with
+               | Some Equal -> Data.unsafe_get data
+               | None -> exn)
+            | _ -> exn
+          in
           reraise exn
 
   let destroy t =
@@ -222,15 +283,20 @@ end
 
 module Rwlock = struct
 
-  type 'k t : value mod portable uncontended = { rwlock : Rw.t; mutable poisoned : bool }
+  type 'k t : value mod portable uncontended =
+    { name : 'k Name.t
+    ; rwlock : Rw.t
+    ; mutable poisoned : bool
+    }
 
   type packed : value mod portable uncontended = P : 'k t -> packed
 
   exception Poisoned
 
   let with_write_lock :
-    'k t
-    -> ('k Password.t @ local -> 'a) @ local
+    type k.
+    k t
+    -> (k Password.t @ local -> 'a) @ local
     -> 'a
     @@ portable
     = fun t f ->
@@ -238,11 +304,19 @@ module Rwlock = struct
       match t.poisoned with
       | true -> Rw.unlock t.rwlock; reraise Poisoned
       | false ->
-        match f (Password.unsafe_mk ()) with
+        match f (Password.unsafe_mk t.name) with
         | x -> Rw.unlock t.rwlock; x
         | exception exn ->
           t.poisoned <- true;
           Rw.unlock t.rwlock;
+          let exn =
+            match exn with
+            | Encapsulated (name, data) ->
+              (match Name.equality_witness name t.name with
+               | Some Equal -> Data.unsafe_get data
+               | None -> exn)
+            | _ -> exn
+          in
           reraise exn
 
   let with_read_lock :
@@ -255,7 +329,7 @@ module Rwlock = struct
       match t.poisoned with
       | true -> Rw.unlock t.rwlock; reraise Poisoned
       | false ->
-        match f (Password.Shared.unsafe_mk()) with
+        match f (Password.Shared.unsafe_mk t.name) with
         | x -> Rw.unlock t.rwlock; x
         | exception exn ->
           (* Here we are not poisoning the RwLock, see [capsule.mli] for explanation *)
@@ -276,7 +350,9 @@ module Rwlock = struct
 end
 
 let create_with_mutex () =
-  Mutex.P { mutex = M.create (); poisoned = false }
+  let (P name) = Name.make () in
+  Mutex.P { name; mutex = M.create (); poisoned = false }
 
 let create_with_rwlock () =
-  Rwlock.P { rwlock = Rw.create (); poisoned = false }
+  let (P name) = Name.make () in
+  Rwlock.P { name; rwlock = Rw.create (); poisoned = false }

--- a/otherlibs/stdlib_alpha/capsule.mli
+++ b/otherlibs/stdlib_alpha/capsule.mli
@@ -104,7 +104,7 @@ module Password : sig
      mutex. This guarantees that uncontended access to the capsule is
      only granted to a single domain at once. *)
 
-  val name : 'k t -> 'k Name.t @@ portable
+  val name : 'k t @ local -> 'k Name.t @@ portable
   (** [name t] identifies the capsule that [t] is associated with. *)
 
   (** Shared passwords represent permission to get shared access to a capsule *)
@@ -119,7 +119,7 @@ module Password : sig
         Obtaining a ['k t] requires read acquire the reader-writer lock
         associate with ['k]. *)
 
-    val name : 'k t -> 'k Name.t @@ portable
+    val name : 'k t @ local -> 'k Name.t @@ portable
     (** [name t] identifies the capsule that [t] is associated with. *)
 
   end
@@ -162,7 +162,7 @@ module Mutex : sig
         Unpacking one provides a ['k Mutex.t] together with a fresh
         existential type brand for ['k]. *)
 
-    val name : 'k t -> 'k Name.t @@ portable
+    val name : 'k t @ local -> 'k Name.t @@ portable
     (** [name m] identifies the capsule that [m] is associated with. *)
 
     exception Poisoned

--- a/otherlibs/stdlib_alpha/capsule.mli
+++ b/otherlibs/stdlib_alpha/capsule.mli
@@ -40,6 +40,18 @@
     this interface we will often use ['k] to refer to the capsule associated
     with that brand. *)
 
+(** A [Name.t] is used to enable runtime identification of capsules. *)
+module Name : sig
+
+  type 'k t : value mod global portable many uncontended unique
+  (** A ['k Name.t] represents the identity of a capsule. *)
+
+  val equality_witness : 'k1 t -> 'k2 t -> ('k1, 'k2) Type.eq option @@ portable
+  (** [equality_witness a b] performs a runtime check that the two given names
+      identify the same capsule, returning a witness of the equality if so. *)
+
+end
+
 (** An [Access.t] allows wraping and unwraping [Data.t] values from the current
     capsule. *)
 module Access : sig
@@ -76,11 +88,6 @@ type initial
 (** An [Access.t] for the initial capsule *)
 val initial : initial Access.t
 
-exception Contended of exn @@ contended
-(** If a function accessing the contents of the capsule raises an
-   exception, it is wrapped in [Contended] to avoid leaking access to
-   the data. *)
-
 (** Passwords represent permission to get access to a capsule. *)
 module Password : sig
 
@@ -97,6 +104,9 @@ module Password : sig
      mutex. This guarantees that uncontended access to the capsule is
      only granted to a single domain at once. *)
 
+  val name : 'k t -> 'k Name.t @@ portable
+  (** [name t] identifies the capsule that [t] is associated with. *)
+
   (** Shared passwords represent permission to get shared access to a capsule *)
   module Shared : sig
 
@@ -108,6 +118,9 @@ module Password : sig
 
         Obtaining a ['k t] requires read acquire the reader-writer lock
         associate with ['k]. *)
+
+    val name : 'k t -> 'k Name.t @@ portable
+    (** [name t] identifies the capsule that [t] is associated with. *)
 
   end
 
@@ -148,6 +161,9 @@ module Mutex : sig
     (** [packed] is the type of a mutex for some unknown capsule.
         Unpacking one provides a ['k Mutex.t] together with a fresh
         existential type brand for ['k]. *)
+
+    val name : 'k t -> 'k Name.t @@ portable
+    (** [name m] identifies the capsule that [m] is associated with. *)
 
     exception Poisoned
     (** Mutexes can get marked as poisoned. Any operations on a poisoned mutex
@@ -359,3 +375,9 @@ module Data : sig
         ['a] must cross [portability] *)
 
 end
+
+exception Encapsulated : 'k Name.t * (exn, 'k) Data.t -> exn
+(** If a function accessing the contents of the capsule raises an
+    exception, it is wrapped in [Encapsulated] to avoid leaking access to
+    the data. The [Name.t] can be used to associate the [Data.t] with a
+    particular [Password.t] or [Mutex.t]. *)

--- a/testsuite/tests/capsule-api/data.ml
+++ b/testsuite/tests/capsule-api/data.ml
@@ -81,18 +81,32 @@ exception Leak of int myref
 
 (* An exception raised from [iter] is marked as [contended]: *)
 let () =
-  with_guarded ptr (fun k p ->
+  with_guarded ptr (fun (type k) (k : k Capsule.Password.t) p ->
     match Capsule.Data.iter k (fun r -> reraise (Leak r)) p with
-    | exception Capsule.Contended (Leak r) -> ()
+    | exception Capsule.Encapsulated (name, exn_data) ->
+      (match Capsule.Name.equality_witness name (Capsule.Password.name k) with
+       | Some Equal ->
+         Capsule.Data.iter k (function
+           | Leak r -> ()
+           | _ -> assert false)
+           exn_data
+       | None -> assert false)
     | _ -> assert false)
 ;;
 
 (* An exception raised from [access] is marked as [contended]: *)
 let () =
-  with_guarded ptr (fun k p ->
+  with_guarded ptr (fun (type k) (k : k Capsule.Password.t) (p : _ Capsule.Data.t) ->
     match Capsule.access k
             (fun c -> reraise (Leak (Capsule.Data.unwrap c p))) with
-    | exception Capsule.Contended (Leak r) -> ()
+    | exception Capsule.Encapsulated (name, exn_data) ->
+      (match Capsule.Name.equality_witness name (Capsule.Password.name k) with
+       | Some Equal ->
+         Capsule.Data.iter k (function
+           | Leak r -> ()
+           | _ -> assert false)
+           exn_data
+       | None -> assert false)
     | _ -> assert false)
 ;;
 


### PR DESCRIPTION
In the current capsule api, if an exception crosses a capsule boundary, it gets wrapped in a `Contended` exception wrapper which applies the `contended` modality to the exception. This is used to prevent leaking access to data that is still in the capsule.

Leaking is still possible, however, as in this example:
```
type t = { mutable flag : bool }

exception E of (unit -> unit)

let () =
  let (P m) = create_with_mutex () in
  let ref_data = Data.create (fun () -> { flag = false }) in
  try
    Mutex.with_lock m (fun pw ->
      Data.iter pw (fun t -> raise (E (fun () -> t.flag <- true))) ref_data)
  with
  | E f -> f ()
;;
```

To guard against such examples, we take the approach of wrapping any escaping exceptions in a `Capsule.Encapsulated`, which carries the original `exn` in a `Capsule.Data.t` that corresponds to the capsule the exception originally came from. 

Since the `'k` type parameter of the capsule is made existential by the `exn` type constructor, we introduce the notion of a `Capsule.Name.t` to be able to re-associate the capsule with the mutex that guards it using a runtime check.