### PR TITLE
Revert #11997

### DIFF
--- a/.depend
+++ b/.depend
@@ -2554,7 +2554,6 @@ bytecomp/dll.cmx : \
 bytecomp/dll.cmi :
 bytecomp/emitcode.cmo : \
     lambda/translmod.cmi \
-    bytecomp/symtable.cmi \
     typing/primitive.cmi \
     bytecomp/opcodes.cmi \
     utils/misc.cmi \
@@ -2571,7 +2570,6 @@ bytecomp/emitcode.cmo : \
     bytecomp/emitcode.cmi
 bytecomp/emitcode.cmx : \
     lambda/translmod.cmx \
-    bytecomp/symtable.cmx \
     typing/primitive.cmx \
     bytecomp/opcodes.cmx \
     utils/misc.cmx \
@@ -4615,6 +4613,7 @@ file_formats/cms_format.cmo : \
     typing/shape.cmi \
     parsing/parsetree.cmi \
     utils/misc.cmi \
+    lambda/lambda.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
     parsing/lexer.cmi \
@@ -7733,11 +7732,13 @@ tools/dumpobj.cmo : \
     bytecomp/opcodes.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    lambda/lambda.cmi \
     bytecomp/instruct.cmi \
     typing/ident.cmi \
     utils/config.cmi \
     file_formats/cmo_format.cmi \
     bytecomp/bytesections.cmi \
+    parsing/asttypes.cmi \
     tools/dumpobj.cmi
 tools/dumpobj.cmx : \
     bytecomp/symtable.cmx \
@@ -7745,11 +7746,13 @@ tools/dumpobj.cmx : \
     bytecomp/opcodes.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    lambda/lambda.cmx \
     bytecomp/instruct.cmx \
     typing/ident.cmx \
     utils/config.cmx \
     file_formats/cmo_format.cmi \
     bytecomp/bytesections.cmx \
+    parsing/asttypes.cmi \
     tools/dumpobj.cmi
 tools/dumpobj.cmi :
 tools/eqparsetree.cmo : \

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -150,7 +150,7 @@ let enter info =
   reloc_info := (info, !out_position) :: !reloc_info
 
 let slot_for_literal sc =
-  enter (Reloc_literal (Symtable.transl_const sc));
+  enter (Reloc_literal sc);
   out_int 0
 and slot_for_getglobal cu =
   let reloc_info = Reloc_getcompunit cu in

--- a/file_formats/cmo_format.mli
+++ b/file_formats/cmo_format.mli
@@ -23,7 +23,7 @@ type predef =
 (* Relocation information *)
 
 type reloc_info =
-  | Reloc_literal of Obj.t (* structured constant *)
+  | Reloc_literal of Lambda.structured_constant (* structured constant *)
   | Reloc_getcompunit of Compilation_unit.t (* reference to a compunit *)
   | Reloc_getpredef of predef (* reference to a predef *)
   | Reloc_setcompunit of Compilation_unit.t (* definition of a compunit *)

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -17,6 +17,7 @@
 
 open Config
 open Instruct
+open Lambda
 open Location
 open Opcodes
 open Opnames
@@ -72,6 +73,51 @@ let record_events orig evl =
       relocate_event orig ev;
       Hashtbl.add event_table ev.ev_pos ev)
     evl
+
+(* Print a structured constant *)
+
+let print_float f =
+  if String.contains f '.'
+  then printf "%s" f
+  else printf "%s." f
+
+let rec print_struct_const = function
+    Const_base(Const_int i) -> printf "%d" i
+  | Const_base(Const_float f)
+  | Const_base(Const_unboxed_float f)
+  | Const_base(Const_float32 f)
+  | Const_base(Const_unboxed_float32 f) -> print_float f
+  | Const_base(Const_string (s, _, _)) -> printf "%S" s
+  | Const_immstring s -> printf "%S" s
+  | Const_base(Const_char c) -> printf "%C" c
+  | Const_base(Const_int32 i)
+  | Const_base(Const_unboxed_int32 i) -> printf "%ldl" i
+  | Const_base(Const_nativeint i)
+  | Const_base(Const_unboxed_nativeint i)-> printf "%ndn" i
+  | Const_base(Const_int64 i)
+  | Const_base(Const_unboxed_int64 i) -> printf "%LdL" i
+  | Const_block(tag, args) ->
+      printf "<%d>" tag;
+      begin match args with
+        [] -> ()
+      | [a1] ->
+          printf "("; print_struct_const a1; printf ")"
+      | a1::al ->
+          printf "("; print_struct_const a1;
+          List.iter (fun a -> printf ", "; print_struct_const a) al;
+          printf ")"
+      end
+  | Const_mixed_block _ ->
+    (* CR layouts v5.9: Support constant mixed blocks in bytecode, either by
+        dynamically allocating them once at top-level, or by supporting
+        marshaling into the cmo format for mixed blocks in bytecode.
+    *)
+    Misc.fatal_error "[Const_mixed_block] not supported in bytecode."
+  | Const_float_block a | Const_float_array a ->
+      printf "[|";
+      List.iter (fun f -> print_float f; printf "; ") a;
+      printf "|]"
+  | Const_null -> printf "<null>"
 
 (* Print an obj *)
 
@@ -135,11 +181,6 @@ let find_reloc ic =
 let print_unexpected_reloc reloc_constr reloc_arg =
   printf "<unexpected (%s '%s') reloc>" reloc_constr reloc_arg
 
-let print_unexpected_reloc_literal sc =
-  printf "<unexpected (Reloc_literal ";
-  print_obj sc;
-  printf ") reloc>"
-
 let print_getglobal_name ic =
   if !objfile then begin
     begin try
@@ -147,7 +188,7 @@ let print_getglobal_name ic =
         | Reloc_getcompunit cu ->
           print_string (Compilation_unit.full_path_as_string cu)
         | Reloc_getpredef (Predef_exn predef_exn) -> print_string predef_exn
-        | Reloc_literal sc -> print_obj sc
+        | Reloc_literal sc -> print_struct_const sc
         | Reloc_setcompunit cu ->
           print_unexpected_reloc "Reloc_setcompunit"
             (Compilation_unit.full_path_as_string cu)
@@ -174,8 +215,7 @@ let print_setglobal_name ic =
       match find_reloc ic with
       | Reloc_setcompunit cu ->
         print_string (Compilation_unit.full_path_as_string cu)
-      | Reloc_literal sc ->
-        print_unexpected_reloc_literal sc
+      | Reloc_literal sc -> print_struct_const sc
       | Reloc_getcompunit cu ->
         print_unexpected_reloc "Reloc_getcompunit"
           (Compilation_unit.full_path_as_string cu)
@@ -204,8 +244,7 @@ let print_primitive ic =
     begin try
       match find_reloc ic with
         Reloc_primitive s -> print_string s
-      | Reloc_literal sc ->
-        print_unexpected_reloc_literal sc
+      | Reloc_literal sc -> print_struct_const sc
       | Reloc_getcompunit cu ->
         print_unexpected_reloc "Reloc_getcompunit"
           (Compilation_unit.full_path_as_string cu)
@@ -486,7 +525,7 @@ let print_code ic len =
 let print_reloc (info, pos) =
   printf "    %d    (%d)    " pos (pos/4);
   match info with
-  | Reloc_literal sc -> print_obj sc; printf "\n"
+  | Reloc_literal sc -> print_struct_const sc; printf "\n"
   | Reloc_getcompunit cu ->
     printf "require        %s\n"
       (Compilation_unit.full_path_as_string cu)


### PR DESCRIPTION
Revert https://github.com/ocaml/ocaml/pull/11997, and translate structured constants into their representation at link time instead of compile time. This avoids a problem with the new structured constants introduced by JS extensions in bytecode, where previously they were marshaled with the upstream runtime.

Tested by existing tests + the rest of `or_null` PRs.