### PR TITLE
Fix CFG selection handling of polling

### DIFF
--- a/.github/workflows/selection.yml
+++ b/.github/workflows/selection.yml
@@ -1,0 +1,35 @@
+name: Selection changes reminder
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'backend/selectgen.ml'
+      - 'backend/arm64/selection.ml'
+      - 'backend/amd64/selection.ml'
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Create PR Comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO=${{ github.repository }}
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          COMMENT="## Selection Change Check
+
+          This PR modifies the original selection pass (targeting Mach).
+          Please check whether the changes should also be applied to the
+          CFG variant of the pass."
+
+           # Check if comment already exists
+          if ! gh pr view $PR_NUMBER --json comments -q '.comments[].body' --repo $REPO | grep -q "Parser Change Checklist"; then
+            gh pr comment $PR_NUMBER --body "$COMMENT" --repo $REPO
+            echo "Comment added successfully."
+          else
+            echo "Comment already exists. Skipping."
+          fi

--- a/.github/workflows/selection.yml
+++ b/.github/workflows/selection.yml
@@ -27,7 +27,7 @@ jobs:
           CFG variant of the pass."
 
            # Check if comment already exists
-          if ! gh pr view $PR_NUMBER --json comments -q '.comments[].body' --repo $REPO | grep -q "Parser Change Checklist"; then
+          if ! gh pr view $PR_NUMBER --json comments -q '.comments[].body' --repo $REPO | grep -q "Selection Change Check"; then
             gh pr comment $PR_NUMBER --body "$COMMENT" --repo $REPO
             echo "Comment added successfully."
           else

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -293,7 +293,7 @@ class virtual selector_generic =
       | Cprobe_is_enabled { name } -> basic_op (Probe_is_enabled { name }), []
       | Cbeginregion -> basic_op Begin_region, []
       | Cendregion -> basic_op End_region, args
-      | Cpackf32 | Copaque | Cpoll | Cbswap _ | Cprefetch _ | Craise _
+      | Cpackf32 | Copaque | Cbswap _ | Cprefetch _ | Craise _
       | Ctuple_field (_, _) ->
         Misc.fatal_error "Selection.select_oper"
 

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -224,6 +224,7 @@ class virtual selector_generic =
         (* Inversion addr/datum in Istore *))
       | Cdls_get -> basic_op Dls_get, args
       | Calloc mode -> basic_op (Alloc { bytes = 0; dbginfo = []; mode }), args
+      | Cpoll -> basic_op Poll, args
       | Caddi -> self#select_arith_comm Simple_operation.Iadd args
       | Csubi -> self#select_arith Simple_operation.Isub args
       | Cmuli -> self#select_arith_comm Simple_operation.Imul args


### PR DESCRIPTION
This pull request adds a missing case
to handle the `Cpoll` constructor in
the selection pass. The bug was that
the CFG pipeline was not in sync with
the original pipeline.

In an attempt to try to not see that kind
of issues again, the pull request is
also adding a CI check akin to the
parse tree one, so that if a contributor
changes the original selection pipeline,
they are reminded to do the same for
the CFG one.