### PR TITLE
Fix mistake in upstream PR12735 backport and add test case

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4337,7 +4337,7 @@ let dls_get ~dbg = Cop (Cdls_get, [], dbg)
 let perform ~dbg eff =
   let cont =
     make_alloc dbg ~tag:Runtimetags.cont_tag
-      [int_const dbg 0]
+      [int_const dbg 0; int_const dbg 0]
       ~mode:Cmm.Alloc_mode.Heap
   in
   (* Rc_normal means "allow tailcalls". Preventing them here by using Rc_nontail

--- a/testsuite/tests/effects/pr3362.ml
+++ b/testsuite/tests/effects/pr3362.ml
@@ -1,0 +1,25 @@
+(* TEST
+   skip;
+   reason = "CR ocaml 5 effects: re-enable this test";
+   runtime5;
+   { bytecode; }
+   { native; }
+*)
+
+open Effect
+open Effect.Deep
+
+type _ t += F : string t
+
+let handle comp =
+  Gc.compact ();
+  try_with comp ()
+    { effc = fun (type a) (e : a t) ->
+      Gc.compact ();
+      match e with
+      | F -> Some (fun (k : (a,_) continuation) ->
+        Gc.compact (); continue k "Hello, world!")
+      | _ -> None }
+
+let () = handle (fun () ->
+  Gc.compact (); print_endline (perform F ^ (" " ^ perform F)))

--- a/testsuite/tests/effects/pr3362.reference
+++ b/testsuite/tests/effects/pr3362.reference
@@ -1,0 +1,1 @@
+Hello, world! Hello, world!


### PR DESCRIPTION
The test case isn't currently enabled (will add this to #2215), but it will now pass.