### PR TITLE
Unboxed product exhaustiveness

### DIFF
--- a/testsuite/tests/typing-layouts-products/exhaustiveness.ml
+++ b/testsuite/tests/typing-layouts-products/exhaustiveness.ml
@@ -1,0 +1,26 @@
+(* TEST
+   flags = "-w +8";
+   expect;
+*)
+
+(* This is a regression test. The example below used to give an exhaustiveness
+   warning because we forgot a case in [Parmatch.simple_match]. *)
+
+type t = A | B
+
+let f t t' =
+  match #(t,t') with
+  | #(A, _) -> true
+  | #(B, _) -> false
+[%%expect{|
+type t = A | B
+Lines 4-6, characters 2-20:
+4 | ..match #(t,t') with
+5 |   | #(A, _) -> true
+6 |   | #(B, _) -> false
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+#(B, _)
+
+val f : t -> 'a -> bool = <fun>
+|}]

--- a/testsuite/tests/typing-layouts-products/exhaustiveness.ml
+++ b/testsuite/tests/typing-layouts-products/exhaustiveness.ml
@@ -14,13 +14,5 @@ let f t t' =
   | #(B, _) -> false
 [%%expect{|
 type t = A | B
-Lines 4-6, characters 2-20:
-4 | ..match #(t,t') with
-5 |   | #(A, _) -> true
-6 |   | #(B, _) -> false
-Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-#(B, _)
-
 val f : t -> 'a -> bool = <fun>
 |}]

--- a/testsuite/tests/typing-layouts-unboxed-records/exhaustiveness.ml
+++ b/testsuite/tests/typing-layouts-unboxed-records/exhaustiveness.ml
@@ -18,3 +18,23 @@ type t = A | B
 type r = #{ x : t; y : t; }
 val f : t -> t -> bool = <fun>
 |}]
+
+(* CR layouts v7.2: The below error is not as good as it could be. The example
+   case is #{y=A; _ }, but should be #{y=A; x=B}. Normal boxed records get the
+   nicer pattern. See the corresponding CR in [Parmatch.discr_pat].
+*)
+let g t t' =
+  match #{ x = t; y = t' } with
+  | #{ x = A; _ } -> true
+  | #{ y = B; _ } -> false
+[%%expect{|
+Lines 2-4, characters 2-26:
+2 | ..match #{ x = t; y = t' } with
+3 |   | #{ x = A; _ } -> true
+4 |   | #{ y = B; _ } -> false
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+#{y=A; _ }
+
+val g : t -> t -> bool = <fun>
+|}]

--- a/testsuite/tests/typing-layouts-unboxed-records/exhaustiveness.ml
+++ b/testsuite/tests/typing-layouts-unboxed-records/exhaustiveness.ml
@@ -16,13 +16,5 @@ let f t t' =
 [%%expect{|
 type t = A | B
 type r = #{ x : t; y : t; }
-Lines 5-7, characters 2-30:
-5 | ..match #{ x = t; y = t' } with
-6 |   | #{ x = A; y = _ } -> true
-7 |   | #{ x = B; y = _ } -> false
-Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-#{x=B; _ }
-
 val f : t -> t -> bool = <fun>
 |}]

--- a/testsuite/tests/typing-layouts-unboxed-records/exhaustiveness.ml
+++ b/testsuite/tests/typing-layouts-unboxed-records/exhaustiveness.ml
@@ -1,0 +1,28 @@
+(* TEST
+   flags = "-w +8 -extension layouts_beta";
+   expect;
+*)
+
+(* This is a regression test. The example below used to give an exhaustiveness
+   warning because we forgot a case in [Parmatch.simple_match]. *)
+
+type t = A | B
+type r = #{ x : t; y : t }
+
+let f t t' =
+  match #{ x = t; y = t' } with
+  | #{ x = A; y = _ } -> true
+  | #{ x = B; y = _ } -> false
+[%%expect{|
+type t = A | B
+type r = #{ x : t; y : t; }
+Lines 5-7, characters 2-30:
+5 | ..match #{ x = t; y = t' } with
+6 |   | #{ x = A; y = _ } -> true
+7 |   | #{ x = B; y = _ } -> false
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+#{x=B; _ }
+
+val f : t -> t -> bool = <fun>
+|}]

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -177,9 +177,11 @@ let all_coherent column =
           | Const_unboxed_float32 _
           | Const_string _), _ -> false
       end
-    | Tuple l1, Tuple l2 -> l1 = l2
+    | Tuple l1, Tuple l2 ->
+      List.equal (Option.equal String.equal) l1 l2
     | Unboxed_tuple l1, Unboxed_tuple l2 ->
-      List.equal (fun (lbl1, _) (lbl2, _) -> lbl1 = lbl2) l1 l2
+      List.equal
+        (fun (lbl1, _) (lbl2, _) -> Option.equal String.equal lbl1 lbl2) l1 l2
     | Record (lbl1 :: _), Record (lbl2 :: _) ->
       Array.length lbl1.lbl_all = Array.length lbl2.lbl_all
     | Record_unboxed_product (lbl1 :: _), Record_unboxed_product (lbl2 :: _) ->
@@ -432,7 +434,8 @@ let simple_match d h =
   | Lazy, Lazy -> true
   | Record _, Record _ -> true
   | Record_unboxed_product _, Record_unboxed_product _ -> true
-  | Tuple len1, Tuple len2 -> len1 = len2
+  | Tuple lbls1, Tuple lbls2 ->
+    List.equal (Option.equal String.equal) lbls1 lbls2
   | Unboxed_tuple lbls1, Unboxed_tuple lbls2 ->
     List.equal (fun (l1, _) (l2, _) -> Option.equal String.equal l1 l2)
       lbls1 lbls2

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -532,7 +532,7 @@ let discr_pat q pss =
     | ((head, _), _) :: rows ->
       match head.pat_desc with
       | Any -> refine_pat acc rows
-      | Tuple _ | Lazy -> head
+      | Tuple _ | Unboxed_tuple _ | Lazy -> head
       | Record lbls ->
         (* N.B. we could make this case "simpler" by refining the record case
            using [all_record_args].
@@ -550,7 +550,12 @@ let discr_pat q pss =
         in
         let d = { head with pat_desc = Record fields } in
         refine_pat d rows
-      | _ -> acc
+      | Construct _ | Constant _ | Record_unboxed_product _ | Variant _
+      | Array _ -> acc
+      (* CR layouts v7.2: the Record_unboxed_product case should get behavior
+         similar to the [Record] case above, but it's not completely trivial
+         due. See [typing-layouts-unboxed-records/exhaustiveness.ml] for an
+         example where this causes us to give a marginally worse warning. *)
   in
   let q, _ = deconstruct q in
   match q.pat_desc with

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -431,10 +431,16 @@ let simple_match d h =
   | Constant c1, Constant c2 -> const_compare c1 c2 = 0
   | Lazy, Lazy -> true
   | Record _, Record _ -> true
+  | Record_unboxed_product _, Record_unboxed_product _ -> true
   | Tuple len1, Tuple len2 -> len1 = len2
+  | Unboxed_tuple lbls1, Unboxed_tuple lbls2 ->
+    List.equal (fun (l1, _) (l2, _) -> Option.equal String.equal l1 l2)
+      lbls1 lbls2
   | Array (am1, _, len1), Array (am2, _, len2) -> am1 = am2 && len1 = len2
   | _, Any -> true
-  | _, _ -> false
+  | ( Construct _ | Variant _ | Constant _ | Lazy | Record _
+    | Record_unboxed_product _ | Tuple _ | Unboxed_tuple _ | Array _ | Any),
+    _ -> false
 
 
 


### PR DESCRIPTION
Exhaustiveness checking for unboxed product patterns is currently busted (the analysis thinks they are not exhaustive even when they are).

This PR fixes that, in three steps:
- The first commit adds tuple and record tests showing the issue.
- The second commit fixes the issue.
- The third commit improves another pattern matching function where I noticed we had missed similar cases. The function (`Parmatch.discr_pat`) is used for generating the counterexample in exhaustiveness warnings, and this commit adds a test showing it's still suboptimal in the unboxed records case, to be improved in a future PR.

Review: @rtjoa could you take a look at this?  Hopefully it's clear enough from the surrounding code, but if you want a reference for the complete exhaustiveness algorithm it's [here](http://moscova.inria.fr/~maranget/papers/warn/warn.pdf).