### PR TITLE
Update documentation of Stdlib.Gc.control for OCaml 5

### DIFF
--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -132,9 +132,13 @@ CAMLprim value caml_gc_get(value v)
 
   res = caml_alloc_tuple (11);
   Store_field (res, 0, Val_long (Caml_state->minor_heap_wsz));          /* s */
+  Store_field (res, 1, Val_long (0));
   Store_field (res, 2, Val_long (caml_percent_free));                   /* o */
   Store_field (res, 3, Val_long (atomic_load_relaxed(&caml_verb_gc)));  /* v */
+  Store_field (res, 4, Val_long (0));
   Store_field (res, 5, Val_long (caml_max_stack_wsize));                /* l */
+  Store_field (res, 6, Val_long (0));
+  Store_field (res, 7, Val_long (0));
   Store_field (res, 8, Val_long (caml_custom_major_ratio));             /* M */
   Store_field (res, 9, Val_long (caml_custom_minor_ratio));             /* m */
   Store_field (res, 10, Val_long (caml_custom_minor_max_bsz));          /* n */

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -45,7 +45,7 @@ type stat =
 
     heap_chunks : int;
     (** Number of contiguous pieces of memory that make up the major heap.
-        This metrics is currently not available in OCaml 5: the field value is
+        This metric is currently not available in OCaml 5: the field value is
         always [0]. *)
 
     live_words : int;
@@ -74,12 +74,12 @@ type stat =
 
     free_blocks : int;
     (** Number of blocks in the free list.
-        This metrics is currently not available in OCaml 5: the field value is
+        This metric is currently not available in OCaml 5: the field value is
         always [0]. *)
 
     largest_free : int;
     (** Size (in words) of the largest block in the free list.
-        This metrics is currently not available in OCaml 5: the field value
+        This metric is currently not available in OCaml 5: the field value
         is always [0]. *)
 
     fragments : int;
@@ -95,7 +95,7 @@ type stat =
 
     stack_size: int;
     (** Current size of the stack, in words.
-        This metrics is currently not available in OCaml 5: the field value is
+        This metric is currently not available in OCaml 5: the field value is
         always [0].
         @since 3.12 *)
 
@@ -127,7 +127,9 @@ type control =
         number is less than or equal to 1000, it is a percentage of
         the current heap size (i.e. setting it to 100 will double the heap
         size at each increase). If it is more than 1000, it is a fixed
-        number of words that will be added to the heap. Default: 15. *)
+        number of words that will be added to the heap. Default: 15.
+        This metric is currently not available in OCaml 5: the field value is
+        always [0]. *)
 
     space_overhead : int;
     (** The major GC speed is computed from this parameter.
@@ -164,7 +166,9 @@ type control =
        If [max_overhead >= 1000000], compaction is never triggered.
        On runtime4, if compaction is permanently disabled, it is strongly
        suggested to set [allocation_policy] to 2.
-       Default: 500. *)
+       Default: 500.
+       This metric is currently not available in OCaml 5: the field value is
+       always [0]. *)
 
     stack_limit : int;
     (** The maximum size of the fiber stacks (in words).
@@ -217,6 +221,9 @@ type control =
 
         Default: 2.
 
+        This metric is currently not available in OCaml 5: the field value is
+        always [0].
+
         ----------------------------------------------------------------
 
         @since 3.11 *)
@@ -226,6 +233,8 @@ type control =
         out variations in its workload. This is an integer between
         1 and 50.
         Default: 1.
+        This metric is currently not available in OCaml 5: the field value is
+        always [0].
         @since 4.03 *)
 
     custom_major_ratio : int;


### PR DESCRIPTION
Some fields are always set to 0 in runtime 5. Update the documentation to specify this. (We already do this for `Gc.stat`.)