### PR TITLE
Reset domain lock in caml_thread_reinitialize

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -572,10 +572,9 @@ static void caml_thread_reinitialize(void)
   Active_thread->next = Active_thread;
   Active_thread->prev = Active_thread;
 
-  // CR ocaml 5 domains: systhreads doesn't maintain domain lock
   /* Within the child, the domain_lock needs to be reset and acquired. */
-  // caml_reset_domain_lock();
-  // caml_acquire_domain_lock();
+  caml_reset_domain_lock();
+  caml_acquire_domain_lock();
 
   /* The lock needs to be initialized again. This process will also be
      the effective owner of the lock. So there is no need to run


### PR DESCRIPTION
Systhreads overrides `caml_atfork_hook` with `caml_thread_reinitialize`, so it also needs to reinitialize the domain lock. This is necessary to release the master lock in the child after forking. Resolves the CR regarding this.