### PR TITLE
Add Capsule.Condition

### DIFF
--- a/otherlibs/stdlib_alpha/capsule.ml
+++ b/otherlibs/stdlib_alpha/capsule.ml
@@ -349,6 +349,21 @@ module Rwlock = struct
 
 end
 
+module Condition = struct
+
+  type 'k t : value mod portable uncontended
+
+  external create : unit -> 'k t @@ portable = "caml_ml_condition_new"
+  external wait : 'k t -> M.t -> unit @@ portable = "caml_ml_condition_wait"
+  external signal : 'k t -> unit @@ portable = "caml_ml_condition_signal"
+  external broadcast : 'k t -> unit @@ portable = "caml_ml_condition_broadcast"
+
+  let wait t (mut : 'k Mutex.t) _password =
+    (* [mut] is locked, so we know it is not poisoned. *)
+    wait t mut.mutex
+
+end
+
 let create_with_mutex () =
   let (P name) = Name.make () in
   Mutex.P { name; mutex = M.create (); poisoned = false }


### PR DESCRIPTION
Adds condition variables to the capsule API, which are already used in `tdelvecchio-portable-stdlib-5.2.0minus-4`. They have the same implementation as `Stdlib.Condition`, but work with `Capsule.Mutex`.