### PR TITLE
Portable Effects

### DIFF
--- a/stdlib/dune
+++ b/stdlib/dune
@@ -20,6 +20,8 @@
   (modules_before_stdlib camlinternalFormatBasics camlinternalAtomic))
  (flags
   (:standard
+   -extension-universe
+   alpha
    -strict-sequence
    -g
    -absname

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -48,9 +48,6 @@ external resume :
 
 external runstack : ('a, 'b) stack -> ('c -> 'a) -> 'c -> 'b @@ portable = "%runstack"
 
-external runstack_contended :
-  ('a, 'b) stack -> ('c @ contended -> 'a) -> 'c @ contended -> 'b @@ portable = "%runstack"
-
 module Deep = struct
 
   type ('a,'b) continuation : value mod uncontended
@@ -120,7 +117,7 @@ module Deep = struct
       | None -> reperform_portable eff k last_fiber
     in
     let s = alloc_stack_portable handler.retc handler.exnc effc in
-    runstack_contended s comp arg
+    runstack s comp arg
 
   type 'a effect_handler =
     { effc: 'b. 'b t -> (('b,'a) continuation -> 'a) option }
@@ -149,7 +146,7 @@ module Deep = struct
       | None -> reperform_portable eff k last_fiber
     in
     let s = alloc_stack_portable (fun x -> x) (fun e -> raise e) effc' in
-    runstack_contended s comp arg
+    runstack s comp arg
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace @@ portable =
@@ -248,7 +245,7 @@ module Shallow = struct
       | _ -> error ()
     in
     let s = alloc_stack_portable error error effc in
-    match runstack_contended s f' () with
+    match runstack s f' () with
     | exception E k -> k
     | _ -> error ()
 

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -12,6 +12,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
+external raise : exn -> 'a @ portable @@ portable = "%reraise"
+external raise_notrace : exn -> 'a @ portable @@ portable = "%raise_notrace"
+external raise_with_backtrace: exn -> Printexc.raw_backtrace -> 'a @ portable @@ portable = "%raise_with_backtrace"
+
 type 'a t = ..
 external perform : 'a t -> 'a @@ portable = "%perform"
 
@@ -77,7 +81,7 @@ module Deep = struct
     resume (take_cont_noexc k) (fun e -> raise e) e (cont_last_fiber k)
 
   let[@inline never] discontinue_with_backtrace k e bt =
-    resume (take_cont_noexc k) (fun e -> Printexc.raise_with_backtrace e bt)
+    resume (take_cont_noexc k) (fun e -> raise_with_backtrace e bt)
       e (cont_last_fiber k)
 
   external reperform :
@@ -176,8 +180,6 @@ module Shallow = struct
   external cont_set_last_fiber_contended :
     ('a, 'b) continuation @ contended -> last_fiber -> unit @@ portable = "%setfield1"
 
-  external raise : exn -> 'a @ portable @@ portable = "%reraise"
-
   let failwith msg = raise (Failure msg)
 
   let[@inline never] fiber : type a b. (a -> b) -> (a, b) continuation @@ portable = fun f ->
@@ -231,7 +233,7 @@ module Shallow = struct
     continue_gen k (fun e -> raise e) v handler
 
   let discontinue_with_backtrace k v bt handler =
-    continue_gen k (fun e -> Printexc.raise_with_backtrace e bt) v handler
+    continue_gen k (fun e -> raise_with_backtrace e bt) v handler
 
   let[@inline never] fiber_portable : type a b. (a -> b) @ portable -> (a, b) continuation @ portable @@ portable = fun f ->
     let module M = struct type _ t += Initial_setup__ : a t end in
@@ -284,7 +286,7 @@ module Shallow = struct
     continue_gen_portable k (fun e -> raise e) v handler
 
   let discontinue_with_backtrace_portable k v bt handler =
-    continue_gen_portable k (fun e -> Printexc.raise_with_backtrace e bt) v handler
+    continue_gen_portable k (fun e -> raise_with_backtrace e bt) v handler
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace @@ portable =

--- a/stdlib/effect.mli
+++ b/stdlib/effect.mli
@@ -33,7 +33,7 @@ exception Continuation_already_resumed
 (** Exception raised when a continuation is continued or discontinued more
     than once. *)
 
-external perform : 'a t -> 'a = "%perform"
+external perform : 'a t -> 'a @@ portable = "%perform"
 (** [perform e] performs an effect [e].
 
     @raise Unhandled if there is no handler for [e]. *)
@@ -41,17 +41,17 @@ external perform : 'a t -> 'a = "%perform"
 module Deep : sig
   (** Deep handlers *)
 
-  type ('a,'b) continuation
+  type ('a,'b) continuation : value mod uncontended
   (** [('a,'b) continuation] is a delimited continuation that expects a ['a]
       value and returns a ['b] value. *)
 
-  val continue: ('a, 'b) continuation -> 'a -> 'b
+  val continue: ('a, 'b) continuation -> 'a -> 'b @@ portable
   (** [continue k x] resumes the continuation [k] by passing [x] to [k].
 
       @raise Continuation_already_resumed if the continuation has already been
       resumed. *)
 
-  val discontinue: ('a, 'b) continuation -> exn -> 'b
+  val discontinue: ('a, 'b) continuation -> exn -> 'b @@ portable
   (** [discontinue k e] resumes the continuation [k] by raising the
       exception [e] in [k].
 
@@ -59,7 +59,7 @@ module Deep : sig
       resumed. *)
 
   val discontinue_with_backtrace:
-    ('a, 'b) continuation -> exn -> Printexc.raw_backtrace -> 'b
+    ('a, 'b) continuation -> exn -> Printexc.raw_backtrace -> 'b @@ portable
   (** [discontinue_with_backtrace k e bt] resumes the continuation [k] by
       raising the exception [e] in [k] using [bt] as the origin for the
       exception.
@@ -75,8 +75,15 @@ module Deep : sig
       is the value handler, [exnc] handles exceptions, and [effc] handles the
       effects performed by the computation enclosed by the handler. *)
 
-  val match_with: ('c -> 'a) -> 'c -> ('a,'b) handler -> 'b
+  val match_with: ('c -> 'a) -> 'c -> ('a,'b) handler -> 'b @@ portable
   (** [match_with f v h] runs the computation [f v] in the handler [h]. *)
+
+  type ('a,'b) handler_portable =
+    { retc: 'a -> 'b;
+      exnc: exn -> 'b;
+      effc: 'c.'c t @ contended -> (('c,'b) continuation @ portable -> 'b) option }
+
+  val match_with_portable: ('c @ contended -> 'a) @ portable -> 'c @ contended -> ('a,'b) handler_portable @ portable -> 'b @@ portable
 
   type 'a effect_handler =
     { effc: 'b. 'b t -> (('b, 'a) continuation -> 'a) option }
@@ -84,11 +91,16 @@ module Deep : sig
       [fun x -> x] and an exception handler that raises any exception
       [fun e -> raise e]. *)
 
-  val try_with: ('b -> 'a) -> 'b -> 'a effect_handler -> 'a
+  val try_with: ('b -> 'a) -> 'b -> 'a effect_handler -> 'a @@ portable
   (** [try_with f v h] runs the computation [f v] under the handler [h]. *)
 
+  type 'a effect_handler_portable =
+    { effc: 'b. 'b t @ contended -> (('b, 'a) continuation @ portable -> 'a) option }
+
+  val try_with_portable: ('c @ contended -> 'a) @ portable -> 'c @ contended -> 'a effect_handler_portable @ portable -> 'a @@ portable
+
   external get_callstack :
-    ('a,'b) continuation -> int -> Printexc.raw_backtrace =
+    ('a,'b) continuation -> int -> Printexc.raw_backtrace @@ portable =
     "caml_get_continuation_callstack"
   (** [get_callstack c n] returns a description of the top of the call stack on
       the continuation [c], with at most [n] entries. *)
@@ -101,7 +113,7 @@ module Shallow : sig
   (** [('a,'b) continuation] is a delimited continuation that expects a ['a]
       value and returns a ['b] value. *)
 
-  val fiber : ('a -> 'b) -> ('a, 'b) continuation
+  val fiber : ('a -> 'b) -> ('a, 'b) continuation @@ portable
   (** [fiber f] constructs a continuation that runs the computation [f]. *)
 
   type ('a,'b) handler =
@@ -112,7 +124,7 @@ module Shallow : sig
       is the value handler, [exnc] handles exceptions, and [effc] handles the
       effects performed by the computation enclosed by the handler. *)
 
-  val continue_with : ('c,'a) continuation -> 'c -> ('a,'b) handler -> 'b
+  val continue_with : ('c,'a) continuation -> 'c -> ('a,'b) handler -> 'b @@ portable
   (** [continue_with k v h] resumes the continuation [k] with value [v] with
       the handler [h].
 
@@ -120,7 +132,7 @@ module Shallow : sig
       resumed.
    *)
 
-  val discontinue_with : ('c,'a) continuation -> exn -> ('a,'b) handler -> 'b
+  val discontinue_with : ('c,'a) continuation -> exn -> ('a,'b) handler -> 'b @@ portable
   (** [discontinue_with k e h] resumes the continuation [k] by raising the
       exception [e] with the handler [h].
 
@@ -130,7 +142,7 @@ module Shallow : sig
 
   val discontinue_with_backtrace :
     ('a,'b) continuation -> exn -> Printexc.raw_backtrace ->
-    ('b,'c) handler -> 'c
+    ('b,'c) handler -> 'c @@ portable
   (** [discontinue_with k e bt h] resumes the continuation [k] by raising the
       exception [e] with the handler [h] using the raw backtrace [bt] as the
       origin of the exception.
@@ -139,8 +151,46 @@ module Shallow : sig
       resumed.
    *)
 
+   val fiber_portable : ('a -> 'b) @ portable -> ('a, 'b) continuation @ portable @@ portable
+   (** [fiber_portable f] constructs a continuation that runs the computation [f]. *)
+
+  type ('a,'b) handler_portable =
+    { retc: 'a -> 'b;
+      exnc: exn -> 'b;
+      effc: 'c.'c t @ contended -> (('c,'a) continuation @ portable -> 'b) option }
+  (** [('a,'b) handler] is a handler record with three fields -- [retc]
+      is the value handler, [exnc] handles exceptions, and [effc] handles the
+      effects performed by the computation enclosed by the handler. *)
+
+  val continue_with_portable : ('c,'a) continuation @ portable contended -> 'c -> ('a,'b) handler_portable @ portable -> 'b @@ portable
+  (** [continue_with_portable k v h] resumes the continuation [k] with value [v] with
+      the handler [h].
+
+      @raise Continuation_already_resumed if the continuation has already been
+      resumed.
+   *)
+
+  val discontinue_with_portable : ('c,'a) continuation @ portable contended -> exn -> ('a,'b) handler_portable @ portable -> 'b @@ portable
+  (** [discontinue_with_portable k e h] resumes the continuation [k] by raising the
+      exception [e] with the handler [h].
+
+      @raise Continuation_already_resumed if the continuation has already been
+      resumed.
+   *)
+
+  val discontinue_with_backtrace_portable :
+    ('a,'b) continuation @ portable contended -> exn -> Printexc.raw_backtrace ->
+    ('b,'c) handler_portable @ portable -> 'c @@ portable
+  (** [discontinue_with_portable k e bt h] resumes the continuation [k] by raising the
+      exception [e] with the handler [h] using the raw backtrace [bt] as the
+      origin of the exception.
+
+      @raise Continuation_already_resumed if the continuation has already been
+      resumed.
+   *)
+
   external get_callstack :
-    ('a,'b) continuation -> int -> Printexc.raw_backtrace =
+    ('a,'b) continuation -> int -> Printexc.raw_backtrace @@ portable =
     "caml_get_continuation_callstack"
   (** [get_callstack c n] returns a description of the top of the call stack on
       the continuation [c], with at most [n] entries. *)

--- a/stdlib/effect.mli
+++ b/stdlib/effect.mli
@@ -109,7 +109,7 @@ end
 module Shallow : sig
   (* Shallow handlers *)
 
-  type ('a,'b) continuation
+  type ('a,'b) continuation : value mod uncontended
   (** [('a,'b) continuation] is a delimited continuation that expects a ['a]
       value and returns a ['b] value. *)
 
@@ -162,7 +162,7 @@ module Shallow : sig
       is the value handler, [exnc] handles exceptions, and [effc] handles the
       effects performed by the computation enclosed by the handler. *)
 
-  val continue_with_portable : ('c,'a) continuation @ portable contended -> 'c -> ('a,'b) handler_portable @ portable -> 'b @@ portable
+  val continue_with_portable : ('c,'a) continuation @ portable -> 'c -> ('a,'b) handler_portable @ portable -> 'b @@ portable
   (** [continue_with_portable k v h] resumes the continuation [k] with value [v] with
       the handler [h].
 
@@ -170,7 +170,7 @@ module Shallow : sig
       resumed.
    *)
 
-  val discontinue_with_portable : ('c,'a) continuation @ portable contended -> exn -> ('a,'b) handler_portable @ portable -> 'b @@ portable
+  val discontinue_with_portable : ('c,'a) continuation @ portable -> exn -> ('a,'b) handler_portable @ portable -> 'b @@ portable
   (** [discontinue_with_portable k e h] resumes the continuation [k] by raising the
       exception [e] with the handler [h].
 
@@ -179,7 +179,7 @@ module Shallow : sig
    *)
 
   val discontinue_with_backtrace_portable :
-    ('a,'b) continuation @ portable contended -> exn -> Printexc.raw_backtrace ->
+    ('a,'b) continuation @ portable -> exn -> Printexc.raw_backtrace ->
     ('b,'c) handler_portable @ portable -> 'c @@ portable
   (** [discontinue_with_portable k e bt h] resumes the continuation [k] by raising the
       exception [e] with the handler [h] using the raw backtrace [bt] as the

--- a/stdlib/effect.mli
+++ b/stdlib/effect.mli
@@ -83,7 +83,7 @@ module Deep : sig
       exnc: exn -> 'b;
       effc: 'c.'c t @ contended -> (('c,'b) continuation @ portable -> 'b) option }
 
-  val match_with_portable: ('c @ contended -> 'a) @ portable -> 'c @ contended -> ('a,'b) handler_portable @ portable -> 'b @@ portable
+  val match_with_portable: ('c -> 'a) @ portable -> 'c -> ('a,'b) handler_portable @ portable -> 'b @@ portable
 
   type 'a effect_handler =
     { effc: 'b. 'b t -> (('b, 'a) continuation -> 'a) option }
@@ -97,7 +97,7 @@ module Deep : sig
   type 'a effect_handler_portable =
     { effc: 'b. 'b t @ contended -> (('b, 'a) continuation @ portable -> 'a) option }
 
-  val try_with_portable: ('c @ contended -> 'a) @ portable -> 'c @ contended -> 'a effect_handler_portable @ portable -> 'a @@ portable
+  val try_with_portable: ('c -> 'a) @ portable -> 'c -> 'a effect_handler_portable @ portable -> 'a @@ portable
 
   external get_callstack :
     ('a,'b) continuation -> int -> Printexc.raw_backtrace @@ portable =


### PR DESCRIPTION
Adds a mirror effect API that lets you work with portable continuations created from portable functions. 
Refer to the portable effects doc for discussion of why this is safe.

Draft since this relies on enabling alpha mode extensions. It will also likely be subsumed by @lpw25's new effect API, but we might need this version for the initial rollout.

Note that safely enabling portable effects will also require adding `unyielding` to the DLS/Capsule APIs.