### PR TITLE
Promote `val_modalities` to `Stable`

### DIFF
--- a/jane/doc/extensions/modes/intro.md
+++ b/jane/doc/extensions/modes/intro.md
@@ -1,0 +1,9 @@
+# Introduction to the Mode System
+
+The locality mode used for [Stack allocation](../local/intro.md) has been
+extended to more axes, each tracking a property of values, in order to support
+features such as [Parallelism](../parallelism/intro.md) and
+[Uniqueness](../uniqueness/intro.md). This documentation gives a general
+introduction to the mode system.
+
+*This is a stub. Documentation will come soon.*

--- a/jane/doc/extensions/parallelism/intro.md
+++ b/jane/doc/extensions/parallelism/intro.md
@@ -1,0 +1,13 @@
+# Introduction to Parallelism
+
+OCaml 5 introduces multicore, which allows parallel execution in a single process.
+Based on that, the OCaml Language team developed a collection of compiler features and libraries:
+- Extending the [mode system](../modes/intro.md) to track values' concurrent
+  usages, so they can be used concurrently safely.
+- Higher-level parallelism primitives to allow users to fully expose
+  opportunities of parallelism in their programs, without worrying low-level
+  details such as overhead.
+- Integration to existing concurrency frameworks such as [Async].
+- ..and more.
+
+*This is a stub. Documentation will come soon.*

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -89,7 +89,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
-          value_mode global,many,nonportable,unyielding;join(aliased,contended)(modevar#1[aliased,uncontended .. unique,uncontended])
+          value_mode global,many,nonportable,unyielding;join(aliased,contended)(modevar#1[aliased,contended .. unique,uncontended])
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
           alloc_mode global,many,nonportable,unyielding;id(modevar#7[aliased,contended .. unique,uncontended])

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -89,7 +89,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern 
           Tpat_var "fib"
-          value_mode global,many,nonportable,unyielding;join(aliased,contended)(modevar#1[aliased,uncontended .. unique,uncontended])
+          value_mode global,many,nonportable,unyielding;join(aliased,contended)(modevar#1[aliased,contended .. unique,uncontended])
         expression 
           Texp_function
           alloc_mode global,many,nonportable,unyielding;id(modevar#7[aliased,contended .. unique,uncontended])

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -794,9 +794,9 @@ let (~x:x0, ~s, ~(y:int), ..) : (x:int * s:string * y:int * string) =
    (~x: 1, ~s: "a", ~y: 2, "ignore me")
 
 [%%expect{|
-val x0 : int @@ portable = 1
-val s : string @@ portable = "a"
-val y : int @@ portable = 2
+val x0 : int = 1
+val s : string = "a"
+val y : int = 2
 |}]
 
 module M : sig
@@ -835,9 +835,9 @@ val foo :
   ('a : value_or_null) ('b : value_or_null).
     'a -> (unit -> 'b) -> (unit -> 'b) -> 'b =
   <fun>
-val x : int @@ portable = 1
+val x : int = 1
 val y : int = 2
-val x : int @@ portable = 1
+val x : int = 1
 val y : int = 2
 val f : (foo:int * bar:int) -> int = <fun>
 val f : (x:int * int) -> int = <fun>

--- a/testsuite/tests/templates/basic/bad_arg_impl.reference
+++ b/testsuite/tests/templates/basic/bad_arg_impl.reference
@@ -2,7 +2,7 @@ File "bad_arg_impl.ml", line 1:
 Error: The argument module bad_arg_impl.ml
        does not match the parameter signature monoid.cmi: 
        Values do not match:
-         val append : unit -> unit -> [> `Banana ]
+         val append : unit -> unit -> [> `Banana ] @@ portable
        is not included in
          val append : t -> t -> t
        The type "unit -> unit -> [> `Banana ]" is not compatible with the type

--- a/testsuite/tests/typing-modes/incl_modalities.ml
+++ b/testsuite/tests/typing-modes/incl_modalities.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags += "-extension mode_alpha";
+    flags += "-extension mode";
     expect;
 *)
 

--- a/testsuite/tests/typing-modes/md_modalities.ml
+++ b/testsuite/tests/typing-modes/md_modalities.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags += "-extension mode_alpha";
+    flags += "-extension mode";
     expect;
 *)
 

--- a/testsuite/tests/typing-modes/modes.ml
+++ b/testsuite/tests/typing-modes/modes.ml
@@ -455,18 +455,6 @@ let foo () =
 val foo : unit -> unit = <fun>
 |}]
 
-(* modalities on normal values requires [-extension mode_alpha] *)
-module type S = sig
-  val x : string -> string @ local @@ foo bar
-end
-[%%expect{|
-Line 2, characters 38-41:
-2 |   val x : string -> string @ local @@ foo bar
-                                          ^^^
-Error: The extension "mode" is disabled and cannot be used
-|}]
-
-
 (*
  * Modification of return modes in argument position
  *)

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags+="-extension mode_alpha";
+    flags+="-extension mode";
    expect;
 *)
 

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -25,7 +25,7 @@ end
 val portable_use : 'a @ portable -> unit = <fun>
 module type S = sig val x : 'a -> unit end
 module type SL = sig type 'a t end
-module M : sig type 'a t = int val x : 'a -> unit @@ portable end
+module M : sig type 'a t = int val x : 'a -> unit end
 module F : functor (X : S) -> sig type t = int val x : 'a -> unit end
 |}]
 

--- a/testsuite/tests/typing-modes/portable_interface.mli
+++ b/testsuite/tests/typing-modes/portable_interface.mli
@@ -1,6 +1,6 @@
 (* TEST
     readonly_files = "portable_interface.mli use_portable_interface.ml";
-    flags += "-extension mode_alpha";
+    flags += "-extension mode";
     setup-ocamlc.byte-build-env;
     module = "portable_interface.mli";
     ocamlc.byte;

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -62,7 +62,7 @@ module M = struct
     let x @ contended = "hello"
 end
 [%%expect{|
-module M : sig val x : string @@ portable contended end
+module M : sig val x : string @@ contended end
 |}]
 
 (* Testing the defaulting behaviour.
@@ -162,7 +162,7 @@ Error: Signature mismatch:
 (* CR zqian: add tests when this becomes testable. *)
 
 (* When module doesn't have signature, the values' modes/modalities are still
-   flexible. *)
+   flexible. However, using the values will constrain the modes/modalities. *)
 module Without_inclusion = struct
     module M = struct
         let x @ portable = fun x -> x
@@ -266,7 +266,7 @@ end
 module Close_over_value :
   sig
     module M : sig val x : string @@ portable end
-    val foo : unit -> unit @@ portable
+    val foo : unit -> unit
   end
 |}]
 
@@ -854,7 +854,7 @@ module M_portable = struct
     end
 [%%expect{|
 module M_nonportable : sig val f : unit -> unit end
-module M_portable : sig val f : unit -> unit @@ portable end
+module M_portable : sig val f : unit -> unit end
 |}]
 
 let (foo @ portable) () =

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension mode_alpha";
+ flags = "-extension mode";
  expect;
 *)
 

--- a/testsuite/tests/typing-modes/val_modalities_floor.ml
+++ b/testsuite/tests/typing-modes/val_modalities_floor.ml
@@ -9,7 +9,7 @@ strongest instead of legacy *)
  ";
 {
    setup-ocamlopt.byte-build-env;
-   flags = "-extension mode_alpha";
+   flags = "-extension mode";
 
    {
     src = "def_portable.ml";

--- a/testsuite/tests/typing-unique/rbtree.ml
+++ b/testsuite/tests/typing-unique/rbtree.ml
@@ -508,10 +508,10 @@ module Make_Okasaki :
       val fold :
         'a 'b ('c : value_or_null).
           ('a -> 'b -> 'c -> 'c) -> 'c -> ('a, 'b) tree -> 'c
-      val balance_left : ('a, 'b) tree -> ('a, 'b) tree @@ portable
-      val balance_right : ('a, 'b) tree -> ('a, 'b) tree @@ portable
+      val balance_left : ('a, 'b) tree -> ('a, 'b) tree
+      val balance_right : ('a, 'b) tree -> ('a, 'b) tree
       val ins : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree
-      val set_black : ('a, 'b) tree -> ('a, 'b) tree @@ portable
+      val set_black : ('a, 'b) tree -> ('a, 'b) tree
       val insert : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree
     end
 Line 110, characters 16-52:

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -505,6 +505,19 @@ module type S = sig
 
       type nonrec equate_error = equate_step * error
 
+      (* In the following we have both [Const.t] and [t]. The former is parameterized by
+         constant modes and thus its behavior fully determined. It is what users read and
+         write on constructor arguments, record fields and value descriptions in signatures.
+
+         The latter is parameterized by variable modes and thus its behavior changes as the
+         variable modes change. It is used in module type inference: structures are inferred
+         to have a signature containing a list of value descriptions, each of which carries a
+         modality. This modality depends on the mode of the value, which is a variable.
+         Therefore, we parameterize the modality over the variable mode.
+
+         Utilities are provided to convert between [Const.t] and [t], such as [of_const],
+         [zap_to_id], [zap_to_floor], etc.. *)
+
       module Const : sig
         (** A modality that acts on [Value] modes. Conceptually it is a sequnce
             of [atom] that acts on individual axes. *)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2161,7 +2161,7 @@ let tree_of_value_description id decl =
   (* Important: process the fvs *after* the type; tree_of_type_scheme
      resets the naming context *)
   let snap = Btype.snapshot () in
-  let moda = Mode.Modality.Value.zap_to_floor decl.val_modalities in
+  let moda = Mode.Modality.Value.zap_to_id decl.val_modalities in
   let qtvs = extract_qtvs [decl.val_type] in
   let apparent_arity =
     let rec count n typ =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3198,7 +3198,7 @@ let transl_value_decl env loc ~sig_modalities valdecl =
   let modalities =
     match valdecl.pval_modalities with
     | [] -> sig_modalities
-    | l -> Typemode.transl_modalities ~maturity:Alpha Immutable
+    | l -> Typemode.transl_modalities ~maturity:Stable Immutable
         valdecl.pval_attributes l
   in
   let modalities = Mode.Modality.Value.of_const modalities in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1042,7 +1042,7 @@ let apply_pmd_modalities env sig_modalities pmd_modalities mty =
     match pmd_modalities with
     | [] -> sig_modalities
     | _ :: _ ->
-      Typemode.transl_modalities ~maturity:Alpha Immutable [] pmd_modalities
+      Typemode.transl_modalities ~maturity:Stable Immutable [] pmd_modalities
   in
   (*
   Workaround for pmd_modalities
@@ -1248,7 +1248,7 @@ and approx_sig_items env ssg=
                 | [] -> sg
                 | _ ->
                   let modalities =
-                    Typemode.transl_modalities ~maturity:Alpha Immutable [] moda
+                    Typemode.transl_modalities ~maturity:Stable Immutable [] moda
                   in
                   let recursive =
                     not @@ Builtin_attributes.has_attribute "no_recursive_modalities" attrs
@@ -1750,7 +1750,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
   let names = Signature_names.create () in
 
   let sig_modalities =
-      Typemode.transl_modalities ~maturity:Alpha Immutable [] psg_modalities
+      Typemode.transl_modalities ~maturity:Stable Immutable [] psg_modalities
   in
 
   let transl_include ~loc env sig_acc sincl modalities =
@@ -1776,7 +1776,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
       match modalities with
       | [] -> sig_modalities
       | _ ->
-        Typemode.transl_modalities ~maturity:Alpha Immutable [] modalities
+        Typemode.transl_modalities ~maturity:Stable Immutable [] modalities
     in
     let sg =
       if not @@ Mode.Modality.Value.Const.is_id modalities then
@@ -2563,7 +2563,7 @@ let simplify_app_summary app_view = match app_view.arg with
     | false, None   -> Includemod.Error.Anonymous, mty
 
 let maybe_infer_modalities ~loc ~env ~md_mode ~mode =
-  if Language_extension.(is_at_least Mode Alpha) then begin
+  if Language_extension.(is_at_least Mode Stable) then begin
     (* Values are packed into a structure at modes weaker than they actually
       are. This is to allow our legacy zapping behavior. For example:
 


### PR DESCRIPTION
This PR promotes modalities on values descriptions and module declarations to `Stable`.

There are no longer behaviors controlled by `mode_alpha`, but maybe it's fine to keep it for future convenience.

I confirm that our internal code base builds without changes, with this PR.