### PR TITLE
Module aliases save locks instead of walking them immediately

### DIFF
--- a/testsuite/tests/templates/basic/bad_instance_wrong_mode.ml
+++ b/testsuite/tests/templates/basic/bad_instance_wrong_mode.ml
@@ -2,4 +2,6 @@ let (f @ portable) () =
   let module Monoid_utils_of_list_monoid =
     Monoid_utils(Monoid)(List_monoid) [@jane.non_erasable.instances]
   in
+  (* module alias doesn't walk locks; using it does. *)
+  let _ = Monoid_utils_of_list_monoid.concat in
   ()

--- a/testsuite/tests/templates/basic/bad_instance_wrong_mode.reference
+++ b/testsuite/tests/templates/basic/bad_instance_wrong_mode.reference
@@ -1,4 +1,4 @@
-File "bad_instance_wrong_mode.ml", line 3, characters 4-68:
-3 |     Monoid_utils(Monoid)(List_monoid) [@jane.non_erasable.instances]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+File "bad_instance_wrong_mode.ml", line 6, characters 10-44:
+6 |   let _ = Monoid_utils_of_list_monoid.concat in
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The value "Monoid_utils_of_list_monoid.concat" is nonportable, so cannot be used inside a function that is portable.

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -901,3 +901,64 @@ let () =
   ()
 [%%expect{|
 |}]
+
+(* CR zqian: finer treatment of packing and unpacking *)
+module type Empty = sig end
+
+module type S = sig
+  val foo : 'a -> 'a
+  val baz : 'a -> 'a @@ portable
+end
+
+module M : S = struct
+  let foo = fun x -> x
+  let baz = fun x -> x
+end
+[%%expect{|
+module type Empty = sig end
+module type S = sig val foo : 'a -> 'a val baz : 'a -> 'a @@ portable end
+module M : S
+|}]
+
+let (bar @ portable) () =
+    let m = (module M : Empty) in
+    ()
+[%%expect{|
+Line 2, characters 20-21:
+2 |     let m = (module M : Empty) in
+                        ^
+Error: Modules are nonportable, so cannot be used inside a function that is portable.
+|}]
+
+let m = (module M : S)
+[%%expect{|
+val m : (module S) = <module>
+|}]
+
+let (bar @ portable) () =
+    let module M' = (val m : Empty) in
+    ()
+[%%expect{|
+Line 2, characters 25-26:
+2 |     let module M' = (val m : Empty) in
+                             ^
+Error: The value "m" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+(* CR zqian: this mode crossing should work *)
+module M : sig
+  val x : int
+end = struct
+  let x = 42
+end
+
+let (foo @ portable) () =
+  let _ = M.x in
+  ()
+[%%expect{|
+module M : sig val x : int end
+Line 8, characters 10-13:
+8 |   let _ = M.x in
+              ^^^
+Error: The value "M.x" is nonportable, so cannot be used inside a function that is portable.
+|}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -948,7 +948,7 @@ let diff env1 env2 =
 (* Functions for use in "wrap" parameters in IdTbl *)
 let wrap_identity x = x
 let wrap_value vda = Val_bound vda
-let wrap_module mda = Mod_local (mda, [])
+let wrap_module mda = Mod_local (mda, locks_empty)
 
 (* Forward declarations *)
 
@@ -2089,7 +2089,7 @@ let rec components_of_module_maker
               NameMap.add (Ident.name id) mda c.comp_modules;
             env :=
               store_module ~update_summary:false ~check:None
-                id addr pres md shape [] !env
+                id addr pres md shape locks_empty !env
         | Sig_modtype(id, decl, _) ->
             let final_decl =
               (* The prefixed items get the same scope as [cm_path], which is

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -339,6 +339,12 @@ type lock =
   | Exclave_lock
   | Unboxed_lock (* to prevent capture of terms with non-value types *)
 
+type locks = lock list
+
+let locks_empty = []
+
+let locks_is_empty l = l = locks_empty
+
 type lock_item =
   | Value
   | Module
@@ -719,7 +725,7 @@ and module_data =
     mda_address : address_lazy;
     mda_shape: Shape.t; }
 
-and module_alias_locks = lock list
+and module_alias_locks = locks
   (** If the module is an alias for another module, this is the list of locks
       from the original module to this module. This is accumulative: write
       [module B = A;; module C = B;;], then [C] will record all locks from [A]
@@ -2614,7 +2620,7 @@ module Add_signature(T : Types.Wrapped)(M : sig
   val add_value: ?shape:Shape.t -> mode:(Mode.allowed * 'r0) Mode.Value.t -> Ident.t ->
     T.value_description  -> t -> t
   val add_module_declaration: ?arg:bool -> ?shape:Shape.t -> check:bool
-    -> Ident.t -> module_presence -> T.module_declaration -> ?locks:lock list ->
+    -> Ident.t -> module_presence -> T.module_declaration -> ?locks:locks ->
     t -> t
   val add_modtype: ?shape:Shape.t -> Ident.t -> T.modtype_declaration -> t -> t
 end) = struct

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -204,13 +204,7 @@ type shared_context =
   | Module
   | Probe
 
-type lock =
-  | Escape_lock of escaping_context
-  | Share_lock of shared_context
-  | Closure_lock of closure_context * Mode.Value.Comonadic.r
-  | Region_lock
-  | Exclave_lock
-  | Unboxed_lock (* to prevent capture of terms with non-value types *)
+type lock
 
 (** Items whose accesses are affected by locks *)
 type lock_item =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -403,7 +403,7 @@ val add_module: ?arg:bool -> ?shape:Shape.t ->
 val add_module_lazy: update_summary:bool ->
   Ident.t -> module_presence -> Subst.Lazy.module_type -> t -> t
 val add_module_declaration: ?arg:bool -> ?shape:Shape.t -> check:bool ->
-  Ident.t -> module_presence -> module_declaration -> t -> t
+  Ident.t -> module_presence -> module_declaration -> ?locks:lock list -> t -> t
 val add_module_declaration_lazy: ?arg:bool -> update_summary:bool ->
   Ident.t -> module_presence -> Subst.Lazy.module_declaration -> t -> t
 val add_modtype: Ident.t -> modtype_declaration -> t -> t
@@ -467,7 +467,7 @@ val enter_module:
   module_type -> t -> Ident.t * t
 val enter_module_declaration:
   scope:int -> ?arg:bool -> ?shape:Shape.t -> string -> module_presence ->
-  module_declaration -> t -> Ident.t * t
+  module_declaration -> ?locks:lock list -> t -> Ident.t * t
 val enter_modtype:
   scope:int -> string -> modtype_declaration -> t -> Ident.t * t
 val enter_class: scope:int -> string -> class_declaration -> t -> Ident.t * t

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -204,7 +204,11 @@ type shared_context =
   | Module
   | Probe
 
-type lock
+type locks
+
+val locks_empty : locks
+
+val locks_is_empty : locks -> bool
 
 (** Items whose accesses are affected by locks *)
 type lock_item =
@@ -269,7 +273,7 @@ type actual_mode = {
     the locks. [ty] is optional as the function works on modules and classes as well, for
     which [ty] should be [None]. *)
 val walk_locks : loc:Location.t -> env:t -> item:lock_item -> lid:Longident.t ->
-  Mode.Value.l -> type_expr option -> lock list -> actual_mode
+  Mode.Value.l -> type_expr option -> locks -> actual_mode
 
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
@@ -294,12 +298,12 @@ val lookup_cltype:
   defined (always legacy), and thus not returned. *)
 val lookup_module_path:
   ?use:bool -> loc:Location.t -> load:bool -> Longident.t -> t ->
-    Path.t * lock list
+    Path.t * locks
 val lookup_modtype_path:
   ?use:bool -> loc:Location.t -> Longident.t -> t -> Path.t
 val lookup_module_instance_path:
   ?use:bool -> loc:Location.t -> load:bool -> Global_module.Name.t -> t ->
-    Path.t * lock list
+    Path.t * locks
 
 val lookup_constructor:
   ?use:bool -> loc:Location.t -> constructor_usage -> Longident.t -> t ->
@@ -397,7 +401,7 @@ val add_module: ?arg:bool -> ?shape:Shape.t ->
 val add_module_lazy: update_summary:bool ->
   Ident.t -> module_presence -> Subst.Lazy.module_type -> t -> t
 val add_module_declaration: ?arg:bool -> ?shape:Shape.t -> check:bool ->
-  Ident.t -> module_presence -> module_declaration -> ?locks:lock list -> t -> t
+  Ident.t -> module_presence -> module_declaration -> ?locks:locks -> t -> t
 val add_module_declaration_lazy: ?arg:bool -> update_summary:bool ->
   Ident.t -> module_presence -> Subst.Lazy.module_declaration -> t -> t
 val add_modtype: Ident.t -> modtype_declaration -> t -> t
@@ -461,7 +465,7 @@ val enter_module:
   module_type -> t -> Ident.t * t
 val enter_module_declaration:
   scope:int -> ?arg:bool -> ?shape:Shape.t -> string -> module_presence ->
-  module_declaration -> ?locks:lock list -> t -> Ident.t * t
+  module_declaration -> ?locks:locks -> t -> Ident.t * t
 val enter_modtype:
   scope:int -> string -> modtype_declaration -> t -> Ident.t * t
 val enter_class: scope:int -> string -> class_declaration -> t -> Ident.t * t

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -301,7 +301,7 @@ let error_of_filter_arrow_failure ~explanation ~first ty_fun
 let type_module =
   ref ((fun _env _md -> assert false) :
        Env.t -> Parsetree.module_expr -> Typedtree.module_expr * Shape.t *
-        Env.lock list)
+        Env.locks)
 
 (* Forward declaration, to be filled in by Typemod.type_open *)
 

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -333,7 +333,7 @@ val report_error: loc:Location.t -> Env.t -> error -> Location.error
 (* Forward declaration, to be filled in by Typemod.type_module *)
 val type_module:
   (Env.t -> Parsetree.module_expr -> Typedtree.module_expr * Shape.t *
-    Env.lock list) ref
+    Env.locks) ref
 (* Forward declaration, to be filled in by Typemod.type_open *)
 val type_open:
   (?used_slot:bool ref -> override_flag -> Env.t -> Location.t ->

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -332,7 +332,8 @@ val report_error: loc:Location.t -> Env.t -> error -> Location.error
 
 (* Forward declaration, to be filled in by Typemod.type_module *)
 val type_module:
-  (Env.t -> Parsetree.module_expr -> Typedtree.module_expr * Shape.t) ref
+  (Env.t -> Parsetree.module_expr -> Typedtree.module_expr * Shape.t *
+    Env.lock list) ref
 (* Forward declaration, to be filled in by Typemod.type_open *)
 val type_open:
   (?used_slot:bool ref -> override_flag -> Env.t -> Location.t ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2587,31 +2587,36 @@ let maybe_infer_modalities ~loc ~env ~md_mode ~mode =
     Mode.Modality.Value.id
   end
 
-type alias =
-  | No
-  | Yes_walk_locks
-  | Yes_hold_locks
+type 'locks alias =
+  | No : unit alias
+  | Yes_walk_locks : unit alias
+  | Yes_hold_locks : Env.lock list alias
 
-let is_alias = function
+let is_alias : type locks. locks alias -> bool = function
   | No -> false
   | Yes_walk_locks | Yes_hold_locks -> true
 
-let rec type_module_maybe_hold_locks ~alias sttn funct_body anchor env smod =
+let locks_of_non_aliasable : type locks. locks alias -> locks = function
+  | No -> ()
+  | Yes_walk_locks -> ()
+  | Yes_hold_locks -> []
+
+let rec type_module_maybe_hold_locks :
+type locks. alias:locks alias -> _ -> _ -> _ -> _ -> _ -> _ * _ * locks =
+fun ~alias sttn funct_body anchor env smod ->
   Builtin_attributes.warning_scope smod.pmod_attributes
     (fun () -> type_module_aux ~alias sttn funct_body anchor env smod)
 
 and type_module ?(alias=false) sttn funct_body anchor env smod =
   let alias = if alias then Yes_walk_locks else No in
-  let md, shape, locks =
+  let md, shape, () =
     type_module_maybe_hold_locks ~alias sttn funct_body anchor env smod
   in
-  begin match locks with
-  | [] -> ()
-  | _ :: _ -> Misc.fatal_error "locks should not be held"
-  end;
   md, shape
 
-and type_module_aux ~alias sttn funct_body anchor env smod =
+and type_module_aux :
+type locks. alias:locks alias -> _ -> _ -> _ -> _ -> _ -> _ * _ * locks =
+fun ~alias sttn funct_body anchor env smod ->
   match smod.pmod_desc with
     Pmod_ident lid ->
       let path, locks =
@@ -2629,12 +2634,13 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
           mod_loc = smod.pmod_loc }
       in
       let sg' = Signature_names.simplify _finalenv names sg in
-      if List.length sg' = List.length sg then md, shape, [] else
+      let locks = locks_of_non_aliasable alias in
+      if List.length sg' = List.length sg then md, shape, locks else
       let md, shape =
         wrap_constraint_with_shape env false md
           (Mty_signature sg') shape Tmodtype_implicit
       in
-      md, shape, []
+      md, shape, locks
   | Pmod_functor(arg_opt, sbody) ->
       let t_arg, ty_arg, newenv, funct_shape_param, funct_body =
         match arg_opt with
@@ -2674,10 +2680,10 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
         mod_env = env;
         mod_attributes = smod.pmod_attributes;
         mod_loc = smod.pmod_loc },
-      Shape.abs funct_shape_param body_shape, []
+      Shape.abs funct_shape_param body_shape, locks_of_non_aliasable alias
   | Pmod_apply _ | Pmod_apply_unit _ ->
       let md, shape = type_application smod.pmod_loc sttn funct_body env smod in
-      md, shape, []
+      md, shape, locks_of_non_aliasable alias
   | Pmod_constraint(sarg, smty, smode) ->
       check_no_modal_modules ~env smode;
       let smty = Option.get smty in
@@ -2726,7 +2732,7 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
         mod_env = env;
         mod_attributes = smod.pmod_attributes;
         mod_loc = smod.pmod_loc },
-      Shape.leaf_for_unpack, []
+      Shape.leaf_for_unpack, locks_of_non_aliasable alias
   | Pmod_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
   | Pmod_instance glob ->
@@ -2745,18 +2751,23 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
       in
       type_module_path_aux ~alias sttn env path locks lid smod
 
-and type_module_path_aux ~alias sttn env path locks (lid : _ loc) smod =
-  let locks =
+and type_module_path_aux :
+type locks. alias:locks alias -> _ -> _ -> _ -> Env.lock list -> _ -> _ ->
+    _ * _ * locks =
+fun ~(alias : locks alias) sttn env path locks (lid : _ loc) smod ->
+  let walk_locks () =
+    let vmode =
+      Env.walk_locks ~loc:lid.loc ~env ~item:Module ~lid:lid.txt
+        Mode.Value.(legacy |> disallow_right) None locks
+    in
+    Mode.Value.submode_exn vmode.mode Mode.Value.legacy;
+    ()
+  in
+  let locks : locks =
     match alias with
     | Yes_hold_locks -> locks
-    | No | Yes_walk_locks -> begin
-        let vmode =
-          Env.walk_locks ~loc:lid.loc ~env ~item:Module ~lid:lid.txt
-            Mode.Value.(legacy |> disallow_right) None locks
-        in
-        Mode.Value.submode_exn vmode.mode Mode.Value.legacy;
-        []
-      end
+    | No -> walk_locks ()
+    | Yes_walk_locks -> walk_locks ()
   in
   let alias = is_alias alias in
   let md = { mod_desc = Tmod_ident (path, lid);


### PR DESCRIPTION
In this PR, module aliases don't walk locks immediately. Instead, they hold locks to be walked later when the alias is used.

Note: the following program is allowed by the current PR, but shouldn't when we have stack-allocated modules:
```
module M @ local = struct
end

let (f @ global) () = let module N = M in ()
```

**_Please review by commits._**