### PR TITLE
Fix `constrain_type_jkind` for unboxed records with `any` and erroneous jkind annotations

### DIFF
--- a/testsuite/tests/typing-layouts-unboxed-records/basics.ml
+++ b/testsuite/tests/typing-layouts-unboxed-records/basics.ml
@@ -712,3 +712,11 @@ Error: The universal type variable 'a was declared to have kind any.
        But it was inferred to have kind value_or_null
          because of the definition of t at line 1, characters 0-40.
 |}]
+
+type a = B of b
+and b : any = #{ i : int ; j : int }
+[%%expect{|
+>> Fatal error: unboxed product jkinds don't line up
+Uncaught exception: Misc.Fatal_error
+
+|}]

--- a/testsuite/tests/typing-layouts-unboxed-records/basics.ml
+++ b/testsuite/tests/typing-layouts-unboxed-records/basics.ml
@@ -731,3 +731,15 @@ Line 1, characters 9-15:
 Error: Type "b" has layout "value & value".
        Variants may not yet contain types of this layout.
 |}]
+type a = B of b
+and b : any & any & any = #{ i : int ; j : int }
+[%%expect{|
+Line 2, characters 0-48:
+2 | and b : any & any & any = #{ i : int ; j : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error:
+       The layout of b is any & any & any
+         because of the annotation on the declaration of the type b.
+       But the layout of b must be representable
+         because it's the type of a constructor field.
+|}]

--- a/testsuite/tests/typing-layouts-unboxed-records/basics.ml
+++ b/testsuite/tests/typing-layouts-unboxed-records/basics.ml
@@ -713,10 +713,21 @@ Error: The universal type variable 'a was declared to have kind any.
          because of the definition of t at line 1, characters 0-40.
 |}]
 
+
+(************************************************************)
+
+(* This is a regression test. Previously, we hit a fatal error because the [any]
+   annotation obscured the fact that the unboxed record is a product, breaking
+   an invariant assumed by [Ctype.constrain_type_jkind].
+
+   [a] was necessary to trigger the error because it called
+   [check_representable] on [b], constraining its kind to be a sort variable. *)
 type a = B of b
 and b : any = #{ i : int ; j : int }
 [%%expect{|
->> Fatal error: unboxed product jkinds don't line up
-Uncaught exception: Misc.Fatal_error
-
+Line 1, characters 9-15:
+1 | type a = B of b
+             ^^^^^^
+Error: Type "b" has layout "value & value".
+       Variants may not yet contain types of this layout.
 |}]

--- a/testsuite/tests/typing-layouts-unboxed-records/basics.ml
+++ b/testsuite/tests/typing-layouts-unboxed-records/basics.ml
@@ -731,6 +731,15 @@ Line 1, characters 9-15:
 Error: Type "b" has layout "value & value".
        Variants may not yet contain types of this layout.
 |}]
+type a = B of b_portable
+and b_portable : any mod portable = #{ i : int ; j : int }
+[%%expect{|
+Line 1, characters 9-24:
+1 | type a = B of b_portable
+             ^^^^^^^^^^^^^^^
+Error: Type "b_portable" has layout "value & value".
+       Variants may not yet contain types of this layout.
+|}]
 type a = B of b
 and b : any & any & any = #{ i : int ; j : int }
 [%%expect{|

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2367,7 +2367,11 @@ let constrain_type_jkind ~fixed env ty jkind =
                   mode-crossing restrictions, so we recur, just duplicating
                   the jkind. *)
                recur ty's_jkinds (List.init num_components (fun _ -> jkind))
-             | _ -> Misc.fatal_error "unboxed product jkinds don't line up"
+             | _ ->
+               (* Products don't line up. This is only possible if [ty] was
+                  given a jkind annotation of the wrong product arity.
+               *)
+               Error (Jkind.Violation.of_ (Not_a_subjkind (ty's_jkind, jkind)))
              end
           in
           match get_desc ty with

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -975,7 +975,7 @@ let transl_declaration env sdecl (id, uid) =
          decompose the product of [any]s and recurse on the labels. *)
       match sdecl.ptype_kind with
       | Ptype_record_unboxed_product lbls
-        when Jkind.is_max (Jkind.terrible_relax_l jkind) ->
+        when Jkind.has_layout_any (Jkind.terrible_relax_l jkind) ->
         Jkind.Builtin.product ~why:Unboxed_record
           (List.map (fun _ -> jkind) lbls)
       | Ptype_abstract | Ptype_variant _ | Ptype_record _

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -967,12 +967,13 @@ let transl_declaration env sdecl (id, uid) =
       | None, None -> jkind_default
     in
     let jkind =
-      (* Unboxed records are given a product-of-[any]s jkind
+      (* Hack: unboxed records are given a product-of-[any]s jkind
          when they would otherwise be given [any].
 
          This allows [estimate_type_jkind] to give an estimate that's
          just barely good enough, such that [constain_type_jkind] can always
-         decompose the product of [any]s and recurse on the labels. *)
+         decompose the product of [any]s and recurse on the labels.
+         See https://github.com/ocaml-flambda/flambda-backend/pull/3399. *)
       match sdecl.ptype_kind with
       | Ptype_record_unboxed_product lbls
         when Jkind.has_layout_any (Jkind.terrible_relax_l jkind) ->


### PR DESCRIPTION
Currently, the below breaks an invariant of `Ctype.constrain_type_jkind`, causing a fatal error instead of a type error:
```ocaml
type a = B of b
and b : any = #{ i : int ; j : int }
```

Specifically, the `any` annotation obscures the fact that the unboxed record is a product, breaking the following invariant assumed by `Ctype.constrain_type_jkind`: a type with a product kind is given a product jkind of the correct arity by `estimate_type_jkind`. (`constrain_type_jkind` is called to check that `b` is representable as the argument to `B`.)

We fix this by giving unboxed records a product-of-`any`s jkind when they would otherwise be given `any`. This allows `estimate_type_jkind` to give an estimate that's just barely good enough, such that `constain_type_jkind` can always recurse on the labels.

Still, it's possible to get a "products jkinds don't line up" error if `b` is given a jkind annotation with an incorrect arity.
```ocaml
type a : B of b
and b : any & any & any = #{ i : int ; j : int }
```
We fix this simply returning a type error instead of a fatal error when product jkinds don't line up, as this should only reachable with incorrect annotations.

Review: @ccasin 